### PR TITLE
Automatically populate the unit options based on the selected nutrient.

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -18,6 +18,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+'use strict';
+
 var code;
 var current_cropbox;
 var images = [];
@@ -26,6 +28,12 @@ var img_path;
 var angles = {};
 var imagefield_imgid = {};
 var imagefield_url = {};
+
+var units = [
+	[ 'g', 'mg', "\u00B5g", '% DV' ],
+	[ 'mol/l', 'moll/l', 'mmol/l', 'mval/l', 'ppm', "\u00B0rH", "\u00B0fH", "\u00B0e", "\u00B0dH", 'gpg' ],
+	[ 'kJ', 'kcal' ],
+];
 
 function stringStartsWith (string, prefix) {
     return string.slice(0, prefix.length) == prefix;
@@ -106,17 +114,37 @@ function select_nutriment(event, ui) {
 	id = id.replace("_label", "");
 	$('#' + id).focus();
 	$('#' + id + '_unit').val(ui.item.unit);
-	if (ui.item.unit == '') {
-		$('#' + id + '_unit').hide();
-		$('#' + id + '_unit_percent').hide();
+	var unit = (ui.item.unit == '%' ? 'g' : ui.item.unit).toLowerCase();
+	var unitElement = $('#' + id + '_unit');
+	var percentElement = $('#' + id + '_unit_percent');
+	if (unit == '') {
+		unitElement.hide();
+		percentElement.hide();
 	}
-	else if (ui.item.unit == '%') {
-		$('#' + id + '_unit').hide();
-		$('#' + id + '_unit_percent').show();
+	else if (unit == '%') {
+		unitElement.hide();
+		percentElement.show();
 	}
 	else {
-		$('#' + id + '_unit').show();
-		$('#' + id + '_unit_percent').hide();	
+		unitElement.show();
+		percentElement.hide();
+
+		for (var entryIndex = 0; entryIndex < units.length; ++entryIndex) {
+			var entry = units[entryIndex];
+			for (var unitIndex = 0; unitIndex < entry.length; ++unitIndex) {
+				var unitEntry = entry[unitIndex].toLowerCase();
+				if (unitEntry == unit) {
+					var domElement = unitElement[0];
+					domElement.options.length = 0; // Remove current entries.
+					for (var itemIndex = 0; itemIndex < entry.length; ++itemIndex) {
+						var unitValue = entry[itemIndex];
+						domElement.options[domElement.options.length] = new Option(unitValue, unitValue, unitValue.toLowerCase() == unit);
+					}
+
+					return;
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #386 again, also fixed 'kJ'/'kcal' not being selectable for 'Energy from Fat'.