### PR TITLE
separator_before_colon as NO-BREAK SPACE

### DIFF
--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -66,7 +66,7 @@ sub separator_before_colon($) {
 	my $l = shift;
 
 	if ($l eq 'fr') {
-		return ' ';
+		return "\N{U+00A0}";
 	}
 	else {
 		return '';


### PR DESCRIPTION
Force French colon separator to be a 'NO-BREAK SPACE' (U+00A0).