### PR TITLE
Remove dead symlinks

### DIFF
--- a/html/js/jquery-interestingviews-selectclip.js
+++ b/html/js/jquery-interestingviews-selectclip.js
@@ -1,1 +1,0 @@
-/home/off-fr/cgi/jquery-interestingviews-selectclip.js

--- a/ingredients/additifs/authorized_additives.txt
+++ b/ingredients/additifs/authorized_additives.txt
@@ -1,1 +1,0 @@
-/home/off-fr/cgi/authorized_additives.pl

--- a/ingredients/additifs/extract_additives.pl
+++ b/ingredients/additifs/extract_additives.pl
@@ -1,1 +1,0 @@
-/home/off-fr/cgi/extract_additives.pl

--- a/lang/es/tags/labels.txt
+++ b/lang/es/tags/labels.txt
@@ -1,1 +1,0 @@
-/home/off-fr/cgi/labels.es.txt

--- a/lang/fr/tags/categories.txt
+++ b/lang/fr/tags/categories.txt
@@ -1,1 +1,0 @@
-/home/off-fr/cgi/categories.txt

--- a/lang/fr/tags/labels.txt
+++ b/lang/fr/tags/labels.txt
@@ -1,1 +1,0 @@
-/home/off-fr/cgi/labels.txt


### PR DESCRIPTION
Git on Windows finally supports symlinks, so I enabled those and found some dead symlinks, that actually point to absolute paths.

All of these files do not exist on the production server either, so I think it should be save to delete them.