### PR TITLE
Pet-specific examples in the product editor

### DIFF
--- a/po/openpetfoodfacts/openpetfoodfacts.pot
+++ b/po/openpetfoodfacts/openpetfoodfacts.pot
@@ -57,7 +57,6 @@ msgctxt "labels_example"
 msgid "No sugar, No colorings"
 msgstr ""
 
-
 msgctxt "ingredients_text_example"
 msgid ""
 "Cereals 85.5% (_wheat_ flour, whole-_wheat_ flour 11%), malt extract, "

--- a/po/openpetfoodfacts/openpetfoodfacts.pot
+++ b/po/openpetfoodfacts/openpetfoodfacts.pot
@@ -36,3 +36,30 @@ msgstr ""
 msgctxt "android_app_link"
 msgid "https://play.google.com/store/apps/details?id=org.openpetfoodfacts.scanner&hl=en"
 msgstr ""
+
+msgctxt "brands_example"
+msgid "Purina, Pedigree"
+msgstr ""
+
+msgctxt "product_name_example"
+msgid "Pro Plan Adult, rich in chicken"
+msgstr ""
+
+msgctxt "generic_name_example"
+msgid "Complete pet food for adult cats"
+msgstr ""
+
+msgctxt "categories_example"
+msgid "Dry adult cat food"
+msgstr ""
+
+msgctxt "labels_example"
+msgid "No sugar, No colorings"
+msgstr ""
+
+
+msgctxt "ingredients_text_example"
+msgid ""
+"Cereals 85.5% (_wheat_ flour, whole-_wheat_ flour 11%), malt extract, "
+"ascorbic acid"
+msgstr ""


### PR DESCRIPTION
ingredients_text_example is from https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/common-web.pot , but I removed cocoa.