### PR TITLE
Add linked data array to JSON tags API.

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1317,7 +1317,7 @@ sub display_list_of_tags($$) {
 			$html .= "<tr><td>";
 			
 			my $display = '';
-			
+			my $linkeddata;
 			if ($tagtype eq 'nutrition_grades') {
 				if ($tagid =~ /^a|b|c|d|e$/) {
 					my $grade = $tagid;
@@ -1328,7 +1328,8 @@ sub display_list_of_tags($$) {
 				}
 			}
 			elsif (defined $taxonomy_fields{$tagtype}) {
-				$display = display_taxonomy_tag($lc, $tagtype, $tagid);				 			 
+				$display = display_taxonomy_tag($lc, $tagtype, $tagid);
+				$linkeddata = $properties{$tagtype}{$tagid};
 			}
 			else {
 				$display = canonicalize_tag2($tagtype, $tagid);
@@ -1345,6 +1346,10 @@ sub display_list_of_tags($$) {
 				url => format_subdomain($subdomain) . $product_link,
 				products => $products + 0, # + 0 to make the value numeric
 			};
+			
+			if (defined $linkeddata) {
+				$tagentry->{linkeddata} = $linkeddata;
+			}
 
 			if (defined $tags_images{$lc}{$tagtype}{get_fileid($icid)}) {
 				my $img = $tags_images{$lc}{$tagtype}{get_fileid($icid)};


### PR DESCRIPTION
Example: http://world.productopener.localhost/categories.json
`{"count":4,"tags":[{"id":"en:pizza-with-ham-and-cheese","name":"Pizza
with ham and
cheese","products":1,"url":"http://world.productopener.localhost/category/pizza-with-ham-and-cheese"},{"id":"en:pizzas","name":"Pizzas","linkeddata":{"wikidata:en":"Q177"},"products":1,"url":"http://world.productopener.localhost/category/pizzas"},{"id":"en:pizzas-pies-and-quiches","name":"Pizzas
pies and quiches","linkeddata":{"pnns_group_2:en":"Pizza pies and
quiche"},"products":1,"url":"http://world.productopener.localhost/category/pizzas-pies-and-quiches"},{"id":"en:meals","name":"Meals","linkeddata":{"pnns_group_2:en":"One-dish
meals"},"products":1,"url":"http://world.productopener.localhost/category/meals"}]}`