### PR TITLE
Issue/962 no nutrition facts

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -151,6 +151,11 @@ else {
 	
 	$product_ref->{no_nutrition_data} = remove_tags_and_quote(decode utf8=>param("no_nutrition_data"));	
 	
+	my $no_nutrition_data = 0;
+	if ((defined $product_ref->{no_nutrition_data}) and ($product_ref->{no_nutrition_data} eq 'on')) {
+		$no_nutrition_data = 1;
+	}
+
 	defined $product_ref->{nutriments} or $product_ref->{nutriments} = {};
 
 	my @unknown_nutriments = ();
@@ -270,6 +275,22 @@ else {
 		}
 	}
 	
+	if ($no_nutrition_data) {
+		# Delete all non-carbon-footprint nids.
+		foreach my $key (keys $product_ref->{nutriments}) {
+			next if $key =~ /_/;
+			next if $key eq 'carbon-footprint';
+
+			delete $product_ref->{nutriments}{$key};
+			delete $product_ref->{nutriments}{$key . "_unit"};
+			delete $product_ref->{nutriments}{$key . "_value"};
+			delete $product_ref->{nutriments}{$key . "_modifier"};
+			delete $product_ref->{nutriments}{$key . "_label"};
+			delete $product_ref->{nutriments}{$key . "_100g"};
+			delete $product_ref->{nutriments}{$key . "_serving"};
+		}
+	}
+
 	# Compute nutrition data per 100g and per serving
 	
 	$admin and print STDERR "compute_serving_size_date\n";

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -1385,8 +1385,12 @@ $html .= "</div><!-- fieldset -->
 <div class=\"fieldset\" id=\"nutrition\"><legend>$Lang{nutrition_data}{$lang}</legend>\n";
 
 	my $checked = '';
+	my $tablestyle = 'display: table;';
+	my $disabled = '';
 	if ((defined $product_ref->{no_nutrition_data}) and ($product_ref->{no_nutrition_data} eq 'on')) {
 		$checked = 'checked="checked"';
+		$tablestyle = 'display: none;';
+		$disabled = 'disabled="disabled"';
 	}
 
 	$html .= <<HTML
@@ -1436,7 +1440,7 @@ JS
 <div style="position:relative">
 
 
-<table id="nutrition_data_table" class="data_table">
+<table id="nutrition_data_table" class="data_table" style="$tablestyle">
 <thead class="nutriment_header">
 <th colspan="2">
 $Lang{nutrition_data_table}{$lang}<br/>
@@ -1559,6 +1563,13 @@ HTML
 		
 		# print STDERR "nutriment: $nutriment - nid: $nid - shown: $shown - class: $class - prefix: $prefix \n";
 		
+		my $disabled_backup = $disabled;
+		if ($nid eq 'carbon-footprint') {
+			# Workaround, so that the carbon footprint, that could be in a location different from actual nutrition facts,
+			# will never be disabled.
+			$disabled = '';
+		}
+		
 		my $input = '';
 		
 		
@@ -1566,7 +1577,7 @@ HTML
 <tr id="nutriment_${enid}_tr" class="nutriment_$class"$display>
 <td>$label</td>
 <td>
-<input class="nutriment_value" id="nutriment_${enid}" name="nutriment_${enid}" value="$value" />
+<input class="nutriment_value" id="nutriment_${enid}" name="nutriment_${enid}" value="$value" $disabled/>
 HTML
 ;
 
@@ -1607,13 +1618,14 @@ HTML
 		else {
 			$hide_percent = ' style="display:none"';
 		}
-		
+
 		$input .= <<HTML
 <span class="nutriment_unit_percent" id="nutriment_${enid}_unit_percent"$hide_percent>%</span>
-<select class="nutriment_unit" id="nutriment_${enid}_unit" name="nutriment_${enid}_unit"$hide_select>
+<select class="nutriment_unit" id="nutriment_${enid}_unit" name="nutriment_${enid}_unit"$hide_select $disabled>
 HTML
 ;		
-		
+		$disabled = $disabled_backup;
+
 		foreach my $u (@units) {
 			my $selected = '';
 			if ($unit eq $u) {

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -1395,6 +1395,22 @@ $html .= "</div><!-- fieldset -->
 HTML
 ;
 
+	$initjs .= <<JS
+\$('#no_nutrition_data').change(function() {
+	if (\$(this).prop('checked')) {
+		\$('#nutrition_data_table input').prop('disabled', true);
+		\$('#nutrition_data_table select').prop('disabled', true);
+		\$('#nutrition_data_table input.nutriment_value').val('');
+		\$('#nutrition_data_table').hide();
+	} else {
+		\$('#nutrition_data_table input').prop('disabled', false);
+		\$('#nutrition_data_table select').prop('disabled', false);
+		\$('#nutrition_data_table').show();
+	}
+});
+JS
+;
+
 	$html .= display_tabs($product_ref, $select_add_language, "nutrition_image", $product_ref->{sorted_langs}, \%Langs, ["nutrition_image"]);
 	
 	$initjs .= display_select_crop_init($product_ref);

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -1411,6 +1411,8 @@ HTML
 		\$('#nutrition_data_table select').prop('disabled', false);
 		\$('#nutrition_data_table').show();
 	}
+
+	\$(document).foundation('equalizer', 'reflow');
 });
 JS
 ;


### PR DESCRIPTION
1. clear and hide nutrient input fields if the "no nutrients" checkbox is checked
2. clear most $nids when `no_nutrition_data=on` is set in the API

Fixes #962