### PR TITLE
Finish IU support

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -3,7 +3,7 @@
 # This file is part of Product Opener.
 # 
 # Product Opener
-# Copyright (C) 2011-2017 Association Open Food Facts
+# Copyright (C) 2011-2018 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 # 
@@ -1679,7 +1679,12 @@ HTML
 	my $nutriments = '';
 	foreach my $nid (@{$other_nutriments_lists{$nutriment_table}}) {
 		if ((not defined $product_ref->{nutriments}{$nid}) or ($product_ref->{nutriments}{$nid} eq '')) {
-			$other_nutriments .= '{ "value" : "' . $Nutriments{$nid}{$lang} . '", "unit" : "' . $Nutriments{$nid}{unit} . '" },' . "\n";
+			my $supports_iu = "false";
+			if ((exists $Nutriments{$nid}{iu}) and ($Nutriments{$nid}{iu} > 0)) {
+				$supports_iu = "true";
+			}
+
+			$other_nutriments .= '{ "value" : "' . $Nutriments{$nid}{$lang} . '", "unit" : "' . $Nutriments{$nid}{unit} . '", "iu": ' . $supports_iu . '  },' . "\n";
 		}
 		$nutriments .= '"' . $Nutriments{$nid}{$lang} . '" : "' . $nid . '",' . "\n";
 	}

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -1,7 +1,7 @@
 // This file is part of Product Opener.
 // 
 // Product Opener
-// Copyright (C) 2011-2017 Association Open Food Facts
+// Copyright (C) 2011-2018 Association Open Food Facts
 // Contact: contact@openfoodfacts.org
 // Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 // 
@@ -137,6 +137,10 @@ function select_nutriment(event, ui) {
 					for (var itemIndex = 0; itemIndex < entry.length; ++itemIndex) {
 						var unitValue = entry[itemIndex];
 						domElement.options[domElement.options.length] = new Option(unitValue, unitValue, false, unitValue.toLowerCase() == unit);
+					}
+
+					if (ui.item.iu) {
+						domElement.options[domElement.options.length] = new Option('IU', 'IU', false, 'iu' == unit);
 					}
 
 					return;


### PR DESCRIPTION
Expands upon 6e741e2fae2ad96b3d039beb3bb2f6c4d43646a7 and closes #352.

The basics were already done, but IU/UI was not selectable when adding "Vitamin A" or "Vitamin D" to a product initially.