### PR TITLE
Use "sameAs" instead of "linkeddata".

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1,7 +1,7 @@
 ﻿# This file is part of Product Opener.
 # 
 # Product Opener
-# Copyright (C) 2011-2017 Association Open Food Facts
+# Copyright (C) 2011-2018 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 # 
@@ -1317,7 +1317,7 @@ sub display_list_of_tags($$) {
 			$html .= "<tr><td>";
 			
 			my $display = '';
-			my $linkeddata;
+			my @sameAs = ();
 			if ($tagtype eq 'nutrition_grades') {
 				if ($tagid =~ /^a|b|c|d|e$/) {
 					my $grade = $tagid;
@@ -1329,7 +1329,12 @@ sub display_list_of_tags($$) {
 			}
 			elsif (defined $taxonomy_fields{$tagtype}) {
 				$display = display_taxonomy_tag($lc, $tagtype, $tagid);
-				$linkeddata = $properties{$tagtype}{$tagid};
+				if ((defined $properties{$tagtype}) and (defined $properties{$tagtype}{$tagid})) {
+					foreach my $key (keys %weblink_templates) {
+						next if not defined $properties{$tagtype}{$tagid}{$key};
+						push @sameAs, sprintf($weblink_templates{$key}{href}, $properties{$tagtype}{$tagid}{$key});
+					}
+				}
 			}
 			else {
 				$display = canonicalize_tag2($tagtype, $tagid);
@@ -1347,8 +1352,8 @@ sub display_list_of_tags($$) {
 				products => $products + 0, # + 0 to make the value numeric
 			};
 			
-			if (defined $linkeddata) {
-				$tagentry->{linkeddata} = $linkeddata;
+			if (($#sameAs >= 0)) {
+				$tagentry->{sameAs} = \@sameAs;
 			}
 
 			if (defined $tags_images{$lc}{$tagtype}{get_fileid($icid)}) {


### PR DESCRIPTION
For some reason, #972 was closed by 9626d6e42aea15d65b2daca2bc7c4b25679dc7e8 in conjunction with #968.

```
{
   "count":4,
   "tags":[
      {
         "id":"en:wines",
         "products":1,
         "name":"Wines",
         "sameAs":[
            "https://www.wikidata.org/wiki/Q282"
         ],
         "url":"http://world.productopener.localhost/category/wines"
      },
      {
         "id":"en:alcoholic-beverages",
         "products":1,
         "name":"Alcoholic beverages",
         "url":"http://world.productopener.localhost/category/alcoholic-beverages"
      },
      {
         "id":"en:wines-from-greece",
         "products":1,
         "name":"Wines from Greece",
         "sameAs":[
            "https://www.wikidata.org/wiki/Q1779616"
         ],
         "url":"http://world.productopener.localhost/category/wines-from-greece"
      },
      {
         "id":"en:beverages",
         "products":1,
         "name":"Beverages",
         "sameAs":[
            "https://www.wikidata.org/wiki/Q40050"
         ],
         "url":"http://world.productopener.localhost/category/beverages"
      }
   ]
}
```

Actually fixes #391

---

Advantages over the previous approach
- Full URL
- Known from schema.org
- Also used in the OFF website when displaying weblinks

Disadvantages
- Does not display "all" linked data right now, but that can be fixed by adding weblink templates.