### PR TITLE
Make $cursor immortal

### DIFF
--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -136,6 +136,7 @@ else {
 print "Update key: $key\n\n";
 
 my $cursor = $products_collection->query($query_ref)->fields({ code => 1 });;
+$cursor->immortal(1);
 my $count = $cursor->count();
 
 my $n = 0;


### PR DESCRIPTION
I just noticed the comment in `update_all_products.pl` regarding the cursor possibly timing out when processing a _lot_ of products. Making the cursor immortal should take care of this. It should still be safe, because it will be cleaned up if it runs out of scope.

http://search.cpan.org/dist/MongoDB/lib/MongoDB/Cursor.pm#immortal
> Ordinarily, a cursor "dies" on the database server after a certain length of time (approximately 10 minutes), to prevent inactive cursors from hogging resources. This option indicates that a cursor should not die until all of its results have been fetched or it goes out of scope in Perl.