### PR TITLE
plant milks/dairies

### DIFF
--- a/lib/ProductOpener/SiteQuality_off.pm
+++ b/lib/ProductOpener/SiteQuality_off.pm
@@ -141,6 +141,11 @@ sub detect_categories ($) {
 			}
 		}
 	}
+
+	# Plant milks should probably not be dairies https://github.com/openfoodfacts/openfoodfacts-server/issues/73
+	if (has_tag($product_ref, "categories", "en:plant-milks") and has_tag($product_ref, "categories", "en:dairies")) {
+		push $product_ref->{quality_tags}, "plant-milk-also-is-dairy";
+	}
 	
 }
 


### PR DESCRIPTION
This quality asset allows users to find plant milks that are also categorized as dairies, because of the former categories taxonomy. In conjunction with the updated taxonomy, I think this should be enough to close #73.