### PR TITLE
Wikidata for input

### DIFF
--- a/docker/backend-git/conf/Config.pm
+++ b/docker/backend-git/conf/Config.pm
@@ -314,7 +314,15 @@ last_edit_dates
 
 %weblink_templates = (
 
-	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata' },
+	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata', parse => sub
+	{
+		my ($url) = @_;
+		if ($url =~ /^https?:\/\/www.wikidata.org\/wiki\/(Q\d+)$/) {
+			return $1
+		}
+
+		return;
+	} },
 
 );
 

--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -243,7 +243,15 @@ last_edit_dates
 
 %weblink_templates = (
 
-	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata' },
+	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata', parse => sub
+	{
+		my ($url) = @_;
+		if ($url =~ /^https?:\/\/www.wikidata.org\/wiki\/(Q\d+)$/) {
+			return $1
+		}
+
+		return;
+	} },
 
 );
 

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -360,7 +360,15 @@ last_edit_dates
 
 %weblink_templates = (
 
-	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata' },
+	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata', parse => sub
+	{
+		my ($url) = @_;
+		if ($url =~ /^https?:\/\/www.wikidata.org\/wiki\/(Q\d+)$/) {
+			return $1
+		}
+
+		return;
+	} },
 
 );
 

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -272,7 +272,15 @@ last_edit_dates
 
 %weblink_templates = (
 
-	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata' },
+	'wikidata:en' => { href => 'https://www.wikidata.org/wiki/%s', text => 'Wikidata', parse => sub
+	{
+		my ($url) = @_;
+		if ($url =~ /^https?:\/\/www.wikidata.org\/wiki\/(Q\d+)$/) {
+			return $1
+		}
+
+		return;
+	} },
 
 );
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2028,6 +2028,32 @@ sub canonicalize_taxonomy_tag($$$)
 			return $matched_tagid;
 		}
 	}
+
+	if ($tag =~ /^https?:\/\/.+/) {
+		# Test for linked data URLs, ie. https://www.wikidata.org/wiki/Q1234
+		my $matched_tagid;
+		foreach my $property_key (keys %weblink_templates) {
+			next if not defined $weblink_templates{$property_key}{parse};
+			my $property_value = $weblink_templates{$property_key}{parse}->($tag);
+			if (defined $property_value) {
+				foreach my $canon_tagid (keys %{$properties{$tagtype}}) {
+					if ((defined $properties{$tagtype}{$canon_tagid}{$property_key}) and ($properties{$tagtype}{$canon_tagid}{$property_key} eq $property_value)) {
+						if (defined $matched_tagid) {
+							# Bail out on multiple matches for a single tag.
+							undef $matched_tagid;
+							last;
+						}
+						
+						$matched_tagid = $canon_tagid;
+					}
+				}
+			}
+		}
+
+		if (defined $matched_tagid) {
+			return $matched_tagid;
+		}
+	}
 		
 	if ($tag =~ /^(\w\w):/) {
 		$tag_lc = $1;

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2007,6 +2007,27 @@ sub canonicalize_taxonomy_tag($$$)
 	$tag =~ s/^ //g;
 	$tag =~ s/ $//g;		
 	
+	if (($tag =~ /^(\w+:\w\w):(.+)/) and (defined $properties{$tagtype})) {
+		# Test for linked data, ie. wikidata:en:Q1234
+		my $property_key = $1;
+		my $property_value = $2;
+		my $matched_tagid;
+		foreach my $canon_tagid (keys %{$properties{$tagtype}}) {
+			if ((defined $properties{$tagtype}{$canon_tagid}{$property_key}) and ($properties{$tagtype}{$canon_tagid}{$property_key} eq $property_value)) {
+				if (defined $matched_tagid) {
+					# Bail out on multiple matches for a single tag.
+					undef $matched_tagid;
+					last;
+				}
+				
+				$matched_tagid = $canon_tagid;
+			}
+		}
+
+		if (defined $matched_tagid) {
+			return $matched_tagid;
+		}
+	}
 		
 	if ($tag =~ /^(\w\w):/) {
 		$tag_lc = $1;

--- a/t/tags.t
+++ b/t/tags.t
@@ -29,4 +29,7 @@ ok( has_tag($product_ref, 'nexist', 'en:test'), 'has_tag should be true after ad
 # verify known Wikidata ID is converted to the taxonomy tag
 is( canonicalize_taxonomy_tag('en', 'categories', 'wikidata:en:Q470974'), 'fr:fitou', '"wikidata:en:Q470974" should be canonicalized to "fr:fitou"' );
 
+# verify known Wikidata URL is converted to the taxonomy tag
+is( canonicalize_taxonomy_tag('en', 'categories', 'https://www.wikidata.org/wiki/Q470974'), 'fr:fitou', 'Wikidata URL "https://www.wikidata.org/wiki/Q470974" should be canonicalized to "fr:fitou"' );
+
 done_testing();

--- a/t/tags.t
+++ b/t/tags.t
@@ -26,4 +26,7 @@ ok( !has_tag($product_ref, 'test', 'de:mein-tag'), 'has_tag should be false afte
 add_tag($product_ref, 'nexist', 'en:test');
 ok( has_tag($product_ref, 'nexist', 'en:test'), 'has_tag should be true after add' );
 
+# verify known Wikidata ID is converted to the taxonomy tag
+is( canonicalize_taxonomy_tag('en', 'categories', 'wikidata:en:Q470974'), 'fr:fitou', '"wikidata:en:Q470974" should be canonicalized to "fr:fitou"' );
+
 done_testing();


### PR DESCRIPTION
Allow users (in reality probably rather APIs) to enter `https://www.wikidata.org/wiki/Q470974` or `wikidata:en:Q470974` as taxonomy tags and convert it to the known taxonomy tag.

I think that this could be a good approach to work on taxonomies. For example, auto-suggest could be updated to also query Wikidata for some taxonomy tags. As a follow-up to this change, we could also consider adding a taxonomy tag automatically from Wikidata, if the types and hierarchy match some expectations.