### PR TITLE
Update MongoDB retry handling (with Log::Any)

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -50,6 +50,10 @@ requires 'Log::Any', '>= 1.705';
 requires 'Log::Log4perl', '>= 1.49';
 requires 'Log::Any::Adapter::Log4perl', '>= 0.08';
 
+# Retry
+requires 'Action::CircuitBreaker';
+requires 'Action::Retry';
+
 on 'test' => sub {
   requires 'Test::More', '>= 1.302049, < 2.0';
   requires 'Test::Perl::Critic';

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -29,6 +29,7 @@ BEGIN
 	use vars       qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT = qw();            # symbols to export by default
 	@EXPORT_OK = qw(
+					&execute_query
 					&get_products_collection
 					&get_emb_codes_collection
 					&get_recent_changes_collection
@@ -47,7 +48,21 @@ use MongoDB;
 use Tie::IxHash;
 use Log::Any qw($log);
 
-our $client;
+use Action::CircuitBreaker;
+use Action::Retry;
+
+my $client;
+my $action = Action::CircuitBreaker->new();
+
+sub execute_query {
+	my ($sub) = @_;
+
+	return Action::Retry->new(
+          attempt_code => sub { $action->run($sub) },
+          on_failure_code => sub { my ($error, $h) = @_; die $error; }, # by default Action::Retry would return undef
+		  strategy => { Fibonacci => { max_retries_number => 3, } },
+      )->run();
+}
 
 sub get_products_collection {
 	return get_collection($mongodb, 'products');

--- a/lib/ProductOpener/Missions.pm
+++ b/lib/ProductOpener/Missions.pm
@@ -215,7 +215,9 @@ sub compute_missions_for_user($) {
 				$log->debug("querying condition", { condition => $i }) if $log->is_debug();
 
 				
-				my $cursor = get_products_collection()->query($query_ref)->fields({});
+				my $cursor = execute_query(sub {
+					return get_products_collection()->query($query_ref)->fields({});
+				});				
 				my $count = $cursor->count();
 				
 				if ($count < $condition_ref->[0]) {

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -282,7 +282,10 @@ sub store_product($$) {
 
 			delete $product_ref->{old_code};
 			
-			get_products_collection()->delete_one({"_id" => $product_ref->{_id}});
+			execute_query(sub {
+				return $new_products_collection->delete_one({"_id" => $product_ref->{_id}});
+			});
+			
 			$product_ref->{_id} = $product_ref->{code};
 
 		}


### PR DESCRIPTION
Instead of having a custom retry logic for every query, I moved it to the `ProductOpener::Data` module, so that it can be reused properly. I also added `Action::Retry` to allow for a slight delay between retries, and implemented `Action::CircuitBreaker` on top of it, so that we don't query an already unresponsive MongoDB server.