### PR TITLE
Update data URLs in data.en.html

### DIFF
--- a/lang/en/texts/data.en.html
+++ b/lang/en/texts/data.en.html
@@ -16,24 +16,31 @@ with the Open Food Facts community.</p>
 
 <p>Database dumps and exports are generated nightly.</p>
 
-<p>Information on the different fields for the MongoDB dump and CSV exports is available at <a href="https://world.openfoodfacts.org/data/data-fields.txt">https://world.openfoodfacts.org/data/data-fields.txt</a></p>
+<p>Information on the different fields for the MongoDB dump and CSV exports is available at <a href="https://static.openfoodfacts.org/data/data-fields.txt">https://world.openfoodfacts.org/data/data-fields.txt</a></p>
 
 
 <h3>MongoDB dump</h3>
 
 <p>Data for all products is available in a MongoDB database dump.</p>
 
-<p>Link : <a href="https://world.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz">https://world.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz</a>
-<p>sha256sum : <a href="https://world.openfoodfacts.org/data/sha256sum">https://world.openfoodfacts.org/data/sha256sum</a>
-<p>md5sum : <a href="https://world.openfoodfacts.org/data/md5sum">https://world.openfoodfacts.org/data/md5sum</a>
+<dl>
+ <dt>Link</dt>
+ <dd><a href="https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz">https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz</a></dd>
+ <dt>sha256sum</dt>
+ <dd><a href="https://static.openfoodfacts.org/data/sha256sum">https://static.openfoodfacts.org/data/sha256sum</a></dd>
+ <dt>md5sum</dt>
+ <dd><a href="https://static.openfoodfacts.org/data/md5sum">https://static.openfoodfacts.org/data/md5sum</a></dd>
+</dl>
 
 <h3>CSV Data Export</h3>
 
 <p>Data for all products, or some of the products, can be downloaded in CSV format (readable with OpenOffice, Excel and many other software)
  through the <a href="https://world.openfoodfacts.org/cgi/search.pl">advanced search form</a>.</p>
  
-<p>Link : <a href="https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.csv">https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.csv</a>
-
+<dl>
+ <dt>Link</dt>
+ <dd><a href="https://static.openfoodfacts.org/data/en.openfoodfacts.org.products.csv">https://static.openfoodfacts.org/data/en.openfoodfacts.org.products.csv</a></dd>
+</dl>
 
 <p>The file encoding is Unicode UTF-8. The character that separates fields is &lt;tab&gt; (tabulation).</p>
 
@@ -43,7 +50,10 @@ with the Open Food Facts community.</p>
 
 <p>The database is also available in the RDF format. <a href="https://fr.blog.openfoodfacts.org/news/des-donnees-libres-et-liees-export-rdf-des-donnees">announcement in French</a>.</p>
 
-<p>Link: <a href="https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.rdf">https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.rdf</a>
+<dl>
+ <dt>Link</dt>
+ <dd><a href="https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.rdf">https://world.openfoodfacts.org/data/en.openfoodfacts.org.products.rdf</a></dd>
+</dl>
 
 <h2>Experimental JSON API</h2>
 


### PR DESCRIPTION
The current syntax of "Links :" with spaces around the separator looks weird, and having a separate paragraph for each link is superfluous. Therefore, I would like to propose using a definition list instead. This should also help translators in Crowdin.

I also replaced the domain `world.openfoodfacts.org` with `static.openfoodfacts.org` in this page, because the content should be identical for all regions/languages, and thus does not need translation.