### PR TITLE
Remove HTML::Defang

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -28,7 +28,6 @@ requires 'MongoDB', '>= 1.4.5'; # libmongodb-perl has an older version
 requires 'URI::Escape::XS';
 requires 'Encode::Punycode';
 requires 'GraphViz2';
-requires 'HTML::Defang';
 requires 'Algorithm::CheckDigits';
 requires 'Geo::IP';
 requires 'Image::OCR::Tesseract';

--- a/lib/ProductOpener/Index.pm
+++ b/lib/ProductOpener/Index.pm
@@ -60,7 +60,6 @@ use Cache::Memcached::Fast;
 use Digest::MD5 qw(md5);
 use URI::Escape;
 use URI::Escape::XS;
-use HTML::Defang;
 #use Text::Unaccent::PurePerl "unac_string";
 use Text::Unaccent "unac_string";
 use DateTime;


### PR DESCRIPTION
I removed all references to the `HTML::Defang` module, and `ProductOpener::Index` still compiles, so apparently it was unused.

Fixes #1226