### PR TITLE
Taxonomy IDs

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -48,6 +48,7 @@ requires 'Email::Stuffer';
 requires 'Text::CSV', '>= 1.99, < 2.0';
 requires 'Text::Fuzzy';
 requires 'File::Copy::Recursive';
+requires 'Data::GUID';
 
 # Logging
 requires 'Log::Any', '>= 1.705';

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1069,7 +1069,7 @@ sub build_tags_taxonomy($$$) {
 		my %parents = ();
 		my @current_uuids = ();
 
-		sub map_uuid_to_tagid {
+		my $map_uuid_to_tagid = sub {
 			my ($tagtype, $tagid, $uuids_ref) = @_;
 
 			if ((not defined $tagtype) or (not defined $tagid)) {
@@ -1086,7 +1086,7 @@ sub build_tags_taxonomy($$$) {
 			}
 
 			$tagid_to_uuid{$tagtype}{$tagid} = \@uuids;
-		}
+		};
 
 		$canon_tagid = undef;
 
@@ -1124,7 +1124,7 @@ sub build_tags_taxonomy($$$) {
 			$line =~ s/\s+$//;
 
 			if ($line =~ /^(\s*)$/) {
-				map_uuid_to_tagid($tagtype, $canon_tagid, \@current_uuids);
+				$map_uuid_to_tagid->($tagtype, $canon_tagid, \@current_uuids);
 				$canon_tagid = undef;
 				%parents = ();
 				@current_uuids = ();
@@ -1228,7 +1228,7 @@ sub build_tags_taxonomy($$$) {
 			}
 		}
 
-		map_uuid_to_tagid($tagtype, $canon_tagid, \@current_uuids);
+		$map_uuid_to_tagid->($tagtype, $canon_tagid, \@current_uuids);
 		close $IN;
 
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2577,6 +2577,13 @@ sub canonicalize_taxonomy_tag($$$)
 		}
 	}
 
+	if ($tag =~ m/^($uuid_pattern)$/ia) {
+		my $uuid = Data::GUID->from_string($1);
+		if ((defined $uuid) and (defined $uuid_to_tagid{$tagtype}) and (defined $uuid_to_tagid{$tagtype}{$uuid})) {
+			return $uuid_to_tagid{$tagtype}{$uuid};
+		}
+	}
+
 	if ($tag =~ /^https?:\/\/.+/) {
 		# Test for linked data URLs, ie. https://www.wikidata.org/wiki/Q1234
 		my $matched_tagid;


### PR DESCRIPTION
A proposal for adding unique stable IDs to taxonomy tags.

- When reading taxonomies from the `$tagtype.txt` file, import UUIDs from lines beginning with `_uuid`.
- If a taxonomy tag does not have any UUID after the import, generate a new UUID.
- Output all UUIDs into `$tagtype.result.txt`, so they can be exported to the Wiki.
- Maps UUIDs to the `$canon_tagid` and vice-versa.
- Updated `canonicalize_taxonomy_tag` to support lookup by the tag UUIDs.
- Multiple UUIDs for a tag are supported, so that tags can be merged.

Closes #405 