### PR TITLE
Use SameSite cookie for CSRF defense

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -51,8 +51,6 @@ use Encode;
 use JSON::PP;
 use Log::Any qw($log);
 
-use WWW::CSRF qw(CSRF_OK);
-
 ProductOpener::Display::init();
 
 if ($User_id eq 'unwanted-user-french') { 
@@ -2096,7 +2094,6 @@ HTML
 <label for="comment" style="margin-left:10px">$Lang{delete_comment}{$lang}</label>
 <input type="text" id="comment" name="comment" value="" />
 HTML
-	. hidden(-name=>'csrf', -value=>generate_po_csrf_token($User_id), -override=>1)
 	. submit(-name=>'save', -label=>lang("delete_product_page"), -class=>"button small")
 	. end_form();
 
@@ -2108,12 +2105,6 @@ elsif ($action eq 'process') {
 	$product_ref->{interface_version_modified} = $interface_version;
 	
 	if ($type eq 'delete') {
-		my $csrf_token_status = check_po_csrf_token($User_id, param('csrf'));
-		if (not ($csrf_token_status eq CSRF_OK)) {
-			$log->warn("User tried product deletion with invalid CSRF", { user_id => $User_id, code => $code }) if $log->is_warn();
-			display_error(lang("error_invalid_csrf_token"), 403);
-		}
-
 		$product_ref->{deleted} = 'on';
 		$comment = lang("deleting_product") . separator_before_colon($lc) . ":";
 	}

--- a/cgi/reset_password.pl
+++ b/cgi/reset_password.pl
@@ -40,8 +40,6 @@ use URI::Escape::XS;
 use Encode;
 use Log::Any qw($log);
 
-use WWW::CSRF qw(CSRF_OK);
-
 ProductOpener::Display::init();
 
 my $type = param('type') || 'send_email';
@@ -128,8 +126,7 @@ if ($action eq 'display') {
 	if ($type eq 'send_email') {
 	
 		$html .= "\n$Lang{userid_or_email}{$lang}"
-		. textfield(-name=>'userid_or_email', -value=>'', -size=>40, -override=>1) . "<br>"
-		. hidden(-name=>'csrf', -value=>generate_po_csrf_token(cookie('b')), -override=>1);
+		. textfield(-name=>'userid_or_email', -value=>'', -size=>40, -override=>1) . "<br>";
 	}
 	elsif ($type eq 'reset') {
 		$html .= "<table>"
@@ -140,7 +137,6 @@ if ($action eq 'display') {
 		. "</table>"
 		. hidden(-name=>'resetid', -value=>param('resetid'), -override=>1)
 		. hidden(-name=>'token', -value=>param('token'), -override=>1)
-		. hidden(-name=>'csrf', -value=>generate_po_csrf_token(param('resetid')), -override=>1)
 	}
 	
 
@@ -154,11 +150,6 @@ if ($action eq 'display') {
 elsif ($action eq 'process') {
 
 if ($type eq 'send_email') {
-
-	my $csrf_token_status = check_po_csrf_token(cookie('b'), param('csrf'));
-	if (not ($csrf_token_status eq CSRF_OK)) {
-		display_error(lang("error_invalid_csrf_token"), 403);
-	}
 
 	my @userids = ();
 	if (defined $email_ref) {
@@ -198,11 +189,6 @@ if ($type eq 'send_email') {
 
 }
 elsif ($type eq 'reset') {
-	my $csrf_token_status = check_po_csrf_token(param('resetid'), param('csrf'));
-	if (not ($csrf_token_status eq CSRF_OK)) {
-		display_error(lang("error_invalid_csrf_token"), 403);
-	}
-	
 	my $userid = get_fileid(param('resetid'));
 	my $user_ref = retrieve("$data_root/users/$userid.sto");
 	if (defined $user_ref) {

--- a/cpanfile
+++ b/cpanfile
@@ -20,7 +20,6 @@ requires 'XML::FeedPP'; # libxml-feedpp-perl
 requires 'URI::Find'; # liburi-find-perl
 requires 'XML::Simple'; # libxml-simple-perl
 requires 'experimental'; # libexperimental-perl
-requires 'WWW::CSRF'; # libwww-csrf-perl
 requires 'Apache2::Request'; # libapache2-request-perl
 requires 'Digest::MD5'; # libdigest-md5-perl
 

--- a/docker/backend-dev/conf/Config.pm
+++ b/docker/backend-dev/conf/Config.pm
@@ -42,8 +42,6 @@ BEGIN
 		$facebook_app_id
 		$facebook_app_secret
 		
-		$csrf_secret
-		
 		$mongodb
 		$mongodb_host
 	
@@ -160,8 +158,6 @@ $data_root = $ProductOpener::Config2::data_root;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
-
-$csrf_secret = $Blogs::Config2::csrf_secret;
 
 $reference_timezone = 'Europe/Paris';
 

--- a/docker/backend-dev/conf/Config2.pm
+++ b/docker/backend-dev/conf/Config2.pm
@@ -37,7 +37,6 @@ BEGIN
 		$mongodb_host
 		$facebook_app_id
 	    $facebook_app_secret
-		$csrf_secret
 		
 	);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
@@ -58,7 +57,5 @@ $mongodb_host = "mongodb://mongodb:27017";
 
 $facebook_app_id = "";
 $facebook_app_secret = "";
-
-$csrf_secret = "EYvfj3GDJnc2UPVqTwTGPgWC";
 
 1;

--- a/lib/ProductOpener/Config2_sample.pm
+++ b/lib/ProductOpener/Config2_sample.pm
@@ -37,7 +37,6 @@ BEGIN
 		$mongodb_host
 		$facebook_app_id
 	    $facebook_app_secret
-		$csrf_secret
 		$crowdin_project_identifier
 		$crowdin_project_key
 		
@@ -62,8 +61,6 @@ $mongodb_host = "mongodb://localhost";
 
 $facebook_app_id = "";
 $facebook_app_secret = "";
-
-$csrf_secret = "SWMAqq4znqqaHN9q7UWM5xQ5aJqKqPsekcwSuvjkkTmTtTXvPpyZxXkY25kqgaXQbLFVEaqZ";
 
 $crowdin_project_identifier = '';
 $crowdin_project_key = '';

--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -42,8 +42,6 @@ BEGIN
 		$facebook_app_id
 		$facebook_app_secret
 
-		$csrf_secret
-
 		$google_cloud_vision_api_key
 		
 		$crowdin_project_identifier
@@ -119,7 +117,6 @@ $data_root = $ProductOpener::Config2::data_root;
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
 
-$csrf_secret = $ProductOpener::Config2::csrf_secret;
 $google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 
 $crowdin_project_identifier = $ProductOpener::Config2::crowdin_project_identifier;

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -42,8 +42,6 @@ BEGIN
 		$facebook_app_id
 		$facebook_app_secret
 		
-		$csrf_secret
-		
 		$google_cloud_vision_api_key
 		
 		$crowdin_project_identifier
@@ -216,7 +214,6 @@ $data_root = $ProductOpener::Config2::data_root;
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
 
-$csrf_secret = $ProductOpener::Config2::csrf_secret;
 $google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 
 $crowdin_project_identifier = $ProductOpener::Config2::crowdin_project_identifier;

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -42,8 +42,6 @@ BEGIN
 		$facebook_app_id
 		$facebook_app_secret
 		
-		$csrf_secret
-		
 		$crowdin_project_identifier
 		$crowdin_project_key
 				
@@ -113,8 +111,6 @@ $data_root = $ProductOpener::Config2::data_root;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
-
-$csrf_secret = $Blogs::Config2::csrf_secret;
 
 $crowdin_project_identifier = $ProductOpener::Config2::crowdin_project_identifier;
 $crowdin_project_key = $ProductOpener::Config2::crowdin_project_key;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6137,7 +6137,7 @@ HTML
 			$test = "-test";
 		}
 		my $session = {} ;
-		my $cookie2 = cookie (-name=>'session', -expires=>'-1d',-value=>$session, domain=>".$lc$test.$server_domain", -path=>'/') ;
+		my $cookie2 = cookie (-name=>'session', -expires=>'-1d',-value=>$session, domain=>".$lc$test.$server_domain", -path=>'/', -samesite=>'Lax') ;
 		print header (-cookie=>[$cookie, $cookie2], -expires=>'-1d', -charset=>'UTF-8');
 	}
 	elsif (defined $cookie) {

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -53,8 +53,6 @@ BEGIN
 					
 					&check_session
 
-					&generate_po_csrf_token
-					&check_po_csrf_token
 					&generate_token
 
 					);	# symbols to export on request
@@ -77,7 +75,6 @@ use Email::IsEmail qw/IsEmail/;
 use Crypt::PasswdMD5 qw(unix_md5_crypt);
 use Math::Random::Secure qw(irand);
 use Crypt::ScryptKDF qw(scrypt_hash scrypt_hash_verify);
-use WWW::CSRF qw(generate_csrf_token check_csrf_token CSRF_OK);
 use Log::Any qw($log);
 
 sub generate_token {
@@ -715,16 +712,6 @@ sub save_user() {
 	elsif (defined $Visitor_id) {
 		store("$data_root/virtual_users/$Visitor_id.sto", \%User);
 	}
-}
-
-sub generate_po_csrf_token($) {
-	my ( $user_id ) = @_;
-	generate_csrf_token($user_id, $csrf_secret);
-}
-
-sub check_po_csrf_token($$) {
-	my ( $user_id, $csrf_token) = @_;
-	check_csrf_token($user_id, $csrf_secret, $csrf_token);
 }
 
 1;

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -489,14 +489,14 @@ sub init_user()
 			    {
 					# Set a persistent cookie
 					$log->debug("setting persistent cookie") if $log->is_debug();
-					$cookie = cookie (-name=>$cookie_name, -value=>$session, -path=>'/', -domain=>".$server_domain",
+					$cookie = cookie (-name=>$cookie_name, -value=>$session, -path=>'/', -domain=>".$server_domain", -samesite=>'Lax',
 							-expires=>'+' . $length . 's');
 			    }
 			    else
 			    {
 				# Set a session cookie
 					$log->debug("setting session cookie") if $log->is_debug();
-					$cookie = cookie (-name=>$cookie_name, -value=>$session, -path=>'/', -domain=>".$server_domain");
+					$cookie = cookie (-name=>$cookie_name, -value=>$session, -path=>'/', -domain=>".$server_domain", -samesite=>'Lax');
 			    }
 			}
 		    }
@@ -615,7 +615,7 @@ sub init_user()
 			# Set a cookie
 			if (not defined $cookie)
 			{
-			 $cookie = cookie (-name=>'b', -value=>$b, -path=>'/', -expires=>'+86400000s') ;
+			 $cookie = cookie (-name=>'b', -value=>$b, -path=>'/', -expires=>'+86400000s', -samesite=>'Lax') ;
 			 $log->info("setting b cookie", { bcookie => $cookie }) if $log->is_info();
 			} 
 		}

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -643,10 +643,6 @@ msgctxt "error_invalid_address"
 msgid "Invalid address."
 msgstr ""
 
-msgctxt "error_invalid_csrf_token"
-msgid "Invalid CSRF token."
-msgstr ""
-
 msgctxt "error_invalid_email"
 msgid "Invalid e-mail address"
 msgstr ""

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -584,10 +584,6 @@ msgctxt "error_invalid_address"
 msgid "Invalid address."
 msgstr "Ungültige Adresse."
 
-msgctxt "error_invalid_csrf_token"
-msgid "Invalid CSRF token."
-msgstr "Ungültiges CSRF-Token."
-
 msgctxt "error_invalid_email"
 msgid "Invalid e-mail address"
 msgstr "Ungültige E-Mail-Adresse"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -564,10 +564,6 @@ msgctxt "error_invalid_address"
 msgid "Invalid address."
 msgstr "Invalid address."
 
-msgctxt "error_invalid_csrf_token"
-msgid "Invalid CSRF token."
-msgstr "Invalid CSRF token."
-
 msgctxt "error_invalid_email"
 msgid "Invalid e-mail address"
 msgstr "Invalid e-mail address"

--- a/po/common/obsolete.pot
+++ b/po/common/obsolete.pot
@@ -637,10 +637,6 @@ msgctxt "error_invalid_address"
 msgid "Invalid address."
 msgstr ""
 
-msgctxt "error_invalid_csrf_token"
-msgid "Invalid CSRF token."
-msgstr ""
-
 msgctxt "error_invalid_email"
 msgid "Invalid e-mail address"
 msgstr ""


### PR DESCRIPTION
## Description
Removed all references to `WWW::CSRF` and replaced it with `SameSite=Lax` cookies.

Due to browser enhancements, manual token checks are not the single most useful defense against CSRF [any more](https://scotthelme.co.uk/csrf-is-dead/). Also see [OWASP](https://www.owasp.org/index.php?title=Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet&oldid=242455#Alternate_CSRF_Defense:_SameSite_cookie_attribute).

## Related issues and discussion
I believe that this fixes #1147 while retaining security precautions.
