### PR TITLE
Enable HTTP/2

### DIFF
--- a/conf/nginx/sites-available/cestemballepresdechezvous
+++ b/conf/nginx/sites-available/cestemballepresdechezvous
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 

--- a/conf/nginx/sites-available/combiendesucres
+++ b/conf/nginx/sites-available/combiendesucres
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 

--- a/conf/nginx/sites-available/howmuchsugar
+++ b/conf/nginx/sites-available/howmuchsugar
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 

--- a/conf/nginx/sites-available/madenearme
+++ b/conf/nginx/sites-available/madenearme
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 

--- a/conf/nginx/sites-available/madenearme-uk
+++ b/conf/nginx/sites-available/madenearme-uk
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 

--- a/conf/nginx/sites-available/obf
+++ b/conf/nginx/sites-available/obf
@@ -33,8 +33,8 @@ server {
 	#
 	# include snippets/snakeoil.conf;
 
-	listen 443 ssl;
-	listen [::]:443 ssl;
+	listen 443 http2 ssl;
+	listen [::]:443 http2 ssl;
 
 	include snippets/ssl.openbeautyfacts.org;
         include snippets/ssl-params.conf;

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -57,9 +57,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl default_server;
+	listen 443 ssl http2 default_server;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl default_server;
+	listen [::]:443 ssl http2 default_server;
 
 	include snippets/ssl.openfoodfacts.org;
 	include snippets/ssl-params.conf;

--- a/conf/nginx/sites-available/off-preprod
+++ b/conf/nginx/sites-available/off-preprod
@@ -40,8 +40,8 @@ server {
 	listen 80;
 	listen [::]:80;
 
-	listen 443 ssl;
-	listen [::]:443 ssl;
+	listen 443 http2 ssl;
+	listen [::]:443 http2 ssl;
 
 	server_name *.preprod.openfoodfacts.org preprod.openfoodfacts.eu *.preprod.openfoodfacts.eu;
 

--- a/conf/nginx/sites-available/opf
+++ b/conf/nginx/sites-available/opf
@@ -38,8 +38,8 @@ server {
 	listen 80;
 	listen [::]:80;
 
-	listen 443 ssl;
-	listen [::]:443 ssl;
+	listen 443 http2 ssl;
+	listen [::]:443 http2 ssl;
 
 	server_name *.openproductsfacts.org openproductsfacts.org;
 

--- a/conf/nginx/sites-available/opff
+++ b/conf/nginx/sites-available/opff
@@ -21,8 +21,8 @@ server {
         listen 80 ;
         listen [::]:80 ;
 
-        listen 443 ssl;
-        listen [::]:443 ssl;
+        listen 443 http2 ssl;
+        listen [::]:443 http2 ssl;
 
         include snippets/ssl.openpetfoodfacts.org;
         include snippets/ssl-params-opff.conf;
@@ -38,8 +38,8 @@ server {
 	listen 80;
 	listen [::]:80;
 
-	listen 443 ssl;
-	listen [::]:443 ssl;
+	listen 443 http2 ssl;
+	listen [::]:443 http2 ssl;
 
 	server_name *.openpetfoodfacts.org openpetfoodfacts.eu *.openpetfoodfacts.eu;
 

--- a/conf/nginx/sites-available/whatsinmyshampoo
+++ b/conf/nginx/sites-available/whatsinmyshampoo
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 

--- a/conf/nginx/sites-available/whatsinmyyogurt
+++ b/conf/nginx/sites-available/whatsinmyyogurt
@@ -42,9 +42,9 @@ server {
 
 	# 13/09/2016: got error "nginx: [emerg] invalid parameter "http2" "
 	#listen 443 ssl http2 default_server;
-	listen 443 ssl;
+	listen 443 http2 ssl;
 	#listen [::]:443 ssl http2 default_server;
-	listen [::]:443 ssl;
+	listen [::]:443 http2 ssl;
 	#include snippets/ssl-ssl-api-test.openfoodfacts.org;
 	include snippets/ssl-params.conf;
 


### PR DESCRIPTION
Simply enables HTTP/2 for the configured sites. As OFF is now deployed on Debian Stretch (as far as I know), HTTP/2 should be available in the `nginx-full` package. Using HTTP/2 should allow for better parallel download of static resources and fixes #745.