### PR TITLE
Fix amino_acids and nucleotides

### DIFF
--- a/po/tags/aa.po
+++ b/po/tags/aa.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ach.po
+++ b/po/tags/ach.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/af.po
+++ b/po/tags/af.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ak.po
+++ b/po/tags/ak.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/am.po
+++ b/po/tags/am.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ar.po
+++ b/po/tags/ar.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/as.po
+++ b/po/tags/as.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ast.po
+++ b/po/tags/ast.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/az.po
+++ b/po/tags/az.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/be.po
+++ b/po/tags/be.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ber.po
+++ b/po/tags/ber.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/bg.po
+++ b/po/tags/bg.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/bm.po
+++ b/po/tags/bm.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/bn.po
+++ b/po/tags/bn.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/bo.po
+++ b/po/tags/bo.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/br.po
+++ b/po/tags/br.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/bs.po
+++ b/po/tags/bs.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ca.po
+++ b/po/tags/ca.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ce.po
+++ b/po/tags/ce.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/chr.po
+++ b/po/tags/chr.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/co.po
+++ b/po/tags/co.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/crs.po
+++ b/po/tags/crs.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/cs.po
+++ b/po/tags/cs.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/cv.po
+++ b/po/tags/cv.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/cy.po
+++ b/po/tags/cy.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/da.po
+++ b/po/tags/da.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/de.po
+++ b/po/tags/de.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/el.po
+++ b/po/tags/el.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/en.po
+++ b/po/tags/en.po
@@ -388,11 +388,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr "amino-acid"
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr "amino-acids"
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "nucleotide"
 

--- a/po/tags/en_AU.po
+++ b/po/tags/en_AU.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "nucleotide"
 

--- a/po/tags/en_GB.po
+++ b/po/tags/en_GB.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "nucleotide"
 

--- a/po/tags/eo.po
+++ b/po/tags/eo.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/es.po
+++ b/po/tags/es.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/et.po
+++ b/po/tags/et.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/eu.po
+++ b/po/tags/eu.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/fa.po
+++ b/po/tags/fa.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/fi.po
+++ b/po/tags/fi.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/fil.po
+++ b/po/tags/fil.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/fo.po
+++ b/po/tags/fo.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/fr.po
+++ b/po/tags/fr.po
@@ -372,11 +372,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr "acide-amine"
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr "acides-amines"
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "nucleotide"
 

--- a/po/tags/ga.po
+++ b/po/tags/ga.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/gd.po
+++ b/po/tags/gd.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/gl.po
+++ b/po/tags/gl.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/gu.po
+++ b/po/tags/gu.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ha.po
+++ b/po/tags/ha.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/he.po
+++ b/po/tags/he.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/hi.po
+++ b/po/tags/hi.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/hr.po
+++ b/po/tags/hr.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ht.po
+++ b/po/tags/ht.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/hu.po
+++ b/po/tags/hu.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/hy.po
+++ b/po/tags/hy.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/id.po
+++ b/po/tags/id.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "nukleotida"
 

--- a/po/tags/ii.po
+++ b/po/tags/ii.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/is.po
+++ b/po/tags/is.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/it.po
+++ b/po/tags/it.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/iu.po
+++ b/po/tags/iu.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ja.po
+++ b/po/tags/ja.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/jv.po
+++ b/po/tags/jv.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ka.po
+++ b/po/tags/ka.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/kab.po
+++ b/po/tags/kab.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/kk.po
+++ b/po/tags/kk.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/km.po
+++ b/po/tags/km.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/kn.po
+++ b/po/tags/kn.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ko.po
+++ b/po/tags/ko.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ku.po
+++ b/po/tags/ku.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/kw.po
+++ b/po/tags/kw.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ky.po
+++ b/po/tags/ky.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/la.po
+++ b/po/tags/la.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/lb.po
+++ b/po/tags/lb.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/lo.po
+++ b/po/tags/lo.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/lol.po
+++ b/po/tags/lol.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr "crwdns103886:0crwdne103886:0"
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr "crwdns103888:0crwdne103888:0"
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "crwdns103890:0crwdne103890:0"
 

--- a/po/tags/lt.po
+++ b/po/tags/lt.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/lv.po
+++ b/po/tags/lv.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/me.po
+++ b/po/tags/me.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/mg.po
+++ b/po/tags/mg.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/mi.po
+++ b/po/tags/mi.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ml.po
+++ b/po/tags/ml.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/mn.po
+++ b/po/tags/mn.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/mr.po
+++ b/po/tags/mr.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ms.po
+++ b/po/tags/ms.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/mt.po
+++ b/po/tags/mt.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/my.po
+++ b/po/tags/my.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/nb.po
+++ b/po/tags/nb.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ne.po
+++ b/po/tags/ne.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/nl.po
+++ b/po/tags/nl.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/nl_BE.po
+++ b/po/tags/nl_BE.po
@@ -317,11 +317,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/nl_NL.po
+++ b/po/tags/nl_NL.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/nn.po
+++ b/po/tags/nn.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/no.po
+++ b/po/tags/no.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/nr.po
+++ b/po/tags/nr.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/oc.po
+++ b/po/tags/oc.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/pa.po
+++ b/po/tags/pa.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/pl.po
+++ b/po/tags/pl.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/pt.po
+++ b/po/tags/pt.po
@@ -285,11 +285,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/pt_BR.po
+++ b/po/tags/pt_BR.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/pt_PT.po
+++ b/po/tags/pt_PT.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/qu.po
+++ b/po/tags/qu.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/rm.po
+++ b/po/tags/rm.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ro.po
+++ b/po/tags/ro.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ru.po
+++ b/po/tags/ru.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ry.po
+++ b/po/tags/ry.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sa.po
+++ b/po/tags/sa.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sat.po
+++ b/po/tags/sat.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sc.po
+++ b/po/tags/sc.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sco.po
+++ b/po/tags/sco.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sd.po
+++ b/po/tags/sd.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sg.po
+++ b/po/tags/sg.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sh.po
+++ b/po/tags/sh.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/si.po
+++ b/po/tags/si.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sk.po
+++ b/po/tags/sk.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sl.po
+++ b/po/tags/sl.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sma.po
+++ b/po/tags/sma.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sn.po
+++ b/po/tags/sn.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/so.po
+++ b/po/tags/so.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/son.po
+++ b/po/tags/son.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sq.po
+++ b/po/tags/sq.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sr.po
+++ b/po/tags/sr.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sr_CS.po
+++ b/po/tags/sr_CS.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ss.po
+++ b/po/tags/ss.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/st.po
+++ b/po/tags/st.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sv.po
+++ b/po/tags/sv.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/sw.po
+++ b/po/tags/sw.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ta.po
+++ b/po/tags/ta.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tags.pot
+++ b/po/tags/tags.pot
@@ -475,12 +475,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/te.po
+++ b/po/tags/te.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tg.po
+++ b/po/tags/tg.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/th.po
+++ b/po/tags/th.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ti.po
+++ b/po/tags/ti.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tl.po
+++ b/po/tags/tl.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tn.po
+++ b/po/tags/tn.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tr.po
+++ b/po/tags/tr.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ts.po
+++ b/po/tags/ts.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tt.po
+++ b/po/tags/tt.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tw.po
+++ b/po/tags/tw.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ty.po
+++ b/po/tags/ty.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/tzl.po
+++ b/po/tags/tzl.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ug.po
+++ b/po/tags/ug.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/uk.po
+++ b/po/tags/uk.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ur.po
+++ b/po/tags/ur.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/uz.po
+++ b/po/tags/uz.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/val.po
+++ b/po/tags/val.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/ve.po
+++ b/po/tags/ve.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/vec.po
+++ b/po/tags/vec.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/vi.po
+++ b/po/tags/vi.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/vls.po
+++ b/po/tags/vls.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/wa.po
+++ b/po/tags/wa.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/wo.po
+++ b/po/tags/wo.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/xh.po
+++ b/po/tags/xh.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/yi.po
+++ b/po/tags/yi.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/yo.po
+++ b/po/tags/yo.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/zea.po
+++ b/po/tags/zea.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/zh_CN.po
+++ b/po/tags/zh_CN.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr "核苷酸"
 

--- a/po/tags/zh_HK.po
+++ b/po/tags/zh_HK.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/zh_TW.po
+++ b/po/tags/zh_TW.po
@@ -480,12 +480,12 @@ msgid "amino-acid"
 msgstr ""
 
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
 #. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 

--- a/po/tags/zu.po
+++ b/po/tags/zu.po
@@ -420,11 +420,11 @@ msgctxt "amino_acids:singular"
 msgid "amino-acid"
 msgstr ""
 
-msgctxt "amino_acid:plural"
+msgctxt "amino_acids:plural"
 msgid "amino-acids"
 msgstr ""
 
-msgctxt "nucleotide:singular"
+msgctxt "nucleotides:singular"
 msgid "nucleotide"
 msgstr ""
 


### PR DESCRIPTION
Rename `amino_acid:plural` and `nucleotide:singular` to match the config definition. I believe this fixes #1529 