### PR TITLE
Test logging

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -55,4 +55,5 @@ on 'test' => sub {
   requires 'Test::More', '>= 1.302049, < 2.0';
   requires 'Test::Perl::Critic';
   requires 'Test::Number::Delta';
+  requires 'Log::Any::Adapter::TAP';
 };

--- a/t/additives.t
+++ b/t/additives.t
@@ -20,7 +20,7 @@ my $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 # vitamine C is not used as an additive (no fuction)
 
@@ -106,10 +106,6 @@ is_deeply($product_ref->{additives_original_tags}, [
                               ],
 );
 
-
-#use Data::Dumper;
-#print STDERR Dumper($product_ref);
-
 is(canonicalize_taxonomy_tag("fr", "additives", "erythorbate de sodium"), "en:e316");
 is(canonicalize_taxonomy_tag("fr", "additives", "acide citrique"), "en:e330");
 
@@ -123,9 +119,6 @@ $product_ref = {
 };
 
 extract_ingredients_classes_from_text($product_ref);
-
-#use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e503',
@@ -143,10 +136,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-#use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
-
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 				'en:e502',
@@ -161,9 +151,6 @@ $product_ref = {
 };
 
 extract_ingredients_classes_from_text($product_ref);
-
-#use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e500',
@@ -180,9 +167,6 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
-
 is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e173',
                                 'en:e175',
@@ -196,9 +180,6 @@ $product_ref = {
 };
 
 extract_ingredients_classes_from_text($product_ref);
-
-use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e965ii',
@@ -216,9 +197,6 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
-
 0 and is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e160a',
                                 'en:e160c',
@@ -233,9 +211,6 @@ $product_ref = {
 };
 
 extract_ingredients_classes_from_text($product_ref);
-
-use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 0 and is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e100',
@@ -254,9 +229,6 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
-
 is_deeply($product_ref->{additives_original_tags}, [
                                 'en:e160a',
                               ],
@@ -270,9 +242,6 @@ $product_ref = {
 };
 
 extract_ingredients_classes_from_text($product_ref);
-
-use Data::Dumper;
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e14xx',
@@ -303,8 +272,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref->{additives_original_tags});
+diag explain $product_ref->{additives_original_tags};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e967',
@@ -347,7 +315,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e300',
@@ -361,7 +329,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e300',
@@ -375,8 +343,6 @@ $product_ref = {
 };
 
 extract_ingredients_classes_from_text($product_ref);
-
-#print STDERR $product_ref->{additives} . "\n";
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e300',
@@ -392,7 +358,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
         "en:vitamin-a",
@@ -408,7 +374,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
         "en:vitamin-e",
@@ -424,7 +390,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
         "en:folic-acid",
@@ -442,7 +408,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
         "en:vitamin-d",
@@ -462,7 +428,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
         "en:vitamin-c",
@@ -481,7 +447,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
@@ -503,7 +469,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
@@ -525,7 +491,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -550,7 +516,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -571,7 +537,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -592,7 +558,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
@@ -627,7 +593,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
@@ -663,9 +629,9 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR Dumper($product_ref->{additives_original_tags});
+diag explain $product_ref->{additives_original_tags};
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e322i',
@@ -681,9 +647,9 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR Dumper($product_ref->{additives_original_tags});
+diag explain $product_ref->{additives_original_tags};
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e422',
@@ -732,7 +698,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -751,7 +717,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e341"
@@ -771,7 +737,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
         "en:e1400",
@@ -818,7 +784,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -844,7 +810,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e300",
@@ -876,7 +842,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e300",
@@ -897,7 +863,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e330",
@@ -914,7 +880,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -950,7 +916,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
         "en:e1001",
@@ -967,7 +933,7 @@ Lait partiellement écrémé, eau, lactose, maltodextrines, huiles végétales (
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
         "en:e322i",
@@ -999,7 +965,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
         "en:e472c",
@@ -1056,7 +1022,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -1077,7 +1043,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -1092,7 +1058,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
                               ],
@@ -1111,7 +1077,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e330",
@@ -1130,7 +1096,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e422",
@@ -1152,7 +1118,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e500',
@@ -1186,8 +1152,6 @@ is_deeply($product_ref->{additives_original_tags}, [
 ],
 );
 
-#print STDERR Dumper($product_ref->{additives_original_tags});
-
 
 $product_ref = {
         lc => "fr",
@@ -1198,7 +1162,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e252",
@@ -1218,7 +1182,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e163",
@@ -1242,7 +1206,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e322',
@@ -1261,7 +1225,6 @@ is_deeply($product_ref->{additives_original_tags}, [
                               ],
 );
 
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 
 
@@ -1274,7 +1237,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e330',
@@ -1288,7 +1251,6 @@ is_deeply($product_ref->{additives_original_tags}, [
                               ],
 );
 
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 
 
@@ -1302,7 +1264,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e501',
@@ -1310,7 +1272,6 @@ is_deeply($product_ref->{additives_original_tags}, [
                               ],
 );
 
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 
 $product_ref = {
@@ -1322,7 +1283,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e330',
@@ -1330,7 +1291,6 @@ is_deeply($product_ref->{additives_original_tags}, [
                               ],
 );
 
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 
 
@@ -1344,7 +1304,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e414',
@@ -1357,7 +1317,6 @@ is_deeply($product_ref->{additives_original_tags}, [
                               ],
 );
 
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 
 $product_ref = {
@@ -1369,7 +1328,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e171',
@@ -1377,8 +1336,6 @@ is_deeply($product_ref->{additives_original_tags}, [
 
                               ],
 );
-
-#print STDERR Dumper($product_ref->{additives_original_tags});
 
 
 
@@ -1391,7 +1348,7 @@ $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-print STDERR $product_ref->{additives} . "\n";
+diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
 

--- a/t/additives.t
+++ b/t/additives.t
@@ -5,12 +5,11 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
-
-use Log::Any::Adapter ('Stderr');
 
 # dummy product for testing
 
@@ -38,7 +37,7 @@ is_deeply($product_ref->{vitamins_tags}, [
 );
 
 
-# false positives: acides gras -> E-570 
+# false positives: acides gras -> E-570
 
 # Make sure 100% is not recognized as E-100
 my $product_ref = {
@@ -78,7 +77,7 @@ my $product_ref = {
 
 extract_ingredients_classes_from_text($product_ref);
 
-is($product_ref->{additives}, 
+is($product_ref->{additives},
 ' [ acide-citrique -> en:e330  -> exists  -- ok  ]  [ colorant -> fr:colorant  ]  [ e120 -> en:e120  -> exists  -- ok  ]  [ vitamine-c -> en:e300  -> exists  -- mandatory_additive_class: en:acidity-regulator,en:antioxidant,en:flour-treatment-agent,en:sequestrant,en:acid (current: en:colour)  -> exists as a vitamin en:vitamin-c  ]  [ e500 -> en:e500  -> exists  -- mandatory_additive_class: en:acidity-regulator, en:raising-agent (current: en:vitamins)  -- e-number  ] '
 );
 
@@ -658,7 +657,7 @@ is_deeply($product_ref->{minerals_tags}, [
 
 $product_ref = {
         lc => "fr",
-        ingredients_text => 
+        ingredients_text =>
 "Lactosérum déminéralisé (lait) - Huiles végétales (Palme, Colza, Coprah, Tournesol, Mortierella alpina) - Lactose (lait) - Lait écrémé - Galacto- oligosaccharides (GOS) (lait) - Protéines de lactosérum concentrées (lait) - Fructo- oligosaccharides (FOS) - Huile de poisson - Chlorure de choline - Emulsifiant: lécithine de soja - Taurine - Nucléotides - Inositol - L-tryptophane - L-carnitine - Vitamines (C, PP, B5, B9, A, E, B8, B12, BI, D3, B6, K1, B2) - Minéraux (carbonate de calcium, chlorures de potassium et de magnésium, citrates de potassium et de sodium, phosphate de calcium, sulfates de fer, de zinc, de cuivre et de manganèse, iodure de potassium, sélénite de sodium)."
 };
 
@@ -676,7 +675,7 @@ is_deeply($product_ref->{additives_original_tags}, [
 
 $product_ref = {
         lc => "fr",
-        ingredients_text => 
+        ingredients_text =>
 "Purée de pomme 40 %, sirop de glucose-fructose, farine de blé, protéines de lait, sucre, protéines de soja, purée de framboise 5 %, lactosérum, protéines de blé hydrolysées, sirop de glucose, graisse de palme non hydrogénée, humectant : glycérol végétal, huile de tournesol, minéraux (potassium, calcium, magnésium, fer, zinc, cuivre, sélénium, iode), jus concentré de raisin, arômes naturels, jus concentré de citron, levure désactivée, correcteur d'acidité : citrates de sodium, sel marin, acidifiant : acide citrique, vitamines A, B1, B2, B5, B6, B9, B12, C, D, H, PP et E (lactose, protéines de lait), cannelle, poudres à lever (carbonates de sodium, carbonates d'ammonium)."
 };
 
@@ -1193,7 +1192,7 @@ is_deeply($product_ref->{additives_original_tags}, [
 $product_ref = {
         lc => "fr",
         ingredients_text =>
-"Liste des ingrédients : viande de porc, sel, lactose, épices, sucre, dextrose, ail, conservateurs : nitrate de potassium et nitrite de sodium, ferments, boyau naturel de porc. Poudre de fleurage : talc et carbonate de calcium. 164 g de viande de porc utilisée poudre 100 g de produit fini. 
+"Liste des ingrédients : viande de porc, sel, lactose, épices, sucre, dextrose, ail, conservateurs : nitrate de potassium et nitrite de sodium, ferments, boyau naturel de porc. Poudre de fleurage : talc et carbonate de calcium. 164 g de viande de porc utilisée poudre 100 g de produit fini.
 "
 };
 
@@ -1285,7 +1284,7 @@ is_deeply($product_ref->{additives_original_tags}, [
           'en:e120',
           'en:e960',
           'en:e250',
-	
+
                               ],
 );
 
@@ -1307,7 +1306,7 @@ print STDERR $product_ref->{additives} . "\n";
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e501',
-	
+
                               ],
 );
 
@@ -1327,7 +1326,7 @@ print STDERR $product_ref->{additives} . "\n";
 
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e330',
-	
+
                               ],
 );
 
@@ -1354,7 +1353,7 @@ is_deeply($product_ref->{additives_original_tags}, [
           'en:e500',
           'en:e440i',
           'en:e330',
-	
+
                               ],
 );
 
@@ -1364,7 +1363,7 @@ is_deeply($product_ref->{additives_original_tags}, [
 $product_ref = {
         lc => "fr",
         ingredients_text =>
-"dioxyde titane, le glutamate de sodium, 
+"dioxyde titane, le glutamate de sodium,
 ",
 };
 
@@ -1375,7 +1374,7 @@ print STDERR $product_ref->{additives} . "\n";
 is_deeply($product_ref->{additives_original_tags}, [
           'en:e171',
           'en:e621',
-	
+
                               ],
 );
 

--- a/t/allergens.t
+++ b/t/allergens.t
@@ -5,6 +5,7 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Tags qw/:all/;
@@ -34,7 +35,7 @@ is_deeply($product_ref->{allergens_tags}, [
 'en:molluscs',
 'en:mustard',
 'en:nuts',
-] 
+]
 );
 
 is_deeply($product_ref->{traces_tags},  [
@@ -60,7 +61,7 @@ is_deeply($product_ref->{allergens_tags}, [
 "en:gluten",
 "en:mustard",
 "en:sesame-seeds",
-] 
+]
 );
 
 is_deeply($product_ref->{traces_tags},  [
@@ -89,7 +90,7 @@ is_deeply($product_ref->{allergens_tags}, [
 "en:lupin",
 "en:mustard",
 "en:soybeans",
-] 
+]
 );
 
 is_deeply($product_ref->{traces_tags},  [
@@ -118,7 +119,7 @@ use Data::Dumper;
 is_deeply($product_ref->{allergens_tags}, [
 'en:gluten',
 'en:milk',
-] 
+]
 );
 
 is_deeply($product_ref->{traces_tags},  [
@@ -142,7 +143,7 @@ use Data::Dumper;
 #print STDERR Dumper($product_ref);
 
 is_deeply($product_ref->{allergens_tags}, [
-] 
+]
 );
 
 is_deeply($product_ref->{traces_tags},  [
@@ -169,7 +170,7 @@ print STDERR Dumper($product_ref->{allergens_tags});
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:molluscs',
-] 
+]
 );
 
 
@@ -273,7 +274,7 @@ is($product_ref->{ingredients_text_with_allergens_fr},
 $product_ref = {
         lc => "fr", lang => "fr",
         ingredients_text_fr => "Farine de blé 97%",
-	allergens => "Sulfites",	
+	allergens => "Sulfites",
 };
 
 compute_languages($product_ref);

--- a/t/allergens.t
+++ b/t/allergens.t
@@ -21,9 +21,7 @@ my $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{traces_tags});
+diag explain $product_ref->{traces_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:celery',
@@ -54,9 +52,6 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-
 is_deeply($product_ref->{allergens_tags}, [
 "en:gluten",
 "en:mustard",
@@ -80,9 +75,6 @@ $product_ref = {
 
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
-
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
 
 is_deeply($product_ref->{allergens_tags}, [
 "en:celery",
@@ -113,9 +105,6 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-
 is_deeply($product_ref->{allergens_tags}, [
 'en:gluten',
 'en:milk',
@@ -139,9 +128,6 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-
 is_deeply($product_ref->{allergens_tags}, [
 ]
 );
@@ -164,9 +150,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:molluscs',
@@ -182,9 +166,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:molluscs',
@@ -200,9 +182,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:molluscs',
@@ -218,9 +198,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:molluscs',
@@ -236,9 +214,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:gluten',
@@ -257,9 +233,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:gluten',
@@ -280,9 +254,7 @@ $product_ref = {
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
 
-use Data::Dumper;
-#print STDERR Dumper($product_ref);
-print STDERR Dumper($product_ref->{allergens_tags});
+diag explain $product_ref->{allergens_tags};
 
 is_deeply($product_ref->{allergens_tags}, [
 'en:gluten',

--- a/t/display.t
+++ b/t/display.t
@@ -3,6 +3,7 @@
 use Modern::Perl '2012';
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Display qw/:all/;
 

--- a/t/food.t
+++ b/t/food.t
@@ -5,6 +5,7 @@ use warnings;
 
 use Test::More;
 use Test::Number::Delta relative => 1.001;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Food qw/:all/;
 
@@ -19,7 +20,7 @@ is( mmoll_to_unit(1, "\N{U+00B0}fH"), 10.00 );
 is( mmoll_to_unit(1, "\N{U+00B0}e"), 7.02 );
 is( mmoll_to_unit(1, "\N{U+00B0}dH"), 5.6 );
 is( mmoll_to_unit(1, 'gpg'), 5.847 );
-	
+
 is( unit_to_mmoll(1, 'mol/l'), 1000 );
 is( unit_to_mmoll('1', 'mmol/l'), 1 );
 is( unit_to_mmoll(1, 'mmol/l'), 1 );

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -6,6 +6,7 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::TagsEntries qw/:all/;

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -12,10 +12,6 @@ use ProductOpener::Tags qw/:all/;
 use ProductOpener::TagsEntries qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 
-binmode(STDIN, ":encoding(UTF-8)");
-binmode(STDOUT, ":encoding(UTF-8)");
-binmode(STDERR, ":encoding(UTF-8)");
-
 # dummy product for testing
 
 my $product_ref = {
@@ -25,8 +21,7 @@ my $product_ref = {
 
 extract_ingredients_from_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 
 is($product_ref->{ingredients_n}, 17);
@@ -211,8 +206,7 @@ extract_ingredients_classes_from_text($product_ref);
 #"huile-de-palme"
 #],
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 
 my $expected_product_ref =
@@ -356,9 +350,6 @@ delete $product_ref->{nucleotides_prev_tags};
 delete $product_ref->{amino_acids_prev_tags};
 delete $product_ref->{minerals_prev_tags};
 delete $product_ref->{minerals_prev};
-
-
-use Data::Dumper;
 
 $expected_product_ref = {
           'ingredients_n_tags' => [
@@ -565,7 +556,7 @@ $expected_product_ref = {
                                   'en:diphosphates',
                                   'en:sodium-hydrogen-carbonate',
                                   'en:sodium-bicarbonate',
-		
+
                                 ],
           'ingredients_text' => "Marmelade d'oranges 41% (sirop de glucose-fructose, sucre, pulpe d'orange 4.5%, jus d'orange concentr\x{e9} 1.4% (\x{e9}quivalent jus d'orange 7.8%), pulpe d'orange concentr\x{e9}e 0.6% (\x{e9}quivalent pulpe d'orange 2.6%), g\x{e9}lifiant (pectines), acidifiant (acide citrique), correcteurs d'acidit\x{e9} (citrate de calcium, citrate de sodium), ar\x{f4}me naturel d'orange, \x{e9}paississant (gomme xanthane)), chocolat 24.9% (sucre, p\x{e2}te de cacao, beurre de cacao, graisses v\x{e9}g\x{e9}tales (illipe, mangue, sal, karit\x{e9} et palme en proportions variables), ar\x{f4}me, \x{e9}mulsifiant (l\x{e9}cithine de soja), lactose et prot\x{e9}ines de lait), farine de bl\x{e9}, sucre, oeufs, sirop de glucose-fructose, huile de colza, poudre \x{e0} lever (carbonate acide d'ammonium, diphosphate disodique, carbonate acide de sodium), sel, \x{e9}mulsifiant (l\x{e9}cithine de soja).",
           'lc' => 'fr',
@@ -780,10 +771,7 @@ $expected_product_ref = {
         };
 
 
-is_deeply($product_ref, $expected_product_ref);
-
-print STDERR Dumper($product_ref);
-#exit;
+is_deeply($product_ref, $expected_product_ref) || diag explain $product_ref;
 
 # test synonyms for flavouring/flavour/flavor/flavoring
 my $product_ref = {
@@ -805,8 +793,7 @@ delete $product_ref->{minerals_prev_tags};
 delete $product_ref->{minerals_prev};
 
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 $expected_product_ref = {
 'ingredients_n_tags' => [
@@ -873,8 +860,7 @@ delete $product_ref->{minerals_prev_tags};
 delete $product_ref->{minerals_prev};
 
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 $expected_product_ref = {
 

--- a/t/ingredients_clean.t
+++ b/t/ingredients_clean.t
@@ -13,10 +13,6 @@ use ProductOpener::Tags qw/:all/;
 use ProductOpener::TagsEntries qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 
-binmode(STDIN, ":encoding(UTF-8)");
-binmode(STDOUT, ":encoding(UTF-8)");
-binmode(STDERR, ":encoding(UTF-8)");
-
 # dummy product for testing
 
 my $product_ref = {
@@ -27,8 +23,7 @@ my $product_ref = {
 compute_languages($product_ref);
 clean_ingredients_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 is($product_ref->{ingredients_text_fr}, "lait 98 % ,sel,ferments lactiques,coagulant");
 
@@ -44,8 +39,7 @@ $product_ref = {
 compute_languages($product_ref);
 clean_ingredients_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 is($product_ref->{ingredients_text_fr}, "");
 
@@ -59,8 +53,7 @@ $product_ref = {
 compute_languages($product_ref);
 clean_ingredients_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 is($product_ref->{ingredients_text_fr}, "viande de porc (Origine UE), pistaches (fruits à coque) 5%, lactose (lait), sel, dextroses poivre, sucre, ail, ferments, conservateur : nitrate de potassium ; antioxydant : érythorbate de sodium. 134 g de viande utilisés pour 100 g de produit fini.");
 
@@ -73,8 +66,7 @@ $product_ref = {
 compute_languages($product_ref);
 clean_ingredients_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 is($product_ref->{ingredients_text_fr}, "ln rédients : Sauce soja 38.3% fèves de soja dégraissées'&i se blé, fèves de sop 1.6%, alcoo ), sucre eau, (eall, riz, alcool, ma t de riz, sel, correcteur d'acidité : acide sel, aldbôt;qolorant : caramel ordinaire ; amidon modifié de diamidon acétylé, phosphate de diamidon hydroxypro)/é'");
 
@@ -87,8 +79,7 @@ $product_ref = {
 compute_languages($product_ref);
 clean_ingredients_text($product_ref);
 
-use Data::Dumper;
-print STDERR Dumper($product_ref);
+diag explain $product_ref;
 
 is($product_ref->{ingredients_text_fr}, "viande de porc 72 %. gras de porc, eau, farine (BLE), conservateur E325, épices et arornales, sel cle Guérarandes 1.1%. lactose (LAIT), acidifiant :E 262, conservateurs:E250 E316, arormes, arome naturel.");
 

--- a/t/ingredients_clean.t
+++ b/t/ingredients_clean.t
@@ -6,6 +6,7 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Tags qw/:all/;

--- a/t/lang.t
+++ b/t/lang.t
@@ -5,6 +5,7 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Lang qw/:all/;
 use ProductOpener::Config qw/:all/;
@@ -50,7 +51,7 @@ foreach my $link (@links) {
 	foreach my $lang (keys %{$Lang{$field}}) {
 		my $textid = $Lang{$field}{$lang};
 		$textid =~ s/.*\///;
-		
+
 		if ($textid ne $en_links{$link} ) {
 
 		#	print "$link - $lang - $textid\n";
@@ -59,7 +60,7 @@ foreach my $link (@links) {
 				"$field link - lang: $lang - textid: $textid -- file /lang/$lang/texts/$textid.html does not exist");
 		}
 
-		
+
 	}
 
 }

--- a/t/lang.t
+++ b/t/lang.t
@@ -38,10 +38,6 @@ test_links($slug_regex, @slug_links);
 #			<li><a href="$Lang{footer_terms_link}{$lc}">$Lang{footer_terms}{$lc}</a></li>
 #			<li><a href="$Lang{footer_data_link}{$lc}">$Lang{footer_data}{$lc}</a></li>
 
-binmode(STDOUT, "encoding(UTF-8)");
-binmode(STDERR, "encoding(UTF-8)");
-
-
 my @links = ("legal", "terms", "data");
 my %en_links = ("legal" => "legal", "terms" => "terms-of-use", "data" => "data");
 
@@ -54,10 +50,9 @@ foreach my $link (@links) {
 
 		if ($textid ne $en_links{$link} ) {
 
-		#	print "$link - $lang - $textid\n";
-
 			ok ( -e "$data_root/lang/$lang/texts/$textid.html",
 				"$field link - lang: $lang - textid: $textid -- file /lang/$lang/texts/$textid.html does not exist");
+
 		}
 
 

--- a/t/perlcritic.t
+++ b/t/perlcritic.t
@@ -3,6 +3,7 @@
 use Modern::Perl '2012';
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 eval { require Test::Perl::Critic };
 plan skip_all => 'T::P::Critic required for this test' if $@;

--- a/t/products.t
+++ b/t/products.t
@@ -3,6 +3,7 @@
 use Modern::Perl '2012';
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Products qw/:all/;
 

--- a/t/store.t
+++ b/t/store.t
@@ -3,6 +3,7 @@
 use Modern::Perl '2012';
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Store qw/:all/;
 

--- a/t/tags.t
+++ b/t/tags.t
@@ -3,6 +3,7 @@
 use Modern::Perl '2012';
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Tags qw/:all/;
 

--- a/t/text.t
+++ b/t/text.t
@@ -3,6 +3,7 @@
 use Modern::Perl '2012';
 
 use Test::More;
+use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Text qw/:all/;
 


### PR DESCRIPTION
Apparently, using `print` in unit tests is against [best practices](https://perldoc.perl.org/Test/More.html#Diagnostics) of the test module. I replaced manual logging to `STDERR` with `diag` and `Data::Dumper` with the mentioned `explain`.