### PR TITLE
Fix "prefer_related_applications" being ignored

### DIFF
--- a/cgi/manifest.pl
+++ b/cgi/manifest.pl
@@ -1,22 +1,22 @@
 #!/usr/bin/perl -w
 
 # This file is part of Product Opener.
-# 
+#
 # Product Opener
 # Copyright (C) 2011-2018 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
-# 
+#
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -65,7 +65,7 @@ $manifest{description} = lang('site_description');
 $manifest{start_url} = format_subdomain($subdomain);
 $manifest{scope} = '/';
 $manifest{display} = 'standalone';
-$manifest{prefer_related_applications} = 'true';
+$manifest{prefer_related_applications} = $JSON::PP::true;
 
 my @keys = qw(theme_color icons related_applications background_color);
 foreach my $key (@keys) {
@@ -73,6 +73,6 @@ foreach my $key (@keys) {
 }
 
 my $data = encode_json(\%manifest);
-	
+
 print "Content-Type: application/manifest+json; charset=UTF-8\r\nCache-Control: max-age=86400\r\n\r\n" . $data;
 


### PR DESCRIPTION
Resolves a warning from Chrome. which warns us that `prefer_related_applications` is ignored, because it's not an actual boolean value:
> manifest.pl:1 Manifest: property 'prefer_related_applications' ignored, type boolean expected.
