### PR TITLE
Issue 1661/ocr onthefly : run Cloud Vision and call robotoff for all newly uploaded images

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -90,6 +90,20 @@ sub normalize_code($) {
 		if ((length($code) eq 12) and ($ean_check->is_valid('0' . $code))) {
 			$code = '0' . $code;
 		}
+		
+		# Remove leading 0 for codes with 14 digits
+		if ((length($code) eq 14) and ($code =~ /^0/)) {
+			$code = $';
+		}
+		
+		# Remove 5 or 6 leading 0s for EAN8
+		# 00000080050100 (from Ferrero)
+		if ((length($code) eq 14) and ($code =~ /^000000/)) {
+			$code = $';
+		}
+		if ((length($code) eq 13) and ($code =~ /^00000/)) {
+			$code = $';
+		}		
 	}
 	return $code;
 }

--- a/scripts/convert_ferrero_data.pl
+++ b/scripts/convert_ferrero_data.pl
@@ -1,0 +1,138 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+# 
+# Product Opener
+# Copyright (C) 2011-2018 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+# 
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use utf8;
+
+
+binmode(STDOUT, ":encoding(UTF-8)");
+binmode(STDERR, ":encoding(UTF-8)");
+
+use ProductOpener::Import qw/:all/;
+
+use CGI qw/:cgi :form escapeHTML/;
+use URI::Escape::XS;
+use Storable qw/dclone/;
+use Encode;
+use JSON::PP;
+use Time::Local;
+use XML::Rules;
+
+use Log::Any::Adapter ('Stderr');
+
+# default language (needed for cleaning fields)
+
+$lc = "fr";
+
+%global_params = (
+	lc => 'fr',
+	countries => "France",
+	brands => "Ferrero",
+	# stores => "Casino",
+);
+
+
+
+
+
+my @csv_fields_mapping_ingredients = (
+
+["GTIN de l'article déclaré", "code"],
+["Libellé court", "product_name_fr_if_not_existing"],
+["Marque", "brands"],
+["Nombre de portions exact", "number_of_servings"],
+["Nombre de portions approximatif", "number_of_servings_estimate"],
+["Les allergènes", "allergens"],
+["Ingrédients","ingredients_txt_fr"],
+["Conditions particulières de conservation", "conservation_fr"],
+["Format du Produit", "packaging"],
+
+);
+
+my @csv_fields_mapping_nutrition = (
+
+["GTIN", "code"],
+["Quantité", "nutriments.energy_kJ", ["Nutriment", "Energie"], ["Taille de la portion", "100.0000"], ["Unité", "Kilojoules (kj)"] ],
+["Quantité", "nutriments.fat_g", ["Nutriment", "Matières grasses"], ["Taille de la portion", "100.0000"] ],
+["Quantité", "nutriments.saturated-fat_g", ["Nutriment", "Acides gras saturés"], ["Taille de la portion", "100.0000"] ],
+
+);
+
+#			["nutrients.ENERKJ.[0].RoundValue", "nutriments.energy_kJ"],
+#			["nutrients.FAT.[0].RoundValue", "nutriments.fat_g"],
+#			["nutrients.FASAT.[0].RoundValue", "nutriments.saturated-fat_g"],
+#			["nutrients.CHOAVL.[0].RoundValue", "nutriments.carbohydrates_g"],
+#			["nutrients.SUGAR.[0].RoundValue", "nutriments.sugars_g"],
+#			["nutrients.FIBTG.[0].RoundValue", "nutriments.fiber_g"],
+#			["nutrients.PRO.[0].RoundValue", "nutriments.proteins_g"],
+#			["nutrients.SALTEQ.[0].RoundValue", "nutriments.salt_g"],
+
+
+my @csv_fields_mapping_photos = (
+
+["GTIN", "code"],
+["URL", "download_to:/srv/off/imports/ferrero/images/"],
+
+);
+
+my @files = get_list_of_files(@ARGV);
+
+# first load the CSV file, then get the product name from the images
+
+foreach my $file (@files) {
+
+	if ($file =~ /ingredients.*\.csv/) {
+		load_csv_file({ file => $file, encoding => "UTF-8", separator => "\t", skip_lines=> 0, skip_empty_codes=>1, csv_fields_mapping => \@csv_fields_mapping_ingredients});
+	}
+	elsif ($file =~ /nutrition.*\.csv/) {
+		load_csv_file({ file => $file, encoding => "UTF-8", separator => "\t", skip_lines=> 0, skip_empty_codes=>1, csv_fields_mapping => \@csv_fields_mapping_nutrition});
+	}
+	elsif ($file =~ /photos.*\.csv/) {
+		load_csv_file({ file => $file, encoding => "UTF-8", separator => "\t", skip_lines=> 0, skip_empty_codes=>1, csv_fields_mapping => \@csv_fields_mapping_photos});
+	}
+}
+
+# Fix specific issues that are not likely to be present in other sources
+# -> otherwise fix them in Import::clean_fields_for_all_products
+
+foreach my $code (sort keys %products) {
+	
+	my $product_ref = $products{$code};
+	
+	# number of servings in product name:
+	# TIC TAC MENTHE BOX T200
+	if ((defined $product_ref->{product_name_fr_if_not_existing}) and ($product_ref->{product_name_fr_if_not_existing} =~ /\bT(\d+)\b/)) {
+		$product_ref->{number_of_servings} = $1;
+		$product_ref->{product_name_fr_if_not_existing} =~ s/\bT(\d+)\b//g;
+	}
+
+	assign_quantity_from_field($product_ref, "product_name_fr_if_not_existing");
+}
+
+# Clean / normalize fields
+
+clean_fields_for_all_products();
+
+print_csv_file();
+
+print_stats();
+

--- a/scripts/import_csv_file.pl
+++ b/scripts/import_csv_file.pl
@@ -510,11 +510,20 @@ while (my $imported_product_ref = $csv->getline_hr ($io)) {
 
 
 	foreach my $field (@param_fields) {
+	
+		# fields suffixed with _if_not_existing are loaded only if the product does not have an existing value
+		
+		if (not ((defined $imported_product_ref->{$field}) and ($imported_product_ref->{$field} !~ /^\s*$/))
+			and ((defined $imported_product_ref->{$field . "_if_not_existing"}) and ($imported_product_ref->{$field . "_if_not_existing"} !~ /^\s*$/))
+			print STDERR "no existing value for $field, using value from ${field}_if_not_existing: " . $imported_product_ref->{$field . "_if_not_existing"} . "\n";
+			$imported_product_ref->{$field} = $imported_product_ref->{$field . "_if_not_existing"}
+		) {
+		
 
 		if ((defined $imported_product_ref->{$field}) and ($imported_product_ref->{$field} !~ /^\s*$/)) {
 
 
-			print "defined and non empty value for field $field : " . $imported_product_ref->{$field} . "\n";
+			print STDERR "defined and non empty value for field $field : " . $imported_product_ref->{$field} . "\n";
 
 			if (($field =~ /product_name/) or ($field eq "brands")) {
 				$stats{products_with_info}{$code} = 1;

--- a/scripts/process_new_image_off.sh
+++ b/scripts/process_new_image_off.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# script to process images with cloud vision and to call computer vision
+# algorithm
+# to be executed through incron:
+# incrontab -e -u off
+# /srv/off/new_images IN_CREATE /srv/off/scripts/process_new_image_off.sh $@/$#
+
+export PERL5LIB=.
+
+cd /srv/off/scripts
+
+/srv/off/scripts/run_cloud_vision_ocr.pl $1
+
+

--- a/scripts/run_cloud_vision_ocr.pl
+++ b/scripts/run_cloud_vision_ocr.pl
@@ -1,0 +1,137 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+# 
+# Product Opener
+# Copyright (C) 2011-2018 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+# 
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use utf8;
+
+binmode(STDOUT, ":encoding(UTF-8)");
+
+use ProductOpener::Config qw/:all/;
+use ProductOpener::Store qw/:all/;
+
+use CGI qw/:cgi :form escapeHTML/;
+use URI::Escape::XS;
+use Storable qw/dclone/;
+use Encode;
+use JSON::PP;
+use LWP::UserAgent;
+use MIME::Base64;
+
+# 1551113262.3302748614028.front_fr.30.jpg
+
+my $file = $ARGV[0];
+
+my $destination = readlink $file;
+
+my $code;
+
+if ($file =~ /^([^\.]*)\.(\d+)\./) {
+	$code = $2;
+}
+
+my $path = $destination;
+$path =~ s/.*\/images/\/images/;
+
+my $auth = "";
+if ($server_domain =~ /^dev\./) {
+	$auth = "off:off@";
+}
+
+my $image_url = "https://" . $auth . "static." . $server_domain . $path;
+my $json_url = $image_url;
+$json_url =~ s/\.([^\.]+)$//;
+$json_url .= ".json";
+
+my $json_file = $destination;
+$json_file =~ s/\.([^\.]+)$//;
+$json_file .= ".json";
+
+open (LOG, ">> $data_root/logs/run_cloud_vision_ocr.log");
+print LOG "file: $file destination: $destination code: $code image_url: $image_url json_file: $json_file\n";
+
+
+my $url = "https://alpha-vision.googleapis.com/v1/images:annotate?key=" . $ProductOpener::Config::google_cloud_vision_api_key;
+# alpha-vision.googleapis.com/
+
+my $ua = LWP::UserAgent->new();
+
+
+
+open (IMAGE, $file) || die "Could not read $file: $!\n";
+binmode(IMAGE);
+local $/;
+my $image = <IMAGE>;
+close IMAGE;
+
+my $api_request_ref = 		 
+	{
+		requests => 
+			[ 
+				{
+					features => [{ type => 'TEXT_DETECTION'}, { type => 'LOGO_DETECTION'},
+					{ type => 'SAFE_SEARCH_DETECTION'}, { type => 'FACE_DETECTION'}]
+#					, image => { source => { imageUri => $image_url}}
+					, image => { content => encode_base64($image)}
+				}
+			]
+	}
+;
+my $json = encode_json($api_request_ref);
+				
+my $request = HTTP::Request->new(POST => $url);
+$request->header( 'Content-Type' => 'application/json' );
+$request->content( $json );
+
+my $res = $ua->request($request);
+
+my $status;
+	
+if ($res->is_success) {
+
+	#$log->info("request to google cloud vision was successful") if $log->is_info();
+
+	my $json_response = $res->decoded_content;
+	
+	# my $cloudvision_ref = decode_json($json_response);
+	
+	open (my $OUT, ">:encoding(UTF-8)", $json_file) or die("Cannot write $json_file: $!\n");
+	print $OUT $json_response;
+	close $OUT;			
+	
+	print LOG "--> success\n";
+	
+	# Call robotoff to process the image and/or json from Cloud Vision
+	
+	my $response = $ua->post( "https://robotoff.openfoodfacts.org/api/v1/images/import", 
+	{ 'barcode' => $code,
+		'image_url' => $image_url,
+		'ocr_url' => $json_url,
+		'server_domain' => $auth . "api." . $server_domain} );
+	
+	unlink($file);
+}
+else {
+	#$log->warn("google cloud vision request not successful", { code => $res->code, response => $res->message }) if $log->is_warn();
+	print LOG "--> error: $res->code $res->message\n";	
+}
+
+close LOG;

--- a/scripts/run_cloud_vision_ocr.pl
+++ b/scripts/run_cloud_vision_ocr.pl
@@ -65,8 +65,8 @@ my $json_file = $destination;
 $json_file =~ s/\.([^\.]+)$//;
 $json_file .= ".json";
 
-open (LOG, ">> $data_root/logs/run_cloud_vision_ocr.log");
-print LOG "file: $file destination: $destination code: $code image_url: $image_url json_file: $json_file\n";
+open (my $LOG, ">>", "$data_root/logs/run_cloud_vision_ocr.log");
+print $LOG "file: $file destination: $destination code: $code image_url: $image_url json_file: $json_file\n";
 
 
 my $url = "https://alpha-vision.googleapis.com/v1/images:annotate?key=" . $ProductOpener::Config::google_cloud_vision_api_key;
@@ -76,11 +76,11 @@ my $ua = LWP::UserAgent->new();
 
 
 
-open (IMAGE, $file) || die "Could not read $file: $!\n";
-binmode(IMAGE);
+open (my $IMAGE, "<", $file) || die "Could not read $file: $!\n";
+binmode($IMAGE);
 local $/;
-my $image = <IMAGE>;
-close IMAGE;
+my $image = <$IMAGE>;
+close $IMAGE;
 
 my $api_request_ref = 		 
 	{
@@ -117,7 +117,7 @@ if ($res->is_success) {
 	print $OUT $json_response;
 	close $OUT;			
 	
-	print LOG "--> success\n";
+	print $LOG "--> success\n";
 	
 	# Call robotoff to process the image and/or json from Cloud Vision
 	
@@ -131,7 +131,7 @@ if ($res->is_success) {
 }
 else {
 	#$log->warn("google cloud vision request not successful", { code => $res->code, response => $res->message }) if $log->is_warn();
-	print LOG "--> error: $res->code $res->message\n";	
+	print $LOG "--> error: $res->code $res->message\n";	
 }
 
-close LOG;
+close $LOG;


### PR DESCRIPTION
See https://github.com/openfoodfacts/openfoodfacts-server/issues/1661

There's another change on Images.pm that I have commited to master that creates a symlink in /srv/off/new_images whenever an image is uploaded : https://github.com/openfoodfacts/openfoodfacts-server/commit/cd4701ad189de63c940c33c31da247c2174ed26f

Then there is an incrontab that watches that directory:

incrontab -l -u off
/srv/off/new_images IN_CREATE /srv/off/scripts/process_new_image_off.sh $@/$#

This in turns calls /srv/off/scripts/run_cloud_vision_ocr.pl (which calls cloud vision and robotoff for ocr analysis etc.)

Logs are in /srv/off/logs# more run_cloud_vision_ocr.log

