### PR TITLE
Update Image Upload

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,7 @@
 Product Opener
-Copyright (C) 2011-2015 Association Open Food Facts
+Copyright (C) 2011-2019 Association Open Food Facts
 Contact: contact@openfoodfacts.org
-Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+Address: 21 rue des Iles, 94100 Saint-Maur des Fossï¿½s, France
 
 Product Opener is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/cpanfile
+++ b/cpanfile
@@ -46,6 +46,7 @@ requires 'Data::Dumper::AutoEncode';
 requires 'XML::Rules';
 requires 'Email::Stuffer';
 requires 'Text::CSV', '>= 1.99, < 2.0';
+requires 'Digest::SHA3', '>= 1.04';
 
 # Logging
 requires 'Log::Any', '>= 1.705';

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -490,11 +490,12 @@ sub process_image_upload($$$$$$) {
 			# create the the directories for the product
 			make_path("$image_base_path/", { chmod => 0755 });
 
-			$imgid = Digest::SHA3->new(224)->addfile($file, 'b')->b64digest;
+			my $hash = Digest::SHA3->new(224)->addfile($file, 'b')->b64digest;
+			$imgid = time() . "." . $hash;
 			local $log->context->{imgid} = $imgid;
 			my $img_path = "$image_base_path/$imgid.$extension";
 			# Check that we don't already have the image with the same name
-			if (-e $img_path) {
+			if (glob("$image_base_path/*.$hash.$extension")) {
 				return -3;
 			}
 

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -450,13 +450,16 @@ sub process_image_upload($$$$$$) {
 	if ($file) {
 		$log->debug("processing uploaded file") if $log->is_debug();
 
-		if ($file !~ /\.(gif|jpeg|jpg|png)$/i) {
-			# We have a "blob" without file name and extension?
-			# try to assume it is jpeg (and let ImageMagick read it anyway if it's something else)
-			# $file .= ".jpg";
+		# Validate file type using PerlMagick: https://stackoverflow.com/a/11083323/11963
+		$log->trace("validating file type") if $log->is_trace();
+		my $validate = Image::Magick->new();
+		my ($width, $height, $size, $format) = $validate->Ping($file);
+		local $log->context->{format} = $format;
+		if (not (defined $format)) {
+			$log->info("file type invalid") if $log->is_info();
+			$img_id = -5;
 		}
-
-		if (1 or ($file =~ /\.(gif|jpeg|jpg|png)$/i)) {
+		else {
 			$log->debug("file type validated") if $log->is_debug();
 
 			my $extension = 'jpg';

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -64,6 +64,7 @@ use ProductOpener::Products qw/:all/;
 
 use CGI qw/:cgi :form escapeHTML/;
 
+use File::Path qw(make_path);
 use Image::Magick;
 use Graphics::Color::RGB;
 use Graphics::Color::HSL;
@@ -472,17 +473,11 @@ sub process_image_upload($$$$$$) {
 			my $current_product_ref = retrieve_product($code);
 			$imgid = $current_product_ref->{max_imgid} + 1;
 
-			# if for some reason the images directories were not created at product creation (it can happen if the images directory's permission / ownership are incorrect at some point)
-			# create them
-
-			# Create the directories for the product
-			foreach my $current_dir  ($www_root . "/images/products") {
-				(-e "$current_dir") or mkdir($current_dir, 0755);
-				foreach my $component (split("/", $path)) {
-					$current_dir .= "/$component";
-					(-e "$current_dir") or mkdir($current_dir, 0755);
-				}
-			}
+			# if for some reason the images directories were not created
+			# at product creation (it can happen if the images directory's
+			# permission / ownership are incorrect at some point),
+			# create the the directories for the product
+			make_path("$www_root/images/products/$path/", { chmod => 0755 });
 
 			my $lock_path = "$www_root/images/products/$path/$imgid.lock";
 			while (-e $lock_path) {


### PR DESCRIPTION
1. Perform image validation and existence checks before copying images to the product's image directory.
2. Validate the image's file type using PerlMagick.
3. Use the SHA3 hash of the image content as the `$imgid`, so that we do not need to have a separate counter (which seems to be problematic, because images sometimes get overwritten, see #423).