### PR TITLE
Migrate to GeoIP2

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -30,7 +30,7 @@ requires 'URI::Escape::XS';
 requires 'Encode::Punycode';
 requires 'GraphViz2';
 requires 'Algorithm::CheckDigits';
-requires 'Geo::IP';
+requires 'GeoIP2', '>= 2.006001, < 3.0';
 requires 'Image::OCR::Tesseract';
 requires 'DateTime', '>= 1.50';
 requires 'DateTime::Locale', '>= 1.22';

--- a/docker/backend-dev/conf/Config.pm
+++ b/docker/backend-dev/conf/Config.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -31,35 +31,36 @@ BEGIN
 	@EXPORT_OK = qw(
 		%admins
 		%moderators
-		
+
 		$server_domain
 		@ssl_subdomains
 		$data_root
 		$www_root
+		$geolite2_path
 		$reference_timezone
 		$contact_email
 		$admin_email
-		
+
 		$facebook_app_id
 		$facebook_app_secret
-		
+
 		$mongodb
 		$mongodb_host
 
 		$memd_servers
-	
+
 		$google_analytics
-		
+
 		$thumb_size
 		$crop_size
 		$small_size
 		$display_size
 		$zoom_size
-		
+
 		$page_size
-		
+
 		%options
-		
+
 		%wiki_texts
 
 		@product_fields
@@ -69,13 +70,13 @@ BEGIN
 		@drilldown_fields
 		@taxonomy_fields
 		@export_fields
-		
+
 		%tesseract_ocr_available_languages
-		
+
 		%weblink_templates
-		
+
 		@edit_rules
-		
+
 	);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -166,6 +167,8 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 # server paths
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
+
+$geolite2_path = $ProductOpener::Config2::geolite2_path;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
@@ -319,8 +322,8 @@ product_name
 generic_name
 quantity
 packaging
-brands 
-categories 
+brands
+categories
 origins
 manufacturing_places
 labels

--- a/docker/backend-dev/conf/Config2.pm
+++ b/docker/backend-dev/conf/Config2.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -33,6 +33,7 @@ BEGIN
 		@ssl_subdomains
 		$data_root
 		$www_root
+		$geolite2_path
 		$mongodb
 		$mongodb_host
 		$memd_servers
@@ -52,6 +53,8 @@ $server_domain = "productopener.localhost";
 # server paths
 $www_root = "/opt/product-opener/html";
 $data_root = "/mnt/podata";
+
+$geolite2_path = '/usr/local/share/GeoLite2-Country/GeoLite2-Country.mmdb';
 
 $mongodb = "off";
 $mongodb_host = "mongodb://mongodb:27017";

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -33,13 +33,16 @@ RUN set -x \
 	&& apk --update --no-cache add \
 		imagemagick6 \
 		graphviz \
-		tesseract-ocr geoip \
+		tesseract-ocr \
 		# As of Alpine 3.7, zbar is only available in testing.
 		imagemagick@edge \
-		zbar@testing \
-	&& /etc/periodic/monthly/geoip \
-	&& ln -s /usr/share/GeoIP /usr/local/share/GeoIP
+		zbar@testing
 
+ADD https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz /tmp/GeoLite2-Country.tar.gz
+RUN set -x \
+  && tar xfz /tmp/GeoLite2-Country.tar.gz -C /usr/local/share \
+  && rm /tmp/GeoLite2-Country.tar.gz \
+  && mv /usr/local/share/GeoLite2-Country_* /usr/local/share/GeoLite2-Country
 
 # Prepare Apache to include our custom config
 RUN set -x \

--- a/docker/productopener/templates/backend-conf.yaml
+++ b/docker/productopener/templates/backend-conf.yaml
@@ -60,6 +60,7 @@ data:
     		@ssl_subdomains
     		$data_root
     		$www_root
+        $geolite2_path
     		$reference_timezone
     		$contact_email
     		$admin_email
@@ -195,6 +196,8 @@ data:
     # server paths
     $www_root = $ProductOpener::Config2::www_root;
     $data_root = $ProductOpener::Config2::data_root;
+
+    $geolite2_path = $ProductOpener::Config2::geolite2_path;
 
     $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
     $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
@@ -431,6 +434,7 @@ data:
     		@ssl_subdomains
     		$data_root
     		$www_root
+        $geolite2_path
     		$mongodb
         $mongodb_host
         $memd_servers
@@ -451,6 +455,8 @@ data:
     # server paths
     $www_root = "/opt/product-opener/html";
     $data_root = "/mnt/podata";
+
+    $geolite2_path = '/usr/local/share/GeoLite2-Country/GeoLite2-Country.mmdb';
 
     $mongodb = "off";
     $mongodb_host = "mongodb://{{ .Release.Name }}-mongodb:27017";

--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -31,11 +31,12 @@ BEGIN
 	@EXPORT_OK = qw(
 		%admins
 		%moderators
-		
+
 		$server_domain
 		@ssl_subdomains
 		$data_root
 		$www_root
+		$geolite2_path
 		$reference_timezone
 		$contact_email
 		$admin_email
@@ -44,7 +45,7 @@ BEGIN
 		$facebook_app_secret
 
 		$google_cloud_vision_api_key
-		
+
 		$crowdin_project_identifier
 		$crowdin_project_key
 
@@ -52,21 +53,21 @@ BEGIN
 		$mongodb_host
 
 		$memd_servers
-	
+
 		$google_analytics
-		
+
 		$thumb_size
 		$crop_size
 		$small_size
 		$display_size
 		$zoom_size
-		
+
 		$page_size
 
 		%options
 
 		%wiki_texts
-		
+
 		@product_fields
 		@product_other_fields
 		@display_fields
@@ -74,9 +75,9 @@ BEGIN
 		@drilldown_fields
 		@taxonomy_fields
 		@export_fields
-		
-		%tesseract_ocr_available_languages		
-		
+
+		%tesseract_ocr_available_languages
+
 		%weblink_templates
 
 		@edit_rules
@@ -126,6 +127,8 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 # server paths
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
+
+$geolite2_path = $ProductOpener::Config2::geolite2_path;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
@@ -251,8 +254,8 @@ generic_name
 quantity
 packaging
 periods_after_opening
-brands 
-categories 
+brands
+categories
 origins
 manufacturing_places
 labels

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -31,40 +31,41 @@ BEGIN
 	@EXPORT_OK = qw(
 		%admins
 		%moderators
-		
+
 		$server_domain
 		@ssl_subdomains
 		$data_root
 		$www_root
+		$geolite2_path
 		$reference_timezone
 		$contact_email
 		$admin_email
-		
+
 		$facebook_app_id
 		$facebook_app_secret
-		
+
 		$google_cloud_vision_api_key
-		
+
 		$crowdin_project_identifier
 		$crowdin_project_key
-		
+
 		$mongodb
 		$mongodb_host
 
 		$memd_servers
-	
+
 		$google_analytics
-		
+
 		$thumb_size
 		$crop_size
 		$small_size
 		$display_size
 		$zoom_size
-		
+
 		$page_size
-		
+
 		%options
-		
+
 		%wiki_texts
 
 		@product_fields
@@ -74,13 +75,13 @@ BEGIN
 		@drilldown_fields
 		@taxonomy_fields
 		@export_fields
-		
+
 		%tesseract_ocr_available_languages
-		
+
 		%weblink_templates
-		
+
 		@edit_rules
-		
+
 	);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -282,6 +283,8 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
 
+$geolite2_path = $ProductOpener::Config2::geolite2_path;
+
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
 
@@ -362,7 +365,7 @@ $options{favicons} = <<HTML
 <meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png">
 <meta name="msapplication-config" content="/images/favicon/browserconfig.xml">
 <meta name="_globalsign-domain-verification" content="2ku73dDL0bAPTj_s1aylm6vxvrBZFK59SfbH_RdUya" />
-<meta name="flattr:id" content="dw637l"> 
+<meta name="flattr:id" content="dw637l">
 HTML
 ;
 
@@ -484,19 +487,19 @@ net_weight_value net_weight_unit drained_weight_value drained_weight_unit volume
 other_information conservation_conditions recycling_instructions_to_recycle
  recycling_instructions_to_discard
 nutrition_grade_fr_producer
-recipe_idea origin customer_service producer preparation warning 
+recipe_idea origin customer_service producer preparation warning
 );
 
 
 # fields shown on product page
 # do not show purchase_places
 
-@display_fields = qw(generic_name quantity packaging brands categories labels origin origins 
+@display_fields = qw(generic_name quantity packaging brands categories labels origin origins
 producer manufacturing_places emb_codes link stores countries);
 
 # fields displayed in a new section after the nutrition facts
 
-@display_other_fields = qw(other_information preparation recipe_idea warning conservation_conditions 
+@display_other_fields = qw(other_information preparation recipe_idea warning conservation_conditions
 recycling_instructions_to_recycle recycling_instructions_to_discard customer_service);
 
 
@@ -540,8 +543,8 @@ product_name
 generic_name
 quantity
 packaging
-brands 
-categories 
+brands
+categories
 origins
 manufacturing_places
 labels
@@ -658,7 +661,7 @@ $options{display_tag_additives} = [
 	'wikipedia',
 	'title:efsa_evaluation_overexposure_risk_title',
 	'efsa_evaluation',
-	'efsa_evaluation_overexposure_risk',	
+	'efsa_evaluation_overexposure_risk',
 	'efsa_evaluation_exposure_table',
 #	'@efsa_evaluation_exposure_mean_greater_than_noael',
 #	'@efsa_evaluation_exposure_95th_greater_than_noael',
@@ -779,7 +782,7 @@ $options{nova_groups_tags} = {
 # other ingredients that we can consider as ultra-processed
 
 "ingredients/en:dextrose" => 4,
-# This can be deleted, it is a synonym of en:glucose in the ingredients taxo aleene@2018-10-09 
+# This can be deleted, it is a synonym of en:glucose in the ingredients taxo aleene@2018-10-09
 "ingredients/en:milk-powder" => 4,
 # This can be deleted, was already entered above aleene@2018-10-09
 "ingredients/en:milk-proteins" => 4,
@@ -844,7 +847,7 @@ $options{nova_groups_tags} = {
 "additives/en:e151" => 4, #Brilliant black bn" => 4, #black pn" => 4, #E 151" => 4, #C.I. 28440" => 4, #Brilliant Black PN" => 4, #Food Black 1" => 4, #Naphthol Black" => 4, #C.I. Food Brown 1" => 4, #Brilliant Black A
 "additives/en:e152" => 4, #Black 7984" => 4, #Food Black 2" => 4, #carbon black
 "additives/en:e153" => 4, #Vegetable carbon
-"additives/en:e154" => 4, #Brown FK" => 4, #Kipper Brown 
+"additives/en:e154" => 4, #Brown FK" => 4, #Kipper Brown
 "additives/en:e155" => 4, #Brown ht" => 4, #Chocolate brown HT
 "additives/en:e15x" => 4, #E15x food additive
 "additives/en:e160" => 4, #carotene

--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -31,11 +31,12 @@ BEGIN
 	@EXPORT_OK = qw(
 		%admins
 		%moderators
-		
+
 		$server_domain
 		@ssl_subdomains
 		$data_root
 		$www_root
+		$geolite2_path
 		$reference_timezone
 		$contact_email
 		$admin_email
@@ -44,7 +45,7 @@ BEGIN
 		$facebook_app_secret
 
 		$google_cloud_vision_api_key
-		
+
 		$crowdin_project_identifier
 		$crowdin_project_key
 
@@ -52,21 +53,21 @@ BEGIN
 		$mongodb_host
 
 		$memd_servers
-	
+
 		$google_analytics
-		
+
 		$thumb_size
 		$crop_size
 		$small_size
 		$display_size
 		$zoom_size
-		
+
 		$page_size
 
 		%options
 
 		%wiki_texts
-		
+
 		@product_fields
 		@product_other_fields
 		@display_fields
@@ -74,9 +75,9 @@ BEGIN
 		@drilldown_fields
 		@taxonomy_fields
 		@export_fields
-		
-		%tesseract_ocr_available_languages		
-		
+
+		%tesseract_ocr_available_languages
+
 		%weblink_templates
 
 		@edit_rules
@@ -126,6 +127,8 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 # server paths
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
+
+$geolite2_path = $ProductOpener::Config2::geolite2_path;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
@@ -251,8 +254,8 @@ product_name
 generic_name
 quantity
 packaging
-brands 
-categories 
+brands
+categories
 origins
 manufacturing_places
 labels

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -31,40 +31,41 @@ BEGIN
 	@EXPORT_OK = qw(
 		%admins
 		%moderators
-		
+
 		$server_domain
 		@ssl_subdomains
 		$data_root
 		$www_root
+		$geolite2_path
 		$reference_timezone
 		$contact_email
 		$admin_email
-		
+
 		$facebook_app_id
 		$facebook_app_secret
-		
+
 		$google_cloud_vision_api_key
-		
+
 		$crowdin_project_identifier
 		$crowdin_project_key
-				
+
 		$mongodb
 		$mongodb_host
 
 		$memd_servers
-	
+
 		$google_analytics
-		
+
 		$thumb_size
 		$crop_size
 		$small_size
 		$display_size
 		$zoom_size
-		
+
 		$page_size
-		
+
 		%options
-		
+
 		%wiki_texts
 
 		@product_fields
@@ -74,11 +75,11 @@ BEGIN
 		@drilldown_fields
 		@taxonomy_fields
 		@export_fields
-		
+
 		%tesseract_ocr_available_languages
-		
+
 		%weblink_templates
-	
+
 		@edit_rules
 	);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
@@ -124,6 +125,8 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 # server paths
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
+
+$geolite2_path = $ProductOpener::Config2::geolite2_path;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
@@ -295,8 +298,8 @@ product_name
 generic_name
 quantity
 packaging
-brands 
-categories 
+brands
+categories
 origins
 manufacturing_places
 labels

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -90,12 +90,12 @@ sub normalize_code($) {
 		if ((length($code) eq 12) and ($ean_check->is_valid('0' . $code))) {
 			$code = '0' . $code;
 		}
-		
+
 		# Remove leading 0 for codes with 14 digits
 		if ((length($code) eq 14) and ($code =~ /^0/)) {
 			$code = $';
 		}
-		
+
 		# Remove 5 or 6 leading 0s for EAN8
 		# 00000080050100 (from Ferrero)
 		if ((length($code) eq 14) and ($code =~ /^000000/)) {
@@ -103,7 +103,7 @@ sub normalize_code($) {
 		}
 		if ((length($code) eq 13) and ($code =~ /^00000/)) {
 			$code = $';
-		}		
+		}
 	}
 	return $code;
 }
@@ -170,11 +170,9 @@ sub init_product($) {
 		$product_ref->{lc} = $lc;
 		$product_ref->{lang} = $lc;
 	}
-	use Geo::IP;
-	my $gi = Geo::IP->new(GEOIP_MEMORY_CACHE);
-	# look up IP address '24.24.24.24'
-	# returns undef if country is unallocated, or not defined in our database
-	my $country = $gi->country_code_by_addr(remote_addr());
+
+	use ProductOpener::GeoIP;
+	my $country = ProductOpener::GeoIP::get_country_for_ip(remote_addr());
 
 	# ugly fix: products added by yuka should have country france, regardless of the server ip
 	if ($creator eq 'kiliweb') {

--- a/scripts/gen_users_emails_list.pl
+++ b/scripts/gen_users_emails_list.pl
@@ -1,22 +1,22 @@
 #!/usr/bin/perl -w
 
 # This file is part of Product Opener.
-# 
+#
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
-# 
+#
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -28,9 +28,6 @@ use utf8;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Store qw/:all/;
 use Geo::IP;
-
-my $gi = Geo::IP->new(GEOIP_MEMORY_CACHE);
-
 
 my @userids;
 
@@ -46,16 +43,17 @@ foreach my $userid (@userids)
 	next if $userid eq 'all';
 
 	my $user_ref = retrieve("$data_root/users/$userid");
-	
+
 	my $first = '';
 	if (! exists $user_ref->{discussion}) {
 		$first = 'first';
 	}
-	
+
 	# print $user_ref->{email} . "\tnews_$user_ref->{newsletter}$first\tdiscussion_$user_ref->{discussion}\n";
-	
+
 	if ($user_ref->{newsletter}) {
-		my $country = $gi->country_code_by_addr($user_ref->{ip});
+		use ProductOpener::GeoIP;
+		my $country = my $country = ProductOpener::GeoIP::get_country_for_ip($user_ref->{ip});
 		defined $country or $country = "";
 		my $lc = $user_ref->{initial_lc} || "";
 		my $cc = $user_ref->{initial_cc} || "";

--- a/scripts/obsolete/update_all_products_countries_fix.pl
+++ b/scripts/obsolete/update_all_products_countries_fix.pl
@@ -1,22 +1,22 @@
 #!/usr/bin/perl -w
 
 # This file is part of Product Opener.
-# 
+#
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
-# 
+#
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -46,9 +46,6 @@ use Storable qw/dclone/;
 use Encode;
 use JSON::PP;
 
-use Geo::IP;
-my $gi = Geo::IP->new(GEOIP_MEMORY_CACHE);
-
 my %places = ();
 open (my $IN, q{<}, "places.txt");
 while(<$IN>) {
@@ -65,45 +62,45 @@ my %new_countries = ();
 
 		my $products_with_country = 0;
 		my $products_without_country = 0;
-		
+
 my $cursor = $products_collection->query({})->fields({ code => 1 });;
 my $count = $cursor->count();
-	
+
 	print  "$count products to update\n";
-	
+
 	my $new = 0;
 	my $existing = 0;
-	
+
 	while (my $product_ref = $cursor->next) {
-        
-		
+
+
 		my $code = $product_ref->{code};
 		my $path = product_path($code);
-		
+
 		print  "updating product $code\n";
-		
+
 		$product_ref = retrieve_product($code);
-		
+
 		if ((defined $product_ref) and ($code ne '')) {
-		
+
 			$lc = $product_ref->{lc};
-			
+
 			if ($product_ref->{countries} =~ /:/) {
 				my $country = $product_ref->{countries};
 				$country =~ s/.*://;
 				my $countryid = canonicalize_taxonomy_tag('en', "countries", $country);
 				print $product_ref->{countries} . " --> id: " . $countryid . " --> " .display_taxonomy_tag($lc, "countries", $countryid) . "\n";
-			
+
 				$product_ref->{countries} = display_taxonomy_tag($lc, "countries", $countryid);
 		if ($code ne '993605347529') {
-			store("$data_root/products/$path/product.sto", $product_ref);		
+			store("$data_root/products/$path/product.sto", $product_ref);
 			$products_collection->save($product_ref);
 			}
 			}
 		}
-		
+
 	}
 
-	
+
 exit(0);
 


### PR DESCRIPTION
The original GeoLite database was [discontinued at the beginning of this year](https://support.maxmind.com/geolite-legacy-discontinuation-notice/). In order to keep server-side geolocation, we need to migrate to an alternative. ie. [GeoLite2](https://dev.maxmind.com/geoip/geoip2/geolite2/). As GeoLite2 isn't packaged for Linux distributions (yet?), we need to download it manually and configure where the `.mmd` file is located. (See the updated `Dockerfile` for an example.)