### PR TITLE
Use `$subdomain` for CSV export of search results

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4124,7 +4124,7 @@ sub search_and_export_products($$$$$) {
 		print $csv;
 
 
-
+		my $uri = format_subdomain($subdomain);
 		while (my $product_ref = $cursor->next) {
 
 			$csv = "";
@@ -4146,7 +4146,7 @@ sub search_and_export_products($$$$$) {
 
 				if ($field eq 'code') {
 
-					$csv .= format_subdomain($cc) . product_url($product_ref->{code}) . "\t";
+					$csv .= $uri . product_url($product_ref->{code}) . "\t";
 
 				}
 


### PR DESCRIPTION
**Description:** Results in the `$subdomain` of the search page in the CSV export, instead of the country without a language code.

**Related issues and discussion:** Fixes #263
