### PR TITLE
Add quality tags for GS1 prefixes

### DIFF
--- a/lib/ProductOpener/SiteQuality_off.pm
+++ b/lib/ProductOpener/SiteQuality_off.pm
@@ -792,6 +792,43 @@ sub check_bug_created_t_missing($) {
 
 }
 
+sub check_codes($) {
+
+	my $product_ref = shift;
+
+	check_code_gs1_prefixes($product_ref);
+
+}
+
+sub check_code_gs1_prefixes($) {
+
+	my $product_ref = shift;
+
+	if ((not (defined $product_ref->{code}))) {
+		return;
+	}
+
+	my $code = $product_ref->{code};
+	# https://github.com/openfoodfacts/openfoodfacts-server/issues/1129
+	if ($code =~ /^99[0-9]{10,11}$/) {
+		push @{$product_ref->{quality_tags}}, 'gs1-coupon-prefix';
+	}
+	elsif ($code =~ /^98[5-9][0-9]{9,10}$/) {
+		push @{$product_ref->{quality_tags}}, 'gs1-future-coupon-prefix';
+	}
+	elsif ($code =~ /^98[1-4][0-9]{9,10}$/) {
+		push @{$product_ref->{quality_tags}}, 'gs1-coupon-common-currency-area-prefix';
+	}
+	elsif ($code =~ /^980[0-9]{9,10}$/) {
+		push @{$product_ref->{quality_tags}}, 'gs1-refund-prefix';
+	}
+	elsif ($code =~ /^97[8-9][0-9]{9,10}$/) {
+		push @{$product_ref->{quality_tags}}, 'gs1-isbn-prefix';
+	}
+	elsif ($code =~ /^977[0-9]{9,10}$/) {
+		push @{$product_ref->{quality_tags}}, 'gs1-issn-prefix';
+	}
+}
 
 # Run site specific quality checks
 
@@ -806,6 +843,7 @@ sub check_quality($) {
 	check_nutrition_grades($product_ref);
 	check_quantity($product_ref);
 	check_bugs($product_ref);
+	check_codes($product_ref);
 
 	detect_categories($product_ref);
 }

--- a/t/sitequality.t
+++ b/t/sitequality.t
@@ -8,71 +8,123 @@ use Log::Any::Adapter 'TAP';
 use ProductOpener::SiteQuality qw/:all/;
 use ProductOpener::Tags qw/:all/;
 
+sub check_quality_and_test_product_has_quality_tag($$$$) {
+	my $product_ref = shift;
+	my $tag = shift;
+	my $reason = shift;
+	my $yesno = shift;
+	ProductOpener::SiteQuality::check_quality($product_ref);
+	if ($yesno){
+		ok( has_tag($product_ref, 'quality', $tag), $reason );
+	}
+	else {
+		ok( !has_tag($product_ref, 'quality', $tag), $reason );
+	}
+}
+
+sub product_with_energy_has_quality_tag($$$) {
+	my $energy = shift;
+	my $reason = shift;
+	my $yesno = shift;
+
+	my $product_ref = {
+		lc => "de",
+		nutriments => {
+			energy => $energy
+		}
+	};
+
+	check_quality_and_test_product_has_quality_tag($product_ref, 'illogically-high-energy-value', $reason, $yesno);
+}
+
+sub product_with_code_has_quality_tag($$$$) {
+	my $code = shift;
+	my $tag = shift;
+	my $reason = shift;
+	my $yesno = shift;
+
+	my $product_ref = {
+		code => $code
+	};
+
+	check_quality_and_test_product_has_quality_tag($product_ref, $tag, $reason, $yesno);
+}
+
 # illogically-high-energy-value - does not add tag, if there is no nutriments.
 my $product_ref_without_nutriments = {
 	lc => "de"
 };
-
-ProductOpener::SiteQuality::check_quality($product_ref_without_nutriments);
-
-ok( !has_tag($product_ref_without_nutriments, 'quality', 'illogically-high-energy-value'), 'product does not have illogically-high-energy-value tag as it has no nutrients' );
+check_quality_and_test_product_has_quality_tag($product_ref_without_nutriments, 'illogically-high-energy-value', 'product does not have illogically-high-energy-value tag as it has no nutrients', 0);
 
 # illogically-high-energy-value - does not add tag, if there is no energy.
 my $product_ref_without_energy_value = {
 	lc => "de",
 	nutriments => {}
 };
-
-ProductOpener::SiteQuality::check_quality($product_ref_without_energy_value);
-
-ok( !has_tag($product_ref_without_energy_value, 'quality', 'illogically-high-energy-value'), 'product does not have illogically-high-energy-value tag as it has no energy_value' );
+check_quality_and_test_product_has_quality_tag($product_ref_without_energy_value, 'illogically-high-energy-value', 'product does not have illogically-high-energy-value tag as it has no energy_value', 0);
 
 # illogically-high-energy-value - does not add tag, if energy_value is below 3800 - 3799
-my $product_ref_with_low_energy_value = {
-	lc => "de",
-	nutriments => {
-		energy => 3799
-	}
-};
-
-ProductOpener::SiteQuality::check_quality($product_ref_with_low_energy_value);
-
-ok( !has_tag($product_ref_with_low_energy_value, 'quality', 'illogically-high-energy-value'), 'product does not have illogically-high-energy-value tag as it has an energy_value below 3800: 3799' );
+product_with_energy_has_quality_tag(3799, 'product does not have illogically-high-energy-value tag as it has an energy_value below 3800: 3799', 0);
 
 # illogically-high-energy-value - does not add tag, if energy_value is below 3800 - 40
-my $product_ref_with_lower_energy_value = {
-	lc => "de",
-	nutriments => {
-		energy => 40
-	}
-};
-
-ProductOpener::SiteQuality::check_quality($product_ref_with_lower_energy_value);
-
-ok( !has_tag($product_ref_with_lower_energy_value, 'quality', 'illogically-high-energy-value'), 'product does not have illogically-high-energy-value tag as it has an energy_value below 3800: 40' );
+product_with_energy_has_quality_tag(40, 'product does not have illogically-high-energy-value tag as it has an energy_value below 3800: 40', 0);
 
 # illogically-high-energy-value - does not add tag, if energy_value is equal 3800
-my $product_ref_with_lowish_energy_value = {
-	lc => "de",
-	nutriments => {
-		energy => 3800
-	}
-};
-
-ProductOpener::SiteQuality::check_quality($product_ref_with_lowish_energy_value);
-
-ok( !has_tag($product_ref_with_lowish_energy_value, 'quality', 'illogically-high-energy-value'), 'product does not have illogically-high-energy-value tag as it has an energy_value of 3800' );
+product_with_energy_has_quality_tag(3800, 'product does not have illogically-high-energy-value tag as it has an energy_value of 3800: 40', 0);
 
 # illogically-high-energy-value - does add tag, if energy_value is above 3800
-my $product_ref_with_high_energy_value = {
-	lc => "de",
-	nutriments => {
-		energy => 3801
-	}
-};
+product_with_energy_has_quality_tag(3801, 'product does have illogically-high-energy-value tag as it has an energy_value of 3800: 3801', 1);
 
-ProductOpener::SiteQuality::check_quality($product_ref_with_high_energy_value);
+# gs1-issn-prefix
+product_with_code_has_quality_tag('977000000000', 'gs1-issn-prefix', 'product with GTIN-12 has gs1-issn-prefix tag because of the barcode prefix 977', 1);
+product_with_code_has_quality_tag('9770000000000', 'gs1-issn-prefix', 'product with GTIN-13 has gs1-issn-prefix tag because of the barcode prefix 977', 1);
+product_with_code_has_quality_tag('976000000000', 'gs1-issn-prefix', 'product with GTIN-12 has no gs1-issn-prefix tag because of the barcode prefix 976', 0);
+product_with_code_has_quality_tag('9760000000000', 'gs1-issn-prefix', 'product with GTIN-13 has no gs1-issn-prefix tag because of the barcode prefix 976', 0);
 
-ok( has_tag($product_ref_with_high_energy_value, 'quality', 'illogically-high-energy-value'), 'product not have illogically-high-energy-value tag as it has an energy_value of 3801' );
+# gs1-isbn-prefix
+product_with_code_has_quality_tag('978000000000', 'gs1-isbn-prefix', 'product with GTIN-12 has gs1-isbn-prefix tag because of the barcode prefix 978', 1);
+product_with_code_has_quality_tag('9780000000000', 'gs1-isbn-prefix', 'product with GTIN-13 has gs1-isbn-prefix tag because of the barcode prefix 978', 1);
+product_with_code_has_quality_tag('979000000000', 'gs1-isbn-prefix', 'product with GTIN-12 has gs1-isbn-prefix tag because of the barcode prefix 979', 1);
+product_with_code_has_quality_tag('9790000000000', 'gs1-isbn-prefix', 'product with GTIN-13 has gs1-isbn-prefix tag because of the barcode prefix 979', 1);
+product_with_code_has_quality_tag('976000000000', 'gs1-isbn-prefix', 'product with GTIN-12 has no gs1-isbn-prefix tag because of the barcode prefix 976', 0);
+product_with_code_has_quality_tag('9760000000000', 'gs1-isbn-prefix', 'product with GTIN-13 has no gs1-isbn-prefix tag because of the barcode prefix 976', 0);
+
+# gs1-refund-prefix
+product_with_code_has_quality_tag('980000000000', 'gs1-refund-prefix', 'product with GTIN-12 has gs1-refund-prefix tag because of the barcode prefix 980', 1);
+product_with_code_has_quality_tag('9800000000000', 'gs1-refund-prefix', 'product with GTIN-13 has gs1-refund-prefix tag because of the barcode prefix 980', 1);
+product_with_code_has_quality_tag('976000000000', 'gs1-refund-prefix', 'product with GTIN-12 has no gs1-refund-prefix tag because of the barcode prefix 976', 0);
+product_with_code_has_quality_tag('9760000000000', 'gs1-refund-prefix', 'product with GTIN-13 has no gs1-refund-prefix tag because of the barcode prefix 976', 0);
+
+# gs1-coupon-common-currency-area-prefix
+product_with_code_has_quality_tag('981000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-12 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 981', 1);
+product_with_code_has_quality_tag('9810000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-13 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 981', 1);
+product_with_code_has_quality_tag('982000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-12 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 982', 1);
+product_with_code_has_quality_tag('9820000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-13 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 982', 1);
+product_with_code_has_quality_tag('983000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-12 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 983', 1);
+product_with_code_has_quality_tag('9830000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-13 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 983', 1);
+product_with_code_has_quality_tag('984000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-12 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 984', 1);
+product_with_code_has_quality_tag('9840000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-13 has gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 984', 1);
+product_with_code_has_quality_tag('976000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-12 has no gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 976', 0);
+product_with_code_has_quality_tag('9760000000000', 'gs1-coupon-common-currency-area-prefix', 'product with GTIN-13 has no gs1-coupon-common-currency-area-prefix tag because of the barcode prefix 976', 0);
+
+# gs1-future-coupon-prefix
+product_with_code_has_quality_tag('985000000000', 'gs1-future-coupon-prefix', 'product with GTIN-12 has gs1-future-coupon-prefix tag because of the barcode prefix 985', 1);
+product_with_code_has_quality_tag('9850000000000', 'gs1-future-coupon-prefix', 'product with GTIN-13 has gs1-future-coupon-prefix tag because of the barcode prefix 985', 1);
+product_with_code_has_quality_tag('986000000000', 'gs1-future-coupon-prefix', 'product with GTIN-12 has gs1-future-coupon-prefix tag because of the barcode prefix 986', 1);
+product_with_code_has_quality_tag('9860000000000', 'gs1-future-coupon-prefix', 'product with GTIN-13 has gs1-future-coupon-prefix tag because of the barcode prefix 986', 1);
+product_with_code_has_quality_tag('987000000000', 'gs1-future-coupon-prefix', 'product with GTIN-12 has gs1-future-coupon-prefix tag because of the barcode prefix 987', 1);
+product_with_code_has_quality_tag('9870000000000', 'gs1-future-coupon-prefix', 'product with GTIN-13 has gs1-future-coupon-prefix tag because of the barcode prefix 987', 1);
+product_with_code_has_quality_tag('988000000000', 'gs1-future-coupon-prefix', 'product with GTIN-12 has gs1-future-coupon-prefix tag because of the barcode prefix 988', 1);
+product_with_code_has_quality_tag('9880000000000', 'gs1-future-coupon-prefix', 'product with GTIN-13 has gs1-future-coupon-prefix tag because of the barcode prefix 988', 1);
+product_with_code_has_quality_tag('989000000000', 'gs1-future-coupon-prefix', 'product with GTIN-12 has gs1-future-coupon-prefix tag because of the barcode prefix 989', 1);
+product_with_code_has_quality_tag('9890000000000', 'gs1-future-coupon-prefix', 'product with GTIN-13 has gs1-future-coupon-prefix tag because of the barcode prefix 989', 1);
+product_with_code_has_quality_tag('976000000000', 'gs1-future-coupon-prefix', 'product with GTIN-12 has no gs1-future-coupon-prefix tag because of the barcode prefix 976', 0);
+product_with_code_has_quality_tag('9760000000000', 'gs1-future-coupon-prefix', 'product with GTIN-13 has no gs1-future-coupon-prefix tag because of the barcode prefix 976', 0);
+
+# gs1-coupon-prefix
+product_with_code_has_quality_tag('990000000000', 'gs1-coupon-prefix', 'product with GTIN-12 has gs1-coupon-prefix tag because of the barcode prefix 99', 1);
+product_with_code_has_quality_tag('9900000000000', 'gs1-coupon-prefix', 'product with GTIN-13 has gs1-coupon-prefix tag because of the barcode prefix 99', 1);
+product_with_code_has_quality_tag('976000000000', 'gs1-coupon-prefix', 'product with GTIN-12 has no gs1-coupon-prefix tag because of the barcode prefix 976', 0);
+product_with_code_has_quality_tag('9760000000000', 'gs1-coupon-prefix', 'product with GTIN-13 has no gs1-coupon-prefix tag because of the barcode prefix 976', 0);
 
 done_testing();


### PR DESCRIPTION
**Description:** Based on the [GS1 Specs](https://www.gs1.org/docs/barcodes/GS1_General_Specifications.pdf), add quality tags that help with identifying non-food products or non-products (refunds/coupons).
**Related issues and discussion:** Fixes #1129
