### PR TITLE
Update index page caption

### DIFF
--- a/lang/en/texts/index.en.html
+++ b/lang/en/texts/index.en.html
@@ -31,7 +31,7 @@ and people from all around the world will find thousand of usage ideas that we w
 
 <p>Got ideas? Share them on the <a href="https://openfoodfacts.uservoice.com/">Idea Forum</a>!</p>
 
-<h2>Last products added:</h2>
+<h2>Recently updated products:</h2>
 
 <p>&rarr; <a href="/state/to-be-completed">products being added</a> (in particular products added with the iPhone, Android and Windows Phone apps)</p>
 

--- a/lang/en/texts/index.foundation.en.html
+++ b/lang/en/texts/index.foundation.en.html
@@ -3,7 +3,7 @@
 <div class="row hide-when-logged-in">
 
 	<div class="medium-12 large-6 columns">
-	
+
 <h2>Discover</h2>
 
 <p>Open Food Facts is a food products database made by everyone, for everyone.</p>
@@ -12,7 +12,7 @@
 <p>&rarr; <a href="/discover">Learn more about Open Food Facts</a></p>
 
 	</div>
-	
+
 	<div class="medium-12 large-6 columns">
 
 <h2>Contribute</h2>
@@ -26,7 +26,7 @@ exciting projects you can contribute to in many different ways.</p>
 	</div>
 </div>
 
-<h2>Last products added:</h2>
+<h2>Recently updated products:</h2>
 
 <p>&rarr; <a href="/state/to-be-completed">products from the mobile app that need to be completed</a></p>
 


### PR DESCRIPTION
**Description:** As discussed in #1848 and on Slack, the index page does not show the latest added products, but latest modified products with complete products first. Because of that, the front page should not claim it's showing the latest added products.
**Related issues and discussion:** Fixes #1848
