### PR TITLE
Set `ingredients-($lc-)over-30-percent-digits` quality tag

### DIFF
--- a/lib/ProductOpener/SiteQuality_off.pm
+++ b/lib/ProductOpener/SiteQuality_off.pm
@@ -539,6 +539,14 @@ sub check_nutrition_data($) {
 	}
 }
 
+sub calculate_digit_percentage($) {
+	my $text = shift;
+	return 0.0 if not defined $text;
+	my $tl = length($text);
+	return 0.0 if $tl <= 0;
+	my $dc = () = $text =~ /\d/g;
+	return $dc / ($tl * 1.0);
+}
 
 sub check_ingredients($) {
 	my $product_ref = shift;
@@ -612,6 +620,9 @@ sub check_ingredients($) {
 		}
 	}
 
+	if ((defined $product_ref->{ingredients_text}) and (calculate_digit_percentage($product_ref->{ingredients_text}) > 0.3)) {
+		push @{$product_ref->{quality_tags}}, 'ingredients-over-30-percent-digits';
+	}
 
 	if (defined $product_ref->{languages_codes}) {
 
@@ -622,6 +633,10 @@ sub check_ingredients($) {
 			if (defined $product_ref->{$ingredients_text_lc}) {
 
 				$log->debug("ingredients text", { quality => $product_ref->{$ingredients_text_lc} }) if $log->is_debug();
+
+				if (calculate_digit_percentage($product_ref->{$ingredients_text_lc}) > 0.3) {
+					push @{$product_ref->{quality_tags}}, 'ingredients-' . $display_lc . '-over-30-percent-digits';
+				}
 
 				if ($product_ref->{$ingredients_text_lc} =~ /,(\s*)$/is) {
 

--- a/t/sitequality.t
+++ b/t/sitequality.t
@@ -127,4 +127,61 @@ product_with_code_has_quality_tag('9900000000000', 'gs1-coupon-prefix', 'product
 product_with_code_has_quality_tag('976000000000', 'gs1-coupon-prefix', 'product with GTIN-12 has no gs1-coupon-prefix tag because of the barcode prefix 976', 0);
 product_with_code_has_quality_tag('9760000000000', 'gs1-coupon-prefix', 'product with GTIN-13 has no gs1-coupon-prefix tag because of the barcode prefix 976', 0);
 
+# ingredients-de-over-30-percent-digits - with more than 30%
+my $over_30 = '(52,3 0) 0,2 (J 23 (J 2,3 g 0,15 g';
+my $at_30 = '123abcdefg';
+my $product_ref = {
+	lc => 'de',
+	languages_codes => {
+		de => 1
+	},
+	ingredients_text_de => $over_30
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'ingredients-de-over-30-percent-digits'), 'product with more than 30% digits in the language-specific ingredients has tag ingredients-over-30-percent-digits' ) or diag explain $product_ref;
+
+# ingredients-de-over-30-percent-digits - with exactly 30%
+$product_ref = {
+	lc => 'de',
+	languages_codes => {
+		de => 1
+	},
+	ingredients_text_de => $at_30
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( !has_tag($product_ref, 'quality', 'ingredients-de-over-30-percent-digits'), 'product with at most 30% digits in the language-specific ingredients has no ingredients-over-30-percent-digits tag' ) or diag explain $product_ref;
+
+# ingredients-de-over-30-percent-digits - without a text
+$product_ref = {
+	lc => 'de',
+	languages_codes => {
+		de => 1
+	}
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( !has_tag($product_ref, 'quality', 'ingredients-de-over-30-percent-digits'), 'product with no language-specific ingredients text has no ingredients-over-30-percent-digits tag' ) or diag explain $product_ref;
+
+# ingredients-over-30-percent-digits - with more than 30%
+$product_ref = {
+	lc => 'de',
+	ingredients_text => $over_30
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'ingredients-over-30-percent-digits'), 'product with more than 30% digits in the ingredients has tag ingredients-over-30-percent-digits' ) or diag explain $product_ref;
+
+# ingredients-over-30-percent-digits - with exactly 30%
+$product_ref = {
+	lc => 'de',
+	ingredients_text => $at_30
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( !has_tag($product_ref, 'quality', 'ingredients-over-30-percent-digits'), 'product with at most 30% digits in the ingredients has no ingredients-over-30-percent-digits tag' ) or diag explain $product_ref;
+
+# ingredients-over-30-percent-digits - without a text
+$product_ref = {
+	lc => 'de'
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( !has_tag($product_ref, 'quality', 'ingredients-over-30-percent-digits'), 'product with no ingredients text has no ingredients-over-30-percent-digits tag' ) or diag explain $product_ref;
+
 done_testing();


### PR DESCRIPTION
**Description:** Adds the `ingredients-($lc-)over-30-percent-digits` quality tag to a product if the `ingredients_text` or a language-specific text (ie. `ingredients_text_de`) contains >30% digits.
**Related issues and discussion:** Closes #1861 
