### PR TITLE
remove old emb_codes_orig logic, do it in Tags.pm instead, fixes bug …

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -187,12 +187,6 @@ else {
 
 			add_tags_to_field($product_ref, $lc, $field, $additional_fields);
 
-			if ($field eq 'emb_codes') {
-				# French emb codes
-				$product_ref->{emb_codes_orig} = $product_ref->{emb_codes};
-				$product_ref->{emb_codes} = normalize_packager_codes($product_ref->{emb_codes});
-			}
-
 			print STDERR "product_jqm_multilingual.pl - lc: $lc - adding value to field $field - additional: $additional_fields - existing: $product_ref->{$field}\n";
 
 			compute_field_tags($product_ref, $lc, $field);

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -299,11 +299,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 		if (defined param($field)) {
 			$product_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));
-			if ($field eq 'emb_codes') {
-				# French emb codes
-				$product_ref->{emb_codes_orig} = $product_ref->{emb_codes};
-				$product_ref->{emb_codes} = normalize_packager_codes($product_ref->{emb_codes});
-			}
+
 			$log->debug("before compute field_tags", { code => $code, field_name => $field, field_value => $product_ref->{$field}}) if $log->is_debug();
 			if ($field =~ /ingredients_text/) {
 				# the ingredients_text_with_allergens[_$lc] will be recomputed after
@@ -666,9 +662,7 @@ JAVASCRIPT
 	}
 
 	my $value = $product_ref->{$field};
-	if (defined $product_ref->{$field . "_orig"}) {
-		$value = $product_ref->{$field . "_orig"};
-	}
+
 	if ((defined $value) and (defined $taxonomy_fields{$field})) {
 		$value = display_tags_hierarchy_taxonomy($lc, $field, $product_ref->{$field . "_hierarchy"});
 		# Remove tags

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3254,11 +3254,15 @@ sub compute_field_tags($$$) {
 
 	if (defined $tags_fields{$field}) {
 
+		my $value = $product_ref->{$field};
+
 		$product_ref->{$field . "_tags" } = [];
 		if ($field eq 'emb_codes') {
 			$product_ref->{"cities_tags" } = [];
+			$value = normalize_packager_codes($product_ref->{emb_codes});
 		}
-		foreach my $tag (split(',', $product_ref->{$field} )) {
+		
+		foreach my $tag (split(',', $value)) {
 			if (get_fileid($tag) ne '') {
 				push @{$product_ref->{$field . "_tags" }}, get_fileid($tag);
 				if ($field eq 'emb_codes') {


### PR DESCRIPTION
…#1881

We used to have an emb_codes_orig field with the original value typed by users, and a normalized value in emb_codes. It's not needed and causes problems. The normalization is now done before computing the emb_codes_tags.