### PR TITLE
Send an actual 404 status if a product does not exist

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8717,6 +8717,7 @@ sub display_product_api($)
 	my $product_ref = retrieve_product($code);
 
 	if ((not defined $product_ref) or (not defined $product_ref->{code})) {
+		$request_ref->{status} = 404;
 		$response{status} = 0;
 		$response{status_verbose} = 'product not found';
 		if ($request_ref->{jqm}) {
@@ -9016,6 +9017,11 @@ sub display_structured_response($)
 		my $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
 		. $xs->XMLout($request_ref->{structured_response}); 	# noattr -> force nested elements instead of attributes
 
+		my $status = $request_ref->{status};
+		if (defined $status) {
+			print header ( -status => $status );
+		}
+
 		print header( -type => 'text/xml', -charset => 'utf-8', -access_control_allow_origin => '*' ) . $xml;
 
 	}
@@ -9036,6 +9042,11 @@ sub display_structured_response($)
 
 		$jsonp =~ s/[^a-zA-Z0-9_]//g;
 
+		my $status = $request_ref->{status};
+		if (defined $status) {
+			print header ( -status => $status );
+		}
+
 		if (defined $jsonp) {
 			print header( -type => 'text/javascript', -charset => 'utf-8', -access_control_allow_origin => '*' ) . $jsonp . "(" . $data . ");" ;
 		}
@@ -9043,6 +9054,10 @@ sub display_structured_response($)
 			print header( -type => 'application/json', -charset => 'utf-8', -access_control_allow_origin => '*' ) . $data;
 		}
 	}
+
+	my $r = Apache2::RequestUtil->request();
+	$r->rflush;
+	$r->status(200);
 
 	exit();
 }


### PR DESCRIPTION
**Description:** Instead of sending 200, actually send 404, so that the status can be parsed using common RESTful practices. Same status trick as in #1815.
**Related issues and discussion:** Fixes #976
