### PR TITLE
Fix typo when building tags

### DIFF
--- a/scripts/build_tags_taxonomy.pl
+++ b/scripts/build_tags_taxonomy.pl
@@ -3,7 +3,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -47,27 +47,27 @@ my $file = $tagtype . ".txt";
 if (($tagtype eq "ingredients") and ($server_domain =~ /openfoodfacts|off.travis/)) {
 
 	$file = "ingredients.all.txt";
-		
+
 	open (my $OUT, ">:encoding(UTF-8)", "$data_root/taxonomies/$file") or die("Cannot write $data_root/taxonomies/$file : $!\n");
-	
+
 	foreach my $taxonomy ("additives_classes", "additives", "minerals", "vitamins", "nucleotides", "other_nutritional_substances", "ingredients") {
-	
+
 		if (open (my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/$taxonomy.txt")) {
-		
+
 			print $OUT "# $taxonomy.txt\n\n";
-			
+
 			while (<$IN>) {
 				print $OUT $_;
 			}
-			
-			print OUT "\n\n";
+
+			print $OUT "\n\n";
 			close($IN);
 		}
 		else {
 			print STDERR "Missing $data_root/taxonomies/$tagtype.txt\n";
 		}
 	}
-	
+
 	close ($OUT);
 }
 


### PR DESCRIPTION
**Description:** Replaced bare word file handle `OUT` with the used file handle `$OUT`.
**Related issues and discussion:** Fixes #1963 
