### PR TITLE
Remove ManUp.js

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6130,7 +6130,6 @@ HTML
 
 <script src="$static_subdomain/bower_components/foundation/js/foundation.min.js"></script>
 <script src="$static_subdomain/bower_components/foundation/js/vendor/jquery.cookie.js"></script>
-<script async defer src="$static_subdomain/bower_components/ManUp.js/manup.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js" integrity="sha384-222hzbb8Z8ZKe6pzP18nTSltQM3PdcAwxWKzGOKOIF+Y3bROr5n9zdQ8yTRHgQkQ" crossorigin="anonymous"></script>
 $scripts
 <script>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "win32"
   ],
   "dependencies": {
-    "@bower_components/ManUp.js": "https://github.com/boyofgreen/ManUp.js.git#*",
     "@bower_components/foundation": "zurb/bower-foundation#^5.5.3",
     "@bower_components/iolazyload": "cdowdy/io-lazyload#^1.2.0",
     "@bower_components/jquery-ui": "components/jqueryui#^1.12.1",
@@ -44,7 +43,6 @@
     "@bower_components/leaflet.markercluster": "Leaflet/Leaflet.markercluster#>=1.0.0",
     "@bower_components/osmtogeojson": "tyrasd/osmtogeojson#^2.2.12",
     "@bower_components/papaparse": "mholt/papaparse#^5.0.0",
-    "ManUp.js": "https://github.com/boyofgreen/ManUp.js.git#*",
     "components-jqueryui": "components/jqueryui#^1.12.1",
     "foundation-sites": "zurb/bower-foundation#^5.5.3",
     "iolazyload": "cdowdy/io-lazyload#^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,10 +137,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@bower_components/ManUp.js@https://github.com/boyofgreen/ManUp.js.git#*", "ManUp.js@https://github.com/boyofgreen/ManUp.js.git#*":
-  version "0.0.0"
-  resolved "https://github.com/boyofgreen/ManUp.js.git#6dae0a9799dc07a936ac817d2e886138208ff44e"
-
 "@bower_components/foundation@zurb/bower-foundation#^5.5.3", foundation-sites@zurb/bower-foundation#^5.5.3:
   version "5.5.3"
   resolved "https://codeload.github.com/zurb/bower-foundation/tar.gz/b879716aa268e1f88fe43de98db2db4487af00ca"


### PR DESCRIPTION
**Description:** The 404 requests to `/undefined` are caused by `meta` and `link` elements generated by [ManUp.js](https://github.com/boyofgreen/manUp.js) dynamically: boyofgreen/ManUp.js#7. Since all relevant browsers (including current versions of iOS) do implement the [Web App Manifest spec](https://w3c.github.io/manifest/) to a good enough extent, I believe that we simply don't need ManUp.js any more. It was really useful two years ago, but the browser landscape has improved since then.
**Related issues and discussion:** Fixes #1968