### PR TITLE
Remove bower_components

### DIFF
--- a/cgi/madenearyou.pl
+++ b/cgi/madenearyou.pl
@@ -1,22 +1,22 @@
 #!/usr/bin/perl -w
 
 # This file is part of Product Opener.
-# 
+#
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
-# 
+#
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -52,15 +52,15 @@ $lang = 'fr';
 sub display_madenearyou($) {
 
 	my $request_ref = shift;
-	
+
 	not $request_ref->{blocks_ref} and $request_ref->{blocks_ref} = [];
-	
+
 
 	my $title = $request_ref->{title};
 	my $description = $request_ref->{description};
 	my $content_ref = $request_ref->{content_ref};
 	my $blocks_ref = $request_ref->{blocks_ref};
-	
+
 
 	my $html = <<HTML
 
@@ -75,10 +75,10 @@ sub display_madenearyou($) {
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
 <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/themes/ui-lightness/jquery-ui.css" />
-<script type="text/javascript" src="/bower_components/foundation/js/vendor/jquery.cookie.js"></script>	
+<script type="text/javascript" src="/js/dist/jquery.cookie.js"></script>
 
 <script src="/js/jquery.iframe-transport.min.js"></script>
-<script src="/js/jquery.fileupload.min.js"></script>	
+<script src="/js/jquery.fileupload.min.js"></script>
 <script src="/js/load-image.min.js"></script>
 <script src="/js/canvas-to-blob.min.js"></script>
 <script src="/js/jquery.fileupload-ip.min.js"></script>
@@ -89,15 +89,15 @@ $header
 \$(function() {
 
 $initjs
-	
+
 });
 </script>
 
-<link rel="stylesheet" href="/bower_components/leaflet/dist/leaflet.css">
-<script src="/bower_components/leaflet/dist/leaflet.js"></script>
-<link rel="stylesheet" href="/bower_components/leaflet.markercluster/dist/MarkerCluster.css" />
-<link rel="stylesheet" href="/bower_components/leaflet.markercluster/dist/MarkerCluster.Default.css" />
-<script src="/bower_components/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
+<link rel="stylesheet" href="/js/dist/leaflet.css">
+<script src="/js/dist/leaflet.js"></script>
+<link rel="stylesheet" href="/js/dist/MarkerCluster.css" />
+<link rel="stylesheet" href="/js/dist/MarkerCluster.Default.css" />
+<script src="/js/dist/leaflet.markercluster.js"></script>
 
 <meta property="fb:admins" content="706410516" />
 <meta property="og:site_name" content="C'est emballé près de chez vous"/>
@@ -148,7 +148,7 @@ background: #ffffff;
 	margin-right:2em;
 }
 
-.sharebutton { float:left; padding-right:10px;padding-bottom:5px;}	
+.sharebutton { float:left; padding-right:10px;padding-bottom:5px;}
 
 a, a:visited {
 	color:blue;
@@ -177,7 +177,7 @@ font-size:48px;
 
 <link href='https://fonts.googleapis.com/css?family=Fredericka+the+Great' rel='stylesheet' type='text/css'>
 
-	
+
 </head>
 <body>
 
@@ -267,7 +267,7 @@ style="width:65px; height:63px;"></iframe></div>
         FB.init({appId: '156259644527005', status: true, cookie: true,
                  xfbml: true});
      };
-	 
+
       (function() {
         var e = document.createElement('script');
         e.type = 'text/javascript';
@@ -276,9 +276,9 @@ style="width:65px; height:63px;"></iframe></div>
         e.async = true;
         document.getElementById('fb-root').appendChild(e);
       }());
-	  
 
-    </script>	
+
+    </script>
 
 <script type="text/javascript" src="https://apis.google.com/js/plusone.js">
   {lang: 'fr'}
@@ -293,8 +293,8 @@ HTML
 ;
 
 	print header ( -expires=>'-1d', -charset=>'UTF-8');
-	
-	
+
+
 	binmode(STDOUT, ":encoding(UTF-8)");
 	print $html;
 
@@ -344,14 +344,14 @@ for (my $i = 0; $i < $tags_n ; $i++) {
 	my $tagtype = remove_tags_and_quote(decode utf8=>param("tagtype_$i"));
 	my $tag_contains = remove_tags_and_quote(decode utf8=>param("tag_contains_$i"));
 	my $tag = remove_tags_and_quote(decode utf8=>param("tag_$i"));
-		
+
 	push @search_tags, [
 		$tagtype, $tag_contains, $tag,
 	];
 }
 
 foreach my $tagtype (@search_ingredient_classes) {
-	
+
 	$search_ingredient_classes{$tagtype} = param($tagtype);
 	not defined $search_ingredient_classes{$tagtype} and $search_ingredient_classes{$tagtype} = 'indifferent';
 }
@@ -361,7 +361,7 @@ for (my $i = 0; $i < $nutriments_n ; $i++) {
 	my $nutriment = remove_tags_and_quote(decode utf8=>param("nutriment_$i"));
 	my $nutriment_compare = remove_tags_and_quote(decode utf8=>param("nutriment_compare_$i"));
 	my $nutriment_value = remove_tags_and_quote(decode utf8=>param("nutriment_value_$i"));
-		
+
 	push @search_nutriments, [
 		$nutriment, $nutriment_compare, $nutriment_value,
 	];
@@ -387,22 +387,22 @@ if ($action eq 'process') {
 	# Display the search results or construct CSV file for download
 
 	# analyze parameters and construct query
-	
+
 	my $current_link = "/cgi/search.pl?action=process";
-	
+
 	my $query_ref = {};
 
 	my $page = param('page') || 1;
 	if (($page < 1) or ($page > 1000)) {
 		$page = 1;
 	}
-	
+
 	# Search terms
-	
+
 	if ((defined $search_terms) and ($search_terms ne '')) {
-	
-		my %terms = ();	
-	
+
+		my %terms = ();
+
 		foreach my $term (split(/,|'|\s/, $search_terms)) {
 			if (length(get_fileid($term)) >= 2) {
 				$terms{normalize_search_terms(get_fileid($term))} = 1;
@@ -412,59 +412,59 @@ if ($action eq 'process') {
 			$query_ref->{_keywords} = { '$all' => [keys %terms]};
 			$current_link .= "\&search_terms=" . URI::Escape::XS::encodeURIComponent($search_terms);
 		}
-			
+
 	}
-	
+
 	# Tags criteria
-	
+
 	my $and;
-	
+
 	for (my $i = 0; $i < $tags_n ; $i++) {
-	
+
 		my ($tagtype, $contains, $tag) = @{$search_tags[$i]};
-		
+
 		if (($tagtype ne 'search_tag') and ($tag ne '')) {
-		
+
 			my $tagid = get_fileid(canonicalize_tag2($tagtype, $tag));
-			
+
 			if ($tagtype eq 'additives') {
 				$tagid =~ s/-.*//;
-			}	
-			
+			}
+
 			if ($tagid ne '') {
-			
+
 				# 2 or 3 criterias on the same field?
 				my $remove = 0;
 				if (defined $query_ref->{$tagtype . "_tags"}) {
 					$remove = 1;
 					$and = [{ $tagtype . "_tags" => $query_ref->{$tagtype . "_tags"} }];
 				}
-			
+
 				if ($contains eq 'contains') {
 					$query_ref->{$tagtype . "_tags"} = $tagid;
 				}
 				else {
 					$query_ref->{$tagtype . "_tags"} =  { '$ne' => $tagid };
 				}
-				
+
 				if ($remove) {
 					push @$and, { $tagtype . "_tags" => $query_ref->{$tagtype . "_tags"} };
 					delete $query_ref->{$tagtype . "_tags"};
 					$query_ref->{"\$and"} = $and;
 				}
-				
+
 				$current_link .= "\&tagtype_$i=$tagtype\&tag_contains_$i=$contains\&tag_$i=" . URI::Escape::XS::encodeURIComponent($tag);
-				
+
 				# TODO: 2 or 3 criterias on the same field
 				# db.foo.find( { $and: [ { a: 1 }, { a: { $gt: 5 } } ] } ) ?
 			}
 		}
-	}	
-	
+	}
+
 	# Ingredient classes
-	
+
 	foreach my $tagtype (@search_ingredient_classes) {
-	
+
 		if ($search_ingredient_classes{$tagtype} eq 'with') {
 			$query_ref->{$tagtype . "_n"}{ '$gte'} = 1;
 			$current_link .= "\&$tagtype=with";
@@ -474,15 +474,15 @@ if ($action eq 'process') {
 			$current_link .= "\&$tagtype=without";
 		}
 	}
-	
+
 	# Nutriments
-	
+
 	for (my $i = 0; $i < $nutriments_n ; $i++) {
-	
+
 		my ($nutriment, $compare, $value, $unit) = @{$search_nutriments[$i]};
-		
+
 		if (($nutriment ne 'search_nutriment') and ($value ne '')) {
-					
+
 			if ($compare eq 'eq') {
 				$query_ref->{"nutriments.${nutriment}_100g"} = $value + 0.0; # + 0.0 to force scalar to be treated as a number
 			}
@@ -493,50 +493,50 @@ if ($action eq 'process') {
 				else {
 					$query_ref->{"nutriments.${nutriment}_100g"} = { '$' . $compare  => $value + 0.0 };
 				}
-			}				
+			}
 			$current_link .= "\&nutriment_$i=$nutriment\&nutriment_compare_$i=$compare\&nutriment_value_$i=" . URI::Escape::XS::encodeURIComponent($value);
-			
+
 			# TODO support range queries: < and > on the same nutriment
 			# my $doc32 = $collection->find({'x' => { '$gte' => 2, '$lt' => 4 }});
 		}
-	}		
+	}
 
-	
+
 	my @fields = keys %tag_type_singular;
-	
+
 	foreach my $field (@fields) {
-	
+
 		next if defined $search_ingredient_classes{$field};
 
 		if ((defined param($field)) and (param($field) ne '')) {
-		
+
 			$query_ref->{$field} = decode utf8=>param($field);
 			$current_link .= "\&$field=" . URI::Escape::XS::encodeURIComponent(decode utf8=>param($field));
-		}	
+		}
 	}
-	
+
 	if (defined $sort_by) {
 		$current_link .= "&sort_by=$sort_by";
 	}
-	
+
 	$current_link .= "\&page_size=$limit";
-	
+
 	# Graphs
-	
+
 	foreach my $axis ('x','y') {
 		if (param("axis_$axis") ne '') {
 			$current_link .= "\&axis_$axis=" .  URI::Escape::XS::encodeURIComponent(decode utf8=>param("axis_$axis"));
 		}
-	}	
-	
+	}
+
 	if (param('graph_title') ne '') {
 		$current_link .= "\&graph_title=" . URI::Escape::XS::encodeURIComponent(decode utf8=>param("graph_title"));
 	}
-	
+
 	if (param('map_title') ne '') {
 		$current_link .= "\&map_title=" . URI::Escape::XS::encodeURIComponent(decode utf8=>param("map_title"));
 	}
-		
+
 	foreach my $series (@search_series) {
 
 		next if $series eq 'default';
@@ -544,24 +544,24 @@ if ($action eq 'process') {
 			$current_link .= "\&series_$series=on";
 		}
 	}
-	
+
 	$request_ref->{current_link_query} = $current_link;
-	
+
 	my $html = '';
-	
+
 	$log->info("building query", { lc => $lc, cc => $cc, query => $query_ref }) if $log->is_info();
-	
+
 	$query_ref->{lc} = $lc;
-	
+
 	# Graph, map, export or search
 
 
-	
+
 		$request_ref->{current_link_query} .= "&generate_map=1";
-		
+
 		# We want products with emb codes
-		$query_ref->{"emb_codes_tags"} = { '$exists' => 1 };	
-		
+		$query_ref->{"emb_codes_tags"} = { '$exists' => 1 };
+
 		${$request_ref->{content_ref}} .= $html . search_and_map_products($request_ref, $query_ref, $graph_ref);
 
 		$request_ref->{title} = lang("search_title_map");
@@ -569,8 +569,8 @@ if ($action eq 'process') {
 			$request_ref->{title} = $map_title . " - " . lang("search_map");
 		}
 		$request_ref->{full_width} = 1;
-		
-		
+
+
 		my $html =	<<HTML
 <div id="container" style="height: 600px"></div>
 HTML
@@ -578,5 +578,5 @@ HTML
 		$request_ref->{content_ref} = \$html;
 
 	display_madenearyou($request_ref);
-	
+
 }

--- a/cgi/top_translators.pl
+++ b/cgi/top_translators.pl
@@ -1,22 +1,22 @@
 #!/usr/bin/perl -w
 
 # This file is part of Product Opener.
-# 
+#
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
-# 
+#
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -38,7 +38,7 @@ ProductOpener::Display::init();
 
 $scripts .= <<SCRIPTS
 <script src="/js/datatables.min.js"></script>
-<script src="/bower_components/papaparse/papaparse.min.js"></script>
+<script src="/js/dist/papaparse.min.js"></script>
 SCRIPTS
 ;
 

--- a/conf/nginx/sites-available/obf
+++ b/conf/nginx/sites-available/obf
@@ -116,7 +116,7 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
-	location ~ ^/(.well-known|fonts|images|css|js|rss|files|resources|foundation|bower_components)/ {
+	location ~ ^/(.well-known|fonts|images|css|js|rss|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -154,7 +154,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(.well-known|fonts|images|css|js|rss|data|files|resources|foundation|bower_components)/ {
+	location ~ ^/(.well-known|fonts|images|css|js|rss|data|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/off-preprod
+++ b/conf/nginx/sites-available/off-preprod
@@ -87,7 +87,7 @@ server {
 	}
 
 
-	location ~ ^/(.well-known|fonts|images|css|js|rss|data|files|resources|foundation|bower_components)/ {
+	location ~ ^/(.well-known|fonts|images|css|js|rss|data|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/opf
+++ b/conf/nginx/sites-available/opf
@@ -137,7 +137,7 @@ server {
 	}
 
 
-	location ~ ^/(.well-known|fonts|images|css|js|rss|files|resources|foundation|bower_components)/ {
+	location ~ ^/(.well-known|fonts|images|css|js|rss|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/conf/nginx/sites-available/opff
+++ b/conf/nginx/sites-available/opff
@@ -137,7 +137,7 @@ server {
 	}
 
 
-	location ~ ^/(.well-known|fonts|images|css|js|rss|files|resources|foundation|bower_components)/ {
+	location ~ ^/(.well-known|fonts|images|css|js|rss|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/docker/frontend-git/conf/nginx.conf
+++ b/docker/frontend-git/conf/nginx.conf
@@ -45,7 +45,7 @@ server {
 
 	# Static files are served directly by NGINX
 
-	location ~ ^/(.well-known|fonts|images|js|css|rss|data|files|resources|foundation|bower_components)/ {
+	location ~ ^/(.well-known|fonts|images|js|css|rss|data|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { src, dest, series } = require('gulp')
+const { src, dest, series, parallel } = require('gulp')
 const sass = require('gulp-sass')
 const sourcemaps = require('gulp-sourcemaps')
 const minifyCSS = require('gulp-csso')
@@ -42,6 +42,26 @@ function css() {
     .pipe(dest('./html/css/dist'))
 }
 
+function js() {
+  return src([
+      './node_modules/foundation-sites/js/vendor/*.js',
+      './node_modules/foundation-sites/js/foundation.min.js',
+      './node_modules/jqueryui/jquery-ui.min.js',
+      './node_modules/papaparse/papaparse.min.js',
+      './node_modules/osmtogeojson/osmtogeojson.js',
+      './node_modules/leaflet/dist/**/*.*',
+      './node_modules/leaflet.markercluster/dist/**/*.*',
+      './node_modules/iolazyload/dist/js/iolazy.min.js'
+    ], { sourcemaps: true })
+    .pipe(dest('./html/js/dist', { sourcemaps: true }))
+}
+
+function jQueryUiThemes() {
+  return src('./node_modules/jqueryui/themes/base/**/*.css', { sourcemaps: true })
+    .pipe(dest('./html/css/dist/jqueryui/themes/base', { sourcemaps: true }))
+}
+
+exports.js = js
 exports.css = css
 exports.icons = icons
-exports.default = series(icons, css)
+exports.default = parallel(js, jQueryUiThemes, series(icons, css))

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3188,9 +3188,9 @@ JS
 
 	if ((scalar @map_layers) > 0) {
 		$header .= <<HTML
-	<link rel="stylesheet" href="$static_subdomain/bower_components/leaflet/dist/leaflet.css">
-	<script src="$static_subdomain/bower_components/leaflet/dist/leaflet.js"></script>
-	<script src="$static_subdomain/bower_components/osmtogeojson/osmtogeojson.js"></script>
+	<link rel="stylesheet" href="$static_subdomain/js/dist/leaflet.css">
+	<script src="$static_subdomain/js/dist/leaflet.js"></script>
+	<script src="$static_subdomain/js/dist/osmtogeojson.js"></script>
 	<script src="$static_subdomain/js/display-tag.js"></script>
 HTML
 ;
@@ -5321,11 +5321,11 @@ JS
 		if ($emb_codes > 0) {
 
 			$header .= <<HTML
-<link rel="stylesheet" href="$static_subdomain/bower_components/leaflet/dist/leaflet.css">
-<script src="$static_subdomain/bower_components/leaflet/dist/leaflet.js"></script>
-<link rel="stylesheet" href="$static_subdomain/bower_components/leaflet.markercluster/dist/MarkerCluster.css">
-<link rel="stylesheet" href="$static_subdomain/bower_components/leaflet.markercluster/dist/MarkerCluster.Default.css">
-<script src="$static_subdomain/bower_components/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
+<link rel="stylesheet" href="$static_subdomain/js/dist/leaflet.css">
+<script src="$static_subdomain/js/dist/leaflet.js"></script>
+<link rel="stylesheet" href="$static_subdomain/js/dist/MarkerCluster.css">
+<link rel="stylesheet" href="$static_subdomain/js/dist/MarkerCluster.Default.css">
+<script src="$static_subdomain/js/dist/leaflet.markercluster.js"></script>
 HTML
 ;
 
@@ -5740,7 +5740,7 @@ $og_images2
 <meta property="og:description" content="$canon_description">
 $options{favicons}
 <link rel="stylesheet" href="$static_subdomain/css/dist/app.css?v=$file_timestamps{"css/dist/app.css"}">
-<link rel="stylesheet" href="$static_subdomain/bower_components/jquery-ui/themes/base/jquery-ui.min.css">
+<link rel="stylesheet" href="$static_subdomain/css/dist/jqueryui/themes/base/jquery-ui.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css" integrity="sha384-HIipfSYbpCkh5/1V87AWAeR5SUrNiewznrUrtNz1ux4uneLhsAKzv/0FnMbj3m6g" crossorigin="anonymous">
 <link rel="search" href="$formatted_subdomain/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="$Lang{site_name}{$lang}">
 <style media="all">
@@ -6104,11 +6104,11 @@ HTML
 
 <div id="fb-root"></div>
 
-<script src="$static_subdomain/bower_components/foundation/js/vendor/modernizr.js"></script>
+<script src="$static_subdomain/js/dist/modernizr.js"></script>
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
-<script src="$static_subdomain/bower_components/iolazyload/dist/js/iolazy.min.js" defer></script>
-<script src="$static_subdomain/bower_components/foundation/js/vendor/jquery.js"></script>
-<script src="$static_subdomain/bower_components/jquery-ui/jquery-ui.min.js"></script>
+<script src="$static_subdomain/js/dist/iolazy.min.js" defer></script>
+<script src="$static_subdomain/js/dist/jquery.js"></script>
+<script src="$static_subdomain/js/dist/jquery-ui.min.js"></script>
 
 <script>
 \$(function() {
@@ -6128,8 +6128,8 @@ HTML
 });
 </script>
 
-<script src="$static_subdomain/bower_components/foundation/js/foundation.min.js"></script>
-<script src="$static_subdomain/bower_components/foundation/js/vendor/jquery.cookie.js"></script>
+<script src="$static_subdomain/js/dist/foundation.min.js"></script>
+<script src="$static_subdomain/js/dist/jquery.cookie.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js" integrity="sha384-222hzbb8Z8ZKe6pzP18nTSltQM3PdcAwxWKzGOKOIF+Y3bROr5n9zdQ8yTRHgQkQ" crossorigin="anonymous"></script>
 $scripts
 <script>
@@ -6239,7 +6239,7 @@ HTML
 
 	# Use static subdomain for images, js etc.
 	my $static = format_subdomain('static');
-	$html =~ s/(?<![a-z0-9-])(?:https?:\/\/[a-z0-9-]+\.$server_domain)?\/(images|js|foundation|bower_components)\//$static\/$1\//g;
+	$html =~ s/(?<![a-z0-9-])(?:https?:\/\/[a-z0-9-]+\.$server_domain)?\/(images|js|css)\//$static\/$1\//g;
 	# (?<![a-z0-9-]) -> negative look behind to make sure we are not matching /images in another path.
 	# e.g. https://apis.google.com/js/plusone.js or //cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-rc.2/images/select2.min.js
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "perlc": "yarn run perlc:startup && yarn run perlc:cgi",
     "perlc:startup": "perl -c -CS -Ilib lib/startup_apache2.pl",
     "perlc:cgi": "node compile_cgi.js",
-    "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), 'html/bower_components', 'junction') } catch (e) { }\" && opencollective-postinstall"
+    "postinstall": "opencollective-postinstall"
   },
   "repository": {
     "type": "git",
@@ -36,14 +36,7 @@
     "win32"
   ],
   "dependencies": {
-    "@bower_components/foundation": "zurb/bower-foundation#^5.5.3",
-    "@bower_components/iolazyload": "cdowdy/io-lazyload#^1.2.0",
-    "@bower_components/jquery-ui": "components/jqueryui#^1.12.1",
-    "@bower_components/leaflet": "Leaflet/Leaflet#>=1.5.1",
-    "@bower_components/leaflet.markercluster": "Leaflet/Leaflet.markercluster#>=1.0.0",
-    "@bower_components/osmtogeojson": "tyrasd/osmtogeojson#^2.2.12",
-    "@bower_components/papaparse": "mholt/papaparse#^5.0.0",
-    "components-jqueryui": "components/jqueryui#^1.12.1",
+    "jqueryui": "components/jqueryui#^1.12.1",
     "foundation-sites": "zurb/bower-foundation#^5.5.3",
     "iolazyload": "cdowdy/io-lazyload#^1.2.0",
     "leaflet": "Leaflet/Leaflet#>=1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,43 +137,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@bower_components/foundation@zurb/bower-foundation#^5.5.3", foundation-sites@zurb/bower-foundation#^5.5.3:
-  version "5.5.3"
-  resolved "https://codeload.github.com/zurb/bower-foundation/tar.gz/b879716aa268e1f88fe43de98db2db4487af00ca"
-
-"@bower_components/iolazyload@cdowdy/io-lazyload#^1.2.0", iolazyload@cdowdy/io-lazyload#^1.2.0:
-  version "1.1.0"
-  resolved "https://codeload.github.com/cdowdy/io-lazyload/tar.gz/e27f25f0dd58adf67b6db8a1b355e47d6001e6fc"
-
-"@bower_components/jquery-ui@components/jqueryui#^1.12.1", components-jqueryui@components/jqueryui#^1.12.1:
-  version "1.12.1"
-  resolved "https://codeload.github.com/components/jqueryui/tar.gz/44ecf3794cc56b65954cc19737234a3119d036cc"
-
-"@bower_components/leaflet.markercluster@Leaflet/Leaflet.markercluster#>=1.0.0", leaflet.markercluster@Leaflet/Leaflet.markercluster#>=1.0.0:
-  version "1.4.1"
-  resolved "https://codeload.github.com/Leaflet/Leaflet.markercluster/tar.gz/94f9815a46ba279157f4976f39360197aa90aaee"
-
-"@bower_components/leaflet@Leaflet/Leaflet#>=1.5.1", leaflet@Leaflet/Leaflet#>=1.5.1:
-  version "1.5.1"
-  resolved "https://codeload.github.com/Leaflet/Leaflet/tar.gz/2e3e0ffbe87f246eb76d86d2633ddd59b262830b"
-
-"@bower_components/osmtogeojson@tyrasd/osmtogeojson#^2.2.12", osmtogeojson@tyrasd/osmtogeojson#^2.2.12:
-  version "2.2.12"
-  resolved "https://codeload.github.com/tyrasd/osmtogeojson/tar.gz/9d04588a9776bd9d7479d4c9df0bc6b01b9fa3a5"
-  dependencies:
-    JSONStream "0.8.0"
-    concat-stream "~1.0.1"
-    geojson-numeric "0.2.0"
-    geojson-rewind "0.1.0"
-    htmlparser2 "3.5.1"
-    optimist "~0.3.5"
-    osm-polygon-features "^0.9.1"
-    xmldom "~0.1.16"
-
-"@bower_components/papaparse@mholt/papaparse#^5.0.0", papaparse@mholt/papaparse#^5.0.0:
-  version "5.0.0"
-  resolved "https://codeload.github.com/mholt/papaparse/tar.gz/1f43cb8f01201e03157339850da32c835aaaa454"
-
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"
@@ -1916,6 +1879,10 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+foundation-sites@zurb/bower-foundation#^5.5.3:
+  version "5.5.3"
+  resolved "https://codeload.github.com/zurb/bower-foundation/tar.gz/b879716aa268e1f88fe43de98db2db4487af00ca"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -2644,6 +2611,10 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+iolazyload@cdowdy/io-lazyload#^1.2.0:
+  version "1.1.0"
+  resolved "https://codeload.github.com/cdowdy/io-lazyload/tar.gz/e27f25f0dd58adf67b6db8a1b355e47d6001e6fc"
+
 is-absolute@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
@@ -2938,6 +2909,10 @@ isstream@^0.1.2, isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+jqueryui@components/jqueryui#^1.12.1:
+  version "1.12.1"
+  resolved "https://codeload.github.com/components/jqueryui/tar.gz/44ecf3794cc56b65954cc19737234a3119d036cc"
+
 js-base64@^2.1.8:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
@@ -3080,6 +3055,14 @@ lead@^1.0.0:
   integrity sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=
   dependencies:
     flush-write-stream "^1.0.2"
+
+leaflet.markercluster@Leaflet/Leaflet.markercluster#>=1.0.0:
+  version "1.4.1"
+  resolved "https://codeload.github.com/Leaflet/Leaflet.markercluster/tar.gz/94f9815a46ba279157f4976f39360197aa90aaee"
+
+leaflet@Leaflet/Leaflet#>=1.5.1:
+  version "1.5.1"
+  resolved "https://codeload.github.com/Leaflet/Leaflet/tar.gz/2e3e0ffbe87f246eb76d86d2633ddd59b262830b"
 
 leven@^3.1.0:
   version "3.1.0"
@@ -3961,6 +3944,19 @@ osm-polygon-features@^0.9.1:
   resolved "https://registry.yarnpkg.com/osm-polygon-features/-/osm-polygon-features-0.9.2.tgz#20ae41130c486e49a3b2a3c2b58a1419c4986778"
   integrity sha1-IK5BEwxIbkmjsqPCtYoUGcSYZ3g=
 
+osmtogeojson@tyrasd/osmtogeojson#^2.2.12:
+  version "2.2.12"
+  resolved "https://codeload.github.com/tyrasd/osmtogeojson/tar.gz/9d04588a9776bd9d7479d4c9df0bc6b01b9fa3a5"
+  dependencies:
+    JSONStream "0.8.0"
+    concat-stream "~1.0.1"
+    geojson-numeric "0.2.0"
+    geojson-rewind "0.1.0"
+    htmlparser2 "3.5.1"
+    optimist "~0.3.5"
+    osm-polygon-features "^0.9.1"
+    xmldom "~0.1.16"
+
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -3984,6 +3980,10 @@ pako@^1.0.0:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+
+papaparse@mholt/papaparse#^5.0.0:
+  version "5.0.0"
+  resolved "https://codeload.github.com/mholt/papaparse/tar.gz/1f43cb8f01201e03157339850da32c835aaaa454"
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
I removed the `bower_components` directory by adding some simple copy tasks to the `gulpfile.js`. This removes the need to symlink directories in the `postinstall` step and simplifies the package restore step, too. Visually and functionally, this is identical to the previous version in the `master` branch.