### PR TITLE
fix icon's line-height

### DIFF
--- a/scss/templates/_icons.scss
+++ b/scss/templates/_icons.scss
@@ -17,7 +17,8 @@
 	font-weight: normal;
 	// speak: none; // only necessary if not using the private unicode range (firstGlyph option)
 	text-decoration: none;
-	text-transform: none;
+  text-transform: none;
+  line-height: 1;
 }
 
 %<%= cssClass%> {


### PR DESCRIPTION
**Description:** Applies the same line-height to the custom icon font as Foundation Fonts did: https://github.com/zurb/foundation-icon-fonts/blob/d0cf672fb32ba3db65d0ce6bb3b6b17ed820ac36/_foundation-icons.scss#L308
**Related issues and discussion:** Fixes #1984
