### PR TITLE
new stats feature for tags, bug #2028

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1529,7 +1529,7 @@ sub display_list_of_tags($$) {
 			}
 			
 			# do not compute the tag display if we just need stats
-			next if (defined $request_ref->{stats});
+			next if ((defined $request_ref->{stats}) and ($request_ref->{stats}));
 
 			my $info = '';
 			my $css_class = '';
@@ -1679,7 +1679,7 @@ sub display_list_of_tags($$) {
 		$html .= "</tbody></table></div>";
 		
 		
-		if (defined $request_ref->{stats}) {
+		if ((defined $request_ref->{stats}) and ($request_ref->{stats})) {
 		
 			$html =~ s/<table(.*)<\/table>//is;
 		


### PR DESCRIPTION
This is a new feature to compute and display stats for tags: how many unique ones exist, and how many occurences they represent, for known tags and unknown tags (not recognized in the taxonomy).

https://fr.dev.openfoodfacts.org/editeur/scamark/ingredients&stats=1

This feature is very useful for ingredients, but it's available for all types of tags. And it can be used on subsets of products.