### PR TITLE
replace regexps by tr, alleviate regexp memory leak, bug #2053

### DIFF
--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -37,7 +37,7 @@ BEGIN
 		&retrieve
 		&unac_string_perl
 	);
-	%EXPORT_TAGS = (all => [@EXPORT_OK]);  
+	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
 use vars @EXPORT_OK ; # no 'my' keyword for these
 
@@ -77,50 +77,50 @@ sub unac_string_perl($) {
 sub get_fileid($) {
 
 	my $file = shift;
-	
+
 	if (not defined $file) {
 		return "";
 	}
-	
-	$file =~ s/œ|Œ/oe/g;
-	$file =~ s/æ|Æ/ae/g;
-	
-	$file =~ s/ß/ss/g;
-	
-	$file =~ s/ç/c/g;
-	$file =~ s/ñ/n/g;
-	
+
 	# do not lowercase UUIDs
 	# e.g.
 	# yuka.VFpGWk5hQVQrOEVUcWRvMzVETGU0czVQbTZhd2JIcU1OTXdCSWc9PQ
 	# (app)Waistline: e2e782b4-4fe8-4fd6-a27c-def46a12744c
-	if ($file !~ /^([a-z\-]+)\.([a-zA-Z0-9-]{8})([a-zA-Z0-9-]*)$/) {
+	if ($file !~ /^([a-z\-]+)\.([a-zA-Z0-9-_]{8})([a-zA-Z0-9-_]*)$/) {
 		$file = lc($file);
-		$file =~ s/\./-/g;
+		$file =~ tr/./-/;
 	}
-	
+
 	#$file = decode("UTF-16", unac_string('UTF-16',encode("UTF-16", $file)));
-	$file = unac_string_perl($file);
-	
+
+	# Remove one call to a subfunction and just inline the subfunction content
+	# $file = unac_string_perl($file);
+
+	$file =~ tr/àáâãäåçèéêëìíîïòóôõöùúûüýÿ/aaaaaaceeeeiiiiooooouuuuyy/;
+
+	$file =~ s/œ|Œ/oe/g;
+	$file =~ s/æ|Æ/ae/g;
+	$file =~ s/ß/ss/g;
+
 	# turn characters that are not letters and numbers to -
 	# except extended UTF-8 characters
 	# $file =~ s/[^a-z0-9-]/-/g;
-	
+
 	# turn special chars to -
 	$file =~ s/[\000-\037]/-/g;
-	
+
 	# zero width space
 	$file =~ s/\x{200B}/-/g;
-	
+
 	# avoid turning &quot; in -quot-
-	$file =~ s/\&(quot|lt|gt);/-/g;	
-	
+	$file =~ s/\&(quot|lt|gt);/-/g;
+
 	$file =~ s/[\s!"#\$%&'()*+,\/:;<=>?@\[\\\]^_`{\|}~¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿×ˆ˜–—‘’‚“”„†‡•…‰‹›€™\t]/-/g;
 	$file =~ s/-+/-/g;
 	$file =~ s/^-//;
 	$file =~ s/-$//;
-	
-	return $file;	
+
+	return $file;
 }
 
 
@@ -128,15 +128,15 @@ sub get_urlid($) {
 
 	my $input = shift;
 	my $file = $input;
-	
+
 	$file = get_fileid($file);
-	
+
 	if ($file =~ /[^a-zA-Z0-9-]/) {
 		$file = URI::Escape::XS::encodeURIComponent($file);
 	}
-	
+
 	$log->trace("get_urlid", { in => $input, out => $file }) if $log->is_trace();
-	
+
 	return $file;
 }
 
@@ -144,16 +144,16 @@ sub get_urlid($) {
 sub get_ascii_fileid($) {
 
 	my $file = shift;
-	
+
 	$file = get_fileid($file);
 
 	if ($file =~ /[^a-zA-Z0-9-]/) {
 		$file = "xn--" .  encode('Punycode',$file);
 	}
-	
+
 	$log->debug("get_ascii_fileid", { file => $file }) if $log->is_debug();
 
-	return $file;	
+	return $file;
 }
 
 
@@ -161,7 +161,7 @@ sub get_ascii_fileid($) {
 sub store {
 	my $file = shift @_;
 	my $ref = shift @_;
-	
+
 	return lock_store($ref, $file);
 }
 

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -96,7 +96,7 @@ sub get_fileid($) {
 	# Remove one call to a subfunction and just inline the subfunction content
 	# $file = unac_string_perl($file);
 
-	$file =~ tr/àáâãäåçèéêëìíîïòóôõöùúûüýÿ/aaaaaaceeeeiiiiooooouuuuyy/;
+	$file =~ tr/àáâãäåçèéêëìíîïñòóôõöùúûüýÿ/aaaaaaceeeeiiiinooooouuuuyy/;
 
 	$file =~ s/œ|Œ/oe/g;
 	$file =~ s/æ|Æ/ae/g;

--- a/t/store.t
+++ b/t/store.t
@@ -2,6 +2,8 @@
 
 use Modern::Perl '2012';
 
+use utf8;
+
 use Test::More;
 use Log::Any::Adapter 'TAP';
 
@@ -15,5 +17,10 @@ foreach my $test (@tests) {
 	ok( length get_urlid($test) > 0, "get_urlid(${test})" );
 	ok( length get_ascii_fileid($test) > 0, "get_ascii_fileid(${test})" );
 }
+
+is(get_fileid("Café au lait, bœuf gros sel de Guérande"), "cafe-au-lait-boeuf-gros-sel-de-guerande");
+is(get_fileid("ethic-advisor.UUID_in-MiXeD_CaSe"),"ethic-advisor.UUID-in-MiXeD-CaSe");
+is(get_fileid("àáâãäåçèéêëìíîïòóôõöùúûüýÿ"),"aaaaaaceeeeiiiiooooouuuuyy");
+is(get_fileid("Farine de blé 56g *"),"farine-de-ble-56g");
 
 done_testing();

--- a/t/store.t
+++ b/t/store.t
@@ -20,7 +20,7 @@ foreach my $test (@tests) {
 
 is(get_fileid("Café au lait, bœuf gros sel de Guérande"), "cafe-au-lait-boeuf-gros-sel-de-guerande");
 is(get_fileid("ethic-advisor.UUID_in-MiXeD_CaSe"),"ethic-advisor.UUID-in-MiXeD-CaSe");
-is(get_fileid("àáâãäåçèéêëìíîïòóôõöùúûüýÿ"),"aaaaaaceeeeiiiiooooouuuuyy");
+is(get_fileid("àáâãäåçèéêëìíîïñòóôõöùúûüýÿ"),"aaaaaaceeeeiiiinooooouuuuyy");
 is(get_fileid("Farine de blé 56g *"),"farine-de-ble-56g");
 
 done_testing();


### PR DESCRIPTION
replace a bunch of regexps by a call to tr() in get_fileid

there seem to be some kind of memory leak in those regexps (which may be fixed in perl 5.26 and up, but we have 5.24 in prod and dev).