### PR TITLE
Add an alias for "Whole Almonds" -> almonds

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -24713,7 +24713,7 @@ nl:Gepelde noten
 zh:带壳坚果
 
 <en:Nuts
-en:Almonds, Whole almonds
+en:Almonds
 de:Mandeln
 es:Almendras
 fr:Amandes
@@ -24731,6 +24731,11 @@ hu:Héjas mandula
 nl:Gepelde amandelen
 
 <en:Almonds
+en:Whole almonds
+fr:Amandes entières
+
+<en:Almonds
+en:Almond flakes, Sliced almonds
 fr:Amandes effilées
 
 <en:Almonds

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -24713,7 +24713,7 @@ nl:Gepelde noten
 zh:带壳坚果
 
 <en:Nuts
-en:Almonds
+en:Almonds, Whole almonds
 de:Mandeln
 es:Almendras
 fr:Amandes


### PR DESCRIPTION
**Checklist:**

Make sure you've done all the following (You can delete the checklist before submitting)

* [x] Code is well documented
* [x] Include unit tests for new functionality
* [x] Code passes Travis builds in your branch
* [x] If you have multiple commits please combine them into one commit by squashing them.
* [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/master/CONTRIBUTING.md)

**Description:**

A common mismatch between a product name ("Whole almonds") and a guessed category is to assume Whole Almonds are Whole Almond Puree.
This (I think is the right syntax) to add an alias.

**Related issues and discussion:** https://github.com/openfoodfacts/openfoodfacts-hungergames/issues/32
