### PR TITLE
Don't save empty edits

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -278,7 +278,7 @@ else {
 	detect_allergens_from_text($product_ref);
 	compute_carbon_footprint_from_ingredients($product_ref);
 	compute_carbon_footprint_from_meat_or_fish($product_ref);
-	
+
 	# Nutrition data
 
 	# Do not allow nutrition edits through API for data provided by producers
@@ -438,13 +438,17 @@ else {
 
 	my $time = time();
 	$comment = $comment . remove_tags_and_quote(decode utf8=>param('comment'));
-	store_product($product_ref, $comment);
+	if (store_product($product_ref, $comment)) {
+		# Notify robotoff
+		send_notification_for_product_change($product_ref, "updated");
 
-	# Notify robotoff
-	send_notification_for_product_change($product_ref, "updated");
-
-	$response{status} = 1;
-	$response{status_verbose} = 'fields saved';
+		$response{status} = 1;
+		$response{status_verbose} = 'fields saved';
+	}
+	else {
+		$response{status} = 0;
+		$response{status_verbose} = 'not modified';
+	}
 }
 
 my $data =  encode_json(\%response);


### PR DESCRIPTION
**Description:** If the computed `%diff` of the product is `undef` or empty, do not actually store the product changes on disk (neither `.sto` files, nor MongoDB). To enable reporting this to end users, `store_product` now returns `1` if the save was successful; otherwise it returns `0`.
**Related issues and discussion:** Fixes #374
