### PR TITLE
Common.pot wasn't sound, thus the issue in Crowdin

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -2414,7 +2414,7 @@ msgid "Serving size"
 msgstr ""
 
 msgctxt "serving_size_prepared"
-msgid ""
+msgid "Prepared serving size"
 msgstr ""
 
 msgctxt "serving_size_example"


### PR DESCRIPTION
Common.pot wasn't sound, thus the issue in Crowdin. This is why all changes should occur in common.pot and Crowdin should do the rest, including for French.
