### PR TITLE
Replace deprecated MongoDB::Collection::save method

### DIFF
--- a/scripts/update_all_products_from_dir_in_mongodb.pl
+++ b/scripts/update_all_products_from_dir_in_mongodb.pl
@@ -1,22 +1,22 @@
 #!/usr/bin/perl -w
 
 # This file is part of Product Opener.
-# 
+#
 # Product Opener
-# Copyright (C) 2011-2018 Association Open Food Facts
+# Copyright (C) 2011-2019 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
-# 
+#
 # Product Opener is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -103,16 +103,17 @@ my $count = $#products;
 my $i = 0;
 
 my %codes = ();
-	
+
 	print STDERR "$count products to update\n";
-	
+
+	my $products_collection = get_products_collection();
 	foreach my $code (@products) {
 
 		#next if ($code ne "4072700318675");
-		
+
 		my $path = product_path($code);
-		
-		
+
+
 		#my $product_ref = retrieve_product($code);
 		my $product_ref = retrieve("$data_root/products/$path/product.sto") or print "not defined $data_root/products/$path/product.sto\n";
 
@@ -126,44 +127,41 @@ my %codes = ();
 				delete $product_ref->{"countries.20131226"};
 			}
 			if (exists $product_ref->{"countries.20131227"}) {
-                                delete $product_ref->{"countries.20131227"};
-                        }
+				delete $product_ref->{"countries.20131227"};
+			}
 			if (exists $product_ref->{"countries.beforescanbot"}) {
-                                delete $product_ref->{"countries.beforescanbot"};
-                        }
+				delete $product_ref->{"countries.beforescanbot"};
+			}
 			if (exists $product_ref->{"traces.tags"}) {
-                                delete $product_ref->{"traces.tags"};
-                        }
+				delete $product_ref->{"traces.tags"};
+			}
 			if (exists $product_ref->{"categories.tags"}) {
-                                delete $product_ref->{"categories.tags"};
-                        }
-                        if (exists $product_ref->{"packaging.tags"}) {
-                                delete $product_ref->{"packaging.tags"};
-                        }
-                        if (exists $product_ref->{"labels.tags"}) {
-                                delete $product_ref->{"labels.tags"};
-                        }
-                        if (exists $product_ref->{"origins.tags"}) {
-                                delete $product_ref->{"origins.tags"};
-                        }
-                        if (exists $product_ref->{"brands.tags"}) {
-                                delete $product_ref->{"brands.tags"};
-                        }
+				delete $product_ref->{"categories.tags"};
+			}
+			if (exists $product_ref->{"packaging.tags"}) {
+				delete $product_ref->{"packaging.tags"};
+			}
+			if (exists $product_ref->{"labels.tags"}) {
+				delete $product_ref->{"labels.tags"};
+			}
+			if (exists $product_ref->{"origins.tags"}) {
+				delete $product_ref->{"origins.tags"};
+			}
+			if (exists $product_ref->{"brands.tags"}) {
+				delete $product_ref->{"brands.tags"};
+			}
 
-
-
-foreach my $k (keys %{$product_ref}) {
-                                $k =~ /\./ and print "$k\t";
-                        }
-
+			foreach my $k (keys %{$product_ref}) {
+				$k =~ /\./ and print "$k\t";
+			}
 
 		}
-		
+
 		if ((defined $product_ref) and ($code ne '')) {
 			next if ((defined $product_ref->{empty}) and ($product_ref->{empty} == 1));
 			next if ((defined $product_ref->{deleted}) and ($product_ref->{deleted} eq 'on'));
 			print STDERR "updating product $code -- " . $product_ref->{code} . " \n";
-			my $return = get_products_collection()->save($product_ref , { safe => 1 });		
+			my $return = $products_collection->replace_one({"_id" => $product_ref->{_id}}, $product_ref, { upsert => 1 });
 			print STDERR "return $return\n";
 			$i++;
 			$codes{$code} = 1;


### PR DESCRIPTION
The update script currently causes an error if an up-to-date version of the MongoDB driver is used:
```
\033[32m------------------ 3/ Import products -------------------\033[0m
Tags.pm - loading geofile villes-geo-france-galichon-20130208.csv
Tags.pm - loading geofile villes-geo-france-complement.csv
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: main::find_products() called too early to check prototype at /opt/product-opener/scripts/update_all_products_from_dir_in_mongodb.pl line 85.
1 products - 3900000419772
200 products to update
updating product 3900000419772 -- 3900000419772
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: # *** DEPRECATION WARNING ***
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: # The 'save' method will be removed in a future major release.
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: # Use 'replace_one' with upsert instead.
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #    MongoDB::Collection::save called at /opt/product-opener/scripts/update_all_products_from_dir_in_mongodb.pl line 166
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: # *** DEPRECATION WARNING ***
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: # The 'update' method will be removed in a future major release.
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: # Use $_, $_ or 'replace_one' instead.
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #    MongoDB::Collection::update called at /opt/perl/local/lib/perl5/x86_64-linux-thread-multi/MongoDB/Collection.pm line 1733
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: #    MongoDB::Collection::save called at /opt/product-opener/scripts/update_all_products_from_dir_in_mongodb.pl line 166
<h1>Software error:</h1>
<pre>Can't locate object method &quot;acknowledged&quot; via package &quot;MongoDB::UpdateResult&quot; at /opt/perl/local/lib/perl5/x86_64-linux-thread-multi/MongoDB/Collection.pm line 1697.
</pre>
<p>
For help, please send mail to this site's webmaster, giving this error message
and the time and date of the error.

</p>
[Mon Aug  5 20:46:22 2019] update_all_products_from_dir_in_mongodb.pl: Can't locate object method "acknowledged" via package "MongoDB::UpdateResult" at /opt/perl/local/lib/perl5/x86_64-linux-thread-multi/MongoDB/Collection.pm line 1697.
```

This can easily be avoided by using the recommended `replace_one` sub instead.