### PR TITLE
Nutriscore exempt edit

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -420,6 +420,7 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:food additives
 	en:honeys
 	en:vinegars
+	en:salts
 	en:pet-food
 	en:non-food-products
 

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -417,7 +417,7 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:coffees
 	en:teas
 	en:herbal-teas
-	en:food additives
+	en:food-additives
 	en:honeys
 	en:vinegars
 	en:salts

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -417,8 +417,7 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:coffees
 	en:teas
 	en:herbal-teas
-	fr:levure
-	fr:levures
+	en:food additives
 	en:honeys
 	en:vinegars
 	en:pet-food

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -421,6 +421,7 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:honeys
 	en:vinegars
 	en:salts
+	en:spices
 	en:pet-food
 	en:non-food-products
 


### PR DESCRIPTION
All food additives are exempt from Nutriscore. This will include yeast, gelatin and flavourings, which are mentioned explicitly the the NutriScore articles.