### PR TITLE
added plurals for Polish additives classes, bug #2177

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -6529,7 +6529,7 @@ lt:E331, E331 food additive
 lv:E331, E331 food additive
 mt:E331, E331 food additive
 nl:E331, Natriumcitraten
-pl:E331, E331 food additive
+pl:E331, E331 food additive, cytryniany sodu
 pt:E331, E331 food additive
 ro:E331, E331 food additive
 ru:E331, Натрия гидроцетрат
@@ -12971,7 +12971,7 @@ lt:E503, E503 food additive
 lv:E503, Amonija karbonāts
 mt:E503, E503 food additive
 nl:E503, Ammoniumcarbonaat
-pl:E503, Węglan amonu
+pl:E503, Węglan amonu, węglany amonu
 pt:E503, Carbonato de amônio
 ro:E503, E503 food additive
 ru:E503, Карбонаты аммония: карбонат аммония, гидрокарбонат аммония, карбонат аммония
@@ -17467,28 +17467,28 @@ vegan:en:yes
 vegetarian:en:yes
 
 
-en:E954, Saccharin and its Na, K and Ca salts, Saccharin
+en:E954, Saccharin and its salts, Saccharin, Saccharin sodium salt, saccharin sodium, sodium saccharin salt, Saccharin calcium salt, Saccharin calcium, Calcium saccharine, Saccharin potassium salt, Saccharine potassium, Potassium saccharine
 bg:E954, Захарин и неговите натриеви, калиеви и калциеви соли, Захарин
-ca:E954, Sacarina i les seves sals de sodi, potassi i calci
-cs:E954, Sacharin a jeho sodná, draselná a vápenatá sůl, Sacharin, Cukerín, Zuckerin, E 954
+ca:E954, Sacarina i les seves sals de sodi potassi i calci
+cs:E954, Sacharin a jeho sodná draselná a vápenatá sůl, Sacharin, Cukerín, Zuckerin, E 954
 da:E954, Saccharin and its na. k and ca salts, Sakkarin, Saccharin
 de:E954, Saccharin, Benzoesäuresulfimid, E 954
 el:E954, Σακχαρινες
-es:E954, Sacarina, Sacarina y sus sales de sodio, potasio y calcio, E 954
-et:E954, Sahhariin ning selle naatrium-, kaalium- ja kaltsiumsoolad
-fi:E954, Sakariini ja sen na-, k- ja ca-suolat i, Sakariini, Sakkariini
+es:E954, Sacarina, Sacarina y sus sales de sodio potasio y calcio, E 954
+et:E954, Sahhariin ning selle naatrium- kaalium- ja kaltsiumsoolad
+fi:E954, Sakariini ja sen na- k- ja ca-suolat i, Sakariini, Sakkariini
 fr:E954, Saccharine et ses sels, saccharinates, Saccharine, Saccharine de calcium, Saccharine de potassium, Saccharine de sodium, sels de Saccharine, saccharinate de calcium, saccharinate de potassium, saccharinate de sodium, Sulphimide benzoïque, Saccharine et ses sels de na, k et ca, 6155-57-3, 10332-51-1, Saccharinate, E-954, 81-07-2, 6381-91-5, C7H5NO3S, 128-44-9, 6485-34-3, Saccarine
-hu:E954, Szacharin és na-, k- és ca-sói, Szacharin
-it:E954, Saccarina e suoi sali na, k e ca, Saccarina, C7H5NO3S
-lt:E954, Sacharinas ir jo na, k ir ca druskos, Sacharinas
+hu:E954, Szacharin és na- k- és ca-sói, Szacharin
+it:E954, Saccarina e suoi sali na k e ca, Saccarina, C7H5NO3S
+lt:E954, Sacharinas ir jo na k ir ca druskos, Sacharinas
 lv:E954, Saccharin and its na. k and ca salts
 mt:E954, Saccharin and its na. k and ca salts
-nl:E954, Sacharine en het natrium-, kalium- en calciumzout daarvan, Sacharine, Saccharine
-pl:E954, Sacharyna i jej sole: sodowa, potasowa i wapniowa, Sacharyna, Sacharynian sodu
-pt:E954, — sacarina e seus sais de sódio, potássio e cálcio, Sacarina
+nl:E954, Sacharine en het natrium- kalium- en calciumzout daarvan, Sacharine, Saccharine
+pl:E954, Sacharyna i jej sole: sodowa potasowa i wapniowa, Sacharyna, Sacharynian sodu, sacharyny
+pt:E954, Sacarina e seus sais de sódio potássio e cálcio, Sacarina
 ro:E954, Saccharin and its na. k and ca salts, Zaharină
-sk:E954, — sacharín a jeho soli na k a ca
-sl:E954, Saharin in njegove natrijeve, kalijeve in kalcijeve soli, Saharin
+sk:E954, Sacharín a jeho soli na k a ca
+sl:E954, Saharin in njegove natrijeve kalijeve in kalcijeve soli, Saharin
 sv:E954, Saccharin and its na. k and ca salts, Sackarin, Sackarinat, Sackarinater, E 954
 e_number:en:954
 wikidata:en:Q191381
@@ -18338,17 +18338,17 @@ additives_classes:en: en:preservative
 vegan:en:no
 vegetarian:en:no
 
-en:E1200, Polydextrose
+en:E1200, Polydextrose, 68424-04-4
 bg:E1200, Полидекстроза
 ca:E1200, Polidextrosa
 cs:E1200, Polydextrosa
 da:E1200, Polydextrose
-de:E1200, Polydextrose, E 1200
+de:E1200, Polydextrose
 el:E1200, Πολυδεξτροζη
 es:E1200, Polidextrosa
 et:E1200, Polüdekstroos
 fi:E1200, Polydekstroosi
-fr:E1200, , Polydextrose, E 1200, 68424-04-4
+fr:E1200, Polydextrose
 hu:E1200, Polidextróz
 it:E1200, Polidestrosio
 lt:E1200, Polidekstrozė

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -21,7 +21,7 @@ lv: Skābe
 cs: Kyselina
 et: Hape
 hu: Étkezési sav
-pl: Kwas
+pl: Kwas, Kwasy
 sl: Kislina
 lt: Rūgštis
 mt: Aċidu
@@ -65,7 +65,7 @@ lv: Skābuma regulētājs
 cs: Regulátor kyselosti
 et: Happesuse regulaator
 hu: Savanyúságot szabályozó anyag
-pl: Regulator kwasowości
+pl: Regulator kwasowości, Regulatory kwasowości
 sl: Sredstvo za uravnavanje kislosti
 lt: Rūgštingumą reguliuojanti medžiaga
 mt: Regolatur tal-Aċidità
@@ -110,7 +110,7 @@ lv: Pretsalipes viela
 cs: Protispékavá látka
 et: Paakumisvastane aine
 hu: Csomósodást és lesülést gátló anyag
-pl: Substancja przeciwzbrylająca
+pl: Substancja przeciwzbrylająca, Substancje przeciwzbrylające
 sl: Sredstvo proti sprijemanju
 lt: Lipnumą reguliuojanti medžiaga
 mt: Aġent kontra t-tagħqid
@@ -154,7 +154,7 @@ lv: Putu dzēsējs
 cs: Odpěňovač
 et: Vahutamisvastane aine
 hu: Habzásgátló
-pl: Substancja przeciwpieniąca
+pl: Substancja przeciwpieniąca, Substancje przeciwpieniące
 sl: Sredstvo proti penjenju
 lt: Medžiaga nuo putojimo
 mt: Aġent kontra r-ragħwa
@@ -195,7 +195,7 @@ sv: Antioxidationsmedel
 lv: Antioksidants
 et: Antioksüdant
 hu: Antioxidáns
-pl: Przeciwutleniacz
+pl: Przeciwutleniacz, przeciwutleniacze
 sl: Antioksidant
 lt: Antioksidantas
 mt: Antiossidant
@@ -244,7 +244,7 @@ lv: Apjoma palielinātājs
 cs: Plnidlo
 et: Mahuaine
 hu: Tömegnövelő szer
-pl: Substancja wypełniająca
+pl: Substancja wypełniająca, Substancje wypełniające
 sl: Sredstvo za povečanje prostornine
 lt: Užpildas
 mt: Aġent li jżid il-volum
@@ -303,7 +303,7 @@ lv: Krāsa
 cs: Barvivo
 et: Toiduvärv
 hu: Színezék
-pl: Barwnik
+pl: Barwnik, Barwniki
 sl: Barvilo
 lt: Dažiklis
 mt: Kulur
@@ -354,7 +354,7 @@ lv: Emulgators
 cs: Emulgátor
 et: Emulgaator
 hu: Emulgeálószer
-pl: Emulgator
+pl: Emulgator, Emulgatory
 sl: Emulgator
 lt: Emulsiklis
 mt: Emulsifikant
@@ -442,7 +442,7 @@ lv: Cietinātājs
 cs: Zpevňující látka
 et: Tardaine
 hu: Szilárdítóanyag
-pl: Substancja wiążąca
+pl: Substancja wiążąca, Substancje wiążące
 sl: Utrjevalec
 lt: Kietiklis
 mt: Aġent li jissoda
@@ -486,7 +486,7 @@ lv: Garšas pastiprinātājs
 cs: Látka zvýrazňující chuť a vůni
 et: Lõhna- ja maitsetugevdaja
 hu: Ízfokozó
-pl: Wzmacniacz smaku
+pl: Wzmacniacz smaku, Wzmacniacze smaku
 sl: Ojačevalec arome
 lt: Aromato ir skonio stipriklis
 mt: Tejjieb il-ħwawar
@@ -530,7 +530,7 @@ lv: Miltu apstrādes līdzeklis
 cs: Látka zlepšující mouku
 et: Jahu parendaja
 hu: Lisztkezelő szer
-pl: Środek do przetwarzania mąki (polepszacz)
+pl: Środek do przetwarzania mąki (polepszacz), Środki do przetwarzania mąki (polepszacze)
 sl: Sredstvo za obdelavo moke
 lt: Miltų apdorojimo medžiaga
 mt: Aġent għat-trattament tad-dqiq
@@ -574,7 +574,7 @@ lv: Putu veidotājs
 cs: Pěnotvorná látka
 et: Vahustusaine
 hu: Habosítószer
-pl: Substancja pianotwórcza
+pl: Substancja pianotwórcza, Substancje pianotwórcze
 sl: Sredstvo za penjenje
 lt: Putojimą sukelianti medžiaga
 mt: Aġent li jagħmel ir-ragħwa
@@ -618,7 +618,7 @@ lv: Recinātājs
 cs: Želírující látka
 et: Želeeriv aine
 hu: Zselésítőanyag
-pl: Substancja żelująca
+pl: Substancja żelująca, Substancje żelujące
 sl: Želirno sredstvo
 lt: Stingdiklis
 mt: Aġent li jgħaqqad f’ġel
@@ -660,7 +660,7 @@ lv: Glazētājviela
 cs: Lešticí látka
 et: Glaseeraine
 hu: Fényezőanyag
-pl: Substancja glazurująca
+pl: Substancja glazurująca, Substancje glazurujące
 sl: Sredstvo za glaziranje
 lt: Glajinė medžiaga
 mt: Aġent li jagħmel l-ikel ileqq
@@ -702,7 +702,7 @@ lv: Mitrumuzturētājs
 cs: Zvlhčující látka
 et: Niiskusesäilitaja
 hu: Nedvesítőszer
-pl: Substancja utrzymująca wilgoć
+pl: Substancja utrzymująca wilgoć, Substancje utrzymujące wilgoć
 lt: Drėgmę išlaikanti medžiaga
 sk: Zvlhčovadlo
 ro: Agent de umezire
@@ -775,7 +775,7 @@ lv: Konservants
 cs: Konzervant
 et: Säilitusaine
 hu: Tartósítószer
-pl: Substancja konserwująca
+pl: Substancja konserwująca, Substancja niekonserwująca, Substancje konserwujące
 sl: Modificirani škrob
 lt: Konservantas
 mt: Preservattiv
@@ -819,7 +819,7 @@ lv: Propelents
 cs: Balicí plyn
 et: Propellent
 hu: Hajtógáz
-pl: Gaz nośny
+pl: Gaz nośny, Gazy nośne
 sl: Konzervans
 lt: Suslėgtosios dujos
 mt: Gass propellent
@@ -863,7 +863,7 @@ lv: Irdinātājs
 cs: Kypřicí látka
 et: Kergitusaine
 hu: Térfogatnövelő szer
-pl: Substancja spulchniająca
+pl: Substancja spulchniająca, Substancje spulchniające
 sl: Potisni plin
 lt: Tešlos kildymo medžiaga
 mt: Aġent li jgħolli l-ikel
@@ -951,7 +951,7 @@ lv: Stabilizētājs
 cs: Stabilizátor
 et: Stabilisaator
 hu: Stabilizátor
-pl: Stabilizator
+pl: Stabilizator, Stabilizatory
 sl: Vezivo
 lt: Stabilizatorius
 mt: Stabbilizzatur
@@ -995,7 +995,7 @@ lv: Saldinātājs
 cs: Sladidlo
 et: Magusaine
 hu: Édesítőszer
-pl: Substancja słodząca
+pl: Substancja słodząca, Substancje słodzące
 sl: Stabilizator
 lt: Saldiklis
 mt: Dolċifikant
@@ -1040,7 +1040,7 @@ lv: Biezinātājs
 cs: Zahušťovadlo
 et: Paksendaja
 hu: Sűrítőanyag
-pl: Substancja zagęszczająca
+pl: Substancja zagęszczająca, Substancje zagęszczające
 sl: Sladilo
 lt: Tirštiklis
 mt: Aġent li jgħaqqad


### PR DESCRIPTION
Additives classes are used for additives and ingredients parsing, so we need both singular and plurals, as well as synonyms used in ingredients lists.