### PR TITLE
Fix bad hashes in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRashBFBRxs2FiUqFJDLdiebA==
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
@@ -24,7 +24,7 @@
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
-    lodash "^4.5"
+    lodash "^4.17.11"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
@@ -3228,7 +3228,7 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.3.0, lodash@^4.5, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3987,7 +3987,6 @@ pako@^1.0.0:
 
 papaparse@mholt/papaparse#^5.0.1:
   version "5.0.1"
-  uid "408823330b59469c0ad214a4e0465e63bb11a783"
   resolved "https://codeload.github.com/mholt/papaparse/tar.gz/408823330b59469c0ad214a4e0465e63bb11a783"
 
 parent-module@^1.0.0:


### PR DESCRIPTION
Apparently, #2186 introduced a bad package hash: https://gist.github.com/rajo/26d634d817f2217fa15d05404965e8a4

Fixed by running `yarn install --update-checksums`