### PR TITLE
Issue/1466

### DIFF
--- a/lib/ProductOpener/SiteQuality_off.pm
+++ b/lib/ProductOpener/SiteQuality_off.pm
@@ -464,24 +464,24 @@ sub check_nutrition_data($) {
 			push @{$product_ref->{quality_tags}}, "not-comparable-nutrition-data";
 		}
 	}
+	my $is_dried_product = has_tag($product_ref, "categories", "en:dried-products-to-be-rehydrated");
 
-	if ((defined $product_ref->{no_nutrition_data}) and ($product_ref->{no_nutrition_data} eq 'on')) {
 
+	my $nutrition_data_prepared = defined $product_ref->{nutrition_data_prepared} && $product_ref->{nutrition_data_prepared} eq 'on';
+	my $no_nutrition_data = defined $product_ref->{no_nutrition_data} &&  $product_ref->{no_nutrition_data} eq 'on';
+
+	$log->debug("nutrition_data_prepared: " . $nutrition_data_prepared) if $log->debug();
+
+	if ( $no_nutrition_data ) {
 		push @{$product_ref->{quality_tags}}, "no-nutrition-data";
-	}
-
-
-	if (defined $product_ref->{nutriments}) {
-
-		if ((defined $product_ref->{nutrition_data_prepared}) and ($product_ref->{nutrition_data_prepared} eq 'on')) {
+	} else {
+		if ( $nutrition_data_prepared ) {
 			push @{$product_ref->{quality_tags}}, "nutrition-data-prepared";
 
-			if (not has_tag($product_ref, "categories", "en:dried-products-to-be-rehydrated")) {
+			if (not $is_dried_product ) {
 				push @{$product_ref->{quality_tags}}, "nutrition-data-prepared-without-category-dried-products-to-be-rehydrated";
 			}
 		}
-
-
 		if ((defined $product_ref->{nutrition_data_per}) and ($product_ref->{nutrition_data_per} eq 'serving')) {
 
 			if ((not defined $product_ref->{serving_size}) or ($product_ref->{serving_size} eq '')) {
@@ -491,15 +491,25 @@ sub check_nutrition_data($) {
 				push @{$product_ref->{quality_tags}}, "nutrition-data-per-serving-missing-serving-quantity-is-zero";
 			}
 		}
+	}
 
+	my $has_prepared_data = 0;
 
+	if (defined $product_ref->{nutriments}) {
 
 		my $nid_n = 0;
 		my $nid_zero = 0;
 
 		my $total = 0;
 
+
 		foreach my $nid (keys %{$product_ref->{nutriments}}) {
+			$log->debug("nid: " . $nid . ": " . $product_ref->{nutriments}{$nid} ) if $log->is_debug();
+
+			if ( $nid =~ /_prepared_100g$/ && $product_ref->{nutriments}{$nid} > 0) {
+				$has_prepared_data = 1;
+			}
+
 			next if $nid =~ /_/;
 
 			if (($nid !~ /energy/) and ($nid !~ /footprint/) and ($product_ref->{nutriments}{$nid . "_100g"} > 105)) {
@@ -520,7 +530,9 @@ sub check_nutrition_data($) {
 			if (($nid eq 'fat') or ($nid eq 'carbohydrates') or ($nid eq 'proteins') or ($nid eq 'salt')) {
 				$total += $product_ref->{nutriments}{$nid . "_100g"};
 			}
+
 		}
+
 
 		if ($total > 105) {
 			push @{$product_ref->{quality_tags}}, "nutrition-value-total-over-105";
@@ -558,6 +570,12 @@ sub check_nutrition_data($) {
 		if ((defined $product_ref->{nutriments}{energy}) and ($product_ref->{nutriments}{energy} > 3800)) {
 			push @{$product_ref->{quality_tags}}, 'illogically-high-energy-value';
 		}
+	}
+	$log->debug("has_prepared_data: " . $has_prepared_data) if $log->debug();
+
+	# issue 1466: Add quality facet for dehydrated products that are missing prepared values
+	if ( $is_dried_product && ( $no_nutrition_data || not( $nutrition_data_prepared && $has_prepared_data ) )  ) {
+		push @{$product_ref->{quality_tags}}, "missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated";
 	}
 }
 

--- a/t/sitequality.t
+++ b/t/sitequality.t
@@ -184,4 +184,88 @@ $product_ref = {
 ProductOpener::SiteQuality::check_quality($product_ref);
 ok( !has_tag($product_ref, 'quality', 'ingredients-over-30-percent-digits'), 'product with no ingredients text has no ingredients-over-30-percent-digits tag' ) or diag explain $product_ref;
 
+# issue 1466: Add quality facet for dehydrated products that are missing prepared values
+
+$product_ref = {
+	categories_tags => undef
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( ! has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'product without dried category with no other qualities is not flagged for issue 1466' ) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated']
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with no other qualities is flagged for issue 1466' ) or diag explain $product_ref;
+
+# positive control 1
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutrition_data_prepared => 'on',
+	nutriments => {
+		energy_prepared_100g => 5
+	}
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( ! has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with prepared data is not flagged for issue 1466' ) or diag explain $product_ref;
+
+# positive control 2
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutrition_data_prepared => 'on',
+	nutriments => {
+		energy_prepared_100g => 5,
+		fat_prepared_100g => 2.7
+	}
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( ! has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with 2 prepared data values is not flagged for issue 1466' ) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutrition_data_prepared => 'on',
+	nutriments => undef
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with undefined nutriments hash is flagged for issue 1466' ) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutrition_data_prepared => 'on',
+	nutriments => {
+		energy => 46
+	}
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with nutriments hash with unrelated data is flagged for issue 1466' ) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutriments => {
+		energy_prepared_100g => 5
+	}
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with nutrition_data_prepared off is flagged for issue 1466' ) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutrition_data_prepared => 'on',
+	nutriments => {
+		energy_prepared_100g => 5
+	},
+	no_nutrition_data => 'on'
+
+};
+ProductOpener::SiteQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'quality', 'missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with no nutrition data checked prepared data is flagged for issue 1466' ) or diag explain $product_ref;
+
 done_testing();


### PR DESCRIPTION
**Description:**

Code changes for issue 1466.

**Related issues and discussion:** #[ISSUE NUMBER]

I found a number of inconsistencies in the existing logic related to other quality tags.  They looked like bugs to me but I tried to change as little existing logic as possible except where I thought it was an obvious bug.

Below are my notes from what I encountered in the assignment of quality tags in SiteQuality_off.pm:

 

- I moved check for nutriments hash below unrelated quality logic because I thought that logic should be applied applied even if there is not hash.  I am not sure if that hash is ever undefined, even if no nutriments are filled out.
-    fixed issue that could both tag no-nutrition-data and nutrition-data-prepared* and nutrition-data-per-serving*.
-  nutrition-all-values-zero logic wrong, I didn't change anything here
-  no-nutrition-data does not clear the nutriment values in the UI, I didn't change anything here
-  per serving or prepared does not clear the other's nutrition values from the UI, I didn't change anything here