### PR TITLE
Use minideb base container image

### DIFF
--- a/docker/backend-dev/conf/Config.pm
+++ b/docker/backend-dev/conf/Config.pm
@@ -29,6 +29,7 @@ BEGIN
 	use vars       qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT = qw();
 	@EXPORT_OK = qw(
+		%string_normalization_for_lang
 		%admins
 		%moderators
 
@@ -85,6 +86,58 @@ BEGIN
 use vars @EXPORT_OK ; # no 'my' keyword for these
 
 use ProductOpener::Config2;
+
+# define the normalization applied to change a string to a tag id (in particular for taxonomies)
+# tag ids are also used in URLs.
+
+# unaccent:
+# - useful when accents are sometimes ommited (e.g. in French accents are often not present on capital letters),
+# either in print, or when typed by users.
+# - dangerous if different words (in the same context like ingredients or category names) have the same unaccented form
+# lowercase:
+# - useful when the same word appears in lowercase, with a first capital letter, or in all caps.
+
+%string_normalization_for_lang = (
+	# no_language is used for strings that are not in a specific language (e.g. user names)
+	no_language => {
+		unaccent => 1,
+		lowercase => 1,
+	},
+	# default is used for languages that do not have specified values
+	default => {
+		unaccent => 0,
+		lowercase => 1,
+	},
+	# German umlauts should not be converted (e.g. ä -> ae) as there are many conflicts
+	de => {
+		unaccent => 0,
+		lowercase => 1,
+	},
+	# French has very few actual conflicts caused by unaccenting (one counter example is "pâtes" and "pâtés")
+	# Accents or often not present in capital letters (beginning of word, or in all caps text).
+	fr => {
+		unaccent => 1,
+		lowercase => 1,
+	},
+	# Same for Spanish, Italian and Portuguese
+	es => {
+		unaccent => 1,
+		lowercase => 1,
+	},
+	it => {
+		unaccent => 1,
+		lowercase => 1,
+	},
+	pt => {
+		unaccent => 1,
+		lowercase => 1,
+	},
+	# English has very few accented words, and they are very often not accented by users or in ingredients lists etc.
+	en => {
+		unaccent => 1,
+		lowercase => 1,
+	},
+);
 
 %admins = map { $_ => 1 } qw(
 admin

--- a/docker/backend-dev/conf/apache.conf
+++ b/docker/backend-dev/conf/apache.conf
@@ -28,7 +28,7 @@ ServerName productopener.localhost
 LogLevel warn
 ScriptAlias /cgi/ "/opt/product-opener/cgi/"
 
-<Directory /opt/product-opener/lib/html>
+<Directory /opt/product-opener/html>
 Require all granted
 </Directory>
 

--- a/docker/backend-dev/conf/po-foreground.sh
+++ b/docker/backend-dev/conf/po-foreground.sh
@@ -37,8 +37,8 @@ then
 fi
 
 perl -I/opt/product-opener/lib -I/opt/perl/local/lib/perl5 /opt/product-opener/scripts/build_lang.pl
-chown -R apache:apache /mnt/podata
-chown -R apache:apache /opt/product-opener/html/images/products
+chown -R www-data:www-data /mnt/podata
+chown -R www-data:www-data /opt/product-opener/html/images/products
 
 # https://github.com/docker-library/httpd/blob/75e85910d1d9954ea0709960c61517376fc9b254/2.4/alpine/httpd-foreground
 set -e
@@ -46,4 +46,4 @@ set -e
 # Apache gets grumpy about PID files pre-existing
 rm -f /usr/local/apache2/logs/httpd.pid
 
-exec httpd -DFOREGROUND
+exec apache2ctl -DFOREGROUND

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,96 +1,55 @@
-ARG ALPINE_VERSION=3.10.1
-# mod_perl is only available in Alpine edge as a @testing package.
-# Unfortunately, as the edge version can have another version of Perl
-# than the stable version of Alpine Linux. In that case, mod_perl won't load.
-# To work around this, we compile mod_perl on our own. This should be removed once
-# apache2-mod-perl-dev gets moved to the community or the main repository.
-FROM alpine:${ALPINE_VERSION} AS build_modperl
-RUN set -x \
-  && apk --no-cache add alpine-sdk coreutils cmake \
-  && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
-  && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
-  && mkdir /packages \
-  && chown builder:abuild /packages
-USER builder
-RUN set -x \
-   && cd /packages \
-   # depth=1000 was chosen arbitarily. Increase if build fails.
-   && git clone --depth=10000 https://git.alpinelinux.org/aports \
-   && cd aports/testing/apache2-mod-perl \
-   && abuild-keygen -a -i \
-   && abuild -R \
-   && echo $(sed -E -n 's/^pkgver=(.+)$/\1/p' /packages/aports/testing/apache2-mod-perl/APKBUILD)-r$(sed -E -n 's/^pkgrel=(.+)$/\1/p' /packages/aports/testing/apache2-mod-perl/APKBUILD) > /home/builder/packages/testing/x86_64/ver.txt
-
-# Base stage that adds the Perl runtime and some build utilities to httpd:alpine
-FROM alpine:${ALPINE_VERSION} AS modperl
-
-COPY --from=build_modperl /home/builder/packages/testing/x86_64 /packages
-RUN set -x \
-    && echo -e '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main\n@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community\n@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
-    && apk -U add --no-cache tzdata git curl wget perl perl-dev openssl openssl-dev make gcc libc-dev zlib-dev \
-    && apk add /packages/apache2-mod-perl-$(cat /packages/ver.txt).apk --allow-untrusted \
-    && rm -rf /var/cache/apk/* /packages/
+FROM bitnami/minideb:buster AS modperl
 
 # Install cpm to install cpanfile dependencies
-RUN curl -o- -L --compressed https://git.io/cpm | perl - install App::cpm -g && rm -rf ~/.perl-cpm
-
-# Stage that just adds some runtime packages that will be used in the runnable stage and the builder stage
-FROM modperl AS alpinemodperl
-
 RUN set -x \
-	  && apk --update --no-cache add \
-    imagemagick6 \
+    && install_packages \
+    apache2 \
+    apt-utils \
+    cpanminus \
+    g++ \
+    gcc \
+    libapache2-mod-perl2 \
+    # libexpat1-dev \
+    make \
+    wget \
+    imagemagick \
 		graphviz \
 		tesseract-ocr \
-    imagemagick \
-		zbar@testing
+    # perlmagick \
+    # Packages from ./cpanfile
+    libwww-perl \
+    libimage-magick-perl \
+    libxml-encoding-perl  \
+    libtext-unaccent-perl \
+    libmime-lite-perl \
+    libcache-memcached-fast-perl \
+    libjson-pp-perl \
+    libclone-perl \
+    libcrypt-passwdmd5-perl \
+    libencode-detect-perl \
+    libgraphics-color-perl \
+    libbarcode-zbar-perl \
+    libxml-feedpp-perl \
+    liburi-find-perl \
+    libxml-simple-perl \
+    libexperimental-perl \
+    libapache2-request-perl \
+    libdigest-md5-perl \
+    libtime-local-perl
 
 # Stage for installing/compiling cpanfile dependencies
-FROM alpinemodperl AS builder
-
-COPY --from=build_modperl /home/builder/packages/testing/x86_64 /packages
-RUN apk --update --no-cache add \
-		alpine-sdk \
-		imagemagick6 \
-		imagemagick6-dev \
-		graphviz \
-		graphviz-dev \
-		tesseract-ocr \
-		tesseract-ocr-dev \
-    imagemagick \
-		zbar@testing \
-		zbar-dev@testing \
-    apache2-dev \
-    && apk add /packages/apache2-mod-perl-dev-$(cat /packages/ver.txt).apk --allow-untrusted \
-    # Add ZBar perl module from git: https://rt.cpan.org/Ticket/Display.html?id=128085
-    && wget https://github.com/mchehab/zbar/archive/0.22.2.tar.gz \
-    && tar xfz 0.22.2.tar.gz \
-    && rm 0.22.2.tar.gz \
-    && cd zbar-0.22.2/perl \
-    && perl Makefile.PL \
-    && ln -s MYMETA.yml META.yml \
-    && cpm install -L /tmp/local . \
-    && cd ../.. \
-    && rm -rf zbar-0.22.2
+FROM modperl AS builder
 
 WORKDIR /tmp
-
-# Dependency of libapreq2-2.13, which is not installed automatically.
-RUN cpm install ExtUtils::XSBuilder::ParseSource
 
 # Install Product Opener from the workdir.
 COPY ./cpanfile /tmp/cpanfile
 
 # Add ProductOpener runtime dependencies from cpan
-RUN cpm install --without-test
-
-# Separate stage/layer that can be used to run unit tests
-FROM builder AS tester
-
-RUN cpm install --with-test
+RUN cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps .
 
 # Helper stage, so that we don't try to install GeoIP upon every rebuild of the source
-FROM alpinemodperl AS alpinemodperlgeoip
+FROM modperl AS modperlgeoip
 
 ADD https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz /tmp/GeoLite2-Country.tar.gz
 RUN set -x \
@@ -102,7 +61,7 @@ RUN set -x \
   && mkdir -p /usr/local/apache2/conf/sites-enabled \
   && echo 'IncludeOptional conf/sites-enabled/*.conf' >> /usr/local/apache2/conf/httpd.conf
 
-FROM alpinemodperlgeoip AS runnable
+FROM modperlgeoip AS runnable
 
 # Copy Perl libraries from the builder image
 COPY --from=builder /tmp/local/ /opt/perl/local/

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION=3.9.4
+ARG ALPINE_VERSION=3.10.1
 # mod_perl is only available in Alpine edge as a @testing package.
 # Unfortunately, as the edge version can have another version of Perl
 # than the stable version of Alpine Linux. In that case, mod_perl won't load.

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -58,8 +58,7 @@ RUN set -x \
   && rm /tmp/GeoLite2-Country.tar.gz \
   && mv /usr/local/share/GeoLite2-Country_* /usr/local/share/GeoLite2-Country \
   # Prepare Apache to include our custom config
-  && mkdir -p /usr/local/apache2/conf/sites-enabled \
-  && echo 'IncludeOptional conf/sites-enabled/*.conf' >> /usr/local/apache2/conf/httpd.conf
+  && rm /etc/apache2/sites-enabled/000-default.conf
 
 FROM modperlgeoip AS runnable
 

--- a/docker/build_yarn.bat
+++ b/docker/build_yarn.bat
@@ -1,2 +1,2 @@
-docker run --rm -it -v node_modules:/mnt/node_modules -v %~dp0../:/mnt -w /mnt node:12.7.0-alpine yarn install
-docker run --rm -it -v node_modules:/mnt/node_modules -v %~dp0../:/mnt -w /mnt node:12.7.0-alpine yarn run build
+docker run --rm -it -v node_modules:/mnt/node_modules -v %~dp0../:/mnt -w /mnt node:12.9.0-alpine yarn install
+docker run --rm -it -v node_modules:/mnt/node_modules -v %~dp0../:/mnt -w /mnt node:12.9.0-alpine yarn run build

--- a/docker/build_yarn.sh
+++ b/docker/build_yarn.sh
@@ -1,2 +1,2 @@
-docker run --rm -it -v node_modules:/mnt/node_modules -v ../:/mnt -w /mnt node:12.7.0-alpine yarn install
-docker run --rm -it -v node_modules:/mnt/node_modules -v ../:/mnt -w /mnt node:12.7.0-alpine yarn run build
+docker run --rm -it -v node_modules:/mnt/node_modules -v ../:/mnt -w /mnt node:12.9.0-alpine yarn install
+docker run --rm -it -v node_modules:/mnt/node_modules -v ../:/mnt -w /mnt node:12.9.0-alpine yarn run build

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
         source: ./backend-dev/scripts/
         target: /opt/scripts/
   frontend:
-    image: nginx:1.17.2-alpine
+    image: nginx:1.17.3-alpine
     volumes:
       - type: bind
         source: ../

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 ﻿version: "3.7"
 services:
   mongodb:
-    image: mongo:4.0.11
+    image: mongo:4.0.12
     volumes:
       - dbdata:/var/lib/mongodb
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
         target: /mnt/podata/log.conf
       - type: bind
         source: ./backend-dev/conf/apache.conf
-        target: /etc/apache2/conf.d/product-opener.conf
+        target: /etc/apache2/sites-enabled/product-opener.conf
       - type: bind
         source: ./backend-dev/conf/po-foreground.sh
         target: /usr/local/bin/po-foreground.sh

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.7.0-alpine as builder
+FROM node:12.8.1-alpine as builder
 
 # Install Product Opener from the workdir.
 COPY . /opt/product-opener/
@@ -10,6 +10,6 @@ RUN yarn install
 # Run gulp
 RUN yarn run build
 
-FROM nginx:1.17.2-alpine
+FROM nginx:1.17.3-alpine
 WORKDIR /opt/product-opener
 COPY --from=builder /opt/product-opener/html/ /opt/product-opener/html/

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.8.1-alpine as builder
+FROM node:12.9.0-alpine as builder
 
 # Install Product Opener from the workdir.
 COPY . /opt/product-opener/

--- a/docker/productopener/templates/backend-conf.yaml
+++ b/docker/productopener/templates/backend-conf.yaml
@@ -53,7 +53,8 @@ data:
     	use vars       qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
     	@EXPORT = qw();
     	@EXPORT_OK = qw(
-    		%admins
+    		%string_normalization_for_lang
+        %admins
     		%moderators
 
     		$server_domain
@@ -111,6 +112,58 @@ data:
     use vars @EXPORT_OK ; # no 'my' keyword for these
 
     use ProductOpener::Config2;
+
+    # define the normalization applied to change a string to a tag id (in particular for taxonomies)
+    # tag ids are also used in URLs.
+
+    # unaccent:
+    # - useful when accents are sometimes ommited (e.g. in French accents are often not present on capital letters),
+    # either in print, or when typed by users.
+    # - dangerous if different words (in the same context like ingredients or category names) have the same unaccented form
+    # lowercase:
+    # - useful when the same word appears in lowercase, with a first capital letter, or in all caps.
+
+    %string_normalization_for_lang = (
+      # no_language is used for strings that are not in a specific language (e.g. user names)
+      no_language => {
+        unaccent => 1,
+        lowercase => 1,
+      },
+      # default is used for languages that do not have specified values
+      default => {
+        unaccent => 0,
+        lowercase => 1,
+      },
+      # German umlauts should not be converted (e.g. ä -> ae) as there are many conflicts
+      de => {
+        unaccent => 0,
+        lowercase => 1,
+      },
+      # French has very few actual conflicts caused by unaccenting (one counter example is "pâtes" and "pâtés")
+      # Accents or often not present in capital letters (beginning of word, or in all caps text).
+      fr => {
+        unaccent => 1,
+        lowercase => 1,
+      },
+      # Same for Spanish, Italian and Portuguese
+      es => {
+        unaccent => 1,
+        lowercase => 1,
+      },
+      it => {
+        unaccent => 1,
+        lowercase => 1,
+      },
+      pt => {
+        unaccent => 1,
+        lowercase => 1,
+      },
+      # English has very few accented words, and they are very often not accented by users or in ingredients lists etc.
+      en => {
+        unaccent => 1,
+        lowercase => 1,
+      },
+    );
 
     %admins = map { $_ => 1 } qw(
     admin

--- a/docker/productopener/templates/backend-deployment.yaml
+++ b/docker/productopener/templates/backend-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           command: ['sh', '-c', 'mkdir -p /mnt/podata/products && mkdir -p /mnt/podata/logs && mkdir -p /mnt/podata/users && ln -sf /opt/product-opener/lang /mnt/podata/lang && ln -sf /opt/product-opener/po /mnt/podata/po && ln -sf /opt/product-opener/po/openfoodfacts /opt/product-opener/po/site-specific && ln -sf /opt/product-opener/taxonomies /mnt/podata/taxonomies && ln -sf /opt/product-opener/ingredients /mnt/podata/ingredients && ln -sf /opt/product-opener/emb_codes /mnt/podata/emb_codes && cp /opt/product-opener/log.conf /mnt/podata/log.conf && chown -R daemon:daemon /mnt/podata && chown -R daemon:daemon /opt/product-opener/html/images/products && perl -I/opt/product-opener/lib -I/opt/perl/local/lib/perl5 /opt/product-opener/scripts/build_lang.pl']
           volumeMounts:
             - name: {{ include "productopener.backend.fullname" . }}-config
-              mountPath: "/usr/local/apache2/conf/sites-enabled/product-opener.conf"
+              mountPath: "/etc/apache2/sites-enabled/product-opener.conf"
               subPath: apache.conf
             - name: {{ include "productopener.backend.fullname" . }}-config
               mountPath: "/opt/product-opener/lib/ProductOpener/Config.pm"
@@ -54,7 +54,7 @@ spec:
               name: http
           volumeMounts:
             - name: {{ include "productopener.backend.fullname" . }}-config
-              mountPath: "/usr/local/apache2/conf/sites-enabled/product-opener.conf"
+              mountPath: "/etc/apache2/sites-enabled/product-opener.conf"
               subPath: apache.conf
             - name: {{ include "productopener.backend.fullname" . }}-config
               mountPath: "/opt/product-opener/lib/ProductOpener/Config.pm"


### PR DESCRIPTION
Instead of using Alpine Linux as the base image for our backend container image, we now use [bitnami/minideb](https://hub.docker.com/r/bitnami/minideb). The alpine based image is smaller and can be faster, but as we had to mix stable and edge packages to get apache2's mod_perl, it broke down too easily.

Also contains:
- fix: New `%ProductOpener::Config::string_normalization_for_lang` option had not been added, yet.
- build: Updates to 3rd party container images.