### PR TITLE
fix nova issue #2230, set a null unit for nova group + add test

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -3098,6 +3098,7 @@ sub mmoll_to_unit {
 		nl => "Cafeïne",
 		nl_be => "Cafeïne",
 		pt => "Cafeína",
+
 		unit => "mg",
 	},
 	taurine => {
@@ -3252,6 +3253,11 @@ sub mmoll_to_unit {
 		en => "Nutrition score - France",
 		nl => "Voedingsscore - FR",
 		el => "Βαθμολογία θρεπτικής αξίας-FR",
+		unit => "",
+	},
+	"nova-group" => {
+		en => "NOVA group",
+		fr => "Groupe NOVA",
 		unit => "",
 	},
 	"beta-carotene" => {

--- a/t/food.t
+++ b/t/food.t
@@ -283,5 +283,32 @@ my $expected_product_ref = {
 
 is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
+$product_ref = {
+	nutriments => { "nova-group" => 4, "nova-group_100g" => 4, "nova-group_serving" => 4},
+	nutrition_data_per => "serving",
+	quantity => "100 g",
+	serving_size => "25 g",
+};
+
+compute_serving_size_data($product_ref);
+
+my $expected_product_ref = 
+ {
+    'nutriments' => {
+      'nova-group' => 4,
+      'nova-group_100g' => 4,
+      'nova-group_serving' => 4
+    },
+    'nutrition_data_per' => 'serving',
+    'nutrition_data_prepared_per' => '100g',
+    'product_quantity' => 100,
+    'quantity' => '100 g',
+    'serving_quantity' => 25,
+    'serving_size' => '25 g'
+  }
+
+ ;
+
+is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
 done_testing();


### PR DESCRIPTION
We were missing a unit (which is null) for the nova group, so it got multiplied / divided in the nutriments hash.