### PR TITLE
add plurals of additives (de)

### DIFF
--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -72,7 +72,7 @@ mt: Regolatur tal-Aċidità
 sk: Regulátor kyslosti
 ro: Corector de aciditate
 bg: Регулатор на киселинност
-de: Säureregulator
+de: Säureregulator, Säureregulatoren
 wikidata:en:Q898753
 description:en:Acidity regulators are substances which alter or control the acidity or alkalinity of a foodstuff.
 description:cs:Regulátory kyselosti se rozumějí látky, které mění nebo řídí kyselost nebo alkalitu potraviny.
@@ -96,7 +96,7 @@ description:sv:Surhetsreglerande medel: ämnen som förändrar eller styr ett li
 
 en: Anti-caking agent, anticaking agent, anti-stick agent, drying agent, dusting agent
 ga: Oibreán frithstolptha
-de: Rieselhilfe, Antiagglomerationsmittel
+de: Rieselhilfe, Antiagglomerationsmittel, Rieselhilfen
 da: Antiklumpningsmiddel
 el: Αντισυσσωματωτικό
 es: Antiaglomerante, antiaglutinante, agente antiadherente, agente antiaglutinante, angente de empolvo, agente de sacado
@@ -184,7 +184,7 @@ description:sv:Skumdämpningsmedel: ämnen som förhindrar eller minskar skumbil
 
 en: Antioxidant, antibrowning agent, antioxidany synergist
 ga: Frithocsaídeoir
-de: Antioxidant, Antioxidations-mittel, Antioxidationsmittel
+de: Antioxidant, Antioxidations-mittel, Antioxidationsmittel, Antioxidantien, Antioxidanzien
 el: Αντιοξειδωτικό
 es: Antioxidante, antipardeamiento, sinérgicos de antioxidantes
 fi: Hapettumisenestoaine
@@ -230,7 +230,7 @@ description:fr:Additif alimentaire utilisé pour décolorer des denrées aliment
 
 en: Bulking agent, filler
 ga: Toirteoir
-de: Füllstoff
+de: Füllstoff, Füllstoffe
 da: Fyldemiddel
 el: Διογκωτικό
 es: Agente de carga, Incrementador de volumen, agente de relleno, incrementadores del volumen
@@ -289,7 +289,7 @@ description:fr:Additif alimentaire utilisé pour dissoudre, diluer, disperser ou
 
 en: Colour, color, colouring, coloring, decorative pigment, surface colorant
 ga: Dath
-de: Farbstoff
+de: Farbstoff, Farbstoffe
 da: Farve
 el: Χρωστική ουσία
 es: Colorante, color, colorante de superficie, pigmentos de coloración y decoración, pigmentos de coloración, pigmentos de decoración
@@ -340,7 +340,7 @@ description:fr:Additif alimentaire qui stabilise, retient ou intensifie la coule
 
 en: Emulsifier, clouding agent, crystallization inhibitor, density adjustment agent, dispersing agent, plasticizer, surface active agent, suspension agent
 ga: Eiblitheoir
-de: Emulgator
+de: Emulgator, Emulgatoren
 da: Emulgator
 el: Γαλακτωματοποιητής
 es: Emulgente, Emulsificante, emulsionante, agente dispersante, agente enturbiador, agentes enturbiadores, agente tensoactivo, corrector de la densidad, estabilizadores de una suspensión, estabilizador de una suspensión, inhibidor de la cristalización, plastificante
@@ -384,7 +384,7 @@ description:sv:Emulgeringsmedel: ämnen som gör det möjligt att skapa eller bi
 
 en: Emulsifying salts, emulsifying salt synergist, melding salt
 ga: Salainn eiblithe
-de: Schmelzsalze
+de: Schmelzsalze, Schmelzsalz
 da: Smeltesalt
 el: Γαλακτωματοποιητικά άλατα
 es: Sales fundentes, Sales emulsionantes, sales de mezcla, sinergista de sal emulsionante, sales de fundido
@@ -730,7 +730,7 @@ description:sv:Fuktighetsbevarande medel: ämnen som förhindrar uttorkning av l
 
 en: Modified starch
 ga: Stáirse modhnaithe
-de: Modifizierte Stärke
+de: Modifizierte Stärke, Modifizierte Stärken
 da: Fugtighedsbevarende middel
 el: Τροποποιημένο άμυλο
 es: Almidón modificado
@@ -761,7 +761,7 @@ description:fr:Additif alimentaire gazeux, qui est introduit dans un conteneur p
 
 en: Preservative, antimicrobial preservative, antimicrobial synergist, antimould and antirope agent, antimycotic agent, bacteriophage control agent, fungistatic agent
 ga: Leasaitheach
-de: Konservierungsstoff
+de: Konservierungsstoff, Konservierungsstoffe
 da: Modificeret stivelse
 el: Συντηρητικό
 es: Conservante, Conservador, agente conservador, agente antimicótico, agente de control de bacteriófagos, agente fungistático, agentes inhibidores de mohos y hongos filamentosos, conservadores antimicrobianos, conservador antimicrobiano, sustancias conservadoras, sustancia conservadora, conservadores
@@ -937,7 +937,7 @@ description:sv:Komplexbildare: ämnen som bildar kemiska komplex med metalljoner
 
 en: Stabiliser, stabilizer, binder, colloidal stabilizer, emulsion stabilizer, foam stabilizer, stabilizer synergist
 ga: Cobhsaitheoir
-de: Stabilisator
+de: Stabilisator, Stabilisatoren
 da: Kompleksdannere
 el: Σταθεροποιητής
 es: Estabilizador, estabilizadores, estabilizadores coloidales, estabilizadores de emulsión, estabilizadores de espuma, estabilizador coloidal, estabilizador de emulsión, estabilizador de espuma, sinergistas estabilizadores, estabilizante, estabilizantes


### PR DESCRIPTION
**Description:**

Added plurals for some additives in german

**Related issues and discussion:** #2231

stephane in Slack:

Could someone add the German plurals of additives classes in this file https://github.com/openfoodfacts/openfoodfacts-server/blob/master/taxonomies/additives_classes.txt ? e.g. Säureregulator -> Säureregulator, Säureregulatoren
This helps a lot to correctly parse ingredients, to recognize additives, compute NOVA etc.
