### PR TITLE
Corrections to categories.txt in "taxonomies"

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -33334,6 +33334,7 @@ de:vegetarische Nudelsalate
 fr:Salades de pâtes végétariennes
 nl:Vegetarische pasta salades
 
+<en:Pies
 en:Two-crust Pies, 2 crust pies
 fr:Tourtes, Tourte
 nl:Pies, pie

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -18957,6 +18957,7 @@ de:Kokosnussbälle mit Schokoladenüberzug
 es:Bolitas de coco recubiertas de chocolate
 fr:Boules de noix de coco enrobées de chocolat
 
+<en:Confectioneries
 en:Dragées
 de:Dragées, Dragees
 es:Grageados

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -39674,7 +39674,6 @@ es:Corazones de alcachofas
 fr:Coeurs d'artichauts, Fonds d'artichauts
 nl:Artisjokharten
 
-
 <en:Vegetable rods
 en:Asparagus
 de:Spargel
@@ -39682,6 +39681,10 @@ es:Espárragos, Espárragos frescos
 fr:Asperges, asperge, Asperges fraîches
 la:Asparagus officinalis
 nl:Asperges
+
+<en:Asparagus
+en:Miniature asparagus
+fr:Asperges miniatures
 
 <en:Asparagus
 en:Green asparagus


### PR DESCRIPTION
**Description**
Made minor changes to _taxonomies/categories.txt_ to improve the hierachy and help with api usage and searching.

**Issues resolved :**
1. Changed "en:Whole tunas" to be a sub-category of Tunas and Fishes

Causes some items to be categorized as "whole tuna" without being categorized as "Tuna" or "fish".

Example: https://world.openfoodfacts.org/product/3250392332808/odyssee-thon-entier-au-naturel-112-g-net-egoutte-odysee-intermarche

2. Added Dragées as a sub-category of Confectioneries

For similar reasons

3. Added "Two-crust Pies, 2 crust pies" as a sub-category of "Pies"

For similar reason as above 
