### PR TITLE
Add rapeseed as an ingredient of it's own

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -17140,7 +17140,7 @@ from_palm_oil:en:no
 en:colza oil
 bg:рапично олио
 cs:řepkový olej
-de:Rapsöl, Raps
+de:Rapsöl
 el:κραμβέλαιο
 es:aceite de colza, aceite de nabina
 fi:rapsiöljy, rypsiöljy
@@ -41889,6 +41889,15 @@ wikidata:en:Q2963415
 wikipedia:fr:https://fr.wikipedia.org/wiki/Chicorée_frisée
 # ingredient/fr:frisée has 158 products in 4 languages @2019-05-10
 
+<en:root vegetable
+en:Rapeseed, rape, oilseed rape
+de:Raps
+la:Brassica napus
+wikidata:en:Q177932
+wikipedia:en:https://en.wikipedia.org/wiki/Rapeseed
+
+<en:Rapeseed
+en:Canola
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #


### PR DESCRIPTION
de:Raps (en:Rapeseed) could be used as an ingredient of it's own and isn't required to be used as an oil.

To be fair, this mostly applies to [Open Pet Food Facts](https://world.openpetfoodfacts.org/).