### PR TITLE
Issue 2296/nutriscore : colza / walnut / olive oils are now considered as fruits/vegetable/nuts

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -3200,8 +3200,8 @@ sub mmoll_to_unit {
 		unit => "mmol/l",
 	},
 	"fruits-vegetables-nuts" => {
-		en => "Fruits, vegetables and nuts",
-		fr => "Fruits, légumes et noix",
+		en => "Fruits, vegetables, nuts and rapeseed, walnut and olive oils",
+		fr => "Fruits, légumes, noix et huiles de colza, noix et olive",
 		es => "Frutas, verduras y nueces",
 		el => "Φρούτα, λαχανικά, καρποί",
 		nl => "Fruit, groenten en noten",
@@ -3216,8 +3216,8 @@ sub mmoll_to_unit {
 	},
 
 	"fruits-vegetables-nuts-estimate" => {
-		en => "Fruits, vegetables and nuts (estimate from ingredients list)",
-		fr => "Fruits, légumes et noix (estimation avec la liste des ingrédients)",
+		en => "Fruits, vegetables, nuts and rapeseed, walnut and olive oils (estimate from ingredients list)",
+		fr => "Fruits, légumes, noix et huiles de colza, noix et olive (estimation avec la liste des ingrédients)",
 		es => "Frutas, verduras y nueces (estimación de la lista de ingredientes)",
 		nl => "Fruit, groenten en noten (Schat uit ingrediëntenlijst)",
 		nl_be => "Fruit, groenten en noten (Schat uit ingrediëntenlijst)",
@@ -3906,6 +3906,13 @@ my %fruits_vegetables_nuts_by_category = (
 	"en:jams" => 50,
 	"en:fruits-based-foods" => 85,
 	"en:vegetables-based-foods" => 85,
+	# 2019/08/31: olive oil, walnut oil and colza oil are now considered in the same fruits, vegetables and nuts category
+	"en:olive-oils" => 100,
+	"en:walnut-oils" => 100,
+	# adding multiple wordings for colza/rapeseed oil in case we change it at some point
+	"en:colza-oils" => 100,
+	"en:rapeseed-oils" => 100,
+	"en:rapeseeds-oils" => 100,
 );
 
 my @fruits_vegetables_nuts_by_category_sorted = sort { $fruits_vegetables_nuts_by_category{$b} <=> $fruits_vegetables_nuts_by_category{$a} } keys %fruits_vegetables_nuts_by_category;

--- a/t/nutriscore.t
+++ b/t/nutriscore.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Number::Delta relative => 1.001;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::Tags qw/:all/;
+use ProductOpener::Food qw/:all/;
+
+
+my @tests = (
+
+[{ lc=>"en", categories=>"cookies", nutriments=>{energy_100g=>3460, fat_100g=>90, "saturated-fat_100g"=>15, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 20, "e"],
+[{ lc=>"en", categories=>"olive oils", nutriments=>{energy_100g=>3460, fat_100g=>92, "saturated-fat_100g"=>14, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 6, "c"],
+[{ lc=>"en", categories=>"colza oils", nutriments=>{energy_100g=>3760, fat_100g=>100, "saturated-fat_100g"=>7, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 5, "c"],
+[{ lc=>"en", categories=>"walnut oils", nutriments=>{energy_100g=>3378, fat_100g=>100, "saturated-fat_100g"=>10, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 6, "c"],
+[{ lc=>"en", categories=>"sunflower oils", nutriments=>{energy_100g=>3378, fat_100g=>100, "saturated-fat_100g"=>10, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 11, "d"],
+
+);
+
+foreach my $test_ref (@tests) {
+
+	my $product_ref = $test_ref->[0];
+	compute_field_tags($product_ref, $product_ref->{lc}, "categories");
+	special_process_product($product_ref);
+	compute_nutrition_score($product_ref);
+
+	is($product_ref->{nutrition_grade_fr}, $test_ref->[2]);
+	is($product_ref->{nutriments}{"nutrition-score-fr"}, $test_ref->[1]) or diag explain $product_ref;
+
+}
+
+
+done_testing();


### PR DESCRIPTION
Added a 100% estimate of fruits/vegetables/nuts for products in the colza / walnut / olive oils category.

+ tests.

Olive oils and Walnut oils are now C instead of D.