### PR TITLE
fix for issue #2010: continue page size in recent change pagination

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4014,6 +4014,13 @@ sub display_pagination($$$$) {
 						}
 
 						$link = $current_link_query . "&page=$i";
+
+						# issue 2010: the limit, aka page_size is not persisted through the navigation links from some workflows,
+						# so it is lost on subsequent pages
+						if ( defined $limit && $link !~ /page_size/ ) {
+							$log->info("Using limit " .$limit) if $log->is_info();
+							$link .= "&page_size=" . $limit;
+						}
 					}
 
 					$html_pages .=  '<li><a href="' . $link . '">' . $i . '</a></li>';

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -59,7 +59,6 @@ BEGIN
 
 					&canonicalize_taxonomy_tag
 					&canonicalize_taxonomy_tag_link
-					&canonicalize_taxonomy_2tag_link
 					&exists_taxonomy_tag
 					&display_taxonomy_tag
 					&display_taxonomy_tag_link
@@ -2017,27 +2016,6 @@ sub canonicalize_taxonomy_tag_link($$$) {
 	$log->info("tax tag 1 /$path/$tagurl") if $log->is_info();
 	return "/$path/$tagurl";
 }
-
-
-
-sub canonicalize_taxonomy_2tag_link($$$$$) {
-	my $target_lc = shift; $target_lc =~ s/_.*//;
-	my $tagtype = shift;
-	my $tag = shift;
-	my $tagtype2 = shift;
-	my $tag2 = shift;
-
-	$tag = display_taxonomy_tag($target_lc,$tagtype, $tag);
-	my $tagurl = get_taxonomyurl($target_lc,$tag);
-	my $path = $tag_type_singular{$tagtype}{$target_lc};
-
-	$tag2 = display_taxonomy_tag($target_lc,$tagtype2, $tag2);
-	my $tagurl2 = get_taxonomyurl($target_lc,$tag2);
-	my $path2 = $tag_type_singular{$tagtype2}{$target_lc};
-	$log->info("tax tag 2 /$path/$tagurl/$path2/$tagurl2") if $log->is_info();
-	return "/$path/$tagurl/$path2/$tagurl2";
-}
-
 
 # The display_taxonomy_tag_link function makes many calls to other functions, in particular it calls twice display_taxonomy_tag_link
 # Will be replaced by display_taxonomy_tag_link_new function


### PR DESCRIPTION
changes for issue 2010 ... page_size aka limit is not persisted through pagination method and navigation links on the recent changes page

also removed unused method canonicalize_taxonomy_2tag_link from Tags.pm

**Related issues and discussion:** #2010
