### PR TITLE
fix for autorotate rev bug #2321, related to #2318

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -498,7 +498,11 @@ sub store_product($$) {
 		# The product was updated after the form was loaded..
 
 		# New product over deleted product?
-		if ($rev == 0) {
+		# can be also bug https://github.com/openfoodfacts/openfoodfacts-server/issues/2321
+		# where 2 changes were recorded in the same rev
+		# to avoid similar bugs, and to have the same number of changes and rev,
+		# assign the number of changes to the rev
+		if ($rev < $current_rev) {
 			$rev = $current_rev;
 		}
 	}
@@ -1084,7 +1088,11 @@ sub compute_product_history_and_completeness($$) {
 				foreach my $current_or_previous_ref (\%current, \%previous) {
 					if (defined $current_or_previous_ref->{languages_codes}) {
 						foreach my $language_code (@{$current_or_previous_ref->{languages_codes}}) {
-							next if $language_code eq $current_or_previous_ref->{lc};
+							# commenting next line so that we see changes for both ingredients_text and ingredients_text_$lc
+							# even if they are the same.
+							# keeping ingredients_text as at the start of the project, we had only ingredients_text and
+							# not language specific versions
+							# next if $language_code eq $current_or_previous_ref->{lc};
 							next if defined $languages_codes{$language_code};
 							push @languages_codes, $language_code;
 							$languages_codes{$language_code} = 1;

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -690,6 +690,10 @@ sub compute_completeness_and_missing_tags($$$) {
 	my $previous_ref = shift;
 
 	my $lc = $product_ref->{lc};
+	if (not defined $lc) {
+		# Try lang field
+		$lc = $product_ref->{lang};
+	}
 
 	# Compute completeness and missing tags
 

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -257,6 +257,12 @@ while (my $product_ref = $cursor->next) {
 					compute_data_sources($product_ref);
 					store("$data_root/products/$path/changes.sto", $changes_ref);
 				}
+				else {
+					next;
+				}
+			}
+			else {
+				next;
 			}
 		}
 

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -249,9 +249,13 @@ while (my $product_ref = $cursor->next) {
 				my $last_rev = $change_ref->{rev};
 				my $current_rev = $product_ref->{rev};
 				print STDERR "current_rev: $current_rev - last_rev: $last_rev\n";
-				if ($last_rev != $current_rev) {
+				if ($last_rev > $current_rev) {
+					print STDERR "-> setting rev to $last_rev\n";
 					$fix_rev_not_incremented_fixed++;
 					$product_ref->{rev} = $last_rev;
+					compute_product_history_and_completeness($product_ref, $changes_ref);
+					compute_data_sources($product_ref);
+					store("$data_root/products/$path/changes.sto", $changes_ref);
 				}
 			}
 		}
@@ -580,6 +584,7 @@ while (my $product_ref = $cursor->next) {
 
 			compute_product_history_and_completeness($product_ref, $changes_ref);
 			compute_data_sources($product_ref);
+			store("$data_root/products/$path/changes.sto", $changes_ref);
 		}
 
 		if (not $pretend) {

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -98,6 +98,7 @@ my $comment = '';
 my $fix_serving_size_mg_to_ml = '';
 my $fix_missing_lc = '';
 my $fix_zulu_lang = '';
+my $fix_rev_not_incremented = '';
 my $run_ocr = '';
 my $autorotate = '';
 my $query_ref = {};	# filters for mongodb query
@@ -122,6 +123,7 @@ GetOptions ("key=s"   => \$key,      # string
 			"fix-serving-size-mg-to-ml" => \$fix_serving_size_mg_to_ml,
 			"fix-missing-lc" => \$fix_missing_lc,
 			"fix-zulu-lang" => \$fix_zulu_lang,
+			"fix-rev-not-incremented" => \$fix_rev_not_incremented,
 			"user_id=s" => \$User_id,
 			"comment=s" => \$comment,
 			"run-ocr" => \$run_ocr,
@@ -162,7 +164,7 @@ if ((not $process_ingredients) and (not $compute_nutrition_score) and (not $comp
 	and (not $compute_serving_size)
 	and (not $compute_data_sources) and (not $compute_history)
 	and (not $run_ocr) and (not $autorotate)
-	and (not $fix_missing_lc) and (not $fix_serving_size_mg_to_ml) and (not $fix_zulu_lang)
+	and (not $fix_missing_lc) and (not $fix_serving_size_mg_to_ml) and (not $fix_zulu_lang) and (not $fix_rev_not_incremented)
 	and (not $compute_codes) and (not $compute_carbon) and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)) {
 	die("Missing fields to update or --count option:\n$usage");
 }
@@ -215,6 +217,8 @@ $cursor->immortal(1);
 my $n = 0;	# number of products updated
 my $m = 0;	# number of products with a new version created
 
+my $fix_rev_not_incremented_fixed = 0;
+
 while (my $product_ref = $cursor->next) {
 
 	my $code = $product_ref->{code};
@@ -224,7 +228,7 @@ while (my $product_ref = $cursor->next) {
 		print STDERR "code field undefined for product id: " . $product_ref->{id} . " _id: " . $product_ref->{_id} . "\n";
 	}
 	else {
-		print STDERR "updating product $code\n";
+		print STDERR "updating product $code ($n)\n";
 	}
 
 	next if $just_print_codes;
@@ -236,6 +240,21 @@ while (my $product_ref = $cursor->next) {
 		$lc = $product_ref->{lc};
 
 		my $product_values_changed = 0;
+
+		if ($fix_rev_not_incremented) { # https://github.com/openfoodfacts/openfoodfacts-server/issues/2321
+
+			my $changes_ref = retrieve("$data_root/products/$path/changes.sto");
+			if (defined $changes_ref) {
+				my $change_ref = @$changes_ref[-1];
+				my $last_rev = $change_ref->{rev};
+				my $current_rev = $product_ref->{rev};
+				print STDERR "current_rev: $current_rev - last_rev: $last_rev\n";
+				if ($last_rev != $current_rev) {
+					$fix_rev_not_incremented_fixed++;
+					$product_ref->{rev} = $last_rev;
+				}
+			}
+		}
 
 		# Fix zulu lang, bug https://github.com/openfoodfacts/openfoodfacts-server/issues/2063
 
@@ -449,9 +468,16 @@ while (my $product_ref = $cursor->next) {
 						print STDERR "rotating image $imgid by " .  (- $product_ref->{images}{$imgid}{orientation}) . "\n";
 						my $User_id_copy = $User_id;
 						$User_id = "autorotate-bot";
+
+						# Save product so that OCR results now:
+						# autorotate may call image_process_crop which will read the product file on disk and
+						# write a new one
+						store("$data_root/products/$path/product.sto", $product_ref);
+
 						eval {
-							my $updated_product_ref = process_image_crop($code, $imgid, $product_ref->{images}{$imgid}{imgid}, - $product_ref->{images}{$imgid}{orientation}, undef, undef, -1, -1, -1, -1);
-							$product_ref->{images}{$imgid} = $updated_product_ref->{images}{$imgid};
+
+							# process_image_crops saves a new version of the product
+							$product_ref = process_image_crop($code, $imgid, $product_ref->{images}{$imgid}{imgid}, - $product_ref->{images}{$imgid}{orientation}, undef, undef, -1, -1, -1, -1);
 						};
 						$User_id = $User_id_copy;
 					}
@@ -588,6 +614,10 @@ while (my $product_ref = $cursor->next) {
 }
 
 print "$n products updated (pretend: $pretend) - $m new versions created\n";
+
+if ($fix_rev_not_incremented_fixed) {
+	print "$fix_rev_not_incremented_fixed rev fixed\n";
+}
 
 exit(0);
 


### PR DESCRIPTION
This fixes the autorotate bug where the rev was not correctly incremented in the saved product file.

There is also a script to fix that revision for the products that have not yet been edited after the autorotate.

For products that have already been edited, the next change has unfortunately been merged with the autorotate in a single product file.