### PR TITLE
German translations, spelling corrections for additives

### DIFF
--- a/t/ingredients_tags.t
+++ b/t/ingredients_tags.t
@@ -48,7 +48,7 @@ my @tests = (
 
 	[ { lc => "fr", ingredients_text => "Lait de vache pasteurisé (origine: France), crème pasteurisée (origine France), sel (origine UE), ferments."}, [ 'en:pasteurised-cow-s-milk', 'en:pasteurized-cream', 'en:salt', 'en:ferment'  ], ],
 	[ { lc => "en", ingredients_text => "Organically grown green tea"}, [ "en:green-tea" ], ],
-	[ { lc => "fr", ingredients_text => "Céleri - rave, choux - fleurs, béta - carotène"}, [ "en:celeriac", "en:cauliflower", "en:e160" ], ],
+	[ { lc => "fr", ingredients_text => "Céleri - rave, choux - fleurs, béta - carotène"}, [ "en:celeriac", "en:cauliflower", "en:e160a" ], ],
 	[ { lc => "fr", ingredients_text => "Pâte de cacao de Madagascar, café"},["fr:Pâte de cacao de Madagascar", "en:coffee"]],
 	[ { lc => "es", ingredients_text => "Vinagre, chile rojo y sal."},["en:vinegar", "en:red-chili-pepper", "en:salt"]],
 	[ { lc => "fr", ingredients_text => "Farine de blé 56 g* ; beurre concentré 25 g* (soit 30 g* en beurre reconstitué); sucre 22 g* ; œufs frais 2 g"}, [ "en:wheat-flour", "en:butterfat", "en:sugar", "en:fresh-egg" ], ],

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1938,7 +1938,7 @@ wikidata:en:Q191907
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2014.3492
 efsa_evaluation_date:en: 2014-01-22
 efsa_evaluation:en: Scientific Opinion on the reconsideration of the ADI and a refined exposure assessment of beta-apo-8'-carotenal (E 160e)
-# Stabiliser/carrier may not be vegetarian, can be e.g. fish gelatine, which does not need to be labeled in EU right
+# Stabilizer/carrier may not be vegetarian, can be e.g. fish gelatine, which does not need to be labeled in EU right
 # https://www.vrg.org/blog/2012/02/15/beta-carotene-in-us-beverages-not-stabilized-with-gelatin-unlike-some-products-in-the-uk
 # https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32007L0068
 vegan:en:maybe
@@ -3011,7 +3011,7 @@ sk:E170, Uhličitan vápenatý, CI pigment biely 18
 sl:E170, Kalcijev karbonat, CI Pigment White 18
 sv:E170, Kalciumkarbonat, CI Pigment White 18
 e_number:en:170
-mandatory_additive_class:en: en:acidity-regulator, en:anti-caking-agent, en:stabiliser, en:firming-agent, en:flour-treatment-agent, en:glazing-agent, en:colour
+mandatory_additive_class:en: en:acidity-regulator, en:anti-caking-agent, en:stabilizer, en:firming-agent, en:flour-treatment-agent, en:glazing-agent, en:colour
 wikidata:en:Q23767
 efsa_evaluation_url:en:http://www.efsa.europa.eu/fr/efsajournal/doc/2318.pdf
 efsa_evaluation_date:en:2011/07/26
@@ -3282,13 +3282,13 @@ en:E180, Litholrubine bk, CI Pigment Red 57, Rubinpigment, Pigment Rubine, Litho
 bg:E180, Литолрубин bk, CI червен пигмент 57, рубин пигмент
 ca:E180, Litol-Rubina BK, Pigment Rubí
 cs:E180, Litholrubin bk, CI červený pigment 57, rubínový pigment
-da:E180, Rubinpigment bk (litholrubin bk), CI Pigment Red 57
-de:E180, Litholrubin bk, E 180, Litholrubin, Rubinpigment BK
+da:E180, Rubinpigment bk, litholrubin bk, CI Pigment Red 57
+de:E180, Litholrubin BK, E 180, Litholrubin, Rubinpigment BK
 el:E180, Λιθορουμπινη βκ, Κόκκινο CI Pigment 57, rubinpigment
 es:E180, Litolrubina bk, CI Pigment Red 57, rubinpigment, Litol-rubina BK
 et:E180, Litoolrubiin bk, CI punane pigment 57, rubiinpigment
 fi:E180, Litolirubiini bk, CI Pigment Red 57, Rubiinipigmentti
-fr:E180, Lithol-rubine BK, Litholrubine BK, Pigment Rubine, Carmin 6B, Lithol rubine BK, TANNIC ACID, Fuchsine lithol BK, D&C Red No. 7, D et C Red No. 7, Carmine 6B, Brilliant Carmine 6B, Permanent Rubin L6B, Litholrubine, Latolrubine, C.I. Pigment Red 57, C.I. Pigment Red 57:1, C.I. 15850:1, Rubinpigment BK, Rubinpigment, 4B-Toner, pigmento rubí, carmín 6B, CI 15850, D&C red 7 (USA), Lithol rubin toner BKL, Pigment rouge C. I. no 57, pigment rubis
+fr:E180, Lithol-rubine BK, Litholrubine BK, Pigment Rubine, Carmin 6B, Lithol rubine BK, TANNIC ACID, Fuchsine lithol BK, D&C Red No. 7, D et C Red No. 7, Carmine 6B, Brilliant Carmine 6B, Permanent Rubin L6B, Litholrubine, Latolrubine, C.I. Pigment Red 57, C.I. Pigment Red 57:1, C.I. 15850:1, Rubinpigment BK, Rubinpigment, 4B-Toner, pigmento rubí, carmín 6B, CI 15850, D&C red 7, Lithol rubin toner BKL, Pigment rouge C. I. no 57, pigment rubis
 hu:E180, Litolrubin BK, CI Pigment Red 57, Rubinpigment
 it:E180, Litolrubino bk, CI pigmento rosso 57, pigmento rubino
 lt:E180, Litolrubinas bk, Raudonasis pigmentas CI Nr. 57, rubino pigmentas
@@ -6638,7 +6638,7 @@ ru:E332, Цитрат калия
 sk:E332, E332 food additive
 sl:E332, E332 food additive
 sv:E332, Kaliumcitrat, Kaliumcitrater, E 332
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer
 e_number:en:332
 wikidata:en:Q419921
 additives_classes:en: en:sequestrant, en:stabilizer
@@ -6668,7 +6668,7 @@ ro:E332(i), Citrat monopotasic
 sk:E332(i), Citran draselný, Kálium-citrát
 sl:E332(i), Monokalijev citrat
 sv:E332(i), Monokaliumcitrat
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer
 e_number:en:332
 wikidata:en:Q419921
 additives_classes:en: en:sequestrant, en:stabilizer
@@ -6697,7 +6697,7 @@ sk:E332(ii), Citran tridraselný, Kálium-citrát
 sl:E332(ii), Trikalijev citrat
 sv:E332(ii), Trikaliumcitrat
 e_number:en:332
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer
 wikidata:en:Q419921
 additives_classes:en: en:sequestrant, en:stabilizer
 
@@ -6724,7 +6724,7 @@ ro:E333, E333 food additive
 sk:E333, Citrát trivápenatý
 sl:E333, E333 food additive
 sv:E333, E333 food additive
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser, en:firming-agent
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:firming-agent
 e_number:en:333
 wikidata:en:Q420280
 additives_classes:en: en:sequestrant, en:stabilizer
@@ -6755,7 +6755,7 @@ ro:E333(i), Citrat monocalcic
 sk:E333(i), Citran monovápenatý, Kalcium-citrát
 sl:E333(i), Monokalcijev citrat
 sv:E333(i), Monokalciumcitrat
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser, en:firming-agent
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:firming-agent
 e_number:en:333
 wikidata:en:Q420280
 additives_classes:en: en:sequestrant, en:stabilizer
@@ -6812,7 +6812,7 @@ ro:E333(iii), Citrat tricalcic
 sk:E333(iii), Citran trivápenatý (dicitran trivápenatý), Kalcium-citrát
 sl:E333(iii), Trikalcijev citrat
 sv:E333(iii), Trikalciumcitrat
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser, en:firming-agent
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:firming-agent
 e_number:en:333
 wikidata:en:Q420280
 additives_classes:en: en:sequestrant, en:stabilizer
@@ -7098,7 +7098,7 @@ ro:E339, E339 food additive
 sk:E339, E339 food additive
 sl:E339, E339 food additive
 sv:E339, Natriumfosfat
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser, en:emulsifier, en:thickener, en:humectant, en:raising-agent
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:emulsifier, en:thickener, en:humectant, en:raising-agent
 e_number:en:339
 wikidata:en:Q3249706
 additives_classes:en: en:emulsifier, en:humectant, en:preservative, en:sequestrant, en:stabilizer, en:thickener
@@ -7410,16 +7410,16 @@ sk:E341(iii), Fosforečnan trivápenatý
 sl:E341(iii), Trikalcijev fosfat
 sv:E341(iii), Trikalciumfosfat, Kalciumortofosfat, pentakalciumhydroximonofosfat
 e_number:en:341
-mandatory_additive_class:en: en:acidity-regulator, en:anti-caking-agent, en:stabiliser, en:acid
+mandatory_additive_class:en: en:acidity-regulator, en:anti-caking-agent, en:stabilizer, en:acid
 wikidata:en:Q426664
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabilizer, en:thickener
 organic_eu:en:authorized
 
-en:E342, Ammonium phosphates: (i) monoammonium phosphate (ii) diammonium phosphate
+en:E342, Ammonium phosphate, monoammonium phosphate, diammonium phosphate
 bg:E342, E342 food additive
 cs:E342, E342 food additive
 da:E342, E342 food additive
-de:E342, E342 food additive
+de:E342, Ammoniumphosphat
 el:E342, E342 food additive
 es:E342, E342 food additive
 et:E342, E342 food additive
@@ -9227,7 +9227,7 @@ efsa_evaluation_adi_established:en: en:no
 vegan:en:yes
 vegetarian:en:yes
 
-en:E419, Gum ghatti (thickener) (Stabilizer (food)stabiliser)
+en:E419, Gum ghatti
 bg:E419, E419 food additive
 cs:E419, E419 food additive
 da:E419, E419 food additive
@@ -9250,6 +9250,7 @@ sk:E419, E419 food additive
 sl:E419, E419 food additive
 sv:E419, E419 food additive
 e_number:en:419
+additives_classes:en: en:stabilizer, en:thickener
 wikidata:en:Q18967232
 vegan:en:yes
 vegetarian:en:yes
@@ -13221,7 +13222,7 @@ ro:E508, Clorură de potasiu, Silvină
 sk:E508, Chlorid draselný, Sylvín
 sl:E508, Kalijev klorid
 sv:E508, Kaliumklorid, Sylvin, E 508
-mandatory_additive_class:en: en:flavour-enhancer, en:stabiliser, en:thickener
+mandatory_additive_class:en: en:flavour-enhancer, en:stabilizer, en:thickener
 e_number:en:508
 wikidata:en:Q184630
 additives_classes:en: en:stabilizer, en:thickener
@@ -13252,7 +13253,7 @@ ru:E509, Хлорид кальция, CaCl2, Хлористый кальций, 
 sk:E509, Chlorid vápenatý
 sl:E509, Kalcijev klorid
 sv:E509, Kalciumklorid, E 509
-mandatory_additive_class:en: en:firming-agent, en:stabiliser, en:thickener
+mandatory_additive_class:en: en:firming-agent, en:stabilizer, en:thickener
 e_number:en:509
 wikidata:en:Q208451
 additives_classes:en: en:stabilizer, en:thickener
@@ -13555,7 +13556,7 @@ ro:E516, Sulfat de calciu, Ghips, Selenit
 sk:E516, Síran vápenatý, Sadra, sadrovec
 sl:E516, Kalcijev sulfat, Gypsum, selenit
 sv:E516, Kalciumsulfat, Gips, selenit
-mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabiliser, en:firming-agent, en:flour-treatment-agent
+mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:firming-agent, en:flour-treatment-agent
 e_number:en:516
 wikidata:en:Q407258
 additives_classes:en: en:sequestrant, en:stabilizer
@@ -14129,7 +14130,7 @@ sl:E551, Silicijev dioksid, silikagel
 sv:E551, Kiseldioxid, Kvarts
 e_number:en:551
 wikidata:en:Q116269
-mandatory_additive_class:en: en:anti-caking-agent, en:anti-foaming-agent, en:stabiliser
+mandatory_additive_class:en: en:anti-caking-agent, en:anti-foaming-agent, en:stabilizer
 colour_index:en:CI 7811
 additives_classes:en: en:carrier
 organic_eu:en:authorized
@@ -18557,7 +18558,7 @@ additives_classes:en: en:carrier, en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
-en:E1401, Modified starch, Modified starch ((Acid-treated starch) Stabilizer (food)stabiliser)
+en:E1401, Acid-treated modified starch
 bg:E1401, E1401 food additive
 cs:E1401, E1401 food additive
 da:E1401, E1401 food additive
@@ -18613,7 +18614,7 @@ additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
-en:E1403, Bleached starch, Bleached starch (Stabilizer (food)stabiliser)
+en:E1403, Bleached starch
 bg:E1403, E1403 food additive
 cs:E1403, E1403 food additive
 da:E1403, E1403 food additive
@@ -18727,7 +18728,7 @@ additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
-en:E1411, Distarch glycerol (thickening agent)
+en:E1411, Distarch glycerol
 bg:E1411, E1411 food additive
 cs:E1411, E1411 food additive
 da:E1411, E1411 food additive
@@ -18751,6 +18752,7 @@ sl:E1411, E1411 food additive
 sv:E1411, E1411 food additive
 e_number:en:1411
 wikidata:en:Q18967214
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
@@ -18894,6 +18896,7 @@ sl:E1421, E1421 food additive
 sv:E1421, E1421 food additive
 e_number:en:1421
 wikidata:en:Q18944665
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
@@ -18950,10 +18953,11 @@ sl:E1423, E1423 food additive
 sv:E1423, E1423 food additive
 e_number:en:1423
 wikidata:en:Q18608829
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
-en:E1430, Distarch glycerine, Distarch glycerine (Stabilizer (food)stabiliser)
+en:E1430, Distarch glycerine
 bg:E1430, E1430 food additive
 cs:E1430, E1430 food additive
 da:E1430, E1430 food additive
@@ -18977,6 +18981,7 @@ sl:E1430, E1430 food additive
 sv:E1430, E1430 food additive
 e_number:en:1430
 wikidata:en:Q18967212
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
@@ -19009,7 +19014,7 @@ additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
-en:E1441, Hydroxy propyl distarch glycerine, Hydroxy propyl distarch glycerine (Stabilizer (food)stabiliser)
+en:E1441, Hydroxy propyl distarch glycerine
 bg:E1441, E1441 food additive
 cs:E1441, E1441 food additive
 da:E1441, E1441 food additive
@@ -19033,6 +19038,7 @@ sl:E1441, E1441 food additive
 sv:E1441, E1441 food additive
 e_number:en:1441
 wikidata:en:Q18967235
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
@@ -19089,6 +19095,7 @@ sl:E1443, E1443 food additive
 sv:E1443, E1443 food additive
 e_number:en:1443
 wikidata:en:Q18967237
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
@@ -19175,6 +19182,7 @@ sl:E1452, Aluminijev oktenil sukcinat škroba
 sv:E1452, Stärkelse-aluminium-oktenyl-succinat
 e_number:en:1452
 wikidata:en:Q18967287
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 
@@ -19204,6 +19212,7 @@ sl:E14XX, E14XX food additive
 sv:E14XX, E14XX food additive
 zh:化製澱粉
 e_number:en:1499
+additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 vegan:en:yes
 vegetarian:en:yes
 

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -467,7 +467,7 @@ bg:E110, Сънсет жълто FCF, CI хранително жълто 3, Yell
 ca:E110, Groc ataronjat S
 cs:E110, Sunset yellow FCF, Yellow 6, Žluť SY, E 110
 da:E110, Sunset yellow FCF, Yellow 6
-de:E110, Gelborange s, Food Yellow 3, Gelborange-S, Sunsetgelb FCF, Yellow 6, Gelborange
+de:E110, Gelborange S, Food Yellow 3, Gelborange-S, Sunsetgelb FCF, Yellow 6, Gelborange
 el:E110, Κιτρινο sunset FCF, Κίτρινο CI food 3, Yellow 6
 es:E110, Amarillo anaranjado s, CI food yellow 3, Yellow 6, Amarillo crepúsculo, C.I. 15985, Amarillo ocaso, E 110
 et:E110, Päikeseloojangukollane FCF, CI kollane toiduvärv 3, Yellow 6
@@ -954,7 +954,7 @@ bg:E131, Патент синьо v
 ca:E131, Blau patentat V
 cs:E131, Patentní modř v
 da:E131, Patent blue v
-de:E131, Patentblau v, Patentblau, patentblau E 131
+de:E131, Patentblau V, Patentblau, patentblau E 131
 el:E131, Πατεντ μπλε v
 es:E131, Azul patentado V, Azul patente v, Azul sulfán
 et:E131, Patentsinine v
@@ -1000,7 +1000,7 @@ bg:E132, Индиготин, индиго кармин
 ca:E132, Indigotina, carmí indi
 cs:E132, Indigotin, indigocarmine, Indigo karmín
 da:E132, Indigotin (indigocarmin)
-de:E132, Indigotin (indigokarmin), Indigokarmin, Indigotin, E 132, Indigocarmin, Indigotin I
+de:E132, Indigotin (Indigokarmin), Indigokarmin, Indigotin, E 132, Indigocarmin, Indigotin I
 el:E132, Ινδικοτινη, ινδικοκαρμινη
 es:E132, Indigotina, carmín de índigo, E 132
 et:E132, Indigotiin, indigokarmiin
@@ -1096,7 +1096,7 @@ bg:E140, E140 food additive
 ca:E140, Clorofil i Clorofilines
 cs:E140, E140 food additive
 da:E140, E140 food additive
-de:E140, Chlorophyll c1
+de:E140, Chlorophyll C1
 el:E140, E140 food additive
 es:E140, Clorofilas
 et:E140, E140 food additive
@@ -1266,7 +1266,7 @@ bg:E141, E141 food additive
 ca:E141, Complexos cúprics de clorofil i clorofilines
 cs:E141, E141 food additive
 da:E141, E141 food additive
-de:E141, E141 food additive
+de:E141, Kupferhaltigen Komplexe der Chlorophylle und Chlorophylline
 el:E141, E141 food additive
 es:E141, Complejos cúpricos de clorofilas, Complejos cúpricos de clorofilas y clorofilinas
 et:E141, E141 food additive
@@ -1300,7 +1300,7 @@ en:E141(i), Copper complexes of chlorophylls, CI Natural Green 3, Copper Chlorop
 bg:E141(i), Медни комплекси на хлорофили, CI натурално зелено 3, меден хлорофил
 cs:E141(i), Měďnaté komplexy chlorofylů, CI přírodní zeleň 3, chlorofyl mědi
 da:E141(i), Chlorophyll-kobber-kompleks, CI Natural Green 3
-de:E141(i), Kupferkomplexe der chlorophylle
+de:E141(i), Kupferkomplexe der Chlorophylle
 el:E141(i), Συμπλοκα των χλωροφυλλων με χαλκο, Πράσινο CI natural 3, χαλκοχλωροφύλλη
 es:E141(i), Complejos cúpricos de clorofilas, CI Natural Green 3, clorofila cúprica
 et:E141(i), Klorofüllide vasekompleksid, CI looduslik roheline 3, vaskklorofüll
@@ -1332,7 +1332,7 @@ en:E141(ii), Copper complexes of chlorophyllins, Sodium Copper Chlorophyllin, Po
 bg:E141(ii), Медни комплекси на хлорофилини, Натриев меден хлорофилин, калиев меден хлорофилин
 cs:E141(ii), Měďnaté komplexy chlorofylinů
 da:E141(ii), Chlorophyllin-kobber-kompleks, Natriumkobberchlorophyllin, kaliumkobberchlorophyllin
-de:E141(ii), Kupferkomplexe der chlorophylline synonyme
+de:E141(ii), Kupferkomplexe der Chlorophylline
 el:E141(ii), Συμπλοκα των χλωροφυλλινων με χαλκο, Χαλκοχλωροφυλλινικό νάτριο, χαλκοχλωροφυλλινικό κάλιο
 es:E141(ii), Complejos cúpricos de clorofilinas, Clorofilina cúprica de sodio, clorofilina cúprica de potasio
 et:E141(ii), Klorofülliinide vasekompleksid, Naatriumvaskklorofülliin, kaaliumvaskklorofülliin
@@ -1593,7 +1593,7 @@ en:E150b, Caustic sulphite caramel, caramel E150b
 bg:E150b, Карамел основен сулфит
 cs:E150b, Kaustický sulfitový karamel
 da:E150b, Kaustisk sulfiteret karamel
-de:E150b, Sulfitlaugen-zuckerkulör, Karamell E150b
+de:E150b, Sulfitlaugen-Zuckerkulör, Karamell E150b, Sulfitlaugen-Zuckercouleur
 el:E150b, Καυστικο θειωδες καραμελοχρωμα
 es:E150b, Caramelo de sulfito cáustico, caramelo cáustico
 et:E150b, Leeliseline sulfitkaramell
@@ -1629,7 +1629,7 @@ en:E150c, Ammonia caramel, baker's caramel, confectioner's caramel, beer caramel
 bg:E150c, Амониев карамел
 cs:E150c, Amoniakový karamel
 da:E150c, Ammonieret karamel
-de:E150c, Ammoniak-zuckerkulör
+de:E150c, Ammoniak-Zuckerkulör, Ammoniak-Zuckercouleur
 el:E150c, Εναμμωνιο καραμελοχρωμα
 es:E150c, Caramelo amónico, El caramelo amónico, caramelo de panadería, caramelo de confitería, caramelo de cerveza
 et:E150c, Ammooniumkaramell
@@ -1669,7 +1669,7 @@ en:E150d, Sulphite ammonia caramel, Sulfite ammonia caramel, Caramel Colour Ammo
 bg:E150d, Карамел амониев сулфит
 cs:E150d, Amoniak-sulfitový karamel
 da:E150d, Ammonieret sulfiteret karamel
-de:E150d, Ammoniumsulfit-zuckerkulör, Zuckerkulör E150d
+de:E150d, Ammoniumsulfit-Zuckerkulör, Zuckerkulör E150d, Ammoniumsulfit-Zuckercouleur
 el:E150d, Εναμμωνιο θειωδες καραμελοχρωμα
 es:E150d, Caramelo de sulfito amónico, Caramelo sulfito de amoníaco, caramelo clase iv, Caramelo sulfito de amoníaco, caramelo a prueba de ácidos, caramelo de bebidas gaseosas
 et:E150d, Ammooniumsulfitkaramell
@@ -1909,12 +1909,12 @@ colour_index:en:CI 77266
 vegan:en:yes
 vegetarian:en:yes
 
-en:E160, carotene
+en:E160, Carotenoids
 bg:E160, E160 food additive
 ca:E160, Carotenoides
 cs:E160, E160 food additive
 da:E160, E160 food additive
-de:E160, E160 food additive
+de:E160, Carotinoide
 el:E160, E160 food additive
 es:E160, Carotenoides, Caroteno
 et:E160, E160 food additive
@@ -1934,11 +1934,12 @@ sk:E160, E160 food additive
 sl:E160, E160 food additive
 sv:E160, E160 food additive
 e_number:en:160
+wikidata:en:Q191907
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2014.3492
 efsa_evaluation_date:en: 2014-01-22
 efsa_evaluation:en: Scientific Opinion on the reconsideration of the ADI and a refined exposure assessment of beta-apo-8'-carotenal (E 160e)
-vegan:en:yes
-vegetarian:en:yes
+vegan:en:maybe
+vegetarian:en:maybe
 
 en:E160a, Alpha-carotene, Beta-carotene, Gamma-carotene, carotene
 bg:E160a, Каротин
@@ -1973,8 +1974,8 @@ efsa_evaluation_date:en: 2016-03-18
 efsa_evaluation:en: Safety of the proposed extension of use of synthetic Beta-carotene [E 160a(ii)] in foods for special medical purposes in young children
 additives_classes:en: en:colour
 vegan:en:maybe
-vegetarian:en:yes
-from_palm_oil:en:yes
+vegetarian:en:maybe
+from_palm_oil:en:maybe
 
 # description:en:E160a can be consumed by all religious groups, vegans and vegetarians.
 
@@ -1983,7 +1984,7 @@ en:E160a(i), Beta-carotene
 bg:E160a(i), Бета-каротин
 cs:E160a(i), Beta-karoten
 da:E160a(i), Beta-caroten
-de:E160a(i), Beta-carotin
+de:E160a(i), Beta-Carotin
 el:E160a(i), Β-καροτενιο
 es:E160a(i), Beta-caroteno, Betacaroteno, ß-caroteno
 et:E160a(i), Beetakaroteen
@@ -2009,8 +2010,8 @@ efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2016.4434
 efsa_evaluation_date:en: 2016-03-18
 efsa_evaluation:en: Safety of the proposed extension of use of synthetic Beta-carotene [E 160a(ii)] in foods for special medical purposes in young children
 additives_classes:en: en:colour
-vegan:en:yes
-vegetarian:en:yes
+vegan:en:maybe
+vegetarian:en:maybe
 
 # description:en:E160a can be consumed by all religious groups, vegans and vegetarians.
 
@@ -2118,7 +2119,7 @@ bg:E160b, Анато, биксин, норбиксин (i), БИКСИН И НО
 ca:E160b, Bixina
 cs:E160b, Annatto, bixin, norbixin
 da:E160b, Annattoekstrakter (bixin, norbixin)
-de:E160b, Annatto (bixin, norbixin), BIXIN UND NORBIXIN, Annatto, Achote, Orlean, E 160b, Anatto
+de:E160b, Annatto (Bixin; Norbixin), BIXIN UND NORBIXIN, Annatto, Achote, Orlean, E 160b, Anatto
 el:E160b, Αννατο, μπιξινη, νορμπιξινη (i)
 es:E160b, Annato, bixina, norbixina, Achiote
 et:E160b, Annaato, biksiin, norbiksiin (i)
@@ -2152,7 +2153,7 @@ bg:E160c, Паприка екстракт, капсантин, капсоруб�
 ca:E160c, Capsantina
 cs:E160c, Paprikový extrakt, kapsanthin, kapsorubin, Capsanthin
 da:E160c, Paprikaekstrakt (capsanthin, capsorubin)
-de:E160c, Paprikaextrakt (capsanthin, capsorubin), Capsanthin, E 160c
+de:E160c, Paprikaextrakt (Capsanthin; Capsorubin), Capsanthin, E 160c
 el:E160c, Εκχυλισμα παπρικας, καψανθινη, καψορουμπινη
 es:E160c, Extracto de pimentón, capsantina, capsorrubina, Oleorresina de pimentón, Oleoresina de pimentón, Extracto de paprika, Oleoresina del pimentón, E 160c, Extracto del pimentón
 et:E160c, Paprikaekstrakt, kapsantiin, kapsorubiin
@@ -2218,7 +2219,7 @@ en:E160e, Beta-apo-8′-carotenal (c30), Apocarotenal, Beta-apo-8'-carotenal, C.
 bg:E160e, Бета-апо-8′-каротенал (c30)
 cs:E160e, Β-apo-8′-karotenal (c 30)
 da:E160e, Beta-apo-8′-carotenal(c30)
-de:E160e, Beta-apo-8′-carotinal (c 30), 8′-Apo-β-caroten-8′-al, E 160e, Apocarotinal, Beta-Apocarotinal, 8'-Apo-β-caroten-8'-al
+de:E160e, Beta-apo-8′-carotinal (C30), 8′-Apo-β-caroten-8′-al, E 160e, Apocarotinal, Beta-Apocarotinal, 8'-Apo-β-caroten-8'-al
 el:E160e, Β-απο-8′-καροτεναλη (c30)
 es:E160e, Beta-apo-8′-carotenal (c30), Apocarotenal, Beta-apo-8'-carotenal, E 160e
 et:E160e, Beeta-apo-8′-karotenaal (c30)
@@ -2658,7 +2659,7 @@ bg:E162, Оцветител от червено цвекло, бетанин
 ca:E162, Betanina, vermell de remolatxa
 cs:E162, Betalainová červeň, betanin
 da:E162, Rødbedefarve (betaniner)
-de:E162, Betanin (betenrot), Betanin, Beetenrot, Betanoin, E 162, Betenrot
+de:E162, Betanin, Beetenrot, Betanoin, Betenrot
 el:E162, Ερυθρα χρωστικη της ριζας των τευτλων, βετανινη
 es:E162, Rojo de remolacha, Betanina, Betacianina, E 162, Rojo remolacha
 et:E162, Peedipunane, betaniin
@@ -3056,7 +3057,7 @@ bg:E172, Железни оксиди и железни хидроксиди
 ca:E172, Òxids i hidròxids de ferro
 cs:E172, Oxidy a hydroxidy železa
 da:E172, Jernoxider og jernhydroxider
-de:E172, Eisenoxide und eisenhydroxide synonyme
+de:E172, Eisenoxide und Eisenhydroxide, Eisenoxide, Eisenhydroxide
 el:E172, Οξειδια του σιδηρου και υδροξειδια του σιδηρου συνώνυμα
 es:E172, Óxidos e hidróxidos de hierro
 et:E172, Raudoksiidid ja raudhüdroksiidid
@@ -3089,11 +3090,11 @@ vegetarian:en:yes
 
 
 <en:E172
-en:E172(i), E172(i) food additive
+en:E172(i), Black iron oxide
 bg:E172(i), E172(i) food additive
 cs:E172(i), E172(i) food additive
 da:E172(i), E172(i) food additive
-de:E172(i), E172(i) food additive
+de:E172(i), Eisenoxidschwarz
 el:E172(i), E172(i) food additive
 es:E172(i), E172(i) food additive
 et:E172(i), E172(i) food additive
@@ -3121,11 +3122,11 @@ vegan:en:yes
 vegetarian:en:yes
 
 <en:E172
-en:E172(ii), E172(ii) food additive, iron(III) oxide, ferric oxide
+en:E172(ii), Red iron oxide, iron(III) oxide, ferric oxide
 bg:E172(ii), E172(ii) food additive
 cs:E172(ii), E172(ii) food additive, Oxid železitý, Fe2O3
 da:E172(ii), E172(ii) food additive
-de:E172(ii), E172(ii) food additive, Eisen(III)-oxid, Fe2O3, Oxidrot, Dieisentrioxid, Eisenoxide
+de:E172(ii), Eisen(III)-oxid, Fe2O3, Oxidrot, Dieisentrioxid, Eisenoxidrot
 el:E172(ii), E172(ii) food additive
 es:E172(ii), E172(ii) food additive, óxido férrico, Fe2O3, herrumbre, óxido de hierro, sesquióxido de hierro, trióxido de hierro, óxido de hierro (III)
 et:E172(ii), E172(ii) food additive, Raud(III)oksiid
@@ -3151,16 +3152,16 @@ efsa_evaluation:en: Scientific Opinion on the re-evaluation of iron oxides and h
 additives_classes:en: en:colour
 
 <en:E172
-en:E172(iii), E172(iii) food additive
+en:E172(iii), Yellow iron oxide
 bg:E172(iii), E172(iii) food additive
 cs:E172(iii), E172(iii) food additive
 da:E172(iii), E172(iii) food additive
-de:E172(iii), E172(iii) food additive
+de:E172(iii), Eisenoxidgelb
 el:E172(iii), E172(iii) food additive
 es:E172(iii), E172(iii) food additive
 et:E172(iii), E172(iii) food additive
 fi:E172(iii), E172(iii) food additive
-fr:E172(iii), Oxyde de fer jaune, oxyde et hydroxyde de fer jaune et rouge,, oxyde et hydroxyde de fer jaune
+fr:E172(iii), Oxyde de fer jaune, oxyde et hydroxyde de fer jaune et rouge, oxyde et hydroxyde de fer jaune
 hu:E172(iii), E172(iii) food additive
 it:E172(iii), E172(iii) food additive
 lt:E172(iii), E172(iii) food additive
@@ -5523,12 +5524,12 @@ vegetarian:en:yes
 
 
 
-en:E306, Tocopherol-rich extract
+en:E306, Tocopherol-rich extract, Tocopherols
 bg:E306, Токоферол-обогатен екстракт
 ca:E306, Extracte ric en tocoferols
 cs:E306, Extrakt s vysokým obsahem tokoferolů
 da:E306, Tocopherolrig ekstrakt
-de:E306, Stark tocopherolhaltige extrakte
+de:E306, Stark tocopherolhaltige Extrakte, Tocopherol-haltige Extrakte
 el:E306, Εκχυλισμα πλουσιο σε τοκοφερολες
 es:E306, Extracto rico en tocoferoles, Extracto rico en tocoferol
 et:E306, Tokoferoolikontsentraat
@@ -5555,11 +5556,11 @@ organic_eu:en:authorized
 vegan:en:yes
 vegetarian:en:yes
 
-en:E307a, tocopherol
+en:E307a, Alpha-tocopherol
 bg:E307a, E307a food additive
 cs:E307a, E307a food additive
 da:E307a, E307a food additive
-de:E307a, E307a food additive
+de:E307a, Alpha-Tocopherol, α-Tocopherol
 el:E307a, E307a food additive
 es:E307a, E307a food additive
 et:E307a, E307a food additive
@@ -5587,11 +5588,11 @@ additives_classes:en: en:antioxidant
 vegan:en:yes
 vegetarian:en:yes
 
-en:E307b, tocopherol
+en:E307b, Alpha-tocopherol
 bg:E307b, E307b food additive
 cs:E307b, E307b food additive
 da:E307b, E307b food additive
-de:E307b, E307b food additive
+de:E307b, Alpha-Tocopherol, α-Tocopherol
 el:E307b, E307b food additive
 es:E307b, E307b food additive
 et:E307b, E307b food additive
@@ -5619,11 +5620,11 @@ additives_classes:en: en:antioxidant
 vegan:en:yes
 vegetarian:en:yes
 
-en:E307c, tocopherol
+en:E307c, Alpha-tocopherol
 bg:E307c, E307c food additive
 cs:E307c, E307c food additive
 da:E307c, E307c food additive
-de:E307c, E307c food additive
+de:E307c, Alpha-Tocopherol, α-Tocopherol
 el:E307c, E307c food additive
 es:E307c, E307c food additive
 et:E307c, E307c food additive
@@ -5656,7 +5657,7 @@ bg:E308, E308 food additive
 ca:E308, γ-tocoferol
 cs:E308, E308 food additive
 da:E308, E308 food additive
-de:E308, E308 food additive
+de:E308, Gamma-Tocopherol, γ-Tocopherol
 el:E308, E308 food additive
 es:E308, E308 food additive
 et:E308, E308 food additive
@@ -5690,7 +5691,7 @@ bg:E309, E309 food additive
 ca:E309, δ-tocoferol
 cs:E309, E309 food additive
 da:E309, E309 food additive
-de:E309, δ-Tocopherol
+de:E309, Delta-Tocopherol, δ-Tocopherol
 el:E309, E309 food additive
 es:E309, E309 food additive
 et:E309, E309 food additive
@@ -5723,7 +5724,7 @@ bg:E307, Алфа-токоферол, dl-α-токоферол
 ca:E307, α-tocoferol
 cs:E307, Alfa-tokoferol
 da:E307, Alfa-tocopherol, dl-α-Tocopherol
-de:E307, Alpha-tocopherol, DL-α-Tocopherol
+de:E307, Alpha-Tocopherol, DL-α-Tocopherol
 el:E307, Α-τοκοφερολη, dl-α-Τοκοφερόλη
 es:E307, Alfa-tocoferol, Tocoferol alfa, DL-α-tocoferol, Α-Tocoferol, tocoferoles, Vitamina E(sintética)
 et:E307, Alfa-tokoferool, dl-α-tokoferool
@@ -6042,7 +6043,7 @@ bg:E319, Третичен бутилхидроквинон (тбхк), Терт-
 ca:E319, Tertbutilhidroquinona, TBHQ
 cs:E319, Terciární butylhydrochinon (tbhq), Terc-butyl-1\,4-benzendiol
 da:E319, Tert-butylhydroquinon (tbhq), tert-Butyl-1\,4-benzendiol
-de:E319, Tertiär-butylhydrochinon (tbhq), tert-Butyl-1\,4-benzendiol
+de:E319, Tertiär-butylhydrochinon, TBHQ, tert-Butyl-1\,4-benzendiol
 el:E319, Τριτοταγης βουτυλ-υδροκινονη (tbhq), τριτ. βουτυλο-βενζολοδιόλη-1\,4
 es:E319, Terbutilhidroquinona (tbhq), t-butil-1\,4-bencenodiol
 et:E319, Tertsiaarbutüülhüdrokinoon (tbhq), Tert-butüül-1\,4-benseendiool
@@ -6074,7 +6075,7 @@ bg:E320, Бутил хидроксианизол (бха)
 ca:E320, Butilhidroxianisol, BHA
 cs:E320, Butylhydroxyanisol (bha), 3-terc-butyl-4-hydroxyanisol
 da:E320, Butylhydroxyanisol (bha), 3-tert-Butyl-4-hydroxyanisol, Butylhydroxyanisol
-de:E320, Butylhydroxyanisol (bha), 3-tert-Butyl-4-hydroxyanisol, Butylhydroxyanisol, E 320
+de:E320, Butylhydroxyanisol, BHA, 3-tert-Butyl-4-hydroxyanisol, Butylhydroxyanisol, E 320
 el:E320, Βουτυλ-υδροξυανισολη (bha), 3-τριτ. βουτυλ-4-υδροξυανισόλη
 es:E320, Butilhidroxianisol, 3-t-butil-4-hidroxianisol, BHA, E 320, Hidroxibutilanisol
 et:E320, Butüülhüdroksüanisool (bha)
@@ -6101,12 +6102,12 @@ additives_classes:en: en:antioxidant
 vegan:en:yes
 vegetarian:en:yes
 
-en:E321, Butylated hydroxytoluene (bht), 2\,6-Ditertiary-butyl-p-cresol, Butylated hydroxytoluene, BHT, bht added to preserve freshness
+en:E321, Butylated hydroxytoluene, BHT, 2\,6-Ditertiary-butyl-p-cresol, Butylated hydroxytoluene, bht added to preserve freshness
 bg:E321, Бутилхидрокситолуол (бхт), 2\,6-дитретичен-бутил-р-крезол
 ca:E321, Butilhidroxitoluè, BHT
 cs:E321, Butylhydroxytoluen (bht), 2\,6-diterciární butyl-p-krezol, Butylhydroxytoluen
 da:E321, Butylhydroxytoluen (bht), 2\,6-Di-tert-butyl-p-cresol
-de:E321, Butylhydroxytoluen (bht), 2\,6-Di-tert-butyl-p-kresol, Butylhydroxytoluol
+de:E321, Butylhydroxytoluen, BHT, 2\,6-Di-tert-butyl-p-kresol, Butylhydroxytoluol
 el:E321, Βουτυλ-υδροξυτολουολιο (βητ), 2\,6-Δι-τριτ. βουτυλο-p-κρεσόλη
 es:E321, Butilhidroxitolueno, 2\,6-di-t-butil-p-cresol
 et:E321, Butüülhüdroksütolueen (bht), 2\,6-di-tert-butüül-p-kresool
@@ -6517,7 +6518,7 @@ en:E331, Sodium citrates
 bg:E331, E331 food additive
 cs:E331, E331 food additive
 da:E331, E331 food additive
-de:E331, E331 food additive
+de:E331, Natriumcitrat, Natriumzitrat
 el:E331, E331 food additive
 es:E331, Citratos de sodio
 et:E331, E331 food additive
@@ -6816,7 +6817,7 @@ bg:E334, L(+)-винена киселина, винена киселина, Ли
 ca:E334, Àcid tartàric, àcid L(+)-tartàric
 cs:E334, L(+)-kyselina vinná, Kyselina vinná, E 334, Kyselina hroznová
 da:E334, L(+)-tartaric acid, tartaric acid, L-Vinsyre, L-2\,3-dihydroxybutandisyre, Vinsyre, E-334
-de:E334, Weinsäure (l+), L-Weinsäure, L-2\,3-Dihydroxybutandisäure, Weinsäure, Threarsäure, Tartaric acid, 2\,3-Dihydroxybutandisäure, 2\,3-Dihydroxybernsteinsäure, E 334, Dihydroxybernsteinsäure, D-(-)-Weinsäure, Traubensäure, Weinsteinsäure
+de:E334, L(+)-Weinsäure, Weinsäure (L+), L-Weinsäure, L-2\,3-Dihydroxybutandisäure, Weinsäure, Threarsäure, Tartaric acid, 2\,3-Dihydroxybutandisäure, 2\,3-Dihydroxybernsteinsäure, E 334, Dihydroxybernsteinsäure, D-(-)-Weinsäure, Traubensäure, Weinsteinsäure
 el:E334, L(+)-τρυγικο οξυ, τρυγικο οξυ
 es:E334, Ácido tartárico, Ácido l(+)-tartárico, E 334, Crémor tartaro, Ácido tártrico
 et:E334, L(+)-viinhape, viinhape, L-viinhape, L-2\,3-dihüdroksübutaandihape
@@ -7073,7 +7074,7 @@ bg:E339, E339 food additive
 ca:E339, Fosfat de sodi
 cs:E339, E339 food additive
 da:E339, E339 food additive
-de:E339, E339 food additive
+de:E339, Natriumphosphate
 el:E339, E339 food additive
 es:E339, Fosfatos de sodio, Fosfato de sodio, Fosfato sódico, Fosfatos sodicos, E 339, Ortofosfatos de sodio
 et:E339, E339 food additive
@@ -7184,7 +7185,7 @@ bg:E340, E340 food additive
 ca:E340, Fosfat de potassi
 cs:E340, E340 food additive
 da:E340, E340 food additive
-de:E340, E340 food additive
+de:E340, Kaliumphosphate
 el:E340, E340 food additive
 es:E340, Fosfatos de potasio, Fosfato de potasio, Fosfato potásico
 et:E340, E340 food additive
@@ -7606,7 +7607,7 @@ bg:E350, E350 food additive
 ca:E350, Malat de sodi
 cs:E350, E350 food additive
 da:E350, E350 food additive
-de:E350, E350 food additive
+de:E350, Natriummalate
 el:E350, E350 food additive
 es:E350, Malato de sodio, Malato disodico, Malato sódico
 et:E350, E350 food additive
@@ -7634,7 +7635,7 @@ vegetarian:en:yes
 en:E350(i), Sodium malate
 bg:E350(i), Натриев малат
 cs:E350(i), Jablečnan disodný
-da:E350(i), Natriummalat
+da:E350(i), Natriummalat, Dinatriummalat
 de:E350(i), Natriummalat
 el:E350(i), Μηλικο νατριο
 es:E350(i), Malato sódico
@@ -8287,7 +8288,7 @@ bg:E385, Калциев динатриев етилен диамин тетра�
 ca:E385, Etilendiaminotetracetat de calci i disodi, EDTA de calci i disodi
 cs:E385, Dvojsodnovápenatá sůl kyseliny diamintetraoctové
 da:E385, Calciumdinatriumethylendiamintetraacetat, Calciumdinatrium-EDTA
-de:E385, Calcium-dinatrium-ethylendiamintetraacetat, Calcium-Dinatrium-EDTA
+de:E385, Calcium-Dinatrium-Ethylendiamintetraacetat, Calcium-Dinatrium-EDTA
 el:E385, Αιθυλενοδιαμινοτετραοξικο ασβεστιονατριο
 es:E385, Ácido etilendiaminotetraacético, EDTA, AEDT, Etilendiamino-tetracetato de calcio y disodio, EDTA disódico y cálcico
 et:E385, Kaltsiumdinaatriumetüleendiamiintetraatsetaat, Kaltsiumdinaatrium-EDTA
@@ -8485,7 +8486,7 @@ bg:E392, Екстракти от розмарин
 ca:E392, Extracte de romaní
 cs:E392, Výtažky z rozmarýnu, Rozmarýnové extrakty
 da:E392, Ekstrakter af rosmarin
-de:E392, Extrakt aus rosmarin
+de:E392, Extrakt aus Rosmarin
 el:E392, Εκχυλισματα δενδρολιβανου
 es:E392, Extractos de romero
 et:E392, Rosmariiniekstrakt
@@ -8749,7 +8750,7 @@ bg:E406, Агар, Гелоза, бенгалски, цейлонски, кит�
 ca:E406, Agar, agar-agar
 cs:E406, Agar, Agar agar, Japonská želatina, E 406, Kanten
 da:E406, Agar, E-406
-de:E406, Agar-agar, Agar, Chinesische Gelatine, E 406, Agartang, Japanische Gelatine, Nähragar, Japanischer Fischleim
+de:E406, Agar-Agar, Agar, Chinesische Gelatine, E 406, Agartang, Japanische Gelatine, Nähragar, Japanischer Fischleim
 el:E406, Agar
 es:E406, Agar-agar, Agar, E 406, Agaragar, Kanten
 et:E406, Agar, Bengali, tseiloni, Agar-agar
@@ -8794,7 +8795,7 @@ nl:E407, Carrageen
 pl:E407, Karagen
 pt:E407, Carragenina, Carragenano, Carragenanos
 ro:E407, Caragenan
-ru:E407, Каррагинан и его соли, Каррагинан, E407a, Ирландский мох, Карраген
+ru:E407, Каррагинан и его соли, Каррагинан, Ирландский мох, Карраген
 sk:E407, Karagénan, Karagén
 sl:E407, Karagenan
 sv:E407, Karragenan, E 407
@@ -8816,7 +8817,7 @@ en:E407a, Processed eucheuma seaweed
 bg:E407a, Обработени eucheuma водорасли
 cs:E407a, Guma eucheuma / afinát řasy eucheuma, Zpracovaná řasa eucheuma
 da:E407a, Forarbejdet eucheuma-tang
-de:E407a, Verarbeitete euchema-algen
+de:E407a, Verarbeitete Euchema-Algen
 el:E407a, Τροποποιημενα φυκη eucheuma
 es:E407a, Alga eucheuma transformada
 et:E407a, Tselluloosi sisaldav karrageen
@@ -9805,7 +9806,7 @@ bg:E435, Полиоксиетилен сорбитан моностеарат, �
 ca:E435, Monoestearat de sorbitan polioxietilenat, polisorbat 60
 cs:E435, Polyoxyethylensorbitanmonostearát, polysorbát 60
 da:E435, Polyoxyethylen(20)sorbitanmonostearat, Polysorbat 60
-de:E435, Polyoxyethylen-sorbitanmonostearat, Polysorbat 60, E 435, Polyoxyethylen-sorbitan-monostearat, Polyoxyethylen(20)-sorbitan-monostearat
+de:E435, Polyoxyethylen-Sorbitanmonostearat, Polysorbat 60, E 435, Polyoxyethylen-sorbitan-monostearat, Polyoxyethylen(20)-sorbitan-monostearat
 el:E435, Μονοστεατικη πολυοξυ-αιθυλενο-σορβιτανη, Polysorbate 60
 es:E435, Monoestearato de sorbitán polioxietilenado, Polisorbato 60
 et:E435, Polüosküetüleen sorbitaanmonostearaat, Polüsorbaat 60
@@ -10211,7 +10212,7 @@ bg:E445, Глицеролови естери на дървесна смола
 ca:E445, Èster glicèrid de la colofònia de fusta
 cs:E445, Glycerolestery dřevných pryskyřic
 da:E445, Glycerolestere af fyrreharpiks
-de:E445, Glycerinester aus wurzelharz, Harzester, Estergummi, Glycerinester, E 445, Glyzerinester
+de:E445, Glycerinester aus Wurzelharz, Harzester, Estergummi, Glycerinester, E 445, Glyzerinester
 el:E445, Εστερες γλυκερολης με κολοφωνιο ξυλου
 es:E445, Ésteres glicéridos de resina de madera, Éster glicérido de resina de madera, Ésteres glicéridos de colofonia de madera
 et:E445, Glycerol esters of wood rosin
@@ -10880,7 +10881,7 @@ bg:E452, E452 food additive
 ca:E452, Polifosfat
 cs:E452, E 452
 da:E452, E452 food additive
-de:E452, E452 food additive
+de:E452, Polyphosphate
 el:E452, E452 food additive
 es:E452, Polifosfatos
 et:E452, E452 food additive
@@ -11252,7 +11253,7 @@ en:E460(i), Microcrystalline cellulose
 bg:E460(i), Микрокристална целулоза
 cs:E460(i), Mikrokrystalická celulosa
 da:E460(i), Mikrokrystallinsk cellulose
-de:E460(i), Mikrokristalline cellulose
+de:E460(i), Mikrokristalline Cellulose
 el:E460(i), Μικροκρυσταλλικη κυτταρινη
 es:E460(i), Celulosa microcristalina
 et:E460(i), Mikrokristalne tselluloos
@@ -11625,7 +11626,7 @@ bg:E470a, Натриеви\, калиеви и калциеви соли на м
 ca:E470a, Sal sòdica d'àcids grassos
 cs:E470a, Sodné\, draselné a vápenaté soli mastných kyselin
 da:E470a, Natrium-\, kalium- og calciumsalte af fedtsyrer
-de:E470a, Natrium-\, kalium- und calciumsalze der speisefettsäuren
+de:E470a, Natrium-\, Kalium- und Calciumsalze der Speisefettsäuren
 el:E470a, Αλατα λιπαρων οξεων με νατριο, καλιο και ασβεστιο, Άλατα με νάτριο
 es:E470a, Sales sódicas\, potásicas y cálcicas de ácidos grasos
 et:E470a, Rasvhapete naatrium-\, kaalium- ja kaltsiumsoolad
@@ -11654,7 +11655,7 @@ bg:E470b, Магнезиеви соли на мастни киселини
 ca:E470b, Sal magnèsica d'àcids grassos
 cs:E470b, Hořečnaté soli mastných kyselin
 da:E470b, Magnesiumsalte af fedtsyrer
-de:E470b, Magnesiumsalze der speisefettsäuren
+de:E470b, Magnesiumsalze der Speisefettsäuren
 el:E470b, Αλατα λιπαρων οξεων με μαγνησιο
 es:E470b, Sales magnésicas de ácidos grasos
 et:E470b, Rasvhapete magneesiumisoolad
@@ -11683,7 +11684,7 @@ bg:E471, Моно- и диглицериди на мастни киселини,
 ca:E471, Monoglicèrid o diglicèrid d'àcids grassos
 cs:E471, Mono- a diglyceridy mastných kyselin, Glycerylmonostearát, glycerylmonopalmitát, glycerylmonooleát, monostearin, monopalmitin, monoolein
 da:E471, Mono- og diglycerider af fedtsyrer, Glycerylmonostearat, glycerylmonopalmitat
-de:E471, Mono- und diglyceride von speisefettsäuren, Glycerylmonostearat, Glycerylmonopalmitat, Glycerylmonooleat, Monostearin, Monopalmitin, Monoolein, E 471
+de:E471, Mono- und Diglyceride von Speisefettsäuren, Glycerylmonostearat, Glycerylmonopalmitat, Glycerylmonooleat, Monostearin, Monopalmitin, Monoolein, E 471
 el:E471, Μονο- και διγλυκεριδια λιπαρων οξεων, Μονοστεατικό γλυκερύλιο, μονοπαλμιτικό γλυκερύλιο, μονοελαϊκό γλυκερύλιο, μονοστεατίνη, μονοπαλμιτίνη
 es:E471, mono- y diglicéridos de ácidos grasos, Monoglicéridos y diglicéridos de ácidos grasos, Mono y diglicéridos de ácidos grasos, Monodiglicéridos de ácidos grasos, Monoestearato de glicerilo, monopalmitato de glicerilo, monooleato de glicerilo, monoestearina, monopalmitina, monooleína
 et:E471, Rasvhapete mono- ja diglütseriidid, Glütserüülmonostearaat, glütserüülmonopalmitaat, glütserüülmonooleaat, monosteariin, monopalmitiin
@@ -11716,7 +11717,7 @@ en:E472, acid esters of mono- and diglycerides of fatty acids
 bg:E472, E472 food additive
 cs:E472, E472 food additive
 da:E472, E472 food additive
-de:E472, E472 food additive
+de:E472, Säureester von Mono- und Diglyceride von Speisefettsäuren
 el:E472, E472 food additive
 es:E472, E472 food additive
 et:E472, E472 food additive
@@ -11744,7 +11745,7 @@ bg:E472a, Естери на оцетната киселина с моно- и д
 ca:E472a, Èster acètic de monoglicèrids o diglicèrids d'àcids grassos
 cs:E472a, Estery mono- a diglyceridů mastných kyselin s kyselinou octovou
 da:E472a, Edikkesyreestere af mono- og diglycerider af fedtsyrer
-de:E472a, Essigsäureester von mono- und diglyceriden von speisefettsäuren
+de:E472a, Essigsäureester von Mono- und Diglyceriden von Speisefettsäuren
 el:E472a, Εστερες του οξικου οξεος με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E472a, Ésteres acéticos de monoglicéridos y diglicéridos de ácidos grasos
 et:E472a, Rasvhapete mono- ja diglütseriidide estrid äädikhappega
@@ -11772,7 +11773,7 @@ en:E472b, Lactic acid esters of mono- and diglycerides of fatty acids
 bg:E472b, Естери на млечната киселина с моно- и диглицериди на мастни киселини
 cs:E472b, Estery mono- a diglyceridů mastných kyselin s kyselinou mléčnou
 da:E472b, Mælkesyreestere af mono- og diglycerider af fedtsyrer
-de:E472b, Milchsäureester von mono- und diglyceriden von speisefettsäuren
+de:E472b, Milchsäureester von Mono- und Diglyceriden von Speisefettsäuren
 el:E472b, Εστερες του γαλακτικου οξεος με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E472b, Ésteres lácticos de monoglicéridos y diglicéridos de ácidos grasos
 et:E472b, Rasvhapete mono- ja diglütseriidide estrid piimhappega
@@ -11800,7 +11801,7 @@ en:E472c, Citric acid esters of mono- and diglycerides of fatty acids
 bg:E472c, Естери на лимонената киселина с моно- и диглицериди на мастни киселини
 cs:E472c, Estery mono- a diglyceridů mastných kyselin s kyselinou citronovou
 da:E472c, Citronsyreestere af mono- og diglycerider af fedtsyrer
-de:E472c, Citronensäureester von mono- und diglyceriden von speisefettsäuren
+de:E472c, Citronensäureester von Mono- und Diglyceriden von Speisefettsäuren
 el:E472c, Εστερες του κιτρικου οξεος με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E472c, Ésteres cítricos de monoglicéridos y diglicéridos de ácidos grasos, Ésteres cítricos de mono y diglicéridos de ácidos grasos
 et:E472c, Rasvhapete mono- ja diglütseriidide estrid sidrunhappega
@@ -11828,7 +11829,7 @@ en:E472d, Tartaric acid esters of mono- and diglycerides of fatty acids
 bg:E472d, Естери на винената киселина с моно- и диглицериди на мастни киселини
 cs:E472d, Estery mono- a diglyceridů mastných kyselin s kyselinou vinnou
 da:E472d, Vinsyreestere af mono- og diglycerider af fedtsyrer
-de:E472d, Weinsäureester von mono- und diglyceriden von speisefettsäuren
+de:E472d, Weinsäureester von Mono- und Diglyceriden von Speisefettsäuren
 el:E472d, Εστερες του τρυγικου οξεος με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E472d, Ésteres tartáricos de monoglicéridos y diglicéridos de ácidos grasos
 et:E472d, Rasvhapete mono- ja diglütseriidide estrid viinhappega
@@ -11856,7 +11857,7 @@ bg:E472e, Естери на моно- и диацетилвинената кис
 ca:E472e, Èster monoacetiltartàric o diacetiltartàric de monoglicèrids o diglicèrids d'àcids grassos
 cs:E472e, Estery mono- a diglyceridů mastných kyselin s kyselinou mono- a diacetylvinnou
 da:E472e, Mono- og diacetylvinsyreestere af mono- og diglycerider af fedtsyrer
-de:E472e, Mono- und diacetylweinsäureester von mono- und diglyceriden von speisefettsäuren, Diacetylweinsäureglyceride, Diacetylweinsäureester von Mono- und Diglyceriden von Speisefettsäuren, E 472e
+de:E472e, Mono- und Diacetylweinsäureester von Mono- und Diglyceriden von Speisefettsäuren, Diacetylweinsäureglyceride, Diacetylweinsäureester von Mono- und Diglyceriden von Speisefettsäuren, E 472e
 el:E472e, Εστερες του μονο- και διακετυλοτρυγικου οξεος με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E472e, Ésteres monoacetiltartárico y diacetiltartárico de monoglicéridos y diglicéridos de ácidos grasos, Éster monoacetiltartárico de mono- y diglicéridos de ácidos grasos
 et:E472e, Rasvhapete mono- ja diglütseriidide estrid mono- ja diatsetüülviinhappega
@@ -11884,7 +11885,7 @@ en:E472f, Mixed acetic and tartaric acid esters of mono- and diglycerides of fat
 bg:E472f, Смесени естери на оцетната и винената киселина с моно- и диглицериди на мастни киселини
 cs:E472f, Směsné estery mono- a diglyceridů mastných kyselin s kyselinou octovou a vinnou
 da:E472f, Blandede eddikesyre- og vinsyreestere af mono- og diglycerider af fedtsyrer
-de:E472f, Gemischte essig- und weinsäureester von mono- und diglyceriden von speisefettsäuren
+de:E472f, Gemischte Essig- und Weinsäureester von Mono- und Diglyceriden von Speisefettsäuren
 el:E472f, Μεικτοι εστερες του οξικου και τρυγικου οξεος με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E472f, Mixed acetic and tartaric acid esters of mono- and diglycerides of fatty acids
 et:E472f, Rasvhapete mono- ja diglütseriidide estrid äädik- ja viinhappe seguga
@@ -11911,7 +11912,7 @@ en:E472g, Succinylated monoglycerides
 bg:E472g, E472g food additive
 cs:E472g, E472g food additive
 da:E472g, E472g food additive
-de:E472g, E472g food additive
+de:E472g, Succinylierte Monoglyceride
 el:E472g, E472g food additive
 es:E472g, E472g food additive
 et:E472g, E472g food additive
@@ -11942,7 +11943,7 @@ bg:E473, Естери на мастни киселини и захароза, С
 ca:E473, Sucroèster d'àcids grassos
 cs:E473, Estery sacharosy s mastnými kyselinami, Estery sacharosy
 da:E473, Saccharoseestere af fedtsyrer
-de:E473, Zuckerester von speisefettsäuren, Saccharoseester, Zuckerester, E 473, Saccharoseester von Speisefettsäuren
+de:E473, Zuckerester von Speisefettsäuren, Saccharoseester, Zuckerester, E 473, Saccharoseester von Speisefettsäuren
 el:E473, Εστερες λιπαρων οξεων με σακχαροζη, Εστεροσάκχαρα
 es:E473, Sucroésteres de ácidos grasos, Sucroésteres, Ésteres de sacarosa de los ácidos grasos
 et:E473, Rasvhapete sahharoosestrid
@@ -12048,7 +12049,7 @@ bg:E475, Полиглицеролови естери на мастни кисе�
 ca:E475, Èster poliglicèrid d'àcids grassos
 cs:E475, Estery polyglycerolu s mastnými kyselinami
 da:E475, Polyglycerolestere af fedtsyrer
-de:E475, Polyglycerinester von speisefettsäuren
+de:E475, Polyglycerinester von Speisefettsäuren
 el:E475, Πολυγλυκεριδια λιπαρων οξεων
 es:E475, Ésteres poliglicéricos de ácidos grasos
 et:E475, Rasvhapete polüglütseroolestrid
@@ -12077,7 +12078,7 @@ bg:E476, Полиглицерол полирицинолеат, Е476, PGPR
 ca:E476, Poliricinoleat de poligliceril
 cs:E476, Polyglycerylpolyricinoleát
 da:E476, Polyglycerolpolyricinoleat
-de:E476, Polyglycerin-polyricinoleat, E 476, PGPR
+de:E476, Polyglycerin-Polyricinoleat, E 476, PGPR
 el:E476, Πολυγλυκεριδια του πολυρικινελαϊκου οξεος
 es:E476, Polirricinoleato de poliglicerol, Polyglycerol polyricinoleate
 et:E476, Ritsinoolhappe polüglütseroolestrid
@@ -12109,7 +12110,7 @@ bg:E477, Пропан-1\,2-диол естери на мастни кисели�
 ca:E477, Èster d'1,2-propà-diol d'àcids grassos
 cs:E477, Estery propan-1\,2-diolu s mastnými kyselinami
 da:E477, Propylenglycolestere af fedtsyrer
-de:E477, Propylenglycolester von speisefettsäuren
+de:E477, Propylenglycolester von Speisefettsäuren
 el:E477, Εστερες λιπαρων οξεων με προπανοδιολη-1\,2
 es:E477, Ésteres de propano-1\,2-diol de ácidos grasos
 et:E477, Rasvhapete propüleenglükoolestrid
@@ -12171,7 +12172,7 @@ bg:E479b, Термично окислено соево масло с моно-и
 ca:E479b, Oli de soja oxidat tèrmicament i en interacció amb monoglicèrids i diglicèrids d'àcids grassos
 cs:E479b, Směsný produkt interakce tepelně opracovaného sójového oleje s mono- a diglyceridy mastných kyselin
 da:E479b, Termisk oxideret sojaolie omsat med mono- og diglycerider af fedtsyrer
-de:E479b, Thermooxidiertes sojaöl verestert mit mono- und diglyceriden von speisefettsäuren
+de:E479b, Thermooxidiertes Sojaöl verestert mit Mono- und Diglyceriden von Speisefettsäuren
 el:E479b, Θερμικως οξειδωμενο σογιελαιο που εχει αντιδρασει με μονο- και διγλυκεριδια λιπαρων οξεων
 es:E479b, Aceite de soja oxidado térmicamente en interacción con monoglicéridos y diglicéridos de ácidos grasos
 et:E479b, Termiliselt oksüdeeritud sojaõli rasvhapete mono- ja diglütseriidide estrid
@@ -12940,7 +12941,7 @@ en:E502, Carbonates
 bg:E502, E502 food additive
 cs:E502, E502 food additive
 da:E502, E502 food additive
-de:E502, E502 food additive
+de:E502, Carbonate
 el:E502, E502 food additive
 es:E502, Carbonatos
 et:E502, E502 food additive
@@ -14754,7 +14755,7 @@ bg:E579, Феро глюконат, Феро-ди-D-глюконат дихид�
 ca:E579, Gluconat ferrós
 cs:E579, Glukonan železnatý
 da:E579, Ferrogluconat, Ferrodi-D-gluconatdihydrat
-de:E579, Eisen(ii)-gluconat, Eisengluconat, E 579, Eisen(II)Gluconat
+de:E579, Eisengluconat, Eisen(II)-gluconat, Eisen(II)Gluconat
 el:E579, Γλυκονικος σιδηρος
 es:E579, Gluconato ferroso
 et:E579, Ferroglükonaat
@@ -15766,7 +15767,7 @@ bg:E901, Пчелен восък, бял и жълт, Бял восък
 ca:E901, Cera d'abelles
 cs:E901, Včelí vosk, bílý a žlutý, Bílý vosk, E 901
 da:E901, Bivoks, hvidt og gult, Hvidt voks, E-901
-de:E901, Bienenwachs; weiss und gelb, weißes Wachs, Bienenwachs, E 901, Myricin, Cera Flava
+de:E901, Bienenwachs; weiß und gelb, weißes Wachs, Bienenwachs, E 901, Myricin, Cera Flava, Bienenwachs; weiß und gelb
 el:E901, Κηρος μελισσων, λευκος και κιτρινος, Λευκός κηρός
 es:E901, Cera de abeja, blanca y amarilla, Cera blanca, Cera estampada
 et:E901, Kollane ja valge meevaha, Valge vaha, Mesilasvaha, Vaha
@@ -17334,7 +17335,7 @@ bg:E950, Ацесулфам к, Калиев ацесулфам
 ca:E950, Acesulfam K
 cs:E950, Acesulfam k, Acesulfam draselný
 da:E950, Acesulfamkalium, Acesulfamkalium, Acesulfam K
-de:E950, Acesulfam k
+de:E950, Acesulfam-K
 el:E950, Ακεσουλφαμη κ, Ακεσουλφάμη (άλας με Κ)
 es:E950, Acesulfamo K, Acesulfamo k, Acesulfamo potásico, acesulfame potásico
 et:E950, Kaaliumatsesulfaam, Atsesulfaamkaalium, atsesulfaam-K

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1938,6 +1938,9 @@ wikidata:en:Q191907
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2014.3492
 efsa_evaluation_date:en: 2014-01-22
 efsa_evaluation:en: Scientific Opinion on the reconsideration of the ADI and a refined exposure assessment of beta-apo-8'-carotenal (E 160e)
+# Stabiliser/carrier may not be vegetarian, can be e.g. fish gelatine, which does not need to be labeled in EU right
+# https://www.vrg.org/blog/2012/02/15/beta-carotene-in-us-beverages-not-stabilized-with-gelatin-unlike-some-products-in-the-uk
+# https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32007L0068
 vegan:en:maybe
 vegetarian:en:maybe
 
@@ -2118,8 +2121,8 @@ en:E160b, Annatto, bixin, norbixin, roucou, achiote
 bg:E160b, Анато, биксин, норбиксин (i), БИКСИН И НОРБИКСИН
 ca:E160b, Bixina
 cs:E160b, Annatto, bixin, norbixin
-da:E160b, Annattoekstrakter (bixin, norbixin)
-de:E160b, Annatto (Bixin; Norbixin), BIXIN UND NORBIXIN, Annatto, Achote, Orlean, E 160b, Anatto
+da:E160b, Annattoekstrakter (bixin og norbixin)
+de:E160b, Annatto (Bixin und Norbixin), Bixin und Norbixin, Annatto, Achote, Orlean, E 160b, Anatto, Bixin, Norbixin
 el:E160b, Αννατο, μπιξινη, νορμπιξινη (i)
 es:E160b, Annato, bixina, norbixina, Achiote
 et:E160b, Annaato, biksiin, norbiksiin (i)
@@ -2152,8 +2155,8 @@ en:E160c, Paprika extract, capsanthin, capsorubin, Paprika oleoresin
 bg:E160c, Паприка екстракт, капсантин, капсорубин
 ca:E160c, Capsantina
 cs:E160c, Paprikový extrakt, kapsanthin, kapsorubin, Capsanthin
-da:E160c, Paprikaekstrakt (capsanthin, capsorubin)
-de:E160c, Paprikaextrakt (Capsanthin; Capsorubin), Capsanthin, E 160c
+da:E160c, Paprikaekstrakt (capsanthin og capsorubin)
+de:E160c, Paprikaextrakt (Capsanthin und Capsorubin), Capsanthin, E 160c, Capsorubin
 el:E160c, Εκχυλισμα παπρικας, καψανθινη, καψορουμπινη
 es:E160c, Extracto de pimentón, capsantina, capsorrubina, Oleorresina de pimentón, Oleoresina de pimentón, Extracto de paprika, Oleoresina del pimentón, E 160c, Extracto del pimentón
 et:E160c, Paprikaekstrakt, kapsantiin, kapsorubiin
@@ -3016,8 +3019,11 @@ efsa_evaluation:en:Scientific Opinion on re‐evaluation of calcium carbonate (E
 efsa_evaluation_overexposure_risk:en: en:no
 additives_classes:en: en:colour, en:stabilizer
 organic_eu:en:authorized
-vegan:en:yes
-vegetarian:en:yes
+#“Eggshells, snail shells and most seashells are predominantly calcium carbonate and can be used as industrial sources of that chemical.” https://en.wikipedia.org/wiki/Calcium_carbonate#Biological_sources
+#Oyster shell source may not be needed to label in USA
+#https://www.vrg.org/blog/2011/12/12/calcium-carbonate-in-most-soy-rice-beverages-and-in-calcium-supplements-derived-from-a-mineral-source-not-oyster-shell-source-does-not-have-to-be-labeled/
+vegan:en:maybe
+vegetarian:en:maybe
 
 en:E171, Titanium dioxide
 bg:E171, Титанов диоксид, Титанов двуокис, Титаниев двуокис, Титаниев диоксид
@@ -6700,7 +6706,7 @@ bg:E333, E333 food additive
 ca:E333, Citrats de calci
 cs:E333, Citrát vápenatý
 da:E333, E333 food additive
-de:E333, Calciumcitrat, Tricalciumcitrat, E 333, Kalziumzitrat
+de:E333, Calciumcitrat, Tricalciumcitrat, E 333, Kalziumzitrat, Calciumcitrate
 el:E333, E333 food additive
 es:E333, Citratos de calcio, citrato cálcico, citrato de calcio, Sal amarga, E 333
 et:E333, E333 food additive
@@ -6822,7 +6828,7 @@ el:E334, L(+)-τρυγικο οξυ, τρυγικο οξυ
 es:E334, Ácido tartárico, Ácido l(+)-tartárico, E 334, Crémor tartaro, Ácido tártrico
 et:E334, L(+)-viinhape, viinhape, L-viinhape, L-2\,3-dihüdroksübutaandihape
 fi:E334, L(+)-viinihappo, viinihappo, L-Viinihappo, L-2\,3-Dihydroksibutaanidihappo, 2\,3-dihydroksibutaanidihappo, E 334
-fr:E334, Acide L-tartrique, Acide tartrique, Acide L(+)tartrique, Acide d-α, β-dihydroxysuccinique, Acide dextrotartarique ; acide 3-hydroxy malique, CAS 87-69-4, Acide DL-tartrique, 147-71-7, 147-73-9, Acide DL-tartrique monohydraté, 87-69-4, Acide racémique, 133-37-9, Acide D-tartrique, Tartrate, Acide mesotartrique, C4H6O6
+fr:E334, Acide L-tartrique, Acide tartrique, Acide L(+)tartrique, Acide d-α, β-dihydroxysuccinique, Acide dextrotartarique, acide 3-hydroxy malique, CAS 87-69-4, Acide DL-tartrique, 147-71-7, 147-73-9, Acide DL-tartrique monohydraté, 87-69-4, Acide racémique, 133-37-9, Acide D-tartrique, Tartrate, Acide mesotartrique, C4H6O6
 hu:E334, L(+)-borkősav, borkősav, L-Borkősav, L-2\,3-Dihidroxi-butándisav
 it:E334, L(+)-acido tartarico, acido tartarico, Acido 2\,3-diidrossibutandioico, Tartaro emetico, Tartrato, C4H6O6
 lt:E334, Vyno rūgštis (l(+)-), vyno rūgštis
@@ -8283,7 +8289,7 @@ additives_classes:en: en:antioxidant, en:preservative, en:sequestrant
 vegan:en:yes
 vegetarian:en:yes
 
-en:E385, Calcium disodium ethylenediaminetetraacetate, Calcium disodium EDTA, Calcium disodium ethylene diamine tetra-acetate, Calcium disodium ethylene diamine tetra-acetate; calcium disodium EDTA, calcium-dinatrium-EDTA
+en:E385, Calcium disodium ethylenediaminetetraacetate, Calcium disodium EDTA, Calcium disodium ethylene diamine tetra-acetate, Calcium disodium ethylene diamine tetra-acetate, calcium disodium EDTA, calcium-dinatrium-EDTA
 bg:E385, Калциев динатриев етилен диамин тетраацетат, Калциев динатриев ЕДТА
 ca:E385, Etilendiaminotetracetat de calci i disodi, EDTA de calci i disodi
 cs:E385, Dvojsodnovápenatá sůl kyseliny diamintetraoctové
@@ -9013,7 +9019,7 @@ lv:E413, Tragakants, Tragakantsveķi
 mt:E413, Tragakant, Gomma Tragacant
 nl:E413, Tragant, Tragacanthgom, Tragacanth
 pl:E413, Tragakanta, Guma tragakantowa, Guma tragankowa
-pt:E413, Tragacanto, Goma de tragacanto, alcatira;goma adragante, goma adraganta
+pt:E413, Tragacanto, Goma de tragacanto, alcatira, goma adragante, goma adraganta
 ro:E413, Adragant, Gumă tragacant, Tragacant
 sk:E413, Tragant, Tragantová guma
 sl:E413, Tragakant, gumi tragakant
@@ -11477,7 +11483,7 @@ en:E466, Sodium carboxy methyl cellulose, carboxy methyl cellulose, Carboxymethy
 bg:E466, Натриева карбокси метил целулоза, карбокси метил целулоза, целулозна гума, CMC, NaCMC
 ca:E466, Carboximetilcel·lulosa sòdica
 cs:E466, Sodná sůl karboxymethylcelulosy, karboxymethylcelulosa, celulosová guma, CMC, NaCMC, Karboxymethylcelulóza, Karboxymetylcelulóza, Karboxymetylcelulosa, E 466
-da:E466, Natriumcarboxymethylcellulose (carboxymethylcellulose, cellulosegummi)
+da:E466, Natriumcarboxymethylcellulose (carboxymethylcellulose og cellulosegummi)
 de:E466, Carboxymethylcellulose, natrium-carboxymethylcellulose, cellulosegummi, CMC, NaCMC, Carboxymethylcellulosen, Carboxymethylzellulose, E 466, Natriumcarboxymethylcellulose
 el:E466, Αλας με νατριο της καρβοξυμεθυλοκυτταρινης, καρβοξυμεθυλοκυτταρινη, κομμι κυτταρινης, CMC, NaCMC
 es:E466, Carboximetilcelulosa sódica, carboximetilcelulosa, carboximetil celulosa, goma de celulosa, CMC, NaCMC
@@ -11491,7 +11497,7 @@ lv:E466, Nātrija karboksimetilceluloze, karboksimetilceluloze, celulozes sveķi
 mt:E466, Ċelluloża karbossimetilika tas-sodju, ċelluloża karbossimetilika, gomma taċ-ċelluloża, CMC, NaCMC
 nl:E466, Natriumcarboxymethylcellulose, carboxymethylcellulose, cellulosegom, CMC, NaCMC
 pl:E466, Sól sodowa karboksymetylocelulozy, karboksymetyloceluloza, guma celulozowa, CMC, NaCMC
-pt:E466, Carboximetilcelulose de sódio; carboximetilcelulose; goma de celulose, CMC, NaCMC, Carboximetilcelulose
+pt:E466, Carboximetilcelulose de sódio, carboximetilcelulose, goma de celulose, CMC, NaCMC
 ro:E466, Carboximetilceluloză de sodiu, carboximetilceluloză, gumă de celuloză, CMC, NaCMC
 sk:E466, Sodná soľ karboxymetylcelulózy, karboxymetylcelulóza, celulózová guma, CMC, NaCMC
 sl:E466, Natrijeva karboksimetil celuloza, karboksimetil celuloza, celulozni gumi, CMC, NaCMC
@@ -11568,7 +11574,7 @@ de:E469, Enzymatisch hydrolysierte carboxymethylcellulose, enzymatisch hydrolysi
 el:E469, Ενζυμικα υδρολυμενη καρβοξυμεθυλοκυτταρινη, ενζυμικα υδρολυμενο κομμι κυτταρινησ
 es:E469, Carboximetilcelulosa hidrolizada enzimáticamente, goma de celulosa hidrolizada enzimáticamente
 et:E469, Ensümaatiliselt hüdrolüüsitud karboksümetüültselluloos
-fi:E469, Entsymaattisesti hydrolysoitu karboksimetyyliselluloosa; entsymaattisesti hydrolysoitu selluloosakumi
+fi:E469, Entsymaattisesti hydrolysoitu karboksimetyyliselluloosa, entsymaattisesti hydrolysoitu selluloosakumi
 fr:E469, Carboxyméthylcellulose hydrolysée de manière enzymatique, gomme de cellulose hydrolysée de manière enzymatique
 hu:E469, Enzimesen hidrolizált karboxi-metil-cellulóz, enzimesen hidrolizált cellulózgumi, Nátrium-karboxi-metil-cellulóz
 it:E469, Carbossimetilcellulosa idrolizzata enzimaticamente, gomma di cellulosa idrolizzata enzimaticamente
@@ -12669,7 +12675,7 @@ el:E495, Μονοπαλμιτικη σορβιτανη
 es:E495, Monopalmitato de sorbitano
 et:E495, Sorbitaanmonopalmitaat
 fi:E495, Sorbitaanimonopalmitaatti
-fr:E495, Monopalmitate de sorbitane, Palmitate de sorbitane, mélange d'esters de sorbitol; de sorbitan et d'isosorbide, Span 40
+fr:E495, Monopalmitate de sorbitane
 hu:E495, Szorbitan-monopalmitát
 it:E495, Monopalmitato di sorbitano
 lt:E495, Sorbitano monopalmitatas
@@ -15762,29 +15768,29 @@ e_number:en:900b
 vegan:en:yes
 vegetarian:en:yes
 
-en:E901, White and Yellow Beeswax, beeswax, White wax
-bg:E901, Пчелен восък, бял и жълт, Бял восък
+en:E901, white and yellow beeswax, beeswax, white beeswax, yellow beeswax, white wax
+bg:E901, Пчелен восък бял и жълт, Пчелен восък, Пчелен восък бял, Пчелен восък жълт, Бял восък
 ca:E901, Cera d'abelles
-cs:E901, Včelí vosk, bílý a žlutý, Bílý vosk, E 901
-da:E901, Bivoks, hvidt og gult, Hvidt voks, E-901
-de:E901, Bienenwachs; weiß und gelb, weißes Wachs, Bienenwachs, E 901, Myricin, Cera Flava, Bienenwachs; weiß und gelb
+cs:E901, Včelí vosk bílý a žlutý, Včelí vosk, Včelí vosk bílý, Včelí vosk žlutý, Bílý vosk, E 901
+da:E901, Bivoks hvidt og gult, Bivoks, Bivoks hvidt, Bivoks gult, Hvidt voks, E-901
+de:E901, Bienenwachs weiß und gelb, Bienenwachs, Bienenwachs weiß, Bienenwachs gelb, weißes Wachs, Bienenwachs, E 901, Myricin, Cera Flava, Bienenwachs weiss und gelb
 el:E901, Κηρος μελισσων, λευκος και κιτρινος, Λευκός κηρός
-es:E901, Cera de abeja, blanca y amarilla, Cera blanca, Cera estampada
+es:E901, Cera de abeja blanca y amarilla, Cera de abeja, Cera de abeja blanca, Cera de abeja amarilla, Cera blanca, Cera estampada
 et:E901, Kollane ja valge meevaha, Valge vaha, Mesilasvaha, Vaha
-fi:E901, Mehiläisvaha, valkoinen ja keltainen, Valkoinen mehiläisvaha
+fi:E901, Mehiläisvaha valkoinen ja keltainen, Mehiläisvaha, Mehiläisvaha valkoinen, Mehiläisvaha keltainen, Valkoinen mehiläisvaha
 fr:E901, Cire d'abeille, Cire d'abeille alimentaire, Cire d'abeille blanchâtre, Cire d'abeille jaunâtre, Cire blanche, cire jaune, Cire d'abeilles, Cire d'abeille blanche et jaune, 8012-89-3, 8006-40-4
-hu:E901, Fehér és sárga méhviasz, Fehér viasz, Méhviasz
-it:E901, Cera d'api, binaca e gialla, Cera vergine
-lt:E901, Bičių vaškas, baltas ir geltonas, Baltasis vaškas
-lv:E901, Baltais un dzeltenais bišu vasks, Baltais vasks, Bišu vasks
+hu:E901, Fehér és sárga méhviasz, Méhviasz, Fehér méhviasz, Sárga méhviasz, Fehér viasz
+it:E901, Cera d'api binaca e gialla, Cera d'api, Cera d'api binaca, Cera d'api gialla, Cera vergine
+lt:E901, Bičių vaškas baltas ir geltonas, Bičių vaškas, Bičių vaškas baltas, Bičių vaškas geltonas, Baltasis vaškas
+lv:E901, Baltais un dzeltenais bišu vasks, Bišu vasks, Baltais bišu vasks, Dzeltenais bišu vasks, Baltais vasks
 mt:E901, Xama' tan-naħal, bajda u safra, Xama' bajda
-nl:E901, Bijenwas, wit en geel, Witte was, Ceratiet
-pl:E901, Wosk pszczeli, biały i żółty, Wosk biały
+nl:E901, Bijenwas wit en geel, Bijenwas, Bijenwas wit, Bijenwas geel, Witte was, Ceratiet
+pl:E901, Wosk pszczeli biały i żółty, Wosk pszczeli, Wosk pszczeli biały, Wosk pszczeli żółty, Wosk biały
 pt:E901, Cera de abelhas (branca e amarela), Cera branca, Cera
-ro:E901, Ceară de albine, albă și galbenă, Ceară albă
-sk:E901, Biely a žltý včelí vosk, Biely vosk
-sl:E901, Čebelji vosek, beli in rumeni, beli vosek
-sv:E901, Bivax, vitt och gult, Vitt vax, E 901, Keromanti, Vaxkaka
+ro:E901, Ceară de albine albă și galbenă, Ceară de albine, Ceară de albine albă, Ceară de albine galbenă, Ceară albă
+sk:E901, Biely a žltý včelí vosk, včelí vosk, biely včelí vosk, žltý včelí vosk, biely vosk
+sl:E901, Čebelji vosek beli in rumeni, Čebelji vosek, Čebelji vosek beli, Čebelji vosek rumeni, beli vosek
+sv:E901, Bivax vitt och gult, Bivax, Bivax vitt, Bivax gult, Vitt vax, E 901, Keromanti, Vaxkaka
 e_number:en:901
 wikidata:en:Q143739
 efsa_evaluation_url:en: http://dx.doi.org/10.2903/j.efsa.2007.615

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -1258,7 +1258,7 @@ sv:Bakpulver
 # da:Hævemiddel
 wikidata:en:Q905648
 
-en:stabiliser, stabilizer, stabilizers
+en:stabilizer, stabiliser, stabilizers
 bg:Стабилизатор
 cs:Stabilizátor
 de:Stabilisator, Stabilisatoren
@@ -3745,7 +3745,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Agar
 # description:en:CARRAGEENAN or carrageenins are a family of linear sulfated polysaccharides that are extracted from red edible seaweeds.
 
 # <en:gelling agent
-# <en:stabiliser
+# <en:stabilizer
 en:carrageenan, E407, e 407, e-407, INS 407
 bg:Карагенан
 ca:carragenina

--- a/taxonomies/minerals.txt
+++ b/taxonomies/minerals.txt
@@ -42,7 +42,7 @@ ca:Mineral
 cs:Minerál, Minerální látky
 cy:Mwyn
 da:Mineral
-de:Mineral, Mineralstoffe
+de:Mineral, Mineralstoffe, Minerale, Mineralien
 el:Ορυκτό, Ανόργανα συστατικά, Ανόργανα άλατα
 eo:Mineralo
 es:Mineral, Minerales, Sales minerales
@@ -2128,7 +2128,7 @@ ar:غلوكونات الحديد الثنائي
 bg:Феро глюконат
 cs:Glukonan železnatý
 da:Ferrogluconat
-de:Eisengluconat
+de:Eisengluconat, Eisen(II)-gluconat
 el:Γλυκονικος σιδηρος
 es:Gluconato ferroso
 et:Ferroglükonaat


### PR DESCRIPTION
**Description:**
* add many German translations, spelling corrections for additives (mainly capitalisation)
* carotenoids, carotene, beta-carotene marked as maybe vegetarian and maybe vegan, see e.g. [here](https://www.vrg.org/blog/2012/02/15/beta-carotene-in-us-beverages-not-stabilized-with-gelatin-unlike-some-products-in-the-uk) and [there](https://www.coca-cola.co.uk/faq/ingredients/coca-cola-drinks-suitable-for-vegans-vegetarians)
* calcium carbonate marked as maybe vegetarian and maybe vegan, see e.g. [here](https://en.wikipedia.org/wiki/Calcium_carbonate#Biological_sources) and [there](https://www.vrg.org/blog/2011/12/12/calcium-carbonate-in-most-soy-rice-beverages-and-in-calcium-supplements-derived-from-a-mineral-source-not-oyster-shell-source-does-not-have-to-be-labeled)
* rename E160 in English from carotene to carotenoids, because carotene is for E160a, compare [here](https://en.wikipedia.org/wiki/E160)