### PR TITLE
Enable sequential uploads for blueimp-file-upload

### DIFF
--- a/cgi/import_file_upload.pl
+++ b/cgi/import_file_upload.pl
@@ -180,6 +180,7 @@ HTML
 	$initjs .= <<JS
 
 \$('#file_input_$id').fileupload({
+	sequentialUploads: true,
 	dataType: 'json',
 	url: "/cgi/import_file_upload.pl",
 	formData : [{name: 'action', value: 'process'}],

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -608,6 +608,7 @@ function update_display(imagefield, first_display) {
 	var imagefield = id;
 
    $('#imgupload_' + id).fileupload({
+        sequentialUploads: true,
         dataType: 'json',
         url: '/cgi/product_image_upload.pl',
 		formData : [{name: 'jqueryfileupload', value: 1}, {name: 'imagefield', value: imagefield}, {name: 'code', value: code} ],

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -308,6 +308,7 @@ JS
 \/\/ start off canvas blocks for small screens
 
     \$('#imgupload_search_$id').fileupload({
+		sequentialUploads: true,
         dataType: 'json',
         url: '/cgi/product.pl',
 		formData : [{name: 'jqueryfileupload', value: 1}],


### PR DESCRIPTION
**Description:**
Forces image uploads to be done [sequentially](https://github.com/blueimp/jQuery-File-Upload/wiki/Options#sequentialuploads) instead of in parallel. This should help with some [image uploading problems](https://github.com/openfoodfacts/openfoodfacts-server/issues?utf8=✓&q=label%3A"image+upload"), ie. race conditions.

**Related issues and discussion:** Possibly helps with #304
