### PR TITLE
Robots.txt allow some /cgi URLs

### DIFF
--- a/html/files/robots.txt
+++ b/html/files/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
+Allow: /cgi/product_image.pl
+Allow: /cgi/opensearch.pl
 Disallow: /cgi
 Disallow: /code
 User-agent: Slurp

--- a/html/files/robots.txt
+++ b/html/files/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Disallow: /cgi
+Disallow: /code
+User-agent: Slurp
+Disallow: /
+User-agent: dotbot
+Disallow: /
+User-agent: AhrefsBot 
+Disallow: /
+User-agent: MJ12bot
+Disallow: /

--- a/html/files/robots.txt
+++ b/html/files/robots.txt
@@ -9,3 +9,5 @@ User-agent: AhrefsBot
 Disallow: /
 User-agent: MJ12bot
 Disallow: /
+User-agent: SemrushBot
+Disallow: /


### PR DESCRIPTION
**Description:**
We could allow bots to index the OpenSearch description, so that search engines know how to redirect search requests to OpenFoodFacts. Also, it might be a good idea to have image info pages to be index for better link rank and to get the image license and attribution "out there".

**Related issues and discussion:** N/A
