### PR TITLE
ci: Automatically rebuild taxonomies

### DIFF
--- a/.github/workflows/update_taxonomies.yml
+++ b/.github/workflows/update_taxonomies.yml
@@ -1,0 +1,66 @@
+name: Update Taxonomies
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'taxonomies/*.txt'
+      - '!taxonomies/*.result.txt'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: prepare dependencies and rebuild taxonomies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends cpanminus tesseract-ocr
+        # apt packages from cpanfile
+        sudo apt-get install -y --no-install-recommends graphviz \
+        libwww-perl \
+        libimage-magick-perl \
+        libxml-encoding-perl \
+        libtext-unaccent-perl \
+        libmime-lite-perl \
+        libcache-memcached-fast-perl \
+        libjson-pp-perl \
+        libclone-perl \
+        libcrypt-passwdmd5-perl \
+        libencode-detect-perl \
+        libgraphics-color-perl \
+        libbarcode-zbar-perl \
+        libxml-feedpp-perl \
+        liburi-find-perl \
+        libxml-simple-perl \
+        libexperimental-perl \
+        libapache2-request-perl \
+        libdigest-md5-perl \
+        libtime-local-perl
+        # setup local::lib
+        cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+        # install perl dependencies
+        cpanm --quiet --installdeps --notest --skip-satisfied .
+        # Prepare config
+        export BUILD_DIR=`pwd`
+        ln -s $BUILD_DIR/lib/ProductOpener/Config_off.pm $BUILD_DIR/lib/ProductOpener/Config.pm
+        cp $BUILD_DIR/lib/ProductOpener/Config2_sample.pm $BUILD_DIR/lib/ProductOpener/Config2.pm
+        ln -s $BUILD_DIR/lib/ProductOpener/SiteLang_off.pm $BUILD_DIR/lib/ProductOpener/SiteLang.pm
+        sed -i -e 's|\$server_domain = "openfoodfacts.org";|\$server_domain = "off.travis-ci.org";|g' $BUILD_DIR/lib/ProductOpener/Config2.pm
+        sed -i -e 's|\/home\/off|'$BUILD_DIR'|g' $BUILD_DIR/lib/ProductOpener/Config2.pm
+        # Rebuild taxonomies
+        perl -CS -I$BUILD_DIR/lib $BUILD_DIR/scripts/build_lang.pl
+        node refresh_taxonomies.js
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v1.1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        PULL_REQUEST_BRANCH: rebuild-taxonomies/patch
+        COMMIT_MESSAGE: "build: Rebuilt taxonomies because of changed source files"
+        PULL_REQUEST_TITLE: Update taxonomies
+        PULL_REQUEST_BODY: The taxonomies were automatically rebuilt because of changed source files.

--- a/.github/workflows/update_taxonomies.yml
+++ b/.github/workflows/update_taxonomies.yml
@@ -56,10 +56,9 @@ jobs:
         perl -CS -I$BUILD_DIR/lib $BUILD_DIR/scripts/build_lang.pl
         node refresh_taxonomies.js
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v1.1.1
+      uses: peter-evans/create-pull-request@v1.5.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         PULL_REQUEST_BRANCH: rebuild-taxonomies/patch
         COMMIT_MESSAGE: "build: Rebuilt taxonomies because of changed source files"
         PULL_REQUEST_TITLE: Update taxonomies

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ data/mongodb
 Lang.open*
 users_emails.sto
 html/data/*
+taxonomies/ingredients.all.txt
+Lang.*.sto
 
 # Libraries
 node_modules


### PR DESCRIPTION
**Description:** If a push to `master` (ie. a merged pull request) updates `taxonomies/*.txt*`, try to run `refresh_taxonomies.js` to check if the taxonomies changed content-wise from the previous state, without the `.sto` files being updated in the same push.

**Related issues and discussion:** N/A
