### PR TITLE
load category stats only once, remove bottom and top 5% before comput…

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1418,12 +1418,11 @@ sub display_list_of_tags($$) {
 		#	$th_nutriments = "<th>" . ucfirst($Lang{"products_with_nutriments"}{$lang}) . "</th>";
 		#}
 
-		my $categories_nutriments_ref;
+		my $categories_nutriments_ref = $categories_nutriments_per_country{$cc};
 		my @cols = ();
 
 		if ($tagtype eq 'categories') {
 			if (defined $request_ref->{stats_nid}) {
-				$categories_nutriments_ref = retrieve("$data_root/index/categories_nutriments_per_country.$cc.sto");
 				push @cols, '100g','std', 'min', '10', '50', '90', 'max';
 				foreach my $col (@cols) {
 					$th_nutriments .= "<th>" . lang("nutrition_data_per_$col") . "</th>";
@@ -3402,7 +3401,7 @@ HTML
 
 	if ($tagtype eq 'categories') {
 
-		my $categories_nutriments_ref = retrieve("$data_root/index/categories_nutriments_per_country.$cc.sto");
+		my $categories_nutriments_ref = $categories_nutriments_per_country{$cc};
 
 		$log->debug("checking if this category has stored statistics", { cc => $cc, tagtype => $tagtype, tagid => $tagid }) if $log->is_debug();
 		if ((defined $categories_nutriments_ref) and (defined $categories_nutriments_ref->{$canon_tagid})
@@ -4241,7 +4240,7 @@ sub search_and_export_products($$$$$) {
 			binary => 1
 		});
 
-		my $categories_nutriments_ref = retrieve("$data_root/index/categories_nutriments_per_country.$cc.sto");
+		my $categories_nutriments_ref = $categories_nutriments_per_country{$cc};
 
 		# First pass needed if we flatten results
 		my %flattened_tags = ();
@@ -7555,7 +7554,7 @@ HTML
 	if ( (not ((defined $product_ref->{not_comparable_nutrition_data}) and ($product_ref->{not_comparable_nutrition_data})))
 			and  (defined $product_ref->{categories_tags}) and (scalar @{$product_ref->{categories_tags}} > 0)) {
 
-		my $categories_nutriments_ref = retrieve("$data_root/index/categories_nutriments_per_country.$cc.sto");
+		my $categories_nutriments_ref = $categories_nutriments_per_country{$cc};
 
 		if (defined $categories_nutriments_ref) {
 
@@ -8354,17 +8353,38 @@ sub compute_stats_for_products($$$$$$) {
 
 		next if ($nutriments_ref->{"${nid}_n"} < $min_products);
 
-		$nutriments_ref->{"${nid}_mean"} = $nutriments_ref->{"${nid}_s"} / $nutriments_ref->{"${nid}_n"};
-
-		my $std = 0;
-		foreach my $value (@{$nutriments_ref->{"${nid}_array"}}) {
-			$std += ($value - $nutriments_ref->{"${nid}_mean"}) * ($value - $nutriments_ref->{"${nid}_mean"});
-		}
-		$std = sqrt($std / $nutriments_ref->{"${nid}_n"});
-
-		$nutriments_ref->{"${nid}_std"} = $std;
+		# Compute the mean and standard deviation, without the bottom and top 5% (so that huge outliers
+		# that are likely to be errors in the data do not completely overweight the mean and std)
 
 		my @values = sort { $a <=> $b } @{$nutriments_ref->{"${nid}_array"}};
+		my $nb_values = $#values + 1;
+		my $kept_values = 0;
+		my $sum_of_kept_values = 0;
+
+		my $i = 0;
+		foreach my $value (@values) {
+			$i++;
+			next if ($i <= $nb_values * 0.05);
+			next if ($i >= $nb_values * 0.95);
+			$kept_values++;
+			$sum_of_kept_values += $value;
+		}
+
+		my $mean_for_kept_values = $sum_of_kept_values / $kept_values;
+
+		$nutriments_ref->{"${nid}_mean"} = $mean_for_kept_values;
+
+		my $sum_of_square_differences_for_kept_values = 0;
+		my $i = 0;
+		foreach my $value (@values) {
+			$i++;
+			next if ($i <= $nb_values * 0.05);
+			next if ($i >= $nb_values * 0.95);
+			$sum_of_square_differences_for_kept_values += ($value - $mean_for_kept_values) * ($value - $mean_for_kept_values);
+		}
+		my $std_for_kept_values = sqrt($sum_of_square_differences_for_kept_values / $kept_values);
+
+		$nutriments_ref->{"${nid}_std"} = $std_for_kept_values;
 
 		$stats_ref->{nutriments}{"${nid}_n"} = $nutriments_ref->{"${nid}_n"};
 		$stats_ref->{nutriments}{"$nid"} = $nutriments_ref->{"${nid}_mean"};

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -40,6 +40,8 @@ BEGIN
 
 					@nutrient_levels
 
+					%categories_nutriments_per_country
+
 					&normalize_nutriment_value_and_modifier
 					&assign_nid_modifier_value_and_unit
 
@@ -96,6 +98,22 @@ use Hash::Util;
 use CGI qw/:cgi :form escapeHTML/;
 
 use Log::Any qw($log);
+
+# Load nutrient stats for all categories and countries
+# the stats are displayed on category pages and used in product pages,
+# as well as in data quality checks and improvement opportunity detection
+
+%categories_nutriments_per_country = ();
+
+foreach my $country (keys %{$properties{countries}}, 'en:world') {
+
+	my $country_cc = lc($properties{countries}{$country}{"country_code_2:en"});
+	if ($country eq 'en:world') {
+		$country_cc = 'world';
+	}
+	$categories_nutriments_per_country{$country_cc} = retrieve("$data_root/index/categories_nutriments_per_country.$country_cc.sto");
+}
+
 
 sub normalize_nutriment_value_and_modifier($$) {
 


### PR DESCRIPTION
…ing mean and std, bug #2436

I just remarked that we were loading a 10 Mb file with category stats for each product page view... I'm now loading them at apache startup. They are updated only nightly, and they don't change that much, so it's ok to reload them only when we restart the server.
