### PR TITLE
separate Nutriscore computation to Nutriscore.pm module, bug #2427

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,7 +73,9 @@ jobs:
         libexperimental-perl \
         libapache2-request-perl \
         libdigest-md5-perl \
-        libtime-local-perl
+        libtime-local-perl \
+        libpq-dev \
+        libdbd-pg-perl \
         # setup local::lib
         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
         # install perl dependencies

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -59,6 +59,7 @@ BEGIN
 					&canonicalize_nutriment
 
 					&fix_salt_equivalent
+					&compute_nutriscore
 					&compute_nutrition_score
 					&compute_nutrition_grade
 					&compute_nova_group
@@ -92,6 +93,7 @@ use ProductOpener::Config qw/:all/;
 use ProductOpener::Lang qw/:all/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Images qw/:all/;
+use ProductOpener::Nutriscore qw/:all/;
 
 use Hash::Util;
 
@@ -103,15 +105,14 @@ use Log::Any qw($log);
 # the stats are displayed on category pages and used in product pages,
 # as well as in data quality checks and improvement opportunity detection
 
-%categories_nutriments_per_country = ();
-
-foreach my $country (keys %{$properties{countries}}, 'en:world') {
-
-	my $country_cc = lc($properties{countries}{$country}{"country_code_2:en"});
-	if ($country eq 'en:world') {
-		$country_cc = 'world';
+if (opendir (my $dh, "$data_root/index")) {
+	foreach my $file (readdir($dh)) {
+		if ($file =~ /categories_nutriments_per_country.(\w+).sto$/) {
+			my $country_cc = $1;
+			$categories_nutriments_per_country{$country_cc} = retrieve("$data_root/index/categories_nutriments_per_country.$country_cc.sto");
+		}
 	}
-	$categories_nutriments_per_country{$country_cc} = retrieve("$data_root/index/categories_nutriments_per_country.$country_cc.sto");
+	closedir $dh;
 }
 
 
@@ -4453,10 +4454,6 @@ COMMENT
 # soient dans une catégorie supérieure à l'eau (qui est classée verte).
 # Nous ne disposons pour l'instant pas d'adaptations plus précises du score.
 
-
-
-
-
 	delete $product_ref->{"nutrition-grade-fr"};
 	delete $product_ref->{"nutrition_grade_fr"};
 
@@ -4468,6 +4465,231 @@ COMMENT
 	$product_ref->{"nutrition_grades_tags"} = [$product_ref->{"nutrition_grade_fr"}];
 	$product_ref->{"nutrition_grades"} = $product_ref->{"nutrition_grade_fr"};  # needed for the /nutrition-grade/unknown query
 
+}
+
+
+sub compute_nutriscore($) {
+
+	my $product_ref = shift;
+
+	# Initialize values
+
+	delete $product_ref->{nutrition_score_debug};
+	delete $product_ref->{nutriments}{"nutrition-score"};
+	delete $product_ref->{nutriments}{"nutrition-score_100g"};
+	delete $product_ref->{nutriments}{"nutrition-score_serving"};
+	delete $product_ref->{nutriments}{"nutrition-score-fr"};
+	delete $product_ref->{nutriments}{"nutrition-score-fr_100g"};
+	delete $product_ref->{nutriments}{"nutrition-score-fr_serving"};
+	delete $product_ref->{nutriments}{"nutrition-score-uk"};
+	delete $product_ref->{nutriments}{"nutrition-score-uk_100g"};
+	delete $product_ref->{nutriments}{"nutrition-score-uk_serving"};
+	delete $product_ref->{"nutrition_grade_fr"};
+	delete $product_ref->{"nutrition_grades"};
+	delete $product_ref->{"nutrition_grades_tags"};
+	delete $product_ref->{nutrition_score_warning_no_fiber};
+	delete $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate};
+	delete $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category};
+	delete $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category_value};
+	delete $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts};
+	delete $product_ref->{nutriscore_score};
+	delete $product_ref->{nutriscore_grade};
+
+	defined $product_ref->{misc_tags} or $product_ref->{misc_tags} = [];
+
+	$product_ref->{misc_tags} = ["en:nutriscore-not-computed"];
+
+	my $prepared = '';
+
+	# do not compute a score when we don't have a category
+	if ((not defined $product_ref->{categories}) or ($product_ref->{categories} eq '')) {
+		$product_ref->{"nutrition_grades_tags"} = [ "not-applicable" ];
+		$product_ref->{nutrition_score_debug} = "no score when the product does not have a category";
+		return;
+	}
+
+	if (not defined $product_ref->{nutrition_score_beverage}) {
+		$product_ref->{"nutrition_grades_tags"} = [ "not-applicable" ];
+		$product_ref->{nutrition_score_debug} = "did not determine if it was a beverage";
+		return;
+	}
+
+
+	# do not compute a score for dehydrated products to be rehydrated (e.g. dried soups, powder milk)
+	# unless we have nutrition data for the prepared product
+	# same for en:chocolate-powders, en:dessert-mixes and en:flavoured-syrups
+
+	foreach my $category_tag ("en:dried-products-to-be-rehydrated", "en:chocolate-powders", "en:dessert-mixes", "en:flavoured-syrups", "en:instant-beverages") {
+
+		if (has_tag($product_ref, "categories", $category_tag)) {
+
+			if ((defined $product_ref->{nutriments}{"energy_prepared_100g"})) {
+				$product_ref->{nutrition_score_debug} = "using prepared product data for category $category_tag";
+				$prepared = '_prepared';
+				last;
+			}
+			else {
+				$product_ref->{"nutrition_grades_tags"} = [ "not-applicable" ];
+				$product_ref->{nutrition_score_debug} = "no score for category $category_tag without data for prepared product";
+				return;
+			}
+		}
+	}
+
+	# do not compute a score for coffee, tea etc. except ice teas etc.
+
+	if (defined $options{categories_exempted_from_nutriscore}) {
+
+		my $not_exempted = 0;
+
+		foreach my $category_id (@{$options{categories_not_exempted_from_nutriscore}}) {
+
+			if (has_tag($product_ref, "categories", $category_id)) {
+				$not_exempted = 1;
+				last;
+			}
+		}
+
+		if (not $not_exempted) {
+
+			foreach my $category_id (@{$options{categories_exempted_from_nutriscore}}) {
+
+				if (has_tag($product_ref, "categories", $category_id)) {
+					$product_ref->{"nutrition_grades_tags"} = [ "not-applicable" ];
+					$product_ref->{nutrition_score_debug} = "no nutriscore for category $category_id";
+					return;
+				}
+			}
+		}
+	}
+
+	# Spring waters have grade A automatically, and have a different nutrition table without sugars etc.
+	# do not display warnings about missing fiber and fruits
+
+	if (not ((has_tag($product_ref, "categories", "en:spring-waters")) and not (has_tag($product_ref, "categories", "en:flavored-waters")))) {
+
+		# compute the score only if all values are known
+		# for fiber, compute score without fiber points if the value is not known
+		# foreach my $nid ("energy", "saturated-fat", "sugars", "sodium", "fiber", "proteins") {
+
+		foreach my $nid ("energy", "fat", "saturated-fat", "sugars", "sodium", "proteins") {
+			if (not defined $product_ref->{nutriments}{$nid . $prepared . "_100g"}) {
+				$product_ref->{"nutrition_grades_tags"} = [ "unknown" ];
+				push @{$product_ref->{misc_tags}}, "en:nutrition-not-enough-data-to-compute-nutrition-score";
+				if (not defined $product_ref->{nutriments}{"saturated-fat"  . $prepared . "_100g"}) {
+					push @{$product_ref->{misc_tags}}, "en:nutrition-no-saturated-fat";
+				}
+				$product_ref->{nutrition_score_debug} .= "missing " . $nid . $prepared;
+				return;
+			}
+		}
+
+		# some categories of products do not have fibers > 0.7g (e.g. sodas)
+		# for others, display a warning when the value is missing
+		if ((not defined $product_ref->{nutriments}{"fiber" . $prepared . "_100g"})
+			and not (has_tag($product_ref, "categories", "en:sodas"))) {
+			$product_ref->{nutrition_score_warning_no_fiber} = 1;
+			push @{$product_ref->{misc_tags}}, "en:nutrition-no-fiber";
+		}
+	}
+
+	if ($prepared ne '') {
+		push @{$product_ref->{misc_tags}}, "en:nutrition-grade-computed-for-prepared-product";
+	}
+
+	# Compute the fruit % according to the Nutri-Score rules
+
+	my $fruits = undef;
+
+	if (defined $product_ref->{nutriments}{"fruits-vegetables-nuts-dried" . $prepared . "_100g"}) {
+		$fruits = 2 * $product_ref->{nutriments}{"fruits-vegetables-nuts-dried" . $prepared . "_100g"};
+		push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-dried";
+
+		if (defined $product_ref->{nutriments}{"fruits-vegetables-nuts" . $prepared . "_100g"}) {
+			$fruits += $product_ref->{nutriments}{"fruits-vegetables-nuts" . $prepared . "_100g"};
+			push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts";
+		}
+
+		$fruits = $fruits * 100 / (100 + $product_ref->{nutriments}{"fruits-vegetables-nuts-dried" . $prepared . "_100g"});
+	}
+	elsif (defined $product_ref->{nutriments}{"fruits-vegetables-nuts" . $prepared . "_100g"}) {
+		$fruits = $product_ref->{nutriments}{"fruits-vegetables-nuts" . $prepared . "_100g"};
+		push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts";
+	}
+	elsif (defined $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate" . $prepared . "_100g"}) {
+		$fruits = $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate" . $prepared . "_100g"};
+		$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate} = 1;
+		push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-estimate";
+	}
+	# estimates by category of products. not exact values. it's important to distinguish only between the thresholds: 40, 60 and 80
+	else {
+		foreach my $category_id (@fruits_vegetables_nuts_by_category_sorted ) {
+
+			if (has_tag($product_ref, "categories", $category_id)) {
+				$fruits = $fruits_vegetables_nuts_by_category{$category_id};
+				$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category} = $category_id;
+				$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category_value} = $fruits_vegetables_nuts_by_category{$category_id};
+				push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-from-category";
+				my $category = $category_id;
+				$category =~ s/:/-/;
+				push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-from-category-$category";
+				last;
+			}
+		}
+
+		if (defined $fruits) {
+			$product_ref->{"fruits-vegetables-nuts_100g_estimate"} = $fruits;
+		}
+		else {
+			$fruits = 0;
+			$product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts} = 1;
+			push @{$product_ref->{misc_tags}}, "en:nutrition-no-fruits-vegetables-nuts";
+		}
+
+	}
+
+	if ((defined $product_ref->{nutrition_score_warning_no_fiber}) or (defined $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts})) {
+		push @{$product_ref->{misc_tags}}, "en:nutrition-no-fiber-or-fruits-vegetables-nuts";
+	}
+	else {
+		push @{$product_ref->{misc_tags}}, "en:nutrition-all-nutriscore-values-known";
+	}
+
+	my $saturated_fat = $product_ref->{nutriments}{"saturated-fat" . $prepared . "_100g"};
+	my $fat = $product_ref->{nutriments}{"fat" . $prepared . "_100g"};
+	my $saturated_fat_ratio = 0;
+	if ((defined $saturated_fat) and ($saturated_fat > 0)) {
+		if ($fat <= 0) {
+			$fat = $saturated_fat;
+		}
+		$saturated_fat_ratio = $saturated_fat / $fat * 100;	# in %
+	}
+
+	# Populate the data structure that will be passed to Food::Nutriscore
+
+	my $product_data_ref = {
+		is_beverage => $product_ref->{nutrition_score_beverage},
+		is_water => ((has_tag($product_ref, "categories", "en:spring-waters")) and not (has_tag($product_ref, "categories", "en:flavored-waters"))),
+		is_cheese => ((has_tag($product_ref, "categories", "en:cheeses")) and not (has_tag($product_ref, "categories", "fr:fromages-blancs"))),
+		is_fat => has_tag($product_ref, "categories", "en:fats"),
+
+		energy => $product_ref->{nutriments}{"energy" . $prepared . "_100g"},
+		sugars => $product_ref->{nutriments}{"sugars" . $prepared . "_100g"},
+		saturated_fat => $product_ref->{nutriments}{"saturated-fat" . $prepared . "_100g"},
+		saturated_fat_ratio => $saturated_fat_ratio,
+		sodium => $product_ref->{nutriments}{"sodium" . $prepared . "_100g"} * 1000,	# in mg,
+
+		fruits_vegetables_nuts_colza_walnut_olive_oils => $fruits,
+		fiber => ((defined $product_ref->{nutriments}{"fiber" . $prepared . "_100g"}) ? $product_ref->{nutriments}{"fiber" . $prepared . "_100g"} : 0),
+		proteins => $product_ref->{nutriments}{"proteins" . $prepared . "_100g"},
+	};
+
+	$product_ref->{nutriscore_points} = {};
+
+	my ($nutriscore_score, $nutriscore_grade) = ProductOpener::Food::compute_nutriscore_score_and_grade($product_data_ref, $product_ref->{nutriscore_points});
+
+	$product_ref->{nutriscore_score} = $nutriscore_score;
+	$product_ref->{nutriscore_grade} = $nutriscore_grade;
 }
 
 

--- a/lib/ProductOpener/Nutriscore.pm
+++ b/lib/ProductOpener/Nutriscore.pm
@@ -1,0 +1,349 @@
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2019 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=head1 NAME
+
+ProductOpener::Nutriscore - compute the Nutriscore grade of a food product
+
+=head1 SYNOPSIS
+
+C<ProductOpener::Export> is used to export the data of all populated fields
+of products matching a given MongoDB search query in Open Food Facts CSV format
+(UTF-8 encoding, tab separated).
+
+    use ProductOpener::Export qw/:all/;
+	export_csv( { filehandle=>*STDOUT,
+		query=>{ countries_tags=>"en:france", labels_tags=>"en:organic" } });
+
+Only columns that are not completely empty will be included in the resulting CSV file.
+This is to avoid generating CSV files with thousands of empty columns (e.g. all possible
+nutrients and all the language specific fields like ingredients_text_[language code] for
+all the hundreds of possible languages.
+
+Fields that are computed from other fields are not directly provided by users or producers
+are not exported by default. They can be exported by passing a list of extra fields:
+
+	export_csv( { filehandle=>$fh,
+		extra_fields=>[qw(nova_group nutrition_grade_fr)] });
+
+It is also possible to restrict the set of fields to be exported:
+
+	export_csv( { filehandle=>$fh,
+		fields=>[qw(code ingredients_text_en additives_tags)] });
+
+This module is used in particular to export product data provided by manufacturers on
+the producers platform so that it can then be imported in the public database.
+
+In the producers platform, the C<export_csv> function is executed through a Minion worker.
+
+It is also used in the C<scripts/export_csv_file.pl> script.
+
+
+=head1 DESCRIPTION
+
+Use the list of fields from C<Product::Opener::Config::options{import_export_fields_groups}>
+and the list of nutrients from C<Product::Opener::ProductOpener::nutriments_tables> to list fields
+that need to be exported.
+
+The results of the query are scanned a first time to compute the list of non-empty columns.
+
+The results of the query are scanned a second time to output the CSV file.
+
+This 2 phases approach is done to avoid having to store all the products data in memory.
+
+If the fields to exports are specified with the C<fields> parameter, the first phase is skipped.
+
+=cut
+
+package ProductOpener::Nutriscore;
+
+use utf8;
+use Modern::Perl '2017';
+use Exporter    qw< import >;
+
+use Log::Any qw($log);
+
+BEGIN
+{
+	use vars       qw(@ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+	@EXPORT = qw();            # symbols to export by default
+	@EXPORT_OK = qw(
+
+		&compute_nutriscore_score_and_grade
+
+					);	# symbols to export on request
+	%EXPORT_TAGS = (all => [@EXPORT_OK]);
+}
+
+use vars @EXPORT_OK ;
+
+=head1 FUNCTIONS
+
+=head2 compute_nutriscore_score_and_grade( PRODUCT_DATA_REF, POINTS_REF )
+
+C<compute_nutriscore_score_and_grade()> computes the Nutri-Score score and grade
+of a food product, and also returns the details of the points for each nutrient.
+
+=head3 Arguments
+
+2 hash references need to be passed as arguments:
+
+=head4 PRODUCT_DATA_REF - hash reference to the input product data
+
+The hash must contain values for the following keys:
+
+- energy -> energy in kJ / 100g or 100ml
+- sugars -> sugars in g / 100g or 100ml
+- saturated_fat -> saturated fats in g / 100g or 100ml
+- saturated_fat_ratio -> saturated fat divided by fat * 100 (in %)
+- sodium -> sodium in mg / 100g or 100ml (if sodium is computed from salt, it needs to use a sodium = salt / 2.5 conversion factor
+- fruits_vegetables_nuts_colza_walnut_olive_oils -> % of fruits, vegetables, nuts, and colza / walnut / olive oiles
+- fiber -> fiber in g / 100g or 100ml
+- proteins -> proteins in g / 100g or 100ml
+
+The values will be rounded according to the Nutri-Score rules, they do not need to be rounded before being passed as arguments.
+
+If the product is a beverage, water, cheese, or fat, it must contain a positive value for the corresponding keys:
+- beverage
+- water
+- cheese
+- fat
+
+=head4 POINTS_REF - reference to an empty hash that will be populated with the
+details of the points for each nutrient.
+
+Returned values:
+
+- [nutrient]_value -> rounded values for each nutrient according to the Nutri-Score rules
+- [nutrient] -> points for each nutrient
+- negative_points -> sum of unfavorable nutrients points
+- positive_points -> sum of favorable nutrients points
+
+The nutrients that are counted for the negative and positive points depend on the product type
+(if it is a beverage, cheese or fat) and on the values for some of the nutrients.
+
+=head3 Return values
+
+The function returns a list of 2 values:
+
+- Nutri-Score score from -15 to 40
+- Corresponding nutri-Score letter grade from a to e (in lowercase)
+
+The letter grade depends on the score and on whether the product is a beverage, or is a water.
+
+=cut
+
+sub compute_nutriscore_score_and_grade($$) {
+
+	my $product_data_ref = shift;
+	my $points_ref = shift;
+
+	# We will pass a %point structure to get the details of the computation
+	# so that it can be returned
+	my %points = ();
+
+	my $nutrition_score = compute_nutriscore_score($product_data_ref, $points_ref);
+
+	my $nutrition_grade = compute_nutriscore_grade($nutrition_score, $product_data_ref->{is_beverage}, $product_data_ref->{is_water});
+
+	return ($nutrition_score, $nutrition_grade);
+}
+
+
+my %points_thresholds = (
+
+	# negative points
+
+	energy => [335, 670, 1005, 1340, 1675, 2010, 2345, 2680, 3015, 3350],	# kJ / 100g
+	energy_beverages => [0, 30, 60, 90, 120, 150, 180, 210, 240, 270],	# kJ /100g or 100ml
+	sugars => [4.5, 9, 13.5, 18, 22.5, 27, 31, 36, 40, 45],	# g / 100g
+	sugars_beverages => [0, 1.5, 3, 4.5, 6, 7.5, 9, 10.5, 12, 13.5],	# g / 100g or 100ml
+	saturated_fat => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],	# g / 100g
+	saturated_fat_ratio => [10, 16, 22, 28, 34, 40, 46, 52, 58, 64],	# %
+	sodium => [90, 180, 270, 360, 450, 540, 630, 720, 810, 900],	# mg / 100g
+
+	# positive points
+
+	fruits_vegetables_nuts_colza_walnut_olive_oils => [40, 60, 80, 80, 80],	# %
+	fruits_vegetables_nuts_colza_walnut_olive_oils_beverages => [40, 40, 60, 60, 80, 80, 80, 80, 80, 80],
+	fiber => [0.9, 1.9, 2.8, 3.7, 4.7],	# g / 100g - AOAC method
+	proteins => [1.6, 3.2, 4.8, 6.4, 8.0]	# g / 100g
+);
+
+
+sub compute_nutriscore_score($$) {
+
+	my $product_data_ref = shift;
+	my $points_ref = shift;
+
+	# The values must be rounded with one more digit than the thresolds.
+	# Undefined values are counted as 0 (it can be the case in particular for waters that have different nutrients listed)
+
+	my $averages_ref = {};
+
+	# Round with 1 digit after the comma for energy, saturated fat, saturated fat ratio, sodium and fruits
+
+	foreach my $nutrient (qw(energy saturated_fat saturated_fat_ratio sodium fruits_vegetables_nuts_colza_walnut_olive_oils)) {
+		if (defined $product_data_ref->{$nutrient}) {
+			$averages_ref->{$nutrient} = int($product_data_ref->{$nutrient} * 10 + 0.5) / 10;
+		}
+		else {
+			$averages_ref->{$nutrient} = 0;
+		}
+	}
+
+	# Round with 2 digits for sugars, fiber and proteins
+
+	foreach my $nutrient (qw(sugars fiber proteins)) {
+		if (defined $product_data_ref->{$nutrient}) {
+			$averages_ref->{$nutrient} = int($product_data_ref->{$nutrient} * 100 + 0.5) / 100;
+		}
+		else {
+			$averages_ref->{$nutrient} = 0;
+		}
+	}
+
+	# Special case for sugar: we need to round to 2 digits if we are closed to a threshold defined with 1 digit (e.g. 4.5)
+	# but if the threshold is defined with 0 digit (e.g. 9) we need to round with 1 digit.
+	if ((($averages_ref->{"sugars"} - int($averages_ref->{"sugars"})) > 0.9)
+		or (($averages_ref->{"sugars"} - int($averages_ref->{"sugars"})) < 0.1)) {
+		$averages_ref->{"sugars"} = int($product_data_ref->{"sugars"} * 10 + 0.5) / 10;
+	}
+
+	# Compute the negative and positive points
+
+	foreach my $nutrient (qw(energy sugars saturated_fat saturated_fat_ratio sodium fruits_vegetables_nuts_colza_walnut_olive_oils fiber proteins)) {
+
+		my $nutrient_threshold_id = $nutrient;
+		if ((defined $product_data_ref->{is_beverage}) and ($product_data_ref->{is_beverage})
+			and (defined $points_thresholds{$nutrient_threshold_id . "_beverages"})) {
+			$nutrient_threshold_id .= "_beverages";
+		}
+
+		$points_ref->{$nutrient} = 0;
+		$points_ref->{$nutrient . "_value"} = $averages_ref->{$nutrient};
+
+		foreach my $threshold (@{$points_thresholds{$nutrient_threshold_id}}) {
+			# The saturated fat ratio table uses the greater or equal sign instead of greater
+			if ((($nutrient eq "saturated_fat_ratio") and ($averages_ref->{$nutrient} >= $threshold))
+				or (($nutrient ne "saturated_fat_ratio") and ($averages_ref->{$nutrient} > $threshold))){
+				$points_ref->{$nutrient}++;
+			}
+		}
+	}
+
+	# Negative points
+
+	# If the product is an added fat (oil, butter etc.) the saturated fat points are replaced
+	# by the saturated fat / fat ratio points
+
+	my $fat = "saturated_fat";
+	if ((defined $product_data_ref->{is_fat}) and ($product_data_ref->{is_fat})) {
+		$fat = "saturated_fat_ratio";
+	}
+
+	$points_ref->{negative_points} = 0;
+	foreach my $nutrient ("energy", "sugars", $fat, "sodium") {
+		$points_ref->{negative_points} += $points_ref->{$nutrient};
+	}
+
+	# If the sum of negative points is greater or equal to 11
+	# and if the fruits points are less than the maximum (5 or 10 for beverages)
+	# then proteins do not count
+
+	# If the product is a cheese, always count the proteins points
+
+	$points_ref->{positive_points} = 0;
+
+	my @positive_nutrients = qw(fruits_vegetables_nuts_colza_walnut_olive_oils fiber);
+
+	if (($points_ref->{negative_points} < 11)
+		or ((defined $product_data_ref->{is_cheese}) and ($product_data_ref->{is_cheese}))
+		or (((defined $product_data_ref->{is_beverage}) and ($product_data_ref->{is_beverage}))
+			and ($points_ref->{fruits_vegetables_nuts_colza_walnut_olive_oils} == 10))
+		or (((not defined $product_data_ref->{is_beverage}) or (not $product_data_ref->{is_beverage}))
+			and ($points_ref->{fruits_vegetables_nuts_colza_walnut_olive_oils} == 5)) ) {
+		push @positive_nutrients, "proteins";
+	}
+
+	foreach my $nutrient (@positive_nutrients) {
+		$points_ref->{positive_points} += $points_ref->{$nutrient};
+	}
+
+	my $nutrition_score = $points_ref->{negative_points} - $points_ref->{positive_points};
+
+	return $nutrition_score;
+}
+
+
+sub compute_nutriscore_grade($$$) {
+
+	my $nutrition_score = shift;
+	my $is_beverage = shift;
+	my $is_water = shift;
+
+	my $grade = "";
+
+	if (not defined $nutrition_score) {
+		return '';
+	}
+
+	if ($is_beverage) {
+
+		if ($is_water) {
+			$grade = 'a';
+		}
+		elsif ($nutrition_score <= 1) {
+			$grade = 'b';
+		}
+		elsif ($nutrition_score <= 5) {
+			$grade = 'c';
+		}
+		elsif ($nutrition_score <= 9) {
+			$grade = 'd';
+		}
+		else {
+			$grade = 'e';
+		}
+	}
+	else {
+
+		if ($nutrition_score <= -1) {
+			$grade = 'a';
+		}
+		elsif ($nutrition_score <= 2) {
+			$grade = 'b';
+		}
+		elsif ($nutrition_score <= 10) {
+			$grade = 'c';
+		}
+		elsif ($nutrition_score <= 18) {
+			$grade = 'd';
+		}
+		else {
+			$grade = 'e';
+		}
+	}
+	return $grade;
+}
+
+
+1;
+


### PR DESCRIPTION
I reimplemented the Nutri-Score computation in a separate module.

I separated what is related to Product Opener (e.g. which category the product is in), and what is purely related to the Nutri-Score computation.

At this point, I kept the old Nutri-Score computation too, to check if we get the same results. I fixed a few things related to the number of digits that values need to be rounded to for computing Nutriscore, so there is a very small amount (about 0.25%) where we have a different nutrition score (and thus an even smaller number of different nutrition grades).

I'm testing it on the dev server:

https://world.openfoodfacts.dev/data-quality/nutriscore-computations-different-score
https://world.openfoodfacts.dev/data-quality/nutriscore-computations-same-score