### PR TITLE
better support for obsolete products, bug #2442

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,7 +73,9 @@ jobs:
         libexperimental-perl \
         libapache2-request-perl \
         libdigest-md5-perl \
-        libtime-local-perl
+        libtime-local-perl \
+        libpq-dev \
+        libdbd-pg-perl \
         # setup local::lib
         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
         # install perl dependencies

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -399,7 +399,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	$product_ref->{nutrition_data_prepared} = remove_tags_and_quote(decode utf8=>param("nutrition_data_prepared"));
 
-	if (($admin) and (defined param('obsolete_since_date'))) {
+	if (($admin or $owner) and (defined param('obsolete_since_date'))) {
 		$product_ref->{obsolete} = remove_tags_and_quote(decode utf8=>param("obsolete"));
 		$product_ref->{obsolete_since_date} = remove_tags_and_quote(decode utf8=>param("obsolete_since_date"));
 	}
@@ -887,8 +887,9 @@ HTML
 ;
 	}
 
-	# obsolete products
-	if ($admin) {
+	# obsolete products: restrict to admin on public site
+	# authorize owners on producers platform
+	if ($admin or $owner) {
 
 		my $checked = '';
 		if ((defined $product_ref->{obsolete}) and ($product_ref->{obsolete} eq 'on')) {

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -3258,7 +3258,11 @@ msgid "Withdrawal date"
 msgstr ""
 
 msgctxt "obsolete_since_date_note"
-msgid "Format: YYYY or YYYY-MM"
+msgid "Format: YYYY-MM-DD or YYYY-MM or YYYY"
+msgstr ""
+
+msgctxt "obsolete_since_date_example"
+msgid "2019-09-30 or 2019-09 or 2019"
 msgstr ""
 
 msgctxt "obsolete_warning"
@@ -3747,4 +3751,4 @@ msgstr "data quality error"
 
 msgctxt "data_quality_errors"
 msgid "data quality errors"
-msgstr "data quality errors"
+msgstr "data quality erros"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -3751,4 +3751,4 @@ msgstr "data quality error"
 
 msgctxt "data_quality_errors"
 msgid "data quality errors"
-msgstr "data quality erros"
+msgstr "data quality errors"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -3154,8 +3154,12 @@ msgid "Withdrawal date"
 msgstr "Withdrawal date"
 
 msgctxt "obsolete_since_date_note"
-msgid "Format: YYYY or YYYY-MM"
-msgstr "Format: YYYY or YYYY-MM"
+msgid "Format: YYYY-MM-DD or YYYY-MM or YYYY"
+msgstr "Format: YYYY-MM-DD or YYYY-MM or YYYY"
+
+msgctxt "obsolete_since_date_example"
+msgid "2019-09-30 or 2019-09 or 2019"
+msgstr "2019-09-30 or 2019-09 or 2019"
 
 msgctxt "obsolete_warning"
 msgid "Important note: this product is no longer sold. The data is kept for reference only. This product does not appear in regular searches and is not taken into account for statistics."

--- a/scripts/gen_top_tags_per_country.pl
+++ b/scripts/gen_top_tags_per_country.pl
@@ -147,7 +147,8 @@ $fields_ref->{nutriments} = 1;
 $fields_ref->{nutrition_grade_fr} = 1;
 
 # Sort by created_t so that we can see which product was the nth in each country -> necessary to compute points for Open Food Hunt
-my $cursor = get_products_collection()->query({'empty' => { "\$ne" => 1 }})->sort({created_t => 1})->fields($fields_ref);
+# do not include empty products and products that have been marked as obsolete
+my $cursor = get_products_collection()->query({'empty' => { "\$ne" => 1 }, 'obsolete' => { "\$ne" => 1 }})->sort({created_t => 1})->fields($fields_ref);
 
 my %products_nutriments = ();
 my %countries_categories = ();
@@ -410,7 +411,7 @@ while (my $product_ref = $cursor->next) {
 
 
 
-foreach my $country (keys %{$properties{countries}}, 'en:world') {
+foreach my $country ('en:world', keys %{$properties{countries}}) {
 
 	my $cc = lc($properties{countries}{$country}{"country_code_2:en"});
 	if ($country eq 'en:world') {

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -94,6 +94,7 @@ my $check_quality = '';
 my $compute_codes = '';
 my $compute_carbon = '';
 my $compute_history = '';
+my $compute_sort_key = '';
 my $comment = '';
 my $fix_serving_size_mg_to_ml = '';
 my $fix_missing_lc = '';
@@ -120,6 +121,7 @@ GetOptions ("key=s"   => \$key,      # string
 			"compute-codes" => \$compute_codes,
 			"compute-carbon" => \$compute_carbon,
 			"check-quality" => \$check_quality,
+			"compute-sort-key" => \$compute_sort_key,
 			"fix-serving-size-mg-to-ml" => \$fix_serving_size_mg_to_ml,
 			"fix-missing-lc" => \$fix_missing_lc,
 			"fix-zulu-lang" => \$fix_zulu_lang,
@@ -165,6 +167,7 @@ if ((not $process_ingredients) and (not $compute_nutrition_score) and (not $comp
 	and (not $compute_data_sources) and (not $compute_history)
 	and (not $run_ocr) and (not $autorotate)
 	and (not $fix_missing_lc) and (not $fix_serving_size_mg_to_ml) and (not $fix_zulu_lang) and (not $fix_rev_not_incremented)
+	and (not $compute_sort_key)
 	and (not $compute_codes) and (not $compute_carbon) and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)) {
 	die("Missing fields to update or --count option:\n$usage");
 }
@@ -557,6 +560,7 @@ while (my $product_ref = $cursor->next) {
 
 		if ($compute_nutrition_score) {
 			fix_salt_equivalent($product_ref);
+			compute_nutriscore($product_ref);
 			compute_nutrition_score($product_ref);
 			compute_nutrient_levels($product_ref);
 		}
@@ -591,6 +595,10 @@ while (my $product_ref = $cursor->next) {
 			compute_product_history_and_completeness($product_ref, $changes_ref);
 			compute_data_sources($product_ref);
 			store("$data_root/products/$path/changes.sto", $changes_ref);
+		}
+
+		if ($compute_sort_key) {
+			compute_sort_key($product_ref);
 		}
 
 		if (not $pretend) {


### PR DESCRIPTION
Issue #1592 introduced the possibility for admins to mark products as not being sold anymore ("obsolete"). The products were completely removed from MongoDB, but kept in the file system so that we could show them if they were scanned.

This issue is to improve the handling of obsolete products:

1. Brand owners will be able to mark products as obsolete
2. Obsolete products will be kept in MongoDB, but:
3. The sort order will put them last
4. They will be grayed out in the product list
5. Obsolete products won't be taken into account in category stats