### PR TITLE
Fix install of DBD::Pg during GitHub Actions CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,7 +73,8 @@ jobs:
         libexperimental-perl \
         libapache2-request-perl \
         libdigest-md5-perl \
-        libtime-local-perl
+        libtime-local-perl \
+        libdbd-pg-perl
         # setup local::lib
         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
         # install perl dependencies


### PR DESCRIPTION
**Description:**

Install the `libdbd-pg-perl` package during GitHub Actions PR validation, so that the following error does not occur any more

>  Installing the dependencies failed: Module 'Mojo::Pg' is not installed