### PR TITLE
ci: Ignore PRs on l10n_master

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+    branches-ignore:
+      - l10n_master
 
 jobs:
   gulp:


### PR DESCRIPTION
Attempts to [ignore](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags) the l10n_master branch for PRs with GitHub Actions.