### PR TITLE
Typo fixed

### DIFF
--- a/lang/en/texts/dev-general.html
+++ b/lang/en/texts/dev-general.html
@@ -30,7 +30,7 @@
 		<img src="https://world.openfoodfacts.org/files/presskit/PressKit/developers/summerofcode.png" alt="" style="height: 140px;">	
 		<h3>Google's Summer Of Code</h3>
 		<p>
-			Would you like to mentor students as part of Google's Summer of Docs, and become a better programmer at the same time ?
+			Would you like to mentor students as part of Google's Summer of Code, and become a better programmer at the same time ?
 			Would you like to have one of the best summer opportunities available on the planet, and make a lasting impact on the food system ?
 		</p>
 	</div>


### PR DESCRIPTION
Docs -> Code (I'm guessing that it's a mistake since there's no such thing as Summer of Docs).