### PR TITLE
ci: Build Travis CI as a generic script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+language: generic
 dist: bionic
 branches:
   except:


### PR DESCRIPTION
**Description:**
If no language is defined, Travis CI falls back to Ruby. For some reason, it now tries to run `rake`, which fails because we have no Ruby files. Since we use Perl and node.js in our CI build, using the [`generic`](https://docs.travis-ci.com/user/languages/minimal-and-generic/) language seems like a good alternative.

**Related issues and discussion:** #2506
