### PR TITLE
removing lines that make travis-lint not respond

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,3 @@ script:
   - npm test
 after_failure:
   - cat $HOME/.cpanm/build.log
-notifications:
-  slack: openfoodfacts:Pre9ZXKFH1CYtix8DeJAaFi2


### PR DESCRIPTION
Just checking. For some reason the slack notification makes https://config.travis-ci.com/explore not work.