### PR TITLE
Cache CLDR and it's formatters

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -113,6 +113,7 @@ use ProductOpener::Missions qw(:all);
 use ProductOpener::MissionsConfig qw(:all);
 use ProductOpener::URL qw(:all);
 use ProductOpener::Data qw(:all);
+use ProductOpener::Text qw(:all);
 
 use Cache::Memcached::Fast;
 use Text::Unaccent;
@@ -3824,8 +3825,7 @@ sub search_and_display_products($$$$$) {
 	my $html = '';
 	my $html_count = '';
 
-	my $cldr = CLDR::Number->new(locale => $lc);
-	my $decf = $cldr->decimal_formatter;
+	my $decf = get_decimal_formatter($lc);
 
 	if (not defined $request_ref->{jqm_loadmore}) {
 		if ($count < 0) {
@@ -8816,9 +8816,8 @@ HTML
 
 		my $values2 = '';
 
-		my $cldr = CLDR::Number->new(locale => $lc);
-		my $decf = $cldr->decimal_formatter;
-		my $perf = $cldr->percent_formatter( maximum_fraction_digits => 0 );
+		my $decf = get_decimal_formatter($lc);
+		my $perf = get_percent_formatter($lc, 0);
 		foreach my $col (@cols) {
 
 			my $col_class = '';

--- a/lib/ProductOpener/Text.pm
+++ b/lib/ProductOpener/Text.pm
@@ -30,6 +30,9 @@ BEGIN
 	@EXPORT = qw();            # symbols to export by default
 	@EXPORT_OK = qw(
 					&normalize_percentages
+
+					&get_decimal_formatter
+					&get_percent_formatter
 					
 					);	# symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
@@ -44,21 +47,80 @@ sub normalize_percentages($$) {
 
 	my ($text, $locale) = @_;
 
-	my $cldr = CLDR::Number->new(locale => $locale);
-	my $perf = $cldr->percent_formatter( maximum_fraction_digits => 2 );
-	my $regex = _get_locale_percent_regex($cldr, $perf);
+	my $cldr = _get_cldr($locale);
+	my $perf = get_percent_formatter($locale, 2);
+	my $regex = _get_locale_percent_regex($cldr, $perf, $locale);
 
 	$text =~ s/$regex/''._format_percentage($1, $cldr, $perf).''/eg;
 	return $text;
 
 }
 
+%ProductOpener::Text::cldrs = ();
+sub _get_cldr {
+
+	my ($locale) = @_;
+
+	if (defined $ProductOpener::Text::cldrs{$locale}) {
+		return $ProductOpener::Text::cldrs{$locale};
+	}
+
+	my $cldr = CLDR::Number->new(locale => $locale);
+	$ProductOpener::Text::cldrs{$locale} = $cldr;
+	return $cldr;
+
+}
+
+%ProductOpener::Text::decimal_formatters = ();
+sub get_decimal_formatter {
+
+	my ($locale) = @_;
+
+	my $decf = $ProductOpener::Text::decimal_formatters{$locale};
+	if (defined $decf) {
+		return $decf;
+	}
+
+	my $cldr = _get_cldr($locale);
+	$decf = $cldr->decimal_formatter;
+	$ProductOpener::Text::decimal_formatters{$locale} = $decf;
+	return $decf;
+
+}
+
+%ProductOpener::Text::percent_formatters = ();
+sub get_percent_formatter {
+
+	my ($locale, $maximum_fraction_digits) = @_;
+
+	my $formatters_ref = $ProductOpener::Text::percent_formatters{$locale};
+	my %formatters;
+	if (not (defined $formatters_ref)) {
+		%formatters = ();
+		$formatters_ref = \%formatters;
+		$ProductOpener::Text::percent_formatters{$locale} = $formatters_ref;
+	}
+	else {
+		%formatters = %$formatters_ref;
+	}
+
+	my $perf = $formatters{$maximum_fraction_digits};
+	if (defined $perf) {
+		return $perf;
+	}
+
+	my $cldr = _get_cldr($locale);
+	$perf = $cldr->percent_formatter( maximum_fraction_digits => $maximum_fraction_digits );
+	$formatters{$maximum_fraction_digits} = $perf;
+	return $perf;
+
+}
+
 %ProductOpener::Text::regexes = ();
-sub _get_locale_percent_regex($$) {
+sub _get_locale_percent_regex {
 
-	my ($cldr, $perf) = @_;
+	my ($cldr, $perf, $locale) = @_;
 
-	my $locale = $cldr->locale;
 	if (defined $ProductOpener::Text::regexes{$locale}) {
 		return $ProductOpener::Text::regexes{$locale};
 	}


### PR DESCRIPTION
**Description:**
I noticed that `ProductOpener::Text::normalize_percentages` took a lot of time during the CSV import. According to `Devel::NYTProf` that was caused by creating new instances of `CLDR::Number` and it's formatters in loops.

<table>
<tr><th scope="col">What?</th><th scope="col">Before</th><th scole="col">After</th></tr>
<tr><th scope="row">Subroutine list</th><td><img src="https://user-images.githubusercontent.com/87124/68681800-55a58200-0564-11ea-9cf8-0a86a9456f5d.png"></td><td><img src="https://user-images.githubusercontent.com/87124/68681886-838ac680-0564-11ea-93b0-04d8c627c2f4.png"></td></tr>
<tr><th scope="row">Sub <code>normalize_percentages</code></th><td><img src="https://user-images.githubusercontent.com/87124/68682034-c482db00-0564-11ea-91c9-a8a81c07e36e.png"></td><td><img src="https://user-images.githubusercontent.com/87124/68682071-d4022400-0564-11ea-8e95-49302ff2e84d.png"></td></tr>

Since the same will be done for display purposes on the web, this is likely to speed up web request, too.

**Related issues and discussion:** Related to the performance discussion in #2563
