### PR TITLE
Conditionally run normalize_percentages

### DIFF
--- a/lib/ProductOpener/Text.pm
+++ b/lib/ProductOpener/Text.pm
@@ -33,7 +33,7 @@ BEGIN
 
 					&get_decimal_formatter
 					&get_percent_formatter
-					
+
 					);	# symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -46,6 +46,18 @@ BEGIN
 sub normalize_percentages($$) {
 
 	my ($text, $locale) = @_;
+
+	# Bail out of this function if no known percent sign is found.
+	# This is purely for performance reasons: CLDR functions are
+	# comparatively expensive to run.
+	if ((not (defined $text))
+		or (not ((index($text, "\N{U+0025}") > -1)
+		or (index($text, "\N{U+066A}") > -1)
+		or (index($text, "\N{U+FE6A}") > -1)
+		or (index($text, "\N{U+FF05}") > -1)
+		or (index($text, "\N{U+E0025}") > -1)))) {
+			return $text;
+	}
 
 	my $cldr = _get_cldr($locale);
 	my $perf = get_percent_formatter($locale, 2);


### PR DESCRIPTION
**Description:**
If the main body of normalize_percentages is only run if a known percent sign is present, then a lot of sub calls related to CLDR and formatting can be avoided. Performing the check using `index` is much faster than doing anything else.

In my benchmarks, this brought down the time for `normalize_percentages` from 2.25s exclusive/7.13 inclusive to 647ms exclusive/963ms inclusive.
![image](https://user-images.githubusercontent.com/87124/68762917-6e22a480-0617-11ea-9c93-414ea54a6dc5.png)

**Related issues and discussion:** #2589 
