### PR TITLE
Issue 2396/energy in kj and kcal -- huge change, please review

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -373,6 +373,22 @@ else {
 
 			my $modifier = undef;
 
+			# energy: (see bug https://github.com/openfoodfacts/openfoodfacts-server/issues/2396 )
+			# 1. if energy-kcal or energy-kj is set, delete existing energy data
+			if (($nid eq "energy-kj") or ($nid eq "energy-kcal")) {
+				delete $product_ref->{nutriments}{"energy"};
+				delete $product_ref->{nutriments}{"energy_unit"};
+				delete $product_ref->{nutriments}{"energy_label"};
+				delete $product_ref->{nutriments}{"energy_value"};
+				delete $product_ref->{nutriments}{"energy_modifier"};
+				delete $product_ref->{nutriments}{"energy_100g"};
+			}
+			# 2. if the nid passed is just energy, set instead energy-kj or energy-kcal using the passed unit
+			elsif (($nid eq "energy") and (($unit eq "kJ") or ($unit eq "kcal"))) {
+				$nid = $nid . "-" . lc($unit);
+				$log->debug("energy without unit, set nid with unit instead", { nid => $nid, unit => $unit }) if $log->is_debug();
+			}
+
 			(defined $value) and normalize_nutriment_value_and_modifier(\$value, \$modifier);
 
 			# New label?

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -770,6 +770,9 @@ HTML
 
 if (($action eq 'display') and (($type eq 'add') or ($type eq 'edit'))) {
 
+	# Populate the energy-kcal or energy-kj field from the energy field if it exists
+	compute_serving_size_data($product_ref);
+
 	$log->debug("displaying product", { code => $code }) if $log->is_debug();
 
 	# Lang strings for product.js

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8918,7 +8918,7 @@ HTML
 				if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
 					$value_unit = '?';
 				}
-				elsif ($nid =~ /^energy/) {
+				elsif (($nid eq "energy") or ($nid eq "energy-from-fat")) {
 					$value_unit .= "<br>(" . sprintf("%d", g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, 'kcal')) . ' kcal)';
 				}
 
@@ -9013,7 +9013,7 @@ HTML
 						$value_unit = $product_ref->{nutriments}{$nid . "_modifier"} . " " . $value_unit;
 					}
 
-					if ($nid =~ /^energy/) {
+					if (($nid eq "energy") or ($nid eq "energy-from-fat")) {
 						$value_unit .= "<br>(" . g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, 'kcal') . ' kcal)';
 					}
 				}

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -162,7 +162,13 @@ sub default_unit_for_nid($) {
 
 	my $nid = shift;
 
-	if ($nid eq "energy") {
+	if ($nid eq "energy-kj") {
+		return "kJ";
+	}
+	elsif ($nid eq "energy-kcal") {
+		return "kcal";
+	}
+	elsif ($nid eq "energy") {
 		return "kJ";
 	}
 	elsif ($nid eq "alcohol") {
@@ -375,7 +381,8 @@ sub mmoll_to_unit {
 
 %nutriments_tables = (
 	europe => [(
-		'!energy',
+		'!energy-kj',
+		'!energy-kcal',
 		'-energy-from-fat-',
 		'!fat',
 		'-saturated-fat',
@@ -486,7 +493,7 @@ sub mmoll_to_unit {
 		'carnitine-',
 	)],
 	ca => [(
-		'!energy',
+		'!energy-kcal',
 		'!fat',
 		'-saturated-fat',
 		'--butyric-acid-',
@@ -709,7 +716,7 @@ sub mmoll_to_unit {
 		'carnitine-',
 	)],
 	us => [(
-		'!energy',
+		'!energy-kcal',
 		'-energy-from-fat-',
 		'!fat',
 		'-saturated-fat',
@@ -1018,6 +1025,88 @@ sub mmoll_to_unit {
 		unit => "kj",
 		unit_us => "kcal",
 		unit_ca => "kcal",
+	},
+	"energy-kj"	=> {
+		ar => "الطاقه (kJ)",
+		bg => "Енергийна стойност (kJ)",
+		cs => "Energetická hodnota (kJ)",
+		da => "Energi (kJ)",
+		de => "Energie (kJ)",
+		el => "Ενέργεια (kJ)",
+		en => "Energy (kJ)",
+		es => "Energía (kJ)",
+		et => "Energia (kJ)",
+		fa => "انرژی (kJ)",
+		fi => "Energiav (kJ)",
+		fr => "Énergie (kJ)",
+		fr_synonyms => ["valeurs énergétique (kJ)", "valeur énergétique (kJ)"],
+		ga => "Fuinneamh (kJ)",
+		he => "אנרגיה - קלוריות (kJ)",
+		hu => "Energia (kJ)",
+		it => "Energia (kJ)",
+		lt => "Energinė vertė (kJ)",
+		ja => "エネルギー (kJ)",
+		lv => "Enerģētiskā vērtība (kJ)",
+		mt => "Enerġija (kJ)",
+		nb => "Energi (kJ)",
+		nl => "Energie (kJ)",
+		nl_be => "Energie (kJ)",
+		pt => "Energia (kJ)",
+		pl => "Wartość energetyczna (kJ)",
+		ro => "Valoarea energetică (kJ)",
+		rs => "Energetska vrednost (kJ)",
+		ru => "Энергетическая ценность (kJ)",
+		sl => "Energijska vrednost (kJ)",
+		sk => "Energetická hodnota (kJ)",
+		sv => "Energi (kJ)",
+		tr => "Enerji (kJ)",
+		zh => "能量 (kJ)",
+		zh_CN => "能量 (kJ)",
+		zh_HK => "能量 (kJ)",
+		zh_TW => "能量 (kJ)",
+
+		unit => "kj",
+	},
+	"energy-kcal"	=> {
+		ar => "الطاقه (kcal)",
+		bg => "Енергийна стойност (kcal)",
+		cs => "Energetická hodnota (kcal)",
+		da => "Energi (kcal)",
+		de => "Energie (kcal)",
+		el => "Ενέργεια (kcal)",
+		en => "Energy (kcal)",
+		es => "Energía (kcal)",
+		et => "Energia (kcal)",
+		fa => "انرژی (kcal)",
+		fi => "Energiav (kcal)",
+		fr => "Énergie (kcal)",
+		fr_synonyms => ["valeurs énergétique (kcal)", "valeur énergétique (kcal)"],
+		ga => "Fuinneamh (kcal)",
+		he => "אנרגיה - קלוריות (kcal)",
+		hu => "Energia (kcal)",
+		it => "Energia (kcal)",
+		lt => "Energinė vertė (kcal)",
+		ja => "エネルギー (kcal)",
+		lv => "Enerģētiskā vērtība (kcal)",
+		mt => "Enerġija (kcal)",
+		nb => "Energi (kcal)",
+		nl => "Energie (kcal)",
+		nl_be => "Energie (kcal)",
+		pt => "Energia (kcal)",
+		pl => "Wartość energetyczna (kcal)",
+		ro => "Valoarea energetică (kcal)",
+		rs => "Energetska vrednost (kcal)",
+		ru => "Энергетическая ценность (kcal)",
+		sl => "Energijska vrednost (kcal)",
+		sk => "Energetická hodnota (kcal)",
+		sv => "Energi (kcal)",
+		tr => "Enerji (kcal)",
+		zh => "能量 (kcal)",
+		zh_CN => "能量 (kcal)",
+		zh_HK => "能量 (kcal)",
+		zh_TW => "能量 (kcal)",
+
+		unit => "kcal",
 	},
 	"energy-from-fat" => {
 		cs => "Energie z tuku",
@@ -4820,7 +4909,38 @@ sub compute_serving_size_data($) {
 	#	$product_ref->{nutriments}{'energy.unit'} = 'kj';
 	#}
 
+
 	foreach my $product_type ("", "_prepared") {
+
+		# Energy
+		# Before November 2019, we only had one energy field with an input value in kJ or in kcal, and internally it was converted to kJ
+		# In Europe, the energy is indicated in both kJ and kcal, but there isn't a straightforward conversion between the 2: the energy is computed
+		# by summing some nutrients multiplied by an energy factor. That means we need to store both the kJ and kcal values.
+		# see bug https://github.com/openfoodfacts/openfoodfacts-server/issues/2396
+
+		# If we have a value for energy-kj, use it for energy
+		if (defined $product_ref->{nutriments}{"energy-kj" . $product_type}) {
+			assign_nid_modifier_value_and_unit($product_ref, "energy" . $product_type,
+				$product_ref->{nutriments}{"energy-kj" . $product_type . "_modifier"},
+				$product_ref->{nutriments}{"energy-kj" . $product_type . "_value"},
+				$product_ref->{nutriments}{"energy-kj" . $product_type . "_unit"});
+		}
+		# Otherwise use the energy-kcal value for energy
+		elsif (defined $product_ref->{nutriments}{"energy-kcal" . $product_type }) {
+			assign_nid_modifier_value_and_unit($product_ref, "energy" . $product_type,
+				$product_ref->{nutriments}{"energy-kcal" . $product_type . "_modifier"},
+				$product_ref->{nutriments}{"energy-kcal" . $product_type . "_value"},
+				$product_ref->{nutriments}{"energy-kcal" . $product_type . "_unit"});		}
+		# Otherwise, if we have a value and a unit for the energy field, copy it to either energy-kj or energy-kcal
+		elsif ((defined $product_ref->{nutriments}{"energy" . $product_type . "_value"}) and (defined $product_ref->{nutriments}{"energy" . $product_type . "_unit"})) {
+
+			my $unit = lc($product_ref->{nutriments}{"energy" . $product_type . "_unit"});
+
+			assign_nid_modifier_value_and_unit($product_ref, "energy-$unit" . $product_type,
+				$product_ref->{nutriments}{"energy" . $product_type . "_modifier"},
+				$product_ref->{nutriments}{"energy" . $product_type . "_value"},
+				$product_ref->{nutriments}{"energy" . $product_type . "_unit"});
+		}
 
 		if (not defined $product_ref->{"nutrition_data" . $product_type . "_per"}) {
 			$product_ref->{"nutrition_data" . $product_type . "_per"} = '100g';
@@ -4908,9 +5028,7 @@ sub compute_serving_size_data($) {
 				= sprintf("%.2e",$product_ref->{nutriments}{"carbon-footprint-from-known-ingredients_100g"} / 100.0 * $product_ref->{product_quantity}) + 0.0;
 			}
 		}
-
 	}
-
 }
 
 


### PR DESCRIPTION
This change is to introduce new energy-kj and energy-kcal nutrients. Please see bug #2396 for the explanation of why we need this.

We need to be careful as we need to handle several situations:

1. I will run the update_all_products.pl script to run compute_serving_size_data() that will populate either energy-kj or energy-kcal from the energy field. But it is going to take hours.

2. In the mean time, there will be the new product edit form on the web site, which will first run compute_serving_size_data() before displaying the form, so that we don't have empty values.

3. There is also the apps: they will still have access to the energy value, and when they update the "energy" field (and not "energy-kj" and "energy-kcal"), we will in fact use the unit they pass to set the energy-kj or -kcal field.