### PR TITLE
add support for user groups to define permissions, bug #2085

### DIFF
--- a/cgi/product_image_move.pl
+++ b/cgi/product_image_move.pl
@@ -217,7 +217,7 @@ if ($error) {
 				display_url => "$imgid.$display_size.jpg",
 			};
 
-			if ($admin) {
+			if ($User{moderator}) {
 				$image_data_ref->{uploader} = $product_ref->{images}{$imgid}{uploader};
 				$image_data_ref->{uploaded} = display_date($product_ref->{images}{$imgid}{uploaded_t}) . ""; # trying to convert the object to a scalar
 			}

--- a/cgi/product_image_upload.pl
+++ b/cgi/product_image_upload.pl
@@ -188,7 +188,7 @@ if ($imagefield) {
 				crop_url=>"$imgid.${crop_size}.jpg",
 			};
 
-			if ($admin) {
+			if ($User{moderator}) {
 				$product_ref = retrieve_product($product_id);
 				$image_data_ref->{uploader} = $product_ref->{images}{$imgid}{uploader};
 				$image_data_ref->{uploaded} = $product_ref->{images}{$imgid}{uploaded_t};

--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -119,7 +119,7 @@ else {
 	my @errors = ();
 
 	# 26/01/2017 - disallow barcode changes until we fix bug #677
-	if ($admin and (defined param('new_code'))) {
+	if ($User{moderator} and (defined param('new_code'))) {
 
 		change_product_server_or_code($product_ref, param('new_code'), \@errors);
 		$code = $product_ref->{code};

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -170,14 +170,14 @@ else {
 	}
 	else {
 		$product_id = product_id_for_user($User_id, $Org_id, $code);
-		$product_ref = retrieve_product_or_deleted_product($product_id, $admin);
+		$product_ref = retrieve_product_or_deleted_product($product_id, $User{moderator});
 		if (not defined $product_ref) {
 			display_error(sprintf(lang("no_product_for_barcode"), $code), 404);
 		}
 	}
 }
 
-if (($type eq 'delete') and (not $admin)) {
+if (($type eq 'delete') and (not $User{moderator})) {
 	display_error($Lang{error_no_permission}{$lang}, 403);
 }
 
@@ -256,7 +256,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 	exists $product_ref->{new_server} and delete $product_ref->{new_server};
 
 	# 26/01/2017 - disallow barcode changes until we fix bug #677
-	if ($admin and (defined param('new_code'))) {
+	if ($User{moderator} and (defined param('new_code'))) {
 
 		change_product_server_or_code($product_ref, param('new_code'), \@errors);
 		$code = $product_ref->{code};
@@ -384,7 +384,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	$product_ref->{nutrition_data_prepared} = remove_tags_and_quote(decode utf8=>param("nutrition_data_prepared"));
 
-	if (($admin or $owner) and (defined param('obsolete_since_date'))) {
+	if (($User{moderator} or $owner) and (defined param('obsolete_since_date'))) {
 		$product_ref->{obsolete} = remove_tags_and_quote(decode utf8=>param("obsolete"));
 		$product_ref->{obsolete_since_date} = remove_tags_and_quote(decode utf8=>param("obsolete_since_date"));
 	}
@@ -563,7 +563,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	# product check
 
-	if ($admin or $moderator) {
+	if ($User{moderator}) {
 
 		my $checked = remove_tags_and_quote(decode utf8=>param("photos_and_data_checked"));
 		if ((defined $checked) and ($checked eq 'on')) {
@@ -779,7 +779,7 @@ if (($action eq 'display') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	$scripts .=<<JS
 <script type="text/javascript">
-var admin = $admin;
+var admin = $User{moderator};
 var Lang = {
 JS
 ;
@@ -889,7 +889,7 @@ CSS
 	my $label_new_code = $Lang{new_code}{$lang};
 
 	# 26/01/2017 - disallow barcode changes until we fix bug #677
-	if ($admin) {
+	if ($User{moderator}) {
 		$html .= <<HTML
 <label for="new_code" id="label_new_code">${label_new_code}</label>
 <input type="text" name="new_code" id="new_code" class="text" value="" /><br />
@@ -899,7 +899,7 @@ HTML
 
 	# obsolete products: restrict to admin on public site
 	# authorize owners on producers platform
-	if ($admin or $owner) {
+	if ($User{moderator} or $owner) {
 
 		my $checked = '';
 		if ((defined $product_ref->{obsolete}) and ($product_ref->{obsolete} eq 'on')) {
@@ -995,7 +995,7 @@ function toggle_manage_images_buttons() {
 JS
 ;
 
-	if ($admin) {
+	if ($User{moderator}) {
 		$html .= <<HTML
 <ul id="manage_images_accordion" class="accordion" data-accordion>
   <li class="accordion-navigation">
@@ -1878,11 +1878,11 @@ HTML
 
 		if (($nid eq 'alcohol') or ($nid eq 'energy-kj') or ($nid eq 'energy-kcal')) {
 			my $unit = '';
-			
+
 			if (($nid eq 'alcohol')) { $unit = '% vol / °'; } # alcohol in % vol / °
 			elsif (($nid eq 'energy-kj')) { $unit = 'kJ'; }
 			elsif (($nid eq 'energy-kcal')) { $unit = 'kcal'; }
-			
+
 			$input .= <<"HTML"
 <td>
 <span class="nutriment_unit">$unit</span>
@@ -2117,7 +2117,7 @@ HTML
 
 	# Product check
 
-	if ($admin or $moderator) {
+	if ($User{moderator}) {
 
 		$html .= <<HTML
 <div class=\"fieldset\" id=\"check\"><legend>$Lang{photos_and_data_check}{$lang}</legend>
@@ -2227,7 +2227,7 @@ HTML
 
 	$html .= display_product_history($code, $product_ref);
 }
-elsif (($action eq 'display') and ($type eq 'delete') and ($admin)) {
+elsif (($action eq 'display') and ($type eq 'delete') and ($User{moderator})) {
 
 	$log->debug("display product", { code => $code }) if $log->is_debug();
 
@@ -2257,11 +2257,11 @@ elsif ($action eq 'process') {
 
 	$product_ref->{interface_version_modified} = $interface_version;
 
-	if (($admin) and ($type eq 'delete')) {
+	if (($User{moderator}) and ($type eq 'delete')) {
 		$product_ref->{deleted} = 'on';
 		$comment = lang("deleting_product") . separator_before_colon($lc) . ":";
 	}
-	elsif (($admin) and (exists $product_ref->{deleted})) {
+	elsif (($User{moderator}) and (exists $product_ref->{deleted})) {
 		delete $product_ref->{deleted};
 	}
 

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -31,7 +31,6 @@ BEGIN
 	@EXPORT_OK = qw(
 		%string_normalization_for_lang
 		%admins
-		%moderators
 
 		$server_domain
 		@ssl_subdomains
@@ -146,34 +145,12 @@ use ProductOpener::Config2;
 );
 
 %admins = map { $_ => 1 } qw(
-	agamitsudo
-	aleene
-	bcatelin
-	bojackhorseman
 	charlesnepote
 	hangy
-	javichu
-	kyzh
-	lafel
-	lucaa
-	mbe
-	moon-rabbit
-	raphael0202
-	sebleouf
-	segundo
 	stephane
 	tacinte
-	tacite
 	teolemon
-	twoflower
-
-	jniderkorn
-	desan
-	cedagaesse
-	m-etchebarne
 );
-
-%moderators = map { $_ => 1 } qw();
 
 $options{export_limit} = 10000;
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -70,7 +70,6 @@ BEGIN
 					@search_series
 
 					$admin
-					$moderator
 					$memd
 					$default_request_ref
 					$owner
@@ -207,7 +206,6 @@ sub init()
 	$header = '';
 	$bodyabout = '';
 	$admin = 0;
-	$moderator = 0;
 
 	my $r = shift;
 
@@ -377,13 +375,11 @@ sub init()
 		}
 	}
 
+	# %admin is defined in Config.pm
+	# admins can change permissions for all users
 	if ((%admins) and (defined $User_id) and (exists $admins{$User_id})) {
 		$admin = 1;
 	}
-	if ((%moderators) and (defined $User_id) and (exists $moderators{$User_id})) {
-		$moderator = 1;
-	}
-
 
 	if (defined $User_id) {
 		$styles .= <<CSS
@@ -6597,8 +6593,8 @@ HTML
 			$$minheight_ref = $1 + 22;
 		}
 
-		# Unselect button for admins
-		if ($admin) {
+		# Unselect button for moderators
+		if ($User{moderator}) {
 
 			my $idlc = $id;
 
@@ -6990,7 +6986,7 @@ HTML
 HTML
 ;
 
-	if ($admin) {
+	if ($User{moderator}) {
 		$html .= <<HTML
 <div class="delete_button right" style="float:right;margin-top:-10px;margin-right:10px;">
 <a href="/cgi/product.pl?type=delete&code=$code" class="button small">
@@ -7263,7 +7259,7 @@ HTML
 	}
 	$html .= "</div>";
 
-	if ($admin and ($ingredients_text !~ /^\s*$/)) {
+	if ($User{moderator} and ($ingredients_text !~ /^\s*$/)) {
 
 			my $ilc = $ingredients_text_lang;
 
@@ -7807,7 +7803,7 @@ HTML
 		$html .= display_field($product_ref, 'states');
 	}
 
-	$html .= display_product_history($code, $product_ref) if $admin;
+	$html .= display_product_history($code, $product_ref) if $User{moderator};
 
 	$html .= <<HTML
 <div class="edit_button right" style="float:right;margin-top:-10px;">

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -79,6 +79,8 @@ use Math::Random::Secure qw(irand);
 use Crypt::ScryptKDF qw(scrypt_hash scrypt_hash_verify);
 use Log::Any qw($log);
 
+my @user_groups = qw(producer database app bot moderator);
+
 sub generate_token {
 	my $name_length = shift;
 	my @chars=('a'..'z', 'A'..'Z', 0..9);
@@ -247,6 +249,16 @@ sub display_user_form_admin_only($) {
 
 		$html .= "\n<tr><td>$Lang{organization}{$lang}</td><td>"
 		. textfield(-id=>'organization', -name=>'organization', -value=>$user_ref->{org}, -size=>80, -autocomplete=>'organization', -override=>1) . "</td></tr>";
+
+		$html .= "\n<tr><td colspan=\"2\">" . lang("user_groups") . lang("sep") . ":<ul>";
+
+		foreach my $group (@user_groups) {
+			$html .= "<li>"
+			. checkbox(-name=>"user_group_$group", -label=>lang("user_group_$group") . lang("sep") . ": " . lang("user_group_${group}_description")
+				, -checked=>$user_ref->{$group}, -override=>1)  . "</li>";
+		}
+
+		$html .= "</td></tr>";
 	}
 
 	return $html;
@@ -300,6 +312,10 @@ sub check_user_form($$) {
 		else {
 			delete $user_ref->{org};
 			delete $user_ref->{org_id};
+		}
+
+		foreach my $group (@user_groups) {
+			$user_ref->{$group} = remove_tags_and_quote(param("user_group_$group"));
 		}
 	}
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4101,3 +4101,47 @@ msgstr "Mean value for the %s category"
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
 msgstr "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
+
+msgctxt "user_groups"
+msgid "Groups"
+msgstr "Groups"
+
+msgctxt "user_group_producer"
+msgid "Producer"
+msgstr "Producer"
+
+msgctxt "user_group_producer_description"
+msgid "Must be checked only for accounts of producers who edit their own products. Product ownership will be attributed to producers when they add or edit a product."
+msgstr "Must be checked only for accounts of producers who edit their own products. Product ownership will be attributed to producers when they add or edit a product."
+
+msgctxt "user_group_database"
+msgid "Database"
+msgstr "Database"
+
+msgctxt "user_group_database_description"
+msgid "For external sources of data. Product ownership of imported products will not change."
+msgstr "For external sources of data. Product ownership of imported products will not change."
+
+msgctxt "user_group_app"
+msgid "App"
+msgstr "App"
+
+msgctxt "user_group_app_description"
+msgid "For applications."
+msgstr "For applications."
+
+msgctxt "user_group_bot"
+msgid "Bot"
+msgstr "Bot"
+
+msgctxt "user_group_bot_description"
+msgid "For robots, scripts etc."
+msgstr "For robots, scripts etc."
+
+msgctxt "user_group_moderator"
+msgid "Moderator"
+msgstr "Moderator"
+
+msgctxt "user_group_moderator_description"
+msgid "Moderators have access to special features to edit and review products."
+msgstr "Moderators have access to special features to edit and review products."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -3964,3 +3964,46 @@ msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
 msgstr "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
 
+msgctxt "user_groups"
+msgid "Groups"
+msgstr "Groups"
+
+msgctxt "user_group_producer"
+msgid "Producer"
+msgstr "Producer"
+
+msgctxt "user_group_producer_description"
+msgid "Must be checked only for accounts of producers who edit their own products. Product ownership will be attributed to producers when they add or edit a product."
+msgstr "Must be checked only for accounts of producers who edit their own products. Product ownership will be attributed to producers when they add or edit a product."
+
+msgctxt "user_group_database"
+msgid "Database"
+msgstr "Database"
+
+msgctxt "user_group_database_description"
+msgid "For external sources of data. Product ownership of imported products will not change."
+msgstr "For external sources of data. Product ownership of imported products will not change."
+
+msgctxt "user_group_bot"
+msgid "Bot"
+msgstr "Bot"
+
+msgctxt "user_group_bot_description"
+msgid "For robots, scripts etc."
+msgstr "For robots, scripts etc."
+
+msgctxt "user_group_app"
+msgid "App"
+msgstr "App"
+
+msgctxt "user_group_app_description"
+msgid "For applications."
+msgstr "For applications."
+
+msgctxt "user_group_moderator"
+msgid "Moderator"
+msgstr "Moderator"
+
+msgctxt "user_group_moderator_description"
+msgid "Moderators have access to special features to edit and review products."
+msgstr "Moderators have access to special features to edit and review products."


### PR DESCRIPTION
very simple system to assign users to groups (e.g. moderators, producers etc.), that we can use to enable special features.