### PR TITLE
Replace 'index' text later

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -552,12 +552,6 @@ sub analyze_request($)
 		$request_ref->{text} = 'index';
 	}
 
-	# Index page on producers platform
-	if ((defined $request_ref->{text}) and ($request_ref->{text} eq "index")
-		and (defined $server_options{private_products}) and ($server_options{private_products})) {
-		$request_ref->{text} = 'index-pro';
-	}
-
 	# Api access
 	elsif ($components[0] eq 'api') {
 
@@ -786,6 +780,12 @@ sub analyze_request($)
 		}
 
 		$request_ref->{canon_rel_url} .= $canon_rel_url_suffix;
+	}
+
+	# Index page on producers platform
+	if ((defined $request_ref->{text}) and ($request_ref->{text} eq "index")
+		and (defined $server_options{private_products}) and ($server_options{private_products})) {
+		$request_ref->{text} = 'index-pro';
 	}
 
 	$log->debug("request analyzed", { lc => $lc, lang => $lang, request_ref => Dumper($request_ref)}) if $log->is_debug();


### PR DESCRIPTION
**Description:**
In 6ebac4478b30d65b1f81c58c468577d8dd443d22, the following block was added, which made the previous `if..elsif..else` decision tree work differently.

https://github.com/openfoodfacts/openfoodfacts-server/blob/a5d02f9439e0bdc5602947a1aa58a97c4a070bfd/lib/ProductOpener/Display.pm#L558-L562

For some cases, this caused the `text` property to the `$request_ref` to be set to `undex` instead of `"text"`.

**Related issues and discussion:** Fixes #2652 