### PR TITLE
Add server option to whitelist IPs for all session cookies

### DIFF
--- a/lib/ProductOpener/Config2_sample.pm
+++ b/lib/ProductOpener/Config2_sample.pm
@@ -83,6 +83,7 @@ $robotoff_url = '';
         cookie_domain => "openfoodfacts.dev",   # if not set, default to $server _domain
         private_products => 1,  # Make products visible only to the owner
         export_servers => { public => "off", experiment => "off-exp" },
+		ip_whitelist_session_cookie => [ "172.19.0.1" ],
 );
 
 


### PR DESCRIPTION
**Description:**
While we don't have #1204, other APIs might need to pass the session cookie. This adds a server option to whitelist IPs for all cookies.

**Related issues and discussion:** Fixes #2637
