### PR TITLE
Fix unit tests

### DIFF
--- a/po/openbeautyfacts/de.po
+++ b/po/openbeautyfacts/de.po
@@ -131,7 +131,7 @@ msgstr "https://world.openbeautyfacts.org/images/misc/openbeautyfacts-logo-en.pn
 msgctxt "openfoodhunt_points"
 msgid "It's <a href=\"/open-beauty-hunt\">Open Beauty Hunt</a> on <<site_name>> from Saturday February 21st to Sunday March 1st! Contributors are awarded\n"
 "Explorer points for products they add and Ambassador points for new contributors they recruit. Points are updated every 30 minutes."
-msgstr "Es ist <a href=\"/open-beauty-hunt\">Open Beauty Hunt</a> auf „<site_name>” vom Samstag, den 21. Februar bis Sonntag, den 1. März! Die Mitwirkenden erhalten Entdeckerpunkte für Produkte, die sie hinzufügen und Botschafterpunkte für neue Mitwirkende, die sie einstellen. Die Punkte werden alle 30 Minuten aktualisiert."
+msgstr "Es ist <a href=\"/open-beauty-hunt\">Open Beauty Hunt</a> auf „<<site_name>>” vom Samstag, den 21. Februar bis Sonntag, den 1. März! Die Mitwirkenden erhalten Entdeckerpunkte für Produkte, die sie hinzufügen und Botschafterpunkte für neue Mitwirkende, die sie einstellen. Die Punkte werden alle 30 Minuten aktualisiert."
 
 msgctxt "product_js_upload_image_note"
 msgid "→ With Chrome, Firefox and Safari, you can select multiple pictures (product, ingredients etc.) by clicking them while holding the Ctrl key pressed to add them all in one shot."


### PR DESCRIPTION
Fix the unit test that started failing at some point in time.
```
#   Failed test ''openfoodhunt_points' in 'de' should contain '<<site_name>>''
#   at t/i18n.t line 22.
Wide character in print at /usr/share/perl/5.26/Test2/Formatter/TAP.pm line 105.
#                   'Es ist <a href="/open-beauty-hunt">Open Beauty Hunt</a> auf „<site_name>” vom Samstag, den 21. Februar bis Sonntag, den 1. März! Die Mitwirkenden erhalten Entdeckerpunkte für Produkte, die sie hinzufügen und Botschafterpunkte für neue Mitwirkende, die sie einstellen. Die Punkte werden alle 30 Minuten aktualisiert.'
#     doesn't match '(?^:<<site_name>>)'
# Looks like you failed 1 test of 355.
t/i18n.t ......................... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/355 subtests 
```