### PR TITLE
Make croutons a separate category

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -17716,7 +17716,8 @@ ru:Хлеб белый из пшеничной муки высшего сорт�
 
 # <en:compound
 # mainIngredient:en:wheat
-en:Breads
+<en:Breads
+en:Croutons
 af:Crouton
 be:грэнкі
 bg:крутон


### PR DESCRIPTION
Right now, in production, https://world.openfoodfacts.org/category/croutons redirects to https://world.openfoodfacts.org/category/breads. Also, the "breads" category is linked to https://www.wikidata.org/wiki/Q1197400 instead of https://www.wikidata.org/wiki/Q7802.