### PR TITLE
Move info title to translation

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6106,7 +6106,7 @@ HTML
 HTML
 ;
 	}
-	
+
 	elsif ($lc eq 'es') {
 
 		my $link = lang("donate_link");
@@ -6128,7 +6128,7 @@ HTML
 HTML
 ;
 	}
-	
+
 	elsif ($lc eq 'it') {
 
 		my $link = lang("donate_link");
@@ -6150,7 +6150,7 @@ HTML
 HTML
 ;
 	}
-	
+
 	elsif ($lc eq 'de') {
 
 		my $link = lang("donate_link");
@@ -7776,15 +7776,16 @@ HTML
 		my $group = $product_ref->{nova_group};
 
 		my $display = display_taxonomy_tag($lc, "nova_groups", $product_ref->{nova_groups_tags}[0]);
+		my $a_title = lang('nova_groups_info');
 
 		$html .= <<HTML
 <h4>$Lang{nova_groups_s}{$lc}
-<a href="/nova">
+<a href="/nova" title="${a_title}">
 @{[ display_icon('info') ]}</a>
 </h4>
 
 
-<a href="/nova"><img src="/images/misc/nova-group-$group.svg" alt="$display" style="margin-bottom:1rem;max-width:100%"></a><br>
+<a href="/nova" title="${a_title}"><img src="/images/misc/nova-group-$group.svg" alt="$display" style="margin-bottom:1rem;max-width:100%"></a><br>
 $display
 HTML
 ;
@@ -8156,15 +8157,16 @@ HTML
 		my $group = $product_ref->{nova_group};
 
 		my $display = display_taxonomy_tag($lc, "nova_groups", $product_ref->{nova_groups_tags}[0]);
+		my $a_title = lang('nova_groups_info');
 
 		$html .= <<HTML
 <h4>$Lang{nova_groups_s}{$lc}
-<a href="https://world.openfoodfacts.org/nova" title="NOVA groups for food processing">
+<a href="https://world.openfoodfacts.org/nova" title="${$a_title}">
 @{[ display_icon('info') ]}</a>
 </h4>
 
 
-<a href="https://world.openfoodfacts.org/nova" title="NOVA groups for food processing"><img src="/images/misc/nova-group-$group.svg" alt="$display" style="margin-bottom:1rem;max-width:100%"></a><br>
+<a href="https://world.openfoodfacts.org/nova" title="${$a_title}"><img src="/images/misc/nova-group-$group.svg" alt="$display" style="margin-bottom:1rem;max-width:100%"></a><br>
 $display
 HTML
 ;

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -2954,6 +2954,11 @@ msgctxt "nova_groups_p"
 msgid "NOVA groups"
 msgstr ""
 
+# Title for the link to the explanation of what a NOVA Group is
+msgctxt "nova_groups_info"
+msgid "NOVA groups for food processing"
+msgstr ""
+
 msgctxt "footer_partners"
 msgid "Partners"
 msgstr ""

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -2809,6 +2809,10 @@ msgctxt "nova_groups_p"
 msgid "NOVA groups"
 msgstr "NOVA groups"
 
+msgctxt "nova_groups_info"
+msgid "NOVA groups for food processing"
+msgstr "NOVA groups for food processing"
+
 msgctxt "footer_partners"
 msgid "Partners"
 msgstr "Partners"


### PR DESCRIPTION
**Description:**
Makes the NOVA Group info title translatable.

**Related issues and discussion:** Fixes #2144
