### PR TITLE
Update store badges for better translatability

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6106,7 +6106,7 @@ HTML
 HTML
 ;
 	}
-	
+
 	elsif ($lc eq 'es') {
 
 		my $link = lang("donate_link");
@@ -6128,7 +6128,7 @@ HTML
 HTML
 ;
 	}
-	
+
 	elsif ($lc eq 'it') {
 
 		my $link = lang("donate_link");
@@ -6150,7 +6150,7 @@ HTML
 HTML
 ;
 	}
-	
+
 	elsif ($lc eq 'de') {
 
 		my $link = lang("donate_link");
@@ -6463,10 +6463,10 @@ HTML
 	</div>
 	<div class="small-12 medium-6 large-3 columns app">
 		<div class="title">$Lang{footer_install_the_app}{$lc}</div>
-		<a href="$Lang{ios_app_link}{$lc}">$Lang{ios_app_badge}{$lc}</a>
-		<a href="$Lang{android_app_link}{$lc}">$Lang{android_app_badge}{$lc}</a>
-		<a href="$Lang{windows_phone_app_link}{$lc}">$Lang{windows_phone_app_badge}{$lc}</a>
-		<a href="$Lang{android_apk_app_link}{$lc}">$Lang{android_apk_app_badge}{$lc}</a>
+		<a href="$Lang{ios_app_link}{$lc}"><img src="$Lang{ios_app_icon_url}{$lc}" alt="$Lang{ios_app_icon_alt_text}{$lc}" width="120" height="40" loading="lazy"></a>
+		<a href="$Lang{android_app_link}{$lc}"><img src="$Lang{android_app_icon_url}{$lc}" alt="$Lang{android_app_icon_alt_text}{$lc}" width="102" height="40" loading="lazy"></a>
+		<a href="$Lang{windows_phone_app_link}{$lc}"><img src="$Lang{windows_phone_app_icon_url}{$lc}" alt="$Lang{windows_phone_app_icon_alt_text}{$lc}" width="109" height="40" loading="lazy"></a>
+		<a href="$Lang{android_apk_app_link}{$lc}"><img src="$Lang{android_apk_app_icon_url}{$lc}" alt="$Lang{android_apk_app_icon_alt_text}{$lc}" loading="lazy"></a>
 	</div>
 	<div class="small-12 medium-6 large-3 columns project">
 		<div class="title">$Lang{footer_discover_the_project}{$lc}</div>

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ar_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -996,7 +996,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_AR.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2603,7 +2603,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Arabic.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ar_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ar_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -986,9 +990,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "المنتجات التي لا تحتوي على المكون s٪"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_AR.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_AR.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2589,9 +2598,13 @@ msgid "Site or blog address"
 msgstr "الموقع أو عنوان المدونة"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Arabic.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Arabic.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/bg_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -2579,7 +2579,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Bulgarian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/bg_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/bg_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -2570,9 +2574,13 @@ msgid "Site or blog address"
 msgstr ""
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Bulgarian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Bulgarian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -148,7 +148,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -143,9 +143,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Hegerz war Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://es-ca.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ca_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ca_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -2600,9 +2604,13 @@ msgid "Site or blog address"
 msgstr "Direcció del lloc o bloc"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Spanish.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Spanish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ca_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -2609,7 +2609,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Spanish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -135,9 +135,12 @@ msgctxt "also_edited_by"
 msgid "Product page also edited by"
 msgstr ""
 
-# Please check that the HTML tag stayed intact
-msgctxt "android_apk_app_badge"
-msgid "<img src=\"/images/misc/android-apk.svg\" loading=\"lazy\" alt=\"Android APK\" />"
+msgctxt "android_apk_app_icon_url"
+msgid "/images/misc/android-apk.svg"
+msgstr ""
+
+msgctxt "android_apk_app_icon_alt_text"
+msgid "Android APK"
 msgstr ""
 
 # DO NOT TRANSLATE
@@ -146,10 +149,12 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr ""
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid ""
-"<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg"
-"\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -1034,10 +1039,13 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr ""
 
-msgctxt "ios_app_badge"
-msgid ""
-"<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt="
-"\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr ""
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2709,10 +2717,12 @@ msgid "Site or blog address"
 msgstr ""
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid ""
-"<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store"
-"\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr ""
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -154,7 +154,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -1045,7 +1045,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr ""
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2722,7 +2722,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr ""
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -151,7 +151,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -146,9 +146,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world-cs.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Ke stažení na Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/da_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -999,7 +999,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_DK.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Tilgængelig i App Store"
 
 msgctxt "ios_app_link"
@@ -2615,7 +2615,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Danish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/da_get.svg\" alt=\"Tilgængelig i Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/da_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -989,9 +993,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produkter som ikke indeholder ingrediensen %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_DK.svg\" alt=\"Tilgængelig i App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_DK.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Tilgængelig i App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2601,9 +2610,13 @@ msgid "Site or blog address"
 msgstr "URL eller blog-adresse"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Danish.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Danish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/de_get.svg\" alt=\"Erhältlich bei Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/de_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Erhältlich bei Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produkte, die nicht den Inhaltsstoff %s enthalten"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_DE.svg\" alt=\"Erhältlich im App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_DE.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Erhältlich im App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2602,9 +2611,13 @@ msgid "Site or blog address"
 msgstr "Webseiten- oder Blog-Adresse"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/German.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/German.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/de_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Erhältlich bei Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_DE.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Erhältlich im App Store"
 
 msgctxt "ios_app_link"
@@ -2616,7 +2616,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/German.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -2560,9 +2560,13 @@ msgid "Site or blog address"
 msgstr "Ιστοσελίδα ή διεύθυνση ιστολογίου (blog)"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Greek.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Greek.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -2565,7 +2565,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Greek.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -136,10 +136,13 @@ msgctxt "also_edited_by"
 msgid "Product page also edited by"
 msgstr "Product page also edited by"
 
-# Please check that the HTML tag stayed intact
-msgctxt "android_apk_app_badge"
-msgid "<img src=\"/images/misc/android-apk.svg\" loading=\"lazy\" alt=\"Android APK\" />"
-msgstr "<img src=\"/images/misc/android-apk.svg\" loading=\"lazy\" alt=\"Android APK\" />"
+msgctxt "android_apk_app_icon_url"
+msgid "/images/misc/android-apk.svg"
+msgstr "/images/misc/android-apk.svg"
+
+msgctxt "android_apk_app_icon_alt_text"
+msgid "Android APK"
+msgstr "Android APK"
 
 # DO NOT TRANSLATE
 msgctxt "android_apk_app_link"
@@ -147,9 +150,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Available on Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -979,9 +986,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Products that do not contain the ingredient %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_US.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Available on the App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2592,9 +2604,13 @@ msgid "Site or blog address"
 msgstr "Site or blog address"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/English.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr "Windows Phone Store"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -155,8 +155,8 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
-msgstr "Available on Google Play"
+msgid "Get It On Google Play"
+msgstr "Get It On Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -992,8 +992,8 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_US.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
-msgstr "Available on the App Store"
+msgid "Download on the App Store"
+msgstr "Download on the App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2609,8 +2609,8 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/English.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
-msgstr "Windows Phone Store"
+msgid "Get it from Microsoft"
+msgstr "Get it from Microsoft"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -153,8 +153,8 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
-msgstr "Available on Google Play"
+msgid "Get It On Google Play"
+msgstr "Get It On Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -1000,8 +1000,8 @@ msgid "/images/misc/appstore/black/appstore_DE.svg"
 msgstr "/images/misc/appstore/black/appstore_US.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
-msgstr "Available on the App Store"
+msgid "Download on the App Store"
+msgstr "Download on the App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2617,8 +2617,8 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/English.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
-msgstr "Windows Phone Store"
+msgid "Get it from Microsoft"
+msgstr "Get it from Microsoft"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Available on Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Products that do not contain the ingredient %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_DE.svg"
+msgstr "/images/misc/appstore/black/appstore_US.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Available on the App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2603,9 +2612,13 @@ msgid "Site or blog address"
 msgstr "Site or blog address"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/English.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr "Windows Phone Store"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Available on Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Products that do not contain the ingredient %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_UK.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_UK.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Available on the App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2603,9 +2612,13 @@ msgid "Site or blog address"
 msgstr "Site or blog address"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/English.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr "Windows Phone Store"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -153,8 +153,8 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
-msgstr "Available on Google Play"
+msgid "Get It On Google Play"
+msgstr "Get It On Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -1000,8 +1000,8 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_UK.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
-msgstr "Available on the App Store"
+msgid "Download on the App Store"
+msgstr "Download on the App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2617,8 +2617,8 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/English.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
-msgstr "Windows Phone Store"
+msgid "Get it from Microsoft"
+msgstr "Get it from Microsoft"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/es_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponible en Google Pla"
 
 # Change hl=en to your language, and make sure the url works
@@ -1001,7 +1001,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_ES.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2615,7 +2615,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Spanish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/es_get.svg\" alt=\"Disponible en Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/es_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponible en Google Pla"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -991,9 +995,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Productos que no contienen el ingrediente %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_ES.svg\" alt=\"Disponible en Google Play\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_ES.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2601,9 +2610,13 @@ msgid "Site or blog address"
 msgstr "Dirección del blog o del sitio web"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Spanish.svg\" alt=\"Windows Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Spanish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/eu_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/eu_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/eu_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -134,9 +134,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/fa_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/fa_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -139,7 +139,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/fa_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -139,7 +139,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/fi_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Saatavilla Google Playsta"
 
 # Change hl=en to your language, and make sure the url works
@@ -976,7 +976,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_FI.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Saatavilla App Storesta"
 
 msgctxt "ios_app_link"
@@ -2568,7 +2568,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Finnish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -134,9 +134,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/fi_get.svg\" alt=\"Saatavilla Google Playsta\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/fi_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Saatavilla Google Playsta"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -966,9 +970,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Tuotteet, jotka eivät sisällä ainesosaa %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_FI.svg\" alt=\"Saatavilla App Storesta\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_FI.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Saatavilla App Storesta"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2554,9 +2563,13 @@ msgid "Site or blog address"
 msgstr "Sivuston tai blogin osoite"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Finnish.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Finnish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/fr_get.svg\" alt=\"Disponible sur Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/fr_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponible sur Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -993,9 +997,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Les produits qui ne contiennent pas l'ingrédient %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_FR.svg\" alt=\"Disponible sur App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_FR.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Disponible sur App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2607,9 +2616,13 @@ msgid "Site or blog address"
 msgstr "Adresse de blog ou de site web"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/French.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/French.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/fr_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponible sur Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1003,7 +1003,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_FR.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Disponible sur App Store"
 
 msgctxt "ios_app_link"
@@ -2621,7 +2621,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/French.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "זמין ב־Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -999,7 +999,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_HB.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "זמין ב־App Store"
 
 msgctxt "ios_app_link"
@@ -2616,7 +2616,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Hebrew.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr "החנות של Windows Phone"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"זמין ב־Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "זמין ב־Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -989,9 +993,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "מוצרים שאינם מכילים את הרכיב %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_HB.svg\" alt=\"זמין ב־App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_HB.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "זמין ב־App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2602,9 +2611,13 @@ msgid "Site or blog address"
 msgstr "כתובת אתר או בלוג"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Hebrew.svg\" alt=\"החנות של Windows Phone\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Hebrew.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr "החנות של Windows Phone"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/hu_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Elérhető a Google Playen"
 
 # Change hl=en to your language, and make sure the url works
@@ -993,7 +993,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_HU.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Letölthető az App Store-ból"
 
 msgctxt "ios_app_link"
@@ -2605,7 +2605,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Hungarian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world-hu.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/hu_get.svg\" alt=\"Elérhető a Google Playen\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/hu_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Elérhető a Google Playen"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -983,9 +987,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Termékek, amelyek nem tartalmaznak %s összetevőt"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_HU.svg\" alt=\"Letölthető az App Store-ból\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_HU.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Letölthető az App Store-ból"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2591,9 +2600,13 @@ msgid "Site or blog address"
 msgstr "Webhely vagy blog címe"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Hungarian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Hungarian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -154,7 +154,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/it_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponibile su Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1001,7 +1001,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_IT.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Disponibile su App Store"
 
 msgctxt "ios_app_link"
@@ -2618,7 +2618,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Italian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -149,9 +149,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/it_get.svg\" alt=\"Disponibile su Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/it_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponibile su Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -991,9 +995,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Prodotti che non contengono l'ingrediente %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_IT.svg\" alt=\"Disponibile su App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_IT.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Disponibile su App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2604,9 +2613,13 @@ msgid "Site or blog address"
 msgstr "Indirizzo del blog o del sito web"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Italian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Italian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -149,9 +149,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ja_get.svg\" alt=\"Google Play で利用できます\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ja_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Google Play で利用できます"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -991,9 +995,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "原材料 %s を含まない製品"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_JP.svg\" alt=\"App Store で利用できます\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_JP.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "App Store で利用できます"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2601,9 +2610,13 @@ msgid "Site or blog address"
 msgstr "サイトやブログのアドレス"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Japanese.svg\" alt=\"Windows Phone ストア\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Japanese.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr "Windows Phone ストア"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -154,7 +154,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ja_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Google Play で利用できます"
 
 # Change hl=en to your language, and make sure the url works
@@ -1001,7 +1001,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_JP.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "App Store で利用できます"
 
 msgctxt "ios_app_link"
@@ -2615,7 +2615,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Japanese.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr "Windows Phone ストア"
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world-ko.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ko_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ko_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -989,9 +993,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr ""
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_KR.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_KR.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2596,9 +2605,13 @@ msgid "Site or blog address"
 msgstr ""
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Korean.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Korean.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ko_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -999,7 +999,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_KR.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2610,7 +2610,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Korean.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ms_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ms_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ms_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/nl.po
+++ b/po/common/nl.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/nl_get.svg\" alt=\"Beschikbaar in Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Beschikbaar in Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -979,9 +983,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Producten die ingrediënt %en niet bevatten"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_NL.svg\" alt=\"Beschikbaar in de App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_NL.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Beschikbaar in de App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2589,9 +2598,13 @@ msgid "Site or blog address"
 msgstr "Adres van website of blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Dutch.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Dutch.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/nl.po
+++ b/po/common/nl.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Beschikbaar in Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -989,7 +989,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_NL.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Beschikbaar in de App Store"
 
 msgctxt "ios_app_link"
@@ -2603,7 +2603,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Dutch.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/nl_get.svg\" alt=\"Beschikbaar in Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Beschikbaar in Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Producten die ingrediënt %en niet bevatten"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_NL.svg\" alt=\"Beschikbaar in de App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_NL.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Beschikbaar in de App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2600,9 +2609,13 @@ msgid "Site or blog address"
 msgstr "Adres van website of blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Dutch.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Dutch.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Beschikbaar in Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_NL.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Beschikbaar in de App Store"
 
 msgctxt "ios_app_link"
@@ -2614,7 +2614,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Dutch.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/nl_get.svg\" alt=\"Beschikbaar in Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Beschikbaar in Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Producten die ingrediënt %en niet bevatten"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_NL.svg\" alt=\"Beschikbaar in de App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_NL.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Beschikbaar in de App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2600,9 +2609,13 @@ msgid "Site or blog address"
 msgstr "Adres van website of blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Dutch.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Dutch.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Beschikbaar in Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_NL.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Beschikbaar in de App Store"
 
 msgctxt "ios_app_link"
@@ -2614,7 +2614,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Dutch.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/pl_get.svg\" alt=\"Dostępny w Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Dostępny w Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -991,9 +995,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produkty które nie zawierają składnika %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_PL.svg\" alt=\"Dostępny w Google Play\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_PL.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Dostępny w Google Play"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2600,9 +2609,13 @@ msgid "Site or blog address"
 msgstr "Adres strony lub bloga"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Polish.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Polish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/nl_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Dostępny w Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1001,7 +1001,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_PL.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Dostępny w Google Play"
 
 msgctxt "ios_app_link"
@@ -2614,7 +2614,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Polish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/pt.po
+++ b/po/common/pt.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/pt_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponível no Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -989,7 +989,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_PT_BT.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Disponível na App Store"
 
 msgctxt "ios_app_link"
@@ -2603,7 +2603,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Portuguese-Brazilian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/pt.po
+++ b/po/common/pt.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/pt_get.svg\" alt=\"Disponível no Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/pt_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponível no Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -979,9 +983,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produtos que não contêm o ingrediente %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_PT_PT.svg\" alt=\"Disponível na App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_PT_BT.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Disponível na App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2589,9 +2598,13 @@ msgid "Site or blog address"
 msgstr "Endereço de site ou blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Portuguese-Brazilian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Portuguese-Brazilian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/pt_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponível no Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_PT_BR.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Disponível na App Store"
 
 msgctxt "ios_app_link"
@@ -2615,7 +2615,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Portuguese-Brazilian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/pt_get.svg\" alt=\"Disponível no Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/pt_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponível no Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produtos que não contêm o ingrediente %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_PT_BR.svg\" alt=\"Disponível na App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_PT_BR.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Disponível na App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2601,9 +2610,13 @@ msgid "Site or blog address"
 msgstr "Endereço de site ou blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Portuguese-Brazilian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Portuguese-Brazilian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/pt_get.svg\" alt=\"Disponível no Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/pt_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponível no Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produtos que não contêm o ingrediente %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_PT_PT.svg\" alt=\"Disponível na App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_PT_BT.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Disponível na App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2600,9 +2609,13 @@ msgid "Site or blog address"
 msgstr "Endereço de site ou blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Portuguese-Brazilian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Portuguese-Brazilian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/pt_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponível no Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_PT_BT.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Disponível na App Store"
 
 msgctxt "ios_app_link"
@@ -2614,7 +2614,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Portuguese-Brazilian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -150,7 +150,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ro_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Disponibil pe Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -988,7 +988,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_RO.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2582,7 +2582,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Romanian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -145,9 +145,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ro_get.svg\" alt=\"Disponibil pe Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ro_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Disponibil pe Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -978,9 +982,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr ""
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_RO.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_RO.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2568,9 +2577,13 @@ msgid "Site or blog address"
 msgstr "Adresă site sau blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Romanian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Romanian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/ru_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -999,7 +999,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_RU.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "Доступно в App Store"
 
 msgctxt "ios_app_link"
@@ -2616,7 +2616,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Russian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/ru_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/ru_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -989,9 +993,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Продукты которые не содержат %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_RU.svg\" alt=\"Доступно в App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_RU.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "Доступно в App Store"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2602,9 +2611,13 @@ msgid "Site or blog address"
 msgstr "Адрес сайта или блога"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Russian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Russian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -134,9 +134,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr ""
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/sk_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/sk_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -966,9 +970,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr ""
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_SK.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_SK.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2554,9 +2563,13 @@ msgid "Site or blog address"
 msgstr ""
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Slovak.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Slovak.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -139,7 +139,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/sk_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -976,7 +976,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_SK.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2568,7 +2568,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Slovak.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -2598,9 +2598,13 @@ msgid "Site or blog address"
 msgstr "Spletna stran ali blog naslov"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Slovenian.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Slovenian.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -2603,7 +2603,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Slovenian.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/sv_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_SE.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2600,7 +2600,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Swedish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/sv_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/sv_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Produkter som inte innehåller ingrediensen %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_SE.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_SE.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2586,9 +2595,13 @@ msgid "Site or blog address"
 msgstr "Webbplats eller bloggadress"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Swedish.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Swedish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/th_get.svg\" alt=\"ดาวน์โหลดที่ Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/th_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "ดาวน์โหลดที่ Google Play"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -980,9 +984,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr ""
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_TH.svg\" alt=\"ดาวน์โหลดที่ Google Play\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_TH.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "ดาวน์โหลดที่ Google Play"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2568,9 +2577,13 @@ msgid "Site or blog address"
 msgstr ""
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Thai.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Thai.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/th_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "ดาวน์โหลดที่ Google Play"
 
 # Change hl=en to your language, and make sure the url works
@@ -990,7 +990,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_TH.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "ดาวน์โหลดที่ Google Play"
 
 msgctxt "ios_app_link"
@@ -2582,7 +2582,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Thai.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/tr_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Google Play'de Mevcut"
 
 # Change hl=en to your language, and make sure the url works
@@ -997,7 +997,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_TR.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr "App Store'da Mevcut"
 
 msgctxt "ios_app_link"
@@ -2611,7 +2611,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Turkish.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/tr_get.svg\" alt=\"Google Play'de Mevcut\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/tr_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Google Play'de Mevcut"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -987,9 +991,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "% S bileşenini içermeyen ürünler"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_TR.svg\" alt=\"App Store'da Mevcut\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_TR.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr "App Store'da Mevcut"
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2597,9 +2606,13 @@ msgid "Site or blog address"
 msgstr "Site veya blog adresi"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Turkish.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Turkish.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -149,9 +149,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr ""
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -154,7 +154,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -148,9 +148,14 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Google Playda mavjud\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr ""
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Google Playda mavjud"
+
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr ""
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Google Playda mavjud"
 
 

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/vi_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -1000,7 +1000,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_VN.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2616,7 +2616,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Vietnamese.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/vi_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/vi_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -990,9 +994,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "Các sản phẩm không chứa thành phần %s"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_VN.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_VN.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2602,9 +2611,13 @@ msgid "Site or blog address"
 msgstr "Địa chỉ trang web hoặc blog"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Vietnamese.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Vietnamese.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/zh.po
+++ b/po/common/zh.po
@@ -147,9 +147,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/zh-cn_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/zh-cn_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/zh.po
+++ b/po/common/zh.po
@@ -152,7 +152,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/zh-cn_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/zh-cn_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works
@@ -997,7 +997,7 @@ msgid "/images/misc/appstore/black/appstore_US.svg"
 msgstr "/images/misc/appstore/black/appstore_CN_SC.svg"
 
 msgctxt "ios_app_icon_alt_text"
-msgid "Available on the App Store"
+msgid "Download on the App Store"
 msgstr ""
 
 msgctxt "ios_app_link"
@@ -2604,7 +2604,7 @@ msgid "/images/misc/microsoft/English.svg"
 msgstr "/images/misc/microsoft/Chinese_Simplified.svg"
 
 msgctxt "windows_phone_app_icon_alt_text"
-msgid "Windows Phone Store"
+msgid "Get it from Microsoft"
 msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/zh-cn_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/zh-cn_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"
@@ -987,9 +991,14 @@ msgctxt "ingredients_without_products"
 msgid "Products that do not contain the ingredient %s"
 msgstr "不含有%s成分的产品"
 
-msgctxt "ios_app_badge"
-msgid "<img src=\"/images/misc/appstore/black/appstore_US.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/appstore/black/appstore_CN_SC.svg\" alt=\"Available on the App Store\" width=\"120\" height=\"40\" />"
+# Please change appstore_US.svg to appstore_XX.svg. check the url https://static.openfoodfacts.org/images/misc/appstore/black/appstore_XX.svg
+msgctxt "ios_app_icon_url"
+msgid "/images/misc/appstore/black/appstore_US.svg"
+msgstr "/images/misc/appstore/black/appstore_CN_SC.svg"
+
+msgctxt "ios_app_icon_alt_text"
+msgid "Available on the App Store"
+msgstr ""
 
 msgctxt "ios_app_link"
 msgid "https://apps.apple.com/app/open-food-facts/id588797948"
@@ -2590,9 +2599,13 @@ msgid "Site or blog address"
 msgstr "网站或博客地址"
 
 # Please change English.svg to French.svg or German.svg… Check the url https://static.openfoodfacts.org/images/misc/microsoft/XXXX.svg
-msgctxt "windows_phone_app_badge"
-msgid "<img src=\"/images/misc/microsoft/English.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/microsoft/Chinese_Simplified.svg\" alt=\"Windows Phone Store\" width=\"109\" height=\"40\" />"
+msgctxt "windows_phone_app_icon_url"
+msgid "/images/misc/microsoft/English.svg"
+msgstr "/images/misc/microsoft/Chinese_Simplified.svg"
+
+msgctxt "windows_phone_app_icon_alt_text"
+msgid "Windows Phone Store"
+msgstr ""
 
 # Please change en-us to fr-fr, pt-br or de-ch…Check the URL !
 msgctxt "windows_phone_app_link"

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/zh-hk_get.svg\" alt=\"Google Play立即下載\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/zh-hk_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr "Google Play立即下載"
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/zh-hk_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr "Google Play立即下載"
 
 # Change hl=en to your language, and make sure the url works

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -148,9 +148,13 @@ msgid "https://world.openfoodfacts.org/files/off.apk"
 msgstr "https://world.openfoodfacts.org/files/off.apk"
 
 # Please change en_get.svg to fr_get.svg. check the url https://static.openfoodfacts.org/images/misc/google-play-badge-svg-master/img/XX_get.svg
-msgctxt "android_app_badge"
-msgid "<img src=\"/images/misc/google-play-badge-svg-master/img/en_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
-msgstr "<img src=\"/images/misc/google-play-badge-svg-master/img/zh-tw_get.svg\" alt=\"Available on Google Play\" width=\"102\" height=\"40\" />"
+msgctxt "android_app_icon_url"
+msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
+msgstr "/images/misc/google-play-badge-svg-master/img/zh-tw_get.svg"
+
+msgctxt "android_app_icon_alt_text"
+msgid "Available on Google Play"
+msgstr ""
 
 # Change hl=en to your language, and make sure the url works
 msgctxt "android_app_link"

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -153,7 +153,7 @@ msgid "/images/misc/google-play-badge-svg-master/img/en_get.svg"
 msgstr "/images/misc/google-play-badge-svg-master/img/zh-tw_get.svg"
 
 msgctxt "android_app_icon_alt_text"
-msgid "Available on Google Play"
+msgid "Get It On Google Play"
 msgstr ""
 
 # Change hl=en to your language, and make sure the url works


### PR DESCRIPTION
**Description:**
Splits up the store badge HTML into several translatable tags, and updates the buttons' alt texts to the text that is on the current badges.

**Related issues and discussion:** #1319
