### PR TITLE
allergens: fix gluten wikidata link

### DIFF
--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -30,7 +30,6 @@ sk:glutén, lepok, obyčajná, raž, jačmeň, ovos, špalda, cirok
 sv:gluten, vete, råg, korn, havre, spelt, kamut, vetemjöl, rågmjöl, kornmjöl, havremjöl, speltmjöl, kamutmjöl, vetekli, rågkli, kornkli, havrekli, speltkli, kamutkli, fullkornsvete, fullkornsråg, fullkornskorn, fullkornshavre, fullkornsspelt, fullkornskamut, fullkornsvetemjöl, fullkornsrågmjöl, fullkornshavremjöl, fullkornsveteflingor, fullkornsrågflingor, fullkornshavreflingor, fullkornsspeltflingor, fullkornskamutflingor, malt, vetemalt, vetemaltextrakt, rågmalt, rågmaltextrakt, kornmalt, kornmaltextrakt, havremalt, havremaltextrakt, speltmalt, speltmaltextrakt, kamutmalt, kamutmaltextrakt, vetegryn, råggryn, korngryn, havregryn, speltgryn, kamutgryn, vetegroddar, råggroddar, korngroddar, havregroddar, speltgroddar, kamutgroddar
 th:กลูเต็น,ข้าวสาลี,ข้าวไร,บาร์เลย์
 zh:麸质
-# wikidata:en:Q4413030, Q2249305
 wikidata:en:Q188251
 
 en:crustaceans, crab, lobster, crayfish, prawn, shrimp

--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -30,7 +30,8 @@ sk:glutén, lepok, obyčajná, raž, jačmeň, ovos, špalda, cirok
 sv:gluten, vete, råg, korn, havre, spelt, kamut, vetemjöl, rågmjöl, kornmjöl, havremjöl, speltmjöl, kamutmjöl, vetekli, rågkli, kornkli, havrekli, speltkli, kamutkli, fullkornsvete, fullkornsråg, fullkornskorn, fullkornshavre, fullkornsspelt, fullkornskamut, fullkornsvetemjöl, fullkornsrågmjöl, fullkornshavremjöl, fullkornsveteflingor, fullkornsrågflingor, fullkornshavreflingor, fullkornsspeltflingor, fullkornskamutflingor, malt, vetemalt, vetemaltextrakt, rågmalt, rågmaltextrakt, kornmalt, kornmaltextrakt, havremalt, havremaltextrakt, speltmalt, speltmaltextrakt, kamutmalt, kamutmaltextrakt, vetegryn, råggryn, korngryn, havregryn, speltgryn, kamutgryn, vetegroddar, råggroddar, korngroddar, havregroddar, speltgroddar, kamutgroddar
 th:กลูเต็น,ข้าวสาลี,ข้าวไร,บาร์เลย์
 zh:麸质
-wikidata:en:Q4413030, Q2249305
+# wikidata:en:Q4413030, Q2249305
+wikidata:en:Q188251
 
 en:crustaceans, crab, lobster, crayfish, prawn, shrimp
 ar:قشريات


### PR DESCRIPTION
**Description:**

As pointed by Juho on Slack a while ago, the gluten wikidata link is currently broken. I don't know if the wikidata property ever supported the comma syntax, but it doesn't seem to matter in this case, as neither of the items actually point to gluten. Fixed by replacing with a link to a item pointing to gluten.