### PR TITLE
Run buildJs task in gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,6 +84,7 @@ function copyCss() {
 }
 
 exports.copyJs = copyJs;
+exports.buildJs = buildJs;
 exports.css = css;
 exports.icons = icons;
-exports.default = parallel(copyJs, copyCss, jQueryUiThemes, series(icons, css));
+exports.default = parallel(copyJs, buildJs, copyCss, jQueryUiThemes, series(icons, css));


### PR DESCRIPTION
The `buildJs` task needs to be run in the `default` task to produce `html/js/dist/display.js` and it's friends.