### PR TITLE
Diet for jQuery UI

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -728,7 +728,7 @@ HTML
 <script type="text/javascript" src="/js/dist/tagify.js"></script>
 <script type="text/javascript" src="/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="/js/dist/jquery.fileupload.js"></script>
-<script type="text/javascript" src="/js/dist/load-image.all.js"></script>
+<script type="text/javascript" src="/js/dist/load-image.all.min.js"></script>
 <script type="text/javascript" src="/js/dist/canvas-to-blob.js"></script>
 <script type="text/javascript" src="/js/dist/product-multilingual.js"></script>
 HTML

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -725,12 +725,11 @@ HTML
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/cropper/2.3.4/cropper.min.js"></script>
 <script type="text/javascript" src="/js/jquery.tagsinput.20160520/jquery.tagsinput.min.js"></script>
 <script type="text/javascript" src="/js/jquery.form.js"></script>
-<script type="text/javascript" src="/js/dist/tagify.min.js"></script>
+<script type="text/javascript" src="/js/dist/tagify.js"></script>
 <script type="text/javascript" src="/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="/js/dist/jquery.fileupload.js"></script>
-<script type="text/javascript" src="/js/dist/load-image.all.min.js"></script>
-<script type="text/javascript" src="/js/dist/canvas-to-blob.min.js"></script>
-<script type="text/javascript" src="/foundation/js/foundation/foundation.tab.js"></script>
+<script type="text/javascript" src="/js/dist/load-image.all.js"></script>
+<script type="text/javascript" src="/js/dist/canvas-to-blob.js"></script>
 <script type="text/javascript" src="/js/dist/product-multilingual.js"></script>
 HTML
 ;

--- a/cgi/top_translators.pl
+++ b/cgi/top_translators.pl
@@ -38,7 +38,7 @@ ProductOpener::Display::init();
 
 $scripts .= <<SCRIPTS
 <script src="/js/datatables.min.js"></script>
-<script src="/js/dist/papaparse.min.js"></script>
+<script src="/js/dist/papaparse.js"></script>
 SCRIPTS
 ;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,6 +84,7 @@ function copyCss() {
 }
 
 exports.copyJs = copyJs;
+exports.buildJs = buildJs;
 exports.css = css;
 exports.icons = icons;
-exports.default = parallel(copyJs, copyCss, jQueryUiThemes, series(icons, css));
+exports.default = parallel(copyJs, buildJs, copyCss, jQueryUiThemes, series(icons, css));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,18 +47,19 @@ function copyJs() {
   return src(
     [
       "./node_modules/foundation-sites/js/vendor/*.js",
-      "./node_modules/foundation-sites/js/foundation.min.js",
-      "./node_modules/papaparse/papaparse.min.js",
+      "./node_modules/foundation-sites/js/foundation.js",
+      "./node_modules/papaparse/papaparse.js",
       "./node_modules/osmtogeojson/osmtogeojson.js",
-      "./node_modules/leaflet/dist/**/*.*",
-      "./node_modules/leaflet.markercluster/dist/**/*.*",
+      "./node_modules/leaflet/dist/leaflet.js",
+      "./node_modules/leaflet.markercluster/dist/leaflet.markercluster.js",
       "./node_modules/blueimp-tmpl/js/*.js",
       "./node_modules/blueimp-load-image/js/load-image.all.min.js",
-      "./node_modules/blueimp-canvas-to-blob/js/*.js",
+      "./node_modules/blueimp-canvas-to-blob/js/canvas-to-blob.js",
       "./node_modules/blueimp-file-upload/js/*.js",
-      "./node_modules/@yaireo/tagify/dist/tagify.min.js"
+      "./node_modules/@yaireo/tagify/dist/tagify.js"
     ])
     .pipe(sourcemaps.init())
+    .pipe(uglify())
     .pipe(sourcemaps.write("."))
     .pipe(dest("./html/js/dist"));
 }
@@ -76,6 +77,7 @@ function buildJs() {
 
 function buildjQueryUi() {
   return src([
+    './node_modules/jquery-ui/ui/version.js',
     './node_modules/jquery-ui/ui/widget.js',
     './node_modules/jquery-ui/ui/position.js',
     './node_modules/jquery-ui/ui/keycode.js',
@@ -85,7 +87,7 @@ function buildjQueryUi() {
   ])
   .pipe(sourcemaps.init())
   .pipe(uglify())
-  .pipe(concat('jquery-ui.min.js'))
+  .pipe(concat('jquery-ui.js'))
   .pipe(sourcemaps.write("."))
   .pipe(dest('./html/js/dist'))
 }
@@ -99,20 +101,33 @@ function jQueryUiThemes() {
     ])
     .pipe(sourcemaps.init())
     .pipe(minifyCSS())
-    .pipe(concat('jquery-ui.min.css'))
+    .pipe(concat('jquery-ui.css'))
     .pipe(sourcemaps.write("."))
     .pipe(dest('./html/css/dist/jqueryui/themes/base'));
 }
 
 function copyCss() {
-  return src(["./node_modules/@yaireo/tagify/dist/tagify.css"]).pipe(
-    dest("./html/css/dist")
-  );
+  return src([
+      "./node_modules/leaflet/dist/leaflet.css",
+      "./node_modules/leaflet.markercluster/dist/MarkerCluster.css",
+      "./node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css",
+      "./node_modules/@yaireo/tagify/dist/tagify.css"
+    ])
+    .pipe(sourcemaps.init())
+    .pipe(minifyCSS())
+    .pipe(sourcemaps.write("."))
+    .pipe(dest("./html/css/dist"));
+}
 
+function copyImages() {
+  return src([
+      "./node_modules/leaflet/dist/**/*.png"
+    ])
+    .pipe(dest("./html/css/dist"));
 }
 
 exports.copyJs = copyJs;
 exports.buildJs = buildJs;
 exports.css = css;
 exports.icons = icons;
-exports.default = parallel(copyJs, buildJs, buildjQueryUi, copyCss, jQueryUiThemes, series(icons, css));
+exports.default = parallel(copyJs, buildJs, buildjQueryUi, copyCss, copyImages, jQueryUiThemes, series(icons, css));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ const concat = require("gulp-concat");
 const sass = require("gulp-sass");
 const sourcemaps = require("gulp-sourcemaps");
 const minifyCSS = require("gulp-csso");
-const uglify = require("gulp-uglify");
+const terser = require("gulp-terser-js");
 const svgmin = require("gulp-svgmin");
 
 const sassOptions = {
@@ -59,7 +59,7 @@ function copyJs() {
       "./node_modules/@yaireo/tagify/dist/tagify.js"
     ])
     .pipe(sourcemaps.init())
-    .pipe(uglify())
+    .pipe(terser())
     .pipe(sourcemaps.write("."))
     .pipe(dest("./html/js/dist"));
 }
@@ -71,6 +71,7 @@ function buildJs() {
     './html/js/search.js'
   ])
   .pipe(sourcemaps.init())
+  .pipe(terser())
   .pipe(sourcemaps.write("."))
   .pipe(dest("./html/js/dist"));
 }
@@ -82,11 +83,12 @@ function buildjQueryUi() {
     './node_modules/jquery-ui/ui/position.js',
     './node_modules/jquery-ui/ui/keycode.js',
     './node_modules/jquery-ui/ui/unique-id.js',
+    './node_modules/jquery-ui/ui/safe-active-element.js',
     './node_modules/jquery-ui/ui/widgets/autocomplete.js',
     './node_modules/jquery-ui/ui/widgets/menu.js'
   ])
   .pipe(sourcemaps.init())
-  .pipe(uglify())
+  .pipe(terser())
   .pipe(concat('jquery-ui.js'))
   .pipe(sourcemaps.write("."))
   .pipe(dest('./html/js/dist'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,11 @@
 "use strict";
 
 const { src, dest, series, parallel } = require("gulp");
+const concat = require("gulp-concat");
 const sass = require("gulp-sass");
 const sourcemaps = require("gulp-sourcemaps");
 const minifyCSS = require("gulp-csso");
+const uglify = require("gulp-uglify");
 const svgmin = require("gulp-svgmin");
 
 const sassOptions = {
@@ -46,7 +48,6 @@ function copyJs() {
     [
       "./node_modules/foundation-sites/js/vendor/*.js",
       "./node_modules/foundation-sites/js/foundation.min.js",
-      "./node_modules/jquery-ui-dist/jquery-ui.min.js",
       "./node_modules/papaparse/papaparse.min.js",
       "./node_modules/osmtogeojson/osmtogeojson.js",
       "./node_modules/leaflet/dist/**/*.*",
@@ -56,9 +57,10 @@ function copyJs() {
       "./node_modules/blueimp-canvas-to-blob/js/*.js",
       "./node_modules/blueimp-file-upload/js/*.js",
       "./node_modules/@yaireo/tagify/dist/tagify.min.js"
-    ],
-    { sourcemaps: true }
-  ).pipe(dest("./html/js/dist", { sourcemaps: true }));
+    ])
+    .pipe(sourcemaps.init())
+    .pipe(sourcemaps.write("."))
+    .pipe(dest("./html/js/dist"));
 }
 
 function buildJs() {
@@ -66,14 +68,40 @@ function buildJs() {
     './html/js/display*.js',
     './html/js/product-multilingual.js',
     './html/js/search.js'
-  ], { sourcemaps: false })
-  .pipe(dest('./html/js/dist', { sourcemaps: false }))
+  ])
+  .pipe(sourcemaps.init())
+  .pipe(sourcemaps.write("."))
+  .pipe(dest("./html/js/dist"));
+}
+
+function buildjQueryUi() {
+  return src([
+    './node_modules/jquery-ui/ui/widget.js',
+    './node_modules/jquery-ui/ui/position.js',
+    './node_modules/jquery-ui/ui/keycode.js',
+    './node_modules/jquery-ui/ui/unique-id.js',
+    './node_modules/jquery-ui/ui/widgets/autocomplete.js',
+    './node_modules/jquery-ui/ui/widgets/menu.js'
+  ])
+  .pipe(sourcemaps.init())
+  .pipe(uglify())
+  .pipe(concat('jquery-ui.min.js'))
+  .pipe(sourcemaps.write("."))
+  .pipe(dest('./html/js/dist'))
 }
 
 function jQueryUiThemes() {
-  return src("./node_modules/jquery-ui-dist/**/*.css", {
-    sourcemaps: true
-  }).pipe(dest("./html/css/dist/jqueryui/themes/base", { sourcemaps: true }));
+  return src([
+      './node_modules/jquery-ui/themes/base/core.css',
+      './node_modules/jquery-ui/themes/base/autocomplete.css',
+      './node_modules/jquery-ui/themes/base/menu.css',
+      './node_modules/jquery-ui/themes/base/theme.css',
+    ])
+    .pipe(sourcemaps.init())
+    .pipe(minifyCSS())
+    .pipe(concat('jquery-ui.min.css'))
+    .pipe(sourcemaps.write("."))
+    .pipe(dest('./html/css/dist/jqueryui/themes/base'));
 }
 
 function copyCss() {
@@ -87,4 +115,4 @@ exports.copyJs = copyJs;
 exports.buildJs = buildJs;
 exports.css = css;
 exports.icons = icons;
-exports.default = parallel(copyJs, buildJs, copyCss, jQueryUiThemes, series(icons, css));
+exports.default = parallel(copyJs, buildJs, buildjQueryUi, copyCss, jQueryUiThemes, series(icons, css));

--- a/html/donate/aa.html
+++ b/html/donate/aa.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ach.html
+++ b/html/donate/ach.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/af.html
+++ b/html/donate/af.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ak.html
+++ b/html/donate/ak.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/am.html
+++ b/html/donate/am.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ar.html
+++ b/html/donate/ar.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/as.html
+++ b/html/donate/as.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ast.html
+++ b/html/donate/ast.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/az.html
+++ b/html/donate/az.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/be.html
+++ b/html/donate/be.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ber.html
+++ b/html/donate/ber.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/bg.html
+++ b/html/donate/bg.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/bm.html
+++ b/html/donate/bm.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/bn.html
+++ b/html/donate/bn.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/bo.html
+++ b/html/donate/bo.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/br.html
+++ b/html/donate/br.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/bs.html
+++ b/html/donate/bs.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ca.html
+++ b/html/donate/ca.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ce.html
+++ b/html/donate/ce.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/chr.html
+++ b/html/donate/chr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/co.html
+++ b/html/donate/co.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/crs.html
+++ b/html/donate/crs.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/cs.html
+++ b/html/donate/cs.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/cv.html
+++ b/html/donate/cv.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/cy.html
+++ b/html/donate/cy.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/da.html
+++ b/html/donate/da.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/de.html
+++ b/html/donate/de.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/el.html
+++ b/html/donate/el.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/en_AU.html
+++ b/html/donate/en_AU.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/en_GB.html
+++ b/html/donate/en_GB.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/eo.html
+++ b/html/donate/eo.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/es.html
+++ b/html/donate/es.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/et.html
+++ b/html/donate/et.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/eu.html
+++ b/html/donate/eu.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/fa.html
+++ b/html/donate/fa.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/fi.html
+++ b/html/donate/fi.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/fil.html
+++ b/html/donate/fil.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/fo.html
+++ b/html/donate/fo.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/fr.helloasso.html
+++ b/html/donate/fr.helloasso.html
@@ -26,7 +26,7 @@
 <meta name="flattr:id" content="dw637l">
 
 <link rel="stylesheet" href="https://static.openfoodfacts.org/css/dist/app.css?v=1562940554">
-<link rel="stylesheet" href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css">
+<link rel="stylesheet" href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css" integrity="sha384-HIipfSYbpCkh5/1V87AWAeR5SUrNiewznrUrtNz1ux4uneLhsAKzv/0FnMbj3m6g" crossorigin="anonymous">
 <link rel="search" href="https://fr.openfoodfacts.org/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
 <style media="all">
@@ -105,11 +105,11 @@ $('iframe').load(function(){
 <p>Le formulaire de don est en cours de chargement.<br>Vous pouvez aussi y accéder en <a href="https://www.helloasso.com/associations/open-food-facts/formulaires/1">cliquant ici.</a>
 </p>
 </div>
-	  
+
         <iframe id="haWidget" allowtransparency="true" scrolling="auto" src="https://www.helloasso.com/associations/open-food-facts/formulaires/1/widget" style="width:100%;height:750px;border:none;"></iframe>
 
         <div class="text-left">
-        <h3>A quoi sert votre don</h3> 
+        <h3>A quoi sert votre don</h3>
 <p><b>Pour la technologie :</b> Le développement, la maintenance, et les serveurs qui permettent une croissance continue de la base de données et d’ajouter de nouvelles fonctionnalités à l’application mobile et au site web Open Food Facts.</p>
 <p><b>Pour les personnes et les projets :</b> Pour pouvoir soutenir au mieux la communauté Open Food Facts, collaborer avec des chercheurs et faire en sorte que nos données sur les produits alimentaires aient le plus grand impact sur notre santé, notre planète et la société.</p>
         </div>

--- a/html/donate/fr.html
+++ b/html/donate/fr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ga.html
+++ b/html/donate/ga.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/gd.html
+++ b/html/donate/gd.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/gl.html
+++ b/html/donate/gl.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/gu.html
+++ b/html/donate/gu.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ha.html
+++ b/html/donate/ha.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/he.html
+++ b/html/donate/he.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"
@@ -216,7 +216,7 @@ $('iframe').load(function(){
 
             <p>
               <b>טכנולוגיה:</b> פיתוח, תחזוקה, שרתים כדי לתמוך
-              בצמיחת מסד הנתונים ולהוסיף תכונות חדשות ליישומון ולאתר של 
+              בצמיחת מסד הנתונים ולהוסיף תכונות חדשות ליישומון ולאתר של
               Open Food Facts.
             </p>
 

--- a/html/donate/hi.html
+++ b/html/donate/hi.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/hr.html
+++ b/html/donate/hr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ht.html
+++ b/html/donate/ht.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/hu.html
+++ b/html/donate/hu.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/hy.html
+++ b/html/donate/hy.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/id.html
+++ b/html/donate/id.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ii.html
+++ b/html/donate/ii.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/is.html
+++ b/html/donate/is.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/it.html
+++ b/html/donate/it.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/iu.html
+++ b/html/donate/iu.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ja.html
+++ b/html/donate/ja.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/jv.html
+++ b/html/donate/jv.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ka.html
+++ b/html/donate/ka.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/kab.html
+++ b/html/donate/kab.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/kk.html
+++ b/html/donate/kk.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/km.html
+++ b/html/donate/km.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/kmr.html
+++ b/html/donate/kmr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/kmr_TR.html
+++ b/html/donate/kmr_TR.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/kn.html
+++ b/html/donate/kn.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ko.html
+++ b/html/donate/ko.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/kw.html
+++ b/html/donate/kw.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ky.html
+++ b/html/donate/ky.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/la.html
+++ b/html/donate/la.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/lb.html
+++ b/html/donate/lb.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/lo.html
+++ b/html/donate/lo.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/lol.html
+++ b/html/donate/lol.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/lt.html
+++ b/html/donate/lt.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/lv.html
+++ b/html/donate/lv.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/me.html
+++ b/html/donate/me.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/mg.html
+++ b/html/donate/mg.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/mi.html
+++ b/html/donate/mi.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ml.html
+++ b/html/donate/ml.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/mn.html
+++ b/html/donate/mn.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/mr.html
+++ b/html/donate/mr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ms.html
+++ b/html/donate/ms.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/mt.html
+++ b/html/donate/mt.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/my.html
+++ b/html/donate/my.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/nb.html
+++ b/html/donate/nb.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ne.html
+++ b/html/donate/ne.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/nl.html
+++ b/html/donate/nl.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/nl_NL.html
+++ b/html/donate/nl_NL.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/nn.html
+++ b/html/donate/nn.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/no.html
+++ b/html/donate/no.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/nr.html
+++ b/html/donate/nr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/oc.html
+++ b/html/donate/oc.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/pa.html
+++ b/html/donate/pa.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/pl.html
+++ b/html/donate/pl.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/pt_BR.html
+++ b/html/donate/pt_BR.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/pt_PT.html
+++ b/html/donate/pt_PT.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/qu.html
+++ b/html/donate/qu.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/rm.html
+++ b/html/donate/rm.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ro.html
+++ b/html/donate/ro.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ru.html
+++ b/html/donate/ru.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"
@@ -166,7 +166,7 @@ $('iframe').load(function(){
           она приносит пользу всем!
         </p>
         <p>
-          Когда мы основали Open Food Facts, мы твёрдо решили сделать 
+          Когда мы основали Open Food Facts, мы твёрдо решили сделать
           проект некоммереским, чтобы максимизировать наше влияние, отдавая всю нашу работу.
           We also made the clear choice that we would be totally independent
           from the industry, and thus to never accept any funding that could put
@@ -222,9 +222,9 @@ $('iframe').load(function(){
             </p>
 
             <p>
-              <b> Люди и проекты: </b> Для того, чтобы дать нашу лучшую поддержку сообществу 
-              Open Food Facts, чтобы работать с исследователями и сделать так, чтобы 
-              наши данные о продуктах питания имели большое влияние на наши 
+              <b> Люди и проекты: </b> Для того, чтобы дать нашу лучшую поддержку сообществу
+              Open Food Facts, чтобы работать с исследователями и сделать так, чтобы
+              наши данные о продуктах питания имели большое влияние на наши
               здоровье, планету и общество.
             </p>
           </div>

--- a/html/donate/ry.html
+++ b/html/donate/ry.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sa.html
+++ b/html/donate/sa.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sat.html
+++ b/html/donate/sat.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sc.html
+++ b/html/donate/sc.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sco.html
+++ b/html/donate/sco.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sd.html
+++ b/html/donate/sd.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sg.html
+++ b/html/donate/sg.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sh.html
+++ b/html/donate/sh.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/si.html
+++ b/html/donate/si.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sk.html
+++ b/html/donate/sk.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sl.html
+++ b/html/donate/sl.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sma.html
+++ b/html/donate/sma.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sn.html
+++ b/html/donate/sn.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/so.html
+++ b/html/donate/so.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/son.html
+++ b/html/donate/son.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sq.html
+++ b/html/donate/sq.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sr.html
+++ b/html/donate/sr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sr_CS.html
+++ b/html/donate/sr_CS.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sr_RS.html
+++ b/html/donate/sr_RS.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ss.html
+++ b/html/donate/ss.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/st.html
+++ b/html/donate/st.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sv.html
+++ b/html/donate/sv.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/sw.html
+++ b/html/donate/sw.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ta.html
+++ b/html/donate/ta.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/te.html
+++ b/html/donate/te.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tg.html
+++ b/html/donate/tg.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/th.html
+++ b/html/donate/th.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ti.html
+++ b/html/donate/ti.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tl.html
+++ b/html/donate/tl.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tn.html
+++ b/html/donate/tn.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tr.html
+++ b/html/donate/tr.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ts.html
+++ b/html/donate/ts.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tt.html
+++ b/html/donate/tt.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tw.html
+++ b/html/donate/tw.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ty.html
+++ b/html/donate/ty.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/tzl.html
+++ b/html/donate/tzl.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ug.html
+++ b/html/donate/ug.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/uk.html
+++ b/html/donate/uk.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ur.html
+++ b/html/donate/ur.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/uz.html
+++ b/html/donate/uz.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/val.html
+++ b/html/donate/val.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/ve.html
+++ b/html/donate/ve.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/vec.html
+++ b/html/donate/vec.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/vi.html
+++ b/html/donate/vi.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/vls.html
+++ b/html/donate/vls.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/wa.html
+++ b/html/donate/wa.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/wo.html
+++ b/html/donate/wo.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/xh.html
+++ b/html/donate/xh.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/yi.html
+++ b/html/donate/yi.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/yo.html
+++ b/html/donate/yo.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/zea.html
+++ b/html/donate/zea.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/zh_CN.html
+++ b/html/donate/zh_CN.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/zh_HK.html
+++ b/html/donate/zh_HK.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/zh_TW.html
+++ b/html/donate/zh_TW.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/donate/zu.html
+++ b/html/donate/zu.html
@@ -55,7 +55,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.min.css"
+      href="https://static.openfoodfacts.org/css/dist/jqueryui/themes/base/jquery-ui.css"
     />
     <link
       rel="stylesheet"

--- a/html/js/display-product.js
+++ b/html/js/display-product.js
@@ -173,7 +173,7 @@ class RobotoffAsker extends HTMLElement {
       content.appendChild(script.cloneNode(true));
     }
 
-    content.querySelector('#thumbnail').addEventListener('click', e => {
+    content.querySelector('#thumbnail').addEventListener('click', (e) => {
       const zoomRow = this.shadowRoot.querySelector('#zoomrow');
       if (zoomRow.classList.toggle('hidden')) {
         e.currentTarget.style.cursor = 'zoom-in';
@@ -183,20 +183,20 @@ class RobotoffAsker extends HTMLElement {
       }
     });
 
-    content.querySelector('#zoom').addEventListener('click', e => {
+    content.querySelector('#zoom').addEventListener('click', (e) => {
       const small = e.currentTarget.getAttribute('data-small-src');
       const large = e.currentTarget.getAttribute('data-large-src');
       const zoomIn = e.currentTarget.getAttribute('data-zoom-in-src');
       const zoomOut = e.currentTarget.getAttribute('data-zoom-out-src');
-      if (zoomOut !== '') {
-        e.currentTarget.setAttribute('src', zoomOut);
-        e.currentTarget.setAttribute('data-zoom-in-src', large);
-        e.currentTarget.setAttribute('data-zoom-out-src', '');
-      }
-      else {
+      if (zoomOut === '') {
         e.currentTarget.setAttribute('src', zoomIn);
         e.currentTarget.setAttribute('data-zoom-in-src', '');
         e.currentTarget.setAttribute('data-zoom-out-src', small);
+      }
+      else {
+        e.currentTarget.setAttribute('src', zoomOut);
+        e.currentTarget.setAttribute('data-zoom-in-src', large);
+        e.currentTarget.setAttribute('data-zoom-out-src', '');
       }
     });
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3333,7 +3333,7 @@ JS
 
 	if ((scalar @map_layers) > 0) {
 		$header .= <<HTML
-	<link rel="stylesheet" href="$static_subdomain/js/dist/leaflet.css">
+	<link rel="stylesheet" href="$static_subdomain/css/dist/leaflet.css">
 	<script src="$static_subdomain/js/dist/leaflet.js"></script>
 	<script src="$static_subdomain/js/dist/osmtogeojson.js"></script>
 	<script src="$static_subdomain/js/dist/display-tag.js"></script>
@@ -5504,10 +5504,10 @@ JS
 		if ($emb_codes > 0) {
 
 			$header .= <<HTML
-<link rel="stylesheet" href="$static_subdomain/js/dist/leaflet.css">
+<link rel="stylesheet" href="$static_subdomain/css/dist/leaflet.css">
 <script src="$static_subdomain/js/dist/leaflet.js"></script>
-<link rel="stylesheet" href="$static_subdomain/js/dist/MarkerCluster.css">
-<link rel="stylesheet" href="$static_subdomain/js/dist/MarkerCluster.Default.css">
+<link rel="stylesheet" href="$static_subdomain/css/dist/MarkerCluster.css">
+<link rel="stylesheet" href="$static_subdomain/css/dist/MarkerCluster.Default.css">
 <script src="$static_subdomain/js/dist/leaflet.markercluster.js"></script>
 HTML
 ;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5933,7 +5933,7 @@ $og_images2
 $options{favicons}
 <link rel="canonical" href="$canon_url">
 <link rel="stylesheet" href="$static_subdomain/css/dist/app.css?v=$file_timestamps{"css/dist/app.css"}">
-<link rel="stylesheet" href="$static_subdomain/css/dist/jqueryui/themes/base/jquery-ui.min.css">
+<link rel="stylesheet" href="$static_subdomain/css/dist/jqueryui/themes/base/jquery-ui.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.10/css/select2.min.css" integrity="sha256-FdatTf20PQr/rWg+cAKfl6j4/IY3oohFAJ7gVC3M34E=" crossorigin="anonymous">
 <link rel="search" href="$formatted_subdomain/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="$Lang{site_name}{$lang}">
 <style media="all">
@@ -6493,7 +6493,7 @@ HTML
 
 <script src="$static_subdomain/js/dist/modernizr.js"></script>
 <script src="$static_subdomain/js/dist/jquery.js"></script>
-<script src="$static_subdomain/js/dist/jquery-ui.min.js"></script>
+<script src="$static_subdomain/js/dist/jquery-ui.js"></script>
 <script src="$static_subdomain/js/dist/display.js"></script>
 
 <script>
@@ -6502,7 +6502,7 @@ HTML
 });
 </script>
 
-<script src="$static_subdomain/js/dist/foundation.min.js"></script>
+<script src="$static_subdomain/js/dist/foundation.js"></script>
 <script src="$static_subdomain/js/dist/jquery.cookie.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.10/js/select2.min.js" integrity="sha256-d/edyIFneUo3SvmaFnf96hRcVBcyaOy96iMkPez1kaU=" crossorigin="anonymous"></script>
 $scripts

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -301,7 +301,7 @@ HTML
 <script type="text/javascript" src="/js/dist/jquery.iframe-transport.js"></script>
 <script type="text/javascript" src="/js/dist/jquery.fileupload.js"></script>
 <script type="text/javascript" src="/js/dist/load-image.all.min.js"></script>
-<script type="text/javascript" src="/js/dist/canvas-to-blob.min.js"></script>
+<script type="text/javascript" src="/js/dist/canvas-to-blob.js"></script>
 JS
 ;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,6 +1433,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -1451,6 +1457,23 @@
       "integrity": "sha1-AYsYvBx9BzotyCqkhEI0GixN158=",
       "requires": {
         "bops": "0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "console-control-strings": {
@@ -3845,6 +3868,17 @@
         }
       }
     },
+    "gulp-concat": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
+      "dev": true,
+      "requires": {
+        "concat-with-sourcemaps": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.0"
+      }
+    },
     "gulp-csso": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/gulp-csso/-/gulp-csso-3.0.1.tgz",
@@ -3987,6 +4021,24 @@
         }
       }
     },
+    "gulp-uglify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
+      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
+      "dev": true,
+      "requires": {
+        "array-each": "^1.0.1",
+        "extend-shallow": "^3.0.2",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "isobject": "^3.0.1",
+        "make-error-cause": "^1.1.1",
+        "safe-buffer": "^5.1.2",
+        "through2": "^2.0.0",
+        "uglify-js": "^3.0.5",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      }
+    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -4034,6 +4086,15 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4567,10 +4628,10 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "jquery-ui-dist": {
+    "jquery-ui": {
       "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz",
-      "integrity": "sha1-XAgV08xvkP9fqvWyaKbiO0ypBPo="
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "js-base64": {
       "version": "2.5.1",
@@ -4932,6 +4993,21 @@
       "dev": true,
       "requires": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "make-error-cause": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "dev": true,
+      "requires": {
+        "make-error": "^1.2.0"
       }
     },
     "make-iterator": {
@@ -8047,6 +8123,24 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.20.3",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4021,22 +4021,66 @@
         }
       }
     },
-    "gulp-uglify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
-      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
+    "gulp-terser-js": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-terser-js/-/gulp-terser-js-5.0.1.tgz",
+      "integrity": "sha512-QmlFKkK29But+4XXdSq7xiSXhyL8MpvBPeycmNi77RKwK+gffqAQDuVae70ZTCX0o70znsW4bAciSM6Y3flWNA==",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "extend-shallow": "^3.0.2",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "isobject": "^3.0.1",
-        "make-error-cause": "^1.1.1",
-        "safe-buffer": "^5.1.2",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "object-assign": "^4.1.1",
+        "plugin-error": "^1.0.1",
+        "terser": "^4.1.4",
+        "through2": "^3.0.1",
+        "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "dependencies": {
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "gulplog": {
@@ -4086,15 +4130,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "^1.0.0"
-      }
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4993,21 +5028,6 @@
       "dev": true,
       "requires": {
         "es5-ext": "~0.10.2"
-      }
-    },
-    "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-      "dev": true
-    },
-    "make-error-cause": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
-      "dev": true,
-      "requires": {
-        "make-error": "^1.2.0"
       }
     },
     "make-iterator": {
@@ -7035,6 +7055,24 @@
         "urix": "^0.1.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -7866,6 +7904,25 @@
         }
       }
     },
+    "terser": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
+      "integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8123,24 +8180,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
-      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
-      "dev": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-svgmin": "^2.2.0",
-    "gulp-uglify": "^3.0.2",
+    "gulp-terser-js": "^5.0.1",
     "stylelint": "^11.1.1",
     "stylelint-config-recommended-scss": "4.0.0",
     "stylelint-scss": "^3.13.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@yaireo/tagify": "^2.31.6",
     "blueimp-file-upload": "^10.4.0",
     "foundation-sites": "5.5.3",
-    "jquery-ui-dist": "^1.12.1",
+    "jquery-ui": "^1.12.1",
     "leaflet": "1.5.1",
     "leaflet.markercluster": "1.4.1",
     "opencollective": "^1.0.3",
@@ -51,10 +51,12 @@
   "devDependencies": {
     "eslint": "^6.7.2",
     "gulp": "^4.0.2",
+    "gulp-concat": "^2.6.1",
     "gulp-csso": "^3.0.1",
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-svgmin": "^2.2.0",
+    "gulp-uglify": "^3.0.2",
     "stylelint": "^11.1.1",
     "stylelint-config-recommended-scss": "4.0.0",
     "stylelint-scss": "^3.13.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:lang:common": "perl scripts/check_po_file.pl po/common/en.po",
     "prove": "prove -l",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:scss",
-    "lint:js": "eslint html/js/product-multilingual.js html/js/search.js html/js/display-tag.js",
+    "lint:js": "eslint html/js/product-multilingual.js html/js/search.js html/js/display*.js",
     "lint:css": "stylelint html/css/product-multilingual.css",
     "lint:scss": "stylelint scss/app.scss",
     "perlc": "npm run perlc:startup && npm run perlc:cgi && npm run perlc:scripts",


### PR DESCRIPTION
- Instead of taking pre-minified versions of JS libs from npm, run them through the same minifier with Gulp (since they can be different)
- Create a partial jQuery UI version as suggested in https://github.com/openfoodfacts/openfoodfacts-server/issues/2675#issuecomment-563973740
- Also run our own JS scripts through the minification process (actually saves a bunch of KiB)
- (Re-)Enable Source Maps for everything, but force them to be written to external files (so browsers don't have load this huge comment chunk)

I believe this also fixes #215