### PR TITLE
Make the download of GeoLite2 optional

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ Just run `docker-compose up` in this directory to run a pre-built image and star
 
 Alternatively, run `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up` for local development. This will build a new backend image from your local source files. Note that this binds the docker container to your local develpoment directory, so be sure to build JavaScript etc. by running `npm install && npm run build`, or you will experience missing assets.
 
-Note: You can also build the frontend assets inside docker. See `build_npm.bat` or `build_npm.sh` for more information about this.
+Note: You can also build the frontend assets inside docker. See `build_npm.bat` or `build_npm.sh` for more information about this. If you want to use geolocation, you need to update `docker-compose.geolite2.yml` with your [MaxMind Account](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/) and license information, and include it in the call to `docker-compose`.
 
 ### Accessing Product Opener
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -49,19 +49,10 @@ COPY ./cpanfile /tmp/cpanfile
 # Add ProductOpener runtime dependencies from cpan
 RUN cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps .
 
-# Helper stage, so that we don't try to install GeoIP upon every rebuild of the source
-FROM modperl AS modperlgeoip
+FROM modperl AS runnable
 
-ADD https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz /tmp/GeoLite2-Country.tar.gz
-RUN set -x \
-  # Install GeoIP files locally
-  && tar xfz /tmp/GeoLite2-Country.tar.gz -C /usr/local/share \
-  && rm /tmp/GeoLite2-Country.tar.gz \
-  && mv /usr/local/share/GeoLite2-Country_* /usr/local/share/GeoLite2-Country \
-  # Prepare Apache to include our custom config
-  && rm /etc/apache2/sites-enabled/000-default.conf
-
-FROM modperlgeoip AS runnable
+# Prepare Apache to include our custom config
+RUN rm /etc/apache2/sites-enabled/000-default.conf
 
 # Copy Perl libraries from the builder image
 COPY --from=builder /tmp/local/ /opt/perl/local/

--- a/docker/docker-compose.geolite2.yml
+++ b/docker/docker-compose.geolite2.yml
@@ -1,0 +1,17 @@
+﻿version: "3.7"
+services:
+  backend:
+    volumes:
+      - geolite2:/usr/local/share/GeoLite2-Country
+  geoipupdate:
+    image: tkrs/maxmind-geoipupdate:4.1.5
+    volumes:
+      - geolite2:/usr/local/share/GeoLite2-Country
+    environment:
+      - GEOIP_DB_DIR=/usr/local/share/GeoLite2-Country
+      - EDITION_IDS=GeoLite2-City GeoLite2-Country
+      - SCHEDULE=55 20 * * *
+      - ACCOUNT_ID=0
+      - LICENSE_KEY=000000000000
+volumes:
+  geolite2:

--- a/lib/ProductOpener/GeoIP.pm
+++ b/lib/ProductOpener/GeoIP.pm
@@ -1,7 +1,7 @@
 ﻿# This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2019 Association Open Food Facts
+# Copyright (C) 2011-2020 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -45,9 +45,13 @@ use ProductOpener::Config qw/:all/;
 use GeoIP2::Database::Reader;
 use Log::Any qw($log);
 
-my $gi = GeoIP2::Database::Reader->new(file => $geolite2_path);
+my $gi;
+if (-e $geolite2_path) {
+	$gi = GeoIP2::Database::Reader->new(file => $geolite2_path);
+}
 
 sub get_country_for_ip {
+	return unless $gi;
 	my $ip = shift;
 
 	my $country;
@@ -65,8 +69,8 @@ sub get_country_for_ip {
 	return $country;
 }
 
-
 sub get_country_code_for_ip {
+	return unless $gi;
 	my $ip = shift;
 
 	my $country;
@@ -83,6 +87,5 @@ sub get_country_code_for_ip {
 
 	return $country;
 }
-
 
 1;


### PR DESCRIPTION
**Description:**
Remove download of the GeoLite2 image in the Dockerfile. Also, don't fail everything if the file does not exist, making geolocation an optional feature.

**Related issues and discussion:** Fixes #2828
