### PR TITLE
fix too aggressive uuid extraction from edit comments, fixes #2835

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1077,11 +1077,12 @@ sub get_change_userid_or_uuid($) {
 	# (app)Waistline: e2e782b4-4fe8-4fd6-a27c-def46a12744c
 	# (app)Labeleat1.0-SgP5kUuoerWvNH3KLZr75n6RFGA0
 	# (app)Contributed using: OFF app for iOS - v3.0 - user id: 3C0154A0-D19B-49EA-946F-CC33A05E404A
-	if ((defined $userid) and (defined $options{apps_uuid_prefix}) and (defined $options{apps_uuid_prefix}{$userid}) and ($change_ref->{comment} =~ /$options{apps_uuid_prefix}{$userid}/i)) {
+	#
+	# but not:
+	# (app)Updated via Power User Script
+	if ((defined $userid) and (defined $options{apps_uuid_prefix}) and (defined $options{apps_uuid_prefix}{$userid})
+		and ($change_ref->{comment} =~ /$options{apps_uuid_prefix}{$userid}/i)) {
 		$uuid = $';
-	}
-	elsif ($change_ref->{comment} =~ /(added by|User(\s*)(id)?)(\s*)(:)?(\s*)(\S+)/i) {
-		$uuid = $7;
 	}
 
 	if ((defined $uuid) and ($uuid !~ /^(\s|-|_|\.)*$/)) {

--- a/t/products.t
+++ b/t/products.t
@@ -86,4 +86,20 @@ foreach my $field (@string_fields) {
 
 compute_and_test_completeness($product_ref, 1.0, 'product all fields');
 
+my @get_change_userid_or_uuid_tests = (
+["real-user", "some random comment", "real-user"],
+["stephane", "Updated via Power User Script", "stephane"],
+["kiliweb", "User : WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ", "yuka.WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ"],
+);
+
+foreach my $test_ref (@get_change_userid_or_uuid_tests) {
+
+	my $change_ref = { userid => $test_ref->[0], comment => $test_ref->[1] };
+
+	my $userid = get_change_userid_or_uuid($change_ref);
+
+	is ($userid, $test_ref->[2]) or diag explain $test_ref;
+
+}
+
 done_testing();


### PR DESCRIPTION
I removed a matching regex that was too dangerous, we will now only extract UUIDs from known apps configured in Config.pm.

Also added some tests.