### PR TITLE
call init_emb_codes() on demand, bug #2204

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3200,7 +3200,7 @@ HTML
 		local $log->context->{city_code} = $city_code;
 		$log->debug("city code for tag with emb_code type") if $log->debug();
 
-		die "Initialize EMB codes with ProductOpener::Tags::init_emb_codes()" unless %emb_codes_cities;
+		init_emb_codes() unless %emb_codes_cities;
 		if (defined $emb_codes_cities{$city_code}) {
 			$description .= "<p>" . lang("cities_s") . separator_before_colon($lc) . ": " . display_tag_link('cities', $emb_codes_cities{$city_code}) . "</p>";
 		}
@@ -5319,7 +5319,7 @@ sub get_packager_code_coordinates($) {
 
 	my $city_code = get_city_code($emb_code);
 
-	die "Initialize EMB codes with ProductOpener::Tags::init_emb_codes()" unless %emb_codes_geo;
+	init_emb_codes() unless %emb_codes_geo;
 	if (((not defined $lat) or (not defined $lng)) and (defined $emb_codes_geo{$city_code})) {
 
 		# some lat/lng have , for floating point numbers

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1956,7 +1956,7 @@ sub display_tag_link($$) {
 	if ($tagtype eq 'emb_codes') {
 		my $city_code = get_city_code($tagid);
 
-		die "Initialize EMB codes with ProductOpener::Tags::init_emb_codes()" unless %emb_codes_cities;
+		init_emb_codes() unless %emb_codes_cities;
 		if (defined $emb_codes_cities{$city_code}) {
 			$html .= " - " . display_tag_link('cities', $emb_codes_cities{$city_code}) ;
 		}
@@ -2011,7 +2011,7 @@ sub display_taxonomy_tag_link($$$) {
 	if ($tagtype eq 'emb_codes') {
 		my $city_code = get_city_code($tagid);
 
-		die "Initialize EMB codes with ProductOpener::Tags::init_emb_codes()" unless %emb_codes_cities;
+		init_emb_codes() unless %emb_codes_cities;
 		if (defined $emb_codes_cities{$city_code}) {
 			$html .= " - " . display_tag_link('cities', $emb_codes_cities{$city_code}) ;
 		}
@@ -3272,7 +3272,7 @@ sub compute_field_tags($$$) {
 	my $tag_lc = shift;
 	my $field = shift;
 
-	die "Initialize EMB codes with ProductOpener::Tags::init_emb_codes()" unless %emb_codes_cities;
+	init_emb_codes() unless %emb_codes_cities;
 	# generate the hierarchy of tags from the field values
 
 	if (defined $taxonomy_fields{$field}) {


### PR DESCRIPTION
Sorry @hangy , I changed my mind: it's too dangerous to expect all callers to have called init_emb_codes(), nearly all the scripts in /scripts actually need it. So let's put back an initialization on demand, but keeping the unless clause so that the function is called only once.