### PR TITLE
Fix ingredient warnings UI

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7516,13 +7516,13 @@ JS
 				}
 
 				if ($ingredients_analysis_tag =~ /^en:non-/) {
-					$color = "#ff0000"; # red
+					$color = "#ec5656"; # red
 				}
 				elsif ($ingredients_analysis_tag =~ /^en:maybe-/) {
-					$color = "#ff6600"; # orange
+					$color = "#f9904c"; # orange
 				}
 				else {
-					$color = "#00aa00"; # green
+					$color = "#47a647"; # green
 				}
 			}
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7530,7 +7530,7 @@ JS
 			next if $ingredients_analysis_tag =~ /unknown/;
 
 			if ($icon ne "") {
-				$icon = "<span style=\"font-size:32px;margin-right:0.2em;vertical-align:middle;line-height:24px;\">". display_icon($icon) ."</span>";
+				$icon = "<span style=\"margin-right: 8px;\">". display_icon($icon) ."</span>";
 			}
 
 			$html_analysis .= "<span class=\"alert round label ingredients_analysis\" style=\"background-color:$color;\">"


### PR DESCRIPTION
The ingredient warning labels (palm oil free, vegan,...) were not displayed correctly on Firefox (text not centered), the first commit fixes it.
The colors are quite flashy, the second commit brings more natural colors to the labels.

Before (Firefox):
<img width="694" alt="Capture d’écran 2020-01-24 à 20 20 57" src="https://user-images.githubusercontent.com/9609923/73097631-ee069e00-3ee7-11ea-9484-0fad7dc391c0.png">
After (Firefox):
<img width="693" alt="Capture d’écran 2020-01-24 à 20 20 43" src="https://user-images.githubusercontent.com/9609923/73097624-ea731700-3ee7-11ea-9828-0f9de139934a.png">