### PR TITLE
use barcode scanned in previous photo / scan party mode - WIP

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4118,3 +4118,44 @@ msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
 msgstr "Calculated Nutri-Score grade"
 
+
+msgctxt "scanned_code"
+msgid "Scanned code"
+msgstr "Scanned code"
+
+msgctxt "code_from_filename"
+msgid "Code from file name"
+msgstr "Code from file name"
+
+msgctxt "using_previous_code"
+msgid "Using previous code"
+msgstr "Using previous code"
+
+msgctxt "add_field_values"
+msgid "You can specify field values that will be added to all products for which you will send images."
+msgstr "You can specify field values that will be added to all products for which you will send images."
+
+msgctxt "add_tag_field"
+msgid "Add a field"
+msgstr "Add a field"
+
+msgctxt "scanned_code"
+msgid "Scanned code"
+msgstr "Scanned code"
+
+msgctxt "code_from_filename"
+msgid "Code from file name"
+msgstr "Code from file name"
+
+msgctxt "using_previous_code"
+msgid "Using previous code"
+msgstr "Using previous code"
+
+msgctxt "add_field_values"
+msgid "You can specify field values that will be added to all products for which you will send images."
+msgstr "You can specify field values that will be added to all products for which you will send images."
+
+msgctxt "add_tag_field"
+msgid "Add a field"
+msgstr "Add a field"
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4122,4 +4122,23 @@ msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
 msgstr "Calculated Nutri-Score grade"
 
+msgctxt "scanned_code"
+msgid "Scanned code"
+msgstr "Scanned code"
+
+msgctxt "code_from_filename"
+msgid "Code from file name"
+msgstr "Code from file name"
+
+msgctxt "using_previous_code"
+msgid "Using previous code"
+msgstr "Using previous code"
+
+msgctxt "add_field_values"
+msgid "You can specify field values that will be added to all products for which you will send images."
+msgstr "You can specify field values that will be added to all products for which you will send images."
+
+msgctxt "add_tag_field"
+msgid "Add a field"
+msgstr "Add a field"
 


### PR DESCRIPTION
This is to support "scan party mode" for image uploads:

The first photo contains the barcode, we scan it and recognize it.
The next photo is the front of the product: we don't have a barcode for it, so we use the previous barcode.

But it does not work. I spent hours trying to debug this, but for some reason I can't explain, when I upload my second photo, the "previous_code" is not set.

I think the issue is in there:

``````
  \$('#fileupload').fileupload(
    {
    sequentialUploads: true,
    // Uncomment the following to send cross-domain cookies:
    xhrFields: {withCredentials: true},
	formData : function () {
		var previous_code1 = previous_code;
		return ( [
					{ name : "random", value : Math.random()},
					{ name : "previous_code", value : previous_code + "-"},
					{ name : "previous_code1", value : previous_code1 + "-" + Math.random()},
					{ name : "previous_code_val", value : \$('#previous_code').val()},
					{ name : "previous_imgid", value : previous_imgid}
				]);
		}
	}
  );
``````

If I put 2 alert("previous_code: " + previous_code) before the return, then the first one does not show the previous_code, but the second one does.

So it works if I put an alert (even an empty one), but if I remove it, it fails.

Maybe some race condition or some caching somewhere. I don't understand it.