### PR TITLE
More overrides to reduce language transfer work

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -174,6 +174,17 @@ else {
 				us => "en",
 				ie => "en",
 				nz => "en",
+				il => "he",
+				mx => "es",
+				tr => "tr",
+				ru => "ru",
+				th => "th",
+				dk => "da",
+				at => "de",
+				se => "sv",
+				bg => "bg",
+				pl => "pl",
+			
 		);
 
 		if (defined $lc_overrides{$param_cc}) {


### PR DESCRIPTION
More overrides to reduce language transfer work when an app is sending French photos and data while the image and data are actually in another language