### PR TITLE
script to print all translation of a string, for debugging

### DIFF
--- a/scripts/print_all_translations.pl
+++ b/scripts/print_all_translations.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2019 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use strict;
+use utf8;
+
+use ProductOpener::Tags qw/:all/;
+use ProductOpener::Lang qw/:all/;
+
+binmode(STDOUT, ":encoding(UTF-8)");
+
+my $string = $ARGV[0];
+
+if (not defined $Lang{$string}) {
+	print STDERR "$string does not exist in the .po files\n";
+	exit();
+}
+
+foreach my $l (sort keys %Languages) {
+
+	print $l . "\t" . $Lang{$string}{$l} . "\n";
+}


### PR DESCRIPTION
useful for debugging translations:

/srv/off/scripts# ./print_all_translations.pl n_products | grep '%d'
pt %d produtos