### PR TITLE
Fixes #1109: Change default language from Hindi to English on in.openfoodfacts.org (Open Food Facts India)

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -19570,7 +19570,7 @@ zh-yue:印度
 zu:INdiya
 country_code_2:en:IN
 country_code_3:en:IND
-languages:en:hi,en
+languages:en:en,hi
 
 en:Indonesia, Republic of Indonesia, NKRI, Negara Kesatuan Republik Indonesia, Republik Indonesia, ID, IDN
 ace:Indônèsia


### PR DESCRIPTION
English should be kept as the default language for Indian pages as discussed in the comments 

#1109 