### PR TITLE
script to call pod2html to generate perlpod html doc, issue #2203

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -52,6 +52,7 @@ requires 'File::Copy::Recursive';
 requires 'Spreadsheet::CSV';
 requires 'List::MoreUtils';
 requires 'Excel::Writer::XLSX';
+requires 'Pod::Simple::HTMLBatch';
 
 # Mojolicious/Minion
 requires 'Mojolicious::Lite';

--- a/scripts/generate_perl_html_doc_from_pod.pl
+++ b/scripts/generate_perl_html_doc_from_pod.pl
@@ -1,5 +1,25 @@
 #!/usr/bin/perl -w
 
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2019 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 =head1 NAME
 
 generate_perl_html_doc_from_pod.pl scans the Perl source code of Product Opener
@@ -13,6 +33,9 @@ The script needs to be run from the root of the Product Opener installation
     ./scripts/generate_perl_html_doc_from_pod.pl
 
 =cut
+
+use Modern::Perl '2017';
+use utf8;
 
 use Pod::Simple::HTMLBatch;
 

--- a/scripts/generate_perl_html_doc_from_pod.pl
+++ b/scripts/generate_perl_html_doc_from_pod.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/perl -w
+
+=head1 NAME
+
+generate_perl_html_doc_from_pod.pl scans the Perl source code of Product Opener
+for documentation in POD format to generate documentation in HTML files.
+
+=head1 SYNOPSYS
+
+The script needs to be run from the root of the Product Opener installation
+(e.g. /srv/off/)
+
+    ./scripts/generate_perl_html_doc_from_pod.pl
+
+=cut
+
+use Pod::Simple::HTMLBatch;
+
+my $batchconv = Pod::Simple::HTMLBatch->new;
+
+$batchconv->batch_convert( ["cgi", "scripts", "lib"] , "html/files/doc/perl");


### PR DESCRIPTION
Now that we have quite a few modules with at least some POD documentation, I'm looking into ways to present it. This is the result of pod2html:

https://world.openfoodfacts.org/files/doc/perl/index.html

It doesn't look very nice yet, but it's probably possible to make it nicer with some CSS styles etc.
