### PR TITLE
trying to fix tagify missing background, bug #3047

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -836,7 +836,6 @@ HTML
 
 	$scripts .= <<HTML
 <script type="text/javascript" src="/js/dist/cropper.js"></script>
-<script type="text/javascript" src="/js/jquery.tagsinput.20160520/jquery.tagsinput.min.js"></script>
 <script type="text/javascript" src="/js/jquery.form.js"></script>
 <script type="text/javascript" src="/js/dist/tagify.js"></script>
 <script type="text/javascript" src="/js/dist/jquery.iframe-transport.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,8 @@ const svgmin = require("gulp-svgmin");
 const sassOptions = {
   errLogToConsole: true,
   outputStyle: "expanded",
-  includePaths: ["./node_modules/foundation-sites/scss"]
+  includePaths: ["./node_modules/foundation-sites/scss",
+	"./node_modules/@yaireo/tagify/src"]
 };
 
 function icons() {

--- a/html/css/product-multilingual.css
+++ b/html/css/product-multilingual.css
@@ -26,20 +26,6 @@
  https://github.com/xoxco/jQuery-Tags-Input
  */
 
-div.tagsinput {
-    line-height: 1.2;
-    resize: vertical; /* Make the box manually resizable, vertically (CSS3) */
-}
-
-div.tagsinput input {
-    box-shadow: none;
-}
-
-div.tagsinput input:focus {
-    background: none;
-    border: none;
-}
-
 .ui-selectable { list-style-type: none; margin: 0; padding: 0; }
 
 .ui-selectable img {

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -563,7 +563,7 @@ function initializeTagifyInput(el) {
 	});
 
 	input.on("add", function (event) {
-		let obj;
+		let obj = null;
 
 		try {
 			obj = JSON.parse(window.localStorage.getItem("po_last_tags"));
@@ -574,7 +574,7 @@ function initializeTagifyInput(el) {
 		}
 
 		const tag = event.detail.data.value;
-		if (obj === null) {
+		if (!Array.isArray(obj)) {
 			obj = {};
 			obj[el.id] = [tag];
 		} else if (obj[el.id] === null) {
@@ -610,7 +610,7 @@ function initializeTagifyInput(el) {
 }
 
 function get_recents(tagfield) {
-	let obj;
+	let obj = null;
 	try {
 		obj = JSON.parse(window.localStorage.getItem("po_last_tags"));
 	} catch (e) {
@@ -621,7 +621,8 @@ function get_recents(tagfield) {
 
 	if (
 		obj !== null &&
-		obj[tagfield] !== undefined &&
+    Array.isArray(obj) &&
+		typeof obj[tagfield] !== "undefined" &&
 		obj[tagfield] !== null
 	) {
 		return obj[tagfield];


### PR DESCRIPTION
This is to try to fix the missing background of the tagify dropdown (bug #3047 ). (which is  quite difficult to debug in a browser, because that dropdown disappears as soon as I click in the inspector to try to select it)

I tried, but I didn't manage to get npm to correctly generate the tagify.css file with the default scss values for the variables. My html/dist/tagify.css file has things like border:1px solid var(--tags-border-color) in it, I'm guessing that's not right.

Could you take a look @hangy or @VaiTon ?