### PR TITLE
special naming convention for orgs that are not producers: labels and…

### DIFF
--- a/cgi/import_file_process.pl
+++ b/cgi/import_file_process.pl
@@ -157,10 +157,25 @@ my $args_ref = {
 };
 
 if (defined $Org_id) {
-	$args_ref->{manufacturer} = 1;
 	$args_ref->{source_id} = $Org_id;
 	$args_ref->{source_name} = $Org_id;
-	$args_ref->{global_values} = { data_sources => "Producers, Producer - " . $Org_id, imports => $import_id};
+
+	# We currently do not have organization profiles to differentiate producers, labels, other databases
+	# in the mean time, use a naming convention:  label-something, database-something and treat
+	# everything else as a producers
+	if ($Org_id =~ /^database-/) {
+		$args_ref->{manufacturer} = 0;
+		$args_ref->{global_values} = { data_sources => "Databases, " . $Org_id, imports => $import_id};
+	}
+	elsif ($Org_id =~ /^label-/) {
+		$args_ref->{manufacturer} = 0;
+		$args_ref->{global_values} = { data_sources => "Labels, " . $Org_id, imports => $import_id};
+	}
+	else {
+		$args_ref->{manufacturer} = 1;
+		$args_ref->{global_values} = { data_sources => "Producers, Producer - " . $Org_id, imports => $import_id};
+	}
+
 }
 else {
 	$args_ref->{no_source} = 1;


### PR DESCRIPTION
… databases

This is so that we can import data that does not come directly from manufacturers. e.g. the USDA database, or Code Online, or data provided by some labels that just say "those EANs have this label".