### PR TITLE
ImportConvert.pm: ProductOpener::ImportConvert::recursive_list() called too early to check prototype

### DIFF
--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -1508,7 +1508,7 @@ sub load_csv_file($) {
 	}
 }
 
-
+sub recursive_list($$);
 sub recursive_list($$) {
 
 	my $list_ref = shift;


### PR DESCRIPTION
**Description:**

recursive_list() is being called recursively, early prototype declaration fixed the warning

**Related issues and discussion:** 
fixes #3122
