### PR TITLE
Divide status between: TO DO and DONE

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6958,9 +6958,30 @@ sub display_field($$) {
 			}
 		}
 		my $lang_field = lang($field);
-		if ($lang_field eq '') {
+		if ($lang_field eq '' and $field ne 'states') {
 			$lang_field = ucfirst(lang($field . "_p"));
 		}
+		
+		# Separate To-Do and Done Status
+		if ($field eq 'states') {
+			my $done_status = '';
+			my $to_do_status = '';
+			my @status_split = split(',', $value);
+			foreach my $val (@status_split) {
+				if (index($val, "to-be") != -1) {
+		 			$to_do_status .=$val . ",";
+  		 		}
+		 		else {
+		 		$done_status .=$val . ",";
+		 		}
+			}
+			$to_do_status =~ s/,$//;
+			$done_status =~ s/,$//;
+			$lang_field = "To Do";
+			$value = $to_do_status;
+			$html .= '<p><span class="field">' . "Done" . separator_before_colon($lc)  . ":</span>" . $done_status . "</p>";
+		}
+		
 		$html .= '<p><span class="field">' . $lang_field . separator_before_colon($lc) . ":</span> $value</p>";
 
 		if ($field eq 'brands') {

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4218,3 +4218,14 @@ msgctxt "move_data_and_photos_to_main_language_ignore"
 msgid "Keep existing values and selected photos"
 msgstr "Keep existing values and selected photos"
 
+msgctxt "move_data_and_photos_to_main_language_ignore"
+msgid "Keep existing values and selected photos"
+msgstr "Keep existing values and selected photos"
+
+msgctxt "done_status"
+msgid "Done"
+msgstr "Done"
+
+msgctxt "to_do_status"
+msgid "To do"
+msgstr "To do"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4218,13 +4218,6 @@ msgctxt "move_data_and_photos_to_main_language_ignore"
 msgid "Keep existing values and selected photos"
 msgstr "Keep existing values and selected photos"
 
-<<<<<<< HEAD
-msgctxt "move_data_and_photos_to_main_language_ignore"
-msgid "Keep existing values and selected photos"
-msgstr "Keep existing values and selected photos"
-
-=======
->>>>>>> 5f872810091d8f48a6135147011c75707a8f748e
 msgctxt "done_status"
 msgid "Done"
 msgstr "Done"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4205,8 +4205,4 @@ msgstr "Done"
 
 msgctxt "to_do_status"
 msgid "To do"
-<<<<<<< HEAD
 msgstr "To do"
-=======
-msgstr "To do"
->>>>>>> 5f872810091d8f48a6135147011c75707a8f748e

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4198,3 +4198,11 @@ msgstr "Replace existing values and selected photos"
 msgctxt "move_data_and_photos_to_main_language_ignore"
 msgid "Keep existing values and selected photos"
 msgstr "Keep existing values and selected photos"
+
+msgctxt "done_status"
+msgid "Done"
+msgstr "Done"
+
+msgctxt "to_do_status"
+msgid "To do"
+msgstr "To do"


### PR DESCRIPTION


Signed-off-by: Areesha Tariq <areeshatariq02@gmail.com>

**Description:**
The status is separated as 'To Do' and 'Done', based on whether the status indicates something is done ("Nutrition facts completed" etc.) or not done ("Characteristics to be completed").

**Output:**

![Status](https://user-images.githubusercontent.com/24654457/77850550-cb954780-71ec-11ea-916f-83931c0ac9f9.png)
When Done does not contain any entry, only To Do is displayed:

![To-Do](https://user-images.githubusercontent.com/24654457/78048990-ef46c200-7393-11ea-8791-b90afcf48ca3.png)

When To Do does not contain any entry, only Done is displayed:

![Done](https://user-images.githubusercontent.com/24654457/78049228-3c2a9880-7394-11ea-9d05-c095643e901b.png)

**Related issues and discussion:** 
fixes #2866
