### PR TITLE
parse S. thermophilus, L. acidophilus etc.

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -233,8 +233,23 @@ sub init_allergens_regexps() {
 }
 
 
+# Abbreviations that contain dots.
+# The dots interfere with the parsing: replace them with the full name.
 
 my %abbreviations = (
+
+all => [
+	["B. actiregularis", "bifidus actiregularis"], # Danone trademark
+	["B. lactis", "bifidobacterium lactis"],
+	["L. acidophilus", "lactobacillus acidophilus"],
+	["L. bulgaricus", "lactobacillus bulgaricus"],
+	["L. casei", "lactobacillus casei"],
+	["L. lactis", "lactobacillus lactis"],
+	["L. plantarum", "lactobacillus plantarum"],
+	["L. reuteri", "lactobacillus reuteri"],
+	["L. rhamnosus", "lactobacillus rhamnosus"],
+	["S. thermophilus", "streptococcus thermophilus"],
+],
 
 fr => [
 ["Mat. Gr.", "Matières Grasses"]
@@ -2806,12 +2821,14 @@ sub preparse_ingredients_text($$) {
 	$text =~ s/ \& /$and/g;
 
 	# abbreviations
-	if (defined $abbreviations{$product_lc}) {
-		foreach my $abbreviation_ref (@{$abbreviations{$product_lc}}) {
-			my $source = $abbreviation_ref->[0];
-			my $target = $abbreviation_ref->[1];
-			$source =~ s/\./\\\./g;
-			$text =~ s/$source/$target/ig;
+	foreach my $abbreviations_lc ("all", $product_lc) {
+		if (defined $abbreviations{$abbreviations_lc}) {
+			foreach my $abbreviation_ref (@{$abbreviations{$abbreviations_lc}}) {
+				my $source = $abbreviation_ref->[0];
+				my $target = $abbreviation_ref->[1];
+				$source =~ s/\. /(\\.| |\\. )/g;
+				$text =~ s/(\b|^)$source(\b|$)/$target/ig;
+			}
 		}
 	}
 

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -183,6 +183,8 @@ my @lists =(
 	"phosphates d'ammonium, phosphates de calcium, phosphate d'aluminium et de sodium, diphosphate d'aluminium et de sodium"],
 
 	["fr", "Ingrédient(s) : lentilles vertes* - *issu(e)(s) de l'agriculture biologique.","Ingrédients : lentilles vertes Bio"],
+
+	["en", "S. thermophilus, L casei, L.bulgaricus", "streptococcus thermophilus, lactobacillus casei, lactobacillus bulgaricus"],
 );
 
 foreach my $test_ref (@lists) {

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -6360,7 +6360,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bifidobacterium_bifidum
 # description:en:BIFIDOBACTERIUM ANIMALIS is a gram-positive, anaerobic, rod-shaped bacterium of the Bifidobacterium genus which can be found in the large intestines of humans. Both old names B. animalis and B. lactis are still used on product labels, as this species is frequently used as a probiotic. In most cases, which subspecies is used in the product is not clear. Several companies have attempted to trademark particular strains, and as a marketing technique, have invented scientific-sounding names for the strains.
 
 <en:bifidus
-en:Bifidobacterium lactis, Bifidobacterium animalis
+en:Bifidobacterium lactis, Bifidobacterium animalis, B. lactis, B. animalis
 bg:Bifidobacterium lactis
 de:Bifidobacterium lactis
 es:Bifidobacterium lactis
@@ -6408,7 +6408,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bifidobacterium_longum
 # description:en:Danone decided to add a probiotic strain: BIFIDUS ACTIREGULARIS. Activia products thus contain Bifidobacterium animalis DN 173,010, a proprietary strain of Bifidobacterium, a probiotic which is marketed by Dannon under the trade names Bifidus Regularis, Bifidus Actiregularis, Bifidus Digestivum and Bifidobacterium Lactis.
 
 <en:bifidus
-en:bifidus actiregularis
+en:bifidus actiregularis, b. actiregularis
 bg:Bifidus ActiRegularis
 de:Bifidus ActiRegularis, Bifidus Kultur ActiRegularis
 fi:bifidus actiregularis
@@ -6549,7 +6549,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_delbrueckii_subsp._bulg
 # description:en:LACTOBACILLUS CASEI is a species of genus Lactobacillus found in the human urinary tract and mouth. The most common application of L. casei is industrial, specifically for dairy production.
 
 <en:Lactobacillus
-en:lactobacillus casei
+en:lactobacillus casei, L. casei
 ar:ملبنة مجبنة
 bg:Lactobacillus casei
 ca:Lactobacillus casei
@@ -6583,7 +6583,7 @@ it:L.casei 431
 # description:en:LACTOBACILLUS HELVETICUS is a lactic-acid producing, rod-shaped bacterium of the genus Lactobacillus. It is most commonly used in the production of American Swiss cheese and Emmental cheese, but is also sometimes used in making other styles of cheese, such as Cheddar, Parmesan, Romano, provolone, and mozzarella.
 
 <en:Lactobacillus
-de:Lactobacillus Helvetica
+de:Lactobacillus Helveticus, L. Helveticus
 fi:lactobacillus helveticus
 fr:Lactobacillus helveticus
 hu:Lactobacillus helveticus
@@ -6592,7 +6592,7 @@ nl:Lactobacillus helveticus
 wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_helveticus
 
 <en:Lactobacillus
-en:Lactobacillus lactis, Lactobacillus delbrueckii
+en:Lactobacillus lactis, L. lactis, Lactobacillus delbrueckii
 bg:Lactobacillus lactis
 de:Lactobacillus lactis
 es:Lactobacillus lactis
@@ -6610,7 +6610,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_delbrueckii
 # description:en:LACTOBACILLUS PLANTARUM is a widespread member of the genus Lactobacillus, commonly found in many fermented food products
 
 <en:Lactobacillus
-en:Lactobacillus plantarum
+en:Lactobacillus plantarum, L. plantarum
 bg:Lactobacillus plantarum
 ca:Lactobacillus plantarum
 de:Lactobacillus plantarum
@@ -6636,7 +6636,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_plantarum
 # description:en:LACTOBACILLUS REUTERI is a Gram-positive bacterium that naturally inhabits the gut of mammals and birds. Although L. reuteri occurs naturally in humans, it is not found in all individuals. Dietary supplementation can sustain high levels of it in those with deficiencies.
 
 <en:Lactobacillus
-en:Lactobacillus reuteri
+en:Lactobacillus reuteri, L. reuteri
 bg:Lactobacillus reuteri
 de:Lactobacillus reuteri
 es:Lactobacillus reuteri


### PR DESCRIPTION
We currently treat the . in S. thermophilus as a separator, which results in a "S" ingredient and a "thermophilus" ingredient.