### PR TITLE
Fix FR spelling errors in ingredient taxonomy

### DIFF
--- a/ingredients/additives.txt
+++ b/ingredients/additives.txt
@@ -262,7 +262,7 @@ E381	Citrate d'ammonium ferrique vert	(Citrate d'ammonium ferrique vert)		3	Addi
 E383	Glycerophosphate de calcium	(Glycerophosphate de calcium, épaississant, gélifiant, stabilisant)		3	Additif non autorisé en Europe (liste N° 1129/2011 du 11 Novembre 2011)
 E384	Citrates d’isopropyle	(Citrates d’isopropyle, antioxydant, conservateur, séquestrant)		3	Additif non autorisé en Europe (liste N° 1129/2011 du 11 Novembre 2011)
 E386	EDTA disodique, Disodium ethylenediamine tetra-acetate, Stabilisateurs synthétiques, Disodium édétate, sel de sodium de E385, sel de sodium d'E385	(EDTA disodique, Stabilisateurs synthétiques)		3	Additif non autorisé en Europe (liste N° 1129/2011 du 11 Novembre 2011)
-E385	Éthylène diamine tétra-acétate de calcium disodium, calcium disodium EDTA, CAS 662-33-9,  EDTA calcio-disodique, Ethylène-diamine-tétra-acètate calcio-disodique, CAS 60-00-4, acide éthylene diamine tétra acétique, EDTA de calcium disodique, EDTA  	(EDTA calcio-disodique)		-1	
+E385	Éthylène diamine tétra-acétate de calcium disodium, calcium disodium EDTA, CAS 662-33-9,  EDTA calcio-disodique, Ethylène-diamine-tétra-acétate calcio-disodique, CAS 60-00-4, acide éthylene diamine tétra acétique, EDTA de calcium disodique, EDTA  	(EDTA calcio-disodique)		-1	
 E387	Oxystearin	(Oxystearin, Stabilisateur)		3	Additif non autorisé en Europe (liste N° 1129/2011 du 11 Novembre 2011)
 E388	Acide thiodipropanoïque, Antioxydant synthétique	(Acide thiodipropanoïque, Antioxydant synthétique)		3	Additif non autorisé en Europe (liste N° 1129/2011 du 11 Novembre 2011)
 E389	Thiodipropionate de dilauryle	(Thiodipropionate de dilauryle, antioxydant)		3	Additif non autorisé en Europe (liste N° 1129/2011 du 11 Novembre 2011)

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -7122,7 +7122,7 @@ el:E322, Λεκιθινες, Φωσφατίδια
 es:E322, Lecitinas, Fosfátidos, Lecitina de soja, Lecitina de girasol, Lecitina
 et:E322, Letsitiinid, Fosfatiidid, Letsitiin
 fi:E322, Lesitiinit, Fosfatidit, Lesitiini, Lesitiinejä, Fosfatidejä, Lesitiiniä, soijalesitiini, auringonkukkalesitiini, rapsilesitiini, soijalesitiiniä, auringonkukkalesitiiniä, rapsilesitiiniä, rypsilesitiini, rypsilesitiiniä, E322 soijasta
-fr:E322, Lécithines, Lécithine, Lécithine partiellement hydrolysée, Phosphatidylcholine, Phosphatides, Phospholipides, Phospho lutéines, CAS 8002-43-5, Lecithin
+fr:E322, Lécithines, Lécithine, Lécithine partiellement hydrolysée, Phosphatidylcholine, Phosphatides, Phospholipides, Phospho lutéines, CAS 8002-43-5
 hu:E322, Lecitinek, Foszfatidek, Lecitin
 it:E322, Lecitine, Fosfatidi, Lecitina
 lt:E322, Lecitinai, Fosfatidai
@@ -13710,7 +13710,7 @@ el:E494, Μονοελαϊκη σορβιτανη
 es:E494, Sorbitan monooleate
 et:E494, Sorbitaanmonoleaat
 fi:E494, Sorbitaanimono-oleaatti, Sorbitaanimono-oleaattia
-fr:E494, Monoléate de sorbitane, Monooléate de sorbitan
+fr:E494, Monoléate de sorbitane, Monoléate de sorbitan
 hu:E494, Szorbitan-monooleát
 it:E494, Monooleato di sorbitano
 lt:E494, Sorbitano monoleatas
@@ -14252,7 +14252,7 @@ el:E507, Υδροχλωρικο οξυ, Υδροχλώριο
 es:E507, Ácido clorhídrico, Cloruro de hidrógeno, Acido hidroclorico, Ácido clorídrico, Ácido muriatico, Clorhidrato, Salfumán, E 507, Agua fuerte, Clorhidrico, Salfumant
 et:E507, Soolhape, Vesinikkloriidhape
 fi:E507, Suolahappo, Kloorivety, Vetykloridihappo, Vetykloridi, Suolahappoa, Kloorivetyä, Vetykloridihappoa, Vetykloridia
-fr:E507, Acide chlorhydrique, Chlorure d'hydrogène, Acide muriatique, Esprit de sel, Acide chlohydrique, Acide chlorydrique officinal, 7674-01-0, HCl•2H2O, 13465-05-9, Acide chloridrique
+fr:E507, Acide chlorhydrique, Chlorure d'hydrogène, Acide muriatique, Esprit de sel, Acide chlorhydrique officinal, 7674-01-0, HCl•2H2O, 13465-05-9
 hu:E507, Sósav, Hidrogén-klorid
 it:E507, Acido cloridrico, Cloruro di idrogeno, Spirito di sale, acido muriatico
 lt:E507, Vandenilio chlorido rūgštis, Vandenilio chloridas, Druskos rūgštis

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -58,7 +58,7 @@ da: Surhedsregulerende middel
 el: Ρυθμιστής οξύτητας
 es: Corrector de acidez, correctores de acidez, regulador de la acidez, agente de regulación del pH, agente regulador, reguladores de acidez, soluciones reguladoras, álcali, base
 fi: Happamuudensäätöaine
-fr: Correcteur d’acidité, régulateur de l'acidité, agent tampon, adjusteur du pH, alcali, base, tampon
+fr: Correcteur d’acidité, régulateur de l'acidité, agent tampon, ajusteur du pH, alcali, base, tampon
 it: Correttore di acidità, correttori di acidità
 nl: Zuurteregelaar
 pt: Regulador de acidez
@@ -357,7 +357,7 @@ da: Emulgator
 el: Γαλακτωματοποιητής
 es: Emulgente, Emulsificante, emulsionante, agente dispersante, agente enturbiador, agentes enturbiadores, agente tensoactivo, corrector de la densidad, estabilizadores de una suspensión, estabilizador de una suspensión, inhibidor de la cristalización, plastificante
 fi: Emulgointiaine, Emulgointiainetta, Emulgointiaineet, Emulgointiaineita
-fr: Émulsifiant, agent de dispersion, agent de surface, agent de suspension, agent d'ajustement de la densité, inhibiteur de cristalisation, nébulisant, plastifiant
+fr: Émulsifiant, agent de dispersion, agent de surface, agent de suspension, agent d'ajustement de la densité, inhibiteur de cristallisation, nébulisant, plastifiant
 it: Emulsionante, emulsionanti, agente emulsionante, agenti emulsionanti
 nl: Emulgator
 pt: Emulsionante

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -560,7 +560,7 @@ el:Πυκνωτικό μέσο
 es:Espesante
 et:Paksendaja
 fi:sakeuttamisaine, sakeuttamisaineet
-fr:épaississant, Épaississant, agent épaississant, agents épaississants, épaissisant
+fr:épaississant, Épaississant, agent épaississant, agents épaississants
 ga:Tiúsóir
 hu:Sűrítőanyag
 it:Addensante, Addensanti, agente addensante, agenti addensanti
@@ -7157,7 +7157,7 @@ ca:xilanasa
 de:Xylanasen
 es:xilanasa
 fi:Ksylanaasi
-fr:xylanase, xylananse
+fr:xylanase
 hu:xilanáz
 id:Xylanase
 it:Xilanasi
@@ -7923,7 +7923,7 @@ pt:leite pasteurizado desnatado, leite desnatado pasteurizado
 <en:pasteurized skimmed milk
 en:UHT sterilised skimmed milk
 de:entrahmte H-Milch
-fr:Lait écrémé stérilisé UHT, lait écrémé stérilisé u h t, lait sterilise uht ecreme
+fr:Lait écrémé stérilisé UHT, lait écrémé stérilisé u h t, lait stérilisé uht écrémé
 hu:sovány UHT tej
 nl:UHT-gesteriliseerde magere melk
 # ingredient/fr:lait-ecreme-sterilise-uht has 14 products in french @2019-05-23
@@ -7952,13 +7952,13 @@ wikidata:en:Q10572454
 wikipedia:en:https://fr.wikipedia.org/wiki/Lait_demi-écrémé
 
 <en:semi-skimmed milk
-fr:lait demi écrémé uht, lait sterilise u h t demi-ecreme, lait demi-écrémé stérilisé uht, lait stérilisé uht demi-écrémé, lait demi-écrémé stérilisé u.h.t
+fr:lait demi écrémé uht, lait stérilisé u h t demi-écrémé, lait demi-écrémé stérilisé uht, lait stérilisé uht demi-écrémé, lait demi-écrémé stérilisé u.h.t
 de:fettarme Haltbarmilch, fettarme H-milch
 nl:halfvolle melk uht verhit
 pt:leite UHT meio gordo, leite meio gordo UHT
 
 <fr:lait demi écrémé uht
-fr:lait de montagne demi écrémé sterilisé uht
+fr:lait de montagne demi écrémé stérilisé uht
 
 <en:semi-skimmed milk
 en:organic semi-skimmed milk, semi-skimmed milk from organic farming
@@ -7970,7 +7970,7 @@ nl:biologische halfvolle melk
 # ingredient/nl:biologische-halfvolle-melk has 1 product @2019-05-24
 
 <en:organic semi-skimmed milk
-fr:lait demi-écrémé sterilisé uht biologique,lait demi-écrémé issu de l'agriculture biologique sterilisé uht, lait demi-ecreme sterilise uht issu de l'agriculture biologique, lait demi-écrémé biologique
+fr:lait demi-écrémé stérilisé uht biologique,lait demi-écrémé issu de l'agriculture biologique stérilisé uht, lait demi-écrémé stérilisé uht issu de l'agriculture biologique, lait demi-écrémé biologique
 
 # description:en:PASTEURIZED SEMI-SKIMMED MILK has a butterfat percentage of 1.5-1.8% AND is pasteurised
 
@@ -7978,7 +7978,7 @@ fr:lait demi-écrémé sterilisé uht biologique,lait demi-écrémé issu de l'a
 en:pasteurized semi-skimmed milk
 de:pasteurisierte teilentrahmte Milch
 fi:pastöroitu kevytmaito
-fr:lait demi-écrémé pasteurisé, lait partiellement écrémé pasteurisé, lait pasteurise demi ecreme
+fr:lait demi-écrémé pasteurisé, lait partiellement écrémé pasteurisé, lait pasteurise demi écrémé
 hu:pasztőrözött zsírszegény tej
 it:latte pastorizzato parzialmente scremato, latte parzialmente scremato pastorizzato
 nl:gepasteuriseerde halfvolle melk
@@ -8062,7 +8062,7 @@ fr:lait frais de montagne entier pasteurisé
 
 <en:whole milk
 <en:sterilised milk
-fr:lait de montagne entier sterilisé uht
+fr:lait de montagne entier stérilisé uht
 
 <en:whole milk
 <en:organic milk
@@ -8088,7 +8088,7 @@ it:latte intero sterilizzato, latte sterilizzato intero
 en:UHT pasteurised whole milk
 de:Haltbare Vollmilch, H-Vollmilch
 fi:iskukuumennettu täysmaito
-fr:lait entier sterilisé uht, lait entier sterilise u h t, lait sterilise uht entier
+fr:lait entier stérilisé uht, lait entier stérilisé u h t, lait stérilisé uht entier
 hu:pasztőrözött UHT teljes tej
 nl:UHT gesteriliseerde volle melk
 # ingredient/fr:lait-entier-sterilise-uht has 20 products in 2 languages @2019-05-23
@@ -9373,7 +9373,7 @@ nl:roompoeder, poederroom
 
 <en:cream powder
 en:rehydrated cream powder
-fr:crème en poudre rehydratée
+fr:crème en poudre réhydratée
 # ingredient/rehydrated-cream-powder has 2 products @2019-07-12
 
 <en:cream
@@ -9742,7 +9742,7 @@ vegetarian:en:yes
 # ingredient/fr:babeurre has 166 products in 4 languages @2018-11-15
 
 <en:buttermilk
-fr:babaurre pasteurisé
+fr:babeurre pasteurisé
 
 <en:buttermilk
 en:buttermilk powder
@@ -9995,7 +9995,7 @@ vegan:en:no
 # en:cheese has 579 products in 10 languages @2018-10-28
 
 <en:cheese
-fr:fromages râpées sechés
+fr:fromages râpées séchés
 carbon_footprint_fr_foodges_ingredient:fr:Fromage à pâte dure (type emmental)
 carbon_footprint_fr_foodges_value:fr:5.6
 carbon_footprint_fr_foodges_ingredient:fr:Fromage à pâte molle (type camembert)
@@ -11535,7 +11535,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Ricotta
 # fr:ricotta has 532 products in 6 languages @2018-10-27
 
 <en:ricotta
-fr:ricotta de brébis
+fr:ricotta de brebis
 
 # description:en:  ROQUEFORT  is a sheep milk cheese from the south of France. The cheese is white, tangy, crumbly and slightly moist, with distinctive veins of blue mold. EU law dictates that only those cheeses aged in the natural Combalou caves of Roquefort-sur-Soulzon may bear the name Roquefort, as it is a recognised geographical indication, or has a protected designation of origin.
 
@@ -13908,7 +13908,7 @@ nl:gekookt rundvlees
 fr:viande de boeuf mise en oeuvre
 
 <en:beef meat
-fr:viande de boeuf en poudre, viande de boeuf deshydratée
+fr:viande de boeuf en poudre, viande de boeuf déshydratée
 
 <en:beef
 fr:foie de boeuf
@@ -15187,7 +15187,7 @@ et:Tärklis
 eu:Almidoi
 fa:نشاسته
 fi:Tärkkelys
-fr:amidon, fécules, fecule
+fr:amidon, fécules, fécule
 fy:Stiselmoal
 ga:Stáirse
 he:עמילן
@@ -16747,7 +16747,7 @@ nutriscore_fruits_vegetables_nuts:en:yes
 
 <en:olive oil
 en:black olives oil, black olive oil
-fr:huile d'olivs noires
+fr:huile d'olive noire, huile d'olives noires
 
 <en:olive oil
 en:virgin olive oil
@@ -17628,7 +17628,7 @@ from_palm_oil:en:no
 <en:vegetable oil
 en:mango kernel oil, mango oil
 fi:mangoydinöljy, mangoöljy
-fr:huile de noyaux de mangue, huile végétale de noyeau de mangue
+fr:huile de noyaux de mangue, huile végétale de noyau de mangue
 hu:mangómagolaj, mangóolaj
 # ingredient/fr:noyaux-de-mangue has 31 products in french @2019-03-01
 # matières grasses végétales (palme, karité, sal, noyaux de mangue, illipé, kokum gurgi dans des proportions variables)
@@ -19106,7 +19106,7 @@ nl:droge witte wijn
 <en:white wine
 en:white wine from France
 de:Weißwein aus Frankreich, französischer Weißwein
-fr:vin blanc de France, vin-blanc-arbois-aoc, vinblanc coteaux du layon aop, vin blanc condrieu aop, vin blanc coteaux du lyonnais aop
+fr:vin blanc de France, vin blanc arbois aoc, vin blanc coteaux du layon aop, vin blanc condrieu aop, vin blanc coteaux du lyonnais aop
 hu:francia fehérbor
 # 2019-05-29
 
@@ -19227,7 +19227,7 @@ nl:biologische rode wijn
 <en:red wine
 en:red wine from France
 de:Rotwein aus Frankreich, französischer Rotwein
-fr:vin rouge de France, vin rouge issu du cepage pinot noir, vin rouge issu des cepages merlot, vin rouge puy de dome igp, vin bordeaux rouge, vin rouge bordeaux, vin rouge bordeaux aoc, vin rouge coteaux du lyonnais, vin rouge cote de brouilly, vin rouge de Bourgogne
+fr:vin rouge de France, vin rouge issu du cépage pinot noir, vin rouge issu des cépages merlot, vin rouge puy de dome igp, vin bordeaux rouge, vin rouge bordeaux, vin rouge bordeaux aoc, vin rouge coteaux du lyonnais, vin rouge cote de brouilly, vin rouge de Bourgogne
 hu:francia vörösbor
 
 
@@ -19393,7 +19393,7 @@ et:Madeira
 eu:Madeira
 fi:madeira, madeira-viini
 fo:Madeiravín
-fr:madère, vin de Madére
+fr:Madère, vin de Madère
 gl:Viño da Madeira
 he:יין מאדירה
 hu:Madeira
@@ -22565,7 +22565,7 @@ nl:boekweitflakes
 # pétales de sarrasin (sarrasin, sel)
 
 <en:buckwheat
-fr:sarrasin rehydraté
+fr:sarrasin réhydraté
 
 # description:en:The OAT (Avena sativa) is a species of cereal grain grown for its seed.
 
@@ -24356,7 +24356,7 @@ en:whole grain brown rice
 <en:organic rice
 en:organic brown rice, organic full grain rice
 fi:luomu tumma riisi, luomu täysjyväriisi
-fr:riz complèt bio, riz complet biologique, riz complet issu de l'agriculture biologique
+fr:riz complet bio, riz complet biologique, riz complet issu de l'agriculture biologique
 hu:bio barnarizs
 nl:biozilvervliesrijst
 
@@ -26472,7 +26472,7 @@ fr:sirop d'orge malté
 <fr:sirop d'orge malté
 fr:sirop de malt d'orge déshydraté
 
-fr:sirop de candi, sirop de scucre candi
+fr:sirop de candi, sirop de sucre candi
 
 # nova:en:maple-syrup
 en:maple syrup
@@ -26956,7 +26956,7 @@ hu:rehidratált növényi fehérjék
 fr:protéines de blé
 
 <fr:protéines de blé
-fr:protéines de blé deshydratées
+fr:protéines de blé déshydratées
 
 <fr:protéines de blé
 fr:protéines de blé partiellement hydrolysées
@@ -27017,7 +27017,7 @@ fi:soijaproteiini konsentraatti
 en:dehydrated soy protein
 de:getrocknetes Sojaprotein
 fi:dehydratoitu soijaproteiini
-fr:protéines de soja deshydratées
+fr:protéines de soja déshydratées
 hu:dehidratált szójafehérje
 
 <en:soy protein
@@ -31562,7 +31562,7 @@ nl:gedroogde abrikozen
 en:pitted dried apricots
 de:getrocknete Aprikosen entsteint, entsteinte getrocknete Aprikosen
 fi:kivetön kuivattu aprikoosi, kivettömät kuivatut aprikoosit
-fr:abricots secs denoyautés
+fr:abricots secs dénoyautés
 
 <en:apricot
 en:apricot kernels
@@ -36265,7 +36265,7 @@ carbon_footprint_fr_foodges_ingredient:fr:Raisin
 carbon_footprint_fr_foodges_value:fr:0.8
 
 <en:raisin
-fr:raisins secs rehydratés
+fr:raisins secs réhydratés
 
 <en:raisin
 en:raisin concentrate
@@ -37736,7 +37736,7 @@ nl:Kokospulp
 # 21 products in 3 languages @2018-10-03
 
 <en:coconut pulp
-fr:noix de coco séchée, noix de coco deshydratée
+fr:noix de coco séchée, noix de coco déshydratée
 nl:gedroogde kokosnoot
 ro:nuca de cocos deshidratata
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noix-de-coco-séchée
@@ -42608,7 +42608,7 @@ en:dehydrated bell pepper
 de:getrocknete Paprika
 es:Pimiento deshidratado
 fi:kuivattu paprika
-fr:poivron deshydraté, poivrons deshydratés
+fr:poivron déshydraté, poivrons déshydratés
 
 <en:bell pepper
 en:sweet peppers
@@ -43286,7 +43286,7 @@ it:pomodori semiseccchi
 # ingredient/fr:tomates-semi-séchées has 38 products in 4 languages @2018-12-26
 
 <fr:tomates semi-séchées
-fr:tomates semi-séchées marinées, tomates semi-deshydratées et marinées
+fr:tomates semi-séchées marinées, tomates semi-déshydratées et marinées
 
 
 <en:tomato
@@ -46849,7 +46849,7 @@ es:sésamo, ajonjolí
 eu:Sesamo
 fa:کنجد
 fi:seesami
-fr:sésame, sésam
+fr:sésame
 ga:Seasaman
 gl:Sésamo
 gu:તલ
@@ -47110,13 +47110,13 @@ it:condimenti misti
 # usage:fr:mélange aromatique (maltodextrine, arômes naturels, épices et plantes aromatiques, sel, saccharose, extrait de crustacé )
 
 <en:condiment
-fr:assaisonnemenet saveur barbecue
+fr:assaisonnement saveur barbecue
 
 <en:condiment
-fr:assaisonnemenet goût salé
+fr:assaisonnement goût salé
 
 <en:condiment
-fr:assaisonnemenet goût fromage
+fr:assaisonnement goût fromage
 
 en:spice, spices
 ca:Espècies
@@ -47636,7 +47636,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Turmeric
 en:turmeric powder
 de:Curcumapulver, Kurkumapulver
 fi:kurkumajauhe
-fr:poudre de curcuma, curcuma moulu, curcuma deshydraté
+fr:poudre de curcuma, curcuma moulu, curcuma déshydraté
 it:curcuma in polvere
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:poudre-de-curcuma
 # 40 products @2018-10-11
@@ -48739,7 +48739,7 @@ nl:biologisch dillezaad
 en:dried dill
 de:getrockneter Dill, Dill getrocknet
 fi:kuivattu tilli
-fr:aneth deshydraté
+fr:aneth déshydraté
 
 <en:herb
 en:rosemary
@@ -49356,7 +49356,7 @@ nl:biologische tijm
 en:dried thyme
 de:getrockneter Thymian, Thymian getrocknet
 fi:kuivattu timjami
-fr:thym deshydraté, thym deshydrate
+fr:thym déshydraté, thym deshydrate
 
 <en:thyme
 en:thyme in powder
@@ -52625,12 +52625,12 @@ fr:thé vert au jasmin
 
 <en:green tea
 en:decaffeinated green tea
-fr:thé vert décafeiné
+fr:thé vert décaféiné
 it:te verde decaffeinato, tè verde decaffeinato
 
 <en:black tea
 en:decaffeinated black tea
-fr:thé noir décafeiné
+fr:thé noir décaféiné
 it:te nero decaffeinato, tè nero decaffeinato
 
 # en:tree sorrel
@@ -53768,7 +53768,7 @@ carbon_footprint_fr_foodges_value:fr:1.9
 
 <en:mushroom
 en:forest mushroom
-fr:champignon forestier, champignons forestiers, champignon des bois, champignopns des bois
+fr:champignon forestier, champignons forestiers, champignon des bois, champignons des bois
 
 <en:mushroom
 en:concentrated mushroom juice
@@ -53957,7 +53957,7 @@ la:Boletus edulis
 en:dried cep
 de:getrocknete Steinpilze
 fi:kuivattu herkkutatti
-fr:cèpes deshydratés
+fr:cèpes déshydratés
 
 <en:cep
 de:Steinpilzpulver
@@ -60914,14 +60914,14 @@ nl:vloeibare honing
 # ingredient/fr:miel-liquide has 12 products in french @2019-05-28
 
 <en:honey
-fr:miel crémeux, miel de nectar cremeux, miel de fleurs crémeux
+fr:miel crémeux, miel de nectar crémeux, miel de fleurs crémeux
 de:Honig cremig
 it:miele cremoso
 # ingredient/fr:miel-cremeux has 6 products in 3 languages @2019-05-28
 # ingredient/fr:miel-de-fleurs-cremeux has 4 products @2019-05-28
 
 <fr:miel crémeux
-fr:miel cremeux bio, miel de fleurs cremeux issu de l'agriculture biologique
+fr:miel crémeux bio, miel de fleurs crémeux issu de l'agriculture biologique
 
 <en:honey
 en:flower honey
@@ -60984,7 +60984,7 @@ fr:miel d'Acacia issu de l'Agriculture Biologique, miel bio d'acacia
 en:honey from France
 de:Honig aus Frankreich, französischer Honig
 fi:Ranskalaista hunajaa
-fr:miel d'acacia de france, miel d'acacia récolté en France, Miel d'acacia de Bourgogne, mield'acacia du val de saone, miel d'acacia d'occitanie
+fr:miel d'acacia de france, miel d'acacia récolté en France, Miel d'acacia de Bourgogne, miel d'acacia du val de saone, miel d'acacia d'occitanie
 # ingredient/fr:miel-d-acacia-recolte-en-france has 4 products @2019-05-28
 
 <en:acacia honey
@@ -61018,7 +61018,7 @@ fr:miel de carotte sauvage
 
 <en:honey
 <fr:miel du Gâtinais
-fr:miel de carotte recolté dans le gatinais
+fr:miel de carotte récolté dans le gatinais
 
 <en:honey
 fr:miel de châtaignier, miel de chataigner, miel de fleurs de chataignier
@@ -61053,7 +61053,7 @@ nl:eucalytus honing
 <en:eucalyptus honey
 en:organic eucalyptus honey
 fi:luomu eukalyptushunaja
-fr:miel d'eucalyptus'issu de l'agriculture biologique
+fr:miel d'eucalyptus issu de l'agriculture biologique
 
 <en:honey
 fr:miel de framboisier issu de l'agriculture biologique
@@ -61092,7 +61092,7 @@ nl:lavendelhoning uit de Provence
 fr:miel de litchi
 
 <en:honey
-fr:miel-de-luzerne
+fr:Miel de luzerne
 
 <en:honey
 fr:miel de mandarinier
@@ -61149,11 +61149,11 @@ fr:miel de sapin
 
 <fr:miel de sapin
 <en:honey from France
-fr:fr:miel de sapin recolté en France,  miel de sapin du Jura
+fr:fr:miel de sapin récolté en France,  miel de sapin du Jura
 
 <en:honey
 <en:honey from France
-fr:miel de sarrasin recolté dans le Loiret
+fr:miel de sarrasin récolté dans le Loiret
 
 <en:honey
 en:sunflower honey
@@ -62065,8 +62065,8 @@ fr:café moulu pur arabica, café moulu arabica, café moulu 100 arabica
 fr:cafe moulu pur arabica bio
 
 <en:arabica coffee
-fr:cafe arabica torrefié
-# ingredient/fr:cafe-arabica-torrefié has 18 products in french @2019-05-23
+fr:café arabica torréfié
+# ingredient/fr:cafe-arabica-torréfié has 18 products in french @2019-05-23
 
 <en:arabica coffee
 en:arabica coffee extract
@@ -62778,7 +62778,7 @@ fr:poulet fermier
 # ingredient/fr:poulet-fermier has 13 products in french @2019-05-25
 
 <en:chicken
-fr:poulet deshydraté
+fr:poulet déshydraté
 
 <en:chicken
 fr:machons et ailerons de poulet
@@ -63514,12 +63514,12 @@ fr:œufs frais de poule
 # 3@2019-05-31
 
 <en:chicken egg
-fr:œufs de poules élevées en cage, oeufs de poules élevées en cage, 20 oeufs de poules elevees en cage, 6 oeufs de poules elevees en cage
+fr:œufs de poules élevées en cage, oeufs de poules élevées en cage, 20 oeufs de poules élevées en cage, 6 oeufs de poules élevées en cage
 # ingredient/fr:oeufs-de-poules-élevées-en-cage has 53 products in french @2018-12-18
 
 <fr:œufs de poules élevées en cage
 <en:category A eggs
-fr:oeufs de poules elevees en cage de categorie a
+fr:oeufs de poules élevées en cage de categorie a
 
 <fr:œufs de poules élevées en cage
 fr:oeufs frais de poules élevées en cage, oeufs de poules élevées en cage
@@ -63543,7 +63543,7 @@ fr:œufs de poules élevées en plein air calibre moyen
 
 <en:free range chicken eggs
 <en:organic egg
-fr:oeufs frais de poules elevees en plein air issus de l'agriculture biologique
+fr:oeufs frais de poules élevées en plein air issus de l'agriculture biologique
 
 <en:free range chicken eggs
 <en:category A egg
@@ -63555,7 +63555,7 @@ fr:Oeufs frais de poule élevées en plein air, 12 Oeufs frais de poule élevée
 
 <fr:Oeufs frais de poule élevées en plein air
 <en:organic egg
-fr:oeufs frais de poules elevees en plein air issus de l'agriculture biologique
+fr:oeufs frais de poules élevées en plein air issus de l'agriculture biologique
 
 <en:free range chicken eggs
 fr:Gros Œufs de Poules Élevées en Plein Air
@@ -63960,7 +63960,7 @@ en:free range chicken egg yolk
 de:Hühnereigelb aus Freilandhaltung
 es:yema de huevo de gallinas camperas
 fi:vapaan kanan munankeltuainen
-fr:jaune d'œuf de poules élevées en plein air, jaunes d'œufs de poules élevées en plein air, jaune d'oeuf de poules élevées en plein air, jaunes d'oeufs de poules élevées en plein air, jaune d'oeuf issu d'oeufs de poules elevees en plein air
+fr:jaune d'œuf de poules élevées en plein air, jaunes d'œufs de poules élevées en plein air, jaune d'oeuf de poules élevées en plein air, jaunes d'oeufs de poules élevées en plein air, jaune d'oeuf issu d'oeufs de poules élevées en plein air
 nl:Eigeel van vrije uitloop eieren, scharreleigeelpoeder
 pt:gema de ovo de galinhas criadas ao ar livre
 # ingredient/fr:jaune-d’oeuf-de-poules-élevées-en-plein-air has 61 products in 2 languages @2018-12-18
@@ -66875,7 +66875,7 @@ fr:fond de volaille aromatisé
 # ingredient/fr:fond-de-volaille-aromatisé has 39 products in french @2019-03-09
 
 <en:poultry broth
-fr:bouillon de volaille deshydraté
+fr:bouillon de volaille déshydraté
 
 # description:en:Chicken broth is broth made from chicken.
 
@@ -67189,7 +67189,7 @@ wikidata:en:Q19344541
 
 <en:crust
 en:inedible crust
-fr:croûte non comestible, crôute non consommable
+fr:croûte non comestible, croûte non consommable
 
 # <en:compound
 fr:crème pâtissière
@@ -67573,7 +67573,7 @@ vegan:en:ignore
 vegetarian:en:ignore
 
 <en:sauce
-fr:préparation deshydratée pour sauce
+fr:préparation déshydratée pour sauce
 
 <en:sauce
 fr:sauce au vinaigre balsamique

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -824,7 +824,7 @@ en:No thickening agent, No thickeners
 ca:Sense agent espessidor, Sense espessidors
 de:Ohne Verdickungsmittel
 fi:sakeuttamisaineeton, ei sakeutusaineita
-fr:Sans épaississant, Sans épaississants, Sans épaissisant, Sans épaissisants
+fr:Sans épaississant, Sans épaississants
 hu:Sűrítőanyagmentes, Nincs sűrítőanyag
 nl:Verdikkingsmiddelvrij, Zonder verdikkingsmiddel
 pt:Sem espessante

--- a/taxonomies/nutriments.txt
+++ b/taxonomies/nutriments.txt
@@ -1316,7 +1316,7 @@ et:Tärklis
 eu:Almidoi
 fa:نشاسته
 fi:Tärkkelys
-fr:amidon, fécules, fecule
+fr:amidon, fécules, fécule
 fy:Stiselmoal
 ga:Stáirse
 he:עמילן


### PR DESCRIPTION
The spelling errors were detected by comparing all FR ingredient tokens with Wikipedia tokens. Corrections were manually applied.