### PR TITLE
parse garlic (powdered)

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -902,6 +902,22 @@ sub parse_ingredients_text($) {
 										$debug_ingredients and $log->debug("between is a label", { between => $between, label => $labelid }) if $log->is_debug();
 										$between = '';
 									}
+									else {
+
+										# processing method?
+										my $processingid = 	canonicalize_taxonomy_tag($product_lc, "ingredients_processing", $between);
+										if (exists_taxonomy_tag("ingredients_processing", $processingid)) {
+											if (defined $processing) {
+												$processing .= ", " . $processingid;
+											}
+											else {
+												$processing = $$processingid;
+											}
+											$debug_ingredients and $log->debug("between is a processing", { between => $between, processing => $processingid }) if $log->is_debug();
+											$between = '';
+										}
+									}
+
 								}
 							}
 

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -1176,6 +1176,26 @@ zwiebel in würfel geschnitten, mandeln in würfel" },
 ]
 	],
 
+	# ingredient with (processing) in parenthesis
+	[ { lc => "en", ingredients_text => "garlic (powdered)",},
+[
+  {
+    'id' => 'en:garlic',
+    'processing' => 'en:powdered',
+    'text' => 'garlic'
+  }
+]
+	],
+	[ { lc => "fr", ingredients_text => "piment (en poudre)"},
+[
+  {
+    'id' => 'en:chili-pepper',
+    'processing' => 'en:powdered',
+    'text' => 'piment'
+  }
+]
+	],
+
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
changed the parsing algorithm so that the ingredients processing is recognized if it's in parenthesis after the ingredient. e.g. "Piment (en poudre)".