### PR TITLE
Update linking to hunger-games

### DIFF
--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -244,6 +244,9 @@ server {
 	location = /haz-su-donacion-a-open-food-facts {
 			try_files /donate/es.html =404;
 	}
+	location = /hunger-game {
+		return 301 https://hunger.openfoodfacts.org;
+	}
   
 	# Dynamically generated files and CGI scripts are passed
 	# to the Apache + mod_perl server running on a different

--- a/lang/en/texts/hunger-game.html
+++ b/lang/en/texts/hunger-game.html
@@ -1,7 +1,0 @@
-<!-- no side column -->
-
-<div id="root">
-</div>
-
-<script src="/js/hunger-game/bundle.min.js"></script>
-


### PR DESCRIPTION
Removed `/hunger-game` page;
Added redirect to `hunger.openfoodfacts.org` to nginx config.

To not break the userscript we need to wait for it to update to the new URL.
