### PR TITLE
tags pagination: do not create a 2nd count mongod query if less than 10k results

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1460,7 +1460,7 @@ sub query_list_of_tags($$) {
 
 	if ((not defined $results) or (ref($results) ne "ARRAY") or (not defined $results->[0])) {
 
-		# do not used the smaller cached products_ tags collection if ?nocache=1
+		# do not used the smaller cached products_tags collection if ?nocache=1
 		# or if the user is logged in and nocache is different from 0
 		if ( ((defined $request_ref->{nocache}) and ($request_ref->{nocache}))
 			or ((defined $User_id) and not ((defined $request_ref->{nocache}) and ($request_ref->{nocache} == 0)))
@@ -1533,23 +1533,23 @@ sub query_list_of_tags($$) {
 
 			my $count_results;
 
-			# do not used the smaller cached products_ tags collection if ?nocache=1
+			# do not used the smaller cached products_tags collection if ?nocache=1
 			# or if the user is logged in and nocache is different from 0
 			if ( ((defined $request_ref->{nocache}) and ($request_ref->{nocache}))
 				or ((defined $User_id) and not ((defined $request_ref->{nocache}) and ($request_ref->{nocache} == 0)))
 				) {
 				eval {
-					$log->debug("Executing MongoDB aggregate count query on products_tags collection", { query => $aggregate_count_parameters }) if $log->is_debug();
+					$log->debug("Executing MongoDB aggregate count query on products collection", { query => $aggregate_count_parameters }) if $log->is_debug();
 					$count_results = execute_query(sub {
-						return get_products_tags_collection()->aggregate( $aggregate_count_parameters, { allowDiskUse => 1 } );
+						return get_products_collection()->aggregate( $aggregate_count_parameters, { allowDiskUse => 1 } );
 					});
 				}
 			}
 			else {
 				eval {
-					$log->debug("Executing MongoDB aggregate count query on products collection", { query => $aggregate_count_parameters }) if $log->is_debug();
+					$log->debug("Executing MongoDB aggregate count query on products_tags collection", { query => $aggregate_count_parameters }) if $log->is_debug();
 					$count_results = execute_query(sub {
-						return get_products_collection()->aggregate( $aggregate_count_parameters, { allowDiskUse => 1 } );
+						return get_products_tags_collection()->aggregate( $aggregate_count_parameters, { allowDiskUse => 1 } );
 					});
 				}
 			}


### PR DESCRIPTION
This is a continuation of @syl10100 's PR : https://github.com/openfoodfacts/openfoodfacts-server/pull/3310

When  we have less than 10000 tags (which for almost all tags type is always the case, except for ingredients, editors, possibly categories), we can avoid making a separate count query: we know the number of results from the query that fetches them.