### PR TITLE
set max_retries_number to 0 for MongoDB queries, bug #3350

### DIFF
--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -63,7 +63,9 @@ sub execute_query {
 	return Action::Retry->new(
           attempt_code => sub { $action->run($sub) },
           on_failure_code => sub { my ($error, $h) = @_; die $error; }, # by default Action::Retry would return undef
-		  strategy => { Fibonacci => { max_retries_number => 3, } },
+		  # If we didn't get results from MongoDB, the server is probably overloaded
+		  # Do not retry the query, as it will make things worse
+		  strategy => { Fibonacci => { max_retries_number => 0, } },
       )->run();
 }
 


### PR DESCRIPTION
At the start of the project, I was retrying MongoDB queries once, and @hangy made a better system with Action::Retry. But when the MongoDB server is overloaded (as was the case a week ago), retrying queries make things worse, so I think we should turn off retries, unless at some point we put more than one MongoDB server.