### PR TITLE
Fixed overlap in country dropdown

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -327,6 +327,8 @@ p.details {
   font-size: 0.8em;
 }
 
+.select2-dropdown.select2-dropdown--below {margin-top: 10px;}
+
 @media only screen and (max-width: 40em) { h2 { font-weight:bold; font-size:1.2em;} }
 
 details.recent {


### PR DESCRIPTION
I edited the _off.scss file to add a margin-top to the dropdown menu. This way, the dropdown no longer overlaps the text and makes it easier to read and click on the arrow button. 

**Related issues and discussion:** #3354
<img width="300" alt="original" src="https://user-images.githubusercontent.com/21044058/80834850-8be0c780-8bbf-11ea-9fe2-8e94b8179398.png">
<img width="300" alt="fixed" src="https://user-images.githubusercontent.com/21044058/80834841-85eae680-8bbf-11ea-8cf8-4eb79bb5baa2.png">

