### PR TITLE
Non-EU packager codes download

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ trim_trailing_whitespace = true
 [*.{pm,pl,t}]
 indent_style = tab
 indent_size = 4
+
+# Python files: 4 spaces indentation
+[*.py]
+indent_size = 4

--- a/scripts/packager-codes/non-eu/README.md
+++ b/scripts/packager-codes/non-eu/README.md
@@ -1,0 +1,34 @@
+# Non-EU Packager Codes
+
+A Python application to download and manage non-EU packager codes, as listed on the official page: https://webgate.ec.europa.eu/sanco/traces/output/non_eu_listsPerCountry_en.htm.
+
+## Setup
+
+Requires Python 3.5 or newer. To install, create a virtual environment using your favorite manager and activate it, for example:
+
+```shell script
+python3 -m venv ~/.pyenvs/packager-codes
+source ~/.pyenvs/packager-codes/bin/activate
+```
+
+Install dependencies:
+
+```shell script
+pip install -r requirements.txt
+```
+
+## Usage
+
+Simply run `python packager_codes.py --help` to see the main help.
+
+To download packager code files in the directory `packager_codes_data`:
+
+```shell script
+python packager_codes.py download packager_codes_data
+```
+
+To display the status of the locally downloaded files as compared to the remote:
+
+````shell script
+python packager_codes.py status packager_codes_data
+````

--- a/scripts/packager-codes/non-eu/main.py
+++ b/scripts/packager-codes/non-eu/main.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+import json
+import logging
+from pathlib import Path
+import subprocess
+from typing import Any, Mapping, Sequence
+from urllib.request import urlopen
+
+import click
+
+
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+JSONObject = Mapping[str, Any]
+
+
+def scrape_document_info() -> Sequence[JSONObject]:
+    logger.info("Scraping document information")
+    # Try importing scrapy to check for dependency
+    import scrapy  # noqa
+
+    spider_file_path = Path("non_eu_spider.py").absolute()
+    cmd = "scrapy runspider --output - --output-format json --loglevel WARN".split(" ")
+    cmd.append(str(spider_file_path))
+    cmd_res = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
+    return json.loads(cmd_res.stdout.decode())
+
+
+def download_documents(document_info: Sequence[JSONObject], dest_dir: Path) -> None:
+    logger.info("Downloading %s documents into '%s'", len(document_info), dest_dir)
+    dest_dir = Path(dest_dir)
+    for i, doc_info in enumerate(document_info):
+        dest_path = dest_dir / doc_info["file_path"]
+        logger.info(
+            "(%s/%s) Downloading %s", i + 1, len(document_info), doc_info["url"]
+        )
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with urlopen(doc_info["url"]) as response, dest_path.open("wb") as dest_file:
+            dest_file.write(response.read())
+
+
+def get_diff(
+    scraped: Sequence[JSONObject], local: Sequence[JSONObject]
+) -> Mapping[str, Sequence[JSONObject]]:
+    scraped_names = {d["file_path"]: d for d in scraped}
+    local_names = {d["file_path"]: d for d in local}
+
+    new_docs = set(scraped_names.keys()).difference(local_names.keys())
+    removed_docs = set(local_names.keys()).difference(scraped_names.keys())
+    updated_docs = [
+        doc_name
+        for doc_name, doc in local_names.items()
+        if scraped_names[doc_name]["publication_date"] > doc["publication_date"]
+    ]
+
+    return {
+        "new": [scraped_names[n] for n in new_docs],
+        "removed": [local_names[n] for n in removed_docs],
+        "updated": [scraped_names[n] for n in updated_docs],
+    }
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command()
+@click.argument("data_dir", type=click.Path(file_okay=False))
+@click.option(
+    "--output-format", "-f", type=click.Choice(["summary", "json"]), default="summary"
+)
+def status(data_dir: str, output_format: str) -> None:
+    data_dir = Path(data_dir)
+
+    meta_path = data_dir / "meta.json"
+    logger.info("Loading local metadata from '%s'", meta_path)
+    if not meta_path.exists():
+        local_meta = {"document_info": []}
+    else:
+        with meta_path.open("r") as meta_file:
+            local_meta = json.load(meta_file)
+
+    scraped_info = scrape_document_info()
+    doc_diff = get_diff(scraped_info, local_meta["document_info"])
+
+    if output_format == "json":
+        from pprint import pprint
+
+        pprint(doc_diff)
+    else:
+        text = "Last updated: {}\nNew: {}, Removed: {}, Updated: {}".format(
+            local_meta.get("updated", "never"),
+            len(doc_diff["new"]),
+            len(doc_diff["removed"]),
+            len(doc_diff["updated"]),
+        )
+        click.echo(text)
+
+
+@main.command()
+@click.argument("dest_dir", type=click.Path(file_okay=False))
+def download(dest_dir: str) -> None:
+    dest_dir = Path(dest_dir)
+    if dest_dir.exists():
+        raise click.ClickException(
+            "destination directory '{}' already exists".format(dest_dir)
+        )
+    dest_dir.mkdir()
+
+    document_info = scrape_document_info()
+    download_documents(document_info, dest_dir)
+
+    meta_path = dest_dir / "meta.json"
+    logger.info("Writing metadata in '%s'", meta_path)
+    meta = {
+        "description": "OpenFoodFacts non-EU packager codes",
+        "updated": datetime.now().isoformat(),
+        "document_info": document_info,
+    }
+    with meta_path.open("w") as meta_file:
+        json.dump(meta, meta_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/packager-codes/non-eu/non_eu_spider.py
+++ b/scripts/packager-codes/non-eu/non_eu_spider.py
@@ -1,0 +1,54 @@
+from datetime import datetime, date
+from urllib.parse import urljoin
+from typing import Any
+
+import scrapy
+from scrapy.loader import ItemLoader
+from scrapy.loader.processors import MapCompose
+
+
+def get_one(values: list) -> Any:
+    if len(values) != 1:
+        raise ValueError("values list length must be equal to 1: {}".format(values))
+    return values[0]
+
+
+def extract_publication_date(date_str: str) -> date:
+    return datetime.strptime(date_str.strip(" ()"), "%d/%m/%Y").date()
+
+
+class NonEuDocumentItem(scrapy.Item):
+    country_name = scrapy.Field(output_processor=get_one)  # type: str
+    section = scrapy.Field(output_processor=get_one)  # type: str
+    title = scrapy.Field(output_processor=get_one)  # type: str
+    publication_date = scrapy.Field(
+        input_processor=MapCompose(extract_publication_date), output_processor=get_one
+    )  # type: datetime
+    file_path = scrapy.Field(output_processor=get_one)  # type: str
+    url = scrapy.Field(output_processor=get_one)  # type: str
+
+
+class NonEuSpider(scrapy.Spider):
+    name = "non_eu"
+    start_urls = [
+        "https://webgate.ec.europa.eu/sanco/traces/output/non_eu_listsPerCountry_en.htm"
+    ]
+
+    def parse(self, response):
+        for country_cell in response.xpath("//ul[@class='country-list']/li"):
+            country_name = country_cell.xpath("a[@class='country-name']/text()").get()
+
+            for section_table in country_cell.xpath("ul"):
+                section = section_table.xpath("preceding-sibling::h3[1]/text()").get()
+
+                for doc_link in section_table.xpath("li/a"):
+                    file_path = doc_link.xpath("@href").get()
+
+                    doc_loader = ItemLoader(item=NonEuDocumentItem(), selector=doc_link)
+                    doc_loader.add_value("country_name", country_name)
+                    doc_loader.add_value("section", section)
+                    doc_loader.add_xpath("title", "text()")
+                    doc_loader.add_xpath("publication_date", "span/text()")
+                    doc_loader.add_value("file_path", file_path)
+                    doc_loader.add_value("url", urljoin(response.url, file_path))
+                    yield doc_loader.load_item()

--- a/scripts/packager-codes/non-eu/packager_codes.py
+++ b/scripts/packager-codes/non-eu/packager_codes.py
@@ -62,15 +62,24 @@ def get_diff(
     }
 
 
-@click.group()
+@click.group(help="Manage non-EU packager code data.")
 def main():
     pass
 
 
-@main.command()
+@main.command(
+    help="Show local data status as compared to remote source.\n\n"
+         "DATA_DIR is the path to the local packager code data storage.",
+    no_args_is_help=True,
+)
 @click.argument("data_dir", type=click.Path(file_okay=False))
 @click.option(
-    "--output-format", "-f", type=click.Choice(["summary", "json"]), default="summary"
+    "--output-format",
+    "-f",
+    type=click.Choice(["summary", "json"]),
+    default="summary",
+    help="Command output format.",
+    show_default=True,
 )
 def status(data_dir: str, output_format: str) -> None:
     data_dir = Path(data_dir)
@@ -100,7 +109,11 @@ def status(data_dir: str, output_format: str) -> None:
         click.echo(text)
 
 
-@main.command()
+@main.command(
+    help="Download packager code files.\n\n"
+         "DEST_DIR is the path of the local directory in which to download data.",
+    no_args_is_help=True,
+)
 @click.argument("dest_dir", type=click.Path(file_okay=False))
 def download(dest_dir: str) -> None:
     dest_dir = Path(dest_dir)

--- a/scripts/packager-codes/non-eu/requirements.txt
+++ b/scripts/packager-codes/non-eu/requirements.txt
@@ -1,0 +1,3 @@
+# Requires Python >= 3.5
+click
+scrapy


### PR DESCRIPTION
Scripts to scrape non-EU packager codes, from this page: https://webgate.ec.europa.eu/sanco/traces/output/non_eu_listsPerCountry_en.htm. Usage instructions in README.md.

To do before merging: add code documentation and tests.