### PR TITLE
Add PERL5LIB environment variable to the docker images

### DIFF
--- a/docker/backend-dev/scripts/import_sample_data.sh
+++ b/docker/backend-dev/scripts/import_sample_data.sh
@@ -15,4 +15,4 @@ tar -xzvf 39-.images.tar.gz -C /opt/product-opener/html/images/products
 rm 39-.images.tar.gz
 
 echo "\033[32m------------------ 3/ Import products -------------------\033[0m";
-perl -I/opt/product-opener/lib -I/opt/perl/local/lib/perl5 /opt/product-opener/scripts/update_all_products_from_dir_in_mongodb.pl
+perl -I/opt/product-opener/lib /opt/product-opener/scripts/update_all_products_from_dir_in_mongodb.pl

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -56,6 +56,7 @@ RUN rm /etc/apache2/sites-enabled/000-default.conf
 
 # Copy Perl libraries from the builder image
 COPY --from=builder /tmp/local/ /opt/perl/local/
+ENV PERL5LIB /opt/perl/local/lib/perl5/
 
 EXPOSE 80
 


### PR DESCRIPTION
Makes it easier to run perl scripts, because the dependencies from CPAN are then already included.