### PR TITLE
Corrected Swedish translation for Propellent gas

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -1151,7 +1151,7 @@ pt:Gás propulsor
 ro:Agent de propulsare
 sk:Hnací plyn
 sl:Konzervans
-sv:Konserveringsmedel
+sv:Drivgas
 wikidata:en:Q50419221
 
 


### PR DESCRIPTION
Corrected Swedish translation for Propellent gas (Drivgas) from preservative (Konserveringsmedel)