### PR TITLE
Add Health Star Rating System from Australia

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -18239,10 +18239,18 @@ en:Health Star Rating, Health Star Rating System, HSR
 
 en:Health Star Rating 1
 
+en:Health Star Rating 1.5
+
 en:Health Star Rating 2
+
+en:Health Star Rating 2.5
 
 en:Health Star Rating 3
 
+en:Health Star Rating 3.5
+
 en:Health Star Rating 4
+
+en:Health Star Rating 4.5
 
 en:Health Star Rating 5

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -18234,3 +18234,15 @@ es:Símbolo de Pequeños Productores, SPP, Pequeños Productores
 fr:Symbole des Producteurs Paysans, SPP, Producteurs Paysans
 auth_name:en: SPP
 auth_url:en: https://spp.coop/
+
+en:Health Star Rating, Health Star Rating System, HSR
+
+en:Health Star Rating 1
+
+en:Health Star Rating 2
+
+en:Health Star Rating 3
+
+en:Health Star Rating 4
+
+en:Health Star Rating 5


### PR DESCRIPTION
**Description:**

Health Star Rating System claims to be used by more 10,000 products in Australia.
At least we could add these labels.

http://healthstarrating.gov.au/
