### PR TITLE
Mobile Fix for Product List layout

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -386,3 +386,10 @@ a[aria-controls="idOfLeftMenu"] {
   }
 
 }
+
+@media only screen and (max-width: 28.125em) {
+  .products li, ul.pagination li {float: none; display: inline-block;}
+  ul.products, #pages, ul.button-group  {text-align: center;}
+  ul.pagination li:first-child {display: block;}
+  ul.button-group li {margin-top: 3px;margin-bottom: 3px;}
+}

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -384,10 +384,9 @@ a[aria-controls="idOfLeftMenu"] {
   .icon {
     font-size: 1.8rem;
   }
-
 }
 
-@media only screen and (max-width: 28.125em) {
+@media #{$small-only} {
   .products li, ul.pagination li {float: none; display: inline-block;}
   ul.products, #pages, ul.button-group  {text-align: center;}
   ul.pagination li:first-child {display: block;}

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -392,4 +392,5 @@ a[aria-controls="idOfLeftMenu"] {
   ul.products, #pages, ul.button-group  {text-align: center;}
   ul.pagination li:first-child {display: block;}
   ul.button-group li {margin-top: 3px;margin-bottom: 3px;}
+  #main_column {height: auto !important;}
 }


### PR DESCRIPTION
I edited the _off.scss file by adding a media query that responds to a mobile device. The styles center the products, dropdown, and pagination. It also gets rid of the white-space as mentioned in the issue. 

**Related issues and discussion:** #3420
<img width="404" alt="product_after" src="https://user-images.githubusercontent.com/21044058/81866898-e3771f80-953d-11ea-9644-55c9e3660b09.png">
<img width="416" alt="paging_fixed" src="https://user-images.githubusercontent.com/21044058/81866928-eeca4b00-953d-11ea-8f07-8ba1ddd22918.png">
