### PR TITLE
Fix unescaped string in ingredient analysis

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4323,5 +4323,5 @@ msgstr "Add new entries, synonyms or translations to our multilingual lists of i
 
 # Do not translate #ingredients
 msgctxt "help_improve_ingredients_analysis_instructions"
-msgid "Join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis">ingredients analysis on our wiki</a>, if you would like to help. Thank you!"
-msgstr "If you would like to help, join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis">ingredients analysis on our wiki</a>. Thank you!"
+msgid "Join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingredients analysis on our wiki</a>, if you would like to help. Thank you!"
+msgstr "If you would like to help, join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingredients analysis on our wiki</a>. Thank you!"


### PR DESCRIPTION
Fix unescaped string in ingredient analysis msg that prevented synchronisation
