### PR TITLE
Fix syntax error in the ingredient analysis file

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4314,8 +4314,8 @@ msgid "You can help us recognize more ingredients and better analyze the list of
 msgstr "You can help us recognize more ingredients and better analyze the list of ingredients for this product and others:"
 
 msgctxt "help_improve_ingredients_analysis_1"
-msgstr "Edit this product page to correct spelling mistakes in the ingredients list, and/or to remove ingredients in other languages and sentences that are not related to the ingredients."
 msgid "Edit this product page to correct spelling mistakes in the ingredients list, and/or to remove ingredients in other languages and sentences that are not related to the ingredients."
+msgstr "Edit this product page to correct spelling mistakes in the ingredients list, and/or to remove ingredients in other languages and sentences that are not related to the ingredients."
 
 msgctxt "help_improve_ingredients_analysis_2"
 msgid "Add new entries, synonyms or translations to our multilingual lists of ingredients, ingredient processing methods, and labels."


### PR DESCRIPTION
A standard po file is 
msgctxt "
msgid "
and then msgstr "
