### PR TITLE
Turn the contact us into a more visible CTA on the partners page

### DIFF
--- a/lang/en/texts/partners.html
+++ b/lang/en/texts/partners.html
@@ -8,7 +8,7 @@
     <p>
 
     </p>
-    <p><a href="mailto:contact@openfoodfacts.org">Contact us</a> if you also want to support our action!</p>
+    <p><a href="mailto:contact@openfoodfacts.org" class="button">Contact us if you also want to support our action!</a></p>
 
     <p>Note: to stay independent, we do not accept financial support from companies and foundations related to the food industry, but we are happy to collaborate with producers to automatically integrate data and photos of their products into the database.</p>
 


### PR DESCRIPTION
Turn the contact us into a more visible CTA on the partners page