### PR TITLE
restrict cross language tag matching, fixes #3626

### DIFF
--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -175,6 +175,8 @@ use ProductOpener::Config2;
 
 );
 
+$options{product_type} = "beauty";
+
 @edit_rules = ();
 
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2133,7 +2133,7 @@ sub display_taxonomy_tag_link($$$) {
 	my $css_class = get_tag_css_class($target_lc, $tagtype, $tag);
 
 	my $html;
-	if ((defined $tag_lc) and ($tag_lc ne $lc)) {
+	if ((defined $tag_lc) and ($tag_lc ne $target_lc)) {
 		$html = "<a href=\"/$path/$tagurl\" class=\"$css_class\" lang=\"$tag_lc\">$tag_lc:$tag</a>";
 	}
 	else {
@@ -2191,15 +2191,9 @@ sub get_taxonomy_tag_and_link_for_lang($$$) {
 			and (defined $tag_lc) and (defined $translations_to{$tagtype}{$tagid}{$tag_lc})) {
 			# we have a translation for the tag language
 			# print STDERR "display_taxonomy_tag - translation for the tag language - translations_to{$tagtype}{$tagid}{$tag_lc} : $translations_to{$tagtype}{$tagid}{$tag_lc}\n";
-			if ($tag_lc eq 'en') {
-				# for English, use English tag without prefix as it will be recognized
-				$display = $translations_to{$tagtype}{$tagid}{$tag_lc};
-				$display_lc = 'en';
-			}
-			else {
-				$display = "$tag_lc:" . $translations_to{$tagtype}{$tagid}{$tag_lc};
-				$display_lc = $tag_lc;
-			}
+
+			$display = "$tag_lc:" . $translations_to{$tagtype}{$tagid}{$tag_lc};
+
 			$exists_in_taxonomy = 1;
 		}
 		else {
@@ -2682,6 +2676,11 @@ sub canonicalize_taxonomy_tag($$$)
 			# try matching in other languages
 			my @test_languages = ();
 			
+			if (($tagtype eq "countries") or ($tagtype eq "languages")
+				or ($tagtype eq "labels") or ($tagtype eq "origins")) {
+				@test_languages = ("en");
+			}
+			
 			if (defined $options{product_type}) {
 				
 				if ($options{product_type} eq "food") {
@@ -2689,7 +2688,7 @@ sub canonicalize_taxonomy_tag($$$)
 					if ($tagtype eq "ingredients") {
 						@test_languages = ("la");
 					}
-					elsif ($tagtype eq "additives") {
+					elsif (($tagtype eq "additives") or ($tagtype eq "minerals")) {
 						@test_languages = ("en");
 					}				
 				}
@@ -2979,8 +2978,8 @@ sub display_taxonomy_tag($$$)
 		$tag = $';
 	}
 	else {
-		# print STDERR "WARNING - display_taxonomy_tag - $tag has no language code, assuming lc: $lc\n";
-		$tag_lc = $lc;
+		# print STDERR "WARNING - display_taxonomy_tag - $tag has no language code, assuming target_lc: $lc\n";
+		$tag_lc = $target_lc;
 	}
 
 	my $tagid = $tag_lc . ':' . get_string_id_for_lang($tag_lc, $tag);
@@ -2997,13 +2996,8 @@ sub display_taxonomy_tag($$$)
 		if ((defined $translations_to{$tagtype}) and (defined $translations_to{$tagtype}{$tagid}) and (defined $translations_to{$tagtype}{$tagid}{$tag_lc})) {
 			# we have a translation for the tag language
 			# print STDERR "display_taxonomy_tag - translation for the tag language - translations_to{$tagtype}{$tagid}{$tag_lc} : $translations_to{$tagtype}{$tagid}{$tag_lc}\n";
-			if ($tag_lc eq 'en') {
-				# for English, use English tag without prefix as it will be recognized
-				$display = $translations_to{$tagtype}{$tagid}{$tag_lc};
-			}
-			else {
-				$display = "$tag_lc:" . $translations_to{$tagtype}{$tagid}{$tag_lc};
-			}
+
+			$display = "$tag_lc:" . $translations_to{$tagtype}{$tagid}{$tag_lc};
 		}
 		else {
 			$display = $tag;
@@ -3404,6 +3398,8 @@ sub add_tags_to_field($$$$) {
 			# we do not know the language of the current value of $product_ref->{$field}
 			# so regenerate it in the current language used by the interface / caller
 			$value = display_tags_hierarchy_taxonomy($tag_lc, $field, $product_ref->{$field . "_hierarchy"});
+			print STDERR "add_tags_to_fields value: $value\n";
+			
 			# Remove tags
 			$value =~ s/<(([^>]|\n)*)>//g;
 		}

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2679,14 +2679,35 @@ sub canonicalize_taxonomy_tag($$$)
 		}
 		else {
 
-			# try a few languages
-			my @test_languages = ("en", "fr", "de", "es", "pt", "it", "nl", "ru", "la");
-			# ingredients: the taxonomy is not complete, only try English and Latin (for OBF) to avoid false positives
-			if ($tagtype eq "ingredients") {
-				@test_languages = ("en", "la");
+			# try matching in other languages
+			my @test_languages = ();
+			
+			if (defined $options{product_type}) {
+				
+				if ($options{product_type} eq "food") {
+				
+					if ($tagtype eq "ingredients") {
+						@test_languages = ("la");
+					}
+					elsif ($tagtype eq "additives") {
+						@test_languages = ("en");
+					}				
+				}
+				elsif ($options{product_type} eq "beauty") {
+				
+					# Beauty products ingredients are often in English
+					if ($tagtype eq "ingredients") {
+						@test_languages = ("en", "la");
+					}
+					elsif ($tagtype eq "additives") {
+						@test_languages = ("en");
+					}				
+				}
 			}
 
 			foreach my $test_lc (@test_languages) {
+				
+				next if ($test_lc eq $tag_lc);
 
 				if ((defined $synonyms{$tagtype}) and (defined $synonyms{$tagtype}{$test_lc}) and (defined $synonyms{$tagtype}{$test_lc}{$tagid})) {
 					$tagid = $synonyms{$tagtype}{$test_lc}{$tagid};

--- a/t/additives_tags.t
+++ b/t/additives_tags.t
@@ -41,6 +41,7 @@ my @tests = (
 [ { lc => "pl", ingredients_text => "Mleczna baza [syrop glukozowy, oleje roślinne (kokosowy, z ziaren palmowych w zmiennych proporcjach), mleko w proszku odtłuszczone (5%), serwatka (z mleka) w proszku, regulatory kwasowości: fosforan dipotasowy, cytrynian trisodowy, białka mleka, substancja przeciwzbrylajaca: dwutlenek krzemu], cukier, kawa rozpuszczalna (8,7%), kawa zbożowa rozpuszczalna (ekstrakt prażonego jęczmienia i żyta) (6%), węglan magnezu, mleko w proszku pełne (1%), aromat. Produkt może zawierać soję." }, [ "en:e340ii", "en:e331iii", "en:e551" ] ],
 [ { lc => "pl", ingredients_text => "regulatory kwasowości: kwas cytrynowy i cytryniany sodu." }, [ "en:e330","en:e331" ] ],
 [ { lc => "es", ingredients_text => "Agua, edulcorantes (INS420, INS 960, INS N'952, INS N°954, INS°950, INS N 955), conservantes (INS.218, INS #202, INS N 216)."}, ["en:e420","en:e960","en:e952","en:e954","en:e950","en:e955","en:e218","en:e202","en:e216"]],
+[ { lc => "fr", ingredients_text => "cal" }, []],
 );
 
 foreach my $test_ref (@tests) {

--- a/t/allergens_tags.t
+++ b/t/allergens_tags.t
@@ -40,10 +40,6 @@ my @tests = (
 	[ { lc => "de", ingredients_text => "Zucker, Gewürze, Antioxidations-mittel: Ascorbinsâure, Konservierungsstoff: Natriumnitrit. Kann Spuren von Senf und Sellerie enthalten."}, [ ], [ "en:celery", "en:mustard"] ],
 	[ { lc => "it", ingredients_text => "Puo contenere tracce di frutta a guscio, sesamo, soia e uova"}, [ ], [ "en:eggs", "en:nuts", "en:sesame-seeds", "en:soybeans"] ],
 
-	# for languages when we don't have a translation for "and" in Ingredients.pm
-	# use " and "
-	[ { lc => "xx", ingredients_text => "NUTS AND SOMETHING" }, [ "en:nuts", ] ],
-
 	[ { lc => "fr", traces => "Traces de lait"}, [], ["en:milk"] ],
 	[ { lc => "fr", traces => "Peut contenir des traces de lait et d'autres fruits à coques"}, [], ["en:milk", "en:nuts"] ],
 	[ { lc => "fr", traces => "Lait, Gluten"}, [], ["en:gluten", "en:milk"] ],

--- a/t/ingredients_analysis.t
+++ b/t/ingredients_analysis.t
@@ -26,7 +26,7 @@ my @tests = (
 [ { lc => "fr", ingredients_text => "huile de palme, unknown ingredient" }, [ "en:palm-oil", "en:vegan-status-unknown", "en:vegetarian-status-unknown"] ],
 [ { lc => "fr", ingredients_text => "unknown ingredient" }, [ "en:palm-oil-content-unknown", "en:vegan-status-unknown", "en:vegetarian-status-unknown"] ],
 [ { lc => "fr", ingredients_text => "sucre, unknown ingredient" }, [ "en:palm-oil-content-unknown", "en:vegan-status-unknown", "en:vegetarian-status-unknown"] ],
-[ { lc => "fr", ingredients_text => "sucre, colour: e150" }, [ "en:palm-oil-free", "en:vegan", "en:vegetarian"] ],
+[ { lc => "fr", ingredients_text => "sucre, colorant: e150" }, [ "en:palm-oil-free", "en:vegan", "en:vegetarian"] ],
 [ { lc => "en", ingredients_text => "fat, proteins" }, [ "en:palm-oil-free", "en:non-vegan", "en:maybe-vegetarian"] ],
 [ { lc => "en", ingredients_text => "vegetable fat, vegetable proteins" }, [ "en:may-contain-palm-oil", "en:vegan", "en:vegetarian"] ],
 [ { lc => "en", ingredients_text => "modified palm oil" }, [ "en:palm-oil", "en:vegan", "en:vegetarian"] ],

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -569,14 +569,14 @@ my @tests = (
 	],
 
 # de:konzentriert (and children) and synonyms
-	[ { lc => "de", ingredients_text => "konzentriert shallot, konzentrierter haselnüsse, konzentrierte mandeln, konzentriertes acerola, 
+	[ { lc => "de", ingredients_text => "konzentriert schalotte, konzentrierter haselnüsse, konzentrierte mandeln, konzentriertes acerolakirschen, 
 		zweifach konzentriert, 2 fach konzentriert, doppelt konzentriertes, zweifach konzentriertes, 2-fach konzentriert, dreifach konzentriert, 
 		200fach konzentriertes, eingekochter" }, 
 		[
 			{
 				'id' => 'en:shallot',
 				'processing' => 'en:concentrated',
-				'text' => 'shallot'
+				'text' => 'schalotte'
 			},
 			{
 				'id' => 'en:hazelnut',
@@ -591,7 +591,7 @@ my @tests = (
 			{
 				'id' => 'en:acerola',
 				'processing' => 'en:concentrated',
-				'text' => 'acerola'
+				'text' => 'acerolakirschen'
 			},
 			{
 			    'id' => 'de:zweifach konzentriert',
@@ -631,7 +631,7 @@ my @tests = (
 # de:zerkleinert and variants
 	[ { lc => "de", ingredients_text => "Schalotte zerkleinert, zerkleinerte haselnüsse, zerkleinerter mandeln, zerkleinertes passionsfrucht, 
 						gurken grob zerkleinert, 
-						acerola fein zerkleinert, fein zerkleinerte spinat, 
+						acerolakirschen fein zerkleinert, fein zerkleinerte spinat, 
 						zwiebel zum teil fein zerkleinert,
 						haselnüsse feinst zerkleinert,
 						überwiegend feinst zerkleinert Feigen" }, 
@@ -664,7 +664,7 @@ my @tests = (
 						  {
 						    'id' => 'en:acerola',
 						    'processing' => 'de:fein-zerkleinert',
-						    'text' => 'acerola'
+						    'text' => 'acerolakirschen'
 						  },
 						  {
 						    'id' => 'en:spinach',
@@ -751,7 +751,7 @@ my @tests = (
 	# Test for de:getrocknet and synonyms
 		[ { lc => "de", ingredients_text => "Schalotte getrocknet, getrocknete mandeln, getrockneter zwiebel, 
 				 haselnüsse in getrockneter form, halbgetrocknete spinat, halbgetrocknet gurken, Feigen halb getrocknet, 
-				 Holunder gefriergetrocknet, gefriergetrocknete Papaya, gefriergetrocknetes Kiwi, sonnengetrocknet Ananas, 
+				 Holunder gefriergetrocknet, gefriergetrocknete Papaye, gefriergetrocknetes Kiwi, sonnengetrocknet Ananas, 
 				 sonnengetrocknete Pflaumen, an der Sonne getrocknete Grapefruit, Guaven luftgetrocknet, luftgetrockneter Hagebutten, 
 				 Traube sprühgetrocknet, sprühgetrockneter Tamarinde" }, 
 				[
@@ -798,7 +798,7 @@ my @tests = (
 				  {
 				    'id' => 'en:papaya',
 				    'processing' => 'en:freeze-dried',
-				    'text' => 'Papaya'
+				    'text' => 'Papaye'
 				  },
 				  {
 				    'id' => 'en:kiwi',

--- a/t/tags.t
+++ b/t/tags.t
@@ -167,7 +167,7 @@ is_deeply($product_ref->{categories_tags},
 
 is($product_ref->{categories}, "Alimentos y bebidas de origen vegetal, Alimentos de origen vegetal, Frutas y verduras y sus productos, Frutas y sus productos, Frutas, Manzanas, Frutas del bosque, Frutas tropicales, Plátanos, Ciruelas, Frambuesas, naranjas, limones");
 
-add_tags_to_field($product_ref, "it", "categories", "bogus, limone");
+add_tags_to_field($product_ref, "it", "categories", "bogus, mele");
 compute_field_tags($product_ref, "it", "categories");
 
 is_deeply($product_ref->{categories_tags},
@@ -189,7 +189,8 @@ is_deeply($product_ref->{categories_tags},
    'it:bogus',
  ]
 
-) or diag explain $product_ref->{categories_tags};
+#) or diag explain $product_ref->{categories_tags};
+) or diag explain $product_ref;
 
 
 $product_ref = {
@@ -212,11 +213,11 @@ is_deeply($product_ref->{countries_tags},
    'en:bolivia',
    'en:colombia',
    'en:france',
-   'en:germany',
    'en:italy',
    'en:spain',
    'en:switzerland',
-   'fr:bidon'
+   'fr:bidon',
+   'fr:deutschland',
 ]
 )  or diag explain $product_ref->{countries_tags};
 
@@ -228,13 +229,13 @@ is_deeply($product_ref->{countries_tags},
    'en:bolivia',
    'en:colombia',
    'en:france',
-   'en:germany',
    'en:italy',
    'en:peru',
    'en:spain',
    'en:switzerland',
    'es:bogus',
-   'fr:bidon'
+   'fr:bidon',
+   'fr:deutschland',
 ]
 )  or diag explain $product_ref->{countries_tags};
 
@@ -482,7 +483,7 @@ is_deeply(canonicalize_taxonomy_tag("fr", "test", "yaourt banane"), "en:banana-y
 is_deeply(canonicalize_taxonomy_tag("fr", "test", "yogourts à la banane"), "en:banana-yogurts");
 is_deeply(canonicalize_taxonomy_tag("fr", "labels", "european v-label vegetarian"), "en:european-vegetarian-union-vegetarian");
 
-is_deeply(canonicalize_taxonomy_tag("en", "labels", "pur jus"), "en:pure-juice");
+is_deeply(canonicalize_taxonomy_tag("fr", "labels", "pur jus"), "en:pure-juice");
 # should not be matched to "pur jus" in French and return "en:pure-juice"
 is_deeply(canonicalize_taxonomy_tag("en", "labels", "au jus"), "en:au jus");
 

--- a/taxonomies/amino_acids.txt
+++ b/taxonomies/amino_acids.txt
@@ -14,6 +14,7 @@
 en:L-alanine
 bg:L-аланин
 de:L-Alanin
+fr:L-alanine
 hu:L-alanin
 it:L-alanina
 lt:L-alaninas
@@ -30,6 +31,7 @@ el:L-αργινίνη
 es:L-arginina
 et:L-arginiin
 fi:L-arginiini
+fr:L-arginine
 hu:L-arginin
 it:L-arginina
 lt:L-argininas
@@ -423,6 +425,7 @@ el:L-τυροσίνη
 es:L-tirosina
 et:L-türosiin
 fi:L-tyrosiini
+fr:L-tyrosine
 hu:L-tirozin
 it:L-tirosina
 lt:L-tirozinas
@@ -443,6 +446,7 @@ el:L-βαλίνη
 es:L-valina
 et:L-valiin
 fi:L-valiini
+fr:L-valine
 hu:L-valin
 it:L-valina
 lt:L-valinas

--- a/taxonomies/ingredients.result.txt
+++ b/taxonomies/ingredients.result.txt
@@ -1,27 +1,29 @@
 stopwords:ca:i
-stopwords:da:av, bl. a
-stopwords:de:und, mit, von, aus, enthält, enthalten,mindestens
+stopwords:da:av, blandt andet, bl a, inklusive, heraf
+stopwords:de:und, mit, von, aus, enthält, enthalten, mindestens
 stopwords:el:περιέχει
 stopwords:en:a,an,for,added,to
 stopwords:en:of
-stopwords:en:contains, contain, from, with, produced with, with added
+stopwords:en:contains, contain, from, with, produced with, with added, minimum
 stopwords:es:de,del,la,las,los,una
 stopwords:es:contiene,de,del,la,el,las,los,con,y,e,minimo,maximo,puede,contener,por,categoria,calibre,minimo,min,vereidad,de cultivo,origen,nota,produccion,controlada
-stopwords:fi:sisältää,muun muassa,valio,snellmanin
+stopwords:fi:sisältää,muun muassa,valio,snellmanin, jossa
 stopwords:fr:la,les,des,du,de,d,un,une,ajouté,ajoutés,ajoutée,ajoutées,pour
 stopwords:fr:de,d,des,du,le,la,les,a,aux
 stopwords:fr:aux,au,de,le,du,la,a,et,avec,base,ou,en,proportion,variable, contient, élaboré avec, papier traité, minimum, filets tournants et filets, pour souleves,dont,avec,autres,d'autres,d'
 stopwords:hr:sastojci
 stopwords:hu:tartalmaz, változó arányban, min, zsírtartalom, összetevő, összetétel, amelyből, amiből
 stopwords:id:mengandung
+stopwords:is:úr
 stopwords:it:contiene, nella
+stopwords:nb:av, fra, bl a, blant annet
 stopwords:nl:bevat, met, waarvan, bevatten, van, vervaardigd met, behandeld papier, waaraan toegevoegd, aangezuurd, cacaobestanddelen
 stopwords:nn:av
-stopwords:pl:w tym
+stopwords:pl:w tym, zawiera
 stopwords:pt:do qual, dos quais
 stopwords:sk:obsahuje
 stopwords:sl:vsebuje, sestavine
-stopwords:sv:från, med
+stopwords:sv:av, från, med, innehåller, inklusive, bl a, bland annat, minimum, maximum, varav, certifierad
 stopwords:zh::配料
 
 
@@ -207,20 +209,6 @@ de:Buckellachs (Oncorhynchus gorbuscha)
 fr:Oncorhynchus gorbuscha, Saumon rose à bosse
 la:Oncorhynchus gorbuscha
 
-en:rehydrated soy protein
-de:Rehydriertes Sojaprotein, rehydriertes Sojaproteinisolat, angerührtes Sojaproteinisolat
-es:Proteina de soya rehidratada
-fi:uudelleen hydratoitu soijaproteiini
-fr:protéines de soja réhydratées, protéines végétales de soja réhydratées
-hu:rehidratált szójafehérje
-nl:gerehydrateerde soja-eiwit
-
-< en:Special bread
-de:Sesambrötchen
-
-< en:Strawberry
-fr:morceaux de fraise
-
 fr:extrait naturel d'épice, extraits naturels d'épices
 fi:luontainen mausteuute
 
@@ -247,31 +235,19 @@ fi:uunipaahdettu broilerinfilee
 nl:scharrelkipeiwitpoeder
 
 < de:Joghurtpulver
+en:skimmed milk yogurt powder
 de:Magermilchjoghurtpulver
 fi:jogurttijauhe rasvattomasta maidosta
+sv:skumyoghurtpulver, skummjölksyoghurtpulver
 
 de:kakaohaltiges Getränkepulver
 
 de:Markklößchen
 
-de:Nitritpökelsalz
-
-< de:Nährhefe
-de:Nährhefepulver
-
 < de:Quellkohlensäure
 de:natürliche Quellkohlensäure
 
 de:Reisextrudat
-
-< de:Roggensauerteig
-fr:levain de seigle déshydraté et dévitalisé
-
-< de:Roggensauerteig
-fr:levain de seigle dévitalisé
-
-< de:Roggensauerteig
-nl:rogge zuurdesempoeder
 
 < de:Roggenvollkornschrot
 < en:Malt
@@ -288,6 +264,7 @@ fi:vanilliiniaromi
 fr:
 hu:
 it:
+sv:vanillinarom
 
 < en:Acacia honey
 < en:Honey
@@ -347,12 +324,12 @@ en:Acid, Acidifier
 bg:Киселина
 ca:Acidulant, Àcid
 cs:Kyselina
-da:Syre, Almindelig Syre
+da:Syre, Syrer, Almindelig Syre
 de:Säuerungsmittel, Sauerungsmittel
 el:Μέσο οξίνισης
 es:Acidulante, acidulantes, acidificante
 et:Hape
-fi:Happo, happoa, hapot, happoja
+fi:Happo, Happoa, Hapot, Happoja
 fr:Acidifiant, acide
 ga:Aigéad
 he:חומצה
@@ -361,14 +338,15 @@ it:Acidificante, acidificanti
 lt:Rūgštis
 lv:Skābe
 mt:Aċidu
+nb:Syre, Syrer
 nl:Voedingszuur
 pl:Kwas, Kwasy
 pt:Acidificante
-ro:Acidifiant
+ro:Acidifiant, Agent acidifiant
 ru:Кислота
 sk:Kyselina
 sl:Kislina
-sv:Syra
+sv:Syra, Syror, Surgörare
 description:cs: Kyselinami se rozumějí látky, které zvyšují kyselost potraviny nebo jí udělují kyselou chuť.
 description:da: Syrer: stoffer, der øger en fødevares surhedsgrad og/eller giver den en sur smag.
 description:de: Säuerungsmittel sind Stoffe, die den Säuregrad eines Lebensmittels erhöhen und/oder diesem einen sauren Geschmack verleihen.
@@ -394,28 +372,30 @@ en:Acidity regulator, alkali, base, buffer, buffering agent, pH adjusting agent
 bg:Регулатор на киселинност
 ca:Corrector de l'acidesa, correctors de l'acidesa, Corrector d'acidesa, regulador d'acidesa
 cs:Regulátor kyselosti
-da:Surhedsregulerende middel, surhedsregulerende midler
+da:Surhedsregulerende middel, Surhedsregulerende midler
 de:Säureregulator, Säureregulatoren
 el:Ρυθμιστής οξύτητας
 es:Corrector de acidez, correctores de acidez, regulador de la acidez, agente de regulación del pH, agente regulador, reguladores de acidez, soluciones reguladoras, álcali, base, regulador de acidez
 et:Happesuse regulaator, happesuse regulaatorid
-fi:Happamuudensäätöaine, happamuudensäätöaineet
+fi:Happamuudensäätöaine, Happamuudensäätöaineet, Happamuudensäätöainetta, Happamuudensäätöaineita
 fr:Correcteur d'acidité, régulateur de l'acidité, agent tampon, ajusteur du pH, alcali, base, tampon, régulateur d'acidité
 ga:Rialtán aigéadachta
 he:מווסת חומציות
 hu:Savanyúságot szabályozó anyag, Savanyúságot szabályozó anyagok, Savanyúságot szabályzó anyag, Savanyúságot szabályzó anyagok
+is:Sýrustillar
 it:Correttore di acidità, correttori di acidità, regolatore di acidità, regolatori di acidità
 lt:Rūgštingumą reguliuojanti medžiaga
 lv:Skābuma regulētājs
 mt:Regolatur tal-Aċidità
+nb:Surhetsregulerende middel, Surhetsregulerende midler
 nl:Zuurteregelaar
 pl:Regulator kwasowości, Regulatory kwasowości
 pt:Regulador de acidez, reguladores de acidez
-ro:Corector de aciditate
+ro:Corector de aciditate, Regulator de aciditate
 ru:Регулятор кислотности
 sk:Regulátor kyslosti
 sl:Sredstvo za uravnavanje kislosti
-sv:Surhetsreglerande medel
+sv:Surhetsreglerande medel, Surhetsreglerandemedel, Surhetsregulator
 description:cs: Regulátory kyselosti se rozumějí látky, které mění nebo řídí kyselost nebo alkalitu potraviny.
 description:da: Surhedsregulerende midler: stoffer, som ændrer eller fastholder en fødevares surhedsgrad.
 description:de: Säureregulatoren sind Stoffe, die den Säuregrad oder die Alkalität eines Lebensmittels verändern oder steuern.
@@ -476,6 +456,7 @@ is:agave-síróp
 it:sciroppo d'agave
 nl:agavesiroop
 ru:Сироп агавы
+sv:agavesirap
 zh:龍舌蘭糖漿
 vegan:en: yes
 vegetarian:en: yes
@@ -505,6 +486,7 @@ fi:alaskanseitifilee
 fr:filet de colin d'Alaska, filets de colin d'alaska
 it:Fietti di Merluzzo dell'Alaska
 nl:Alaska koolvisfilet
+sv:alaska pollock-filé, filé av alaska pollock
 
 < en:Alaska pollock
 fr:Portions de bloc de filets de COLIN d'Alaska MSC
@@ -564,8 +546,66 @@ carbon_footprint_fr_foodges_value:fr: 2.7
 
 < en:Alcohol
 en:brandy
+af:brandewyn
+ar:براندي
+be:брэндзі
+bg:бренди
+ca:brandi
+cs:brandy
+cy:brandi
+da:brandy
+de:weinbrand
+el:μπράντυ
 es:brandy
+et:brändi
+eu:brandy
+fa:برندی
+fi:brandy
 fr:brandy
+ga:branda
+gd:branndaidh
+gl:brandy
+gu:બ્રાન્ડી
+he:ברנדי
+hi:ब्रांडी
+hr:vinjak
+hu:borpárlat
+hy:բրենդի
+id:brendi
+io:brandio
+is:brandí
+it:brandy
+ja:ブランデー
+ka:ბრენდი
+ko:브랜디
+lb:wäibrand
+lt:brendis
+lv:brendijs
+ms:brandi
+mt:brendi
+my:ဘရန်ဒီ
+nb:brandy
+nl:brandewijn
+oc:brandy
+pa:ਬਰਾਂਡੀ
+pl:brandy
+pt:conhaque
+ro:vinars
+ru:бренди
+sd:برانڊي
+sr:бренди
+sv:brandy
+ta:பிராந்தி
+te:బ్రాందీ
+th:บรั่นดี
+tr:brendi
+uk:бренді
+ur:برینڈی
+uz:brendi
+vi:brandy
+zh:白兰地
+wikidata:en: Q146470
+wikipedia:en: https://en.wikipedia.org/wiki/Brandy
 
 < en:Alcohol
 en:calvados
@@ -664,6 +704,7 @@ fr:cognac
 hu:cognac, konyak
 it:Cognac
 nl:cognac
+sv:cognac, konjak
 
 < en:Alcohol
 en:Cointreau
@@ -869,6 +910,7 @@ it:rum
 nl:Rum
 pl:Rum
 ru:Ром
+sv:rom
 
 < en:Alcohol
 en:tequila
@@ -944,6 +986,7 @@ hu:vermut
 
 < en:Alcohol
 en:whiskey, whiskeys
+da:whisky
 de:Whiskey
 es:Whiskey
 fi:viski
@@ -1219,10 +1262,10 @@ nn:Søl
 wikipedia:en: https://en.wikipedia.org/wiki/Palmaria_palmata
 
 < en:Algae
-en:Lithotamnium calcareum
-de:Rotalge (Lithotamnium calcareum)
+en:Lithothamnium calcareum
+de:Rotalge (Lithothamnium calcareum)
 fr:algue lithothamnium calcareum, algue marine lithothamnium calcareum
-la:Lithotamnium calcareum
+la:Lithothamnium calcareum
 
 < en:Algae
 en:seaweed
@@ -1277,7 +1320,9 @@ wikipedia:en: https://en.wikipedia.org/wiki/Seaweed
 < en:Seaweed
 en:seaweed extract
 de:Seealgenextrakt
+fi:merileväuute
 fr:extrait d'algues marines
+sv:tångextrakt
 
 < en:Almond
 < en:Hazelnut
@@ -1353,10 +1398,11 @@ pt:amêndoas laminadas
 en:ground almonds
 de:Erdmandeln
 es:almendras molidas
-fi:Jauhettua mantelia, jauhettuja manteleita
+fi:Jauhettua mantelia, jauhettuja manteleita, mantelirouhe
 fr:amandes hachées, amandes moulues
 it:mandorle macinate
 nl:gemalen amandelen
+sv:mandelkross
 
 < en:Almond
 en:organic almond flour
@@ -1429,6 +1475,7 @@ la:Homarus americanus
 < en:American lobster
 fr:bouillon de homard
 de:Hummerbouillon
+sv:hummerfond
 
 < en:American lobster
 fr:pulpe de homard
@@ -1546,6 +1593,7 @@ fi:anjovisuute
 fr:extrait d'anchois
 it:estratto d'acciughe
 nl:ansjovisextract
+sv:ansjovisextrakt
 
 < en:Anchovy
 en:anchovy filets
@@ -1628,12 +1676,146 @@ vegan:en: no
 vegetarian:en: no
 
 < en:Animal
+en:horse
+af:perd
+am:ፈረስ
+an:equus caballus
+ar:خيل
+as:ঘোঁৰা
+av:чу
+ay:kawallu
+az:ev atı
+ba:йорт аты
+be:конь свойскі
+bg:кон
+bi:horse
+bn:ঘোড়া
+bo:རྟ།
+br:marc'h
+bs:konj
+ca:cavall
+co:cavaddu
+cs:kůň
+cv:килти лаша
+cy:ceffyl
+da:hest
+de:hauspferd
+el:άλογο
+eo:ĉevalo
+es:equus ferus caballus
+et:hobune
+eu:zaldi
+fa:اسب
+fi:hevonen
+fj:ose
+fo:ross
+fr:cheval
+fy:hynder
+ga:capall
+gd:each
+gl:cabalo
+gn:kavaju
+gu:ઘોડો
+gv:cabbyl
+he:סוס הבית
+hi:घोड़ा
+hr:domaći konj
+ht:cheval
+hu:ló
+hy:ձի
+ia:cavallo
+id:kuda
+ik:tuttuqpak
+io:kavalo
+is:hestur
+it:equus ferus caballus
+ja:ウマ
+jv:jaran
+ka:შინაური ცხენი
+kk:жылқы
+kn:ಕುದುರೆ
+ko:말
+ks:گُر
+ku:hesp
+kv:вӧв
+kw:margh
+ky:жылкы
+la:equus ferus caballus
+li:taam peerd
+ln:farása
+lo:ມ້າ
+lt:naminis arklys
+lv:mājas zirgs
+mg:soavaly
+mk:коњ
+ml:കുതിര
+mn:адуу
+mr:घोडा
+ms:kuda
+mt:żiemel
+my:မြင်း
+nb:hest
+ne:घोडा
+nl:paard
+nn:hest
+nv:łį́į́ʼ
+oc:equus caballus
+or:ଘୋଡ଼ା
+os:бæх
+pa:ਘੋੜਾ
+pl:koń
+ps:آس
+pt:cavalo
+qu:kawallu
+rm:chaval
+ro:cal
+ru:домашняя лошадь
+rw:ifarashi
+sa:अश्वः
+sc:caddu
+sd:گهوڙو
+se:heabuš
+sg:mbarata
+sh:domaći konj
+sk:kôň
+sl:domači konj
+sm:solofanua
+sn:bhiza
+so:faras
+sq:kali
+sr:домаћи коњ
+su:kuda
+sv:häst
+sw:farasi
+ta:குதிரை
+te:గుర్రము
+tg:асп
+th:ม้า
+tl:kabayo
+tr:at
+tt:йорт аты
+ug:ئات
+uk:кінь свійський
+ur:گھوڑا
+uz:ot (hayvon)
+vi:ngựa
+vo:jevod
+wa:tchivå
+wo:fas w
+yi:פערד
+yo:ẹṣin
+za:max
+zh:马
+wikidata:en: Q726
+wikipedia:en: https://en.wikipedia.org/wiki/Horse
+
+< en:Animal
 en:pork
 ca:Porc
 da:Svin
 de:Schwein
 es:cerdo
-fi:sika
+fi:sika, siasta, sian
 fr:porc
 he:חזיר
 hu:sertés, disznó, malac
@@ -1905,7 +2087,7 @@ eo:Ŝmalco
 es:grasa de cerdo, grasa animal de cerdo, tocino, magro de cerdo, manteca
 eu:Txerri-gantz
 fa:چربی خوک
-fi:Silava
+fi:ihra, silava, läski
 fr:saindoux, gras de porc
 ga:Blonag
 gd:Blonag
@@ -1926,8 +2108,8 @@ pt:banha
 ru:Смалец
 sh:Svinjska mast
 sl:Svinjska mast
-sr:Svinjska mast # sr-el:Svinjska mast
-sv:Ister, fett fläsk
+sr:Svinjska mast
+sv:Ister, fett fläsk, grisfett, fett från gris
 th:มันหมู
 tl:Untosinsal
 tr:Domuz yağı
@@ -1967,12 +2149,12 @@ ca:Proteïna de la llet, proteïnes de la llet
 da:mælkeprotein
 de:Milcheiweiß, Milchprotein, Milcheiweißerzeugnis, Milcheiweisserzeugnis, Magermilchpulverzusatz, Milcheiweiss, Milchproteine
 es:proteína de leche
-fi:maitoproteiini
+fi:maitoproteiini, maitoproteiinit
 fr:protéine de lait, protéines de lait, protéines du lait, protéines laitières, protéines lactiques, protéine lactique, lactoprotéine, lactoprotéines
 hu:tejfehérjék, tejfehérje
 it:proteine del latte
 nl:melkeiwit, melkeiwitten
-pl:Białka mleczne
+pl:Białka mleczne, białka mleka
 pt:proteína do leite, proteínas lácteas
 ro:proteine din lapte
 ru:молочный белок, молочные белки
@@ -1992,6 +2174,7 @@ fi:sianlihaproteiini
 fr:Protéines de porc
 hu:sertésfehérje, sertéshúsfehérje, sertés fehérje
 ro:proteină de porc, proteina de porc
+sv:animaliskt protein av gris
 vegetarian:en: no
 
 < en:Aniseed
@@ -2027,7 +2210,7 @@ pt:Antiaglomerante
 ro:Agent antiaglomerant
 sk:Protihrudkovacia látka
 sl:Sredstvo proti sprijemanju
-sv:Klumpförebyggande medel
+sv:Klumpförebyggande medel, Klumpförebyggandemedel
 description:cs: Protispékavými látkami se rozumějí látky, které snižují sklon jednotlivých částic potraviny ulpívat vzájemně na sobě.
 description:da: Antiklumpningsmidler: stoffer, der reducerer en fødevares individuelle partiklers tendens til at klæbe sammen.
 description:de: Trennmittel sind Stoffe, die die Tendenz der einzelnen Partikel eines Lebensmittels, aneinander haften zu bleiben, herabsetzen.
@@ -2111,12 +2294,13 @@ it:Antiossidante, antiossidanti, agente antiossidante, agenti antiossidanti
 lt:Antioksidantas
 lv:Antioksidants
 mt:Antiossidant
+nb:Antioxidant, Antioksidant
 nl:Antioxydant, Antioxydanten
 pl:Przeciwutleniacz, przeciwutleniacze
 pt:Antioxidante
 ru:антиоксидант, антиокислитель
 sl:Antioksidant
-sv:Antioxidationsmedel
+sv:Antioxidationsmedel, Antioxidantmedel
 description:cs: Antioxidanty se rozumějí látky, které prodlužují trvanlivost potravin tím, že je chrání proti zkáze způsobené oxidací, například proti žluknutí tuků a barevným změnám.
 description:da: Antioxidanter: stoffer, som forlænger en fødevares holdbarhed ved at beskytte den mod ødelæggelse ved iltning som f.eks. fedtharskning og misfarvning.
 description:de: Antioxidationsmittel sind Stoffe, die die Haltbarkeit von Lebensmitteln verlängern, indem sie sie vor den schädlichen Auswirkungen der Oxidation wie Ranzigwerden von Fett und Farbveränderungen schützen.
@@ -2142,9 +2326,10 @@ wikidata:en: Q133948
 en:apple extract
 de:Apfelextrakt
 es:extracto de manzana
-fi:omenauute
+fi:omenauute, omenatiiviste, makeuttava omenauute
 fr:extrait de pomme, concentré de pomme
 nl:appelextract
+sv:äppelkoncentrat, äppelextrakt, sötande äppelextrakt
 
 < en:Apple
 en:apple pieces
@@ -2166,6 +2351,7 @@ nl:gedroogde appel
 pl:liofilizowane jabłka
 pt:maçãs desidratadas
 ru:Сушеное яблоко
+sv:torkat äpple
 
 < en:Apple
 en:Gala apple, Gala apples
@@ -2252,12 +2438,13 @@ sv:äppeljuicekoncentrat
 
 < en:Apple juice
 en:organic apple juice
-da:Økologisk appensinjuice
+da:økologisk æblejuice
 de:Bio-Apfelsaft
 es:Zumo de manzana orgánico
 fi:luomuomenamehu, luomuomenatäysmehu, luomu omenamehu, luomu omenatäysmehu
 fr:jus de pomme issu de l'agriculture biologique, jus de pomme bio, jus de pomme biologique, jus de pommes issues de l'agriculture biologique, jus de pommes bio
 ru:Органический яблочный сок
+sv:ekologisk äppeljuice
 
 < en:Apple juice
 en:pure apple juice
@@ -2271,6 +2458,7 @@ en:dried apple pieces
 de:getrocknete Apfelstückchen
 fi:kuivattu omena paloina
 fr:Morceaux de pommes séchées
+sv:torkade äppelbitar
 
 < en:Apple purée
 fr:purée de pommes concentrée, purée de pomme concentrée, concentrés végétaux de pomme
@@ -2287,7 +2475,9 @@ de:Aprikosenkerne
 es:huesos de albaricoque
 fi:aprikoosinsiemen, aprikoosinsiemenet
 fr:noyaux d'abricots, noyau d'abricot
+nb:aprikoskjerner
 nl:abrikozenpitten
+sv:aprikoskärnor
 
 < en:Apricot
 en:dried apricots
@@ -2563,9 +2753,11 @@ fi:leivinjauhe
 fr:levure chimique
 hu:sütőpor
 it:lievito in polvere
+nb:bakepulver
 nl:bakpoeder
 pl:Proszek do pieczenia
 ro:praf de copt
+sv:bakpulver
 vegan:en: yes
 vegetarian:en: yes
 
@@ -2583,6 +2775,7 @@ de:weißer balsamico Essig
 fi:vaalea balsamietikka
 fr:vinaigre balsamique blanc
 hu:fehér balzsamecet
+sv:vit balsamvinäger
 
 < en:Bamboo
 en:bamboo shoot, bamboo sprouts
@@ -2620,7 +2813,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Bamboo_shoot
 
 < en:Bamboo fibre
 en:bamboo shoot fiber
-de:en:bamboo fibre
+de:bamboo fibre
 fr:fibres de pousses de bambou
 it:fibra di germoglio di bambù
 nl:vezels van bamboescheuten
@@ -2646,6 +2839,13 @@ it:banane secche
 nl:gedroogde banaan
 
 < en:Banana
+< en:Fruit juice
+en:banana juice
+de:bananensaft
+fi:banaanimehu, banaanitäysmehu
+fr:jus de banane
+
+< en:Banana
 < en:Purée
 en:banana puree
 de:Bananenpüree
@@ -2657,6 +2857,7 @@ it:purea di banana
 nl:Bananenpuree
 
 < en:Barley
+en:barley flakes
 de:Gerstenflocken
 fi:ohrahiutale
 fr:flocons d'orge, flocon d'orge
@@ -2664,6 +2865,7 @@ hu:árpapehely
 it:fiocchi d'orzo
 nl:gerstvlokken
 pl:płatki jęczmienne
+sv:kornflingor
 
 < en:Barley
 en:Pearl Barley
@@ -2697,6 +2899,7 @@ pl:Mąka jęczmienna
 pt:farinha de cevada
 ro:făină de orz
 ru:Ячменная мука
+sv:kornmjöl
 
 < en:Barley flour
 en:dextrinated barley flour
@@ -2718,12 +2921,16 @@ fi:täysjyväohrajauho
 fr:farine complète d'orge, farine d'orge complète
 hu:teljes kiőrlésű árpaliszt
 nl:volkoren gerstemeel
+sv:fullkornskornmjöl
 
 < en:Barley malt extract
 de:getrockneter Gerstenmalzextrakt
 
 < en:Barley malt extract
 fr:extrait de malte d'orge houblonné
+
+< en:Barley malt syrup
+fr:sirop de malt d'orge déshydraté
 
 < en:Barn eggs
 nl:scharrel ei poeder
@@ -2781,6 +2988,7 @@ nl:witte basmatirijst
 < en:Basmati rice
 fr:riz basmati cuit
 de:Basmati-Reis gekocht
+fi:keitetty basmatiriisi, kypsennetty basmatiriisi
 it:riso Basmati cotto
 nl:gekookte basmatirijst
 
@@ -2792,6 +3000,7 @@ es:Alubias negras
 fi:mustapapu, mustapavut
 fr:haricots noirs
 nl:Zwarte bonen
+sv:svarta bönor
 
 < en:Beans
 en:great northern beans
@@ -2799,16 +3008,22 @@ fr:Haricots blancs, lingots blancs, haricots lingots, cocos blancs
 
 < en:Beans
 en:green bean, green beans
+da:grønner bønner
 es:judía verde
 fr:haricot vert, haricots verts
+sv:gröna bönor, brytböna, brytbönor
 carbon_footprint_fr_foodges_ingredient:fr: Haricot vert importé par avion
 carbon_footprint_fr_foodges_value:fr: 22.8
 
 < en:Beans
-en:lima beans
+en:lima beans, butter beans
 de:Limabohnen
 es:habas
+fi:limanpapu, voipapu
 fr:Haricot de Lima
+sv:limaböna, smörböna
+wikidata:en: Q1166136
+wikipedia:en: https://en.wikipedia.org/wiki/Lima_bean
 
 < en:Beans
 en:navy beans
@@ -2825,16 +3040,21 @@ en:red beans, red kidney beans
 da:Røde kidneybønner, kidneybønner
 de:Rote Bohnen
 es:Alubias rojas, judias rojas
+fi:punaiset kidneypavut
 fr:haricot rouge, haricots rouges
 it:fagioli rossi
+sv:röda kidneybönor, kidneybönor
 
 < en:Beans
 en:white beans
+da:hvide bønner
 de:weiße Bohnen
 es:Alubias blancas, judia blanca
 fi:valkoinen papu, valkoiset pavut
 fr:Haricots blancs, lingots blancs, haricots lingots, cocos blancs
 it:Fagioli bianchi
+nb:hvite bønner
+sv:vit böna, vita bönor
 
 < en:Beans
 fr:haricot mungo
@@ -2854,6 +3074,14 @@ it:estratto di manzo
 nl:rundvleesextrakt
 
 < en:Beef
+en:beef liver
+ca:foie de res, fetge de res
+es:foie de res, higado de res
+fi:naudan maksa
+fr:foie de boeuf
+sv:nötlever
+
+< en:Beef
 en:grass-fed beef
 ca:res alimentat amb herba
 de:Weidefleisch
@@ -2871,11 +3099,6 @@ vegan:en: no
 vegetarian:en: no
 
 < en:Beef
-fr:foie de boeuf
-ca:foie de res, fetge de res
-es:foie de res, higado de res
-
-< en:Beef
 fr:pur boeuf
 ca:res pura
 es:res puro
@@ -2890,6 +3113,7 @@ fi:naudanliha, naudanlihaa
 fr:viande de bœuf, viande bovine, pure viande bovine, pure viande de boeuf
 hu:
 it:carne di manzo, carne bovina, carne di bovino
+nb:kjøtt av storfe
 nl:Rundvlees
 pl:Mięso wołowe
 ru:Говядина
@@ -2900,6 +3124,16 @@ carbon_footprint_fr_foodges_value:fr: 35.8
 
 < en:Beef fat
 de:Rinderknochenmarkfett
+
+< en:Beef liver
+en:calf's liver
+ca:fetge de vedella, foie de vedella
+de:kalbsleber
+es:higado de ternera, foie de ternera
+fi:vasikanmaksa
+fr:foie de veau
+hu:borjúmáj
+it:fegato di maiale
 
 < en:Beef meat
 de:rindergehacktes
@@ -2922,6 +3156,7 @@ es:extracto de res, extracto de ternera
 fi:Naudanlihatiiviste
 fr:extrait de viande de bœuf, extrait de viande bovine
 hu:marhahúskivonat
+sv:nötköttsextrakt, nötkottextrakt
 vegan:en: no
 vegetarian:en: no
 
@@ -2944,6 +3179,15 @@ fr:viande de bœuf cuite, viande bovine cuite, bœuf cuit
 hu:főtt marhahús
 it:manzo cotto, carne di manzo cotta
 nl:gekookt rundvlees
+
+< en:Beef meat
+en:minced beef, ground beef
+ca:carn molta de vedella
+da:hakked oksekød
+es:carne molida de ternera
+fi:naudan jauheliha, naudan jauhelihaa
+fr:viande hachée de bœuf
+sv:nötfärs
 
 < en:Beef meat
 fr:carpaccio de boeuf
@@ -2976,11 +3220,6 @@ fr:viande de boeuf en poudre, viande de boeuf déshydratée
 
 < en:Beef meat
 fr:viande de boeuf mise en oeuvre
-
-< en:Beef meat
-fr:viande hachée de bœuf
-ca:carn molta de vedella
-es:carne molida de ternera
 
 < en:Beer
 fr:bière blonde
@@ -3015,6 +3254,8 @@ fr:concentré de betterave
 
 < en:Beetroot
 fr:fibres de betterave
+fi:juurikaskuitu
+sv:betfiber
 
 < en:Beetroot
 fr:jus de betterave
@@ -3045,6 +3286,12 @@ it:peperone giallo
 nl:gele paprika
 
 < en:Berries
+en:berry blend, berry mix
+fi:marjaseos
+fr:mélange de fruits rouges
+sv:bärblandning
+
+< en:Berries
 < en:Fruit
 en:blueberry, blueberries, bilberry
 ar:عنب الأحراج
@@ -3055,7 +3302,7 @@ de:Heidelbeer, Heidelbeeren, Heidelbeere
 eo:mirtelo
 es:arándano azul, mora azul
 fa:بیل‌بری
-fi:mustikka
+fi:mustikka, pensasmustikka
 fr:myrtille
 hu:áfonya
 is:Aðalbláber
@@ -3073,6 +3320,27 @@ uk:чорниця
 vi:Việt quất đen
 zh:山桑子
 wikidata:en: Q5812410
+
+< en:Berries
+< en:Fruit
+en:boysenberry, boysenberries
+bg:бойсен
+ca:boysenberry
+da:boysenbær
+de:boysenbeere, boysenbeeren
+fi:boysenmarja
+fr:boysenberry
+it:boysenberry
+ja:ボイセンベリー
+ko:보이즌베리
+nb:boysenbær
+nl:boysenbes
+pl:boysenberry
+pt:boysenberry
+ru:бойзенова ягода
+sv:boysenbär
+wikidata:en: Q896083
+wikipedia:en: https://en.wikipedia.org/wiki/Boysenberry
 
 < en:Berries
 < en:Fruit
@@ -3154,80 +3422,10 @@ wikipedia:en: https://en.wikipedia.org/wiki/Strawberry
 < en:Berries
 fr:fruits rouges lyophilisés
 
-< en:Berries
-< en:Fruit
-< fr:Fruits des bois
-en:blackcurrant
-da:solbær
-de:schwarze Johannisbeere, schwarze Johannisbeeren
-es:grosella negra, grosellas negras
-fi:mustaherukka, mustaherukkaa
-fr:cassis
-hu:fekete ribizli
-it:ribes nero, ribes neri
-nl:zwarte bes, cassisbessen
-pt:groselha negra
-sv:Svart vinbär
-zh:黑加伦
-wikidata:en: Q146604
-wikipedia:en: https://en.wikipedia.org/wiki/Blackcurrant
-
-< en:Berries
-< en:Fruit
-< fr:Fruits des bois
-en:raspberry, raspberries
-af:Framboos
-an:Chordón
-ar:عليق
-br:Flamboez
-bs:Malina
-ca:Gerd
-cs:Malina
-cy:Mafon cochion
-da:hindbær
-de:Himbeeren, Himbeere
-eo:Frambo
-es:frambuesa
-fa:تمشک
-fi:vadelma
-fr:framboise
-ga:Sú craobh
-gd:Sùbh-craoibh
-hi:रसभरी
-ht:Franbwaz
-hu:málna
-hy:Ազնվամորի
-io:Frambo
-it:lamponi, lampone
-ja:ラズベリー
-kk:Таңқурай
-kn:ರಾಸ್‍ಬೆರಿ
-ko:라즈베리
-kv:Ӧмидз
-lo:ໝາກຟະລຳບວດ
-lt:Avietė
-mk:Малина
-mr:रास्पबेरी
-ms:Raspberi
-mt:Lampuna
-nl:framboos, frambozen
-nn:bringebær
-nv:Dzidzé łikaní dinilchííʼígíí
-pl:maliny
-pt:framboesas
-ru:Малина
-sd:راسپ بيري
-sk:Malina
-sr:Малина
-sv:hallon
-sw:Mrasiberi
-ta:ராஸ்பெரி
-te:కోరిందపండు
-th:แรสเบอร์รี
-tl:Prambuwesas
-ty:Rahipere
-uz:Malina
-zh:樹莓
+en:berry preparation
+fi:marjavalmiste
+fr:préparation de fruits rouges
+sv:bärsprodukt
 
 < en:Bifidus
 en:Bifidobacterium bifidum
@@ -3374,11 +3572,13 @@ es:zumo de zanahoria negra
 fi:Musta porkkanamehu
 fr:jus de carotte noire
 it:succo di carote nere
+sv:svartmorotjuice
 
 < en:Black carrot
-en:concentrated black carrot
+en:concentrated black carrot, black carrot concentrate
 de:schwarze Möhre Konzentrat
 fr:concentré de carotte pourpre
+sv:svart morotskoncentrat
 
 < en:Black carrot juice
 fr:jus de carotte noire concentré, jus concentré de carotte noire, jus de carotte pourpre concentré, jus concentré de carotte pourpre
@@ -3401,9 +3601,18 @@ wikidata:en: Q6350358
 wikipedia:en: https://en.wikipedia.org/wiki/Kalamata_olive
 
 < en:Black olive
+en:kalamon olive
+de:kalamon oliven
+fi:kalamon-oliivi, kalamonoliivi
+fr:olives noires kalamon
+sv:kalamonoliver
+
+< en:Black olive
 en:olive paté
 de:Olivenpastete
+fi:oliivimassa
 fr:pâte d'olives
+sv:olivmassa
 
 < en:Black olive
 fr:olives noires avec noyau
@@ -3418,6 +3627,7 @@ es:extracto de pimienta negra
 fi:mustapippuriuute
 fr:extrait de poivre noir
 nl:zwarte peperextract
+sv:svartpepparextrakt
 
 < en:Black pepper
 en:black peppercorns
@@ -3495,15 +3705,13 @@ fi:mustaherukkamehu
 fr:jus de cassis
 it:succo di ribes neri
 nl:zwarte bessensap
+sv:svartvinbärsjuice, svartvinbärssaft
 
-< en:Blackcurrant
-< en:Purée
-en:blackcurrant puree
-de:schwarzes Johannesbeerpüree
-es:puré de cassis
-fi:mustaherukkapyree
-fr:purée de cassis
-nl:Zwarte bessenpuree
+< en:Blackcurrant juice
+en:blackcurrant concentrate
+fi:mustaherukkamehutiiviste, mustaherukkatiiviste
+fr:jus concentré de cassis, jus de cassis concentré, concentré de cassis
+nl:zwarte bessensapconcentraat
 
 < en:Blackcurrant juice
 en:blackcurrant juice from concentrate
@@ -3512,11 +3720,6 @@ es:zumo de cassis a base de concentrado
 fi:mustaherukkamehu tiivisteestä
 fr:jus de cassis à base de concentré
 nl:zwarte bessensap op basis van concentraat
-
-< en:Blackcurrant juice
-fr:jus concentré de cassis, jus de cassis concentré, concentré de cassis
-fi:mustaherukkamehutiiviste
-nl:zwarte bessensapconcentraat
 
 < en:Blanches almonds
 fr:amandes blanchies en poudre
@@ -3545,12 +3748,14 @@ es:Mezcla de mieles originarias y no originarias de la UE
 fi:Sekoitus hunajia EU:sta ja EU:n ulkopuolelta
 fr:mélange de miels originaires et non originaires de l'ue, melange de miels originaires et non originaires de l'union europeenne, mélange de miels originaires et non originaires de la CE, mélange de miels non originaires et originaires de l'UE, Sélection et mélange de miels non originaires et originaires de l'UE, melange de miels originaires et non de l'ue, Mélange de miels originaires et non originaires de la communauté Européenne, de miels originaires et non originaires de la ce, miel originaire et non-originaire de la ce, melange de miels de fleurs originaires et non-originaires de l'ue, melange de miels ue et non-ue
 nl:gemengde EG- en niet EG honing
+sv:blandning av honung från länder inom och utanför eu
 
 < en:Blend of honeys
 en:blend of non-EU honey
 de:Mischung aus Nicht-EU Honig
 fr:mélange de miels non originaires de l'UE, mélange de miels non originaires de la CE, Mélange de miels non originaires de l'Union européenne, melange de miels non ce
 nl:gemengde niet-EU-honing
+sv:blandning av icke-eu-honung
 
 < en:Blend of honeys
 en:mix of flower honeys
@@ -3610,10 +3815,16 @@ fi:villimustikka
 
 < en:Blueberry juice
 en:blueberry juice from concentrate
-de:Heidelbeersaft aus Heidelbeerkonzentrat, Heidelbeer-Saftkonzentrat
+de:Heidelbeersaft aus Heidelbeerkonzentrat
 es:Concentrado de jugo de zarzamora
-fi:mustikkamehu tiivisteestä
+fi:mustikkamehu tiivisteestä, mustikkatäysmehu tiivisteestä, mustikkatäysmehua tiivisteestä
 fr:jus de myrtille à base de concentré, jus de myrtille à base de jus concentré
+sv:blåbärssaft av koncentrat
+
+< en:Blueberry juice
+en:concentrated blueberry juice
+de:Heidelbeer-Saftkonzentrat
+sv:blåbärssaftkoncentrat
 
 < en:Blueberry puree
 de:Heidelbeerpüree aus Konzentrat
@@ -3726,6 +3937,13 @@ vegetarian:en: no
 wikidata:en: Q265868
 wikipedia:en: https://en.wikipedia.org/wiki/Bone
 
+< en:Beef
+< en:Bone
+en:beef bones
+fi:naudan luut, naudan lihaisat luut
+fr:os de boeuf
+sv:ben av nöt, köttiga ben av nöt
+
 < en:Bone
 < en:Chicken
 en:chicken bone
@@ -3744,6 +3962,12 @@ de:Bourbonvanilleschotenextrakt
 
 < en:Bourbon vanilla beans
 fr:vanille bourbon naturelle en gousse
+
+< en:Boysenberry
+< en:Fruit juice
+en:boysenberry juice
+fi:boysenmarjamehu, boysenmarjatäysmehu
+sv:boysenbärsjuice
 
 en:bran
 de:Kleie
@@ -3909,6 +4133,52 @@ fr:pain de mie
 it:pane per toast
 
 < en:Bread
+en:pita, pitta
+az:pita
+be:піта
+bg:пита
+br:pita
+ca:pita
+cs:pita
+cy:bara pita
+da:pita
+de:pita
+el:πίτα
+eo:pita
+es:pita
+fa:نان پیتا
+fi:pitaleipä
+fr:pain pita
+gl:pita
+he:פיתה
+hy:պիտա
+id:pita
+it:pita
+ja:ピタ
+kk:питта
+ko:피타
+lv:pita
+mk:пита
+ms:roti pita
+nb:pita
+nl:pitabroodje
+nn:pita
+pl:pita
+pt:pita
+ru:пита
+sq:pitja
+sr:лепиња
+sv:pitabröd
+th:พีตา
+tl:pita
+tr:pita
+uk:піта
+ur:پیتا
+zh:皮塔饼
+wikidata:en: Q211340
+wikipedia:en: https://en.wikipedia.org/wiki/Pita
+
+< en:Bread
 en:special bread
 de:Spezialbrot
 es:Pan especial
@@ -3991,9 +4261,10 @@ de:Sole, Salzlake
 el:Άρμη
 eo:peklakvo
 es:salmuera
+et:soolvesi
 eu:Gatzun
 fa:آب‌نمک
-fi:suolaliemi
+fi:suolaliemi, suolavesi
 fr:saumure
 gl:Moira
 he:תמלחת
@@ -4015,7 +4286,7 @@ ro:Saramură
 ru:Рапа
 sk:Soľanka
 sl:Slanica
-sv:saltlag
+sv:saltlag, saltlake
 th:น้ำเกลือเข้มข้น
 tr:Salamura
 uk:Ропа
@@ -4089,7 +4360,7 @@ es:caldo, Caldos
 et:puljong
 eu:Salda
 fa:گوشتابه
-fi:liemi
+fi:liemi, liemivalmiste
 fr:bouillon, fond, Bouillons
 ga:anraith
 gd:brot
@@ -4120,7 +4391,7 @@ pt:caldo
 ro:supă
 ru:бульон
 sq:supë
-sv:buljong
+sv:buljong, buljongpreparat
 tl:Tsaa ng karneng baka
 tr:Etsuyu
 uk:Бульйон
@@ -4147,6 +4418,13 @@ de:Suppenbrühe
 fr:bouillon de cuisson
 
 < en:Broth
+en:meat stock, meat broth
+fi:lihaliemi
+fr:bouillon de viande
+sv:köttbuljong, köttfond
+wikidata:en: Q67860017
+
+< en:Broth
 < en:Pork
 fr:fond de porc
 
@@ -4171,6 +4449,7 @@ fi:kasvisliemi
 fr:bouillon végétal, bouillon de légume
 it:brodo vegetale
 nl:groentebouillon
+sv:grönsaksbuljong
 wikidata:en: Q42366457
 
 < en:Broth
@@ -4191,6 +4470,13 @@ de:brauner Parboiled Langkornreis
 fi:parboil-käsitelty pitkäjyväinen tumma riisi, parboil-käsitelty pitkäjyväinen täysjyväriisi
 fr:riz complet long grain étuvé, riz long complet etuve
 hu:forrázott hosszú szemű barnarizs
+
+< en:Brown mustard seed
+< en:Yellow mustard seed
+en:yellow and brown mustard seeds
+fi:keltaiset ja ruskeat sinapinsiemenet
+fr:graines de moutarde jaune et brune
+sv:gult och brunt senapsfrö
 
 < en:Brown rice
 < en:Long grain rice
@@ -4237,6 +4523,7 @@ fi:tattarihiutale
 fr:flocons de sarrasin
 hu:hajdinapehely
 nl:boekweitvlokken
+sv:boveteflingor
 
 < en:Buckwheat
 en:kasha, buckwheat kasha
@@ -4558,14 +4845,14 @@ da:kæarnemælkpulver
 de:Buttermilchpulver
 el:αποβουτυρωμενο γάλα σεβσκόνη
 es:suero de mantequilla en polvo, suero de mantequilla rehidratada
-fi:kirnupiimäjauhe
+fi:kirnumaitojauhe, kirnupiimäjauhe, piimäjauhe
 fr:babeurre en poudre, poudre de babeurre, babeurre déshydraté
 hu:írópor
 it:latticello in polvere
 nl:karnemelkpoeder
-nn:pulverisert kjernemelk
+nn:kjernemelkpulver, pulverisert kjernemelk
 pt:leitelho em pó
-sv:kärnemjölkspulver
+sv:kärnmjölkspulver
 
 < en:Buttermilk
 fr:babeurre pasteurisé
@@ -4626,6 +4913,30 @@ uz:Bryussel karami
 vi:Cải Brussels
 zh:抱子甘藍
 wikidata:en: Q150463
+
+< en:Cabbage
+en:gai lan, chinese broccoli, chinese kale, kailan, kai-lan
+ca:bròquil xinès
+de:kai-lan
+eo:ĉina brokolo
+es:brassica oleracea var. alboglabra
+eu:kai-lan
+fa:کلم‌برگ چینی
+fi:härmekaali, kiinanbrokkoli, kailaan
+fr:brocoli chinois
+he:ברוקולי סיני
+id:kailan
+it:brassica oleracea var. alboglabra
+ja:カイラン
+ko:가이란
+ms:kailan
+nl:kailan
+sv:daggkål, kinesisk broccoli
+th:คะน้า
+za:byaekgaiqlanz
+zh:芥藍
+wikidata:en: Q1677369
+wikipedia:en: https://en.wikipedia.org/wiki/Gai_lan
 
 < en:Cabbage
 en:kale
@@ -4784,12 +5095,15 @@ wikipedia:en: https://en.wikipedia.org/wiki/Savoy_cabbage
 
 < en:Cabbage
 en:white cabbage
+da:hvidkål
 de:Weißkohl, Weisskohl
 es:Col blanca
-fi:keräkaali
+fi:valkokaali
 fr:chou blanc
 it:cavolo bianco
 nl:witte kool
+pl:kapusta biała
+sv:vitkål
 wikidata:en: Q35051
 
 < en:Cabernet
@@ -5135,6 +5449,13 @@ fr:camembert au lait pasteurisé
 ca:camembert de llet pasteuritzada
 es:camembert de leche pasteurizada
 
+< en:Camomile
+en:camomile flower
+da:kamilleblomst
+fi:kamomillankukka
+nb:kamilleblomst
+sv:kamomillblomma
+
 < en:Cane sugar
 en:blonde cane sugar
 fr:sucre blond de canne, sucre de canne blond
@@ -5158,6 +5479,7 @@ hu:nád kockacukor
 
 < en:Cane sugar
 en:organic cane sugar
+da:økologisk rørsukker
 de:Bio-Rohrzucker
 es:caña de azúcar orgánica
 fi:luomu ruokosokeri
@@ -5190,6 +5512,15 @@ hu:barna nád kockacukor
 it:Zollette di zucchero grezzo di canna
 nl:Bruin rietsuiker in klontjes
 
+< en:Canola oil
+en:fully hydrogenated canola oil
+fi:kokonaan kovetettu rypsiöljy
+sv:fullhärdad rypsolja
+
+en:canola oil preparation
+fi:rypsiöljyvalmiste
+sv:rypsoljeberedning
+
 < en:Capelin
 en:Mallotus villosus
 de:Kapelan (Mallotus villosus)
@@ -5216,16 +5547,16 @@ ru:Карамельный сироп
 < en:Sugar
 en:caramelised sugar syrup
 ca:xarop de sucre caramelitzat
-da:karamelliseret sukkersirup
+da:karamelliseret sukkersirup, karameliseret sukkersirup
 de:Caramelzuckersirup, Karamellzuckersirup, Karamell-Zuckersirup
 es:jarabe de azúcar caramelizado, sirope de azúcar caramelizado
-fi:karamellisoitu sokeri, karamellisoitu sokerisiirappi, karamellisokerisiirappi
+fi:karamellisoitu sokerisiirappi, karamellisokerisiirappi
 fr:sirop de sucre caramel, sirop de sucre caramélisé
 hu:karamellizált cukorszirup, karamellizált rizsszirup
 it:sciroppo di zucchero caramellato
 nl:gekaramelliseerde suiker, gekarameliseerde suikerstroop
 pl:cukier skarmelizowanny
-sv:karamellisoitu sokeri
+sv:karamelliserad sockersirap, karamelliserat sockersirap, karamelliserad sirap
 
 < en:Caramelised sugar
 es:azucar caramelizado en polvo
@@ -5250,7 +5581,6 @@ fr:Eau minérale naturelle renforcée au gaz de la source
 < en:Carbonated water
 en:Sparkling water
 de:Sprudelwasser, Wasser mit Kohlensäure
-fi:Hiilihapotettu vesi
 fr:
 wikipedia:en: https://en.wikipedia.org/wiki/Carbonated_water
 
@@ -5411,6 +5741,7 @@ fi:porkkanajauhe
 
 < en:Carrot
 en:carrot extract
+da:gulerodsekstrakt
 de:Karottenextrakt
 es:extracto de zanahorias
 fi:porkkanauute
@@ -5453,7 +5784,7 @@ es:zanahoria amarilla
 fi:keltainen porkkana
 fr:carottes jaunes, carotte jaune
 nl:gele wortel
-sv:gul morot
+sv:gul morot, gula morötter
 
 < en:Carrot
 fr:carottes déshydratées
@@ -5461,6 +5792,7 @@ de:Karotten getrocknet
 fi:kuivatut porkkanat
 it:carote disidratate
 sl:suseno korenje
+sv:torkad morot
 
 < en:Carrot
 fr:carottes en morceaux
@@ -5499,6 +5831,7 @@ fr:jus concentré de carotte, jus concentré de carottes, jus de carotte concent
 it:Succo di carota concentrato
 nl:Geconcentreerd wortelsap
 ru:Концентрированный морковный сок
+sv:morotjuicekoncentrat
 
 < en:Carrot juice
 < en:Celery
@@ -5544,7 +5877,7 @@ it:budello di manzo
 en:pork casing, pork gut
 de:Schweinedarm
 es:tripa de cerdo, tripa natural de cerdo
-fi:porsaansuoli, porsaan suolessa
+fi:siansuoli, porsaansuoli, porsaan suolessa
 fr:boyau de porc
 hu:sertésbél, disznóbél
 it:budello di maiale
@@ -5564,7 +5897,9 @@ nl:collageendarm
 
 < en:Casing
 fr:boyau naturel
+fi:luonnonsuoli
 ro:Membrana naturala comestibila
+sv:naturtarm
 
 < en:Category A eggs
 en:fresh category A eggs
@@ -5576,6 +5911,10 @@ nl:verse categorie A eieren
 < en:Category A eggs
 < en:Free range chicken eggs
 fr:Œufs de catégorie A de poules élevées en plein air, 9 Œufs de catégorie A de poules élevées en plein air
+
+< en:Category A eggs
+< fr:Œufs de poules élevées en cage
+fr:oeufs de poules élevées en cage de categorie a
 
 < en:Cauliflower
 fr:Choux-fleurs en fleurettes
@@ -5681,7 +6020,7 @@ cs:Cereálie
 da:Korn
 de:Getreide
 es:cereales
-fi:vilja
+fi:vilja, viljat
 fr:céréale, céréales
 ga:céréeale, céréales
 he:דגן
@@ -5721,8 +6060,10 @@ sv:kamut
 
 < en:Cereal
 de:Getreideflocken
+fi:viljahiutaleet
 fr:flocons de céréales
 it:fiocchi di cereali
+sv:spannmålsflingor
 
 < en:Cereal
 en:barley
@@ -5752,7 +6093,7 @@ es:cebada
 et:Oder, odra
 eu:Garagar
 fa:جو
-fi:Ohra, Ohraa
+fi:ohra, ohraa, ohrasta
 fr:orge
 ga:Eorna
 gl:Cebada
@@ -5836,6 +6177,7 @@ fi:tattari, viljatar
 fr:sarrasin
 hu:hajdina
 it:grano saraceno
+nb:bokhvete
 nl:boekweit
 pt:trigo mourisco
 sr:Heljda
@@ -5854,7 +6196,7 @@ it:crispies di cereali
 en:cereals containing gluten
 de:Gluten enthaltendes Getreide
 es:cereales con gluten, cereales que contienen gluten
-fi:gluteenia sisältävät viljat
+fi:gluteenia sisältävät viljat, gluteenia sisältävää viljaa
 fr:céréales contenant du gluten
 hu:glutént tartalmazó gabonafélék, glutént tartalmazó gabona
 
@@ -6267,7 +6609,7 @@ es:espelta
 et:Speltanisu
 eu:Espelta
 fa:گندم آلمانی
-fi:speltti, Spelttivehnä
+fi:speltti, spelttivehnä, spelttiä
 fr:épeautre
 ga:speilt
 gl:Espelta
@@ -6340,7 +6682,7 @@ es:trigo
 et:nisu
 eu:Gari
 fa:گندم
-fi:vehnä, Vehnät
+fi:vehnä, vehnät, vehnästä, vehnää
 fo:Hveiti
 fr:blé, froment, blé entier
 ga:cruithneacht
@@ -6437,9 +6779,6 @@ fr:billettes de céréales
 fr:céréales biscuitées
 
 < en:Cereal flour
-de:Malzmehl
-
-< en:Cereal flour
 en:amaranth flour
 de:Amarantmehl
 es:harina de amaranto
@@ -6457,8 +6796,17 @@ fi:tattarijauho
 fr:farine de sarrasin, farine de blé noir
 hu:hajdinaliszt
 it:farina di grano saraceno
+nb:bokhvetemel
 nl:boekweitmeel
 pt:farinha de trigo mourisco
+sv:bovetemjöl
+
+< en:Cereal flour
+en:malt flour
+de:Malzmehl
+fi:mallasjauho
+fr:farine de malt
+sv:maltmjöl
 
 < en:Cereal flour
 en:millet flour
@@ -6478,9 +6826,11 @@ fi:kaurajauho
 fr:farine d'avoine
 hu:zabliszt
 it:farina d'avena
+nb:havremel
 nl:havermeel
 pl:mąka owsiana
 pt:farinha de aveia
+sv:havremjöl
 
 < en:Cereal flour
 en:rye flour
@@ -6491,11 +6841,13 @@ fi:ruisjauho
 fr:farine de seigle
 hu:rozsliszt
 it:farina di segala
+nb:rugmel
 nl:roggebloem
 pl:mąka żytnia
 pt:farinha de centeio
 ro:făină de secară, faina de secara
 ru:Ржаная мука
+sv:rågmjöl
 
 < en:Cereal flour
 en:spelt flour
@@ -6536,7 +6888,7 @@ es:harina de trigo, harina de trigo blando
 et:nisujahu
 eu:Gari-irin
 fa:آرد گندم
-fi:vehnäjauho
+fi:vehnäjauho, vehnäjauhoa
 fr:farine de blé, farines de blé, farine de froment
 he:קמח חיטה
 hr:pšenično brašno
@@ -6548,6 +6900,7 @@ lt:kviešu milti, kvietiniai
 lv:kvietiniai miltai
 mr:कणीक
 ms:Tepung gandum
+nb:hvetemel
 nl:tarwemeel, tarwebloem
 nn:hvetemel
 pl:mąka pszenna
@@ -6556,7 +6909,7 @@ ro:făină de grâu, faina de grau, făină din grâu, faina din grau
 ru:Пшеничная мука, манная крупа
 sa:गोधूमपिष्टम्
 sk:pšeničná múka
-sl:psenicna moka
+sl:psenicna moka, pšenična moka
 sq:pšenično brašno
 sv:vetemjöl
 th:แป้งสาลี
@@ -6684,7 +7037,7 @@ es:queso Cheddar
 et:Cheddari juust
 eu:Cheddar gazta
 fa:پنیر چدار
-fi:Cheddar
+fi:cheddar, cheddar-juusto, cheddarjuusto
 fr:Cheddar, fromage cheddar
 ga:céadar
 gl:Cheddar
@@ -6709,7 +7062,7 @@ pt:Cheddar
 ru:Чеддер
 sk:Čedar
 sl:Čedar
-sv:cheddar
+sv:cheddar, cheddarost
 tr:Cheddar
 uk:Чеддер
 vi:Pho mát Cheddar
@@ -6793,7 +7146,7 @@ en:cured cheese, mature cheese
 es:queso curado
 
 < en:Cheese
-en:edam
+en:edam, edam cheese
 af:Edam
 bg:Едамер
 ca:Formatge edam
@@ -6806,7 +7159,7 @@ eo:edama fromaĝo
 es:edam, queso edam
 eu:Edam gazta
 fa:پنیر ادامر
-fi:Edam, edamjuustoa
+fi:Edam, edamjuusto, edamjuustoa
 fr:edam, fromage edam
 he:אדם
 hu:Edami
@@ -6843,14 +7196,14 @@ bg:Ементал
 bs:Ementaler
 ca:emmental
 cs:Ementál
-da:emmental, Emmentaler
+da:emmental, Emmentaler, emmentaler-ost
 de:Emmentaler
 el:Έμενταλ
 eo:Emental
 es:emmenthal, emmental, queso emmental
 eu:Emmental
 fa:پنیر امنتال
-fi:emmental, emmentaljuusto
+fi:emmental, emmentaljuusto, emmentaljuustoa
 fr:emmental, fromage emmental
 gl:Emmental
 he:אמנטל
@@ -6875,7 +7228,7 @@ ru:Эмменталь
 sk:Ementálsky syr
 sl:Ementalski sir
 sr:Ementaler
-sv:Emmental
+sv:Emmental, emmentalerost, emmentalost
 sw:Emmentaler
 ta:எம்மன்டல்
 tr:Emmental peyniri
@@ -6931,7 +7284,7 @@ ru:Фета
 sc:Feta
 sk:feta
 sr:фета
-sw:Fetaost
+sv:Fetaost, feta
 tl:Feta
 tr:Beyaz peynir
 uk:Фета
@@ -7018,7 +7371,7 @@ es:Gorgonzolo
 et:Gorgonzola juust
 eu:Gorgonzola
 fa:گورگونتزولا
-fi:gorgonzola
+fi:gorgonzola, gorgonzolajuusto
 fr:gorgonzola, gorgonzola AOP
 gl:Gorgonzola
 he:גורגונזולה
@@ -7106,7 +7459,7 @@ de:Grana Padano
 eo:Грана Падано
 es:Grana Padano
 et:Grana Padano
-fi:Grana Padano
+fi:Grana Padano, Grana Padano -juusto
 fr:grana padano, fromage grana padano
 hu:Grana Padano, Grana Padano sajt
 id:Grana Padano
@@ -7175,6 +7528,41 @@ tr:Gravyer peyniri
 uk:Грюєр
 wikidata:en: Q2376488
 wikipedia:en: https://en.wikipedia.org/wiki/Gruyère_cheese
+
+< en:Cheese
+en:halloumi, halloumi cheese
+af:halloumi
+ar:حلوم
+bg:халуми
+ca:hellim
+cs:halloumi
+cy:halloumi
+de:halloumi
+el:χαλλούμι
+eo:halumo
+es:halloumi
+fi:halloumi
+fr:halloumi
+he:חלומי
+id:halloumi
+is:halloumi
+it:halloumi
+ja:ハルーミ
+ko:할루미
+ku:helîme
+la:chalumium
+nb:halloumi
+nl:halloumi
+pl:halloumi
+pt:halloumi
+ru:халлуми
+sv:halloumi
+tr:hellim
+uk:халлумі
+ur:حلومی
+zh:哈羅米芝士
+wikidata:en: Q549793
+wikipedia:en: https://en.wikipedia.org/wiki/Halloumi
 
 < en:Cheese
 en:hard cheese
@@ -7294,6 +7682,24 @@ fr:fromage fondu
 hu:ömlesztett sajt
 it:formaggio fuso
 nl:smeltkaas
+sv:smältost
+
+< en:Cheese
+en:monterey jack, monterey jack cheese
+de:monterey jack
+es:monterey jack
+fi:monterey jack
+fr:monterey jack
+it:monterey jack
+ja:モントレー・ジャック
+ko:몬터레이 잭
+nb:monterey jack
+pl:monterey jack
+th:มอนเตอเรย์แจ็ก
+tr:monterey jack
+zh:傑克芝士
+wikidata:en: Q1056415
+wikipedia:en: https://en.wikipedia.org/wiki/Monterey_Jack
 
 < en:Cheese
 en:mozzarella, mozzarella cheese
@@ -7310,7 +7716,7 @@ ca:mozzarella
 cs:mozzarella, sýr mozzarella
 cv:Моцарелла
 cy:Mosarela
-da:mozzarella
+da:mozzarella, mozzarella ost
 de:Mozzarella
 el:Μοτσαρέλα, τυρι Μοτσαρέλλα
 eo:Mocarelo
@@ -7318,7 +7724,7 @@ es:mozzarella, queso mozzarella
 et:mozzarella
 eu:mozzarella
 fa:موزارلا
-fi:mozzarella, mozzarellajuustoa
+fi:mozzarella, mozzarellajuustoa, mozzarella-juusto
 fr:mozzarella, fromage mozzarella
 fy:mozzarella
 gl:Mozzarella
@@ -7362,7 +7768,7 @@ sk:mozzarella, syr mozzarella
 sl:Mocarela
 sq:mocarela
 sr:моцарела
-sv:mozzarella
+sv:mozzarella, mozzarellaost, mozzarella-ost
 th:มอซซาเรลลา
 tr:Mozzarella
 uk:Моцарела
@@ -7421,7 +7827,7 @@ sh:Parmiđano ređano
 sk:Parmezán
 sl:Parmezan
 sr:пармезан
-sv:parmesan, parmigiano-reggiano
+sv:parmesan, parmigiano-reggiano, parmesanost
 tl:Parmigiano-Reggiano
 tr:Parmesan peyniri
 uk:Пармезан
@@ -7461,6 +7867,7 @@ pt:Pecorino
 ru:Пекорино
 sk:Pecorino
 sl:Pecorino
+sv:pecorino, pecorino-ost
 sw:Pecorino
 uk:Пекоріно
 zh:義大利綿羊乾酪
@@ -7502,7 +7909,7 @@ cs:tvaroh
 da:Kvark
 de:Quark, Weißkäse, Topfen, Schotten, Speisequark
 es:Queso quark
-fi:Rahka
+fi:Rahka, maitorahka
 fr:quark
 he:גבינה לבנה
 hu:túró
@@ -7609,7 +8016,7 @@ eo:Ricotta
 es:Requesón
 et:Ricotta juust
 fa:ریکوتا
-fi:Ricotta
+fi:Ricotta, ricottajuusto
 fr:ricotta, fromage ricotta
 fy:ricotta
 he:ריקוטה
@@ -7630,7 +8037,7 @@ ro:Ricotta
 ru:Рикотта
 sl:Rikota
 sq:Gjiza
-sv:ricotta
+sv:ricotta, ricottaost
 tr:Ricotta
 uk:Рікота
 zh:里考塔
@@ -7717,6 +8124,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sheep_milk_cheese
 < en:Cheese
 en:soft white cheese
 ca:formatge blanc suau, formatge fresc
+da:friskost
 de:Frischkäse
 es:Queso blanco blando, queso fresco
 fi:tuorejuusto, salaattijuusto
@@ -7724,6 +8132,7 @@ fr:fromage frais
 hu:fehér lágysajt
 it:formaggio fresco
 nl:Zachte witte kaas
+sv:färskost
 carbon_footprint_fr_foodges_ingredient:fr: Fromage frais 58% MG
 carbon_footprint_fr_foodges_value:fr: 3.5
 
@@ -7791,6 +8200,21 @@ sw:Tomme
 tr:Tomme
 wikidata:en: Q2164539
 wikipedia:en: https://en.wikipedia.org/wiki/Tomme
+
+< en:Cheese
+en:västerbotten cheese
+da:västerbottensost
+de:västerbotten-käse
+es:queso västerbotten
+fi:västerbotten-juusto
+fr:västerbottensost
+id:keju västerbotten
+ja:ヴェステルボッテン・チーズ
+la:caseus botniae occidentalis
+ro:brânza västerbotten
+sv:västerbottensost
+wikidata:en: Q2096655
+wikipedia:en: https://en.wikipedia.org/wiki/V%C3%A4sterbotten_cheese
 
 < en:Cheese
 es:queso fundido en polvo
@@ -7871,6 +8295,7 @@ es:queso mimolette
 < en:Cheese
 fr:préparation fromagère
 ca:preparació de formatges
+de:käsezubereitung
 es:preparación de quesos
 
 < en:Cheese
@@ -7959,7 +8384,7 @@ it:marroni
 wikidata:en: Q3177204
 
 en:chia, Salvia hispanica
-da:Chiafrø
+da:Chia
 de:chia, Salvia hispanica
 es:chia, chía negra, Salvia hispanica
 fi:chia, salvia hispanica
@@ -7978,12 +8403,13 @@ en:chia seed, chia seeds
 da:Chiafrø
 de:Chiasamen
 es:semillas de chia
-fi:chia-siemen, chia-siemenet
+fi:chia-siemen, chia-siemenet, chiansiemen
 fr:graine de chia, graines de chia
 it:semi di chia
 nb:Chiafrø
 nl:chiazaad
 pt:sementes de chia
+sv:chiafrö, chiafrön
 nutriscore_fruits_vegetables_nuts:en: no
 
 < en:Chicken
@@ -8003,6 +8429,7 @@ de:Hühnerbrühe
 fi:kanaliemi
 fr:bouillon de poulet, fond de poulet
 nl:kippenbouillon
+sv:kycklingfond
 
 < en:Chicken
 fr:extrait de poulet
@@ -8018,7 +8445,7 @@ fr:poulet fermier
 
 < en:Chicken egg
 en:organic chicken egg
-fi:luomukananmuna, luomu kananmuna
+fi:luomukananmuna, luomu kananmuna, luomukanan muna, luomukanan munia
 fr:œufs de poules issus de l'agriculture biologique
 
 < en:Chicken egg
@@ -8045,7 +8472,14 @@ sv:kycklingfett
 < de:Hähnchenfleisch
 < en:Chicken fillet
 de:hähnchenfilet
-fi:broilerinfilee
+fi:broilerinfilee, broilerin filee, broilerin sisäfilee
+
+< en:Chicken fillet
+en:chicken breast fillet
+da:kyllingebrystfilet
+fi:broilerin rintafilee, broilerin rintafileetä
+fr:filet de poitrine de poulet
+sv:kycklingbröstfilé
 
 < en:Chicken fillet
 en:chicken fillet with skin
@@ -8076,6 +8510,7 @@ es:Sabor a pollo
 fi:kana-aromi
 fr:arôme de poulet, arôme de poule
 ro:aromă de pui, aroma de pui
+sv:kycklingarom
 
 < en:Chicken meat
 de:Hähnchenfleisch
@@ -8088,6 +8523,7 @@ de:Hühnerfleischpulver
 en:chicken breast
 es:pechuga de pollo
 fr:blanc de poulet
+sv:kycklingbröst
 carbon_footprint_fr_foodges_ingredient:fr: Blanc de poulet
 carbon_footprint_fr_foodges_value:fr: 4.9
 
@@ -8107,6 +8543,7 @@ fr:filet de poulet, viande de filet de poulet
 it:Filetto di pollo
 nl:kipfilet
 ru:Куриное филе
+sv:kycklingfilé, kycklinginnerfilé, kycklinglårfilé
 
 < en:Chicken meat
 en:chicken thigh, chicken drumstick
@@ -8181,6 +8618,15 @@ de:Kichererbse, Kichererbsen
 la:Cicer arietinum
 
 < en:Chickpea
+en:cooked chickpeas
+da:kogte kikærter
+es:garbanzos cocidos
+fi:keitetty kikherne
+fr:pois chiches cuits
+pt:Grão-de-bico cozido
+sv:kokta kikärter
+
+< en:Chickpea
 < en:Flour
 en:chickpea flour
 es:harina de garbanzo
@@ -8189,11 +8635,6 @@ es:harina de garbanzo
 en:organic chickpea
 fi:luomukikherne, luomu kikherne
 fr:Pois chiches biologiques
-
-< en:Chickpea
-fr:pois chiches cuits
-es:garbanzos cocidos
-pt:Grão-de-bico cozido
 
 < en:Chickpea
 fr:pois chiches précuits
@@ -8225,11 +8666,13 @@ pt:chicória solúvel
 < en:Chicory
 < en:Vegetable fiber
 en:chicory fibre
+da:cikoriefibre
 de:Zichorienfäser
 es:fibra de la raíz de achicoria
 fi:sikurikuitu, sikurijuurikuitu
 fr:fibre de chicorée, fibres de chicorée
 nl:chicoreivezel
+sv:fiber från cikoriarot
 
 < en:Chilean mussel
 en:Mytilus chilensis
@@ -8244,6 +8687,39 @@ de:grüne Chili
 fi:vihreä chili
 fr:piments verts, piment vert
 it:peperoncino verde
+
+< en:Chili pepper
+en:allspice, jamaica pepper, myrtle pepper
+de:Jamaikapfeffer
+fi:maustepippuri
+fr:piment de la jamaïque, piment de Jamaïque
+nl:Jamaicaanse peper
+sv:kryddpeppar
+wikidata:en: Q158468
+wikipedia:en: https://en.wikipedia.org/wiki/Allspice
+
+< en:Chili pepper
+en:bird's eye chili, thai chili
+bn:থাই মরিচ
+da:thai chili
+es:chile ojo de pájaro
+fi:rawit, thai-chili
+fr:piment œil d'oiseau
+hu:thai paprika
+id:cabai rawit
+it:thai pepper
+jv:lombok rawit
+ko:새눈고추
+ms:cili padi
+nl:rawit
+ru:птичий глаз
+su:céngék
+sv:thai chili
+th:พริกขี้หนู
+tl:siling thai
+vi:ớt hiểm
+wikidata:en: Q432426
+wikipedia:en: https://en.wikipedia.org/wiki/Bird%27s_eye_chili
 
 < en:Chili pepper
 en:chili in vinegar
@@ -8293,16 +8769,57 @@ nl:scherpe peperoni, scherpsmakende pepers
 
 < en:Chili pepper
 en:Jalapeno peppers
-da:Jalapeno
+ar:هالبينو
+bg:халапеньо
+ca:bitxo jalapeño
+cs:jalapeño
+da:jalapeno, jalapeño
 de:Jalapeno-Chilis
+eo:ĥalapenjokapsiko
 es:Pimientos Jalapeños, jalapeno
-fi:jalapeno, jalapenot
+et:jalapeño, jalapeno
+fa:هالاپینو
+fi:jalapeño, jalapeno, jalapenot
 fr:piments jalapeño, piment jalapeño
+gl:pemento xalapeño
+he:חלפניו
 hu:jalapeno paprika, jalapeno
+hy:հալապենո
+id:jalapeño
 it:Peperoncini jalapeños
+ja:ハラペーニョ
+kn:ಹಾಲಪೇನ್ಯೊ
+ko:할라페뇨
+ml:ഹലപീനൊ
+nb:jalapeño
 nl:Jalapeno pepers
-pl:Papryczki Jalapeño
-sv:Jalapeno peppar
+pl:Papryczki Jalapeño, jalapeño
+pt:pimenta-jalapenho
+ru:халапеньо
+sk:jalapeño
+sv:Jalapeno peppar, jalapeño, jalapeno, jalapeños, jalapeñochili
+th:ฆาลาเปญโญ
+tl:jalapeño
+tr:jalapeño
+uk:халапеньйо
+zh:墨西哥辣椒
+wikidata:en: Q504133
+wikipedia:en: https://en.wikipedia.org/wiki/Jalape%C3%B1o
+
+< en:Chili pepper
+en:pimiento, pimientos, pimento, pimentos
+ar:فلفل إسباني
+fi:pimento, pimento-chili
+hu:pimiento paprika
+id:cabai ceri
+ja:ピメント
+ko:체리고추
+nl:pimentpasta
+sv:pimento, pimento chili
+uk:пім'єнто
+vi:ớt pimiento
+wikidata:en: Q1236127
+wikipedia:en: https://en.wikipedia.org/wiki/Pimiento
 
 < en:Chili pepper
 en:preserved chili pepper
@@ -8311,11 +8828,14 @@ fi:säilötty chili
 
 < en:Chili pepper
 en:red chili pepper
+da:rød chili
 de:roter Chili, rote Chili-Schoten
 es:chile rojo, chiles rojos, red-chili, chili rojo
 fi:punainen chili
 fr:piment rouge, piments rouges
 it:peperoncini rossi
+nb:rød chili
+sv:röd chili, röd chilipeppar
 
 < en:Chili pepper
 fr:extrait de piment
@@ -8323,11 +8843,7 @@ de:Chiliextrakt
 fi:chiliuute
 it:estratto di peperoncino
 nl:pimentextract
-
-< en:Chili pepper
-fr:piment de la jamaïque, piment de Jamaïque
-de:Jamaikapfeffer
-nl:Jamaicaanse peper
+sv:chilipepparextrakt
 
 < en:Chili pepper
 fr:piment Oiseau
@@ -8337,6 +8853,7 @@ fr:ciboulette déshydratée
 de:Schnittlauch getrocknet
 fi:kuivattu ruohosipuli
 it:erba cipollina essiccata
+sv:torkad gräslök
 
 en:chocolate
 af:Sjokolade
@@ -8471,7 +8988,7 @@ it:ripieno al cioccolato
 
 < en:Chocolate
 en:chocolate pieces, chocolate chips
-da:Chokoladestykker
+da:Chokoladestykker, stykker af chokolade
 de:Schokoladenstücke, Schokoladenstückchen
 es:copos de chocolate, pepitas de chocolate, gotas de chocolate
 fi:suklaarouhe
@@ -8479,7 +8996,7 @@ fr:morceaux de chocolat, pépites de chocolat, copeaux de chocolat
 it:pezzi di cioccolato, goccie di cioccolato
 nl:Chocostukjes
 pt:raspas de chocolate
-sv:Choklad bitar
+sv:Choklad bitar, chokladbitar
 
 < en:Chocolate
 en:chocolate powder
@@ -8502,6 +9019,7 @@ en:chocolate sauce
 de:Schokoladensoße
 fi:suklaakastike
 fr:sauce au chocolat, sauce parfum chocolat
+sv:chokladsås
 
 < en:Chocolate
 en:dark chocolate, black chocolate
@@ -8647,6 +9165,7 @@ fr:chocolat blanc en poudre
 < en:Chokeberry
 < en:Fruit juice
 en:chokeberry juice
+da:aroniasaft, aronia saft
 de:Aroniasaft
 fi:marja-aroniamehu
 fr:jus d'aronia
@@ -8764,19 +9283,20 @@ da:Flåede tomater
 de:stückige Tomaten, Tomaten stückig
 el:πουρές τομάτας
 es:Puré de tomate
-fi:tomaattimurska
+fi:tomaattimurska, tomaattimurskaa
 fr:Purée de tomate, concentré de tomate, concentré de tomates, pâte de tomate, purée de tomates
+sv:krossade tomater, passerade tomater
 
 < en:Chopped tomatoes
 en:tomato pulp
 de:Tomatenfleisch
 es:Pulpa de tomate
-fi:Tomaattisose
+fi:tomaattimassa, tomaattipulppa, tomaatin hedelmäliha
 fr:pulpe de tomate
 it:polpa di pomodoro
 nl:tomatenpulp
 pt:polpa de tomate
-sv:krossade tomater
+sv:krossade tomater, passerade tomater
 carbon_footprint_fr_foodges_ingredient:fr: Tomate pelées ou pulpe de tomate
 carbon_footprint_fr_foodges_value:fr: 1.4
 
@@ -8842,6 +9362,7 @@ cs:Chlorid chromitý
 de:Chrom-III-chlorid
 el:Τριχλωριούχο χρώμιο
 fa:کلرید کرومIII
+fi:KromiIIIkloridi
 fr:chlorure de chrome III
 it:cloruro di cromo III, Tricloruro di cromo
 nl:ChroomIIIchloride
@@ -8929,11 +9450,64 @@ de:natürliches Citrusaroma, natürliches Zitrusaroma
 fi:luontainen sitrusaromi
 fr:arôme naturel d'agrumes, arômes naturels d'agrumes
 hu:természetes citrus aroma
+sv:naturlig citronarom
 
 < en:Citrus fruit
 < en:Fruit
 en:bitter orange
-es:naranja amarga, naranjas amargas de sevilla
+ar:نارنج
+az:narınc
+bo:ཚ་ལུ་མ་སྐྱུར་མོ།
+ca:taronger agre
+ch:kahet
+co:citronu
+cs:pomerančovník hořký
+da:pomerans
+de:bitterorange
+el:νεραντζιά
+eo:bigarado
+es:naranja amarga, naranjas amargas de sevilla, citrus × aurantium
+et:pomerantsipuu
+eu:laranja mingots
+fa:نارنج
+fi:pomeranssi
+fr:bigaradier
+gl:laranxeira amarga
+he:חושחש
+hr:gorka naranča
+ht:zoranj konmenn
+hu:keserű narancs
+id:jeruk pahit
+it:citrus × aurantium
+kk:бигарадия
+ko:쓴귤
+kv:померанец
+la:aurantium
+lt:karčiavaisis citrinmedis
+lv:rūgtais apelsīns
+nb:pomerans
+ne:मुन्तला
+nl:zure sinaasappel
+nn:pomerans
+oc:bigaradièr
+pl:pomarańcza gorzka
+ps:نارنج
+pt:laranja-azeda
+ru:померанец
+sc:aranzu
+sv:pomerans
+sw:mdanzi
+ta:நரந்தம்
+te:చేదు నారింజ
+th:ส้มซ่า
+to:kola
+tr:turunç
+uk:померанець
+ur:کنو
+vi:cam chua
+zh:苦橙
+wikidata:en: Q147096
+wikipedia:en: https://en.wikipedia.org/wiki/Bitter_orange
 
 < en:Citrus fruit
 en:citrus fruit extract
@@ -9011,7 +9585,7 @@ en:kaffir lime
 bn:কাফির লেবু
 de:Kaffernlimette, Kaffernlimetten
 fa:لیموی کفیر
-fi:ryppylimetti, kafferilimetti
+fi:ryppylimetti, kafferilimetti, kaffirlime
 fr:combava
 id:Jeruk purut
 it:limone kaffir
@@ -9030,6 +9604,7 @@ pt:Combava
 ru:Кафир-лайм
 sl:Kombava
 su:Jeruk purut
+sv:kaffirlime
 th:มะกรูด
 ud:Кафир-лайм
 vi:Trấp
@@ -9044,7 +9619,7 @@ cs:Citron
 da:Citron
 de:Zitrone
 es:limón
-fi:sitruuna
+fi:sitruuna, sitruunaa
 fr:citron, citrons
 he:לימון
 hu:citrom
@@ -9053,7 +9628,7 @@ nl:citroen
 pl:Cytryna
 pt:Limão
 ru:Лимон
-sv:citron
+sv:citron, citron frukt
 zh:柠檬
 wikidata:en: Q1093742
 
@@ -9260,7 +9835,7 @@ sn:Ranjisi
 so:Liin
 sq:Portokalli
 sr:наранџа
-sv:Apelsin
+sv:Apelsin, apelsiner
 sw:Chungwa
 ta:தோடை
 te:బత్తాయి
@@ -9325,7 +9900,7 @@ it:enzima coagulante
 nl:stremmingsenzymen, stollingsmiddel
 pl:Enzym koagulujący
 pt:coagulante
-sv:koagulerande enzym, mjölkkoagulerande enzym
+sv:koagulerande enzym, mjölkkoagulerande enzym, mjölkkoagulerande ystenzym
 vegan:en: maybe
 vegetarian:en: maybe
 
@@ -9369,7 +9944,7 @@ ko:레닛
 la:Coagulum
 lt:Šliužo fermentas
 ms:Renet
-nb:løype, animalsk og mikrobiell løpe
+nb:løype, osteløype, løpe, osteløpe, animalsk og mikrobiell løpe
 nl:stremsel
 nn:løpe, løype
 pl:podpuszczka
@@ -9377,7 +9952,7 @@ pt:coalho, quimosina
 ro:cheag
 ru:рассол
 sr:сириште
-sv:löpe
+sv:löpe, ostlöpe, ostenzym
 tr:lab
 zh:凝乳酶
 vegan:en: maybe
@@ -9405,9 +9980,10 @@ it:rivestimento
 lt:apvalkalas
 nb:belegg
 nl:coating
-pl:Przyprawy
+pl:
 ro:inveliş
 sl:skorjica
+sv:överdrag
 tr:kaplama
 vegan:en: ignore
 vegetarian:en: ignore
@@ -9426,7 +10002,7 @@ eo:raspaĵo
 es:pan rallado, migaja de pan rallado, migas de pan
 eu:Ogi birrindu
 fa:آرد سوخاری
-fi:Korppujauho
+fi:Korppujauho, paneerausjauho, leivite
 fr:chapelure, panure, Chapelures
 gl:Pan relado
 he:פירורי לחם
@@ -9443,7 +10019,7 @@ pl:Bułka tarta, panierka
 pt:pão ralado
 ru:Панировочные сухари
 sk:Strúhanka
-sv:Ströbröd, panering
+sv:Ströbröd, brödsmulor, panering, paneringsmjöl
 uk:Паніровка
 vi:Vụn bánh mì
 zh:麵包屑
@@ -9533,7 +10109,7 @@ ms:Biji koko
 nl:cacaobonen, cacaoboon
 ru:какао-бобы
 sq:Gatim me kakao
-sv:kakaoböna
+sv:kakaoböna, kakaobönor
 uk:Какао-боби
 zh:可可豆
 wikidata:en: Q208008
@@ -9552,14 +10128,14 @@ es:manteca de cacao
 et:kakaovōi, Kakaoõli
 eu:Kakao-gurin
 fa:کره کاکائو
-fi:kaakaovoi
+fi:kaakaovoi, kaakaovoita
 fr:beurre de cacao
 gl:Manteiga de cacao
 he:חמאת קקאו
 hr:kakao maslac
 hu:Kakaóvaj
 id:Budidaya kakao
-is:kakósmor
+is:kakósmjör
 it:burro di cacao
 ja:ココアバター
 kk:какао майы
@@ -9569,15 +10145,16 @@ lt:kakovos sviestas
 lv:kakao sviests
 mk:Какаово масло
 ms:Mentega koko
+nb:kakaosmør
 nl:cacaoboter
-pl:masło kakaowe
+pl:masło kakaowe, tłuszcz kakaowy
 pt:manteiga de cacau
 ro:unt de cacao, unt cacao
 ru:масло какао, какао-масло
 sk:kakaové maslo
 sl:Kakavovo maslo
 sq:Gjalpa e kakaos
-sv:kakaosmör
+sv:kakaosmör, kakaofett
 tg:равгани какао
 th:เนยโกโก้
 uk:Какао-олія
@@ -9595,15 +10172,17 @@ de:Kakaomasse
 el:κακαόμαζα
 es:Pasta de cacao, masa del cacao, masa de cacao
 et:kakaomass
-fi:kaakaomassa
+fi:kaakaomassa, kaakaomassaa
 fr:pâte de cacao, cacao en pâte, masse de cacao
 hr:kakaova masa
 hu:kakaómassza
+is:kakómassi
 it:pasta di cacao, massa di cacao
 kk:үгілген какао
 ky:майдаланган какао
 lt:kakavos masė
 lv:kakavos masė
+nb:kakaomasse
 nl:cacaomassa
 pl:miazga kakaowa, masa kakaowa
 pt:pasta de cacau
@@ -9625,7 +10204,7 @@ de:Kakaopulver
 el:σκόνη κακάο
 es:cacao en polvo
 fa:پودر کاکائو
-fi:kaakaojauhe
+fi:kaakaojauhe, kaakaojauhetta
 fr:poudre de cacao, cacao en poudre
 hu:kakaópor
 id:Kakao padat
@@ -9726,6 +10305,7 @@ fr:Pâte de cacao alcalinisée
 
 < en:Cocoa paste
 en:organic cocoa paste
+da:økologisk kakaomasse
 de:Bio-Kakaomasse
 fi:luomu kaakaomassa
 fr:pâte de cacao bio
@@ -9743,11 +10323,11 @@ es:Cacao en polvo procesado con álcali
 fr:Cacao alcalinisé
 
 < en:Cocoa powder
-en:fat reduced cocoa powder, low-fat cocoa powder
+en:fat reduced cocoa powder, low-fat cocoa powder, cocoa powder with low fat content
 bg:обеэмаслено какао на прах
 ca:cacau desgreixat en pols
 cs:Kakaový prášek se sníženým obsahem tuku
-da:skummet kakaopulver
+da:fedtfattigt kakaopulver, fedtreduceret kakaopulver, skummet kakaopulver
 de:fettarmes Kakaopulver, Kakaopulver stark entölt, mageres Kakaopulver, fettreduziertes Kakaopulver, Magerkakaopulver
 es:cacao magro en polvo, cacao desgrasado en polvo, cacao en polvo desgrasado
 et:lahja kakaopulber
@@ -9763,7 +10343,7 @@ pl:niskotłuszczowe kakao w proszku
 pt:cacau magro em pó
 ro:cacao pudra degresata
 ru:обезжиренный какаопорошок
-sv:fettreducerat kakaopulver, skummet kakaopulver
+sv:fettreducerat kakaopulver, fettreducerad kakaopulver, skummet kakaopulver, fettreduserat kakaopulver, avfettat kakaopulver, fettfattigt kakaopulver
 
 < en:Cocoa powder
 en:raw cacao powder
@@ -9792,19 +10372,22 @@ nutriscore_fruits_vegetables_nuts:en: no
 en:coconut extract
 de:Kokosnussextrakt
 es:extracto de coco
-fi:kookosuute
+fi:kookosuute, kookospähkinäuute
 fr:extrait de noix de coco, extrait de coco
 it:estratto di noce di cocco
 nl:Kokosextract
+sv:kokosnötsextrakt
 
 < en:Coconut
 en:coconut flakes
 de:Kokosflocken
 es:Hojuelas de coco
-fi:kookoshiutale
-fr:flocons de coco, fr:flocons de noix de coco
+et:kookoshelbed
+fi:kookoshiutale, kookoshiutaleet
+fr:flocons de coco, flocons de noix de coco
 it:fiocchi di cocco
 nl:Kokosschilfers
+sv:kokosflinga, kokosflingor
 
 < en:Coconut
 en:coconut milk
@@ -9814,10 +10397,11 @@ es:Leche de coco
 fi:kookosmaito
 fr:lait de noix de coco, lait de coco, eau de coco
 it:latte di noce di cocco
+nb:kokosmelk
 nl:kokosmelk
 pl:Mleko kokosowe
 ru:Кокосовое молоко
-sv:kokosmjòlk
+sv:kokosmjölk
 zh:椰子奶
 
 < en:Coconut
@@ -9845,6 +10429,15 @@ es:Agua de coco
 fr:
 
 < en:Coconut
+< en:Flour
+en:coconut flour
+de:kokosmehl, kokosnussmehl
+et:kookosjahu
+fi:kookosjauho
+fr:farine de noix de coco, farine de coco
+sv:kokosmjöl
+
+< en:Coconut
 en:grated coconut
 de:Kokosraspel, Kokosraspeln
 es:coco rallado
@@ -9853,6 +10446,7 @@ fr:noix de coco râpée
 it:cocco grattugiato
 nl:Gemalen kokos
 pt:coco ralado
+sv:riven kokos
 
 < en:Coconut
 es:nectar del brote de la flor del coco
@@ -9863,6 +10457,17 @@ fr:pâte de noix de coco
 < en:Coconut
 nl:kokosnootwater
 fi:kookosvesi
+
+< en:Coconut fat
+en:fully hydrogenated coconut fat
+da:fuldhærdet kokosfett
+de:ganz gehärtetes kokosfett
+es:grasa de coco totalmente hidrogenada
+fi:kokonaan kovetettu kookosrasva, kokonaan kovetettua kookosrasvaa
+fr:graisse de coco totalement hydrogénée
+nb:fullherdet kokosfett
+nl:geheel gehard kokosvet
+sv:fullhärdat kokosfett
 
 < en:Coconut flavouring
 < en:Natural flavouring
@@ -9881,14 +10486,28 @@ en:coconut milk drink
 es:bebida de coco
 
 < en:Coconut milk
-en:powdered coconut milk
-es:leche de coco en polvo
-
-< en:Coconut milk
-fr:lait de noix de coco en poudre, lait de coco en poudre
+en:coconut milk powder, powdered coconut milk
 de:Kokosnussmilchpulver, Kokosmilchpulver
+es:leche de coco en polvo
 fi:kookosmaitojauhe
+fr:lait de noix de coco en poudre, lait de coco en poudre
 it:latte di noci di cocco in polvere
+sv:kokosmjölkspulver
+
+< en:Coconut milk powder
+fr:lait de coco reconstitué
+
+< en:Coconut oil
+en:fractionated coconut oil
+fi:fraktioitu kookosöljy
+fr:huile de coco fractionnée
+sv:fraktionerad kokosolja
+
+< en:Coconut oil
+en:fully hydrogenated coconut oil
+fi:kokonaan kovetettu kookosöljy
+fr:huile de noix de coco totalement hydrogénée, huile de coprah totalement hydrogénée
+sv:fullhärdad kokosolja
 
 < en:Coconut oil
 en:organic coconut oil
@@ -9907,15 +10526,17 @@ fr:huile vierge de noix de coco, huile de coco vierge, Huile vierge de coco
 fr:huile de coco non-hydrogénée, huile de coprah non hydrogénée
 
 < en:Coconut oil
-fr:huile de noix de coco totalement hydrogénée, huile de coprah totalement hydrogénée
-
-< en:Coconut oil
 fr:huile de noix de coco totalement hydrogénée et non-hydrogénée
 
 < en:Coconut pulp
+en:desiccated coconut
+da:tørret kokos
+es:coco deshidratado
+fi:kuivattu kookos, kuivattua kookosta
 fr:noix de coco séchée, noix de coco déshydratée
 nl:gedroogde kokosnoot
 ro:nuca de cocos deshidratata
+sv:torkad kokosnöt
 
 < en:Coconut water
 en:natural coconut water
@@ -9972,6 +10593,7 @@ fr:chair de morue
 < en:Cod
 fr:filet de cabillaud, filets de cabillaud
 fi:turskafilee
+sv:torskfilé, filér av torsk
 
 < en:Cod
 fr:foie de morue
@@ -10146,6 +10768,7 @@ fi:arabiankahvi, arabica-kahvi
 fr:café arabica, arabica, Café 100 % arabica, café pur arabica
 hu:arabica kávé, arabica
 it:caffè Arabica
+sv:arabicakaffer, arabiska kaffe
 
 < en:Coffee
 en:coffee beans
@@ -10163,6 +10786,7 @@ fi:kahviuute
 fr:extrait de café, extraits de café
 it:estratto di caffè
 nl:koffie-extract
+sv:kaffeextrakt
 
 < en:Coffee
 en:coffee powder
@@ -10171,6 +10795,7 @@ es:café en polvo
 fi:kahvijauhe
 fr:café en poudre
 nl:poeder met koffie, koffiepoeder
+sv:kaffepulver
 
 < en:Coffee
 en:cold brew coffee
@@ -10326,7 +10951,16 @@ vegan:en: no
 vegetarian:en: no
 wikipedia:en: https://en.wikipedia.org/wiki/Collagen
 
-en:Colour, color, colouring, coloring, decorative pigment, surface colorant, for color, artificial color, color added, colors added, artificial color added, colours, colors, coloring food
+< en:Collagen
+en:hydrolyzed collagen
+ar:كولاجين متحلل
+de:kollagen-hydrolysat
+es:colágeno hidrolizado
+sv:kollagenpeptider
+vi:collagen peptide
+wikidata:en: Q1779264
+
+en:Colour, color, colouring, coloring, decorative pigment, surface colorant, for color, artificial color, color added, colors added, artificial color added, colours, colors, coloring food, colouring food
 bg:Оцветител
 ca:Colorant, Color, colors, colorants, pigment decoratiu, colorant alimentari, colorants alimentaris
 cs:Barvivo
@@ -10335,16 +10969,18 @@ de:Farbstoff, Farbstoffe, färbende Lebensmittel, färbendes Lebensmittel
 el:Χρωστική ουσία
 es:Colorante, color, colorante de superficie, pigmentos de coloración y decoración, pigmentos de coloración, pigmentos de decoración, colores, colorantes, colorante alimentario, colorantes alimentarios
 et:Toiduvärv
-fi:Väri, Väriä, Värit, Värejä, Väriaine, Väriainetta, Väriaineet, Väriaineita, elintarvikeväri
+fi:Väri, Väriä, Värit, Värejä, Väriaine, Väriainetta, Väriaineet, Väriaineita, Elintarvikeväri, värjäävät elintarvikkeet
 fr:Colorant, colorant de surface, pigment décoratif, pigment colorant, colorants, colorant alimentaire, colorants alimentaires
 ga:Dath
 he:צבע
 hr:Boja
 hu:Színezék, mesterséges színezék, színezőanyag
+is:Litarefni
 it:Colorante, coloranti, alimento colorante
 lt:Dažiklis
 lv:Krāsa
 mt:Kulur
+nb:Farge, Farve, Fargestoff, fødevarer der farver
 nl:Kleuren, Kleurstof, kleurstoffen
 pl:Barwnik, Barwniki
 pt:Corante
@@ -10352,7 +10988,7 @@ ro:Colorant
 ru:Краситель
 sk:Farbivo
 sl:Barvilo
-sv:Färgämne, färgämnen
+sv:Färg, Färgämne, Färgämnen, färgande livsmedel
 zh:色素
 description:cs: Barvivy se rozumějí látky, které potravině dodávají barvu nebo barvu obnovují a zahrnují přírodní složky potravin a přírodních zdrojů, jež jako takové nejsou obvykle požívány jako potraviny a nejsou obvykle používány jako charakteristické složky potravin.
 description:da: Farvestoffer: stoffer, der giver en fødevare farve eller giver den dens farve tilbage og omfatter naturlige bestanddele af fødevarer og andre naturlige kildematerialer, som normalt ikke i sig selv fortæres som fødevarer, og som ikke normalt anvendes som karakteristiske ingredienser i fødevarer.
@@ -10409,6 +11045,7 @@ en:hydrogenated colza oil
 de:Gehärtetes Rapsöl
 fi:kovetettu rapsiöljy
 fr:Huile de colza hydrogénée
+sv:hårdat rapsolja
 
 < en:Colza oil
 en:organic colza oil
@@ -10459,7 +11096,7 @@ da:Koncentrat, fra koncentrat
 de:Konzentrat, aus Konzentrat
 es:concentrado
 fa:کنسانتره
-fi:tiiviste, tiivistetty, tiivisteestä
+fi:tiiviste, tiivistetty, tiivisteestä, tiivisteitä
 fr:concentré, concentrés
 he:תרכיז
 it:concentrato, da concentrato
@@ -10469,12 +11106,12 @@ pl:koncentrat
 pt:concentratos
 sn:Mutape
 sr:Концентрат
-sv:Koncentrat
+sv:Koncentrat, koncentrat från
 wikidata:en: Q1355665
 
 < en:Concentrated apple juice
 en:apple juice from concentrate
-da:Æblejuicekoncentrat
+da:æblejuice fra koncentrat
 de:Apfelsaft aus Konzentrat, Apfelsaft aus Apfelsaftkonzentrat
 es:Zumo de manzana desde concentrado, zumo de manzana a partir de concentrado
 fi:omenamehu tiivisteestä
@@ -10483,7 +11120,7 @@ hu:sűrített almalé, almalé sűrítmény, almalé koncentrátum, almalé konc
 it:succo di mele a base di concentrato
 nl:appelsap uit concentraat
 pl:Sok jabłkowy z koncentratu
-sv:äppeljuicekoncentrat
+sv:äppeljuice från koncentrat
 
 < en:Concentrated celery juice
 en:powdered concentrated celery juice
@@ -10508,7 +11145,7 @@ fi:omena- päärynä- ja rypäletäysmehu tiivisteestä
 < fr:Jus de raisin rouge
 en:red grape from concentrate
 de:rote Trauben aus Traubenkonzentrat
-fi:punainen rypälemehutiiviste
+fi:punainen rypälemehu tiivisteestä
 fr:Raisin rouge à base de concentré
 pt:sumo de uva tinta à base de concentrado
 
@@ -10561,6 +11198,7 @@ en:condensed semi-skimmed milk
 ca:llet condensada parcialment desnatada, llet condensada semidesnatada, llet parcialment desnatada condensada, llet semidesnatada condensada, llet condesnada semidesnatada
 de:Kondensmagermilch, eingedickte entrahmte Milch, teilentrahmte Kondensmilch, kondensierte Magermilch, konzentrierte Magermilch, Magermilchkonzentrat
 es:leche condensada parcialmente desnatada, leche condensada semidesnatada, leche parcialmente desnatada condesada, leche semidesnatada condensada, leche parcialmente desnatada condensada
+fi:kondensoitu vähärasvainen maito, tiivistetty vähärasvainen maito
 fr:lait demi-écrémé condensé
 hu:sűrtett zsírszegény tej, sűrített zsírszegény tej
 nl:gecondenseerde halfvolle melk
@@ -10570,7 +11208,7 @@ en:condensed skimmed milk, concentrated skim milk, concentrated skimmed milk
 ca:llet descremada condensada, llet desnatada condensada, llet condensada descremada, llet condensada desnatada
 de:Kondensmagermilch, eingedickte entrahmte Milch, teilentrahmte Kondensmilch, kondensierte Magermilch, konzentrierte Magermilch, Magermilchkonzentrat
 es:leche descremada condensada, leche desnatada condensada, leche condensada descremada, leche condensada desnatada
-fi:Tiivistetty vähärasvainen maito
+fi:kondensoitu rasvaton maito
 fr:lait écrémé concentré, concentré de lait écrémé, lait écrémé condensé, lait concentré écrémé
 hu:sűrített sovány tej
 it:latte scremato concentrato, latte magro concentrato
@@ -10591,17 +11229,27 @@ nl:gecondenseerde volle melk
 < en:Condensed milk
 en:sweetened condensed milk
 ca:llet condensada ensucrada, llet ensucrada condensada
+da:sukret kondenseret mælk
 de:gezuckerte Kondensmilch, gezuckerte eingedickte Milch
 es:leche condensada azucarada, leche azucarada condensada
-fi:makeutettu kondensoitu maito, makeutettu maitotiiviste
+fi:makeutettu kondensoitu maito, makeutettu maitotiiviste, sokeroitu maitotiiviste, sokeroitua maitotiivistettä
 fr:lait concentré sucré, lait condensé sucré
 hu:édesített sűrített tej
 it:latte concentrato zuccherato
 nl:gecondenseerde gesuikerde melk, gesuikerde gecondenseerde melk
+sv:sockrad kondenserad mjölk, söt kondenserad mjölk, sötad kondenserad mjölk
 wikidata:en: Q57271749
 
 < en:Condensed skimmed milk
+en:sweetened skimmed condensed milk
+da:sukret kondenseret skummetmælk
+de:gezuckerte Kondensmagermilch, Kondensmagermilch gezuckert
+et:magustatud kooritud kondenspiim
+fi:sokeroitu rasvaton maitotiiviste
 fr:lait écrémé concentré sucré
+lt:saldintas sutirštintas nugriebtas pienas
+lv:saldināts iebiezināts vājpiens
+sv:sockrad kondenserad skummjölk, söt kondenserad skummjölk
 
 en:condiment
 am:ܐܨܪܐ
@@ -10611,6 +11259,7 @@ be:смакавыя дабаўкі
 ca:condiment
 cs:ochucovadlo
 cy:Cyfwyd
+da:smagspræparat
 de:Würzmittel
 el:Καρύκευμα
 eo:kondimento
@@ -10632,11 +11281,11 @@ ko:조미료
 ms:Bumbu
 nn:smakstilsetjing
 oc:condiment
-pl:przyprawa
+pl:przyprawa, przyprawy
 pt:condimento
 ro:Mirodenie
 ru:приправы
-sv:smaktillsats
+sv:smaktillsats, smaksättare, smaksättning
 tr:Çeşni
 uk:Смакові добавки
 vi:Phụ gia
@@ -10645,6 +11294,49 @@ vegan:en: ignore
 vegetarian:en: ignore
 wikidata:en: Q2596997
 wikipedia:en: https://en.wikipedia.org/wiki/Condiment
+
+< en:Condiment
+en:miso, miso paste
+ar:ميسو
+az:miso şorbası
+bg:мисо
+ca:miso
+cs:miso
+da:miso
+de:miso
+eo:misoo
+es:miso
+eu:miso
+fa:میسو
+fi:miso, misotahna
+fr:miso, pâte miso
+gd:miso
+gl:miso
+he:מיסו
+hu:miszo
+id:miso
+it:miso
+ja:味噌
+ko:미소
+lb:miso
+lt:sojų pasta
+ms:miso
+my:မီဆို
+nb:miso
+nl:miso
+pl:miso
+pt:missô
+ru:мисо
+sl:miso
+sv:miso, misopasta
+th:มิโซะ
+tl:miso
+tr:miso
+uk:місо
+vi:miso
+zh:味噌
+wikidata:en: Q235169
+wikipedia:en: https://en.wikipedia.org/wiki/Miso
 
 < en:Condiment
 en:mixed condiments, seasoning mix, flavored seasoning, mélange aromatique
@@ -10798,6 +11490,11 @@ fi:korianterinlehti, korianterinlehdet
 fr:feuilles de coriandre, feuille de coriandre
 it:Foglie di coriandolo
 nl:koriander blaadjes
+sv:korianderblad
+
+< en:Coriander
+en:coriander paste
+fi:korianteritahna
 
 < en:Coriander
 fr:arôme de coriandre
@@ -10806,11 +11503,13 @@ es:aroma de cilantro
 < en:Coriander
 < en:Seed
 en:coriander seeds
+da:korianderfrø
 de:Koriandersamen
 es:Semillas de cilantro
-fi:korianterin siemen
+fi:korianterinsiemen
 fr:graine de coriandre, graines de coriandre
 nl:korianderzaad
+sv:korianderfrö
 
 < en:Coriander seeds
 en:coriander powder
@@ -10836,13 +11535,28 @@ en:corn flakes, cornflakes
 ca:blat de moro
 de:Maisflakes, Cornflakes
 es:copos de maíz, corn flakes
-fi:maissihiutale
+et:maisihelbed
+fi:maissihiutale, maissihiutaleet
 fr:pétales de maïs, pétale de maïs, cornflakes, corn flakes, flocons de maïs
 hu:kukoricapehely
 it:fiocchi di mais, cornflakes
 nl:maïsvlokken
 pl:płatki kukurydziane
 pt:flocos de milho
+sv:majsflingor
+
+< en:Corn
+en:corn kernel, corn kernels
+da:majskjerner
+de:
+es:grano de maís
+fi:maissinjyvä, maissinjyviä
+fr:grains de maïs
+nb:majskjerner
+nl:maïskorrels
+pt:grão de milho
+sr:kukuruzni griz
+sv:majskärnor, majskorn
 
 < en:Corn
 en:cornmeal, corn grits, corn semolina, corn meal
@@ -10850,7 +11564,7 @@ da:groftmalet majs
 de:Maisgrieß, Maiskörner, Maisgriess
 el:σιμιγδάλι αραβοσίτου
 es:semola de maíz, granos de maíz
-fi:maissirouhe
+fi:maissisuurimo
 fr:semoule de maïs
 hu:kukoricadara
 it:spezzato di mais, semolino di granoturco
@@ -10881,11 +11595,6 @@ hu:csemegekukorica
 it:mais dolce
 
 < en:Corn
-fr:grains de maïs
-de:
-sr:kukuruzni griz
-
-< en:Corn
 fr:maïs torréfié concassé
 
 < en:Corn
@@ -10903,6 +11612,7 @@ fi:maissijauho, maissijauhoa
 fr:farine de maïs
 hu:kukoricaliszt
 it:farina di mais
+nb:maismel
 nl:maïsmeel
 pl:mąka kukurydziana
 pt:farinha de milho
@@ -10935,6 +11645,12 @@ nl:wit maïsmeel
 sv:vitt majsmjöl
 
 < en:Corn flour
+en:whole grain corn flour
+fi:täysjyvämaissijauho
+fr:farine de mais compléte
+sv:fullkornsmajsmjöl
+
+< en:Corn flour
 en:yellow corn flour
 da:gult majsmel
 de:gelbes Maismehl
@@ -10946,6 +11662,9 @@ it:farina di mais giallo
 nb:gult maismel
 nl:geel maïsmeel
 sv:gult majsmjöl
+
+< en:Corn kernel
+fr:grains de maïs à éclater
 
 < en:Corn starch
 fr:amidon de maïs cireux
@@ -10961,7 +11680,7 @@ da:majssirup
 de:Maissirup
 eo:Maiza siropo
 es:Jarabe de maíz, sirope de maíz
-fi:maissisiirappi, isoglukoosi
+fi:maissisiirappi, isoglukoosi, maissitärkkelyssiirappi
 fr:sirop de maïs
 he:סירופ תירס
 hu:kukoricaszirup
@@ -10988,14 +11707,11 @@ fr:solides de sirop de maïs
 < en:Corn syrup
 < en:Glucose
 fr:sirop de glucose de maïs
+sv:majsglukossirap
 
 < en:Blueberry
 < en:Cornflower
 fr:bleuets
-
-< en:Cornmeal
-de:Maisvollkorngriess
-fr:semoule de maïs complet
 
 < en:Cornmeal
 en:dextrinated cornmeal
@@ -11006,7 +11722,18 @@ hu:dextrinált kukoricadara
 nl:gedextrineerd maïsmeel
 
 < en:Cornmeal
+en:wholegrain maize semolina
+da:fuldkornsmajsgryn
+de:Maisvollkorngriess
+fi:täysjyvämaissisuurimo, karkea täysjyvämaissijauho
+fr:semoule de maïs complet, semoule complète de mais
+it:semolino di mais integrale
+nl:volkoren maïsgriesmeel
+sv:fullkornsmajsgryn
+
+< en:Cornmeal
 fr:maïs moulu
+fi:maissirouhe
 nl:gemalen maïs
 pt:milho moído
 
@@ -11050,6 +11777,7 @@ fi:pastöroitu lehmänmaito
 fr:lait de vache pasteurisé, lait pasteurisé de vache
 hu:pasztőrözött tehéntej
 it:latte di mucca pastorizzato
+nb:pasteurisert kumelk
 nl:gepasteuriseerde koemelk
 pl:Mleko krowie pasteryzowane
 sv:pastöriserad komjölk
@@ -11070,6 +11798,11 @@ es:leche de vaca termizada, leche termizada de vaca
 fr:lait frais de nos vaches non homogeneise
 
 < en:Crab
+en:crab extract
+fr:extrait de crabe
+sv:krabbextrakt
+
+< en:Crab
 en:edible crab, brown crab
 bg:ядивни раци
 cs:krab německý
@@ -11088,19 +11821,20 @@ sv:Krabbtaska
 < en:Crab
 fr:chair de crabe
 
-< en:Crab
-fr:extrait de crabe
+< en:Cranberry
+en:dried cranberries
+da:tørrede tranebærstykker
+de:Cranberries getrocknet
+fi:kuivattu karpalo, kuivatut karpalot, kuivatut karpalopalat
+fr:canneberges séchées, cranberries séchées
+it:cranberry secchi
+sv:torkade tranbär
 
 < en:Cranberry
 en:sugared cranberries
 de:gesüßte Cranberries, Cranberries gesüßt
 fi:sokeroitu karpalo, sokeroidut karpalot
 wikidata:en: Q26897677
-
-< en:Cranberry
-fr:canneberges séchées, cranberries séchées
-de:Cranberries getrocknet
-it:cranberry secchi
 
 < en:Cranberry
 < en:Fruit juice
@@ -11145,13 +11879,17 @@ nl:room uit Normandië
 < en:Cream
 en:cream powder, Powdered cream
 ca:nata en pols, crema de llet en polvo
+da:flødepulver
 de:Cremepulver, Sahnepulver
 es:nata en polvo, crema de llet en polvo
+et:koorepulber
 fi:kermajauhe
 fr:crème en poudre, poudre de crème
 hu:tejszínpor
 it:panna in polvere
 nl:roompoeder, poederroom
+ro:praf de frișcă
+sv:gräddpulver
 
 < en:Cream
 en:fresh cream
@@ -11210,6 +11948,7 @@ hu:pasztőrözött tej és tejszín
 it:latte e panna pastorizzati
 nl:Gepasteuriseerde melk en room
 pt:Leite e natas pateurizados
+sv:pastöriserad mjölk och grädde
 
 < en:Cream
 en:raw cream
@@ -11228,7 +11967,7 @@ fr:crème liquide, demi-crème
 hu:habtejszín
 it:panna liquida
 nl:vloeibare room
-sv:flytande grädde
+sv:flytande grädde, matgrädde
 
 < en:Cream
 en:sour cream, soured cream, grade a cultured cream
@@ -11287,6 +12026,13 @@ fr:crème fouettée
 hu:tejszínhab
 
 < en:Cream
+en:whipping cream
+da:piskefløde
+fi:kuohukerma
+fr:crème à fouetter
+sv:vispgrädde
+
+< en:Cream
 en:whole cream, full cream
 ca:crema de llet sencera, nata sencera
 de:Vollrahm, ganze Sahne
@@ -11308,6 +12054,59 @@ ca:crema de llet en pols rehidratada, crema de llet en pols reconstituida, nata 
 de:Rehydriertes Sahnepulver
 es:crema de leche en polvo rehidratada, crema de leche en polvo reconstituida, nata en pols rehidratada, nata en pols reconstituida
 fr:crème en poudre réhydratée
+
+en:creatine
+ar:كرياتين
+be:крэацін
+bg:креатин
+ca:creatina
+cs:kreatin
+da:kreatin
+de:kreatin
+el:κρεατίνη
+eo:kreatino
+es:creatina
+et:kreatiin
+fa:کراتین فسفات
+fi:kreatiini
+fr:créatine
+gl:creatina
+he:קראטין
+hr:kreatin
+hu:kreatin
+hy:կրեատին
+id:kreatina
+it:creatina
+ja:クレアチン
+ko:크레아틴
+lt:kreatinas
+lv:kreatīns
+mk:креатин
+ml:ക്രിയാറ്റിനിൻ
+ms:kreatina
+nb:kreatin
+nl:creatine
+pl:kreatyna
+pt:creatina
+ro:creatină
+ru:креатин
+sh:kreatin
+sk:kreatín
+sr:kreatin
+sv:kreatin
+tr:kreatin
+uk:креатин
+vi:creatine
+zh:肌酸
+wikidata:en: Q223600
+wikipedia:en: https://en.wikipedia.org/wiki/Creatine
+
+< en:Creatine
+en:creatine monohydrate
+de:kreatin-monohydrat
+fi:kreatiinimonohydraatti
+fr:créatine monohydrate, mono-hydrate de créatine
+wikidata:en: Q27271832
 
 en:Crêpe, Crêpes
 ar:بان كيك
@@ -11391,11 +12190,12 @@ af:Crouton
 be:грэнкі
 bg:крутон
 ca:crostó
+da:crouton, croutoner
 de:Croûton, Croutons
 el:κρουτόν
 es:croûton
 eu:ogi-txigorki
-fi:krutonki
+fi:krutonki, krutongit
 fr:croûton, croûtons
 he:קרוטונים
 it:crostini
@@ -11403,11 +12203,12 @@ ja:クルトン
 kk:ерутон
 kn:ಕ್ರೂಟಾನ್
 ko:크루통
+nb:krutong, krutonger
 nl:crouton, broodkorstjes, croutons
 pl:kruton
 pt:croûton
 ru:гренки
-sv:krutong
+sv:krutong, krutonger
 tr:kruton
 uk:грінки
 zh:麵包丁
@@ -11718,14 +12519,15 @@ nl:komkommersap
 < en:Cucumber
 en:gherkin
 bg:краставица, Корнишон
-da:agurk
+da:agurk, agurker
 de:Gurken, Cornichons
 el:Gurke
 es:pepinillos
-fi:pikkukurkku
+fi:cocktailkurkku, pikkukurkku
 fr:cornichon, cornichons
 it:cetriolini
 nl:augurken, augurk
+sv:inläggningsgurka
 nutriscore_fruits_vegetables_nuts:en: yes
 wikidata:en: Q1365891
 
@@ -11748,7 +12550,29 @@ nl:komkommersap uit concentraat
 < en:Cumin seeds
 fr:cumin moulu
 de:gemahlener Kümmel, Kreuzkümmelpulver
+fi:jauhettu kumina
 it:cumino macinato
+
+en:curing salt, curing salts
+ar:ملح معالج
+de:pökelsalz
+ru:нитритно-посолочная смесь
+wikidata:en: Q5194756
+
+< en:Curing salt
+en:nitrite curing salt
+da:nitritsalt
+de:Nitritpökelsalz
+fi:nitriittisuola
+sv:nitritsalt
+
+< en:Curry paste
+en:red curry paste
+de:rote currypaste
+fi:punainen currytahna
+fr:pâte de curry rouge
+sv:röd currypasta
+wikidata:en: Q67201118
 
 < en:Curry powder
 en:curry
@@ -11928,7 +12752,7 @@ ru:Молочные продукты
 si:ගව කිරි ආශ්‍රිත නිෂ්පාදන
 sl:Mlečni izdelek
 sr:Млечни производи
-sv:Mejeriprodukt
+sv:Mejeriprodukt, mjölkprodukt
 ta:பால் பொருள்
 th:ผลิตภัณฑ์นม
 tr:Mandıra ürünü
@@ -11965,7 +12789,7 @@ es:mantequilla
 et:või
 eu:gurin
 fa:کره
-fi:voi
+fi:voi, voita
 fo:smør
 fr:beurre
 fy:bûter
@@ -12010,7 +12834,7 @@ pl:masło
 pt:manteiga
 qu:mantikilla
 ro:unt
-ru:cли́вочное ма́сло
+ru:cли́вочное ма́сло, сливочное масло
 sa:नवनीतम्
 sc:butiru
 sd:مکڻ
@@ -12274,6 +13098,7 @@ de:Rahm, Sahne, Obers, Nidel, Nidle
 el:Κρέμα γάλακτος
 eo:kremo
 es:crema de leche, nata, crema
+et:rõõsk koor
 eu:esne-gaina
 fa:خامه
 fi:Kerma
@@ -12530,6 +13355,7 @@ fi:maitojauhe
 fr:lait en poudre, poudre de lait
 he:אבקת חלב
 hu:tejpor
+is:mjólkurduft
 it:latte in polvere
 nl:melkpoeder
 pl:mleko w proszku
@@ -12704,8 +13530,11 @@ fi:luomutaateli, luomu taateli
 it:datteri bio
 
 < en:Date
-nl:dadelpuree
 fr:jus de dattes concentré
+
+< en:Date
+nl:dadelpuree
+sv:dadelpuré
 
 < en:Decaffeinated coffee
 fr:café Arabica décaféiné torréfié
@@ -12781,6 +13610,19 @@ zh:鹿肉
 wikidata:en: Q2296872
 wikipedia:en: https://en.wikipedia.org/wiki/Venison
 
+< en:Deer
+en:reindeer, caribou
+da:rensdyr
+de:ren
+es:reno
+fi:poro
+fr:renne
+nb:rein
+pl:ren
+sv:ren
+wikidata:en: Q5410921
+wikipedia:en: https://en.wikipedia.org/wiki/Reindeer
+
 < en:Dehydrated glucose syrup
 fr:sirop de glucose de blé en poudre
 nl:tarweglucosestrooppoeder
@@ -12788,6 +13630,16 @@ sv:glukossirap från vetemjöl
 
 < en:Dehydrated seaweed
 fr:algues réhydratées
+
+< en:Dehydrated soy protein
+en:rehydrated soy protein
+de:Rehydriertes Sojaprotein, rehydriertes Sojaproteinisolat, angerührtes Sojaproteinisolat
+es:Proteina de soya rehidratada
+fi:uudelleen hydratoitu soijaproteiini
+fr:protéines de soja réhydratées, protéines végétales de soja réhydratées
+hu:rehidratált szójafehérje
+nl:gerehydrateerde soja-eiwit
+sv:rehydrerat sojaprotein
 
 < en:Demineralised whey
 fr:lactosérum partiellement déminéralisé, petit lait partiellement déminéralisé
@@ -12812,7 +13664,7 @@ nn:maisdekstrose
 pl:dekstroza kukurydziana
 ro:dextroza din porumb
 sl:dekstroza iz koruze
-sv:majssocker
+sv:majssocker, druvsocker från majs
 tr:misir dekstrozu
 
 < en:Dextrose
@@ -12852,6 +13704,10 @@ en:organic dill seed
 fi:luomu tillinsiemen
 nl:biologisch dillezaad
 
+en:dill butter
+fi:tillivoi
+sv:dillsmör
+
 en:Disaccharide
 ca:Disacàrid
 de:Disaccharid
@@ -12890,7 +13746,7 @@ wikidata:en: Q13444410
 wikipedia:nl: https://nl.wikipedia.org/wiki/Bractechlamys_vexillum
 
 < en:Distilled vinegar
-< en:White vinegar
+< en:Vinegar
 en:white distilled vinegar
 de:weißer destillierter Essig
 es:vinagre blanco destilado
@@ -12997,7 +13853,7 @@ hy:Լափշա
 id:Mi
 io:Nudlo
 is:Núðla
-it:noodles, tagliatelle
+it:noodles
 ja:麺
 jv:Mi
 ka:ატრია
@@ -13023,7 +13879,7 @@ ru:rezance
 sk:rezance
 sr:кнедла
 su:Emih
-sv:Nudlar
+sv:Nudlar, nudel
 sw:Tambi
 ta:நூடுல்ஸ்
 carbon_footprint_fr_foodges_ingredient:fr: Pâte à tarte
@@ -13164,15 +14020,17 @@ fr:abricots secs dénoyautés
 < en:Dried raspberries
 en:freeze-dried raspberries
 de:Himbeeren gefriergetrockent
-fi:pakastekuivattu vadelma
+fi:pakkaskuivattu vadelma, pakastekuivattu vadelma
 fr:framboises lyophilisées
 it:lamponi liofilizzati
+sv:frystorkade hallon
 
 < en:Dried tomatoes
 en:sundried tomatoes
 de:an der Sonne getrocknete Tomaten
 fi:aurinkokuivattu tomaatti, aurinkokuivatut tomaatit
 fr:tomates séchées au soleil
+sv:soltorkad tomat, soltorkade tomater
 
 < en:Dried tomatoes
 fr:tomates séchées réhydratées
@@ -13278,6 +14136,12 @@ en:organic durum wheat
 fi:luomu durumvehnä
 fr:Blé dur biologique
 hu:bio durumbúza
+sv:ekologiskt durumvete
+
+< en:Durum wheat
+en:whole grain durum wheat
+fi:täysjyvädurumvehnä
+fr:blé dur complet
 
 < en:Durum wheat
 fr:blé dur concassé
@@ -13285,6 +14149,11 @@ bg:вид едра твърда пшеница
 
 < en:Durum wheat
 fr:blé dur précuit
+
+< en:Durum wheat flour
+en:dark durum wheat flour
+fi:tumma durumvehnäjauho
+sv:mörkt durumvetemjöl
 
 < en:Durum wheat semolina
 en:organic durum wheat semolina
@@ -13347,7 +14216,7 @@ bg:E100, Куркумин
 bs:E100, Kurkumin
 ca:E100, Curcumina
 cs:E100, Kurkumin
-da:E100, Curcumin
+da:E100, Curcumin, gurkemejeekstrakt
 de:E100, Kurkumin, Kurkumaextrakt
 el:E100, Κουρκουμινη
 es:E100, Curcumina, extracto de cúrcuma
@@ -13375,7 +14244,7 @@ ro:E100, Curcumină
 ru:E100, Куркумины
 sk:E100, Kurkumín
 sl:E100, Kurkumin
-sv:E100, Kurkumin
+sv:E100, Kurkumin, gurkmejaextrakt
 ta:E100, குர்க்குமின்
 th:E100, เคอร์คูมิน
 tr:E100, Kurkumin
@@ -13859,7 +14728,7 @@ sh:Proteaza
 sk:E1101, Proteáza, Proteináza, Proteolytický enzým, Proteázy
 sl:E1101, Peptidaza
 sr:Proteaza
-sv:E1101, Proteas, Peptidaser, Exopeptidas, Endopeptidaser, Peptidas, Exopeptidaser, Endopeptidas, Proteaser
+sv:E1101, Proteas, Peptidaser, Exopeptidas, Endopeptidaser, Peptidas, Exopeptidaser, Endopeptidas, Proteaser, Proteasenzym
 tr:Proteaz
 uk:Протеаза
 vi:Protease
@@ -13998,7 +14867,7 @@ fi:lysotsyymi kananmunasta
 fr:lysozyme d'œuf
 it:lisozima da uovo
 nl:lysozym uit ei
-sv:lysozym av ägg, av ägg
+sv:lysozym från ägg, lysozym av ägg
 
 en:E111, Orange GGN, Alpha-naphthol, Alpha-naphtol, alpha-naphthol orange
 bg:E111, E111 food additive
@@ -14101,6 +14970,7 @@ ja:ポリデキストロース
 lt:E1200, Polidekstrozė
 lv:E1200, Polidekstroze
 mt:E1200, Polidestrożju
+nb:E1200, Polydextrose
 nl:E1200, Polydextrose
 pl:E1200, Polidekstroza
 pt:E1200, Polidextrose
@@ -14660,7 +15530,7 @@ sh:E133, Brilijantno plavo FCF
 sk:E133, Brilantná modrá FCF
 sl:E133, Briljantno modro FCF
 sr:E133, Brilijantno plavo FCF
-sv:E133, Briljantblått FCF
+sv:E133, Briljantblått FCF, Briljantblått
 uk:E133, Діамантовий синій
 additives_classes:en: en:colour
 colour_index:en: CI 42090
@@ -14774,7 +15644,7 @@ sl:E140i, Klorofili, CI Natural Green 3, magnezijev klorofil, E141i, Bakrovi kom
 sq:E140i, Klorofili
 sr:E140i, хлорофил
 su:E140i, Kloropil
-sv:E140i, Klorofyller, CI Natural Green 3, magnesiumklorofyll, E141i, Kopparkomplex av klorofyller, kopparklorofyll
+sv:E140i, Klorofyller, CI Natural Green 3, magnesiumklorofyll, E141i, Kopparkomplex av klorofyller, kopparklorofyll, Klorofyllkopparkomplex
 sw:E140i, Klorofili
 ta:E140i, பச்சையம்
 te:E140i, పత్రహరితం
@@ -14976,25 +15846,26 @@ en:E1404, Oxidised starch, modified potato starch
 bg:E1404, Окислено нишесте, Окисленото нишесте е нишесте
 ca:E1404, Midó oxidat, mido oxidat, mido de patata
 cs:E1404, Oxidovaný škrob
-da:E1404, Oxideret stivelse, Oxideret stivelse er stivelse
+da:E1404, Oxideret stivelse, Oxideret stivelse er stivelse, modificeret kartoffelstivelse
 de:E1404, Oxidierte stärke, modifizierte Kartoffelstärke
 el:E1404, Οξειδωμενο αμυλο
 es:E1404, Almidón oxidado, almidón modificado de patata, almidon de patata modificado
 et:E1404, Oksüdeeritud tärklis
-fi:E1404, Hapetettu tärkkelys, Hapetettua tärkkelystä, muunnettu perunatärkkelys
+fi:E1404, Hapetettu tärkkelys, Hapetettua tärkkelystä, muunnettu perunatärkkelys, modifioitu perunatärkkelys
 fr:E1404, Amidon oxydé, amidon modifié de pomme de terre, amidon modifié de pommes de terre, amidon de pomme de terre modifié, amidon transformé de pommes de terre, amidon de pommes de terre modifié, amidon transformé de pomme de terre, fécule de pomme de terre modifiée, fécule modifiée de pommes de terre
 hu:E1404, Oxidált keményítő, módosított burgonyakeményítő
 it:E1404, Amido ossidato, amido di patate modificiate, amido modificato di patata
 lt:E1404, Oksiduotasis krakmolas
 lv:E1404, Oksidētā ciete, Oksidētā ciete ir ciete
 mt:E1404, Lamtu ossidat
+nb:modifisert potetstivelse
 nl:E1404, Geoxideerd zetmeel, gemodificeerd aardappelzetmeel
 pl:E1404, Skrobia utleniona
 pt:E1404, Amido oxidado, amido modificado de batata
 ro:E1404, Amidon oxidat
 sk:E1404, Oxidovaný škrob
 sl:E1404, Oksidirani škrob, oksidirani škrob je škrob
-sv:E1404, Oxiderad stärkelse
+sv:E1404, Oxiderad stärkelse, modifierad potatisstärkelse
 additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 e_number:en: 1404
 vegan:en: yes
@@ -15797,7 +16668,7 @@ bg:E150a, Обикновен карамел, E150c, Амониев караме�
 bs:E150a, Karamel boja
 ca:E150a, colorant de caramel
 cs:E150a, E150c, Amoniakový karamel
-da:E150a, Madkulør, E150c, Ammonieret karamel
+da:E150a, Madkulør, Sukkerkulør, E150c, Ammonieret karamel
 de:E150a, Zuckerkulör, Zuckercouleur, aromatisches Karamell, E150c, Ammoniak-Zuckerkulör, Ammoniak-Zuckercouleur
 el:E150a, Απλο καραμελοχρωμα, E150c, Εναμμωνιο καραμελοχρωμα
 es:E150a, Caramelo natural, color caramelo, colorante «Color Caramelo», caramelo para licores, caramelo aromático, E150c, Caramelo amónico, El caramelo amónico, caramelo de panadería, caramelo de confitería, caramelo de cerveza
@@ -16371,7 +17242,7 @@ bg:E160a, Каротин, E160ai, Бета-каротин, Бета-кароте
 bs:Karoten
 ca:E160a, Carotè, carotens, beta-carotè, beta-carotens
 cs:E160a, karoteny, E 160a, karoten, E160ai, Beta-karoten, β-karoten
-da:E160a, Karotin, Carotenoider, Karotenoid, E 160, Karoten, Caroten, Carotenoid, E160ai, Beta-caroten, Betakaroten
+da:E160a, Karotin, Carotenoider, Karotenoid, E 160, Karoten, Caroten, Carotenoid, E160ai, Beta-caroten, Betacaroten, Betakaroten
 de:E160a, Carotine, Provitamin A, Karotin, E 160a, Beta-Carotin, Betacarotin, Carotin, Gamma-Carotin, Betakarotin, Alpha-Carotin, Beta-Karotin, γ-Carotin, β-Carotin, β-Karotin, α-Carotin, E160ai
 el:E160a, E160a food additive, E160ai, Β-καροτενιο, β-καροτένιο
 eo:Karoteno
@@ -16401,6 +17272,7 @@ mn:Бета каротин
 ms:Karotena, Beta-Karotena
 mt:E160a, E160a food additive, E160ai, Beta-karotên, beta-karotina
 my:ကဲရော့တင်း
+nb:E160ai, Betakaroten
 nl:E160a, caroteen, Carotenen, Beta-caroteen, Β-caroteen, E160ai, Bèta-caroteen
 nn:Karoten, betakaroten
 no:Karoten
@@ -16619,6 +17491,7 @@ nl:capsicum-extract
 wikidata:en: Q53792073
 
 < en:E160c
+en:natural paprika extract
 fr:extrait naturel de paprika
 
 en:E160d, Lycopene
@@ -17117,7 +17990,7 @@ et:E163, Antotsüaniinid
 eu:E163, Antozianina
 fa:E163, آنتوسیانین
 fi:E163, Antosyaanit, Antosyaani, Antosyaaneja, Antosyaania, Antosyaaniväri, Antosyaaniväriä, Antosyaanivärit, Antosyaanivärejä
-fr:E163, Anthocyanes, Anthocyane
+fr:E163, Anthocyanes, Anthocyane, Anthocyanines
 he:E163, אנתוציאנין
 hu:E163, Antocianinok, Antociánok
 hy:E163, Անտոցիաններ
@@ -17144,7 +18017,7 @@ ru:E163, Антоцианы
 sk:E163, Antokyaníny
 sl:E163, Antocianini, Antocian
 sr:E163, Антоцијан
-sv:E163, Antocyaner, Antocyanin
+sv:E163, Antocyaner, Antocyanin, Antocyaniner
 sw:E163, Antocyanin
 tg:E163, Антосианҳо
 th:E163, แอนโทไซยานิน
@@ -17165,9 +18038,11 @@ wikidata:en: Q262547
 en:black carrot, black carrots
 de:schwarze Karotte
 es:Zanahorias negras
-fi:Musta porkkana
+fi:Musta porkkana, mustaporkkana, mustaporkkanaa
 fr:carotte noire
 it:carote nere
+sv:svart morot
+wikidata:en: Q11767451
 
 en:E163a, Cyanidin
 bg:E163a, E163a food additive
@@ -17940,6 +18815,7 @@ ko:E200, 소르빈산
 lt:E200, Sorbo rūgštis
 lv:E200, Sorbīnskābe, Pīlādžskābe, C6h8o2, Sorbāti
 mt:E200, Aċidu sorbiku
+nb:E200, Sorbinsyre
 nl:E200, Sorbinezuur
 nn:E200, sorbinsyre
 pl:E200, Kwas sorbowy, Kwas sorbinowy
@@ -18017,6 +18893,7 @@ ja:E202, ソルビン酸カリウム
 lt:E202, Kalio sorbatas
 lv:E202, Kālija sorbāts
 mt:E202, Sorbat tal-potassju
+nb:E202, Kaliumsorbat
 nl:E202, Kaliumsorbaat
 nn:E202, kaliumsorbat
 pl:E202, Sorbinian potasu
@@ -19635,7 +20512,7 @@ sh:E262i, Natrijum acetat
 sk:E262, Octan sodný, E262i
 sl:E262, Natrijev acetat, E262i
 sr:E262i, натријум ацетат
-sv:E262, Natriumacetat, E262i
+sv:E262, Natriumacetat, Natriumacetater, E262i
 ta:E262i, சோடியம் அசிட்டேட்
 te:E262i, సోడియం అసిటేట్
 tr:E262i, Sodyum asetat
@@ -20138,7 +21015,7 @@ mr:E290, कार्बन डायॉक्साइड
 ms:E290, Karbon dioksida
 mt:E290, Diossidu tal-karbonju, Gass tal-aċidu karboniku, Silġ niexef (forma solida)
 my:E290, ကာဗွန်ဒိုင်အောက်ဆိုက်
-nb:E290, karbondioksid
+nb:E290, karbondioksid, kullsyre
 ne:E290, कार्बनडाइअक्साइड
 nl:E290, Koolstofdioxide, Koolzuurgas, droogijs (vaste vorm)
 nn:E290, karbondioksid
@@ -20161,7 +21038,7 @@ so:E290, Kaarboon laba ogsaydh
 sq:E290, Dioksidi i karbonit
 sr:E290, ugljen-dioksid
 su:E290, Karbon dioksida
-sv:E290, Koldioxid, Kolsyregas, kolsyresnö (i fast form)
+sv:E290, Koldioxid, Kolsyregas, kolsyresnö, kolsyra
 ta:E290, காபனீரொக்சைட்டு
 te:E290, కార్బన్ డయాక్సైడ్
 th:E290, คาร์บอนไดออกไซด์
@@ -20228,7 +21105,7 @@ sh:E296, Malinska kiselina
 sk:E296, Kyselina jablčná
 sl:E296, Jabolčna kislina
 sr:E296, Malinska kiselina
-sv:E296, Äppelsyra, Malat, E 296
+sv:E296, Äppelsyra, Malat, Äpplesyra, E 296
 ta:E296, மேலிக் அமிலம்
 th:E296, กรดมาลิก
 tr:E296, Malik asit
@@ -20286,6 +21163,7 @@ it:E300, Acido ascorbico, acido l-ascorbico, Ascorbato
 lt:E300, Askorbo rūgštis, l-askorbo rūgštis, Askorbinas
 lv:E300, Askorbīnskābe, l-askorbīnskābe
 mt:E300, Aċidu askorbiku, aċidu l-askorbiku, L-aċidu askorbiku
+nb:E300, Askorbinsyre, L-Askorbinsyre
 nl:E300, Ascorbinezuur, 50-81-7, L-ascorbinezuur
 pl:E300, Kwas askorbinowy, kwas l-askorbinowy, kwas askorbowy
 pt:E300, Ácido ascórbico, ácido l-ascórbico, Vitamina c, C6H8O6, Ascorbato
@@ -21072,10 +21950,12 @@ es:Lecitina de colza, lecitinas de colza
 fi:
 fr:lécithine de colza, lécithines de colza
 hu:repce lecitin
+nb:rapslecitin, rapslecithin
 nl:raapzaadlecithine
 pt:lecitina de colza
 ro:lecitină din rapiță, lecitina din rapita
 sr:lecitin uljane repice
+sv:rapslecitin, rapslecithin
 vegan:en: yes
 vegetarian:en: yes
 
@@ -21083,7 +21963,7 @@ vegetarian:en: yes
 en:soya lecithin, soy lecithin, sin 322
 ca:Lecitina de soja, lecitines de soja, E-322
 cs:sójový lecitin
-da:sojalecitin
+da:sojalecitin, sojalecitiner, sojalecithin, sojalecithiner
 de:Sojalecithine, Sojalecithin, Soja-Lecithine, Emulgator Sojalecithine
 el:λεκιθίνη σόγιας
 es:lecitina de soya, lecitinas de soja, lecitinas de soya, E-322
@@ -21091,6 +21971,7 @@ fi:
 fr:lécithine de soja, lécithines de soja, émulsifiant lécithines de soja, lécithine de soja e322
 he:לציטין סויה
 hu:szójalecitin, szójalecitinek
+is:sojalesitin
 it:lecitina di soia
 nl:sojalecithine
 nn:sojalecitin
@@ -21101,7 +21982,7 @@ ru:соевый лецитин
 sk:sójový lecitin
 sl:sojin lecitin
 sr:sojin lecitin
-sv:sojalecitin
+sv:sojalecitin, sojalecitiner, sojalecithin, sojabönslecitin
 tr:soya lesitini
 uk:Соєвий лецитин
 vegan:en: yes
@@ -21124,13 +22005,14 @@ hu:napraforgó lecitin
 it:lecitina girasole, lecitina di girasole
 lt:saulėgrąžu lecitinas
 lv:lecitinai iš saulègrąžų, saulespuku lecitīns
+nb:solsikkelecithin, solsikkelecitin
 nl:zonnebloemlecithine, zonnebloem-lecithine
 nn:solsikkelecithin
 pl:lecytyny ze slonecznika, lecytyna słonecznika
 pt:lecitina de girassol
 ro:lecitina de florarea-soarelui
 ru:лецитин подсолнечный
-sv:solroslecitin
+sv:solroslecitin, solroslecithin
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q57271747
@@ -21445,7 +22327,7 @@ en:E331, Sodium citrates, e-331
 bg:E331, E331 food additive
 ca:E331, Citrats de sodi
 cs:E331, E331 food additive
-da:E331, E331 food additive
+da:E331, Natriumcitrater
 de:E331, Natriumcitrat, Natriumzitrat, Natriumcitrate
 el:E331, E331 food additive
 es:E331, Citratos de sodio, citrato sodico
@@ -21463,7 +22345,7 @@ pt:E331, E331 food additive
 ro:E331, E331 food additive
 ru:E331, Натрия гидроцетрат
 sl:E331, E331 food additive
-sv:E331, E331 food additive
+sv:E331, Natriumcitrater
 additives_classes:en: en:emulsifier, en:sequestrant, en:stabilizer
 e_number:en: 331
 organic_eu:en: authorized
@@ -21537,11 +22419,13 @@ wikidata:en: Q6460572
 < en:E331
 en:E331iii, Trisodium citrate
 ca:E331iii, Citrat trisòdic, citrat trisodic
+da:E331iii, Trinatriumcitrat
 de:Trinatriumcitrat
 es:E331iii, Citrato trisódico
-fi:E331iii, Trinatriumsitraatti
+fi:E331iii, Trinatriumsitraatti, Trinatriumsitraattia
 fr:E331iii, Citrate trisodique
 hu:E331iii, Trinátrium-citrát
+nb:E331iii, Trinatriumsitrat
 pl:E331iii, Cytrynian trisodowy
 pt:E331iii, Citrato trissódico
 sv:E331iii, Trinatriumcitrat
@@ -21669,7 +22553,7 @@ pt:E333, Citrato de cálcio
 ro:E333, E333 food additive
 sk:E333, Citrát trivápenatý
 sl:E333, E333 food additive
-sv:E333, E333 food additive
+sv:E333, Kalciumcitrater
 additives_classes:en: en:sequestrant, en:stabilizer
 e_number:en: 333
 mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:firming-agent
@@ -22084,7 +22968,7 @@ el:E339, E339 food additive
 es:E339, Fosfatos de sodio, Fosfato de sodio, Fosfato sódico, Fosfatos sodicos, E 339, Ortofosfatos de sodio
 et:E339, E339 food additive
 fa:سدیم فسفات
-fi:E339, Natriumfosfaatti, Natriumfosfaattia, natriumfosfaatit
+fi:E339, Natriumfosfaatit, Natriumfosfaatti, Natriumfosfaattia
 fr:E339, Orthophosphates de sodium, Orthophosphate de sodium, Phosphate monosodique, Phosphate disodique, Phosphate trisodique, Phosphate de sodium, phosphates de sodium
 hu:E339, E339 food additive
 it:E339, E339 food additive, fosfati di sodio
@@ -22099,7 +22983,7 @@ ro:E339, E339 food additive
 ru:Натрия фосфаты
 sk:E339, E339 food additive
 sl:E339, E339 food additive
-sv:E339, Natriumfosfat
+sv:E339, Natriumfosfater, Natriumfosfat
 additives_classes:en: en:emulsifier, en:humectant, en:preservative, en:sequestrant, en:stabilizer, en:thickener
 e_number:en: 339
 mandatory_additive_class:en: en:acidity-regulator, en:sequestrant, en:stabilizer, en:emulsifier, en:thickener, en:humectant, en:raising-agent
@@ -22367,7 +23251,7 @@ pt:E341, Fosfato de cálcio
 ro:E341, Fosfat de calciu
 sk:E341, E341 food additive
 sl:E341, E341 food additive
-sv:E341, E341 food additive
+sv:E341, Kalciumfosfater, Kalciumfosfat
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabilizer, en:thickener
 e_number:en: 341
 mandatory_additive_class:en: en:acidity-regulator, en:raising-agent
@@ -23539,7 +24423,7 @@ en:E392, Extracts of rosemary, rosemary extract
 bg:E392, Екстракти от розмарин
 ca:E392, Extracte de romaní, extracte de romani
 cs:E392, Výtažky z rozmarýnu, Rozmarýnové extrakty
-da:E392, Ekstrakter af rosmarin
+da:E392, Ekstrakter af rosmarin, rosmarinekstrakt
 de:E392, Extrakt aus Rosmarin, Rosmarinextrakt
 el:E392, Εκχυλισματα δενδρολιβανου
 es:E392, Extractos de romero
@@ -23553,11 +24437,11 @@ lv:E392, Ekstrakti no rozmarīna
 mt:E392, Estratti tar-rosmarin
 nl:E392, Extracten van rozemarijn
 pl:E392, Ekstrakty z rozmarynu (wyciągi z rozmarynu)
-pt:E392, Extractos de rosmaninho
+pt:E392, Extractos de rosmaninho, extratos de rosmaninho
 ro:E392, Extracte de rozmarin
 sk:E392, Extrakty z rozmarínu
 sl:E392, Izvlečki rožmarina
-sv:E392, Extrakt av rosmarin
+sv:E392, Extrakt av rosmarin, rosmarinextrakt
 e_number:en: 392
 efsa_evaluation:en: Extension of use of extracts of rosemary -E 392- in fat-based spreads
 efsa_evaluation_date:en: 2015-05-07
@@ -24118,6 +25002,7 @@ fi:guarjauho
 fr:farine de graine de guar
 hu:guarliszt, guar liszt
 it:Farina di guar
+nb:guarkjernemel
 nl:
 sv:
 
@@ -24204,7 +25089,7 @@ ro:E414, Gumă arabică
 ru:E414, Гуммиарабик
 sk:E414, Arabská guma
 sl:E414, Akacijeva guma
-sv:E414, Gummi arabicum
+sv:E414, Gummi arabicum, Akaciagummi, Arabisk gummi
 tr:Arap zamkı
 uk:Гуміарабік
 uz:Aqoqiyo
@@ -24273,6 +25158,7 @@ ja:キサンタンガム
 lt:E415, Ksantano derva
 lv:E415, Ksantāna sveķi
 mt:E415, Gomma xanthan
+nb:E415, Xantangummi
 nl:E415, Xanthaangom, Xanthaan
 nn:xanthan gum
 pl:E415, Guma ksantanowa
@@ -24281,7 +25167,7 @@ ro:E415, Gumă de xantan
 ru:E415, Ксантановая камедь, Ксантан, Е415
 sk:E415, Xantánová živica
 sl:E415, Ksantan gumi
-sv:E415, Xantangummi
+sv:E415, Xantangummi, Xantan, Xanthangummi
 zh:黄原胶
 additives_classes:en: en:emulsifier, en:stabilizer, en:thickener
 e_number:en: 415
@@ -24459,7 +25345,7 @@ ro:E420, Sorbitol, Sirop de sorbitol, E420i
 ru:E420, Сорбит, сорбитовый сироп, Сорбитол, Глюцит, Е420
 sk:E420, Sorbitol, E420i
 sl:E420, Sorbitol, E420i
-sv:E420, Sorbitol, E 420, D-sorbitol, D-glukitol, E420i, D-glucitol
+sv:E420, Sorbitol, E 420, D-sorbitol, D-glukitol, Sorbitoler, E420i, D-glucitol
 additives_classes:en: en:humectant, en:sequestrant, en:stabilizer, en:sweetener, en:thickener
 e_number:en: 420
 vegan:en: yes
@@ -24565,7 +25451,7 @@ et:E422, Glütserool, glütseriin, glicerol
 eu:glizerina
 fa:گلیسیرین
 fi:E422, Glyseroli, Glyserolia, glyseriini
-fr:E422, Glycérol, Trihydroxypropane, glycérine, propan-1‚2‚3-triol, 1‚2‚3-propanetriol
+fr:E422, Glycérol, Trihydroxypropane, glycérine, propan-1‚2‚3-triol, 1‚2‚3-propanetriol, glysérol
 ga:Gliocról
 gl:Glicerol
 gv:glisreen
@@ -24690,7 +25576,7 @@ de:E425i, Konjakgummi
 el:E425i, Κομμι konjac
 es:E425i, Goma konjac
 et:E425i, Rivieri titaanjuure kummi
-fi:E425i, Konjak-hartsi, Konjak-hartsia
+fi:E425i, Konjak-hartsi, Konjak-hartsia, Konjakkikumi
 fr:E425i
 hu:E425i, Konjakgyanta
 it:E425i, Gomma di konjac
@@ -25186,7 +26072,7 @@ bs:Pektin
 ca:E440, Pectina, pectines, Pectina no amidada
 cs:E440a, E440a food additive, E440, Pektin, Pektiny, E440i
 cy:Pectin
-da:E440a, E440a food additive, E440, pektin, E440i, Pectin
+da:E440a, Pektin, E440, Pektiner, Pectiner, E440i, Pectin
 de:E440a, E440a food additive, E440, Pektine, Polygalacturonat, E 440, Pektin, Protopektin, E 440ii, Pectin, Rhamnogalacturonan, E440i
 el:E440a, E440a food additive, E440, Πηκτίνη, E440i, Πηκτινη
 eo:Pektino
@@ -25222,7 +26108,7 @@ sh:Pektin
 sk:E440a, E440a food additive, E440, Pektín, E440i
 sl:E440a, E440a food additive, E440, Pektin, E440i
 sr:пектин
-sv:E440a, E440a food additive, E440, Pektin, E 440, E440i
+sv:E440a, Pektin, E440, Pektiner, Pektin E 440, E440i
 ta:பெக்டின்
 th:เพกทิน
 tr:Pektin
@@ -25548,7 +26434,7 @@ ro:E450, E450 food additive, difosfati
 ru:E450, Пирофосфаты, двузамещенный пирофосфат натрия, трехзамещенный пирофосфат натрия, тетранатрийпирофосфат, двузамещенный пирофосфат калия, тетракалийдифосфат, дикальцийпирофосфат, кальцийдигидропирофосфат, Пирофосфат
 sk:E450, E450 food additive, difosforečnany
 sl:E450, E450 food additive
-sv:E450, Pyrofosfat
+sv:E450, Difosfater, Pyrofosfat
 zh:焦磷酸盐
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabilizer, en:thickener
 e_number:en: 450
@@ -25572,7 +26458,7 @@ el:E450i, Δισοξινο πυροφωσφορικο νατριο
 es:E450i, Difosfato disódico, Pirofosfato ácido de sodio
 et:E450i, Dinaatriumdifosfaat, Dinaatriumdivesinikdifosfaat
 fa:دی‌سدیم پیروفسفات
-fi:E450i, Dinatriumdifosfaatti, Dinatriumdivetydifosfaatti, Dinatriumdivetypyrofosfaatti, Hapan natriumpyrofosfaatti, Dinatriumdifosfaattia, Dinatriumdivetydifosfaattia, Dinatriumdivetypyrofosfaattia
+fi:E450i, Dinatriumdifosfaatti, Dinatriumdivetydifosfaatti, Dinatriumdivetypyrofosfaatti, Hapan natriumpyrofosfaatti, Dinatriumdifosfaattia, Dinatriumdivetydifosfaattia, Dinatriumdivetypyrofosfaattia, E450a
 fr:E450i, Pyrophosphate de sodium acide, Pyrophosphate acide de sodium, diphosphate de sodium, Di-sodium di-phosphate, di-sodium pyrophosphate, CAS 7758-16-9, Dihydrogéno-diphosphate disodique, Dihydrogéno-pyrophosphate disodique, Pyrophosphate disodique, Disodium pyrophosphate, sodium acid pyrophosphate, SAPP, Diphosphoric acid disodium salt, Disodium dihydrogen pyrophosphate, Disodium diphosphate, Disodium dihydrogen diphosphate, E450a, diphosphates de sodium, Pyrophosphate acide de soude, pyrophosphate de soude
 hu:E450i, Dinátrium-difoszfát
 it:E450i, Difosfato disodico
@@ -25896,7 +26782,7 @@ ru:E452, e 452
 sk:E452, E452 food additive
 sl:E452, E452 food additive, e 452
 sr:E452, e 452
-sv:E452, E452 food additive, e 452
+sv:E452, Polyfosfater, e 452
 uk:E452, e 452
 zh:E452, e 452
 additives_classes:en: en:emulsifier, en:humectant, en:sequestrant, en:stabilizer, en:thickener
@@ -26198,6 +27084,7 @@ it:E460i, Cellulosa microcristallina
 lt:E460i, Mikrokristalinė celiuliozė
 lv:E460i, Mikrokristāliskā celuloze
 mt:E460i, Ċelluloża mikrokristallina
+nb:E460i, Mikrokrystallinsk cellulose
 nl:E460i, Microkristallijne cellulose, microkristalline cellulose
 pl:E460i, Celuloza mikrokrystaliczna
 pt:E460i, Celulose microcristalina
@@ -26407,7 +27294,7 @@ ar:كربوكسي ميثيل السليولوز
 bg:E466, Натриева карбокси метил целулоза, карбокси метил целулоза, целулозна гума, CMC, NaCMC
 ca:E466, Carboximetilcel·lulosa sòdica
 cs:E466, Sodná sůl karboxymethylcelulosy, karboxymethylcelulosa, celulosová guma, CMC, NaCMC, Karboxymethylcelulóza, Karboxymetylcelulóza, Karboxymetylcelulosa, E 466
-da:E466, Natriumcarboxymethylcellulose (carboxymethylcellulose og cellulosegummi), carboxymethylcellulose
+da:E466, Natriumcarboxymethylcellulose (carboxymethylcellulose og cellulosegummi), Cellulosegummi, carboxymethylcellulose
 de:E466, Carboxymethylcellulose, natrium-carboxymethylcellulose, cellulosegummi, CMC, NaCMC, Carboxymethylcellulosen, Carboxymethylzellulose, E 466, Natriumcarboxymethylcellulose
 el:E466, Αλας με νατριο της καρβοξυμεθυλοκυτταρινης, καρβοξυμεθυλοκυτταρινη, κομμι κυτταρινης, CMC, NaCMC
 es:E466, Carboximetilcelulosa sódica, carboximetilcelulosa, carboximetil celulosa, goma de celulosa, CMC, NaCMC, gomas de celulosa
@@ -26617,6 +27504,7 @@ it:E470b, Sali di magnesio degli acidi grassi
 lt:E470b, Magnesium salts of fatty acids
 lv:E470b, Taukskābju magnija sāļi
 mt:E470b, Imlieħ tal-manjeżju tal-aċidi grassi
+nb:E470b, Magnesiumsalter av fettsyrer
 nl:E470b, Magnesiumzouten van vetzuren
 pl:E470b, Sole magnezowe kwasów tłuszczowych
 pt:E470b, Sais de magnésio de ácidos gordos
@@ -26647,6 +27535,7 @@ it:E471, Mono- e digliceridi degli acidi grassi, Monostearato di glicerile, mono
 lt:E471, Riebalų rūgščių mono- ir digliceridai, Glicerilmonostearatas, glicerilmonopalmitatas, glicerilmonooleatas, monostearinas, monopalmitinas, monooleinas
 lv:E471, Taukskābju mono- un diglicerīdi, Glicerilmonostearāts, Glicerilmonopalmitāts, Glicerilmonooleāts, monostearīns, monopalmitīns, monooleīns
 mt:E471, Mono- u digliċeridi tal-aċidi grassi, Monostearat tal-gliċeril, Monopalmitat tal-gliċeril, Monooleat tal-gliċeril, Monostearina, Monopalmitina, Monooleina
+nb:E471, Mono- og diglyserider av fettsyrer
 nl:E471, Mono- en diglyceriden van vetzuren, Glycerylmonostearaat, glycerylmonopalmitaat, glycerylmonoöleaat, monostearine, monopalmitine, monoöleïne
 nn:mono- och diglycerider av fettsyror
 pl:E471, Mono- i diglicerydy kwasów tłuszczowych, Monostearynian glicerolu, monopalmitynian glicerolu, monooleinian glicerolu, monostearynian, monopalmitynian, monooleinian
@@ -27579,7 +28468,7 @@ pt:E492, Triestearato de sorbitano
 ro:E492, Tristearat de sorbitan
 sk:E492, Sorbitantristearát
 sl:E492, Sorbitan tristearat
-sv:E492, Sorbitantristearat
+sv:E492, Sorbitantristearat, Sorbitan tristearat
 additives_classes:en: en:emulsifier, en:stabilizer
 e_number:en: 492
 efsa_evaluation:en: Re‐evaluation of sorbitan monostearate -E 491-, sorbitan tristearate -E 492-, sorbitan monolaurate -E 493-, sorbitan monooleate -E 494- and sorbitan monopalmitate -E 495- when used as food additives
@@ -27744,7 +28633,7 @@ mt:E500, E500 food additive
 nl:E500, Natriumcarbonaat, Huishoudsoda, Na2CO3, Dinatriumcarbonaat, natriumcarbonaten
 nn:natriumkarbonater
 pl:E500, Węglany sodu, Węglan sodu, Soda kalcynowana, Soda amoniakalna
-pt:E500, Carbonato de sódio, Barrilha, Na2CO3
+pt:E500, Carbonato de sódio, Barrilha, Na2CO3, Carbonatos de sódio
 ro:E500, Carbonat de sodiu, Soda
 ru:E500, Карбонаты натрия, карбонат натрия, Натрия карбонат, Сода стиральная, Е500, Кальценированная сода, Кристаллическая сода, Кальцинированная сода, Na2CO3
 sk:E500, Uhličitan sodný, Sóda
@@ -27852,7 +28741,7 @@ es:E500ii, Bicarbonato de sodio, Carbonato ácido de sodio, Bicarbonato sódico,
 et:E500ii, Naatriumvesinikkarbonaat, Söögisooda
 eu:sodio hidrogenokarbonato
 fa:جوش شیرین
-fi:E500ii, Natriumvetykarbonaatti, Natriumbikarbonaatti, hapan natriumkarbonaatti, Natriumvetykarbonaattia, Natriumbikarbonaattia
+fi:E500ii, Natriumvetykarbonaatti, Natriumbikarbonaatti, hapan natriumkarbonaatti, Natriumvetykarbonaattia, Natriumbikarbonaattia, Ruokasooda
 fr:E500ii, hydrogénocarbonate de sodium
 gl:Bicarbonato de sodio
 gu:ખાવાનો સોડા
@@ -27873,7 +28762,6 @@ lt:E500ii, Natrio hidrokarbonatas, natrio rūgštusis karbonatas, sodos bikarbon
 lv:E500ii, Nātrija hidrogēnkarbonāts, Nātrija bikarbonāts, nātrija skābais karbonāts
 ml:സോഡിയം ബൈകാർബണേറ്റ്
 mt:E500ii, Karbonat idroġenat tas-sodju, Bikarbonat tas-sodju, karbonat tal-aċidu tas-sodju, Bikarbonat tas-soda
-nb:Thoàⁿ-sng chúi-sò͘ natrium
 nl:E500ii, Natriumwaterstofcarbonaat, Natriumbicarbonaat, zuur natriumcarbonaat, dubbelkoolzure soda, natriumwaterstofcarbonaat/natriumbicarbonaat
 nn:natriumvätekarbonat, natriumhydrogenkarbonat
 oc:Idrogenocarbonat de sòdi
@@ -28138,14 +29026,14 @@ ar:بيكربونات الأمونيوم
 bg:E503ii, Амониев хидроген карбонат
 ca:carbonat àcid d'amoni, bicarbonato amonico
 cs:E503ii, Hydrogenuhličitan amonný
-da:E503ii, Ammoniumhydrogencarbonat, ammoniumväte-hydrogenkarbonat, ammoniumvätekarbonat, Hjortetakssalt
+da:E503ii, Ammoniumhydrogencarbonat, Hjortetakssalt, ammoniumväte-hydrogenkarbonat, ammoniumvätekarbonat
 de:E503ii, Ammoniumhydrogencarbonat, Ammonium-hydrogencarbonat, Ammoniumbicarbonat
 el:E503ii, Οξινο ανθρακικο αμμωνιο
 eo:Amonia bikarbonato
 es:E503ii, Bicarbonato de amonio, Carbonato ácido de amonio, Bicarbonato amónico
 et:E503ii, Ammooniumvesinikkarbonaat
 fa:بی‌کربنات آمونیوم
-fi:E503ii, Ammoniumvetykarbonaatti, Ammoniumvetykarbonaattia, ammoniumbikarbonaatti
+fi:E503ii, Ammoniumvetykarbonaatti, Ammoniumvetykarbonaattia, hirvensarvisuola, ammoniumbikarbonaatti
 fr:E503ii
 gl:Bicarbonato amónico
 hi:अमोनियम बाईकार्बोनेट
@@ -28167,7 +29055,7 @@ ro:E503ii, Bicarbonat de amoniu, Carbonat acid de amoniu
 ru:
 sh:Amonijum bikarbonat
 sk:E503ii, Hydrogenuhličitan amónny
-sl:E503ii, Amonijev hidrogenkarbonat
+sl:E503ii, Amonijev hidrogenkarbonat, hjorthornssalt
 sr:Amonijum bikarbonat
 sv:E503ii, Ammoniumvätekarbonat
 te:అమ్మోనియం బైకార్బొనేట్
@@ -28194,7 +29082,7 @@ eo:magnezia karbonato
 es:E504, Carbonatos de magnesio, Carbonato de magnesio, MgCO3, E504i
 et:E504, Magneesiumkarbonaat, E504i
 fa:منیزیم کربنات
-fi:E504, Magnesiumkarbonaatti, Magnesiumkarbonaattia, E504i, magnesiumvetykarbonaatti
+fi:E504, Magnesiumkarbonaatti, Magnesiumkarbonaattia, Magnesiumkarbonaatit, E504i, magnesiumvetykarbonaatti
 fr:E504, Carbonates de magnésium, Carbonate de magnésium, Magnésium (carbonate), Carbonate acide de magnésium, bicarbonate de magnésium, Hydromagnésite, Carbonate de magnésium hydraté basique, carbonate de magnésium monohydraté, E504i
 ga:carbónáit mhaignéisiam
 hi:मैग्निसियम कार्बोनेट
@@ -28216,7 +29104,7 @@ sh:Magnezijum karbonat
 sk:E504, Uhličitan horečnatý, E504i
 sl:E504, Magnezijev karbonat, E504i
 sr:магнезијум карбонат
-sv:E504, Magnesiumkarbonat, Magnesit, E 504, E504i
+sv:E504, Magnesiumkarbonat, Magnesit, E 504, Magnesiumkarbonater, E504i
 ta:மக்னீசியம் கார்பனேட்டு
 th:แมกนีเซียมคาร์บอเนต
 uk:Карбонат магнію
@@ -28439,7 +29327,7 @@ bs:Amonijum hlorid
 ca:clorur d'amoni
 cs:E510, E510 food additive, Chlorid amonný
 cy:Amoniwm clorid
-da:E510, E510 food additive, Ammoniumklorid
+da:E510, Salmiak, Ammoniumklorid
 de:E510, E510 food additive, Ammoniumchlorid
 el:E510, E510 food additive, Χλωριούχο αμμώνιο
 eo:Amonia klorido
@@ -28480,7 +29368,7 @@ sh:Amonijum hlorid
 sk:E510, E510 food additive, Chlorid amónny
 sl:E510, E510 food additive, Amonijev klorid
 sr:амонијум хлорид
-sv:E510, E510 food additive, Ammoniumklorid
+sv:E510, Salmiak, Ammoniumklorid
 ta:அம்மோனியம் குளோரைடு
 te:అమ్మోనియం క్లోరైడ్
 tg:Навшодир
@@ -33883,7 +34771,7 @@ de:E960, Steviolglycoside, Steviol Glycoside
 el:E960, Γλυκοζιτες στεβιολης συνώνυμα, Γλυκοζιτες στεβιολης
 es:E960, Glucósidos de esteviol, Glicósidos de esteviol
 et:E960, Steviooglükosiidid
-fi:E960, Stevioliglykosidit, Stevioliglykosidejä
+fi:E960, Stevioliglykosidit, Stevioliglykosidejä, Steviaglykosidit
 fr:E960, Glucosides de stéviol, stévioside, rébaudioside A, extrait de stévia, glycosides de stéviol, extrait de feuille de Stévia, Stévia
 hu:E960, Szteviol-glikozidok szinonimák
 it:E960, Glicosidi dello steviolo, glucosidi steviolici
@@ -34073,7 +34961,7 @@ si:E965, මෝල්ටිටෝල්
 sk:E965, Maltitol
 sl:E965, Maltitol
 sr:E965, Малтитол
-sv:E965, maltitol
+sv:E965, maltitol, maltitoler
 ta:E965, maltitol
 uk:E965, Мальтитол
 vi:E965, Maltitol
@@ -34397,7 +35285,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Egg_as_food
 en:barn eggs
 de:Eier aus Bodenhaltung
 es:huevos de granero
-fi:lattiakanojen munat, onnellisen kanan munat, pesämunat
+fi:lattiakanojen munat, vapaan kanan munat, onnellisen kanan munat, pesämunat
 fr:œufs d'élevage au sol, œufs de poules élevées au sol, œufs de ponte au sol, sol, issu de poules élevées au sol
 it:uova di allevamento al suolo
 nl:scharreleieren
@@ -34443,7 +35331,7 @@ nl:categorie A eieren
 en:chicken egg
 de:Hühnerei, Hühnereier, Hühnervollei
 es:Huevo de gallina
-fi:kananmuna
+fi:kananmuna, kananmunaa, kanamunaa
 fr:œufs de poules
 it:Uova di gallina
 nl:kippeneieren
@@ -34473,7 +35361,7 @@ lv:kiausšinių milteliai
 nl:eipoeder, ei-poeder
 pt:ovo em pó
 ru:Яичный порошок
-sv:äggpulve
+sv:äggpulver
 
 < en:Egg
 en:egg white
@@ -34584,7 +35472,7 @@ nl:eieren uit Zwitserland, zwitserse eieren
 en:free range eggs
 de:Freilandeier
 es:Huevos de corral, huevos de gallinas criadas en el suelo
-fi:Vapaan kanan munat, vapaan kanan munia, ulkokanan munat
+fi:ulkomunat
 fr:Oeufs élevés en plein air, oeufs d'élevage en plein air, oeufs plein air
 
 < en:Egg
@@ -34679,17 +35567,19 @@ fr:blanc d'œuf liquide
 it:Albume d'uovo liquido
 
 < en:Egg white
-en:powdered egg white, dehydrated egg white
+en:powdered egg white, dehydrated egg white, egg white powder
 ca:clara d'ou en pols
+da:æggehvidepulver
 de:Eiweißpulver, Eiweisspulver, Eiklarpulver, Trockeneiweiß, Eiklar getrocknet
 el:ασπράδι αυγού σε σκόν
 es:clara de huevo en polvo, clara de huevos en polvo
-fi:munanvalkuaisjauhe, kananmunanvalkuaisjauhe, kuivattu munanvalkuainen
+fi:munanvalkuaisjauhe, kuivattu munanvalkuainen
 fr:blanc d'œuf en poudre, blancs d'œufs en poudre, poudre de blanc d'œuf, blanc d'œuf déshydraté, blanc d'œufs en poudre
 hu:porított tojásfehérje, tojásfehérjepor, szárított tojásfehérje
 it:albume d'uovo in polvere, albume in polvere
 nl:eiwitpoeder, gedroogd ei-eiwit, eiwit in poeder
-sv:äggvita i pulver
+pt:clara de ovo em pó
+sv:äggvitepulver, äggvita i pulver
 
 < en:Egg white
 fr:blanc d'œuf frais, blancs d'œufs frais, blanc d'œufs frais
@@ -34709,18 +35599,20 @@ fr:jaune d'œuf de poules
 < en:Egg yolk
 en:egg yolk powder, eggs yolk powder, powdered egg yolk
 ca:gema d'ou en pols
+da:æggeblommepulver
 de:Eigelbpulver
 es:yema de huevo en polvo
-fi:munankeltuaisjauhe
+fi:munankeltuaisjauhe, keltuaisjauhe
 fr:jaune d'œuf en poudre, jaunes d'œufs en poudre, poudre de jaunes d'œufs, jaune d'œufs en poudre, poudre de jaune d'œuf
 it:tuorli in polvere
 nl:eigeelpoeder
 pt:gemas de ovo em pó
+sv:äggulepulver
 
 < en:Egg yolk
 en:free range egg yolk
 de:Eigelb aus Freilandhaltung
-fi:Vapaan kanan munankeltuainen
+fi:ulkomunankeltuainen
 fr:Jaune d'œuf de poules élevées en liberté
 nl:scharreleigeel
 
@@ -34783,15 +35675,40 @@ de:Holunderbeerenkonzentrat
 es:concentrato di coccole di sambuco
 fi:seljanmarjatiiviste
 
+< en:Elderberry
+< en:Fruit juice
+en:elderberry juice
+de:Holundersaft
+fi:seljanmarjamehu, seljanmarjatäysmehu
+fr:jus de sureau
+it:succo di sambuco
+nl:vlierbessap
+sv:fläderbärsjuice
+
 < en:Elderberry extract
 en:natural elderberry extract
 de:natürlicher Holunderbeerenextrakt
+
+< en:Elderberry juice
+en:elderberry juice concentrate, concentrated elderberry juice
+de:konzentrierter Holundersaft
+fi:seljanmarjamehutiiviste, seljanmarjatäysmehutiiviste
+fr:jus de sureau concentré, jus concentré de sureau
+sv:koncentrerad fläderbärsjuice
+
+< en:Elderberry juice concentrate
+en:elderberry juice from concentrate
+de:Holundersaft aus Konzentrat
+fi:seljanmarjamehu tiivisteestä, seljanmarjatäysmehu tiivisteestä
+fr:jus de sureau à base de concentré
+it:succo di sambuco a base di concentrato
 
 < en:Elderflower
 en:elderflower extract
 de:Holunderblütenextrakt
 fi:seljankukkauute
 fr:Extraits de fleurs de sureau
+sv:fläderblomsextrakt
 
 < en:Emmental
 en:Emmental from France
@@ -34815,11 +35732,11 @@ hu:ömlesztett ementáli
 < en:Emmental from France
 fr:emmental de Savoie IGP
 
-en:Emulsifier, clouding agent, crystallization inhibitor, density adjustment agent, dispersing agent, plasticizer, surface active agent, suspension agent
+en:Emulsifier, clouding agent, crystallization inhibitor, density adjustment agent, dispersing agent, plasticizer, surface active agent, suspension agent, emulsifier blend
 bg:Емулгатор
 ca:Emulgent, emulsionant, emulgents, emulsiu, agent dispersant, agents dispersants
 cs:Emulgátor
-da:Emulgator
+da:Emulgator, Emulgatorer, Emulgeringsmiddel
 de:Emulgator, Emulgatoren
 el:Γαλακτωματοποιητής
 es:Emulgente, Emulsificante, emulsionante, agente dispersante, agente enturbiador, agentes enturbiadores, agente tensoactivo, corrector de la densidad, estabilizadores de una suspensión, estabilizador de una suspensión, inhibidor de la cristalización, plastificante, emulgentes, emulsificantes, agente emulsionante, agentes emulsionantes
@@ -34828,18 +35745,20 @@ fi:Emulgointiaine, Emulgointiainetta, Emulgointiaineet, Emulgointiaineita
 fr:Émulsifiant, agent de dispersion, agent de surface, agent de suspension, agent d'ajustement de la densité, inhibiteur de cristallisation, nébulisant, plastifiant
 ga:Eiblitheoir
 hu:Emulgeálószer, kristályosodásgátló, sűrűségszabályozó szer, diszpergálószer, lágyító, felületaktív anyag, szuszpenziós szer
+is:Yruefni
 it:Emulsionante, emulsionanti, agente emulsionante, agenti emulsionanti
 lt:Emulsiklis
 lv:Emulgators
 mt:Emulsifikant
+nb:Emulgeringsmiddel, Emulgator
 nl:Emulgator, Emulgatoren
 pl:Emulgator, Emulgatory
 pt:Emulsionante, emulsionantes
-ro:Emulsifiant
+ro:Emulsifiant, Emulgator
 ru:Эмульгатор
 sk:Emulgátor
 sl:Emulgator
-sv:Emulgeringsmedel
+sv:Emulgeringsmedel, Emulgering
 description:cs: Emulgátory se rozumějí látky, které umožňují vytvořit nebo uchovat v potravině stejnorodou směs dvou nebo více nemísitelných fází, například oleje a vody.
 description:da: Emulgatorer: stoffer, hvormed man kan danne eller opretholde en homogen blanding af to eller flere ikke-blandbare faser som f.eks. olie og vand i en fødevare.
 description:de: Emulgatoren sind Stoffe, die es ermöglichen, die einheitliche Dispersion zweier oder mehrerer nicht mischbarer Phasen wie z. B. Öl und Wasser in einem Lebensmittel herzustellen oder aufrechtzuerhalten.
@@ -34874,6 +35793,7 @@ fi:Sulatesuola, Sulatesuolaa, Sulatesuolat, Sulatesuoloja
 fr:Sels émulsifiants, sel émulsifiant, sels de fonte, sel de fonte, synergiste de sel émulsifiant
 ga:Salainn eiblithe
 hu:Emulgeálósók
+is:Bræðslusölt
 it:Sale di fusione, sali di fusione
 lt:Emulsinimo druskos
 lv:Emulģējošie sāļi
@@ -34884,7 +35804,7 @@ pt:Sais de fusão
 ro:Săruri de topire
 sk:Emulgujúce soli, Emulgujúce (taviace) soli
 sl:Emulgirne soli
-sv:Smältsalter
+sv:Smältsalt, Smältsalter
 description:cs: Tavicími solemi se rozumějí látky, které převádějí bílkoviny obsažené v sýru do disperzní formy za účelem homogenního rozložení tuků a ostatních složek.
 description:da: Smeltesalte: stoffer, som overfører proteiner i ost til dispergeret form og derved bevirker en homogen fordeling af fedt og andre bestanddele.
 description:de: Schmelzsalze sind Stoffe, die in Käse enthaltene Proteine in eine dispergierte Form überführen und hierdurch eine homogene Verteilung von Fett und anderen Bestandteilen herbeiführen.
@@ -34973,7 +35893,7 @@ mn:Фермент
 mr:उत्प्रेरक
 ms:eEnzim
 my:အင်န်ဇိုင်း
-nb:enzym
+nb:enzym, enzymer
 nl:enzym
 nn:enzym
 oc:enzim
@@ -35144,7 +36064,7 @@ eo:laktazo, β-galaktozidazo
 es:lactasa
 eu:laktasa
 fa:لاکتاز
-fi:laktaasi
+fi:laktaasi, laktaasientsyymi
 fr:lactase
 gl:lactase
 he:לקטאז
@@ -35286,11 +36206,45 @@ wikidata:en: Q170885
 wikipedia:en: https://en.wikipedia.org/wiki/Essential_oil
 
 < en:Essential oil
+en:aniseed oil, anise oil
+de:anisöl
+es:acelte de anis
+fi:anisöljy, anisöljyä
+fr:huile d'anis
+sv:anisolja
+
+< en:Essential oil
+en:eucalyptus oil
+az:eucalyptus oil
+be:эўкаліптавы алей
+de:eukalyptusöl
+et:eukalüptiõli
+fi:eukalyptusöljy
+fr:huile essentielle d'eucalyptus
+hu:eukaliptuszolaj
+hy:նվենու յուղ
+pl:olejek eukaliptusowy
+ru:эвкалиптовое масло
+sl:evkaliptusovo olje
+sv:eukalyptusolja
+te:నీలగిరి తైలం
+uk:евкаліптова олія
+uz:efir moyli ekinlar
+vi:dầu khuynh diệp
+wikidata:en: Q511687
+wikipedia:en: https://en.wikipedia.org/wiki/Eucalyptus_oil
+
+< en:Essential oil
+en:lime oil
+fi:limettiöljy, limeöljy
+sv:limeolja
+
+< en:Essential oil
 en:orange essential oil
 de:Orangenöl
 es:aceite esencial de naranja
 fi:appelsiiniöljy
-fr:huile essentielle d'orange
+fr:huile essentielle d'orange, huile d'orange
 hu:narancs illóolaj, narancsos illóolaj
 it:olio essenziale di arancio
 nl:sinaasappelolie
@@ -35372,7 +36326,7 @@ de:Extrakt
 es:Extracto
 et:Ekstrakt
 fa:شیره
-fi:uute
+fi:uute, uutetta
 fr:extrait
 he:תרכיז
 hu:kivonat
@@ -35395,10 +36349,11 @@ wikipedia:en: https://en.wikipedia.org/wiki/Extract
 en:vegetable extract, vegetable extracts
 de:Pflanzenextrakt, Gemüseextrakte
 es:Extrato vegetal, extratos vegetales
-fi:kasvisuute, kasvisuutteet
+fi:kasvisuutteet
 fr:extraits végétaux
 it:estratto vegetale
 nl:plantaardig extract, plantaardige extracten
+sv:grönsaksextrakt
 
 en:Exxx, Exxx food additive
 bg:Exxx, Exxx food additive
@@ -35471,16 +36426,17 @@ fi:maitorasva
 fr:matière grasse lactique, matière grasse laitière, matière grasse de lait, matière grasse du lait
 hr:mlijecnu mast
 hu:tejzsír
+is:mjólkurfita
 it:grasso del latte
 lt:pieno riebalai
 lv:piena tauki
 nb:melkefett
 nl:melkvet
-pl:tłuszcz mlecny
+pl:tłuszcz mlecny, tłuszcz mleczny, bezwodny tłuszcz mleczny
 pt:gorda do leite
 ro:grasimi din lapte, grăsimi din lapte, grasime din lapte
 ru:молочный жнр
-sv:mjölkfett, mølkfett
+sv:mjölkfett
 vegan:en: no
 vegetarian:en: yes
 
@@ -35532,14 +36488,6 @@ fi:luomu fenkolinsiemen
 nl:biologisch venkelzaad
 
 < en:Fenugreek
-en:dried fenugreek leaves
-de:getrockneter Bockshornklee
-es:hoja de fenegreco seca
-fi:kuivatut sarviapilan lehdet
-fr:feuille de fenugrec séchée
-nl:gedroogd fenegriekblad
-
-< en:Fenugreek
 < en:Seed
 en:fenugreek seed, fenugreek seeds
 de:Bockshornkleesamen, getrocknete Bockshornkleesamen, Bockshornkleesaat
@@ -35547,6 +36495,14 @@ es:semilla de fenegreco, semilla de fenegreco seca
 fi:sarviapilan siemen, sarviapilan siemenet
 fr:graine de fenugrec, graines de fenugrec, graine de fenugrec séchée
 nl:fenegriekzaad, gedroogd fenegriekzaad
+
+< en:Fenugreek
+en:dried fenugreek leaves
+de:getrockneter Bockshornklee
+es:hoja de fenegreco seca
+fi:kuivatut sarviapilan lehdet
+fr:feuille de fenugrec séchée
+nl:gedroogd fenegriekblad
 
 < en:Fenugreek seed
 de:gemahlen Bockshornkleesamen
@@ -35591,7 +36547,7 @@ hu:baktérium kultúra, baktériumkultúra, kultúrák, elő kultúrák
 it:cultura microbiotica, cultura
 nl:Microbiële cultuur
 pl:Kultury bakterii
-sv:mikrobiell kultur, kultur, aktiva kulturer, levande kulturer
+sv:mikrobiell kultur, kultur, aktiva kulturer, levande kulturer, bakteriekultur
 nova:en: 3
 vegan:en: maybe
 vegetarian:en: maybe
@@ -35613,7 +36569,7 @@ de:Reifungskulturen
 < en:Ferment
 fr:ferments de maturation
 
-en:fiber, fibre
+en:fiber, fibre, dietary fibre
 af:Vesel
 ar:ألياف النسيج
 ba:Сүстәр
@@ -35632,7 +36588,7 @@ es:fibra, fibra alimentaria
 et:Kiud
 eu:zuntz
 fa:الیاف
-fi:kuitu
+fi:kuitu, ravintokuitu
 fr:fibre, fibre alimentaire, fibres alimentaires
 ga:Snáithín
 he:סיב
@@ -35666,7 +36622,7 @@ sh:Vlakno
 sk:vlákno
 sq:Fibrat
 sr:влакно
-sv:fiber
+sv:fiber, kostfiber, fibrer
 ta:இழை
 te:fiber
 tr:Lif
@@ -35685,10 +36641,14 @@ fr:fibre d'acacia, fibres d'acacia
 it:fibre di acacia
 nl:acaciavezels
 pt:fibras de acácia
+sv:akaciafiber
 
 < en:Citrus fruit
 < en:Fiber
+en:citrus fibre, citrus fibres
+fi:sitruskuitu
 fr:fibre d'agrume, fibre végétale d'agrumes
+sv:citrusfiber
 
 < en:Fiber
 en:inulin
@@ -35703,7 +36663,7 @@ eo:Inulino
 es:Inulina
 eu:Inulina
 fa:اینولین
-fi:Inuliini
+fi:inuliini, inuliinikuitu
 fr:inuline
 gl:Inulina
 he:אינולין
@@ -35726,7 +36686,7 @@ ru:инулин
 sh:inulin
 sl:Inulin
 sr:Инулин
-sv:Inulin
+sv:inulin, inulinfiber
 th:อินูลิน
 tr:İnülin
 uk:Інулін
@@ -35739,6 +36699,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Inulin
 < en:Fiber
 en:soy fiber
 de:Sojafaser
+fi:soijakuitu
 fr:fibres de soja
 
 < en:Fiber
@@ -35754,13 +36715,13 @@ hu:növényi rostok, növényi rost
 it:fibre vegetali, fibra vegetale
 ja:植物繊維
 ko:식물섬유
-nb:Plantefiber
+nb:vegetabilsk fiber, plantefiber
 nl:plantaardige vezel
 nn:plantefiber
 pl:Błonnik roślinny
 pt:fibra vegetal
 ru:растительное волокно
-sv:Växtfibrer
+sv:vegetabilisk fiber, vegetabilisk fibrer, växtfibrer
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q20026824
@@ -35792,7 +36753,7 @@ es:relleno
 et:Hakkliha
 fa:گوشت چرخ کرده
 fi:täyte
-fr:garniture, fourrage, nappage, farce, fourrage blanc
+fr:garniture, fourrage, nappage, farce, fourrage blanc, remplissage
 gl:Recheo
 he:מלית
 hu:töltelék
@@ -35809,7 +36770,7 @@ nl:garnituur, vulling
 pl:Farsz
 pt:recheio
 ru:фаршировка
-sv:Köttfärs
+sv:fyllning
 ta:உள்வைப்பு
 th:อาหารยัดไส้
 tr:Dolgu
@@ -35830,6 +36791,12 @@ it:farcitura al latte
 nl:melkvulling
 pt:recheio de leite
 vegan:en: no
+
+< en:Filling
+en:raspberry filling
+fi:vadelmatäyte
+fr:garniture aux framboises
+sv:hallonfyllning
 
 en:Firming agent, firming
 bg:Втвърдител
@@ -36420,12 +37387,20 @@ zh:鰈魚
 wikipedia:en: https://en.wikipedia.org/wiki/European_plaice
 
 < en:Fish
+en:fish stock
+de:fischbrühe
+fi:kalaliemi
+fr:bouillon de poisson
+sv:fiskbuljong
+
+< en:Fish
 en:fishpowder, powdered fish
 de:Fischpulver
 fi:kalajauhe, jauhettu kala
 fr:poisson en poudre, poudre de poisson, poisson déshydraté
 it:pesce in polvere
 nl:vispoeder
+sv:fiskpulver
 
 < en:Fish
 en:flounder
@@ -36766,7 +37741,7 @@ pt:escamudo
 ru:сайда
 se:Sáidi
 sq:pollock
-sv:gråsej
+sv:gråsej, sej
 uk:Сайда
 zh:綠青鱈
 wikipedia:en: https://en.wikipedia.org/wiki/Pollachius_virens
@@ -36819,7 +37794,7 @@ ro:Lostriță
 ru:Лососёвые
 sr:лосос
 su:Salmon
-sv:Laxfiskar
+sv:Laxfiskar, lax
 ta:சல்மான் மீன்
 th:ปลาแซลมอน
 tr:Sombalığı
@@ -37372,11 +38347,19 @@ fr:flageolets verts
 it:fagioli nani
 nl:groene flageolets
 
+en:flat bean, helda bean, romano bean
+fi:romanopapu, romanopavut
+nl:snijboon
+nn:snittebønne
+sv:romanabönor
+wikidata:en: Q1828227
+wikipedia:en: https://en.wikipedia.org/wiki/Flat_bean
+
 en:Flavour enhancer, flavour synergist, flavor enhancer, flavor enhancers
 bg:Овкусител
 ca:Potenciador del sabor, Potenciador del gust, potenciadors del gust, potenciadors del sabor
 cs:Látka zvýrazňující chuť a vůni
-da:Smagsforstærker, smagsforstærkere
+da:Smagsforstærker, Smagsforstærkere
 de:Geschmacksverstärker
 el:Ενισχυτικό γεύσης
 es:Potenciador del sabor, potenciadores del sabor, Acentuadores del sabor, acentuadores del aroma, aromatizantes sinergistas, intensificador del sabor, intensificadores del sabor
@@ -37421,24 +38404,26 @@ en:flavouring, flavour, flavor, flavoring, aroma, flavours, flavors, flavourings
 bg:аромат
 ca:Aromes, aroma
 cs:Aroma
-da:smagsstof
+da:smagsstof, smagstoffer, aromaer
 de:Aroma, Aromen
 es:aroma, aromas, aromatizante, aromatizantes, sustancias-aromatizantes, saborizante, saborizantes
-et:lōhna- ja maitseaine
-fi:aromi, aromit
+et:lōhna- ja maitseaine, lōhna- ja maitseained, aroomiaine
+fi:aromi, aromit, aromeja, aromiaineet, aromiaineita, makuaineet
 fr:arôme, arômes
 he:חומרי טעם
 hr:aroma
 hu:aroma, aromák
+is:bragðefni
 it:aroma, aromi
 lt:kvapioji medžiaga
 lv:aromatizētājs
+nb:aroma, aromaer, smakstilsetninger
 nl:aroma, aroma's
 pl:aromat, aromaty
 pt:aromatizante
 ro:aromă, aroma, arome
 ru:ароматизатор
-sv:arom, aromer
+sv:arom, aromer, smakämnen, aromämne, aromämnen
 zh:调味剂
 vegan:en: maybe
 vegetarian:en: maybe
@@ -37491,6 +38476,7 @@ fi:naudanliha-aromi
 fr:arôme de boeuf
 hu:természetes marhahús aroma
 it:aroma al manzo
+sv:biffarom
 vegan:en: no
 vegetarian:en: no
 
@@ -37502,13 +38488,38 @@ fr:arôme de bergamote
 hu:természetes bergamot narancs aroma
 
 < en:Flavouring
+en:blackcurrant flavouring
+da:solbæraroma
+es:aroma de grosella
+fi:mustaherukka-aromi, mustaherukka-aromia
+fr:arôme cassis
+nb:solbær aroma
+pl:aromat czarnej porzeczki
+sv:svartvinbärsarom
+
+< en:Flavouring
+en:blueberry flavouring
+fi:mustikka-aromi
+fr:arôme de myrtille
+sv:blåbärsarom
+
+< en:Flavouring
+en:butter flavouring
+de:butteraroma, butter-aroma
+fi:voiaromi
+fr:arôme de beurre
+sv:smörarom
+
+< en:Flavouring
 en:caramel flavouring
+da:karamelaroma
 de:Karamellaroma, Karamell-Aroma
 es:Sabor caramelo
-fi:karamelliaromi
+fi:karamelliaromi, toffeearomi
 fr:arôme caramel
 hu:karamella aroma, karamell aroma
 nl:caramelaroma
+sv:kolaarom
 
 < en:Flavouring
 en:celery flavouring
@@ -37552,11 +38563,20 @@ hu:kókusz aroma
 it:aroma di cocco
 nl:kokosaroma, kokosnoot-aroma
 
+< en:Flavouring
+en:cream flavouring
+da:flødearoma
+de:sahnearoma
+fi:kerma-aromi
+fr:arôme de crème
+it:aroma di panna
+
 < en:Crustacean
 < en:Flavouring
 fr:arôme crabe
 fi:rapuaromi
 nl:krabaroma
+sv:krabbarom
 
 < en:Flavouring
 en:crustaceans flavouring
@@ -37565,14 +38585,21 @@ fi:äyriäisaromi
 fr:arôme de crustacés
 
 < en:Flavouring
+en:dill flavouring
+fi:tilliaromi
+fr:arôme d'aneth
+sv:dillarom
+
+< en:Flavouring
 en:flavouring preparation, spice preparation
 de:Gewürzzubereitung, Aromaextrakte
-fi:aromivalmiste, maustevalmiste, aromisekoitus
+fi:aromivalmiste, maustevalmiste, aromisekoitus, maustamisvalmiste, makuvalmiste
 fr:préparation aromatisante, préparation aromatique
 hu:fűszerkészítmény
 it:preparazione di spezie
 nl:aromatiserende bereiding
 pt:preparacao aromatizante
+sv:smakberedning
 
 < en:Flavouring
 en:fruit flavouring
@@ -37583,11 +38610,27 @@ fr:arôme de fruit, arômes de fruits
 hu:gyümölcsaroma, gyümölcs aroma
 
 < en:Flavouring
+en:garlic flavouring
+fi:valkosipuliaromi
+fr:arôme d'ail
+sv:vitlökarom, vitlöksarom
+
+< en:Flavouring
 en:grapefruit flavouring
 de:Grapefruitgeschmack
 fi:greippiaromi
 fr:arôme de pamplemousse
 hu:grépfrút aroma, grapefruit aroma
+
+< en:Flavouring
+en:horseradish flavouring
+fi:piparjuuriaromi
+sv:pepparrotsarom
+
+< en:Flavouring
+en:juniper berry flavouring
+fi:katajanmarja-aromi
+sv:enbärsarom
 
 < en:Flavouring
 en:laurel flavouring
@@ -37604,6 +38647,26 @@ fr:arôme de citron, arôme citron
 hu:citromaroma, citrom aroma
 it:aroma di limone
 nl:citroenaroma
+sv:citronarom
+
+< en:Flavouring
+en:lime flavouring
+de:limettenaroma
+fi:limettiaromi
+fr:arôme de citron vert
+sv:limearom
+
+< en:Flavouring
+en:malt flavouring
+fi:mallasaromi
+fr:arôme de malt
+sv:maltarom
+
+< en:Flavouring
+en:mango flavouring
+fi:mangoaromi
+fr:arôme de mangue
+sv:mangoarom
 
 < en:Flavouring
 en:mint flavouring
@@ -37614,23 +38677,31 @@ fr:arôme de menthe
 hu:menta aroma
 
 < en:Flavouring
+en:mushroom flavouring
+fi:sieniaromi
+fr:arôme champignon
+sv:champinjonarom
+
+< en:Flavouring
 en:natural flavouring, natural flavour, natural flavor, natural flavoring, natural flavourings, natural flavorings, natural flavours, natural flavors, natural aroma, natural aromas
 ca:Aroma natural, aromes naturals
-da:naturlig aroma, naturlige aromaer
+da:naturlig aroma, naturlige smagsstoffer, naturlige aromaer
 de:natürliches Aroma, natürliche Aromen
 es:aroma natural, aromas naturales, saborizante natural
-fi:luontainen aromi, luontaiset aromit, luonnollinen aromi, luonnolliset aromit
+fi:luontainen aromi, luontaiset aromit, luonnollinen aromi, luonnolliset aromit, luontaisia aromeja
 fr:arôme naturel, arômes naturels
 he:חומרי טעם טבעיים
 hr:Prirodna aroma
 hu:természetes aroma, természetes aromák, természetazonos aroma, természetazonos aromák
+is:náttúruleg bragðefni
 it:aroma naturale, aromi naturali
+nb:naturlig aroma
 nl:Natuurlijke smaakstoffen, natuurlijk aroma, natuurlijke aroma's
 pl:Naturalny aromat
 pt:aroma natural
 ro:aromă naturală, aroma naturala
-ru:Натуральный ароматизатор
-sv:naturlig arom, naturliga aromer
+ru:Натуральный ароматизатор, ароматизатор натуральный
+sv:naturlig arom, naturliga aromer, naturlig smakämne, naturliga smakämnen, naturligt smakämne, naturliga aromämnen
 zh:天然调味剂
 vegan:en: maybe
 vegetarian:en: maybe
@@ -37679,6 +38750,7 @@ de:Birnenaroma
 fi:päärynäaromi
 fr:arôme de poire
 hu:körte aroma
+sv:päronarom
 
 < en:Flavouring
 en:pepper flavouring
@@ -37693,12 +38765,13 @@ de:Pfefferminzgeschmack
 fi:piparminttuaromi
 fr:arôme de menthe poivrée
 hu:borsmenta aroma
+sv:pepparmintsarom
 
 < en:Flavouring
 en:raspberry flavouring
 de:Himbeeraroma, Himbeer-Aroma
 es:sabor a frambuesa
-fi:vadelma-aromi
+fi:vadelma-aromi, vadelman aromi
 fr:arôme framboise
 hu:málna aroma
 nl:frambozenaroma
@@ -37709,18 +38782,26 @@ de:Meeresfrüchtearoma, Meeresfrüchte-Aroma
 fr:arôme de fruits de mer
 
 < en:Flavouring
+en:shrimp flavouring
+fi:katkarapuaromi
+fr:arôme de crevette
+sv:räkarom
+
+< en:Flavouring
 en:smoke flavouring, smoke flavour, aroma of smoke, smoked flavour
 ca:aroma de fum
 da:røgaroma
 de:Raucharoma
 es:aroma de humo
-fi:savuaromi
+fi:savuaromi, savuaromia
 fr:arôme de fumée, arôme fumé, arôme fumée, aromes de fumee, saveur de fumée
 hu:füst aroma, füst ízesétés, füst íz
 it:aroma di affumicato, aroma di affumicatura
+nb:røykaroma
 nl:rookaroma
 pl:Aromat dymu wędzarniczego
 pt:aroma de fumo
+sv:rökarom
 
 < en:Flavouring
 en:sour orange flavouring
@@ -37752,7 +38833,7 @@ hu:trüffel aroma
 < en:Flavouring
 en:vanilla flavouring
 ca:Aroma de vainilla, aromes de vainilla
-da:vanilijaroma
+da:vaniljearoma, vanilijaroma
 de:VanilleAroma
 es:aroma de vainilla
 fi:vanilja-aromi
@@ -37762,6 +38843,7 @@ it:aroma di vaniglia
 nl:vanillearoma
 pl:Aromat waniliowy
 pt:aroma baunilha
+sv:vaniljarom
 
 < en:Flavouring
 fr:arôme caféine
@@ -37815,7 +38897,9 @@ nn:brune linfrø
 < en:Flour
 en:flax flour, flaxseed flour
 es:semilla de lino amarillo, semillas de lino amarillo, semilla de lino, semillas de lino, semillas de lino marron
+fi:pellavansiemenjauho
 fr:farine de lin, farine de graines de lin
+sv:linfrömjöl
 
 < en:Flax seed
 fr:graines de lin doré
@@ -37858,7 +38942,7 @@ es:harina
 et:jahu
 eu:irin
 fa:آرد
-fi:jauho
+fi:jauho, jauhot
 fo:mjøl
 fr:farine, farines
 fy:moal
@@ -37977,6 +39061,20 @@ pt:Farinha de cereais
 sv:spannmålsmjöl
 
 < en:Flour
+en:chick pea flour
+da:kikærtemel
+fi:kikhernejauho
+fr:farine de pois chiche, farine de pois chiches
+sv:kikärtsmjöl
+
+< en:Flour
+en:flour blend, flour mix
+de:mehlmischung
+fi:jauhoseos
+fr:mélange de farine
+sv:mjölblanding
+
+< en:Flour
 en:pea flour
 de:Erbsenmehl
 es:harina de guisantes
@@ -37987,7 +39085,7 @@ it:farina di piselli
 
 < en:Flour
 en:soy flour, soya flour
-da:Sojamel
+da:Sojamel, sojabønnemel
 de:Sojamehl
 es:harina de soja
 fi:soijajauho
@@ -38000,6 +39098,7 @@ pt:farinha de soja
 ro:făină de soia, faina de soia
 ru:Соевая мука
 sr:sojino brašno
+sv:sojamjöl, mjöl av sojabönor
 
 < en:Flour
 en:tapioca flour
@@ -38014,13 +39113,6 @@ nutriscore_fruits_vegetables_nuts:en: no
 
 < en:Flour
 fr:farine de châtaigne
-
-< en:Flour
-fr:farine de pois chiche, farine de pois chiches
-fi:kikhernejauho
-
-< en:Flour
-fr:farine de pomme de terre, farine de pommes de terre, pomme de terre en poudre
 
 en:Flour treatment agent, dough conditioner, dough strengthening agent, flour bleaching agent, flour improver
 bg:Агент за обработка на брашното
@@ -38039,6 +39131,7 @@ it:Agente di trattamento della farina, agenti di trattamento della farina
 lt:Miltų apdorojimo medžiaga
 lv:Miltu apstrādes līdzeklis
 mt:Aġent għat-trattament tad-dqiq
+nb:Melbehandlingsmiddel
 nl:Meelverbeteraar, Meelverbeteraars
 pl:Środek do przetwarzania mąki, Środki do przetwarzania mąki
 pt:Agente de tratamento da farinha
@@ -38328,7 +39421,7 @@ fr:miel de foret de france
 en:free range chicken egg yolk
 de:Hühnereigelb aus Freilandhaltung
 es:yema de huevo de gallinas camperas
-fi:Vapaan kanan munankeltuainen
+fi:ulkokanan munankeltuainen
 fr:jaune d'œuf de poules élevées en plein air, jaunes d'œufs de poules élevées en plein air, jaune d'oeuf issu d'oeufs de poules élevées en plein air
 nl:Eigeel van vrije uitloop eieren, scharreleigeelpoeder
 pt:gema de ovo de galinhas criadas ao ar livre
@@ -38343,7 +39436,7 @@ nl:gepasteuriseerd eigeel van eieren van hennen met vrije uitloop
 < en:Free range eggs
 en:free range chicken eggs
 de:Hühnereier aus Freilandhaltung
-fi:Vapaan kanan munat, vapaan kanan munia, ulkokanan munat
+fi:ulkokanan munat, ulkokanan munia, ulkokanojen munia
 fr:œuf de poules élevées en plein air, œufs de poules élevées en plein air
 nl:ei van hennen met vrije uitloop
 
@@ -38453,7 +39546,7 @@ es:fructosa
 et:Fruktoos
 eu:Fruktosa
 fa:فروکتوز
-fi:Fruktoosi
+fi:fruktoosi, hedelmäsokeri
 fr:fructose
 fy:Fruktoaze
 gl:Frutosa
@@ -38488,7 +39581,7 @@ sh:Fruktoza
 sl:Fruktóza
 sq:Fruktoza
 sr:fruktoza
-sv:Fruktos
+sv:fruktos, fruktsocker
 ta:புருக்டோசு
 tg:Фруктоза
 th:ฟรักโทส
@@ -38522,7 +39615,8 @@ da:glukos-fruktossirap
 de:Glukose-Fruktose-Sirup, Glukose-Fruktosesirup, Glucose-Fructose-Sirup
 el:σιρόπι γλυκόζης-φρουκτόζης
 es:jarabe de glucosa y fructosa, jarabe de glucosa-fructosa
-fi:glukoosi-fruktoosisiirappi
+et:glükoosi-fruktoosisiirup, glükoosifruktoosisiirup
+fi:glukoosi-fruktoosisiirappi, glukoosi-fruktoosisiirappia, fruktoosi-glukoosisiirappi
 fr:sirop de glucose-fructose, sirop de glucose et de fructose, sirop de fructose-glucose
 hu:glükóz-fruktózszörp, glükóz-fruktózszőrp
 it:sciroppo di glucosio-fruttosio
@@ -38533,7 +39627,7 @@ pt:xarope de glucose-frutose, xarope de glucose e frutose
 ru:глюкозно-фруктозный сироп
 sk:glukózový-fruktózový sirup
 sr:glukozno-fruktozni sirup
-sv:glukos-fruktossirap
+sv:glukos-fruktossirap, glukosfruktossirap
 
 < en:Fructose
 < en:Wheat
@@ -38542,7 +39636,7 @@ fr:fructose de blé
 en:fructose syrup
 de:Fruktose Sirup, Fruktosesirup
 es:Jarabe de fructosa
-fi:fruktoosisiirappi
+fi:fruktoosisiirappi, fruktoosisiirappia
 fr:sirop de fructose
 it:sciroppo di fruttosio
 vegan:en: yes
@@ -38572,7 +39666,7 @@ es:Fruta, frutas
 et:Puuvili
 eu:fruitu
 fa:میوه
-fi:hedelmä
+fi:hedelmä, hedelmiä
 fr:fruit
 gl:Froita
 he:פרי
@@ -38629,7 +39723,7 @@ fr:Acai berry, Baie d'açaï
 
 < en:Fruit
 en:acerola
-de:Acerolakirschen
+de:Acerolakirschen, acerola
 es:acerola
 fi:akerola, acerola
 fr:acérola
@@ -38670,7 +39764,7 @@ es:manzana
 et:õun
 eu:Sagar
 fa:سیب
-fi:omena
+fi:omena, omenaa
 fj:Yapolo
 fo:súrepli
 fr:pomme, pommes
@@ -38747,7 +39841,7 @@ sq:Molla
 sr:јабука
 st:apole
 su:Apel
-sv:äpple
+sv:äpple, äpplen
 sw:Tofaa
 ta:ஆப்பிள்
 te:ఆపిల్
@@ -38863,7 +39957,7 @@ so:safiican
 sq:kajsi
 sr:кајсија
 st:apolokose
-sv:aprikos
+sv:aprikos, aprikoser
 sw:Aprikoti
 ta:சர்க்கரை பாதாமி
 tg:зардолу
@@ -39006,7 +40100,7 @@ ca:Fruits de bosc
 da:Bær
 de:rote Früchte
 es:bayas
-fi:marja, marjat
+fi:marja, marjat, marjoja
 fr:fruit rouge, fruits rouges
 he:פירות יער
 hu:bogyó, bogyótermés, bogyós gyümölcs
@@ -39041,6 +40135,7 @@ ps:تورتوت
 pt:amora
 ru:Ежевика
 sd:ڪاريون ٻيريون
+sv:björnbär
 ta:நாகப்பழம்
 tr:Böğürtlen
 ur:سیاہ توت
@@ -39282,6 +40377,51 @@ wikidata:en: Q81513
 wikipedia:en: https://en.wikipedia.org/wiki/Citrus
 
 < en:Fruit
+en:cloudberry, rubus chamaemorus, nordic berry, bakeapple, knotberry, knoutberry
+az:rubus chamaemorus
+ba:мораҡ
+be:марошка
+ca:móra vermella
+cs:ostružiník moruška
+cy:llwyn mwyar y berwyn
+da:multebær
+de:moltebeere
+eo:kamemoro
+es:rubus chamaemorus
+et:rabamurakas
+fa:تمشک شمالی
+fi:lakka, hilla
+fr:plaquebière
+ga:eithreog shléibhe
+ik:aqpik
+is:múltuber
+it:rubus chamaemorus
+ja:ホロムイイチゴ
+ko:진들딸기
+kv:мырпом
+lt:paprastoji tekšė
+lv:lācene
+ms:rubus chamaemorus
+nb:multe
+nl:kruipbraam
+nn:molte
+os:цъымарайы мæнæргъы
+pl:malina moroszka
+pt:rubus chamaemorus
+ru:морошка
+se:luomi
+sl:barjanska robida
+sr:rubus chamaemorus
+sv:hjortron
+tr:rubus chamaemorus
+tt:морак
+uk:морошка
+vi:rubus chamaemorus
+zh:雲莓
+wikidata:en: Q160092
+wikipedia:en: https://en.wikipedia.org/wiki/Rubus_chamaemorus
+
+< en:Fruit
 en:coconut
 ak:kube
 ar:نارجيل
@@ -39302,10 +40442,10 @@ gl:Coco
 hu:kókuszdió
 it:cocco, noce di cocco
 ml:തേങ്ങ
-nb:kokosnøtt
+nb:kokos, kokosnøtt
 nl:kokosnoot, kokos
 nn:kokosnøtt
-pl:Kokos
+pl:Kokos, kokosowy
 pt:cocos
 ru:кокос
 sa:नारिकेलम्
@@ -39405,7 +40545,7 @@ pl:Daktyle
 ro:Curmală
 ru:финик, финики
 sk:Datľa
-sv:dadlar
+sv:dadel, dadlar
 tt:хөрмә җимеше
 uk:фініки
 zh:椰枣
@@ -39446,6 +40586,7 @@ fi:selja
 fr:sureau
 it:sambuco
 nl:vlier
+sv:fläder
 
 < en:Fruit
 en:fig, figs
@@ -39469,7 +40610,15 @@ nn:fiken
 pl:figa
 ru:инжир
 sk:Figa
+sv:fikon
 wikidata:en: Q2746643
+
+< en:Fruit
+en:fruit concentrates
+de:Früchtekonzentrate
+fi:hedelmätiivisteet
+fr:concentrés de fruits
+it:concentrati di frutta
 
 < en:Fruit
 en:fruit extract
@@ -39622,7 +40771,7 @@ so:Canab
 sq:Rrushi
 sr:Грожђе
 su:Anggur
-sv:Druva
+sv:Druva, vindruva
 sw:Zabibu
 ta:திராட்சை
 te:ద్రాక్ష
@@ -39785,6 +40934,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Kiwifruit
 
 < en:Fruit
 en:lingonberry
+da:tyttebær
 de:Preiselbeeren
 es:Arándanos agrios
 et:pohl
@@ -39793,6 +40943,7 @@ fr:myrtille rouge
 lb:rout Molbier
 lt:Bruknė
 nl:vossebes, rode bosbes
+sv:lingon
 
 < en:Fruit
 en:lychee, Litchi, Litchis
@@ -40037,11 +41188,12 @@ da:Passionsfrugt
 de:Passionsfrucht
 eo:Pasifrukto
 es:maracuyá
-fi:passiohedelmä
+fi:passiohedelmä, passionhedelmä, kärsimyshedelmä
 fr:fruit de la passion, passion, fruits de la passion
 it:frutto della passione
 nl:passievrucht
 ru:маракуйя
+sv:passionsfrukt
 ta:தாட்பூட்
 zh:西番莲
 wikidata:en: Q28836257
@@ -40062,7 +41214,7 @@ de:Pfirsich, Pfirsiche
 el:Ροδάκινο
 eo:persiko
 es:Melocotón, melocotones
-fi:persikka
+fi:persikka, persikat
 fr:pêche
 gl:Pexego
 hi:आड़ू
@@ -40078,7 +41230,7 @@ pl:Brzoskwinia
 pt:pêssegos
 ru:персик
 sk:Broskyňa
-sv:Persika
+sv:persika, persikor
 zh:桃子
 carbon_footprint_fr_foodges_ingredient:fr: Pêche -France-
 carbon_footprint_fr_foodges_value:fr: 0.7
@@ -40376,6 +41528,48 @@ zh:蔷薇果
 wikidata:en: Q46740
 
 < en:Fruit
+en:sea-buckthorn
+ar:أبو فايس
+az:murdarçayabənzər çaytikanı
+ba:һырғанаҡ
+be:абляпіха крушынападобная
+bg:облепиха
+ca:arç groc
+cs:rakytník řešetlákový
+da:havtorn
+de:sanddorn
+eo:ramnoida hipofeo
+et:harilik astelpaju
+fa:سنجد تلخ
+fi:tyrni
+fr:argousier
+gl:espiñeiro marítimo
+gv:bugogue varrey
+hr:pasji trn
+hu:európai homoktövis
+hy:չիչխան սովորական
+kk:шырғанақ
+ky:сары чычырканак
+lt:dygliuotasis šaltalankis
+lv:pabērzu smiltsērkšķis
+nb:tindved
+ne:मलो
+nl:duindoorn
+nn:tindved
+pl:rokitnik zwyczajny
+ps:اکبار
+ro:cătină albă
+ru:облепиха крушиновидная
+sl:navadni rakitovec
+sr:пасји трн
+sv:havtorn
+tg:ангат
+uk:обліпиха звичайна
+zh:沙棘
+wikidata:en: Q165378
+wikipedia:en: https://en.wikipedia.org/wiki/Hippophae_rhamnoides
+
+< en:Fruit
 en:sharon fruit
 es:kaki
 wikipedia:en: https://en.wikipedia.org/wiki/Diospyros_kaki
@@ -40443,12 +41637,6 @@ zh:欧洲甜樱桃
 wikidata:en: Q165137
 
 < en:Fruit
-fr:concentrés de fruits
-de:Früchtekonzentrate
-fi:hedelmätiivisteet
-it:concentrati di frutta
-
-< en:Fruit
 fr:fruits confits
 de:Früchte kandiert
 es:frutas confitadas
@@ -40501,7 +41689,7 @@ pt:suco de maçã
 ru:яблочный сок
 sa:सेवफलरसः
 sl:Jabolčni sok
-sv:Äppelmust
+sv:Äppelmust, äppeljuice, äpplejuice, juice av äpple
 tl:Yago ng mansanas
 tr:Elma suyu
 tt:алма суы
@@ -40509,14 +41697,6 @@ uk:яблучний сік
 vi:Nước táo
 zh:蘋果汁
 wikidata:en: Q618355
-
-< en:Elderberry
-< en:Fruit juice
-fr:jus de sureau
-de:Holundersaft
-fi:seljanmarjamehu
-it:succo di sambuco
-nl:vlierbessap
 
 < en:Fruit juice
 en:fruit juice concentrate
@@ -40528,6 +41708,7 @@ fr:jus concentré de fruits, jus de fruits concentrés
 it:Concentrato di succo di frutta
 nl:vruchtensapconcentraat
 ru:Концентрат фруктового сока
+sv:fruktjuicekoncentrat
 
 < en:Fruit juice
 en:lemon juice
@@ -40554,13 +41735,13 @@ en:lime juice
 da:Limesaft
 de:Limettensaft
 es:Zumo de lima
-fi:limettimehu
+fi:limettimehu, limetäysmehu, limetinmehu
 fr:jus de citron vert
 it:succo di lime
 nl:limoensap
 pl:Sok cytrynowy, sok z cytryny
 ru:Лаймовый сок
-sv:limejuice
+sv:limejuice, limesaft
 
 < en:Fruit juice
 fr:Jus de pruneau obtenu par extraction hydrique
@@ -40569,10 +41750,11 @@ fr:Jus de pruneau obtenu par extraction hydrique
 en:fruit juice from concentrate, fruit juices from concentrate
 de:Fruchtsaft auf Konzentrat Basis, Fruchtsaft aus Fruchtsaftkonzentrat, Fruchtsäfte Konzentrat, Fruchtsäfte aus Konzentraten
 es:zumo de frutas a partir de concentrado
-fi:hedelmämehu tiivisteestä, hedelmämehut tiivisteestä
+fi:hedelmämehu tiivisteestä, hedelmämehut tiivisteestä, tiivisteestä valmistetut täysmehut
 fr:jus de fruits à base de concentré, jus de fruits à base de jus concentrés
 it:succhi di frutta a base di concentrato, succhi di frutta a base di concentrati
 nl:vruchtsap van concentraat, vruchtensap uit concentraat
+sv:fruktjuice från koncentrat, juicer framställd av koncentrat, juice från koncentrat, frukt juice från koncentrat
 
 < en:Fruit juice concentrate
 fr:jus concentré de fruits rouges
@@ -40588,9 +41770,20 @@ de:Apfelpectin
 es:pectina de manzana
 fr:pectine de pomme
 
+< en:Citrus fruit
+< en:Fruit pectin
+en:citrus pectin, modified citrus pectin
+de:zitruspektin, citrus-pektin
+fi:sitruspektiini
+fr:pectine d'agrumes
+sv:citruspektin
+wikidata:en: Q6889398
+wikipedia:en: https://en.wikipedia.org/wiki/Modified_citrus_pectin
+
 en:fruits preparation
 fr:préparation de fruits
 it:preparazione di frutta
+sv:fruktberedning
 
 en:galacto-oligosaccharides
 de:Galacto-oligosaccharides
@@ -40672,15 +41865,16 @@ fr:poudre d'ail, ail en poudre
 hu:fokhagymapor
 it:aglio in polvere, polvere di aglio
 lt:česnakų milteliai
+nb:hvitløkspulver
 nl:knoflookpoeder
 nn:hvitløkspulver
-pl:czosnek sproszkowany
+pl:czosnek sproszkowany, czosnek w proszku
 pt:alho em pó
 ro:pudră de usturoi
 ru:Чесночный порошок
 sk:sušený cesnak
 sl:česen v prahu
-sv:vitlökspulver
+sv:vitlökspulver, vitlökpulver
 tr:sanmsak tozu
 
 < en:Garlic
@@ -40690,6 +41884,7 @@ es:puré de ajo
 fi:valkosipulipyree, valkosipulisose
 fr:purée d'ail
 nl:knoflookpuree
+sv:vitlökspuré
 
 < en:Garlic
 < en:Herb
@@ -40708,12 +41903,69 @@ fr:ail bio
 nl:biologische knoflook
 
 < en:Garlic
-es:ajo tierno
+en:wild garlic, ramsons, buckrams, broad-leaved garlic, wood garlic, bear leek, bear's garlic, allium ursinum
+af:wildeknoffel
+an:allium ursinum
+ar:ثوم الدببة
+az:ayı soğanı
+ba:йыуа
+be:цыбуля мядзведжая
+bg:левурда
+bs:medvjeđi luk
+ca:allium ursinum
+ce:хьонка
+co:allium ursinum
+cs:česnek medvědí
+da:ramsløg
+de:bärlauch
+eo:ursa ajlo
+es:allium ursinum
+et:karulauk
+eu:hartz-baratxuri
+fa:والک
+fi:karhunlaukka, villivalkosipuli
+fr:ail des ours
+fy:blêdlok
+ga:creamh
+hr:medvjeđi luk
+hu:medvehagyma
+hy:ղանձիլ
+id:allium ursinum
+is:bjarnarlaukur
+it:aglio orsino
+ja:ラムソン
+ka:ღანძილი
+kk:ұсақ торлы жуа
+ku:lûş
+lb:heckeknuewelek
+li:daslook
+lt:meškinis česnakas
+lv:laksis
+mk:мечкин лук
+nb:ramsløk
+nl:daslook
+nn:ramslauk
+oc:allium ursinum
+os:скъуда
+pl:czosnek niedźwiedzi
+pt:allium ursinum
+ro:leurdă
+ru:черемша
+sk:cesnak medvedí
+sl:čemaž
+sq:lerthi
+sr:сремуш
+sv:ramslök
+uk:цибуля ведмежа
+ur:لہسن دُب
+vi:tỏi gấu
+wa:a des tchamps
+zh:熊葱
+wikidata:en: Q130882
+wikipedia:en: https://en.wikipedia.org/wiki/Allium_ursinum
 
 < en:Garlic
-fr:ail des ours
-de:Bärlauch
-it:aglio orsino
+es:ajo tierno
 
 < en:Garlic
 fr:ail frais
@@ -40727,7 +41979,7 @@ fi:kuivattu valkosipuli
 it:aglio essicato, aglio secco
 nl:gedroogde knoflook
 nn:tørket hvitløk
-sv:torkad hvidlök
+sv:torkad vitlök, torkad hvidlök
 
 < en:Garlic
 fr:ail semoule
@@ -40750,7 +42002,7 @@ en:Gelling agent, gelifier
 bg:Желиращ агент
 ca:Gelificant, gelificants, agent gelificant, agents gelificants
 cs:Želírující látka
-da:Geleringsmiddel
+da:Geleringsmiddel, Geleringsmidler
 de:Geliermittel
 el:Πηκτωματογόνο
 es:Gelificante, Agente gelificante, gelificantes, agentes gelificantes
@@ -40770,7 +42022,7 @@ ro:Agent gelatinizant
 ru:загустители
 sk:Želírujúca látka
 sl:Želirno sredstvo
-sv:Geleringsmedel
+sv:Geleringsmedel, Geleringmedel
 description:cs: Želírujícími látkami se rozumějí látky, které udělují potravině texturu tím, že vytvářejí gel.
 description:da: Geleringsmidler: stoffer, der giver en fødevare konsistens ved geldannelse.
 description:de: Geliermittel sind Stoffe, die Lebensmitteln durch Gelbildung eine festere Konsistenz verleihen.
@@ -40806,6 +42058,11 @@ la:Penaeus monodon
 wikipedia:en: https://en.wikipedia.org/wiki/Penaeus_monodon
 
 < en:Ginger
+en:ginger juice
+fi:inkiväärimehu, inkivääritäysmehu
+sv:ingefärsjuice
+
+< en:Ginger
 en:ginger paste
 de:Ingwerpaste
 fi:inkivääritahna
@@ -40819,6 +42076,7 @@ fi:inkiväärijauhe, jauhettu inkivääri
 fr:gingembre moulu
 it:zenzero macinato
 nl:gemberpoeder, gemalen gember, gemalen gemberwortel, djahé
+sv:ingefärapulver
 
 < en:Ginger
 en:ginger purée
@@ -40828,7 +42086,7 @@ fi:inkivääripyree, inkiväärisose
 fr:purée de gingembre
 it:purea di zenzero
 nl:gemberpuree
-sv:ingefärspuré
+sv:ingefärspuré, ingefära puré
 
 < en:Ginger
 en:organic ginger
@@ -40845,12 +42103,16 @@ vegan:en: yes
 vegetarian:en: yes
 
 < en:Ginseng
+en:panax ginseng root extract
 de:Panax ginseng Wurzelextrakt
+fi:panax ginseng-juuriuute
+fr:extrait de racine de panax ginseng
+sv:panax ginseng rotextrakt
 
 en:glaze
 bn:গ্লেজ
 cs:glazování
-da:glasering
+da:glasering, glasur
 de:Glasur
 eo:glaceo
 es:glaseado
@@ -40874,11 +42136,17 @@ zh:包糖衣
 wikidata:en: Q15223654
 wikipedia:en: https://en.wikipedia.org/wiki/Glaze_-cooking_technique-
 
+< en:Glaze
+en:chocolate glaze
+et:šokolaadikate
+fi:suklaakuorrute, suklaanmakuinen kuorrute, suklaakuorrutus
+sv:chokladglasyr, kakaoglasyr
+
 en:Glazing agent, coating agent, film forming agent, polishing agent, sealing agent, surface-finishing agent
 bg:Глазиращ агент
 ca:Agent de recobriment
 cs:Lešticí látka
-da:Glasur
+da:Overfladebehandlingsmiddel
 de:Überzugsmittel
 el:Υλικό για γλασάρισμα
 es:Agente de recubrimiento, Agente de glaseado, agente de abrillantado, agente de acabado en superficie, agente de revestimiento, agente formadores de película, agente sellantes
@@ -40897,6 +42165,7 @@ pt:Agente de revestimento
 ro:Agent de glazurare
 sk:Povlaková látka, poleva, leštiaca látka
 sl:Sredstvo za glaziranje
+sv:Ytbehandlingsmedel, Glansmedel
 description:cs: Lešticími látkami -včetně lubrikantů- se rozumějí látky, které po nanesení na vnější povrch udělují potravině lesklý vzhled nebo vytvářejí ochranný povlak.
 description:da: Overfladebehandlingsmidler -herunder glittemidler-: stoffer, der giver en fødevare et skinnende udseende eller udgør et beskyttende lag, når de påføres fødevarens overflade.
 description:de: Überzugmittel -einschließlich Gleitmittel- sind Stoffe, die der Außenoberfläche eines Lebensmittels ein glänzendes Aussehen verleihen oder einen Schutzüberzug bilden.
@@ -41015,11 +42284,13 @@ de:Dextrose
 el:δεξτροζη
 es:dextrosa
 et:dekstroos
-fi:dekstroosi
+fi:dekstroosi, dekstroosia
 fr:dextrose
 he:דקסטרוז
 hu:dextróz
+is:dextrósi
 it:destrosio
+nb:dekstrose
 nl:dextrose
 nn:dekstrose
 pl:dekstroza
@@ -41027,30 +42298,31 @@ ro:dextroză, dextroza
 ru:Декстроза
 sk:dextróza
 sl:dekstroza
-sv:druvsocker, dextros
+sv:dextros
 
 < en:Glucose
 en:glucose syrup
 bg:глюкозе сироп
 ca:xarop de glucosa
 cs:glukózový sirup
-da:glukosesirup
+da:glukosesirup, glucosesirup
 de:Glukosesirup, Glucosesirup, Glukose-Sirup
 el:σιρόπι γλυκόζης
 es:jarabe de glucosa, sirope de glucosa
 et:glükoosisiirup
 eu:Almibar
-fi:glukoosisiirappi
+fi:glukoosisiirappi, tärkkelyssiirappi, glukoosisiirappia, tärkkelyssiirappia
 fr:sirop de glucose
 gl:Almibre
 he:סירופ גלוקוז
 hr:glukozni sirup
 hu:glükózszirup, glükóz szirup
-is:glukósasiróp
+is:glúkósasiróp, glukósasiróp
 it:sciroppo di glucosio
 ja:글루코스 시럽
 lt:gliukozės sirupas
 lv:glikozes sīrups, giikozes sirups
+nb:glukosesirup
 nl:glucosestroop
 nn:glukosesirup
 pl:syrop glukozowy
@@ -41059,7 +42331,7 @@ ro:sirop de glucoză, sirop de glucoza
 ru:Сироп глюкозы
 sk:glukózový sirup
 sr:glukozni sirup
-sv:Glukossirap
+sv:glukossirap, stärkelsesirap, glukos-sirap
 wikidata:en: Q14770547
 wikipedia:en: https://en.wikipedia.org/wiki/Glucose_syrup
 
@@ -41072,10 +42344,10 @@ fr:glucose de blé
 en:high fructose corn syrup, isoglucose
 bg:Високо-фруктозен сироп от царевица
 ca:Xarop de blat de moro alt en fructosa
-da:glukosesirup
+da:glukosesirup, glucosesirup
 de:Maissirup mit hohem Fruktosegehalt
 es:Jarabe de maíz de alta fructosa
-fi:maissisiirappi, isoglukoosi
+fi:maissisiirappi, isoglukoosi, maissitärkkelyssiirappi
 fr:sirop de maïs à haute teneur en fructose, sirop de glucose-fructose de maïs
 hu:Izocukor
 it:Sciroppo di mais ad alto contenuto di fruttosio
@@ -41096,7 +42368,7 @@ fr:sirop de glucose-fructose de blé
 nl:glucose-fructosestroop van tarwe
 sk:glukózový-fruktózový sirup
 sr:glukozno-fruktozni sirup
-sv:glukos-fruktossirap
+sv:glukos-fruktossirap, glukosfruktossirap
 
 < en:Glucose syrup
 en:dehydrated glucose syrup, powdered glucose syrup, dried glucose syrup
@@ -41139,7 +42411,7 @@ pt:Glucoronolactona
 ro:Glucoronolactona
 sh:Glukuronolakton
 sr:Glukuronolakton
-sv:Glukuronolakton
+sv:Glukuronolakton, d-glukuronolakton, d-glukoronolakton
 zh:葡萄糖醛酸內酯
 wikidata:en: Q411638
 wikipedia:en: https://en.wikipedia.org/wiki/Glucuronolactone
@@ -41187,6 +42459,7 @@ et:nisugluteen
 fi:vehnägluteeni
 fr:gluten de blé, gluten de froment
 it:glutine di grano, glutine di frumento
+nb:hvetegluten
 nl:tarwegluten
 pl:gluten pszenny
 pt:glúten de trigo
@@ -41275,15 +42548,22 @@ de:Echter Pfifferling (cantharellus cibarius)
 fr:Cantharellus cibarius, Girolle, Girole, Chanterelle, chanterelles
 la:cantharellus cibarius
 
+< en:Fruit juice
+< en:Gooseberry
+en:gooseberry juice
+fi:karviaismehu, karviaistäysmehu
+sv:krusbärjuice
+
 < en:Grana Padano
 en:Grana Padano PDO cheese, grana padano cheese pdo
 ca:formatge grana padano DOP
 de:Grana Padano g.U. Käse, Grana Padano Käse g.U.
 es:queso grana padano DOP
-fi:Grana Padano -juusto
+fi:Grana Padano SAN, Grana Padano -juusto SAN
 fr:fromage grana padano aop, fr:grana padano dop, Grana Padano AOP
 it:grana padano dop
 pt:queijo Grana Padano DOP
+sv:Grana Padano-ost D O P
 
 < en:Grape
 en:California seedless raisins
@@ -41350,7 +42630,7 @@ es:uvas pasas, pasas, pasas sultanas, uvas pasas sultanas, uva desecada
 et:Rosin
 eu:Mahaspasa
 fa:کشمش
-fi:Rusina
+fi:rusina, rusinat
 fr:raisin sec, raisins sec
 ga:Rísín
 gl:Pasa
@@ -41410,9 +42690,10 @@ wikipedia:en: https://en.wikipedia.org/wiki/Raisin
 en:sultanas
 de:Sultaninen
 es:Sultanas
-fi:sulttaanirusina
+fi:sulttaanirusina, sulttaanirusinoita
 fr:raisins secs sultanines
 it:uva sultanina
+sv:sultanrussin
 wikipedia:en: https://en.wikipedia.org/wiki/Sultana_-grape-
 
 < en:Grape
@@ -41475,6 +42756,7 @@ pt:sumo de uva
 ru:виноградный сок
 sa:द्राक्षाफलरसः
 sq:Lëngu i rrushit
+sv:druvsaft, druvjuice
 tt:виноград суы
 zh:葡萄汁
 wikidata:en: Q1209756
@@ -41484,10 +42766,11 @@ wikipedia:en: https://en.wikipedia.org/wiki/Grape_juice
 en:concentrated grape juice
 de:Traubensaftkonzentrat
 es:zumo de uva concentrado
-fi:rypälemehutiiviste
-fr:jus de raisin concentré, jus de raisin à base de concentré, concentré de jus de raisin
+fi:rypälemehutiiviste, viinirypälemehutiiviste
+fr:jus de raisin concentré, concentré de jus de raisin
 it:ssucco concentrato d'uva
 nl:Geconcentreerd grapefruitsap
+sv:druvsaftkoncentrat, druvjuicekoncentrat
 
 < en:Grape juice
 en:organic grape juice
@@ -41637,8 +42920,9 @@ fr:Oignon de printemps séché
 en:green peas
 de:grüne Erbsen
 es:judias verdes
-fi:Vihreät herneey
+fi:vihreät herneet
 fr:Petits pois, petit pois, pois doux
+sv:gröna ärtor
 vegan:en: yes
 vegetarian:en: yes
 
@@ -41676,6 +42960,7 @@ nl:groene thee-extract
 pl:Ekstrakt z zielonej herbaty
 pt:extrato de ché verde
 ru:экстракт зеленого чая
+sv:grönt te-extrakt
 
 < en:Green tea
 en:green tea from China
@@ -41760,18 +43045,24 @@ it:Gruyère AOP
 fr:farine de graines de caroube et farine de graines de guar
 
 < en:Guarana
-de:Guaranasamenextrakt
-
-< en:Guarana
 de:Guaranasamenpulver
 
 < en:Guarana
 en:guarana extract
+da:guarana-ekstrakt
 de:Guarana-Extrakt
 es:Extracto de guaraná
 fi:guaranauute
 fr:extrait de guarana
 it:estratto di guarana
+sv:guaranaextrakt
+
+< en:Guarana
+en:guarana seed extract
+de:Guaranasamenextrakt
+fi:guaranasiemenuute
+fr:extrait de graine de guarana
+sv:guaranafröextrakt
 
 < en:Guava
 en:guava puree, guavas puree
@@ -41785,9 +43076,10 @@ en:Gum base
 cs:žvýkačková báze
 de:Kaumasse
 es:Base de goma
-fi:kumipohja
+fi:purukumin perusmassa, purukumin perusmassaa
 fr:gomme base
 it:gomma base
+sv:gummibas, tuggummibas
 wikidata:en: Q5618000
 wikipedia:en: https://en.wikipedia.org/wiki/Gum_base
 
@@ -41889,13 +43181,15 @@ wikipedia:en: https://en.wikipedia.org/wiki/Merluccius_gayi
 
 < en:Ham
 en:cooked ham
-da:Kogt skinke
+da:kogt skinke
 de:gekochter Schinken
 es:jamón cocido
-fi:kypsennetty kinkku
+fi:keittokinkku, kypsennetty kinkku
 fr:jambon cuit
 hu:főtt sonka
 it:prosciutto cotto
+pt:fiambre cozinhado
+sv:kokt skinka
 
 < en:Ham
 en:cured ham
@@ -41941,9 +43235,10 @@ it:nocciole macinate
 < en:Hazelnut
 en:hazelnut paste
 cs:oříšková pasta
+da:hasselnödmasse
 de:Haselnüsspaste, Haselnusspaste, Haselnussmasse, Haselnussmark
 es:pasta de avellana, pasta de avellanas
-fi:hasselpähkinätahna
+fi:hasselpähkinätahna, hasselpähkinämassa
 fr:pâte de noisette, purée de noisettes
 hu:mogyoromassza
 it:pasta di nocciole
@@ -41952,6 +43247,7 @@ pl:masa orzechowa
 pt:pasta de avelãs, pasta de avelã
 ro:
 sk:oriešková pasta
+sv:hasselnötsmassa, hasselnötspasta
 
 < en:Hazelnut
 en:hazelnut praline
@@ -41969,6 +43265,7 @@ es:avellanas tostadas
 fi:paahdettu hasselpähkinä
 fr:noisettes grillées, noisettes torréfiées
 it:nocciole tostate
+sv:rostade hasselnötter
 
 < en:Hazelnut
 fr:éclats de noisettes
@@ -42008,7 +43305,7 @@ it:erba, piante aromatiche
 nl:Kruiden
 pl:Zioło
 pt:plantas aromáticas
-sv:örter
+sv:örter, örtkryddor, kryddörter
 vegan:en: yes
 vegetarian:en: yes
 
@@ -42222,6 +43519,7 @@ fr:pimprenelle
 en:camomile, chamomile
 ar:بابونج
 cy:Camri
+da:kamille
 de:Kamille
 el:Χαμομήλι
 es:Manzanilla
@@ -42236,11 +43534,13 @@ jv:Camomile
 ka:გვირილა
 ko:캐모마일
 mr:chamomile
+nb:kamille
 nl:kamille
 pt:Camomila
 ro:Mușețel
 ru:ромашка
 sd:بابونو
+sv:kamomill
 wikipedia:en: https://en.wikipedia.org/wiki/Chamomile
 
 < en:Herb
@@ -42506,6 +43806,7 @@ de:Kräuterextrakt, Kräuterextrakte
 es:Extracto de hierbas
 fi:yrttiuute
 fr:extrait d'herbe
+sv:örtextrakt
 
 < en:Herb
 en:herbes de Provence
@@ -42696,7 +43997,7 @@ eo:Levistiko
 es:levistico
 et:Harilik leeskputk
 fa:انجدان رومی
-fi:liperi, lipstikka
+fi:liperi, lipstikka, lippstikka
 fr:livèche
 ga:Luáiste
 he:לאושטיאן
@@ -43035,14 +44336,14 @@ bs:Kadulja
 ca:Sàlvia
 cs:šalvěj lékařská
 cy:Saets
-da:Læge-Salvie
+da:Læge-Salvie, salvie
 de:Salbei
 el:Φασκόμηλο
 eo:Oficina salvio
 es:salvia
 et:Aedsalvei
 fa:مریم‌گلی
-fi:salvia
+fi:salvia, ryytisalvia
 fr:sauge
 ga:Sáiste
 he:מרווה
@@ -43058,7 +44359,7 @@ lt:Vaistinis šalavijas
 lv:Ārstniecības salvija
 mk:обична жалфија
 ms:Salvia officinalis
-nb:Tesalvie
+nb:Tesalvie, salvie
 nl:salie
 nn:tesalvie
 os:Мыдгæрдæг
@@ -43271,6 +44572,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Atlantic_herring
 
 < en:Herring
 en:herring fillets
+da:sildefileter
 de:
 fi:sillifilee
 fr:filets de harengs
@@ -43653,6 +44955,10 @@ fr:miel de sarrasin récolté dans le Loiret
 < en:Honey from France
 fr:miel du Gâtinais
 
+en:honey roasted peanuts
+fi:hunajapaahdettu maapähkinä
+sv:honungsrostade jordnötter
+
 < en:Hops
 en:hop extract
 bg:экстракт хмеля, хмелевой екстракт
@@ -43666,6 +44972,11 @@ it:estratto di luppolo
 nl:hopextract
 pt:extracto de lupolo
 sk:chmelovy extract
+
+< en:Hops
+en:hop oil
+fi:humalaöljy
+sv:humleolja
 
 < en:Hops
 en:organic hops
@@ -43683,6 +44994,40 @@ de:Totentrompete (Craterellus cornucopioides)
 fr:Craterellus cornucopioides
 la:Craterellus cornucopioides
 wikipedia:en: https://en.wikipedia.org/wiki/Craterellus_cornucopioides
+
+< en:Horse
+< en:Meat
+en:horse meat
+ar:لحم خيل
+az:at əti
+cs:koňské maso
+de:pferdefleisch
+el:κρέας αλόγου
+eo:ĉevalaĵo
+es:carne de caballo
+et:hobuseliha
+fa:گوشت اسب
+fi:hevosenliha
+fr:viande de cheval
+hy:ձիու միս
+id:daging kuda
+it:carne di cavallo
+ja:馬肉
+kk:жылқы еті
+ko:말고기
+ms:daging kuda
+nl:paardenvlees
+pl:konina
+pt:carne equina
+ru:конина
+sk:konské mäso
+sv:hästkött
+tr:at eti
+uk:конина
+uz:qazi
+vi:thịt ngựa
+zh:马肉
+wikidata:en: Q1124327
 
 < en:Humboldt squid
 en:Dosidicus Gigas
@@ -43736,6 +45081,9 @@ wikidata:en: Q911854
 
 < en:Hydrogenated colza oil
 fr:huile de colza totalement hydrogénée, huiles végétales de colza totalement hydrogénée
+fi:kokonaan kovetettu rapsiöljy
+nb:fullherdet rapsolje
+sv:fullhärdad rapsolja
 
 < en:Hydrogenated fat
 en:fully hydrogenated fat
@@ -43778,6 +45126,13 @@ hu:teljesen hidrogénezett növényi zsír
 it:grassi vegetali totalmente idrogenati
 nl:volledig gehydrogeneerde plantaardig vet
 
+< en:Hydrogenated vegetable fat
+en:partially hydrogenated vegetable fat
+es:grasa vegetal parcialmente hidrogenada
+fi:osittain kovetettu kasvirasva
+fr:graisse végétale partiellement hydrogénée
+sv:delvis härdade vegetabiliska fetter
+
 < en:Hydrolised animal protein
 de:hydrolysiertes Schweineprotein
 en:hydrolyzed pork protein
@@ -43804,13 +45159,15 @@ fi:hydrolysoitu maissiproteiini, maissiproteiinihydrosylaatti
 fr:protéine de maïs hydrolysée
 hu:hidrolizált kukoricafehérje
 nl:gehydroliseerd maïseiwit
+sv:hydrolyserat majsprotein
 
 < en:Hydrolysed vegetable protein
 en:soy protein
 ca:proteïna de soja
+da:sojaprotein
 de:Sojaprotein, Sojaproteine, Sojaeiweiß
 es:Proteina de soya, proteina de soja
-fi:soijaproteiini
+fi:soijaproteiini, soijaproteiinivalmiste
 fr:protéine de soja, protéines de soja
 hu:szójafehérje
 it:proteine di soia
@@ -43818,6 +45175,7 @@ nl:soja-eiwit, sojaeiwitten
 pl:Białko sojowe
 ro:proteină de soia, proteina de soia, proteină vegetală din soia, proteina vegetala din soia
 ru:Соевый протеин
+sv:sojaprotein, sojaproteinpeparat
 
 en:ice cream, ice creams
 ab:аршәы
@@ -43907,7 +45265,7 @@ sq:akullorja
 sr:сладолед
 st:aesekerimi
 su:Éskrim
-sv:glass
+sv:glass, gräddglass
 sw:aiskrimu
 ta:குளிர்களி
 te:ఐస్ క్రీం
@@ -44092,6 +45450,9 @@ fr:café soluble lyophilisé
 < en:Instant coffee
 fr:café soluble décaféiné
 
+< en:Invert sugar
+en:invert cane sugar, inverted cane sugar
+
 < en:Invert sugar syrup
 en:cane invert syrup, invert cane syrup
 de:brauner Invertzuckersirup, Invertzuckersirup aus Rohrzucker
@@ -44178,6 +45539,7 @@ fi:jodioitu merisuola
 fr:sel marin iodé
 hu:jódozott tengeri só
 it:sale marino iodato
+sv:joderat havssalt
 
 < en:Iron
 en:elemental iron
@@ -44247,7 +45609,7 @@ pt:difisato de ferro, pirofosfato férrico
 ro:difosfat feric, pirofosfat feric
 sk:difosforečnan železitý, pyrofosforečnan železitý
 sl:železov difosfat, železov pirofosfat
-sv:ferridifosfat, ferripyrofosfat
+sv:ferridifosfat, ferripyrofosfat, järndifosfat
 ta:இரும்பு பைரோபாசுபேட்டு
 zh:焦磷酸铁
 wikidata:en: Q9207442
@@ -44499,6 +45861,39 @@ en:isomaltose
 es:isomaltosa
 wikipedia:en: https://en.wikipedia.org/wiki/Isomaltose
 
+< en:Jalapeno peppers
+en:chipotle
+ca:chipotle
+cs:chipotle
+da:chipotle
+el:τσιπότλε
+es:chile chipotle
+fi:chipotle, chipotle chili
+fr:chipotle
+gl:chipotle
+he:צ'יפוטלה
+hu:chipotle
+it:chipotle
+ja:チポトレ
+kn:ಚಿಪೋಟ್ಲೆ
+ko:치폴레
+nb:chipotle
+nl:chipotle
+pt:chipotle
+ru:чипотле
+sv:chipotle
+th:ชิโปตเล
+uk:чипотле
+wikidata:en: Q860808
+wikipedia:en: https://en.wikipedia.org/wiki/Chipotle
+
+< en:Jalapeno peppers
+en:green jalapeno peppers, green jalapeno
+de:grüne jalapenos
+fi:vihreä jalapeño, vihreä jalapeno, vihreät jalapenot
+fr:piment jalapeño vert
+sv:grön jalapeño
+
 en:juice
 de:Saft
 es:zumo, jugo, sirope, jarabe
@@ -44541,14 +45936,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Juniper_berry
 
 < en:Kaffir lime
 fr:feuilles de combava
-
-en:kaffir lime leaf
-de:Zitronenblatt
-es:hoja limón
-fi:kaffirlimetinlehti
-fr:feuille de citron
-nl:citroenblad
-wikipedia:en: https://en.wikipedia.org/wiki/Kaffir_lime
 
 < en:Kale
 en:baby kale
@@ -44668,6 +46055,7 @@ kk:Бифидобактериялар
 la:Bifidobacterium
 nl:bifidus, Bifidobacterium
 ru:Бифидобактерии
+sv:bifidobacterium, bifidobacterium sp
 tr:Bifido bakterisi
 uk:Біфідобактерії
 uz:Bifidobakteriyalar
@@ -44739,6 +46127,19 @@ fr:ferments lactiques sélectionnés
 nl:geselecteerde fermenten
 
 < en:Lactic ferments
+en:skyr cultures
+da:skyr kultur
+de:Skyr-Kulturen
+fi:skyrhapatteet
+fr:cultures de skyr
+is:skyrgerlar
+nl:skyr-culturen
+
+< en:Lactic ferments
+en:sourdough starter, sourdough culture
+da:surdejskultur
+
+< en:Lactic ferments
 en:Streptococcus thermophilus, s.thermophilus
 bg:streptococcus thermophilus
 de:Streptococcus thermophilus
@@ -44799,6 +46200,7 @@ pt:Lactobacillus acidophilus
 ro:Lapte acidofil
 ru:Lactobacillus acidophilus, Ацидофильная палочка
 sl:Lactobacillus acidophilus
+sv:Lactobacillus acidophilus, kultur av lactobacillus acidophilus
 uk:Lactobacillus acidophilus
 vi:Lactobacillus acidophilus
 zh:嗜酸乳桿菌
@@ -44938,7 +46340,11 @@ fr:ferments lactiques dont lactobacillus casei
 < en:Lactobacillus casei
 it:L.casei 431
 
-en:lactose
+< en:Lactobacillus rhamnosus
+en:Lactobacillus rhamnosus GG
+fi:Lactobacillus rhamnosus GG
+
+en:lactose, milk sugar
 ar:لاكتوز
 be:Лактоза
 bg:Лактоза
@@ -44992,7 +46398,7 @@ sl:Laktoza, mlečni sladkor
 sq:Laktoza
 sr:Лактоза
 su:Laktosa
-sv:Laktos
+sv:Laktos, mjölksocker
 ta:லாக்டோசு
 th:แล็กโทส
 tr:Laktoz
@@ -45088,6 +46494,15 @@ de:Lavendelhonig aus der Provence
 fr:Miel de lavande de Provence
 nl:lavendelhoning uit de Provence
 
+< en:Lavender
+en:lavender flower, lavender flowers
+da:lavendelblomst
+de:lavendelblüten
+fi:laventelinkukka
+fr:fleurs de lavande
+nb:lavendelblomst
+sv:lavendelblomma
+
 < en:Lean stern
 de:Magerquarkpulver
 
@@ -45177,7 +46592,7 @@ bg:фасул
 ca:fesol
 cs:fazol zahradní
 cy:Ffeuen Ffrengig
-da:Bønne
+da:Bønne, bønner
 de:Bohnen, Bohne, Gartenbohne
 el:Φασολιά
 eo:Fazeolo
@@ -45229,7 +46644,7 @@ sl:Navadni fižol
 so:Digir Guud
 sr:пасуљ
 su:Buncis
-sv:böna
+sv:böna, bönor
 sw:Maharagwe
 tg:лӯбиё
 to:Piini
@@ -45406,7 +46821,7 @@ sl:Čičerika
 so:Shunburo
 sq:Qiqra
 sr:леблебија
-sv:kikärter
+sv:kikärt, kikärter, kikärtor
 sw:Mnjegere mkubwa
 ta:கொண்டைக் கடலை
 te:శనగలు
@@ -45636,7 +47051,7 @@ oc:Pese
 or:ମଟର
 os:Тымбылхъæдур
 pa:ਮਟਰ
-pl:Groch zwyczajny
+pl:Groch zwyczajny, groszek
 pt:Ervilha
 qu:Allwirha
 ro:Mazăre
@@ -45651,7 +47066,7 @@ sl:Grah
 sq:Bizelja
 sr:грашак
 su:Kacang polong
-sv:ärt, ärter
+sv:ärt, ärter, ärtor
 sw:Njegere
 ta:பட்டாணி
 te:బఠానీ
@@ -45676,15 +47091,18 @@ fr:Extrait de citron concentré
 < en:Lemon
 en:concentrated lemon juice, lemon extract
 ca:Suc de llimona concentrat
+da:citronsaftkonsentrat, citronjuicekoncentrat
 de:Zitronensaftkonzentrat, Zitronenkonzentrat, Zitronenextrakt
 es:zumo concentrado de limón, extracto de limón, zumo de limón concentrado
-fi:sitruunamehutiiviste, sitruunatäysmehutiiviste
+fi:sitruunamehutiiviste, sitruunatäysmehutiiviste, sitruunauute, sitruunatiiviste
 fr:jus concentré de citron, jus de citron concentré, jus de citrons concentré, concentré de citron, extrait de citron, concentré de jus de citron
 hu:Citromlé koncentrátum, citromlé sűrítmény, sűrített citromlé
 it:succo di limone concentrato, concentrato di limone, estratto di limone
+nb:sitronjuicekonsentrat
 nl:citroenextract
 pl:Sok cytrynowy z koncentratu, Zagęszczony sok cytrynowy
 ru:Концентрированный лимонный сок
+sv:citronkoncentrat, citronsaftkoncentrat, citronjuicekoncentrat, citronextrakt
 
 < en:Lemon
 en:lemon peel, lemon zest
@@ -45694,6 +47112,7 @@ es:Cáscara de limón, ralladura de limon
 fi:sitruunankuori
 fr:Zeste de citron
 nl:Citroenschil, schillen citroen
+sv:citronskal
 
 < en:Lemon
 en:lemon powder
@@ -45756,6 +47175,7 @@ fr:huile de citron, essence de citron, huile essentielle de citron
 hu:citromolaj
 it:essenza di limone, olio essenziale di limone
 nl:Citroenolie
+sv:citronolja
 from_palm_oil:en: no
 
 < en:Lemon balm
@@ -45765,16 +47185,16 @@ fr:mélisse bio
 
 < en:Lemon juice
 en:dried lemon juice
-da:tørket citronsaft
+da:tørket citronsaft, citronsaftpulver
 de:Zitronenpulver, Zitronensaftpulver, Zitronenfruchtpulver
 es:zumo de limón seco
 fi:sitruunamehujauhe, kuivattu sitruunamehu
 fr:jus de citron en poudre, citron en poudre, poudre de citron, jus de citron déshydraté
 it:limone in polvere
 nl:gedroogd citroensap, citroensappoeder
-nn:tørket sitronsaft
+nn:tørket sitronsaft, sitronjuivepulver
 pt:sumo de limão desidratado
-sv:torkad citronjuice
+sv:torkad citronjuice, citronjuicepulver
 
 < en:Lemon juice
 en:lemon juice from concentrate
@@ -45788,14 +47208,16 @@ hu:Citromlé koncentrátum, citromlé sűrítmény, sűrített citromlé
 it:succo di limone da concentrato
 nl:citroensap uit concentraat
 pl:Sok cytrynowy z koncentratu, Zagęszczony sok cytrynowy
+sv:citronjuice från koncentrat, citronsaft från koncentrat
 
 < en:Lemon juice
 en:organic lemon juice
 de:Bio-Zitronensaft
 es:zumo de limón orgánico
-fi:luomu sitruunamehu
+fi:luomusitruunamehu, luomusitruunatäysmehu
 fr:jus de citron bio, jus de citron issu de l'agriculture biologique, jus de citron biologique
 nl:biologisch citroensap
+sv:ekologisk citronjuice
 
 < en:Lemon juice
 en:pasteurized lemon juice
@@ -45882,6 +47304,7 @@ fr:lentille verte, lentilles vertes
 it:lenticchie verdi
 nl:groene linzen
 pt:lentilhas verde
+sv:gröna linser
 carbon_footprint_fr_foodges_ingredient:fr: Lentilles vertes
 carbon_footprint_fr_foodges_value:fr: 0.3
 
@@ -45890,6 +47313,7 @@ en:lentil flour
 de:Linsenmehl
 fi:linssijauho
 fr:farine de lentilles
+sv:linsmjöl
 
 < en:Lentils
 en:pardina lentils
@@ -45910,6 +47334,7 @@ fi:punainen linssi, punaiset linssit
 fr:lentilles corail, lentilles rouges
 it:lenticchie rosse
 nl:rode linzen
+sv:röda linser
 
 < en:Lentils
 fr:lentilles Béluga
@@ -45982,7 +47407,14 @@ nl:limoensap uit concentraat
 
 < en:Lime juice
 fr:jus de citron vert concentré
-fi:limettimehutiiviste, limettitäysmehutiiviste
+fi:limettimehutiiviste, limettitäysmehutiiviste, limemehutiiviste, limetäysmehutiiviste
+sv:limesaftkoncentrat
+
+< en:Fruit juice
+< en:Lingonberry
+en:lingonberry juice
+fi:puolukkamehu, puolukkatäysmehu
+sv:lingonjuice
 
 < en:Linseed oil
 en:Organic linseed oil
@@ -46084,7 +47516,7 @@ da:Marsala
 de:Marsala
 es:Marsala
 fi:marsala, marsala-viini
-fo:Marsalavínfi:Marsala
+fo:Marsalavín
 fr:vin marsala, vin Marsala AOC, marsala
 hr:Marsala
 hu:Marsala
@@ -46157,6 +47589,52 @@ zh:波特酒
 wikidata:en: Q191034
 wikipedia:en: https://en.wikipedia.org/wiki/Port_wine
 
+< en:Liqueur wine
+en:sherry
+af:sjerrie
+bg:шери
+br:gwin jerez
+ca:xerès
+cs:sherry
+cv:херес
+cy:sieri
+da:sherry
+de:sherry
+eo:ŝereo
+es:jerez
+et:šerri
+eu:jerez
+fi:sherry
+fr:xérès
+ga:seiris
+gl:xerez
+he:שרי
+hu:sherry
+hy:խերես
+id:sherry
+it:sherry
+ja:シェリー
+kk:херес
+ko:셰리
+lb:sherry
+lt:cheresas
+ms:syeri
+nb:sherry
+nl:sherry
+nn:sherry
+pl:sherry
+pt:xerez
+ru:херес
+sh:šeri
+sl:šeri
+sv:sherry
+uk:херес
+ur:شیری
+vi:sherry
+zh:雪利酒
+wikidata:en: Q16398
+wikipedia:en: https://en.wikipedia.org/wiki/Sherry
+
 < en:Liquid egg white
 fr:blanc d'œuf liquide pasteurisé
 nl:gepasteuriseerd vloeibaar eiwit
@@ -46173,20 +47651,29 @@ fr:oeuf entier liquide pasteurisé salé
 en:liquorice extract
 de:Lakritz extrakt, Süßholzextrakt
 es:extracto de regaliz
-fi:lakritsiuute
+fi:lakritsiuute, lakritsiuutetta
 fr:extrait de réglisse
 it:estratto di liquirizia
 nl:Zoethoutextract
 pt:extrato de alcaçuz
-sv:lakritsexstrakt
+sv:lakritsextrakt, lakritsexstrakt
 
 < en:Liquorice
-en:liquorice root
+en:liquorice powder
+fi:lakritsijauhe
+nl:zoethoutpoeder
+sv:lakritspulver
+
+< en:Liquorice
+en:liquorice root, licorice root
+da:lakridsrod
 de:Sussholzwurzel
-fi:lakritsijuuri
+fi:lakritsijuuri, lakritsanjuuri
 fr:racine de réglisse
 it:radice di liquirizia
+nb:lakrisrot
 nl:zoethout
+sv:lakritsrot
 
 < en:Liquorice
 en:organic liquorice
@@ -46196,8 +47683,9 @@ fi:luomulakritsi, luomu lakritsi
 fr:réglisse bio
 nl:biologisch zoethout
 
-< en:Liquorice
-nl:zoethoutpoeder
+en:liquorice dragées
+fi:lakritsirae
+sv:lakritsdragé
 
 < en:Liquorice extract
 fr:suc de réglisse
@@ -46369,6 +47857,14 @@ de:Liebstöckel Blätter
 fi:liperin lehdet
 fr:feuilles de livèche
 
+< en:Lovage
+en:lovage root
+da:løvstikkerod
+de:liebstöckelwurzel
+fi:lipstikanjuuri
+fr:racine de livèche
+sv:libbstickarot
+
 < en:Flour
 < en:Lupin
 en:lupin flour
@@ -46414,10 +47910,12 @@ wikidata:en: Q30153
 
 < en:Mackarel
 en:mackarel fillet
+da:makrelfilet
 de:
 es:filete de caballa
-fi:makrillifilee
+fi:makrillifilee, makrillifileetä
 fr:filets de maquereaux
+sv:makrillfilé, makrillfiléer
 
 < en:Mackarel fillet
 en:precooked mackarel fillet
@@ -46627,7 +48125,15 @@ sl:magnezijev kalijev citrat
 sv:magnesiumkaliumcitrat
 
 < en:Malt
+en:caramel malt
+de:karamellmalz
+fi:karamellimallas
+fr:malt caramel
+sv:karamellmalt
+
+< en:Malt
 en:malt extract
+da:maltekstrakt
 de:Malzextrakt
 es:Extracto de malta
 fi:mallasuute
@@ -46638,9 +48144,10 @@ nl:moutextract
 pt:extrato de malte
 ro:extract de malț, extract de malt
 ru:Экстракт солода
+sv:maltextrakt
 
 < en:Malt
-en:malted barley
+en:malted barley, barley malt
 bg:яачменныи солод, ечемично малцов
 cs:ječmenný slad
 da:bygmalt
@@ -46658,7 +48165,7 @@ pt:malte de cevada
 ro:malț din orz, malt din orz, malț de orz, malt de orz
 ru:Солодовый ячмень
 sk:jechyi slad
-sv:korn malt
+sv:kornmalt, korn malt, malt av korn
 zh:含大麥芽片
 
 < en:Malt
@@ -46671,6 +48178,7 @@ fr:malt de blé, malt de froment, blé malté
 hu:búzamaláta
 it:malto di frumento, malto di grano
 nl:tarwemout
+sv:vetemalt, mältade vetekorn
 
 < en:Malt extract
 en:dried malt extract
@@ -46681,11 +48189,16 @@ hu:szárított malátakivonat
 it:estratto di malto in polvere
 
 < en:Malt vinegar
+en:barley malt vinegar
+de:gerstenmalzessig
+fi:ohramallasetikka
 fr:vinaigre de malt d'orge
+sv:kornmaltsvinäger
 
 < en:Malted barley
 en:barley malt extract
 ca:extracte de malta d'ordi
+da:bygmaltekstrakt
 de:Gerstenmalzextrakt
 es:extracto de malta de cebada, extracto de cebada malteada, jarabe de cebada malteada
 et:odralinnaseekstrakt
@@ -46693,26 +48206,35 @@ fi:ohramallasuute, ohramallasuutetta
 fr:extrait de malte d'orge, extrait d'orge malté, extrait d'orge maltée, extrait de malt d'orge
 hu:árpamaláta kivonat
 it:estratto di malto d'orzo
+nb:byggmaltekstrakt
 nl:Gerstemoutextract
 pl:Ekstrakt słodu jęczmiennego
 pt:extrato de malte de cevada
 ro:extract din malț de orz, extract din malt de orz, extract de malț de orz, extract de malt de orz
+sv:kornmaltextrakt, maltextrakt från korn, kornmaltsextrakt
 zh:大麥芽精
 
 < en:Malted barley
 en:malted barley flour, barley malt flour
+da:bygmaltmel
 de:Gerstenmalzmehl
 es:harina de malta, harina de malta de cebada
 fi:ohramallasjauho
 fr:farine de malt d'orge, farine d'orge malté
 hu:árpamalátaliszt
 it:farina di orzo maltato, farina d'orzo maltato, farina di malto d'orzo
+sv:kornmaltmjöl, maltmjöl av korn
 
 < en:Malted barley
 fr:blé malté concassé
 
 < en:Malted barley
 fr:sirop d'orge malté
+
+< en:Malted wheat flour
+en:caramelized wheat malt flour
+fi:karamellisoitu vehnämallasjauho
+sv:karamelliserat vetemaltmjöl
 
 < en:Malted wheat flour
 fr:farine de blé malté torréfié
@@ -46735,6 +48257,7 @@ he:מלטודקסטרינים
 hu:Maltodextrin
 it:Maltodestrine, maltodestrina
 ja:マルトデキストリン
+nb:maltodekstrin
 nl:Maltodextrine
 pl:
 pt:Maltodextrinas, maltodextrina
@@ -46970,6 +48493,7 @@ fi:mangopyree
 fr:purée de mangue, purée de mangues, pulpe de mangue
 it:polpa di mango
 nl:mangopuree
+sv:mangopuré
 
 en:maple syrup
 da:Ahornsirup
@@ -47137,6 +48661,17 @@ wikidata:en: Q106252
 wikipedia:en: https://en.wikipedia.org/wiki/Marzipan
 
 < en:Mayonnaise
+en:chili mayonnaise
+da:chilimayonnaise
+fi:chilimajoneesi
+sv:chilimajonnäs
+
+< en:Mayonnaise
+en:harissa mayonnaise
+fi:harissamajoneesi
+sv:harissamajonnäs
+
+< en:Mayonnaise
 fr:mayonnaise allégée en matière grasse, mayonnaise allégée en matières grasses
 
 en:meat
@@ -47250,6 +48785,40 @@ wikidata:en: Q449506
 wikipedia:en: https://en.wikipedia.org/wiki/Goat_meat
 
 < en:Meat
+en:meatball, meatballs
+ar:كرات اللحم
+az:tefteli
+be:тэфтэлі
+bg:кюфте
+ca:mandonguilla
+cs:masové koule
+de:fleischklößchen
+el:κεφτές
+eo:viandobulo
+es:albóndiga
+eu:haragi-bola
+fa:کله‌گنجشکی
+fi:lihapulla, lihapullat, lihapyörykkä, lihapyörykät
+fr:boulette de viande
+gl:albóndega
+gn:so'o josopy
+id:bola daging
+ja:ミートボール
+kk:тефтели
+ko:고기완자
+nl:gehaktbal
+pt:almôndega
+ro:pârjoală
+ru:тефтели
+sv:köttbulle, köttbullar
+tl:almondigas
+uk:тефтелі
+vi:thịt viên
+zh:肉丸
+wikidata:en: Q4831844
+wikipedia:en: https://en.wikipedia.org/wiki/Meatball
+
+< en:Meat
 en:merguez
 ar:مرقاز
 ca:Merguez
@@ -47276,6 +48845,13 @@ wikidata:en: Q590686
 wikipedia:en: https://en.wikipedia.org/wiki/Chistorra
 
 < en:Meat
+fi:kokolihavalmiste
+sv:helköttsprodukt
+
+< en:Meat
+fi:ruokamakkara
+
+< en:Meat
 fr:saucisse de porc
 carbon_footprint_fr_foodges_ingredient:fr: Saucisse de porc
 carbon_footprint_fr_foodges_value:fr: 5.5
@@ -47295,6 +48871,16 @@ carbon_footprint_fr_foodges_value:fr: 5.1
 fr:steak haché
 ca:filet mòlt, stick tartar
 es:filete picado stick tartar
+fi:jauhelihapihvi
+
+en:meat preparation
+fi:lihavalmiste
+fr:préparation de viande
+wikidata:en: Q12553507
+
+< en:Meat preparation
+fi:kinkkuvalmiste, kinkkuleike
+sv:skinkprodukt
 
 < en:Mediterranean mussel
 en:Mytilus galloprovincialis
@@ -47465,6 +49051,13 @@ de:kandierte Melonen
 fi:kandeerattu meloni
 it:meloni canditi
 
+< en:Melon
+< en:Seed
+en:melon seed
+fi:meloninsiemen
+fr:graines de melon
+sv:melonfrön
+
 < en:Melted cheese
 en:melted powdered cheese
 ca:formatge fos en pols
@@ -47513,7 +49106,7 @@ ro:Mentol
 ru:Ментол
 sh:Mentol
 sr:ментол
-sv:Menthol
+sv:mentol, menthol
 th:เมนทอล
 uk:Ментол
 uz:Mentol
@@ -47524,19 +49117,21 @@ wikipedia:en: https://en.wikipedia.org/wiki/Menthol
 < en:Microbial culture
 en:lactic ferments, lactic starters, lactic cultures, live yoghurt bacteria cultures, live yoghurt cultures, culture of acid-lactic bacteria, lactic acid bacteria, yogurt lactic ferment, cheese culture, cheese cultures
 ca:Ferments làctics
-da:yoghurtkultur
+da:yoghurtkultur, starterkultur, mælkesyrekultur
 de:Milchfermenten, Milchsäurekulturen, Milchsäurebakterienkultur, Milchsäurebakterien, Käsekultur, Milchsäurebakterienkulturen, Joghurtkulturen, Säuerungskulturen, milchsauer vergoren, Milchsäuerungskulturen, Milchsäurekultur, Käsereikulturen, Starterkulturen, Biogarde-Markenkulturen
 el:γαλακτικά ένζυμα
 es:fermentos lácticos, fermentos lácteos, cultivos lácticos, fermentos lácticos seleccionados
-fi:maitohappokäyte, maitohappokannat, maitohappoviljelmä, elävä jogurttiviljelmä, elävä jogurttibakteeriviljelmä, elävät jogurttibakteeriviljelmät, maitohappobakteeriviljelmä, maitohappobakteeriviljelmät, maitohappobakteerit, maitohappobakteerikanta, maitohappobakteerikannat, juustoviljelmä, juustoviljelmät
+fi:maitohappokäyte, maitohappokannat, maitohappoviljelmä, elävä jogurttiviljelmä, elävä jogurttibakteeriviljelmä, elävät jogurttibakteeriviljelmät, maitohappobakteeriviljelmä, maitohappobakteeriviljelmät, maitohappobakteerit, maitohappobakteerikanta, maitohappobakteerikannat, juustoviljelmä, juustoviljelmät, hapankulttuuri, jogurttihapate, maitohappobakteeri, käynnistin kulttuuri
 fr:ferment lactique, ferments lactique, ferments lactiques, ferment lactiques, culture de bactéries lactiques, cultures lactiques, ferment lactique du yaourt, ferments lactiques du yaourt
 hu:tejsavbaktériumok, sajtkultúrák
 it:fermenti lattici, coltura di batteri acidolattici, fermenti lattici vivi, fermenti latici vivi, fermenti lattici dello yogurt
+nb:melkesyrekultur, starterkultur, yoghurtkultur, syrekultur
 nl:melkfermenten, melkkiemen, Melkzuurbacteriën, zuursel
 pl:żywe kultury bakterii jogurtowych
 pt:fermentos lácteos, culturas lácteas, leveduras lacteas, fermentos láticos, fermentos lácticos
 ro:culturi lactice, culturi lactice selecționate, culturi lactice selectionate, fermenți de iaurt, fermenti de iaurt
 ru:Молочные ферменты, пробиотические микроорганизм
+sv:syrningskultur, syrakultur, syrakulturer, mjölksyrakultur, yoghurtkultur, startkultur, filkultur, filmjölkskultur, starterkultur, levande mjölksyrakultur, mjölksyrakulturer
 vegan:en: yes
 vegetarian:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Lactic_acid_bacteria
@@ -47638,6 +49233,7 @@ fr:lait de vache
 hu:tehéntej
 it:latte di mucca
 ja:牛乳
+nb:kumelk
 nl:koemelk
 pl:Krowie mleko
 ro:lapte de vacă, lapte de vaca
@@ -47706,6 +49302,7 @@ nl:geitenmelk
 pl:Kozie mleko
 ro:lapte de capră, lapte de capra
 ru:Козье молоко
+sv:getmjölk
 wikidata:en: Q1418287
 
 < en:Milk
@@ -47780,7 +49377,7 @@ fi:kevytmaito
 fr:lait demi-écrémé, lait partiellement écrémé, Lait à 15.5 g/l de matière grasse
 hu:zsírszegény tej, félzsíros tej
 it:latte parzialmente scremato
-nb:Ekstra lett melk
+nb:lettmelk
 nl:halfvolle melk, gedeeltelijk afgeroomde melk
 pt:leite meio gordo
 sv:mellanmjölk
@@ -47799,6 +49396,7 @@ hu:juhtej, birkatej
 it:latte di pecora
 nl:schapenmelk
 ro:lapte de oaie
+sv:fårmjölk
 wikidata:en: Q2736146
 
 < en:Milk
@@ -47858,9 +49456,10 @@ fi:täysmaito
 fr:lait entier
 hu:teljes tej
 it:latte intero
+nb:helmelk
 nl:volle melk
 pl:Mleko pełne
-sv:Helmjölk
+sv:Helmjölk, sötmjölk
 zh:全脂牛奶
 
 < en:Milk
@@ -47902,12 +49501,14 @@ fr:chocolat au lait en poudre
 
 < en:Milk chocolate
 fr:pépites de chocolat au lait
+da:stykker af mæelkechocolade
 de:Milchschokoladenstückchen, Vollmilchschokoladenstückchen
-fi:maitosuklaarouhe
+fi:maitosuklaarouhe, maitosuklaapaloja
 it:pezzetti di cioccolato di latte
 nl:stukjes melkchocolade
 pl:kawalki czekolady mlecznej
 pt:pepitas de chocolate de leite
+sv:bitar av mjölkchoklad
 
 en:milk minerals
 ca:minerals de la llet
@@ -47941,19 +49542,22 @@ da:skummetmælkspulver
 de:Magermilchpulver
 es:leche desnatada en polvo, leche en polvo desnatada
 et:lössipulber
-fi:rasvaton maitojauhe
+fi:rasvaton maitojauhe, rasvatonta maitojauhetta, rasvatonmaitojauhe
 fr:lait en poudre écrémé, lait écrémé en poudre, poudre de lait écrémé
 he:אבקת חלב רזה
 hr:obrano mlijeko u orahu
 hu:sovány tejpor
+is:undanrennuduft
 it:latte scremato in polvere
 lt:nugriebto pieno milteliai
 lv:sausais vajpiena pulveris
+nb:skummetmelkepulver, skummetmelkpulver
 nl:magere melkpoeder, mageremelkpoeder, mager melkpoeder
-pl:chude mleko w proszku
+pl:chude mleko w proszku, odtłuszczone mleko w proszku
 pt:leite magro em pó, leite em pó magro
 ro:lapte praf degresat
 ru:обезжиренный молоко-порошок
+sk:sušené odstredené mlieko
 sv:skummjölkspulver
 
 < en:Milk powder
@@ -47966,20 +49570,21 @@ de:Vollmilchpulver, Voll_milch_pulver
 el:γάλα σε σκόνη
 es:leche entera en polvo, leche en polvo entera
 et:täispiimapulber
-fi:täysmaitojauhe, kuivattu täysmaito
+fi:täysmaitojauhe, kuivattu täysmaito, täysmaitojauhetta, rasvainen maitojauhe
 fr:lait entier en poudre, poudre de lait entier, lait en poudre entier
 hr:punomasno mlijeko u prahu
 hu:zsiros tejpor, teljes tejpor
+is:nýmjólkurduft
 it:latte intero in polvere
 lt:nenugriebto pieno milteliai
 lv:pilnpiena pulveris
 nl:volle melkpoeder, vollemelkpoeder
-pl:pelne mleko w proszku
+pl:pelne mleko w proszku, pełne mleko w proszku, mleko pełne w proszku
 pt:leite entero em pó, leite em pó gordo
 ro:lapte praf integral
-ru:цельное сухое молоко
+ru:цельное сухое молоко, сухое цельное молоко
 sk:sušené plnotučné mlieko
-sv:helmjölkspulver
+sv:helmjölkspulver, fetthaltigt mjölkpulver, sötmjölkspulver
 
 < en:Milk powder
 fr:lait écrémé à base de poudre de lait
@@ -48108,12 +49713,15 @@ fr:protéines solubles de lait
 < en:Hydrolysed proteins
 < en:Milk proteins
 en:hydrolysed milk protein
+da:hydrolyseret mælkeprotein
 de:Milchproteinhydrolysat, hydrolysiertes Milcheiweiß, hydrolysiertes Milcheiweiss
 es:proteína de leche hidrolizada
-fi:maitoproteiinihydrolysaatti
+fi:hydrolysoitu maitoproteiini, maitoproteiinihydrolysaatti
 fr:protéine de lait hydrolysée
 hu:hidrolizált tejfehérje
+it:proteine de latte idrolizzate
 nl:gehydroliseerd melkeiwit
+sv:hydrolyserat mjölkprotein
 
 < en:Milkcap
 en:bloody milk cap
@@ -48172,17 +49780,18 @@ wikidata:en: Q62138
 wikipedia:en: https://en.wikipedia.org/wiki/Lactarius_deliciosus
 
 < en:Milkfat
-en:butterfat, pastry butter, anhydrous milk fat, concentrated butter, anhydrous butter
+en:butterfat, pastry butter, anhydrous milk fat, concentrated butter, butter oil, anhydrous butter
 bg:безводно масло
 bs:mliječna mast
 cs:mléčný tuk
 cy:braster menyn
-da:smørolie
+da:smørfedt, smørolie
 de:Butterreinfett, wasserfreies Milchfett
 el:βούτυρο τηγμένο
 eo:laktograso
 es:grasa butírica, mantequilla concentrada, mantequilla anhidra
-fi:voirasva, tiivistetty voi
+et:võirasv
+fi:voiöljy, voirasva, tiivistetty voi, vedetön maitorasva
 fr:matière grasse butyrique, graisse butyrique, beurre purifié, beurre fondu, beurre pâtissier, matière grasse laitière anhydre, beurre laitier concentré, beurre concentré
 hu:vajzsír, vajolaj, derített vaj
 id:lemak susu
@@ -48192,13 +49801,13 @@ ko:유지방
 ms:lemak mentega, lemak susu
 nb:vannfritt melkefett
 nl:boterconcentraat, botervet, watervrij melkvet, boterolie, geconcentreerde boter
-pl:tłuszcz mlecny
+pl:tłuszcz mlecny, tłuszcz mleczny, bezwodny tłuszcz mleczny
 pt:gordura butrica, matéria gorda butírica, manteiga concentrada, gordura de leite anhidra
-ro:grasimi din unt
-ru:Молочный жир
+ro:grasimi din unt, grăsime din unt
+ru:Молочный жир, топленое масло
 sl:mlečna maščoba
 sr:anhidrovana mlečna
-sv:mjölkfett, mølkfett
+sv:smörfett, smörolja, koncentrerat smör, vattenfritt mjölkfett
 th:ไขมันเนย
 tl:taba ng gatas
 uk:Молочний жир
@@ -48218,13 +49827,19 @@ it:fiocchi di miglio
 < en:Millet
 fr:graines de millet
 
+< en:Minced beef
+fr:préparation viande hachée de boeuf
+ca:preparació de carn molta de res
+es:preparación de carne molida de res
+
 < en:Mineral water
 en:natural mineral water
 de:Natürliches Mineralwasser
 es:Agua Mineral natural
-fi:luontainen kivennäisvesi
+fi:luontainen kivennäisvesi, luonnollinen mineraalivesi
 fr:eau minérale naturelle
 nl:natuurlijk mineraalwater
+sv:naturligt mineralvatten
 
 en:Minerals, Mineral
 af:Mineraal
@@ -48303,7 +49918,7 @@ so:Macdan
 sq:Minerali
 sr:Минерал
 su:Mineral
-sv:Mineraler, Mineral
+sv:Mineraler, Mineral, Mineralämne
 sw:Madini
 ta:கனிமம்
 te:మినరల్
@@ -49765,6 +51380,7 @@ fi:luontainen minttuaromi, luontaisia minttuaromeja, luontaiset minttuaromit
 fr:arômes naturels de menthe, arôme naturel de menthe, arôme naturel de menthes
 hu:természetes menta aroma
 nl:natuurlijk muntaroma
+sv:naturlig mintsmak
 
 < en:Mitre squid
 en:Uroteuthis chinensis
@@ -49772,6 +51388,19 @@ de:Uroteuthis chinensis
 fr:Uroteuthis chinensis, Calmar mitre
 la:Uroteuthis chinensis, Loligo chinensis
 wikidata:en: Q920979
+
+< en:Mixed spices
+en:lemon pepper, lemon pepper seasoning
+af:suurlemoenpeper
+ar:فلفل الليمون
+de:zitronenpfeffer
+es:pimienta con limón
+fi:sitruunapippuri
+fr:poivre au citron
+lv:citronpipari
+sv:citronpeppar
+wikidata:en: Q206491
+wikipedia:en: https://en.wikipedia.org/wiki/Lemon_pepper
 
 < en:Corn starch
 < en:Modified starch
@@ -49781,10 +51410,11 @@ cs:Modifikovaný kukuřičný škrob
 da:modificeret majsstivelse
 de:modifizierte Maisstärke
 es:Almidón modificado de maiz
-fi:muunnettu maissitärkkelys, modifioitu maissitärkkelys
+fi:muunnettu maissitärkkelys, modifioitu maissitärkkelys, muunneltu maissitärkkelys, muunnettua maissitärkkelystä
 fr:amidon transformé de maïs, amidon de maïs transformé, amidon modifié de maïs, amidon de maïs modifié, amidons modifié de maïs, amidons modifiés de maïs
 hu:módosított kukoricakeményítő
 it:amido modificato di mais, amido di mais modificato
+nb:modifisert maisstivelse
 nl:Gemodificeerd maïszetmeel
 pl:Modyfikowana skrobia kukurydziana
 pt:amido de milho modificado, amido modificado de milho
@@ -50291,6 +51921,9 @@ ca:monoglicèrids i diglicèrids d'àcids grassos de palma, monoglicèrids d'àc
 es:monoglicéridos y diglicéridos de ácidos grasos de palma, monoglicéridos de acidos grasos de palma, diglicéridos de ácidos grasos de palma
 from_palm_oil:en: yes
 
+< en:Monterey jack
+en:pepper jack, pepper jack cheese
+
 < en:Morels
 en:common morel
 ar:غوشنة حلوة
@@ -50446,7 +52079,7 @@ es:seta, champinon, champiñones
 et:Söögiseen
 eu:ziza, Ziza jangarri
 fa:قارچ خوراکی, قارچ چتری
-fi:sieni, Ruokasieni
+fi:sieni, ruokasieni
 fr:champignon, champignons
 fy:Poddestoel
 ga:Beacán
@@ -50499,7 +52132,7 @@ so:Boqoshaa
 sq:Këpurdhat
 sr:Јестиве гљиве, печурка
 su:Fungi
-sv:Matsvampar
+sv:svamp, matsvampar
 sw:Uyoga
 ta:காளான்
 te:పుట్ట గొడుగు, పుట్టగొడుగుల పెంపకం
@@ -50521,27 +52154,6 @@ vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q83093
 wikipedia:en: https://en.wikipedia.org/wiki/Mushroom
-
-< en:Mushroom
-en:black truffle
-ca:tòfona negra
-cy:Cloronen Ffrengig
-de:Schwarze Trüffel
-es:trufa negra
-eu:Boilur beltz
-fi:mustatryffeli
-fr:truffe noire, truffes noires
-hu:Francia szarvasgomba
-it:Tartufo nero
-kk:Жерқұлақ
-nl:zwarte truffel
-pl:trufla czarnozarodnikowa
-ro:Trufă neagră franceză
-ru:Трюфель чёрный
-sr:Crna gomoljača
-sv:Perigordtryffel
-tr:Perigord trüfü
-zh:黑松露
 
 < en:Mushroom
 en:cep
@@ -50610,7 +52222,7 @@ bg:култивирана печурка
 ca:xampinyó
 cs:pečárka dvouvýtrusá
 cy:Madarch meithrin
-da:Havechampignon
+da:Havechampignon, champignon, champignoner
 de:Champignons, Zucht-Champignon
 eo:Ĉampinjono
 es:Agaricus bisporus, champinon cultivado, champinon cultivados, setas cultivadas
@@ -50643,7 +52255,7 @@ pt:cogumelos-de-Paris, Champignon
 qu:Champiñun
 ru:Шампиньон двуспоровый
 sl:Dvotrosni kukmak
-sv:Portabello
+sv:Portabello, champinjon, champinjoner, vit champinjon
 ta:அகாரிகஸ் பைஸ்போரஸ்
 uk:Печериця садова
 zh:雙孢蘑菇
@@ -50838,10 +52450,11 @@ wikipedia:en: https://en.wikipedia.org/wiki/Morchella
 en:mushroom extract
 de:Pilzextrakt
 es:extracto de champiñón
-fi:sieniuute
+fi:sieniuute, herkkusieniuute
 fr:extrait de champignon, extrait de champignons
 it:estratti di funghi
 nl:champignonextract
+sv:svampextrakt, champinjonextrakt
 
 < en:Mushroom
 en:mushroom powder
@@ -50849,6 +52462,7 @@ de:Champignonpulver
 fi:sienijauhe
 fr:poudre de champignon
 nl:champignonpoeder
+sv:champinjonpulver
 
 < en:Mushroom
 en:pholiota
@@ -51011,27 +52625,38 @@ fr:Cèpe d'été, reticulatus
 la:Boletus reticulatus
 
 < en:Mushroom
-en:summer truffle
-az:Yay dombalanı
-be:Труфля летняя
-bg:Летен трюфел
-cs:lanýž letní
-cy:Cloren foch
-de:Sommer-trüffel
-et:Suvetrühvel
-eu:Udako boilur
-fi:kesätryffeli
-fr:truffle d'été, tuber aestivum
-hu:Nyári szarvasgomba
-it:Tartufo Scorzione
-lt:Vasarinis trumas
-nl:Zomertruffel
-pl:trufla letnia
-ru:Трюфель летний
-sv:Sommartryffel
-uk:Трюфель літній
-wikidata:en: Q74692
-wikipedia:en: https://en.wikipedia.org/wiki/Tuber_aestivum
+en:truffle
+ar:ترافل
+ca:tòfona
+da:trøffel
+de:trüffel
+el:τρούφα
+et:trühvel
+eu:boilur
+fr:truffe
+ga:strufal
+he:כמהין
+hi:ट्रफल
+hu:szarvasgomba
+hy:տրյուֆելներ
+id:truffle
+io:truflo
+kk:трюфели
+ko:서양송로
+li:truffel
+nl:truffel
+nn:trøffel
+ru:трюфели
+sr:tartuf
+sv:tryffel
+ta:ராபுள்
+tl:trupo
+tr:trüf mantarı
+uk:трюфелі
+vi:truffle
+zh:松露
+wikidata:en: Q2690965
+wikipedia:en: https://en.wikipedia.org/wiki/Truffle
 
 < en:Mushroom
 en:weeping bolete, Suillus granulatus
@@ -51221,12 +52846,14 @@ es:harina de mostaza
 
 < en:Mustard
 en:mustard powder
+da:sennepspulver, sennepsmel
 de:Senfpulver, Senfmehl
 es:Mostaza en polvo
 fi:sinappijauhe
 fr:moutarde en poudre, poudre de moutarde, farine de moutarde
 it:senape in polvere
 nl:mosterdpoeder
+sv:senapspulver, senapsfröpulver
 
 < en:Mustard
 en:mustard seed
@@ -51234,16 +52861,17 @@ ca:llavors de mostassa, grans de mostassa
 da:sennepsfrø
 de:Senfsaaten, Senfkörner, Senfsaat, Senfsamen, Senfschrot, Senfkorn
 es:grano de mostaza, semillas de mostaza
-fi:sinapinsiemen
+fi:sinapinsiemen, sinapinsiemenet
 fr:graine de moutarde, graines de moutarde
 hu:káposztafélék
 it:Semi di senape
 ja:カラシナ, シロガラシ
+nb:sennepsfrø
 nl:mosterdzaad, mosterdzaden
 pl:
 pt:Semente de mostarda
 sl:gorčično seme
-sv:senapsfrö
+sv:senapsfrö, senapsfrön
 
 < en:Mustard
 fr:moutarde à l'ancienne
@@ -51254,6 +52882,7 @@ de:Dijon-Senf
 fi:dijon-sinappi
 it:senape di Digione
 nl:mosterd van Dijon
+sv:dijonsenap
 
 < en:Mustard
 fr:moutarde forte
@@ -51272,6 +52901,7 @@ en:yellow mustard seed
 de:gelbes Senfkorn, Gelbsenfsaat, Senfsaat gelb
 fi:keltainen sinapinsiemen
 fr:graines de moutarde jaunes
+sv:gult senapsfrö
 
 < en:Mustard seed
 fr:Graines de moutarde issues de l'agriculture durable
@@ -51337,6 +52967,7 @@ de:natürliches Anisaroma, natürliches Anis-Aroma
 fi:luontainen anisaromi
 fr:arôme naturel d'anis
 hu:természetes ánizs aroma
+sv:naturlig anisarom
 
 < en:Natural flavouring
 en:natural apple flavouring
@@ -51354,6 +52985,11 @@ es:aroma natural de albaricoque
 fi:luontainen aprikoosiaromi
 fr:arôme naturel d'abricot
 hu:természetes sárgabarack aroma
+
+< en:Natural flavouring
+en:natural asparagus flavouring
+fi:luontainen parsa-aromi
+sv:naturlig sparrisarom
 
 < en:Natural flavouring
 en:natural banana flavouring
@@ -51376,6 +53012,17 @@ en:natural bergamot orange flavouring
 de:natürliches Bergamottenaroma, natürliches Bergamotten-Aroma
 fi:luontainen bergamottiaromi
 fr:arôme naturel de bergamote
+
+< en:Natural flavouring
+en:natural blackcurrant flavouring
+da:naturlig solbær aroma
+de:natürliches Cassisaroma
+fi:luontainen mustaherukka-aromi
+fr:arôme naturel de cassis
+hu:természetes fekete ribizli aroma
+nb:naturlig smak fra solbær
+nl:natuurlijk cassisaroma
+sv:naturlig svartvinbärssmak
 
 < en:Natural flavouring
 en:natural blueberry flavouring
@@ -51403,9 +53050,10 @@ hu:természetes répa aroma
 < en:Natural flavouring
 en:natural cheddar flavouring
 de:natürliches Cheddararoma, natürliches Cheddar-Aroma
-fi:luontainen cheddar-aromi
+fi:luontainen cheddar-aromi, luontainen cheddarjuustoaromi
 fr:arôme naturel de cheddar
 hu:természetes cheddar aroma
+sv:naturlig cheddarostarom
 vegan:en: no
 vegetarian:en: maybe
 
@@ -51462,6 +53110,10 @@ de:natürliches Cola-Aroma, natürliches Colaaroma
 fi:luontainen kola-aromi
 fr:arôme naturel de cola
 hu:természetes kóla aroma
+
+< en:Natural flavouring
+en:natural dill flavouring
+fr:arôme naturel d'aneth
 
 < en:Natural flavouring
 en:natural estragon flavouring
@@ -51549,8 +53201,15 @@ fr:arôme naturel de miel
 hu:természetes méz aroma
 
 < en:Natural flavouring
+en:natural hops flavouring
+fi:luontainen humala-aromi
+fr:arôme naturel de houblon
+sv:naturlig humlearom
+
+< en:Natural flavouring
 en:natural hot pepper flavouring
 de:natürliches Chiliaroma, natürliches Chili-Aroma
+fi:luontainen chiliaromi
 fr:arôme naturel de piment
 
 < en:Natural flavouring
@@ -51569,7 +53228,7 @@ hu:természetes babér aroma
 
 < en:Natural flavouring
 en:natural lemon flavouring
-de:natürliches Zitronenaroma
+de:natürliches Zitronenaroma, natürliches Zitronen-aroma
 es:Saborizante natural de limón
 fi:luontainen sitruuna-aromi
 fr:arôme naturel de citron, arômes naturels de citron
@@ -51590,6 +53249,12 @@ fr:arôme naturel de citron vert
 hu:természetes lime aroma
 it:aroma naturale di lime
 nl:natuurlijk aroma van limoen
+
+< en:Natural flavouring
+en:natural malt flavouring
+fi:luontainen mallasaromi
+fr:arôme naturel de malt
+sv:naturlig maltarom
 
 < en:Natural flavouring
 en:natural mandarin orange flavour
@@ -51634,6 +53299,7 @@ lt:natūralios apelsino kvapiosios medžiagos
 lv:apelsīnu dabīgs aromatizētājs
 nl:natuurlijk sinaasappelaroma
 pt:aroma de laranja natural
+sv:naturlig apelsinarom
 
 < en:Natural flavouring
 en:natural oregano flavouring
@@ -51648,6 +53314,13 @@ de:natürlicher Paprikageschmack
 fi:luontainen paprika-aromi
 fr:arôme naturel de paprika
 hu:természetes paprika aroma
+
+< en:Natural flavouring
+en:natural parsley flavouring
+de:natürliches petersilienaroma
+fi:luontainen persilja-aromi
+fr:arôme naturel de persil
+sv:naturlig persiljearom
 
 < en:Natural flavouring
 en:natural peach flavouring
@@ -51726,6 +53399,12 @@ vegan:en: no
 vegetarian:en: no
 
 < en:Natural flavouring
+en:natural sea-buckthorn flavouring
+fi:luontainen tyrniaromi
+fr:arôme naturel de baie d'argousier
+sv:naturlig havtornsarom
+
+< en:Natural flavouring
 en:natural shallot flavouring
 de:natürliches Schalottenaroma, natürliches Schalotten-Aroma
 fi:luontainen salottisipuliaromi
@@ -51757,6 +53436,7 @@ de:natürliches Gewürzaroma
 fi:luontainen maustearomi
 fr:arôme naturel d'épices
 hu:természetes fűszer aroma, természetes fűszeraroma
+sv:naturlig krydderi aroma
 
 < en:Natural flavouring
 en:natural star anise aroma
@@ -51810,15 +53490,6 @@ fr:arôme naturel d'agrumes, arômes naturels d'agrumes
 de:natürliche Zitrusfruchtaromen
 hu:természetes citrusaroma
 nl:natuurlijke aroma's van citrusvruchten
-
-< en:Natural flavouring
-fr:arôme naturel d'aneth
-
-< en:Natural flavouring
-fr:arôme naturel de cassis
-de:natürliches Cassisaroma
-hu:természetes fekete ribizli aroma
-nl:natuurlijk cassisaroma
 
 < en:Natural flavouring
 fr:arôme naturel de champignon
@@ -51917,13 +53588,19 @@ fr:eau minérale naturelle volvic
 fr:arôme naturel de poivre avec autres arômes naturels
 fi:luontainen pippuriaromi ja muut luontaiset aromit
 
+< en:Natural flavouring
+< en:Natural peppermint flavouring
+en:natural peppermint flavouring with other natural flavourings
+fi:luontainen piparminttuaromi ja muita luontaisia aromeja
+sv:naturlig pepparmintsarom med andra naturliga aromer
+
 < en:Natural vanilla flavouring
 en:Bourbon vanilla natural flavouring
 de:natürliches Bourbon Vanille-Aroma, naturliches Bourbon Vanille Aroma
-fi:luontainen Bourbon vanilja-aromi
+fi:luontainen Bourbon vanilja-aromi, luontainen bourbonvaniljaaromi
 fr:arôme naturel de vanille bourbon
 it:aroma naturale di vaniglia Bourbon
-sv:naturlig vaniljarom
+sv:naturlig bourbon-vaniljarom
 
 < en:Natural vanilla flavouring
 en:natural organic vanilla flavouring
@@ -51941,11 +53618,12 @@ pt:aroma natural de baunilha biológica
 en:natural vanilla flavouring with other natural flavourings
 de:natürliches Vanillearoma mit anderen natürlichen Aromen
 es:aroma natural de vainilla con otros aromas naturales
-fi:luontainen vanilja-aromi ja muut luontaiset aromit
+fi:luontainen vanilja-aromi ja muita luontaisia aromeja, luontainen vanilja-aromi ja muut luontaiset aromit
 fr:arôme naturel de vanille avec d'autres arômes naturels, arôme naturel de vanille avec autres arômes naturels
 hu:természetes vanília aroma más természetes aromákkal
 it:aroma naturale di vaniglia con altri aromi naturali
 nl:natuurlijk vanillearoma met andere natuurlijke aroma's, natuurlijk vanille aroma en andere natuurlijke aroma's
+sv:naturlig vaniljarom med andra naturliga aromer
 
 < en:Natural vanilla flavouring
 fr:arôme naturel de vanille de madagascar
@@ -51972,6 +53650,16 @@ de:Mimachlamys nobilis
 fr:Mimachlamys nobilis, Coquille Saint-Jacques (Pétoncle)
 la:Chlamys nobilis, Mimachlamys nobilis
 wikidata:en: Q8010071
+
+en:nonpareils, nonpareilles
+de:liebesperlen, nonpareille
+fi:nonparelli
+fr:nonpareille
+it:palline di zucchero
+nl:musketzaad
+sv:nonparell
+wikidata:en: Q316561
+wikipedia:en: https://en.wikipedia.org/wiki/Nonpareils
 
 < en:North pacific hake
 en:Merluccius productus
@@ -52335,9 +54023,9 @@ de:Mandel, Mandeln, Mandelkerne
 el:Αμύγδαλο, αμύγδαλα
 eo:migdalo
 es:almendra, almendras
-et:Mandel, mandlid
+et:Mandel, mandlid, mandleid
 eu:Arbendol
-fi:manteli, mantelit
+fi:manteli, mantelit, mantelia
 fr:amande, amandes
 fy:Mangel
 ga:almóinní
@@ -52351,6 +54039,7 @@ la:Prunis dulcis
 lt:migdolai
 lv:mandeles
 mt:lewż
+nb:mandel
 nl:amandel, amandelen
 oc:Almendra
 pl:Migdały
@@ -52360,7 +54049,7 @@ ru:миндаль
 sk:Mandľa, mandle
 sl:mandlji
 sq:Bajamet
-sv:mandel
+sv:mandel, mandlar
 th:อัลมอนด์
 tt:бәдәм җимеше
 za:Makgai
@@ -52387,7 +54076,7 @@ da:paranødder
 de:Paranuss, Paranüsse, Paranusskerne
 el:καρύδια Βραζιλίας
 es:pacanas, nueces de Brasil, nuez de Brasil, nueces del Amazonas
-et:brasiilia pähklid, parapähklid
+et:brasiilia pähklid, parapähklid, parapähkleid
 fi:parapähkinä, parapähkinät
 fr:noix du brésil
 ga:cnónna peagáin, cnónna Brasaíleacha
@@ -52404,7 +54093,7 @@ ro:nuci de Brazilia
 ru:бразильский орех
 sk:brazílske orechy
 sl:brazilski oreščki
-sv:paranöt
+sv:paranöt, paranötter
 wikidata:en: Q22810770
 
 < en:Nut
@@ -52417,7 +54106,7 @@ da:cashewnødder
 de:Cashewkerne, Kaschunüsse, Cashewnüsse
 el:καρύδια κάσιους
 es:anacardos
-et:kašupähklid, India pähkel
+et:kašupähklid, India pähkel, kašupähkleid
 fi:cashewpähkinä, cashewpähkinät
 fr:noix de cajou
 ga:cnónna caisiú
@@ -52479,7 +54168,7 @@ de:Haselnuss, Haselnüsse, Haselnusse, Haselnusskerne
 el:φουντούκια
 eo:Avelo
 es:avellana, avellanas
-et:Sarapuupähkel, sarapuupähklid
+et:sarapuupähkel, sarapuupähklid, sarapuupähkleid
 eu:Hur
 fa:فندق
 fi:hasselpähkinä, hasselpähkinät
@@ -52505,7 +54194,7 @@ nv:Neeshchʼíínímazí
 pl:orzechy laskowe, Leszczyna pospolita
 pt:avelã, avelãs
 ro:alune de pădure
-ru:лесной орех, лесньым орехом
+ru:лесной орех, лесньым орехом, фундук
 sk:lieskové oriešky
 sl:lešniki
 sv:hasselnöt, hasselnötter
@@ -52523,11 +54212,11 @@ en:macademia nut, macadamia, Queensland nuts
 ar:المكاداميا
 bg:орехи макадамия, орехи Куинсленд
 cs:makadamie
-da:Macadamianød, queenslandnødder
+da:Macadamianød, queenslandnødder, macadamianødder
 de:Makadamianuss, Macadamianüsse, Queenslandnüsse
 el:καρύδια μακαντάμια, καρύδια Κουίνσλαντ
 es:nueces macadamia, nueces de macadamia, nueces de Australia
-et:makadaamiapähklid
+et:makadaamiapähklid, makadaamiapähkleid
 fi:macadamia-pähkinä, queensland-pähkinä, macadamia-pähkinät, queensland-pähkinät
 fr:noix de macadamia, noix du Queensland
 ga:cnónna macadaíme, cnónna Thír na Banríona
@@ -52545,7 +54234,7 @@ ro:nuci de macadamia, nuci de Queensland
 ru:макадамия, орехи Куинсленд
 sk:makadamové orechy, queenslandské orechy
 sl:makadamija, orehi Queensland
-sv:makadamianöt, Queenslandsnöt
+sv:makadamianöt, Queenslandsnöt, macadamianöt
 zh:夏威夷果
 wikidata:en: Q11027461
 
@@ -52557,8 +54246,8 @@ da:pekannødder
 de:Pekannuss, Pekannüsse, Pecannüsse
 el:καρύδια πεκάν
 es:Nueces de pecán
-et:pekanipähklid
-fi:pekaanipähkinät
+et:pekanipähklid, pekaanipähkleid
+fi:pekaanipähkinä, pekaanipähkinät
 fr:noix de pécan
 it:noci del pekan, noci di pecan
 ja:ペカン
@@ -52571,7 +54260,7 @@ ro:nuci Pecan
 ru:пекан
 sk:pekanové orechy
 sl:ameriški orehi
-sv:pekannöt
+sv:pekannöt, pekannötter
 zh:碧根果
 wikidata:en: Q1119911
 
@@ -52583,8 +54272,8 @@ da:pistacienødder
 de:Pistazien
 el:φυστίκια
 es:pistachos, pistacho, alfóncigos
-et:pistaatsiapähklid
-fi:pistaasipähkinät
+et:pistaatsiapähklid, pistaatsiapähkleid
+fi:pistaasipähkinät, pistaasipähkinä
 fr:pistache, pistaches
 ga:cnónna pistéise
 hu:pisztácia
@@ -52600,8 +54289,14 @@ ro:fistic
 ru:фисташки
 sk:pistáciové oriešky
 sl:pistacija
-sv:pistaschmandel
+sv:pistaschmandel, pistaschnöt, pistaschnötter, pistagenöt
 zh:开心果, 阿月浑子
+
+< en:Nut
+en:sweet almond
+fi:makea manteli, makeat mantelit
+fr:amande douce, amandes douces
+sv:sötmandel
 
 < en:Nut
 en:tigernut
@@ -52629,7 +54324,7 @@ de:Walnuss, Walnüsse, Walnusskerne
 el:Καρύδι
 eo:juglandonukso
 es:nuez, nueces
-et:Kreeka pähklid
+et:Kreeka pähklid, Kreeka pähkleid
 eu:Intxaur
 fa:مغز گردو
 fi:saksanpähkinä, saksanpähkinät
@@ -52659,7 +54354,7 @@ pt:noz
 ru:грецкий орех
 sd:اکروٽ
 sk:vlašské orechy
-sv:valnöt
+sv:valnöt, valnötter
 ta:வாதுமைக் கொட்டை
 zh:胡桃木, 核桃仁, 核桃
 carbon_footprint_fr_foodges_ingredient:fr: Noix entières
@@ -52677,6 +54372,9 @@ en:nutmeg extract
 de:Muskatnuss-Extrakt
 fi:muskottipähkinäuute
 fr:extrait de muscade
+
+< en:Nutritional yeast
+de:Nährhefepulver
 
 < en:Oat
 en:oat bran
@@ -52697,8 +54395,9 @@ de:Haferflocken
 el:νιφάφες βρώμης
 eo:Avenflokoj
 es:copos de avena
+et:kaerahelbed
 eu:Olo-malutak
-fi:kaurahiutale, kaurahiutaleet
+fi:kaurahiutale, kaurahiutaleet, kaurahiutaleita
 fr:flocons d'avoine, flocon d'avoine
 hu:zabpehely
 it:fiocchi di avena, fiocchi d'avena
@@ -52706,13 +54405,13 @@ ja:ロールド・オーツ
 ko:납작귀리
 lt:avižiniai dribsniai
 ms:Emping oat
-nb:Havregryn
+nb:havreflak, havregryn
 nl:havermoutvlokken, havermout
 pl:płatki owsiane
 pt:flocos de aveia
 ro:Haferflocken
 ru:Овсяные хлопья
-sv:havreflager, havregryn
+sv:havreflingor, havreflager, havregryn
 tr:Tahıl ezmesi
 uk:Вівсяні пластівці
 zh:大燕麥片
@@ -52744,7 +54443,10 @@ es:copos de avena integrales
 en:whole grain oats
 de:Vollkornhaferglocken
 es:Avena entera en grano
+et:täisterakaer
+fi:täysjyväkaura
 fr:Flocon d'avoine complet
+sv:fullkornshavre
 
 < en:Oat
 en:whole grain rolled oats, whole oat flakes
@@ -52762,13 +54464,24 @@ pt:flocos de aveia integral
 sv:fullkornshavregryn
 
 < en:Oat
-en:wholemeal oat
+en:wholemeal oat, wholegrain oats
 de:Vollkornhafer, Vollkorn-Hafer
 es:Avena integral, copos de avena integral, copos de avena integral laminados
 fi:täysjyväkaura
 fr:avoine complète
 hu:teljes kiőrlésű zab
 nl:volkoren haver
+sv:fullkornshavre
+
+en:oat base
+de:haferbasis
+es:base de avena
+fi:kaurapohja
+fr:jus d'avoine, base d'avoine
+it:base de avena
+nl:haverbasis
+pt:bebida de aveia
+sv:havrebas
 
 < en:Oat bran
 nl:Haverzemelen met kiem
@@ -52792,6 +54505,7 @@ hu:teljes kiőrlésű zabliszt
 nl:volkorenhavermeel
 pl:mąka owsiana pełnoziarnista
 pt:farinha de aveia integral
+sv:fullkornshavremjöl
 
 < en:Octopus
 en:common octopus
@@ -53013,7 +54727,7 @@ so:Dux
 sq:Yndyra
 sr:Масти
 su:Lemak
-sv:Fett, fet
+sv:Fett, fet, matfett
 sw:Mafuta
 ta:கொழுப்பு
 te:కొలెస్టరాల్‌
@@ -53132,7 +54846,7 @@ nl:plantaardige vetten en olie
 pl:tłuszcz olej roślinne
 pt:gordura e óleo vegetais
 ru:Растительные масла и жиры
-sv:Vegetabilisk olja och fett, Vegetabilisk olja, Vegetabilisk fett
+sv:Vegetabilisk olja och fett, vegetabiliskt fett och olja, vegetabiliskt fett och oljor
 carbon_footprint_fr_foodges_ingredient:fr: Huile d'olive
 carbon_footprint_fr_foodges_value:fr: 2.6
 from_palm_oil:en: maybe
@@ -53145,6 +54859,8 @@ es:Oligofructosa
 fi:oligofruktoosi
 fr:oligofructose
 it:oligofruttosio
+nb:oligofruktose
+sv:oligofruktos
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q418945
@@ -53205,6 +54921,7 @@ it:olive nere
 nl:zwarte olijven, zwarte olijf
 pl:Czarne oliwki
 pt:azeitonas pretas
+sv:svarta oliver
 wikidata:en: Q56475549
 
 < en:Olives
@@ -53218,6 +54935,7 @@ fr:olive verte, olives vertes
 it:olive verdi
 nl:groene olijven
 ru:Зелёные оливки
+sv:gröna oliver
 wikidata:en: Q26879770
 
 < en:Olives
@@ -53298,6 +55016,7 @@ fr:oignon grillé, oignons grillés
 it:cipolle grigliate
 nl:gebakken ui, gebakken uien
 pt:cebolas grelhadas
+sv:stekt lök
 
 < en:Onion
 en:dehydrated onion, dried onion
@@ -53368,6 +55087,7 @@ es:Extracto de cebolla
 fi:sipuliuute
 fr:extrait d'oignon
 it:Estratto di cipolla
+sv:lökextrakt
 
 < en:Onion
 en:onion powder, Granulated onion, Dried minced onion
@@ -53383,6 +55103,7 @@ fr:oignon en poudre, oignons en poudre, poudre d'oignons, poudre d'oignon
 hu:vöröshagymapor
 it:cipolla en polvere
 ms:Serbuk bawang
+nb:løkpulver
 nl:uienpoeder, uipoeder, Uienpoeders
 pl:Cebula w proszku
 pt:cebola em pó
@@ -53391,6 +55112,15 @@ sk:sušená cibuľa
 sl:čebula v prahu
 sv:lökpulver
 wikidata:en: Q7093931
+
+< en:Onion
+en:pearl onion, pearl onions
+de:perlzwiebel
+fi:pikkusipuli, pikkusipulit
+fr:oignons grelots
+is:perlulaukur
+wikidata:en: Q508630
+wikipedia:en: https://en.wikipedia.org/wiki/Pearl_onion
 
 < en:Onion
 en:pre fried onions
@@ -53437,8 +55167,10 @@ sv:rödlök
 en:rehydrated onion
 de:rehydrierte Zwiebeln
 es:Cebolla rehidratada
+fi:rekombinoitu sipuli
 fr:oignon réhydraté, oignons réhydratés
 it:cipolla reidratata
+sv:rehydrerad lök
 
 < en:Onion
 en:Roscoff onions
@@ -53494,7 +55226,7 @@ ro:ceapă de tuns
 ru:Лук-батун
 sr:аљма
 su:Bawang daun
-sv:Piplök
+sv:Piplök, walesisk lök
 te:ఉల్లి కాడలు
 tr:Kış soğanı
 uk:Батун
@@ -53518,6 +55250,7 @@ fr:oignon fumé en poudre
 < en:Onion
 fr:oignon jaune, oignons jaunes
 fi:keltasipuli
+sv:gul lök
 
 < en:Onion
 fr:oignon semoule
@@ -53530,9 +55263,6 @@ fr:oignons émincés
 
 < en:Onion
 fr:oignons en morceaux
-
-< en:Onion
-fr:oignons grelots
 
 < en:Onion
 fr:oignons grillés en poudre
@@ -53584,7 +55314,7 @@ da:orangeskal
 de:Orangenschale, Orangenschalen
 es:cáscara de naranja, corteza de naranja
 et:apelsinikoor
-fi:appelsiininkuori
+fi:appelsiininkuori, appelsiinikuori
 fr:zeste d'orange, zestes d'orange, écorce d'orange, écorces d'orange, écorces d'oranges
 hu:narancshéj
 it:scorza d'arancia, scorze di arancia, scorze d'arancia, buccla d'arancia
@@ -53606,7 +55336,7 @@ be:Апельсінавы сок
 bg:Портокалов сок
 bo:ཚ་ལུ་མའི་ཁུ་བ།
 ca:suc de taronja
-da:appelsinjuice
+da:appelsinjuice, appelsinsaft
 de:Orangensaft
 el:Πορτοκαλάδα
 eo:oranĝsuko
@@ -53634,7 +55364,7 @@ pl:Sok pomarańczowy
 pt:suco de laranja
 ru:апельсиновый сок
 sa:नारङ्गफलरसः
-sv:Apelsinjuice
+sv:apelsinjuice, juice av apelsin
 ta:ஆரஞ்சுச் சாறு
 th:น้ำส้ม
 tr:Portakal suyu
@@ -53670,6 +55400,13 @@ fr:extraits naturels d'orange
 es:extracto natural de naranja dulce
 fi:luontainen appelsiiniuute
 
+< en:Orange flavouring
+en:essential orange oil flavour
+da:aæterisk appelsinolie aroma
+fi:eteerinen appelsiiniöljyaromi
+nb:naturling smak fra eterisk appelsinolje
+sv:smak från eterisk apelsinolja
+
 < en:Blood orange
 < en:Orange juice
 de:Blutorangensaft
@@ -53691,17 +55428,24 @@ fi:appelsiinimehutiiviste, appelsiinitäysmehutiiviste
 fr:jus d'orange concentré, concentré de jus d'orange
 it:succo d'arancia concentrato
 nl:sinaasappelconcentraat, geconcentreerd sinaasappelsap
+sv:apelsinjuicekoncentrat
 
 < en:Orange juice
 en:orange juice from concentrate
 da:Appelsinjuice fra koncentrat
 de:Orangensaft aus Konzentrat, Orangensaft aus Orangensaftkonzentrat
 es:Zumo de naranja desde concentrado, zumo de naranja a partir de concentrado
-fi:appelsiinimehu tiivisteestä
+fi:appelsiinimehu tiivisteestä, tiivisteestä valmistettu appelsiinitäysmehu, appelsiinitäysmehu tiivisteestä, appelsiinitäysmehu appelsiinitäysmehutiivisteestä, appelsiinitäysmehua tiivisteestä
 fr:jus d'orange à base de concentré, jus d'orange à base de jus d'orange concentré, jus d'orange à base de jus concentré, jus d'orange à partir de concentré
+hr:sok od naranče iz koncentrata soka naranče
+hu:narancslé narancslé-koncentrátumból
 it:succo d'arancia a base di concentrato
 nl:Sinaasappelsap uit sapconcentraat
 pl:Sok pomarańczowy z koncentratu, Zagęszczony sok pomarańczowy
+ro:suc de portocale obținut din suc concentrat de portocale
+sk:pomarančová šťava z pomarančového koncentrátu
+sl:pomarančni sok iz pomarančnega zgoščenega soka
+sv:apelsinjuice från koncentrat, apelsinsaft av koncentrat, apelsinjuice gjord av apelsinjuicekoncentrat
 
 < en:Orange juice
 en:Organic orange juice
@@ -53918,6 +55662,12 @@ description:es: Aditivos alimentarios gaseosos, introducidos en un envase antes,
 description:fr: Additif alimentaire gazeux, qui est introduit dans un conteneur pendant, durant ou après son remplissage avec une denrée alimentaire avec l'intention de protéger l'aliment par exemple de l'oxydation ou de l'altération.
 
 < en:Palm fat
+en:hydrogenated palm fat
+fi:kovetettu palmurasva
+fr:graisse de palme hydrogénée
+sv:hydrerad palmfett
+
+< en:Palm fat
 en:non-hydrogenated palm fat
 de:unhydriertes Palmfett, Palmfett ungehärtet
 fi:kovettamaton palmurasva, hydrogenoimaton palmurasva
@@ -53927,13 +55677,21 @@ it:grasso di palma non idrogenato
 
 < en:Palm fat
 en:totally hydrogenated palm fat
+da:helt hærdet palmefedt
 de:vollständig gehärtetes Palmfett
-fi:kokonaan kovetettu palmurasva, kokonaan hydrogenoitu palmurasva
+fi:kokonaan kovetettu palmurasva, kokonaan kovetettua palmurasvaa, kokonaan hydrogenoitu palmurasva
 fr:graisse de palme totalement hydrogénée
 hu:teljes mértékben hidrogénezett pálmazsír, teljesen hidrogénezett pálmazsír, teljes mértékben hidrogénezett pálmamag-zsír
+sv:fullhärdat palmfett
 
 < en:Palm kernel oil
-fr:palmiste totalement hydrogénée
+en:hydrogenated palm kernel oil, hydrogenated palm kernel
+fi:kovettu palmuydinöljy, kovetettu palmuydin
+fr:huile de palmiste hydrogénée
+sv:härdat palmkärnolja, härdat palmkärna
+
+< en:Palm kernel oil
+fr:palmiste totalement hydrogénée, huile de palmiste entièrement hydrogénée
 
 < en:Palm kernel oil and fat
 en:palm kernel fat
@@ -53948,15 +55706,16 @@ en:palm kernel oil, palm kernel
 bs:Ulje palminog jezgra
 ca:Oli de palmist
 cs:Palmojádrový olej
-da:Palmeolie
+da:palmekerne olie, palmekerne
 de:Palmkernöl, Palmkern
 es:palmiste
 eu:Palmiste olio
 fa:روغن هسته پالم
-fi:palmuydinöljy, palmuydin
+fi:palmuydinöljy, palmuydin, palmunydin, palmunsiemenöljy
 fr:huile de palmiste, huile végétale de palmiste, palmiste
 hu:pálmamagolaj, pálmamag
 id:Minyak inti kelapa sawit
+is:pálmakjarmaolía
 it:olio di palmisto
 kn:ಪಾಮ್ ಕೆರ್ನಲ್ ಎಣ್ಣೆ
 ln:Mafúta ma ndiká
@@ -53966,7 +55725,7 @@ nl:Palmkernolie
 pl:Olej z ziaren palmowych
 pt:palmiste
 ru:Пальмоядровое масло
-sv:Palmkärnolja
+sv:palmkärnolja, palmkärna, palmkärn
 te:పామ్‌కెర్నల్‌ నూనె
 uk:Пальмоядрова олія
 from_palm_oil:en: yes
@@ -54033,12 +55792,14 @@ ru:Органическое пальмовое масло
 
 < en:Palm oil
 en:palm
+da:palme
 de:Palme
 es:palma
 fi:palmu
 fr:palme
 hu:pálma
 it:palma
+nb:palme
 nl:palm
 pl:palma
 pt:palma
@@ -54086,19 +55847,21 @@ ca:greix de palma, greix vegetal de palma
 da:palmfedtstof
 de:Palmfett
 es:grasa vegetal de palma, manteca de palma
-fi:palmurasva
+et:palmirasv
+fi:palmurasva, palmun rasva
 fr:graisse de palme, graisse végétale de palme, matière grasse de palme, matière grasse végétale de palme, Acides gras de palme
 hu:pálmazsír
 it:grasso di palma, grasso vegetale di palma
 nl:palmvet
 pl:Tłuszcz palmowy
 pt:gordura de palma, gordura vegetal de palma
+ro:grăsime palmier
 ru:Пальмовый жир
 se:palmina mast
 sv:
 
 < en:Palm oil and fat
-en:palm oil, palmoil
+en:palm oil, palmoil, sustainable palm fruit oil
 ar:زيت النخيل
 be:Пальмавы алей
 bg:Палмово масло
@@ -54121,6 +55884,7 @@ hi:ताड़ का तेल
 hr:Palmino ulje
 hu:pálmaolaj
 id:Minyak sawit
+is:pálmaolía
 it:olio di palma
 ja:パーム油
 ka:პალმის ზეთი
@@ -54159,7 +55923,7 @@ en:coconut sugar, coconut palm sugar
 ca:Sucre de coco
 de:Kokosblütenzucker
 es:Azucar de coco
-fi:kookossokeri
+fi:kookossokeri, kookospalmusokeri
 fr:sucre de fleur de coco, sucre de fleur de cocotier, sucre de coco
 hu:kókuszcukor
 id:Gula kelapa
@@ -54167,6 +55931,7 @@ it:zucchero di fiori di cocco, zucchero di cocco
 nn:kokosnøttsukker
 pt:jagra
 su:Gula kalapa
+sv:kokossocker, kokospalmsocker
 ta:தென்னை சர்க்கரை
 wikidata:en: Q5139861
 wikipedia:en: https://en.wikipedia.org/wiki/Coconut_sugar
@@ -54282,9 +56047,10 @@ fr:riz long italien étuvé
 en:parboiled long grain rice, long grain parboiled rice
 de:Dampfgegarter Spitzen-Langkorn-Reis
 es:arroz grano largo vaporizado
-fi:parboil-käsitelty pitkäjyväinen riisi
+fi:pitkäjyväinen parboil riisi, parboil-käsitelty pitkäjyväinen riisi
 fr:riz long étuvé, riz long grain étuvé, riz long grain précuit à la vapeur, riz a grain long parboiled, Riz long grain étuvé cuisson rapide, riz long précuite, riz long grain précuit
 hu:forrázott hosszú szemű rizs
+sv:långkornigt parboil ris
 
 < en:Parboiled rice
 < en:Rice
@@ -54313,7 +56079,9 @@ es:zumo de maracuyá
 fi:passiohedelmämehu
 fr:jus de fruit de la passion, jus de fruits de la passion
 it:succo di frutto della passione
+nb:pasjonsfruktjuice
 nl:passievruchtsap
+sv:passionsfruktjuice
 
 < en:Passion fruit
 < en:Purée
@@ -54325,24 +56093,19 @@ nl:passievruchtenpuree
 en:reconstituted passion fruit juice
 de:Maracujasaft aus Maracujasaftkonzentrat, Passionfruchtsaft aus Konzentrat
 es:zumo de maracuyá a partir de concentrado
-fi:Tiivisteestä valmistettu passionhedelmämehu
+fi:tiivisteestä valmistettu passionhedelmämehu, tiivisteestä valmistettu passiohedelmätäysmehu
 fr:jus de fruit de la passion à base de concentré
+sv:passionsfruktsjuice från koncentrat
 
 < en:Pasta
 en:cooked pasta
 de:Teigwaren gekocht
 es:Pasta cocinada
-fi:kypsennetty pasta
+fi:kypsennetty pasta, keitetty pasta
 fr:pâte cuite, pâte cuites, pâtes cuites
 it:pasta già cotta
 nl:gekookte pasta
-
-< en:Pasta
-en:cooked tagliatelle
-de:Tagliatelle gekocht, Bandnudeln gekocht
-fi:kypsennetty tagliatelle
-fr:tagliatelles cuites
-it:tagliatelle cotte
+sv:kokt pasta
 
 < en:Pasta
 en:durum wheat semolina pasta
@@ -54373,6 +56136,217 @@ carbon_footprint_fr_foodges_ingredient:fr: Pâtes sèches
 carbon_footprint_fr_foodges_value:fr: 0.5
 
 < en:Pasta
+en:lasagne, lasagna, lasagna pasta, lasagne sheets
+af:lasagne
+ar:لازانيا
+az:lazanya
+be:лазанья
+bg:лазаня
+br:lasagne al forno
+ca:lasanya
+cs:lasagne
+cy:lasagna
+da:lasagne
+de:lasagne, lasagneblätter
+eo:lasanjoj
+es:lasaña
+et:lasanje
+eu:lasagna
+fa:لازانیا
+fi:lasagne, lasagnelevyt
+fr:lasagnes, feuilles de lasagnes
+gl:lasaña
+he:לזניה
+hi:लज़ान्या
+hy:լազանյա
+id:lasagna
+is:lasanja
+it:lasagne al forno
+ja:ラザニア
+jv:lasagna
+kn:ಲಜ಼ಾನ್ಯಾ
+ko:라자냐
+la:laganum
+li:lezanja
+lt:lazanija
+mk:лазањи
+ms:lasagna
+nb:lasagne
+nl:lasagne
+pl:lasagne
+pt:lasanha
+ru:лазанья
+se:lasagne
+sk:lazane
+sr:лазање
+sv:lasagne, lasagneplattor
+tl:lasagne
+tr:lazanya
+uk:лазанья
+vi:lasagna
+zh:千層麵
+wikidata:en: Q20034
+wikipedia:en: https://en.wikipedia.org/wiki/Lasagne
+
+< en:Pasta
+en:linguine
+ar:لنغويني
+ca:linguine
+de:linguine
+eo:langetoj
+es:linguine
+fa:لینگوئینی
+fr:linguine
+he:לינגוויני
+is:linguine
+it:linguine
+ja:リングイネ
+ko:링귀네
+lt:linguine
+ms:linguine
+nb:linguini
+nl:linguine
+pl:linguine
+pt:linguine
+ru:лингуине
+sv:linguine, linguini, linguinipasta
+th:ลิงกวีเน
+uk:лінґвіне
+wikidata:en: Q20035
+wikipedia:en: https://en.wikipedia.org/wiki/Linguine
+
+< en:Pasta
+en:penne
+af:penne
+ar:بيني
+ca:macarró
+cs:penne
+de:penne
+el:πέννες
+es:penne
+fa:پنه
+fi:penne
+fr:penne
+he:פנה
+id:penne
+it:penne
+ja:ペンネ
+jv:pénné
+ko:펜네
+ms:penne
+nb:penne
+nl:penne
+pl:penne
+pt:penne
+ru:пенне
+sk:penne
+sv:penne, pennepasta
+th:เปนเน
+uk:пенне
+zh:直通粉
+wikidata:en: Q1063736
+wikipedia:en: https://en.wikipedia.org/wiki/Penne
+
+< en:Pasta
+en:risoni
+fi:risoni, risonipasta
+wikidata:en: Q1317552
+wikipedia:en: https://en.wikipedia.org/wiki/Orzo
+
+< en:Pasta
+en:spaghetti
+af:spaghetti
+ar:سباغيتي
+be:спагеці
+bg:спагети
+ca:espagueti
+cs:špagety
+da:spaghetti
+de:spaghetti
+el:σπαγγέτι
+eo:spagetoj
+es:espagueti
+eu:espageti
+fa:اسپاگتی
+fi:spagetti
+fr:spaghetti
+gl:espaguetes
+he:ספגטי
+hi:स्पगैटी
+hr:špageti
+hu:spagetti
+hy:սպագետտի
+ia:spaghetti
+id:spageti
+is:spaghettí
+it:spaghetti
+ja:スパゲッティ
+jv:spagèti
+kk:спагетти
+ko:스파게티
+ky:спагетти
+la:pasta vermiculata
+lb:spaghetti
+lt:spagečiai
+lv:spageti
+mk:шпагети
+ms:spaghetti
+my:စပါဂတီခေါက်ဆွဲ
+nb:spagetti
+nl:spaghetti
+nn:spagetti
+nv:kʼíneeshbízhiinééz
+pl:spaghetti
+pt:espaguete
+ro:spaghete
+ru:спагетти
+se:spaghetti
+sk:špageta
+sl:špageti
+sr:шпагети
+su:spaghetti
+sv:spagetti
+sw:spaghetti
+ta:ஸ்பாகெட்டி
+th:สปาเกตตี
+tl:ispageti
+tr:spagetti
+uk:спагеті
+vi:spaghetti
+zh:意大利粉
+wikidata:en: Q20026
+wikipedia:en: https://en.wikipedia.org/wiki/Spaghetti
+
+< en:Pasta
+en:tagliatelle
+af:tagliatelle
+ar:تالياتيلي
+ca:tallarina
+cs:tagliatelle
+de:tagliatelle
+el:ταλιατέλες
+es:tallarines
+fa:تالیاتله
+fi:tagliatelle
+fr:tagliatelle
+hu:tagliatelle
+id:tagliatelle
+is:tagliatelle
+it:tagliatelle
+ja:タリアテッレ
+ko:탈리아텔레
+nb:tagliatelle
+nl:tagliatelle
+pl:tagliatelle
+pt:tagliatelle
+ru:тальятелле
+sv:tagliatelle
+th:ตัลยาเตลเล
+uk:тальятеле
+wikidata:en: Q20044
+wikipedia:en: https://en.wikipedia.org/wiki/Tagliatelle
+
+< en:Pasta
 fr:canneloni
 
 < en:Pasta
@@ -54398,6 +56372,7 @@ fi:iskukuumennettu maito, UHT-käsitelty maito, UHT-maito
 fr:lait stérilisé U.H.T
 hu:UHT tej, ultrapasztőrözött tej
 it:Latte pastorizzato UHT
+sv:UHT-behandlad mjölk
 
 < en:Pasteurised milk
 sv:högpastöriserad mjölk
@@ -54516,8 +56491,15 @@ fr:extrait de pois
 
 < en:Hydrolysed proteins
 < en:Pea protein
+en:hydrolysed pea protein, hydrolyzed pea protein
+fi:hydrolysoitu herneproteiini, herneproteiinihydrosylaatti
 fr:protéines de pois hydrolysées
-fi:herneproteiinihydrosylaatti
+sv:hydrolyserat ärtprotein
+
+< en:Pea protein
+en:rehydrated pea protein
+fi:vedellä turvotettu herneproteiini
+sv:rehydrerat ärtprotein
 
 < en:Pea protein
 fr:isolat de proteines de pois
@@ -54526,6 +56508,7 @@ hu:borsófehérje izolátum
 
 < en:Peach
 en:peach juice
+da:ferskenjuice
 de:Pfirsichsaft
 es:Jugo de melocotón
 fi:persikkamehu
@@ -54553,10 +56536,11 @@ fr:pêches en cubes
 en:peach puree
 de:Pfirsichpurée
 es:Pure de melocotón
-fi:persikkapyree
+fi:persikkasose, persikkapyree
 fr:purée de pêches, purée de pêche
 it:purea di pesche
 nl:Perzikkenpuree
+sv:persikopuré
 
 < en:Peach juice
 fr:jus de pêche à base de concentré
@@ -54581,7 +56565,7 @@ el:αραχίδες, αραχίδα, αραπικα φιστικια
 eo:ternukso
 es:cacahuetes, cacahuete, cacahuates, cacahuate
 et:Maapähkel, maapähklid
-fi:maapähkinä, maapähkinät
+fi:maapähkinä, maapähkinät, maapähkinää
 fr:arachides, arachide, cacahuètes, cacahuète, cacahouètes, cacahouète
 ga:Cnó talún, piseanna
 gu:મગફળી
@@ -54620,6 +56604,10 @@ za:Duhdoem
 zh:花生仁, 花生
 
 < en:Peanut
+en:peanut flour
+fr:farine d'arachide
+
+< en:Peanut
 en:peanut with shell
 de:Erdnüsse mit Schale
 es:cacahuete con cáscara
@@ -54642,9 +56630,6 @@ de:geschälte Erdnüsse
 fi:kuoreton maapähkinä, kuorettomat maapähkinät
 fr:cacahuètes décortiquées
 nl:Pinda's in de dop
-
-< en:Peanut
-fr:farine d'arachide
 
 en:peanut butter
 es:crema de cacahuete
@@ -54685,6 +56670,7 @@ it:Succo di pera
 nl:perensap
 pl:Sok gruszkowy
 ru:сок грушевый
+sv:päronjuice
 wikidata:en: Q2461726
 
 < en:Pear juice
@@ -54695,6 +56681,7 @@ fi:päärynämehu tiivisteestä
 fr:jus de poire à base de concentré
 it:succo di pera da concentrato
 nl:perensap uit concentraat
+sv:päronjuice från koncentrat
 
 < en:Pear juice
 fr:jus de poire concentré
@@ -54703,7 +56690,9 @@ fi:päärynämehutiiviste
 it:Succo di pere concentrato
 
 < en:Pecan nut
+en:caramelized pecan nuts
 fr:noix de pécan caramélisées
+sv:karamelliserade pekannötter
 
 < en:Pecorino
 en:pecorino romano, romano, Peccorino Romano PDO cheese
@@ -54752,6 +56741,15 @@ de:pencillium roqueforti (Edelschimmel)
 fr:penicillium roqueforti
 la:pencillium roqueforti
 
+< en:Penicillium
+en:penicillium candidum
+ia:penicillium candidum
+la:penicillium candidum
+nl:penicillium candidum
+pt:penicillium candida
+sv:penicillium candida, penicillium candidum
+wikidata:en: Q3942999
+
 < en:Pepper
 en:black pepper
 ca:Pebre negre
@@ -54766,14 +56764,15 @@ fr:poivre noir
 hu:feketebors
 it:pepe nero
 lt:juodieji piperai
+nb:svart pepper, piper nigrum
 nl:zwarte peper
 nn:svart pepper
 pl:czamy pieprz, pieprz czarny
 pt:pimenta preta
 ro:piper negru
 ru:Черный перец
-sl:cmi poper
-sv:svartpeppar
+sl:cmi poper, črni poper
+sv:svartpeppar, svart peppar
 tr:karabiber
 zh:黑胡椒
 
@@ -54796,6 +56795,7 @@ de:grüner Pfeffer
 es:pimienta verde
 fi:viherpippuri
 fr:poivre vert
+sv:grönpeppar
 
 < en:Pepper
 en:grey pepper, gray pepper
@@ -54809,6 +56809,7 @@ fi:pippuriuute
 fr:extrait de poivre
 it:estratto di pepe
 nl:peperextract
+sv:pepparextrakt
 
 < en:Pepper
 en:peppercorns
@@ -54829,6 +56830,7 @@ da:rød peberfrugt, rød peber
 de:rote Paprika, roter Paprika
 el:κόκκινη πιπεριά
 es:pimiento rojo, pimiento morrón rojo
+et:punane paprika
 fi:punainen paprika
 fr:poivron rouge, poivrons rouge
 hu:kaliforniai paprika, piros bell paprika
@@ -54841,20 +56843,6 @@ ru:Красный перец
 sv:röd paprika
 
 < en:Pepper
-en:white pepper
-cs:Bílý pepř
-da:Hvid peber
-de:weißer Pfeffer, weisser Pfeffer
-es:Pimienta blanca
-fi:valkopippuri
-fr:poivre blanc
-hu:fehérbors
-it:pepe bianco
-nl:witte peper
-pl:Pieprz biały
-sv:vitpeppar
-
-< en:Pepper
 < en:Spice
 en:paprika
 ar:بابريكا
@@ -54865,7 +56853,7 @@ bs:paprika
 ca:piment vermell
 cs:paprika
 cy:Paprica
-da:paprika
+da:paprika, peberfrugt
 de:
 el:πάπρικα
 eo:papriko
@@ -54901,6 +56889,20 @@ zh:辣椒粉
 wikidata:en: Q3127593
 wikipedia:en: https://en.wikipedia.org/wiki/Paprika
 
+< en:Pepper
+en:white pepper
+cs:Bílý pepř
+da:Hvid peber
+de:weißer Pfeffer, weisser Pfeffer
+es:Pimienta blanca
+fi:valkopippuri
+fr:poivre blanc
+hu:fehérbors
+it:pepe bianco
+nl:witte peper
+pl:Pieprz biały
+sv:vitpeppar
+
 < en:Pepper extract
 fr:extrait naturel de poivre
 fi:luontainen pippuriuute
@@ -54930,6 +56932,7 @@ de:Natürliches Pfeffeeminzaroma
 fi:luontainen piparminttuaromi
 fr:arôme naturel de menthe poivrée
 hu:természetes borsmenta aroma
+sv:naturlig pepparmintsarom
 
 < en:Peppermint oil
 en:organic peppermint oil
@@ -55030,7 +57033,7 @@ it:succo di ananas
 nl:Ananassap
 pl:Sok ananasowy, Sok z ananasa
 ru:Ананасовый сок
-sv:Ananas juice
+sv:ananasjuice
 zh:菠萝汁
 
 < en:Pineapple juice
@@ -55042,6 +57045,7 @@ fr:jus d'ananas concentré
 it:succo d'ananas concentrato
 nl:geconcentreerd ananassap
 ru:Концентрированный ананасовый сок
+sv:ananasjuice koncentrat
 
 < en:Fruit juice
 < en:Pink grapefruit
@@ -55079,9 +57083,15 @@ fi:pistaasitahna
 < en:Pistachio nuts
 fr:pistaches en coques
 
+en:pizza base
+fi:pizzapohja
+fr:fond de pizza
+sv:pizzabotten
+
 en:pizza dough
 da:pizzadej
 de:Pizzateig
+fi:pizzataikina
 fr:pâte à pizza
 
 en:plant
@@ -55102,6 +57112,86 @@ vegetarian:en: yes
 
 < en:Plant
 de:steviablätter
+
+< en:Plant
+en:ashwagandha, withania somnifera
+am:ጊዜዋ
+ar:عبعب منوم
+as:অশ্বগন্ধা
+bn:অশ্বগন্ধা
+ca:bufera
+cs:withanie snodárná
+de:schlafbeere
+es:withania somnifera
+et:uimastav juustumari
+fa:گیلاس زمستانی
+fi:rohtokoisio, ashwagandha
+fr:ashwagandha
+gu:અશ્વગંધા
+he:ויתניה משכרת
+hi:अश्वगंधा
+hu:álombogyó
+it:withania somnifera
+ja:アシュワガンダ
+kn:ಅಶ್ವಗಂಧಾ
+ml:അമുക്കുരം
+mr:आसकंद
+ne:अश्वगन्धा
+nl:ashwaganda
+pa:ਅਸ਼ਵਗੰਧਾ
+pl:witania ospała
+pt:withania somnifera
+si:අමුක්කරා
+sv:withania somnifera
+ta:அமுக்கிரா
+te:అశ్వగంధ
+uk:withania somnifera
+vi:sâm ấn độ
+zh:睡茄
+wikidata:en: Q852660
+wikipedia:en: https://en.wikipedia.org/wiki/Withania_somnifera
+
+< en:Plant
+en:burdock, arctium
+ar:أرقطيون
+az:atpıtrağı, bardana, lappa
+be:лопух
+br:seregenn-vras
+bs:arctium
+ca:arctium
+da:burre
+de:kletten
+es:arctium
+et:takjas
+fa:بابا آدم
+fi:takiaiset, takiainen
+fr:bardane
+hr:čičak
+io:bardano
+it:arctium, bardana
+kk:шоңайна
+ku:gula fişek
+ky:уйгак
+lt:varnalėša
+ml:ആർക്ടിയം
+nl:klit
+nn:borreslekta
+os:залмысыф
+pl:łopian
+pt:arctium
+ro:arctium
+ru:лопух
+sh:čičak
+sr:чичак
+sv:kardborresläktet, kardborrar, kardborre
+tg:мушхор
+tl:mores
+uk:лопух
+uz:qariqiz
+vi:chi ngưu bàng
+zh:牛蒡属
+wikidata:en: Q27257
+wikipedia:en: https://en.wikipedia.org/wiki/Arctium
 
 < en:Plant
 en:capers
@@ -55346,7 +57436,7 @@ sa:यष्टी
 sh:Sladić
 sl:Golostebelni sladki koren
 sr:Сладић
-sv:lakrits, Lakritsrot
+sv:lakrits
 ta:அதிமதுரம்
 te:అతిమధురము
 th:ชะเอมเทศ
@@ -55550,7 +57640,7 @@ pt:axeitonas, azeitona
 qu:Asitunas
 ru:маслины, оливка
 sk:Oliva
-sv:Oliv
+sv:Oliv, oliver
 th:นํ้า
 tt:зәйтүн
 zh:阿塞图纳
@@ -55563,6 +57653,14 @@ en:orange leaves
 de:Orangenblätter
 fr:feuilles d'oranger
 it:foglie d'arancio
+
+< en:Plant
+en:plant concentrates
+da:plantekoncentrater
+de:pflanzenkonzentrate
+fi:kasvitiivisteet, kasvitiiviste
+fr:concentrés de plantes
+sv:växtkoncentrat, plantkoncentrat
 
 < en:Plant
 en:plant extracts
@@ -55656,7 +57754,7 @@ es:rooibos
 et:Rooibos, Tee-punapõõsas
 eu:Rooibos
 fa:راوند
-fi:rooibos, kapinroibospensas, kapinroibos
+fi:rooibos, kapinroibospensas, kapinroibos, rooibos-pensaan lehti
 fr:rooibos
 gl:Rooibos
 he:רויבוש
@@ -55694,18 +57792,19 @@ fr:pétales de rose
 it:petalo di rosa
 
 < en:Plant
-en:roselle flower
+en:roselle flower, hibiscus flower, hibiscus flowers
 ar:كركديه
 as:টেঙামৰা
 az:Məkkə çayı
 bg:চুকাই
 ca:rosa de Jamaica
 cs:ibišek súdánský
+da:hibiskusblomst
 de:Karkadeblüten, Roselle, Hibiskus
 eo:Sabdarifo
 es:Flor Roselle
 fa:روزل
-fi:Teehibiskus
+fi:teehibiskus, hibiskus, hibiskuksen kukka
 fr:fleurs de carcadé, fleurs d'hibiscus, hibiscus
 gu:અંબાડી
 hu:rozella
@@ -55720,13 +57819,14 @@ ml:പുളിവെണ്ട
 mr:अंबाडी
 ms:Asam belanda
 my:ချဉ်ပေါင်
+nb:hibiskusblomst
 nl:hibiscusbloem, roselle
 pl:Ketmia szczawiowa
 pt:Vinagreira
 ru:Розелла
 sd:کٽنبڙو
 su:Rosella
-sv:Rosellhibiskus
+sv:Rosellhibiskus, hibiskus, hibiskusblomma
 te:గోంగూర
 th:กระเจี๊ยบเปรี้ยว
 tr:Kerkede
@@ -55750,7 +57850,7 @@ es:Cártamo
 et:Värvisafloor
 eu:Kartamo
 fa:گلرنگ
-fi:Saflori, Värisaflori
+fi:saflori, värisaflori, väriohdake, väriohdaketta, safflori
 fr:carthame
 ga:Cróch bréige
 gl:Cártamo
@@ -55783,7 +57883,7 @@ ru:Сафлор
 sd:کھنبو
 sh:Šafranika
 sr:Шафраника
-sv:Safflor
+sv:Safflor, färgtistel
 te:కుసుమ
 th:คำฝอย
 tr:Aspir
@@ -55919,7 +58019,7 @@ pt:Girassol
 ru:подсолнечник
 si:සූරියකාන්ත
 sl:slnečnica
-sv:solross
+sv:solros
 tl:mirasol
 to:siolaʻā
 tt:көнбагыш
@@ -56178,11 +58278,34 @@ fr:pétales de jasmin
 fr:pin sylvestre
 la:Pinus sylvestris
 
+< en:Fruit concentrates
+< en:Plant concentrates
+en:fruit and plant concentrates
+de:Frucht- und Pflanzenkonzentrate
+es:Concentrado de frutas y plantas
+fi:hedelmä- ja kasvitiiviste, hedelmä- ja kasvitiivisteet
+fr:concentré de fruits et de plantes, concentrés de fruits et de plantes
+it:concentrati di frutta e plante
+nl:vruchten- en plantenconcentraten
+
 < en:Plant extracts
 en:organic plant extracts
 fi:luomu kasviuute
 fr:extraits de plantes bio
 nl:biologische plantextracten
+
+en:plant stanol
+fi:kasvistanoli, kasvistanolit
+fr:stanols végétaux
+pl:stanole roślinne
+sv:växtstanol
+
+< en:Plant stanol
+en:plant stanol ester
+fi:kasvistanoliesteri, kasvistanoliesterit
+fr:esters de stanols végétaux
+pl:estry stanoli roślinnych
+sv:växtstanolester
 
 < en:Plant
 < en:Plantain
@@ -56347,6 +58470,10 @@ de:Blaumohnsamen
 fr:graine de pavot bleu
 
 < en:Pork
+en:dehydrated pork broth, pork stock powder
+fr:bouillon de porc déshydraté
+
+< en:Pork
 en:pork by-product
 de:Nebenprodukt aus Schweinefleisch
 es:Subproducto de cerdo
@@ -56434,10 +58561,8 @@ en:pork skin, sausage skin
 es:tripa de cerdo, tripa natural de cerdo
 
 < en:Pork
+en:pork stock, pork broth
 fr:bouillon de porc
-
-< en:Pork
-fr:bouillon de porc déshydraté
 
 < en:Pork
 fr:coeur de porc
@@ -56459,16 +58584,17 @@ cs:Vepřové maso
 da:Svinekød
 de:Schweinefleisch
 es:carne de cerdo
-fi:sianliha, sianlihaa, porsaanliha, porsaanlihaa
+fi:sianliha, sianlihaa, porsaanliha, porsaanlihaa, viljaporsaanliha
 fr:viande de porc
 hu:sertéshús, disznóhús
 it:carne di suino
+nb:svinekjøtt, kjøtt av svin
 nl:Varkensvlees
 pl:Wieprzowina
 pt:carne de suíno, carne de porco
 ro:carne de porc, carne porc
 ru:Свинина
-sv:griskött
+sv:fläskkött, griskött, svinkött, fläsk, kött från gris
 zh:猪肉
 carbon_footprint_fr_foodges_ingredient:fr: Viande de porc
 carbon_footprint_fr_foodges_value:fr: 7.4
@@ -56479,15 +58605,16 @@ en:pork shoulder
 es:paleta de cerdo
 
 < en:Pork by-product
+en:pork bone
+fr:os de porc
+
+< en:Pork by-product
 fr:couenne et gras de porc
 
 < en:Pork by-product
 fr:graisse de porc
 pt:gordura de suíno
 ro:grăsime de porc, grasime de porc
-
-< en:Pork by-product
-fr:os de porc
 
 < en:Pork by-product
 fr:plasma de porc
@@ -56497,6 +58624,8 @@ fr:protéines de sang de porc
 
 < en:Pork by-product
 fr:sang de porc
+fi:sian veri
+sv:svin blod, blod av svin
 
 < en:Pork by-product
 fr:sang frais de porc
@@ -56575,16 +58704,18 @@ fi:kinkku, kinkkua, siankinkku
 fr:jambon, jambon de porc
 hu:sonka
 it:prosciutto
+nb:skinke
 nl:Ham
 pl:Szynka
 ru:Ветчина
-sv:skinka
+sv:skinka, skinka av gris
 zh:火腿
 
 < en:Pork meat
 en:pork belly, pork bellies
 de:Schweinebauch
 fr:ventre de porc
+sv:sidfläsk
 
 < en:Pork meat
 en:pork liver
@@ -56635,6 +58766,7 @@ fr:chipolatas aux herbes
 fr:Côtes de porc
 ca:costelles de porc
 es:costillas de cerdo
+sv:sida av gris
 
 < en:Pork meat
 fr:couenne de porc, couennes de porc
@@ -56648,9 +58780,12 @@ fr:échine de porc
 
 < en:Pork meat
 fr:épaule de porc
+fi:porsaan lapa
+sv:grisbog
 
 < en:Pork meat
 fr:filet de porc
+sv:ytterfilé av gris
 
 < en:Pork meat
 fr:filet et pointe de porc
@@ -56793,11 +58928,56 @@ es:patata cocida
 fi:kypsennetty peruna
 fr:pomme de terre cuite, pommes de terre cuites
 nl:gegaarde aardappel
+sv:kokt potatis
 
 < en:Flour
 < en:Potato
 en:potato flour
 es:harina de patata
+fi:perunajauho
+fr:farine de pomme de terre, farine de pommes de terre, pomme de terre en poudre
+sv:potatismjöl, potatisstärkelse
+
+< en:Potato
+en:mashed potato, mashed potatoes
+ar:بطاطا مهروسة
+az:kartof püresi
+be:бульбяное пюрэ
+bg:картофено пюре
+bn:আলু ভর্তা
+ca:puré de patates
+cs:bramborová kaše
+cv:токкоми
+da:kartoffelmos
+de:kartoffelpüree
+el:πουρές
+eo:terpomkaĉo
+es:puré de papas
+et:kartulipuder
+fa:پوره سیب‌زمینی
+fi:perunasose, perunamuusi
+fr:purée de pomme de terre, purée de pommes de terre
+ga:brúitín
+he:מחית תפוחי אדמה
+id:kentang tumbuk
+it:purea di patate
+ja:マッシュポテト
+ko:매시트 포테이토
+la:pulticula ex pomis terrestribus
+lt:bulvių košė
+ms:kentang lecek
+nb:potetmos
+nl:aardappelpuree
+pt:purê de batata
+ru:картофельное пюре
+se:buđetnjuvddus
+sv:potatismos
+th:มันฝรั่งบด
+tr:patates püresi
+uk:картопляне пюре
+zh:馬鈴薯泥
+wikidata:en: Q322787
+wikipedia:en: https://en.wikipedia.org/wiki/Mashed_potato
 
 < en:Potato
 en:organic potato
@@ -56831,15 +59011,15 @@ da:kartoffelpulver
 de:Kartoffelpulver
 el:πατάτα σε σκόνη
 es:patata en polvo
-fi:perunajauhe
+fi:perunajauhe, kuivattu peruna
 fr:poudre de pommes de terre, poudre de pomme de terre, pomme de terre déshydratée, pommes de terre déshydratées, pommes de terre en poudre, g de terre déshydratée
 hu:burgonyapor
 it:Patate in polvere
-nl:aardappelpoeder
+nl:aardappelpoeder, gedehydrateerde aardappelen
 pt:Patatas en polvo
 sk:sušené zemiaky
 sl:krompir v prahu
-sv:potatispulver
+sv:potatispulver, torkad potatis
 
 < en:Potato
 en:russet potatoes
@@ -56855,9 +59035,6 @@ nl:voorgebakken aardappel
 sv:forstekt potatis
 carbon_footprint_fr_foodges_ingredient:fr: Frites surgelées
 carbon_footprint_fr_foodges_value:fr: 1.3
-
-< en:Potato
-fr:purée de pomme de terre, purée de pommes de terre
 
 < en:Potato flakes
 en:dehydrated potato flakes
@@ -56975,7 +59152,7 @@ es:pollo
 et:Kana
 eu:oilo
 fa:مرغ خانگی
-fi:kana, kanat
+fi:kana, kanat, broileri
 fj:Toa
 fr:poulet, poulets, poule
 ga:Sicín
@@ -57038,7 +59215,7 @@ so:Dooro
 sq:Pula
 sr:кокошка
 su:Hayam
-sv:kyckling, tamhöna
+sv:kyckling, tamhöna, broiler
 sw:Kuku
 ta:கோழி
 te:కోడి
@@ -57197,6 +59374,7 @@ fi:kanaliemi
 fr:bouillon de poulet, fond de poulet
 it:brodo di pollo
 nl:kippenbouillon
+sv:kycklingbuljong
 
 < en:Poultry broth
 fr:bouillon de volaille déshydraté
@@ -57276,6 +59454,7 @@ fr:peau de poulet
 it:pelle di pollo
 nl:kippenvel
 ro:piele de pui
+sv:kycklingskinn
 
 < en:Poultry skin
 < en:Turkey
@@ -57294,7 +59473,8 @@ wikidata:en: Q599799
 wikipedia:en: https://en.wikipedia.org/wiki/Trisopterus_luscus
 
 < en:Powdered egg white
-de:Hühnerei-Trockeneiweiß, Hühnereiklarpulver, Hühnereieiweißpulver, Hühnereiweißpulver, Hühnereiweisspulver, Hühnertrockeneieiweiß, Hühnertrockeneieiweiss, Hühnerei-Eiweisspulver, Hühnerei-Eiweißpulver, Hühnertrockeneiweiß, Hühnertrockeneiweiss
+de:Hühnerei-Trockeneiweiß, Hühnereiklarpulver, Hühnereieiweißpulver, Hühnereiweißpulver, Hühnereiweisspulver, Hühnertrockeneieiweiß, Hühnertrockeneieiweiss, Hühnerei-Eiweisspulver, Hühnerei-Eiweißpulver, Hühnertrockeneiweiß, Hühnertrockeneiweiss, Hühnereitrockeneiweiß
+fi:kananmunanvalkuaisjauhe
 nl:kippenei-eiwitpoeder
 
 < en:Powdered egg white
@@ -57311,6 +59491,7 @@ fi:uudelleenhydratoitu munavalkuainen
 fr:blanc d'œuf réhydraté
 it:albume reidratato
 nl:gerehydrateerd eiwit
+sv:rehydrerad äggvita
 
 < en:Powdered egg white
 nl:scharrelei-eiwitpoeder
@@ -57333,12 +59514,12 @@ sv:lök brynt i solrosolja
 < en:Precooked tuna
 fr:thon précuit haché
 
-en:Preservative, antimicrobial preservative, antimicrobial synergist, antimould and antirope agent, antimycotic agent, bacteriophage control agent, fungistatic agent
+en:Preservative, antimicrobial preservative, antimicrobial synergist, antimould and antirope agent, antimycotic agent, bacteriophage control agent, fungistatic agent, ingredients of conservation
 bg:Консервант
 ca:Conservant, conservador, conservadors, conservants
 cs:Konzervant
-da:Konserveringsmiddel, konserveringsmidler
-de:Konservierungsstoff, Konservierungsstoffe
+da:Konserveringsmiddel, Konserveringsmidler, Konservering
+de:Konservierungsstoff, Konservierungsstoffe, Konservierungsmittel
 el:Συντηρητικό
 es:Conservante, Conservador, agente conservador, agente antimicótico, agente de control de bacteriófagos, agente fungistático, agentes inhibidores de mohos y hongos filamentosos, conservadores antimicrobianos, conservador antimicrobiano, sustancias conservadoras, sustancia conservadora, conservadores, conservantes, agentes conservadores
 et:Säilitusaine
@@ -57347,6 +59528,7 @@ fr:Conservateur, agent antimoisissure et antifilant, agent antimoisissure, antif
 ga:Leasaitheach
 he:חומר משמר
 hu:Tartósítószer
+is:Rotvarnarefni
 it:Conservante, conservanti, agente conservante, agenti conservanti
 lt:Konservantas
 lv:Konservants
@@ -57359,7 +59541,7 @@ ro:Conservant
 ru:Консервант
 sk:Konzervačná látka
 sl:Konzervans
-sv:Konserveringsmedel
+sv:Konserveringsmedel, Konservering
 description:cs: Konzervanty se rozumějí látky, které prodlužují trvanlivost potravin tím, že je chrání proti zkáze způsobené mikroorganismy, nebo které potraviny chrání před růstem patogenních mikroorganismů.
 description:da: Konserveringsmidler: stoffer, som forlænger en fødevares holdbarhed ved at beskytte den mod ødelæggelse forårsaget af mikroorganismer, og/eller som beskytter mod vækst af patogene mikroorganismer.
 description:de: Konservierungsstoffe sind Stoffe, die die Haltbarkeit von Lebensmitteln verlängern, indem sie sie vor den schädlichen Auswirkungen von Mikroorganismen schützen, und/oder vor dem Wachstum pathogener Mikroorganismen schützen.
@@ -57408,7 +59590,7 @@ pl:Gaz nośny, Gazy nośne
 pt:Gás propulsor
 ro:Agent de propulsare
 sk:Hnací plyn
-sv:Drivgas, Bakpulver, Jäsmedel
+sv:Drivgas
 description:cs: Propelenty se rozumějí plyny jiné než vzduch, které vytlačují potravinu z obalu.
 description:da: Drivgasser: andre gasser end luft, som presser en fødevare ud af en beholder.
 description:de: Treibgase sind andere Gase als Luft, die ein Lebensmittel aus seinem Behältnis herauspressen.
@@ -57561,6 +59743,7 @@ fi:proteiinihydrosylaatit, proteiinihydrosylaatti
 fr:protéine hydrolysée
 hu:hidrolizált fehérjék, hidolizált fehérje
 nl:gehydroliseerd eiwit
+sv:proteinhydrolysat
 
 < en:Protein
 en:vegetable protein
@@ -57570,9 +59753,11 @@ fi:kasviproteiini
 fr:protéines végétales, protéine végétale
 hu:növényi fehérje, növényi fehérjék
 it:proteine vegetali
+nb:vegetabilsk protein
 nl:plantaardige eiwit
 pl:Białko roślinne
 pt:Proteína vegetal
+sv:grönsaksprotein
 vegan:en: yes
 vegetarian:en: yes
 
@@ -57642,6 +59827,7 @@ fr:graine de courge, graines de courge, graines de potiron, graines de citrouill
 it:semi di zucca
 nl:pompoenpitten
 pl:Nasiona dyni
+sv:pumpafrön, pumpakärnor
 
 < en:Pumpkin
 en:pumpkin juice
@@ -57734,17 +59920,31 @@ fi:omenapyree
 fr:purée de pomme
 hu:almapüré
 it:purea di mele
+nb:eplepuŕe
 nl:appelmoes, appelpuree
 ru:Яблочное пюре
+sv:äppelpuré
+
+< en:Blackcurrant
+< en:Purée
+en:blackcurrant puree
+da:solbærpuré
+de:schwarzes Johannesbeerpüree
+es:puré de cassis
+fi:mustaherukkapyree
+fr:purée de cassis
+nl:Zwarte bessenpuree
+sv:svartvinbärspuré
 
 < en:Blueberry
 < en:Purée
 en:blueberry puree, blueberries puree
 de:Blaubeerenpuree
 es:Puré de arándanos
-fi:mustikkapyree
+fi:mustikkasose, soseutettu mustikka, mustikkapyree
 fr:purée de myrtilles
 nl:bosbessenpuree, bosbessenmoes
+sv:blåbärpuré
 
 < en:Purée
 en:concentrated purée
@@ -57804,7 +60004,7 @@ da:Quinoa
 de:Quinoa
 el:Κινόα
 eo:Kvinoo
-es:quinua, quinoa real
+es:Quinoa, quinua, quinoa real
 et:kinoa, Tšiili hanemalts
 eu:Kinoa
 fa:کینوآ
@@ -57936,13 +60136,13 @@ fr:concentré de raisin
 < en:Raisin
 fr:raisins secs réhydratés
 
-en:Raising agent, leavening, leavening agent
+en:Raising agent, leavening, leavening agent, dough raising agent
 ar:عامل نفاشية
 bg:Набухвател
 ca:gasificants
 cs:Kypřicí látka, Kypřidlo
 cy:Lefain
-da:Hævemiddel, hævemidler
+da:Hævemiddel, Hævemidler
 de:Backtriebmittel, Backpulver, Triebmittel
 el:Διογκωτικό αρτοποιίας
 es:Gasificante, Leudante, Agente leudante, agentes gasificantes, gasificantes
@@ -57954,6 +60154,7 @@ ga:Oibreán éiritheach
 he:התפחה
 hu:Térfogatnövelő szer
 id:Bahan pengembang
+is:Lyftiefni
 it:Agente lievitante, agenti lievitanti, lievitante, lievitanti
 ja:膨張剤
 ko:팽창제
@@ -57961,15 +60162,15 @@ lt:Tešlos kildymo medžiaga, Puriklis
 lv:Irdinātājs
 ms:Agen penaik
 mt:Aġent li jgħolli l-ikel
-nb:Hevemiddel
+nb:Hevemiddel, Hevemidler
 nl:Rijsmiddel, Rijsmiddelen
 pl:Substancja spulchniająca, Substancje spulchniające
 pt:Levedante, levedantes
 ro:Agent de afânare
-ru:Разрыхлитель
+ru:Разрыхлитель, Разрыхлители
 sk:Kypriaca látka
 sl:Potisni plin, Kvas
-sv:Drivgas, Bakpulver, Jäsmedel
+sv:Jäsningsmedel, Jäsmedel
 tl:Pampaalsa
 tr:Kabartma ajanı
 uk:Розпушувач харчовий
@@ -58007,7 +60208,7 @@ fi:Rypsi
 fr:
 it:Canola
 pl:Rzepak
-sv:Raps
+sv:Raps, rapsfrön
 
 < en:Rapeseed oil
 en:canola oil
@@ -58015,14 +60216,14 @@ ca:Oli de canola
 da:rapsolie
 de:Ölrübsenöl
 es:
-fi:Rypsiöljy
+fi:rypsiöljy, rypsiöljyä
 fr:huile de navette, huile de canola
 hu:kanolaolaj, canolaolaj, canola olaj, kanola olaj
 it:Olio di canola
 nl:raapolie, canola olie, raapzaadolie
 pl:Olej rzepakowy, olej roślinny rzepakowy
 ru:Рапсовое масло
-sv:Rapsolja, Rapsfett
+sv:rypsolja, rybsolja
 from_palm_oil:en: no
 nutriscore_fruits_vegetables_nuts:en: yes
 wikipedia:en: https://en.wikipedia.org/wiki/Canola_oil
@@ -58043,6 +60244,7 @@ hu:repceolaj, repcemagolaj
 it:Olio di colza
 lt:rapšu ella
 lv:rapsų aliejus
+nb:rapsolje
 nl:Koolzaadolie, plantaardige koolzaadolie, raapzaad, raap
 pl:Olej rzepakowy, olej roślinny rzepakowy
 pt:óleo de colza
@@ -58057,14 +60259,28 @@ nutriscore_fruits_vegetables_nuts:en: yes
 wikidata:en: Q697248
 wikipedia:en: https://en.wikipedia.org/wiki/Colza_oil
 
+< en:Rapeseed oil
+en:non-hydrogenated rapeseed oil
+fi:kovettamaton rapsiöljy
+sv:ohärdad rapsolja
+
+< en:Purée
 < en:Raspberry
-de:Himbeerpulver
+en:raspberry puree
+de:Himbeerpüree
+es:puré de frambuesa
+fi:vadelmasose, vadelmapyree, vadelmapyre
+fr:purée de framboises, purée de framboise
+it:purea di lamponi
+nl:frambozenpuree
+sv:hallonpuré
 
 < en:Raspberry
 en:dried raspberries
 de:getrocknete Himbeeren, Himbeeren getrocknet
 fi:kuivattu vadelma
 fr:Framboises déshydratées
+sv:torkade hallon
 
 < en:Raspberry
 en:organic raspberry
@@ -58078,6 +60294,12 @@ es:licor de frambuesas
 fi:vadelmalikööri
 fr:liqueur de framboises
 nl:frambozenlikeur
+
+< en:Raspberry
+en:raspberry powder
+de:Himbeerpulver, Himbeerfruchtpulver
+fi:vadelmajauhe
+sv:hallonpulver
 
 < en:Raspberry
 en:red raspberries
@@ -58104,16 +60326,11 @@ fr:jus de framboise
 it:succo di lamponi
 nl:Frambozensap
 ru:Малиновый сок
+sv:hallonjuice
 
-< en:Purée
-< en:Raspberry
-en:raspberry puree
-de:Himbeerpüree
-es:puré de frambuesa
-fi:vadelmapyree
-fr:purée de framboises, purée de framboise
-it:purea di lamponi
-nl:frambozenpuree
+< en:Grape juice
+< en:Raspberry juice
+fi:rypäle- ja vadelmatäysmehu tiivisteestä
 
 < en:Raspberry juice
 en:concentrated raspberry juice
@@ -58129,10 +60346,7 @@ de:Himbeersaft aus Konzentrat
 fi:vadelmamehu tiivisteestä, vadelmatäysmehu tiivisteestä
 it:succo di lamponi a base di concentrato
 nl:frambozensap uit sapconcentraat
-
-< en:Grape juice
-< en:Raspberry juice
-fi:rypäle- ja vadelmatäysmehu tiivisteestä
+sv:hallonjuice från koncentrat
 
 < en:Raspberry puree
 fr:purée de framboise concentrée
@@ -58206,6 +60420,7 @@ fr:lait de vache cru, lait cru de vache
 hu:nyers tehéntej
 nl:rauwe koemelk
 ru:коровье молоко
+sv:opastöriserad komjölk
 
 < en:Goat's milk
 < en:Raw milk
@@ -58248,6 +60463,7 @@ fi:punajuurimehu
 fr:jus de betterave rouge
 it:succo di barbabietole rosse
 nl:rodebietensap
+sv:rödbetsjuice
 
 < en:Red beetroot
 fr:betterave rouge déshydratée, betterave rouge en poudre, poudre de betterave rouge
@@ -58267,6 +60483,12 @@ nl:rode peper zaad olie
 
 < en:Red chili pepper
 it:purè di peperoncino rosso
+
+< en:Green lentils
+< en:Red lentils
+en:green and red lentils
+fi:vihreät ja punaiset linssit
+sv:gröna och röda linser
 
 < en:Red lentils
 en:organic red lentils
@@ -58329,6 +60551,12 @@ de:Rotwein aus Frankreich, französischer Rotwein
 fr:vin rouge de France, vin rouge issu du cépage pinot noir, vin rouge issu des cépages merlot, vin rouge puy de dome igp, vin bordeaux rouge, vin rouge bordeaux, vin rouge bordeaux aoc, vin rouge coteaux du lyonnais, vin rouge cote de brouilly, vin rouge de Bourgogne
 hu:francia vörösbor
 
+< en:Reindeer meat
+en:reindeer shoulder
+fi:poron lapa
+fr:épaule de renne
+sv:renbog
+
 < en:Rennet
 en:animal-based rennet
 da:animalsk løbe
@@ -58358,13 +60586,62 @@ it:
 nb:mikrobiell løpe
 nl:
 ro:cheag microbian
-sv:ystenzym
+sv:mikrobiell ostlöpe, mikrobiellt ystenzym, mikrobiellt löpe
+vegan:en: yes
+vegetarian:en: yes
+
+< en:Rennet
+en:vegetable rennet
+da:vegetabilsk osteløbe
+fi:kasviperäinen juustonjuoksutin, kasviperäinen juoksete
+fr:présure végétale
+sv:vegetabiliskt ystenzym
 vegan:en: yes
 vegetarian:en: yes
 
 en:rhizopus
 es:rhizopus
 wikipedia:en: https://en.wikipedia.org/wiki/Rhizopus
+
+en:rhodiola rosea
+az:çəhrayı rodiola
+ba:алтын тамыр
+ca:rhodiola rosea
+cs:rozchodnice růžová
+cy:pren y ddannoedd
+da:almindelig rosenrod
+de:rosenwurz
+el:ροδιόλα η ροδόχρους
+es:rhodiola rosea
+et:roosilõhnaline kuldjuur
+eu:rhodiola rosea
+fi:ruusujuuri
+fr:rhodiola rosea
+hi:रोडियोला रोजिया
+hr:ružičasti žednjak
+hu:illatos rózsásvarjúháj
+is:burnirót
+it:rhodiola rosea
+ja:イワベンケイ
+kk:алтын тамыр
+kl:tullerunnaq
+ko:돌꽃
+ky:алтын тамыр
+ml:റോഡിയോള റോസിയ
+mn:алтан гагнуур
+nb:rosenrot
+nl:rozewortel
+nn:rosenrot
+pl:różeniec górski
+ro:rhodiola rosea
+ru:родиола розовая
+se:gálberássi
+sl:rožni koren
+sv:rosenrot
+uk:родіола рожева
+zh:红景天
+wikidata:en: Q161665
+wikipedia:en: https://en.wikipedia.org/wiki/Rhodiola_rosea
 
 < en:Rhubarb
 en:rhubarb juice
@@ -58574,6 +60851,7 @@ it:riso integrale
 nl:Volkorenrijst
 pl:Ryż brązowy
 ru:Коричневый рис
+sv:råris
 
 < en:Rice
 en:Camargue rice
@@ -58585,11 +60863,13 @@ wikipedia:fr: https://fr.wikipedia.org/wiki/Riz_de_Camargue
 
 < en:Rice
 en:cooked rice
+da:kogt ris
 de:Kochreis
 es:Arroz cocinado
-fi:kypsennetty riisi
+fi:kypsennetty riisi, keitetty riisi
 fr:riz cuisiné, riz cuit
 hu:főtt rizs
+sv:kokt ris
 
 < en:Rice
 en:extruded rice
@@ -58607,6 +60887,7 @@ fi:riisijauho
 fr:Farine de riz
 hu:rizsliszt
 it:farina di riso
+nb:rismel
 nl:rijstebloem, rijstbloem
 pl:Mąka ryżowa
 pt:farinha de arroz
@@ -58627,7 +60908,7 @@ nl:Langkorrelige rijst
 < en:Rice
 en:organic rice
 de:Bio Reis
-fi:luomuriisi, luomu riisi
+fi:luomuriisi, luomu riisi, luomuriisistä
 fr:riz bio
 hu:bio rizs
 it:riso bio
@@ -58644,17 +60925,18 @@ hu:forrázott rizs, előfőzött rizs
 it:riso parboiled
 
 < en:Rice
-en:puffed rice, crisped rice
-da:puffat ris
+en:puffed rice, crisped rice, rice crips
+da:puffede ris, puffat ris
 de:Reisflocken, Puffreis, Reis-Crispies, Reis gepufft, Crisp-Rice
 es:arroz inflados, arroz inflado
-fi:riisihiutale, puffattu riisi
+et:riisikrõpsud
+fi:riisihiutale, riisimuro, riisimurot, puffattu riisi
 fr:flocons de riz, riz soufflé, riz croustillant
 hu:puffasztott rizs
 it:fiocchi di riso, riso soffiato
 nl:gepofte rijst, rijst pofte
 pt:arroz tufado
-sv:puffat ris
+sv:riskrisp, puffat ris
 
 < en:Rice
 en:red rice
@@ -58671,6 +60953,7 @@ es:extracto de arroz
 fi:riisiuute
 fr:extrait de riz, extraits de riz
 hu:rizskivonat
+sv:risextrakt
 
 < en:Rice
 en:rice from Italy, Italian rice
@@ -58708,6 +60991,7 @@ fr:riz thaï, riz jasmin, riz au jasmin, riz parfumé, riz parfume de thailande,
 hu:jázminrizs, jázmin rizs
 it:riso tailandese, di riso tailandese, riso algelsomino
 nl:thaise rijst, jasmijnrijst
+sv:Jasminris
 wikidata:en: Q2733021
 wikipedia:en: https://en.wikipedia.org/wiki/Jasmine_rice
 
@@ -58780,7 +61064,7 @@ en:brown rice flour, full rice flour
 de:Reisvollkornmehl, braunes Reismehl, volles Reismehl
 es:harina de arroz integral
 fi:tumma riisijauho, täysjyväriisijauho
-fr:farine de riz complet
+fr:farine de riz complet, farine complète de riz
 hu:barnariszliszt
 nl:volkoren rijstmeel
 
@@ -58847,7 +61131,7 @@ hu:módosított rizskeményítő
 it:amido modificato di riso
 nl:gemodificeerd rijstzetmeel, getransformeerd rijst zetmeel
 pt:amido de arroz modificado
-sv:modifierad risstärkelse
+sv:modifierad risstärkelse, modifierad stärkelse av ris
 
 en:rice syrup
 de:Reissirup
@@ -58857,6 +61141,7 @@ fr:sirop de riz
 hu:rizsszirup
 it:sciroppo di riso
 nl:Rijststroop
+sv:rissirap
 vegan:en: yes
 vegetarian:en: yes
 
@@ -59013,6 +61298,7 @@ it:barbabietola
 nl:biet, bieten
 pl:Burak
 ru:Свёкла
+sv:rödbeta, rödbetor
 carbon_footprint_fr_foodges_ingredient:fr: Betteraves
 carbon_footprint_fr_foodges_value:fr: 0.2
 wikidata:en: Q165437
@@ -59045,7 +61331,7 @@ es:zanahoria, zanahoria baby
 et:porgand
 eu:azenario
 fa:هویج
-fi:porkkana
+fi:porkkana, porkkanaa
 fr:carotte
 ga:cairéad
 gl:cenoria
@@ -59089,7 +61375,7 @@ oc:pastenaga
 or:ଗାଜର
 os:Уырыдзы
 pa:ਗਾਜਰ
-pl:marchew uprawna
+pl:marchew uprawna, marchew
 pt:cenoura
 qu:Sanurya
 rn:Ikaroti
@@ -59141,7 +61427,7 @@ de:Knollensellerie
 eo:tubercelerio
 es:Apio nabo
 et:Juurseller
-fi:Mukulaselleri
+fi:mukulaselleri, juuriselleri
 fr:céleri-rave
 ga:Soiliriac
 it:sedano rapa
@@ -59240,7 +61526,7 @@ es:hinojo
 et:Apteegitill
 eu:Mihilu
 fa:رازیانه
-fi:Fenkoli
+fi:fenkoli, fenkolia
 fr:Fenouil, Fenouils, Fenouil commun
 ga:Finéal
 gl:Fiúncho
@@ -59555,14 +61841,14 @@ ca:porro
 co:Porru
 cs:pór zahradní
 cy:Cenhinen
-da:Porre
+da:Porre, porrer
 de:Lauch, Lauche, Porrees, Porree
 el:Πράσο
 eo:Poreo
 es:Puerro, Puerros
 eu:Porru
 fa:تره‌فرنگی
-fi:Purjo
+fi:Purjo, purjosipuli
 fr:poireau, poireaux
 ga:Cainneann
 gl:Allo porro
@@ -59649,7 +61935,7 @@ it:cipolla, Cipolle
 ja:タマネギ
 lt:svogūnai
 lv:sīpoli
-nb:løk
+nb:løg
 nl:ui, uien
 nv:tłʼohchin
 pl:cebula
@@ -59748,7 +62034,7 @@ es:patata, papas
 et:kartul, kartulid
 eu:patata
 ff:Kudaku
-fi:peruna
+fi:peruna, perunaa
 fr:pomme de terre, pommes de terre, pommes de terre de consommation
 gd:Buntàta
 gl:pataca
@@ -59770,7 +62056,7 @@ lt:bulvė, bulvės
 mg:Ovy
 mk:компир
 mr:बटाटा
-nb:potet
+nb:potet, poteter
 ne:आलु
 nl:aardappel, aardappelen
 nn:potet, poteter
@@ -59818,7 +62104,7 @@ ca:rave
 co:Radichju
 cs:ředkvička
 cy:Rhuddygl y gerddi
-da:Radise
+da:Radise, ræeddike
 de:rettich, Radieschen
 el:Ρεπάνι
 eo:rafano
@@ -59826,7 +62112,7 @@ es:rábano, Rábanos, Rabanitos
 et:Redis
 eu:Errefau
 fa:ترب
-fi:Retiisi
+fi:Retiisi, retikka, retiisiä
 fr:radis
 ga:Raidis
 gl:Ravo
@@ -59876,7 +62162,7 @@ sl:Redkvica
 sq:Rrepa
 sr:Ротквица
 su:Lobak
-sv:Rädisa
+sv:Rädisa, rättika
 ta:முள்ளங்கி
 te:ముల్లంగి
 tg:Турб
@@ -59903,21 +62189,27 @@ en:Rapeseed, rape, oilseed rape
 da:raps
 de:Raps
 es:Colza, nabina
-fi:rapsi
+fi:rapsi, rapsinsiemenet
 fr:
 it:Colza
 la:Brassica napus
+nb:raps
 nl:Koolzaad
 pl:Rzepak
-sv:Raps
+sv:Raps, rapsfrön
 wikidata:en: Q177932
 wikipedia:en: https://en.wikipedia.org/wiki/Rapeseed
 
 < en:Root vegetable
 en:rutabaga, swede
+da:kålroe
 de:Kohlrübe
 es:colinabo
+et:kaalikas
+fi:lanttu
 fr:rutabaga
+nb:kålrot
+sv:kålrot
 
 < en:Root vegetable
 en:salsify, black salsify
@@ -60002,6 +62294,63 @@ vi:Hẹ tây
 zh:火葱
 wikidata:en: Q193498
 wikipedia:en: https://en.wikipedia.org/wiki/Shallot
+
+< en:Root vegetable
+en:sugar beet
+ar:شمندر سكري
+az:şəkər çuğunduru
+be:цукровы бурак
+bg:захарно цвекло
+bs:šećerna repa
+ca:remolatxa sucrera
+cs:cukrová řepa
+da:sukkerroe
+de:zuckerrübe
+el:ζαχαρότευτλο
+eo:sukerbeto
+et:suhkrupeet
+eu:azukre-erremolatxa
+fa:چغندر قند
+fi:sokerijuurikas
+fr:betterave sucrière
+gl:remolacha azucreira
+gv:beetys shugyr
+he:סלק סוכר
+hr:šećerna repa
+hu:cukorrépa
+hy:շաքարի ճակնդեղ
+io:betravo
+is:sykurrófa
+it:barbabietola da zucchero
+ja:テンサイ
+ka:შაქრის ჭარხალი
+kk:қант қызылшасы
+ko:사탕무
+ky:кант кызылчасы
+lt:cukrinis runkelis
+mk:шеќерна репка
+ml:ഷുഗർ ബീറ്റ്
+nb:sukkerbete
+nl:suikerbiet
+nn:sukkerbete
+os:сæкæры цæхæра
+pl:burak cukrowy
+pt:beterraba-sacarina
+ro:sfeclă de zahăr
+ru:сахарная свёкла
+sh:šećerna repa
+sk:cukrová repa
+sr:šećerna repa
+sv:sockerbeta
+tr:şeker pancarı
+uk:цукровий буряк
+ur:چقندر شکر
+uz:qand lavlagi
+vi:củ cải đường
+yi:בוריק
+zh:糖用甜菜
+wikidata:en: Q151964
+wikipedia:en: https://en.wikipedia.org/wiki/Sugar_beet
 
 < en:Root vegetable
 en:sweet potato
@@ -60326,8 +62675,10 @@ de:Roggengrießkleie
 
 < en:Rye
 de:Roggenschrot
+fi:ruisrouhe
 fr:seigle broyé
 it:faricello di segale
+sv:rågkross
 
 < en:Rye
 en:rye bran
@@ -60335,10 +62686,19 @@ de:Roggenvollkorn
 fi:ruislese
 fr:Son de seigle
 hu:rozskorpa
+sv:rågkli
 
 < en:Rye
 en:rye flakes
+da:rugflager, ruggryn
+de:Roggenflocken
 es:copos de centeno
+fi:ruishiutale
+fr:flocons de seigle
+hu:rozspehely
+it:fiocchi di segale
+nb:rugflak
+sv:rågflingor
 
 < en:Rye
 en:wholemeal rye
@@ -60347,12 +62707,7 @@ fi:täysjyväruis
 fr:seigle complet
 hu:teljes kiőrlésű rozs
 nl:volkorenrogge
-
-< en:Rye
-fr:flocons de seigle
-de:Roggenflocken
-hu:rozspehely
-it:fiocchi di segale
+sv:fullkornsråg
 
 < en:Malt
 < en:Rye
@@ -60361,10 +62716,20 @@ de:Roggenmalz
 fi:ruismallas
 fr:Malt de seigle
 hu:rozsmaláta
+sv:rågmalt
 
 < en:Rye bread
 en:grated rye bread
 fi:ruisleipäraaste
+
+< en:Rye bread
+en:wholemeal rye bread
+fi:täysjyväruisleipä
+sv:fullkornsrågbröd
+
+< en:Malt
+< en:Rye flakes
+fr:flocons de seigle malté
 
 < en:Rye flour
 en:dextrinated rye flour
@@ -60375,8 +62740,17 @@ hu:dextrinált rozsliszt
 nl:gedextrineerd roggemeel
 
 < en:Rye flour
+en:rye malt flour
+fi:ruismallasjauho
 fr:farine de seigle maltée
 nl:gemoute roggemeel
+sv:rågmaltmjöl
+
+< en:Rye flour
+en:sifted rye flour
+da:sigtet rugmel
+fi:lestyruisjauho, ruissihtijauho
+sv:siktat rågmjöl, rågsiktmjöl
 
 < en:Rye malt
 en:rye malt extract
@@ -60385,16 +62759,36 @@ fi:ruismallasuute
 hu:rozsmaláta kivonat
 
 < en:Rye malt
+en:rye malt grist
+de:roggenmalzschrot
+fi:ruismallasrouhe, kaljamallas
+sv:rågmaltkross
+
+< en:Rye malt
 < en:Rye malt extract
 fi:ruismallas ja ruismallasuute
 
+< en:Rye sourdough
+en:whole rye sourdough
+sv:surdeg av fullkornsrågmöl
+
+< en:Rye sourdough
+fr:levain de seigle déshydraté et dévitalisé
+
+< en:Rye sourdough
+fr:levain de seigle dévitalisé
+
+< en:Rye sourdough
+nl:rogge zuurdesempoeder
+
 < en:Safflower
-en:safflower concentrate
+en:safflower concentrate, carthamus concentrate
 de:Saflorkonzentrat, Saflorextrakt
-fi:safloriuute
+fi:safloritiiviste, safloriuute, saffloritiiviste
 fr:extrait de carthame, concentré de carthame
 it:concentrato di cartamo
 nl:saffloerconcentraat
+sv:safflor koncentrat
 
 < en:Safflower
 en:safflower flower
@@ -60435,9 +62829,42 @@ nl:koolvisfilet
 fi:seitifilee
 
 en:sal tree, shorea robusta
+ar:شورية قاسية
+as:শাল গছ
+bn:শাল
+ca:shorea robusta
+cs:damarovník obrovský
+de:salbaum
+eo:fortika ŝoreo
 es:sala, shorea robusta
+fi:intianmerantipuu, sal, salpuu, sal-puu
 fr:sal, shorea robusta
+hi:साल
+hu:szálafa
+id:sala
 it:Shorea robusta
+ja:サラソウジュ
+kn:ಸಾಲ್
+ko:사라수
+lt:stambioji šorėja
+ml:കൈമരുത്
+mr:शोरिया रोबस्टा
+my:အင်ကြင်းပင်
+ne:साल
+nl:salboom
+pl:damarzyk mocny
+ru:сал
+si:සල්
+sk:šórea mohutná
+sv:salträd
+ta:குங்கிலியம்
+te:గుగ్గిలం కలప చెట్టు
+th:สาละ
+uk:салове дерево
+vi:sala
+zh:娑羅樹
+wikidata:en: Q909828
+wikipedia:en: https://en.wikipedia.org/wiki/Shorea_robusta
 
 < en:Salad
 < en:Vegetable
@@ -60575,7 +63002,7 @@ eo:Kultiva eruko
 es:Rúcula
 et:rukola
 fa:منداب
-fi:sinappikaali
+fi:sinappikaali, rucola
 fr:roquette
 gl:Eiruga
 he:בן-חרדל מצוי
@@ -60600,7 +63027,7 @@ ru:руккола
 sd:ڄانڀو
 sq:sallatë manushaqeje
 sr:Рукола
-sv:ruccola
+sv:ruccola, ruccolasallad
 tr:Roka
 uk:Рукола
 zh:芝麻菜
@@ -60618,7 +63045,7 @@ bg:Киселец
 ca:agrella
 cs:šťovík kyselý
 cy:Suran y cŵn
-da:Syre, Almindelig Syre
+da:Syre, Syrer, Almindelig Syre
 de:Sauerampfer
 el:Λάπαθο
 eo:Okzalo
@@ -60675,6 +63102,7 @@ fr:batavia
 fr:mélange de salades, salade mélangée
 de:Mischsalat
 it:Insalata mista
+sv:salladsmix
 
 < en:Salad
 fr:salade composée
@@ -60877,7 +63305,7 @@ de:Speisesalz, Kochsalz, Tafelsalz, Salz
 el:Αλάτι
 eo:Salo, Komuna salo
 es:Sal, sal común, sal de mesa, sales, sal de cocina
-et:Söögisool, keedusool
+et:sool, söögisool, keedusool
 eu:Gatz arrunt, mahaiko gatza
 fa:نمک
 fi:suola, ruokasuola, kuivasuola, suolaa
@@ -60889,7 +63317,7 @@ gn:Juky
 gu:મીઠું
 he:מלח, מלח שולחן, מלח לבישול, מלח יבש
 hi:साधारण नमक
-hr:Kuhinjska sol
+hr:sol, kuhinjska sol
 hu:só, étkezési só, konyhasó, asztali só
 id:Garam dapur
 ig:Ńnú
@@ -60919,19 +63347,19 @@ pl:sól, sól kuchenna
 ps:مالگه
 pt:sal, sal de cozinha, sal de cosina, sal de taula
 ro:sare, Sare de bucătărie
-ru:Поваренная соль
+ru:соль, Поваренная соль
 rw:Umunyu
 sa:लवणम्
 sd:لوڻ
 sh:So
 si:ලුණු
-sl:Sol, Kuhinjska sol
+sl:Sol, Kuhinjska sol, jedilna sol
 sn:Munyu
 so:Milix, Cusbo
 sq:Kripa
 sr:Со
 su:Uyah
-sv:Salt
+sv:salt, koksalt, bordssalt, bordssalt utan jod
 ta:உப்பு
 te:ఉప్పు
 tg:Намак
@@ -60979,19 +63407,22 @@ en:iodised salt, iodized salt
 ar:ملح معالج باليود
 ca:sal iodada
 cs:Jodidovaná sůl
+da:salt tilsat jod
 de:Jodsalz, Iodsalz, jodiertes Speisesalz
 es:Sal yodada
 fa:نمک یددار
-fi:jodioitu suola
+fi:jodioitu suola, jodia sisältävä suola
 fr:Sel iodé, sel de cuisine iodé
 hu:jódozott só
 id:Garam beryodium
 it:Sale iodato
+nb:jodisert salt, salt med jod
 nl:gejodeerd zout
 pl:Jodowanie soli
 pt:Sal iodado
 ro:sare iodată, sare iodata
 ru:Йодированная поваренная соль
+sv:joderat salt, joderad salt, jodsalt, salt med jod
 th:เกลือเสริมไอโอดีน
 uk:Йодована сіль
 vi:Muối iốt
@@ -61047,6 +63478,7 @@ is:Sjávarsalt
 it:sale marino
 ko:천일염
 ms:Garam laut
+nb:havsalt
 nl:zeezout
 pl:Sól morska
 pt:Sal marinho
@@ -61275,6 +63707,38 @@ de:Sambal
 nl:sambal
 
 < en:Sauce
+en:béarnaise sauce
+be:беарнскі соус
+bg:беарнез
+ca:salsa bearnesa
+cs:bearnéská omáčka
+da:bearnaisesauce
+de:sauce béarnaise
+eo:bearnezo
+es:salsa bearnesa
+eu:saltsa bearnes
+fa:سس برنیز
+fi:béarnaisekastike
+fr:sauce béarnaise
+gl:salsa bearnesa
+he:רוטב ביארנז
+it:salsa bernese
+ja:ベアルネーズソース
+kk:беарнэз
+ko:베아르네즈 소스
+nb:béarnaisesaus
+nl:bearnaisesaus
+nn:bearnés
+pl:sos bearneński
+ro:sos bearnez
+ru:беарнский соус
+se:béarnaisebuonjus
+sv:bearnaisesås
+tr:béarnaise sosu
+wikidata:en: Q58265
+wikipedia:en: https://en.wikipedia.org/wiki/B%C3%A9arnaise_sauce
+
+< en:Sauce
 en:bechamel sauce
 af:Witsous
 ar:صلصة البشاميل
@@ -61308,7 +63772,7 @@ pl:Beszamel
 pt:molho béchamel
 ru:бешамель
 sk:Bešamelova omáčka, Wikikuchárka
-sv:Béchamelsås
+sv:Béchamelsås, béchamel
 tr:Beşamel sos
 uk:Бешамель
 vi:Xốt béchamel
@@ -61326,7 +63790,7 @@ de:Bolognese Sauce, Ragù alla bolognese
 eo:bolonja saŭco
 es:Boloñesa
 eu:Boloniar saltsa
-fi:bolognesekastike
+fi:bolognesekastike, bolognese-kastike
 fr:sauce bolognaise
 he:רוטב בולונז
 it:Sugo alla bolognese, Ragù bolognese
@@ -61334,7 +63798,7 @@ ja:ミートソース
 ko:라구 볼로녜세
 pt:Molho à bolonhesa
 ru:Болоньезе
-sv:Köttfärssås
+sv:köttfärssås, bolognesesås
 uk:Болоньєзе
 zh:蕃茄肉醬
 wikidata:en: Q1162965
@@ -61352,6 +63816,48 @@ nl:caramelsaus, karamelsaus
 pl:sosu karmelowego
 pt:molho de caramelo
 ru:карамельный соус
+sv:kolasås
+
+< en:Sauce
+en:cheese sauce
+fi:juustokastike
+fr:sauce au fromage
+nl:kaassaus
+sv:ostsås
+wikidata:en: Q27972032
+
+< en:Sauce
+en:cream sauce
+da:flødesauce
+de:rahmsauce
+es:salsa de crema
+et:koorekastmes
+fi:kermakastike
+fr:sauce à la crème
+nl:crèmesaus
+sv:gräddsås
+wikidata:en: Q10509700
+
+< en:Sauce
+en:espagnole sauce
+ca:salsa espanyola
+es:salsa española
+fa:سس اسپانیول
+fi:sauce espagnole
+fr:sauce espagnole
+he:רוטב אספניול
+id:saus espagnole
+it:salsa spagnola
+ja:エスパニョールソース
+ms:sos espagnole
+pt:molho espanhol
+ru:эспаньоль
+sv:espagnole
+tr:espagnole sosu
+uk:еспаньйол
+zh:棕醬
+wikidata:en: Q2452555
+wikipedia:en: https://en.wikipedia.org/wiki/Espagnole_sauce
 
 < en:Sauce
 en:fish sauce
@@ -61409,6 +63915,30 @@ wikidata:en: Q966327
 wikipedia:en: https://en.wikipedia.org/wiki/Harissa
 
 < en:Sauce
+en:hot sauce, chili sauce
+ar:شطة
+ca:salsa picant
+da:chilisauce
+de:chilisauce
+eo:kapsiketa saŭco
+es:salsa picante
+fi:chilikastike
+fr:sauce chili
+he:רוטב צ'ילי
+id:saus pedas
+it:salsa chili
+ja:チリソース
+ko:핫소스
+nb:chilisaus
+nl:chilisaus
+pl:sos chili
+sv:chilisås, stark sås
+tr:acı sos
+vi:tương ớt
+zh:辣醬
+wikidata:en: Q522171
+
+< en:Sauce
 en:ketchup
 af:Tamatiesous
 ar:كتشب
@@ -61425,7 +63955,7 @@ es:kétchup
 et:Ketšup
 eu:Ketchup
 fa:کچاپ
-fi:ketsuppi, tomaattiketsuppi, tomaattiketsuppia
+fi:ketsuppi, tomaattiketsuppi, tomaattiketsuppia, mausteketsuppi
 fr:ketchup
 ga:Citseap
 gl:Ketchup
@@ -61556,7 +64086,7 @@ sl:Majoneza
 sm:meio
 sq:majonezi
 sr:Мајонез
-sv:majonnäs
+sv:majonnäs, majonäs
 ta:மயோனெய்சு
 tg:Майонез
 th:มายองเนส
@@ -61615,6 +64145,56 @@ wikidata:en: Q1045910
 wikipedia:en: https://en.wikipedia.org/wiki/Mirin
 
 < en:Sauce
+en:pesto, pesto sauce
+af:pesto
+ar:البيستو
+az:pesto
+ba:песто
+be:песта
+bg:песто
+bs:pesto
+ca:pesto
+cs:pesto
+da:pesto
+de:pesto
+el:πέστο
+eo:pesto
+es:pesto
+et:pesto
+eu:pesto
+fa:پستو
+fi:pesto
+fr:pesto
+fy:pesto
+gl:pesto
+he:פסטו
+hu:pesto
+hy:պեստո
+id:pesto
+is:pestó
+it:pesto
+ja:ペスト・ジェノヴェーゼ
+ko:페스토
+ms:pesto
+nb:pesto
+nl:pesto
+oc:pesto
+pl:pesto
+pt:pesto
+ru:песто
+sk:pesto
+sl:pesto
+sv:pesto
+th:เปสโต
+tl:pesto
+tr:pesto
+uk:песто
+vi:pesto
+zh:香蒜醬
+wikidata:en: Q9896
+wikipedia:en: https://en.wikipedia.org/wiki/Pesto
+
+< en:Sauce
 en:prepared sauce
 de:Fertigsoße, Fertigsauce, Soße fertig zubereitet, fertig zubereitete Soße
 fi:Valmistettu kastike
@@ -61654,7 +64234,7 @@ bg:Соев сос
 bn:সয়া সস
 ca:salsa de soia
 cs:sójová omáčka
-da:sojasovs
+da:sojasovs, sojasauce
 de:Sojasauce, Sojasoße, Sojasosse
 el:Σάλτσα σόγιας
 eo:sojsaŭco
@@ -61745,7 +64325,7 @@ es:salsa de tomate
 et:tomatikaste
 eu:tomate saltsa
 fa:سس گوجه فرنگی
-fi:tomaattikastike
+fi:Tomaattikastike
 fr:préparation de tomates décongelée, sauce tomate, préparation à base de tomates, préparation aux tomates
 gl:Salsa de tomate
 gv:soolagh traase
@@ -61797,7 +64377,7 @@ es:vinagreta
 et:vinaigrette
 eu:Ozpin-olio
 fa:وینگرت
-fi:vinaigrette, vinegretti
+fi:vinaigrette, vinegretti, viinietikkakastike
 fr:vinaigrette, sauce vinaigrette
 gl:vinagreta
 he:וינגרט
@@ -62025,6 +64605,12 @@ uk:Пагель
 wikidata:en: Q1654733
 wikipedia:fr: https://fr.wikipedia.org/wiki/Pagellus
 
+< en:Fruit juice
+< en:Sea-buckthorn
+en:sea-buckthorn juice
+fi:tyrnimehu, tyrnitäysmehu
+sv:havtornsjuice
+
 < en:Sea salt
 en:Celtic sea salt
 ca:sal marina celta
@@ -62086,6 +64672,10 @@ fr:Sel de l'Ile de Ré, sel marin de l'Ile de Ré
 < en:Sea salt
 en:salt from Noirmoutier, sea salt from Noirmoutier
 fr:sel de Noirmoutier, sel marin de Noirmoutier
+
+< en:Sea salt
+en:sea salt flakes
+sv:saltflingor
 
 < en:Seaweed
 en:Ascophyllum
@@ -62387,15 +64977,22 @@ wikidata:en: Q40763
 
 < en:Seed
 en:aniseed
+da:anisfrø
 de:Anissamen
 es:semilla de anís, anis, matalahúga
 fi:anis
 fr:graine d'anis vert, anis vert, graine d'anis, anis
 nl:anijszaad
+sv:anis, anisfrö
 te:సోపు
 tt:әнис орлыгы
 wikidata:en: Q33873455
 wikipedia:en: https://en.wikipedia.org/wiki/Anise
+
+< en:Seed
+en:cardamom seed, cardamom seeds
+fi:kardemumman siemen, kardemumman siemeniä
+fr:graines de cardamome
 
 < en:Seed
 en:celery seed
@@ -62404,6 +65001,7 @@ es:Semilla de apio
 fi:sellerinsiemen
 fr:graines de céleri
 nl:Celderij zaad
+sv:sellerifrö
 
 < en:Seed
 en:cumin seeds, cumin
@@ -62411,25 +65009,28 @@ ca:llavors de comí
 da:Spidskommen
 de:Kümmelkörnen, Kreuzkümmel
 es:comino, semillas de comino
-fi:kumina, kuminan siemen
+fi:roomankumina, juustokumina, jeera, juustokuminansiemen
 fr:graines de cumin, cumin
 hu:köménymag
 it:grani di cumino
 nl:komijnzaad, komijnzaden, komijn
 pl:Nasiona kminku
-sv:spiskummin
+sv:spiskummin, spiskumminfrön
 
 < en:Seed
 en:fennel seed
+da:fennikelfrø
 de:Fenchelsamen, Fenchelsaat
 es:Semillas de hinojo
-fi:fenkolinsiemen
+fi:fenkolinsiemen, fenkolin siemen
 fr:graines de fenouil
 it:semi di finocchio
+nb:fennikelfrø
 nl:Venkelzaad
+sv:fänkålsfrö, fänkålsfrön
 
 < en:Seed
-en:flax seed, flax seeds
+en:flax seed, flax seeds, flaxseed
 bg:Ленено семе
 cs:Len setý
 da:Hørfrø
@@ -62437,15 +65038,16 @@ de:Leinsamen, Leinsaat
 es:
 et:Linaseemned
 fa:تخم کتان
-fi:pellavansiemen, pellavansiemenet
+fi:pellavansiemen, pellavansiemenet, pellavansiemeniä
 fr:graine de lin, graines de lin, graines de lin jaune
 hu:Lenmag
 it:semi di lino
+nb:linfrø
 nl:lijnzaad
 nn:linfrø
 pl:Siemię lniane
 pt:linhaça
-sv:linfrön
+sv:linfrön, linfrö
 tr:keten
 nutriscore_fruits_vegetables_nuts:en: no
 wikidata:en: Q911332
@@ -62521,7 +65123,7 @@ pl:orzeszki piniowe
 pt:pinhão
 ru:кедровый орех
 sr:пињол
-sv:pinjenötter
+sv:pinjenötter, pinjekärnor
 tl:Pinyon
 tr:Çam fıstığı
 uk:кедрові горішки
@@ -62631,6 +65233,10 @@ wikidata:en: Q2763698
 
 < en:Seed
 fr:graines grillées
+
+en:seed and berry mix
+fi:siemen-marjaseos
+sv:frö-bärblandning
 
 < en:Selenium
 en:selenium enriched yeast
@@ -62833,12 +65439,13 @@ en:wheat semolina
 ar:سميد
 de:Weizengrieß, Weizengriess
 es:sémola de trigo
-fi:mannasuurimo
+fi:mannasuurimo, vehnäsuurimo
 fr:semoule de blé
 hu:búzadara, gríz
 it:semolino di frumento
 nl:tarwegries
 pt:sêmola de trigo
+sv:vetegryn
 carbon_footprint_fr_foodges_ingredient:fr: Semoule de blé dur
 carbon_footprint_fr_foodges_value:fr: 0.6
 wikidata:en: Q381350
@@ -62893,10 +65500,10 @@ wikidata:en: Q905648
 en:sesame paste, sesame seed paste
 de:Sesampaste
 es:pasta de sésamo
-fi:seesamitahna
+fi:seesamitahna, sesamtahna
 fr:pâte de sésame, pâte de graines de sésame
 it:pasta di sesamo
-sv:sesam-kräm
+sv:sesam-kräm, sesampasta
 
 < en:Sesame
 en:sesame seeds
@@ -62915,13 +65522,14 @@ hu:szezámmag
 it:semi di sesamo, grani di sesamo
 lt:sezamo sėklos
 lv:sezama sēklas
+nb:sesamfrø
 nl:sesamzaad, sesam zaden, sesamzaden
 pl:nasiona sezamu
 pt:sementes de sésamo, sementes de sésam
 ro:semințe de susan
 sk:sezamové semeno
 sl:sezamovo seme
-sv:sesamfrön
+sv:sesamfrön, sesamfrö
 
 < en:Sesame
 fr:sésame complet
@@ -63077,6 +65685,12 @@ fr:boyau naturel de mouton
 < en:Sheeps fat
 fr:viande et gras de mouton
 
+< en:Goat's milk
+< en:Sheeps milk
+en:sheep and goat milk, goat and sheep milk
+fi:vuohen ja lampaan maito, lampaan ja vuohen maito
+fr:lait de brebis et de chèvre
+
 < en:Sheeps milk
 en:pasteurized sheeps milk, pasteurised sheep's milk
 ca:llet d'ovella pasteuritzada, llet pasteuritada d'ovella
@@ -63087,6 +65701,7 @@ fr:lait de brebis pasteurisé, lait pasteurisé de brebis
 hu:pasztőrözött juhtej
 nl:gepasteuriseerde schapenmelk
 ro:lapte de oaie pasteurizat
+sv:pastöriserad fårmjölk
 
 < en:Sheeps milk
 en:raw sheeps milk
@@ -63485,6 +66100,12 @@ nn:rekepasta
 sv:räkpasta
 
 < en:Shrimp
+en:shrimp powder
+fr:poudre de crevette
+nl:garnalenpoeder
+sv:räkpulver
+
+< en:Shrimp
 en:whiteleg shrimp
 de:Penaeus vannamei
 es:camarón
@@ -63503,10 +66124,6 @@ fr:Crevettes entières crues
 
 < en:Shrimp
 fr:crevettes roses
-
-< en:Shrimp
-fr:poudre de crevette
-nl:garnalenpoeder
 
 < en:Shrimp
 fr:queues de crevettes
@@ -63532,6 +66149,7 @@ fr:lait écrémé réhydraté
 hu:visszaállított sovány tej, feloldott sovány tej
 it:latte scremato reidratato
 nl:gerehydrateerde magere melk
+pl:odtworzone odtłuszczone mleko
 
 < en:Pasteurised milk
 < en:Skimmed milk
@@ -63544,6 +66162,7 @@ fr:lait écrémé pasteurisé
 hu:pasztőrözött sovány tej, pasztörizál sovány tej, hőkezelt sovány tej
 it:latte magro pastorizzato
 pt:leite pasteurizado desnatado, leite desnatado pasteurizado
+sv:pastöriserad skummjölk
 
 < en:Skimmed milk powder
 en:caramelised skimmed milk powder
@@ -63639,10 +66258,11 @@ wikipedia:en: https://en.wikipedia.org/wiki/Smoking_-cooking-
 en:beech wood smoke
 de:Buchenholzrauch
 es:Madera de haya ahumada
-fi:pyökkipuusavu
+fi:pyökkipuusavu, pyökistä valmistettu savuaromi
 fr:fumée de bois de hêtre, fumée naturelle au bois de hêtre
 hu:bükkfán füstölt, bükkfa füst
 it:fumo di faggio
+sv:bokträrök
 
 < en:Smoke
 en:liquid smoke
@@ -63662,7 +66282,6 @@ lt:Dūminis mirkalas
 nb:flytende røyk
 pt:fumaça líquida
 ru:Жидкий дым
-sv:rökarom
 uk:Рідкий дим
 zh:煙熏液
 wikidata:en: Q909463
@@ -63760,7 +66379,7 @@ sh:Natrijum-hlorid
 sk:chlorid sodný
 sl:natrijev klorid
 sq:Klouri i natriumit
-sv:natriumklorid
+sv:natriumklorid, nacl
 ta:சோடியம் குளோரைடு
 th:โซเดียมคลอไรด์
 tl:Sodium chloride
@@ -63880,7 +66499,7 @@ nl:Crème fraîche
 pl:Crème fraîche
 pt:Crème fraîche
 ru:Крем-фреш
-sv:Crème fraîche
+sv:Crème fraîche, crème fraiche
 uk:Крем-фреш
 vi:Kem fraîche
 zh:法式酸奶油
@@ -63972,26 +66591,30 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sourdough
 de:Natursauerteig
 
 < en:Sourdough
-de:Roggensauerteig
-fi:ruistaikinanjuuri, ruisjuuri
-fr:levain de seigle
-nl:roggezuurdesem
-
-< en:Sourdough
 de:Sauerteig getrocknet
+fi:kuivattu taikinajuuri
 fr:levain sec, levain déshydraté
 it:lievito naturale secco
 nl:zuurdesempoeder
 
 < en:Sourdough
-en:wheat sourdough
-es:masa madre de trigo, masa madre natural de trigo
+en:rye sourdough
+da:rugsurdej
+de:Roggensauerteig
+fi:ruistaikinanjuuri, ruisjuuri
+fr:levain de seigle
+nl:roggezuurdesem
+sv:rågsurdeg, surdeg av råg
 
 < en:Sourdough
-fr:levain de blé
+en:wheat sourdough
 de:Weizensauerteig
-fi:vehnätaikinanjuuri
+es:masa madre de trigo, masa madre natural de trigo
+fi:vehnätaikinanjuuri, vehnähapantaikina
+fr:levain de blé
 it:lievito madre di frumento
+nb:surdeig av hvete
+sv:vetesurdeg, surdeg av vete, surdeg på vete
 
 < en:Sourdough
 nl:speltzuurdesempoeder
@@ -64015,6 +66638,7 @@ fi:Soijavalmiste
 fr:préparation à base de soja
 nl:sojabereiding
 pt:preparado à base de soja
+sv:sojabönsberedning
 
 < en:Soy preparation
 en:soy milk
@@ -64164,7 +66788,7 @@ pl:Soja
 pt:Soja
 qu:Suya
 ro:soia
-ru:Соя
+ru:Соя, соевый
 rw:Soya
 sh:Soja
 sk:sójové
@@ -64192,7 +66816,11 @@ fi:soijajauho
 fr:son de soja
 
 < en:Soya
-de:Sojaschrot, Sojagrieß
+en:soy base
+de:sojabasis
+es:zumo de soja
+fi:soijapohja
+fr:jus de soja
 
 < en:Soya
 en:soy flakes
@@ -64201,6 +66829,12 @@ fi:soijahiutaleet
 fr:flocons de soja
 it:fiocchi di soia
 nl:Sojavlokken
+
+< en:Soya
+en:soy grits
+de:Sojaschrot, Sojagrieß
+fi:soijarouhe
+sv:sojafärs
 
 < en:Soya
 en:soya base
@@ -64253,10 +66887,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Textured_vegetable_protein
 es:concentrado de soja
 
 < en:Soya
-fr:jus de soja
-es:zumo de soja
-
-< en:Soya
 fr:pousses de soja
 
 < en:Soya bean
@@ -64266,24 +66896,29 @@ fi:vihreä soijapapu
 fr:soja vert
 
 < en:Soya bean
+en:hulled soya bean
+da:afskallede sojabønner
+de:geschälte Sojabohnen
+es:habas de soja descascarilladas
+fi:kuoritut soijapavut
+fr:soja dépelliculé, graines de soja dépelliculées, fèves de soja décortiquées
+it:semi di soia decorticati
+nl:gepelde sojabonen
+sv:skalade sojabönor
+
+< en:Soya bean
 en:organic soya bean
 de:Bio-Sojabohnen
 fi:luomusoijapapu, luomu soijapapu
 fr:soja biologique
 nl:biologische sojabonen
+sv:ekologiska sojabönor
 
 < en:Soya bean
 fr:fèves de soja sans ogm décortiquées
 
 < en:Soya bean
 fr:graines de soja toastées
-
-< en:Soya bean
-fr:soja dépelliculé, graines de soja dépelliculées, fèves de soja décortiquées
-de:geschälte Sojabohnen
-es:habas de soja descascarilladas
-it:semi di soia decorticati
-nl:gepelde sojabonen
 
 < en:Soya lecithin
 en:GMO-free soy lecithin
@@ -64309,6 +66944,13 @@ fr:huile de soja entièrement raffinée
 fr:vin cremant de Loire aop
 
 < en:Special bread
+en:rye bread
+de:Roggenbrot
+fi:ruisleipä
+wikidata:en: Q3893120
+wikipedia:en: https://en.wikipedia.org/wiki/Rye_bread
+
+< en:Special bread
 fr:pain au chocolat
 carbon_footprint_fr_foodges_ingredient:fr: Viennoiseries pain au chocolat
 carbon_footprint_fr_foodges_value:fr: 2.3
@@ -64325,13 +66967,12 @@ fr:pain spécial de campagne
 < en:Special bread
 fr:pain spécial viennois
 
-< en:Rye
+< en:Sesame
 < en:Special bread
-en:rye bread
-de:Roggenbrot
-fi:ruisleipä
-wikidata:en: Q3893120
-wikipedia:en: https://en.wikipedia.org/wiki/Rye_bread
+en:sesame seed bun
+de:Sesambrötchen
+fi:seesamisämpylä, hampurilaissämpylä, hampurilaissämpylää
+nl:sesambroodje
 
 < en:Speckled Scallop
 en:Argopecten irradians concentricus
@@ -64369,14 +67010,6 @@ nl:speculoos
 ru:Спекулос
 
 < en:Spelt
-de:dinkelkleie
-nl:speltzemelen
-
-< en:Spelt
-de:Dinkelvollkornflocken, Dinkelvollkornschrot
-fr:flocons d'épeautre complet
-
-< en:Spelt
 en:inflated spelt
 es:espelta inflada
 
@@ -64388,6 +67021,20 @@ fi:luomu speltti
 fr:épeautre biologique
 hu:bio tönkölybúza
 nl:Biologische spelt
+
+< en:Spelt
+en:spelt bran
+de:dinkelkleie
+fi:spelttilese
+nl:speltzemelen
+sv:dinkelkli
+
+< en:Spelt
+en:whole grain spelt flakes
+de:Dinkelvollkornflocken, Dinkelvollkornschrot
+fi:täysjyväspelttivehnähiutale
+fr:flocons d'épeautre complet
+sv:fullkornsdinkelveteflingor
 
 < en:Spelt
 fr:flocons d'épeautre
@@ -64418,11 +67065,12 @@ fr:farine de petit épeautre
 en:wholemeal spelt flour
 de:Dinkelvollkornmehl
 es:harina de espelta integral, harina integral de espelta
-fi:täysjyväspelttijauho
+fi:täysjyväspelttijauho, täysjyväspelttivehnäjauho
 fr:farine complète d'épeautre, farine d'épeautre complète, farine d'épeautre complet
 hu:teljes kiőrlésű tönkölyliszt
 it:farina integrale di spelta
 nl:volkoren speltmeel
+sv:fullkornsspeltvetemjöl
 
 en:spice, spices
 ca:Espècies
@@ -64430,16 +67078,19 @@ cs:Koření
 da:krydderi, krydderier
 de:Gewürze
 es:especias
+et:vürtsid
 fi:mauste, mausteet
 fr:épice, épices, aromate
 he:תבלין
 hr:Začin
 hu:fűszer, fűszerek
 it:spezie
+nb:krydder, krydderi, krydderier
 nl:specerijen
-pl:przyprawa
+pl:przyprawa, przyprawy
 ru:Специи
-sv:kryddor
+sl:začimbe
+sv:krydda, kryddor, kryddört
 zh:香料
 carbon_footprint_fr_foodges_ingredient:fr: Épices
 carbon_footprint_fr_foodges_value:fr: 2.2
@@ -64466,7 +67117,7 @@ eo:Karvio
 es:Alcaravea
 eu:Txarpoil
 fa:زیره
-fi:kumina, kuminan siemen
+fi:Kumina
 fr:carvi
 ga:Cearbhas
 gl:Carvea
@@ -64509,7 +67160,7 @@ zh:葛縷子
 wikipedia:en: https://en.wikipedia.org/wiki/Caraway
 
 < en:Spice
-en:cardamon
+en:cardamom, cardamon
 af:Kardamom
 ar:هال
 bs:Kardamom
@@ -64573,7 +67224,7 @@ el:Καγιέν
 eo:Kajena pipro
 es:pimienta de cayena, pimienta roja, cayena
 eu:Kaiena
-fi:Cayennepippuri
+fi:Cayennepippuri, cayenne
 fr:piment de Cayenne, cayenne, poivre de cayenne
 gl:Pementa de Caiena
 he:פלפל קאיין
@@ -64592,7 +67243,7 @@ nn:Kajennepepar
 pl:Pieprz cayenne
 pt:pimenta-caiena
 ru:перец кайенский
-sv:cayennepeppar
+sv:cayennepeppar, cayenne, kajennpeppar
 th:พริกชี้ฟ้า
 tl:Kayena
 zh:牛角椒
@@ -64708,7 +67359,7 @@ ca:clavell d'espècia
 co:Viulaccia
 cs:hřebíček
 cv:Гвоздика
-da:Kryddernellike
+da:Kryddernellike, nellike
 de:Nelken, Gewürznelken
 dv:ކަރަންފޫ
 eo:Kariofilo
@@ -64716,7 +67367,7 @@ es:clavos de olor, clavo
 et:Nelk
 eu:Iltze
 fa:میخک صدپر
-fi:Mausteneilikka
+fi:Mausteneilikka, neilikka
 fr:girofle, clou de girofle, clous de girofle
 ga:Clóbh
 gd:Clo-mheas
@@ -64767,7 +67418,7 @@ sl:Nageljnove žbice
 so:Dhaga yare
 sr:Karanfilić
 su:Cengkéh
-sv:Kryddnejlika
+sv:Kryddnejlika, nejlika, kryddnejlikor, nejlikor
 sw:Karafuu, Mkarafuu
 ta:கிராம்பு
 te:లవంగము
@@ -64780,6 +67431,18 @@ wa:Djirofe
 yi:נעגעלע
 zh:丁香
 wikipedia:en: https://en.wikipedia.org/wiki/Clove
+
+< en:Spice
+en:curry paste
+de:currypaste
+es:pasta de curry
+fi:currytahna
+fr:pâte de curry
+ko:커리 페이스트
+nb:karripasta
+sv:currypasta, curry pasta
+wikidata:en: Q5195232
+wikipedia:en: https://en.wikipedia.org/wiki/Curry_paste
 
 < en:Spice
 en:curry powder
@@ -64818,12 +67481,14 @@ es:fenogreco
 fi:sarviapila
 fr:fenugrec
 it:fieno greco
+nb:bukkehornkløver, bukkehornskløver
+sv:bockhornsklöver
 
 < en:Spice
 en:Galangal
 de:Galgant
 es:galangal
-fi:galangal, galanga, galgantti
+fi:galangal, galanga, galgantti, galangajuuri
 fr:galanga
 hu:galangál
 is:galgantrót
@@ -64950,35 +67615,55 @@ fr:épices et plantes aromatique, épice et plante aromatique, épice et plantes
 it:Erbe e spezie
 nl:kruiden en specerijen
 pl:Zioła i przyprawy
-sv:Örter och kryddor
+sv:Örter och kryddor, kryddor och örtkryddor
+
+< en:Spice
+en:kaffir lime leaf
+de:Zitronenblatt
+es:hoja limón
+fi:kaffirlimetinlehti, kaffirlimenlehti
+fr:feuille de citron
+nl:citroenblad
+wikipedia:en: https://en.wikipedia.org/wiki/Kaffir_lime
+
+< en:Spice
+en:lime leaf
+da:limeblad
+fi:limetinlehti, limenlehti
+sv:limeblad
 
 < en:Spice
 en:mace
 ca:Macís
 cs:Muškátový květ
+da:muskatblomme
 de:Macis
 eo:Maciso
 es:Macis
-fi:muskottikukka
+fi:muskotinkukka, muskottikukka
 fr:macis
 it:Macis
 ko:메이스
+nb:muskatblomme
 nl:foelie
 oc:Macís
 pt:Macis
 ru:Мацис
 sk:Muškátový kvet
+sv:muskotblomma
 uk:Мацис
 wikidata:en: Q1882876
 
 < en:Spice
 en:mixed spices
+da:krydderimix
 de:gemischte Gewürze
 es:Mezcla de especias
 fi:mausteseos
 fr:mélange d'épices
+nb:krydderimix
 nl:gemengde specerijen
-sv:kryddblandning
+sv:kryddblandning, kryddmix
 
 < en:Spice
 en:mustard
@@ -65106,7 +67791,7 @@ sh:Muškatov oraščić
 si:සාදික්කා
 sl:Muškatovec
 su:Pala
-sv:Muskotsläktet, muskot
+sv:Muskotsläktet, muskot, muskotnöt
 sw:Kungumanga
 ta:ஜாதிக்காய்
 te:జాజికాయ
@@ -65127,7 +67812,7 @@ en:pink peppercorn, pink berries
 da:rosépeber
 de:Rosa Beeren
 fa:فلفل صورتی
-fi:roseepippuri
+fi:roseepippuri, rosépippuri, perunroseepippuri, ruusupippuri
 fr:baies roses, baies
 it:pepe rosa
 ja:ピンクペッパー
@@ -65142,9 +67827,12 @@ wikipedia:en: https://en.wikipedia.org/wiki/Pink_peppercorn
 
 < en:Spice
 en:spices and spices extracts
+da:krydderi og krydderiekstrakter
 de:Gewürze und Gewürzextrakte
 fi:mausteet ja mausteuutteet
 fr:épices et extrait d'épices
+nb:krydder og krydderekstrakter
+sv:kryddor och kryddextrakt
 
 < en:Spice
 en:star anise
@@ -65252,7 +67940,7 @@ nn:gurkemeie
 oc:Curcuma
 or:ହଳଦୀ
 pa:ਹਲਦੀ
-pl:Ostryż długi
+pl:Ostryż długi, kurkuma
 ps:کورکمن
 pt:curcuma
 ro:Curcuma
@@ -65285,21 +67973,32 @@ wikipedia:en: https://en.wikipedia.org/wiki/Turmeric
 fr:épices moulues
 
 en:spice extract, spices extract
+da:krydderiekstrakt, krydderiekstrakter
 de:Gewürz Extrakte, Gewürzextrakte, Gewurzextrakte, Gewürzextrakt
 es:Extracto de especias
 fi:mausteuute, mausteuutteet
 fr:extrait d'épice, extraits d'épices
 hu:fűszerkivonat, fűszerkivonatok, fűszer kivonat, fűszer kivonatok
 it:Estratto di spezie
+nb:krydderekstrakt, krydderekstrakter
 nl:Kruidenextracten
-sv:kryddextrakt
+pl:ekstrakt z przyprawy
+sl:začimbni ekstrakti
+sv:kryddextrakt, kryddextrakter
 vegan:en: yes
 vegetarian:en: yes
+
+en:spice paste
+fi:maustetahna
+fr:pâte d'épices
+sv:kryddpasta
 
 < en:Spinach
 en:baby spinach
 de:Babyspinat
+fi:babypinaatti, baby-pinaatti
 fr:Jeunes pousses d'épinards
+sv:babyspenat
 
 < en:Spinach
 en:spinach powder
@@ -65380,7 +68079,7 @@ de:Spirulina
 el:Σπιρουλίνα
 eo:Spirulino
 es:spirulina
-fi:spirulina
+fi:spirulina, spirulinaa, spirulina-levä, spiruliinaa
 fr:spirulina, spiruline
 he:ספירולינה
 it:spirulina
@@ -65549,21 +68248,23 @@ de:Stabilisator, Stabilisatoren, Bindemittel
 el:Σταθεροποιητής
 es:Estabilizador, estabilizadores, estabilizadores coloidales, estabilizadores de emulsión, estabilizadores de espuma, estabilizador coloidal, estabilizador de emulsión, estabilizador de espuma, sinergistas estabilizadores, estabilizante, estabilizantes, ligante
 et:Stabilisaator
-fi:Stabilointiaine, Stabilointiainetta, Stabilointiaineet, Stabilointiaineita, sideaine, sidonta-aine
-fr:Stabilisant, liant, stabilisateur colloïdal, stabilisateur d'émulsion, stabilisateur de mousse, stabilisateur, stabilisateurs
+fi:Stabilointiaine, Stabilointiainetta, Stabilointiaineet, Stabilointiaineita, sideaine, sidonta-aine, sidonta-aineet
+fr:Stabilisant, liant, stabilisateur colloïdal, stabilisateur d'émulsion, stabilisateur de mousse, agent stabilisant, stabilisateur, stabilisateurs
 ga:Cobhsaitheoir
 hu:Stabilizátor, kötőanyag
+is:bindiefni
 it:Stabilizzante, stabilizzanti, agente stabilizzante, agenti stabilizzanti, legante, leganti
 lt:Stabilizatorius
 lv:Stabilizētājs
 mt:Stabbilizzatur
+nb:Stabilisator, Stabilisatorer
 nl:Stabilisator, Stabilisatoren
 pl:Stabilizator, Stabilizatory
-pt:Estabilizador
+pt:Estabilizador, Estabilizadores
 ro:Stabilizator
 sk:Stabilizátor
 sl:Vezivo
-sv:Stabiliseringsmedel
+sv:Stabiliseringsmedel, Stabiliseringsämne, Stabilisator, Stabilisatorer, Stabilisering, bindningsämnen
 description:cs: Stabilizátory se rozumějí látky, které umožňují udržovat fyzikálně-chemický stav potraviny; mezi stabilizátory patří látky, které umožňují udržet jednotný rozptyl dvou nebo více navzájem se nesměšujících látek v potravinách, látky, které stabilizují, udržují nebo zintenzivňují stávající barvu potravin, a látky, které zvyšují pojivost určité potraviny, včetně vytváření vzájemných vazeb mezi bílkovinami, které umožňují spojení kusů potravin do rekonstituované potraviny.
 description:da: Stabilisatorer: stoffer, hvormed man kan opretholde en fødevares fysisk-kemiske tilstand. Til stabilisatorer hører stoffer, hvormed der kan opretholdes en homogen fordeling af to eller flere ikke-blandbare stoffer i en fødevare, stoffer, som stabiliserer, bevarer eller forstærker en fødevares farve, og stoffer, som øger fødevarens bindeevne, herunder dannelse af tværbindinger mellem proteiner, der kan binde fødevarestykker i rekonstituerede fødevarer.
 description:de: Stabilisatoren sind Stoffe, die es ermöglichen, den physikalisch-chemischen Zustand eines Lebensmittels aufrechtzuerhalten. Zu den Stabilisatoren zählen Stoffe, die es ermöglichen, die einheitliche Dispersion zweier oder mehrerer nicht mischbarer Phasen in einem Lebensmittel aufrechtzuerhalten, Stoffe, durch welche die vorhandene Farbe eines Lebensmittels stabilisiert, bewahrt oder intensiviert wird, und Stoffe, die die Bindefähigkeit eines Lebensmittels verbessern, einschließlich der Bildung von Proteinvernetzungen, die die Bindung von Lebensmittelstücken in rekonstituierten Lebensmitteln ermöglichen.
@@ -65605,7 +68306,7 @@ es:almidón, fecula
 et:Tärklis
 eu:Almidoi
 fa:نشاسته
-fi:Tärkkelys
+fi:tärkkelys, tärkkelystä
 fr:amidon, fécules, fécule
 fy:Stiselmoal
 ga:Stáirse
@@ -65665,6 +68366,12 @@ wikidata:en: Q41534
 wikipedia:en: https://en.wikipedia.org/wiki/Starch
 
 < en:Starch
+en:barley starch
+fi:ohratärkkelys
+fr:amidon d'orge
+sv:kornstärkelse
+
+< en:Starch
 en:corn starch, maize starch, cornstarch
 ar:نشا الذرة
 ca:Midó de blat de moro
@@ -65680,6 +68387,7 @@ fr:amidon de maïs, fécule de mais, amidon natif de maïs
 he:עמילן תירס
 hu:kukoricakeményítő
 id:Tepung jagung
+is:maíssterkja
 it:Amido di mais
 ko:옥수수 녹말
 lt:Kukurūzų krakmolas
@@ -65707,8 +68415,8 @@ da:Modificeret stivelse, E14XX, E14XX food additive
 de:Modifizierte Stärke, Modifizierte Stärken, E14XX
 el:Τροποποιημένο άμυλο, E14XX
 es:Almidón modificado, E14XX, almidones modificados
-et:Modifitseeritud tärklis, E14XX
-fi:Muunnettu tärkkelys, Muunnettua tärkkelystä, Muunnetut tärkkelykset, Muunnettuja tärkkelyksiä, E14XX, modifioitu tärkkelys
+et:Modifitseeritud tärklis, E14XX, Modifitseeritu tärklis, modifitseeritud tärklis. modifitseeritu tärklis
+fi:Muunnettu tärkkelys, Muunnettua tärkkelystä, Muunnetut tärkkelykset, Muunnettuja tärkkelyksiä, E14XX, Muunneltu tärkkelys, modifioitu tärkkelys
 fr:Amidon modifié, E14XX, Amidons modifiés, amidons transformés, amidon transformé, catégorie d'additifs de 1401 à 1452
 ga:Stáirse modhnaithe
 he:עמילן מעובד
@@ -65736,6 +68444,7 @@ en:pea starch
 de:Erbsenstärke
 fi:hernetärkkelys
 fr:amidon de pois
+sv:ärtstärkelse
 
 < en:Starch
 en:potato starch
@@ -65745,10 +68454,11 @@ da:kartoffelstivelse, Kartoffelmel
 de:Kartoffelstärke, Kartoffelmehl
 es:fécula de patata, Almidón de papa, Almidón de patata
 et:Kartulitärklis
-fi:perunatärkkelys, perunajauho
+fi:perunatärkkelys
 fr:amidon de pommes de terre, amidon de pomme de terre, fécule de pommes de terre, fécule de pomme de terre
 hu:burgonyakeményítő
 id:Tepung kentang
+is:kartöflusterkja
 it:Fecola di patate, amido di patata, amido di patate
 ja:片栗粉
 ko:감자 녹말
@@ -65783,7 +68493,7 @@ sv:risstärkelse
 
 < en:Starch
 en:tapioca starch, tapioca, manioc starch
-da:tapiokastivelse
+da:tapiokastivelse, tapiocastivelse
 de:Tapiocastärke, Tapiokastärke
 el:άμυλο ταπιόκαζ, Ταπιόκα
 es:almidón de tapioca, almidón de mandioca
@@ -65791,9 +68501,10 @@ fi:tapiokatärkkelys
 fr:amidon de tapioca, fécule de tapioca, tapioca, amidon de manioc, fécule de manioc
 hu:tápiókakeményítő
 it:amido di tapioca
+nb:tapiokastivelse, tapioka
 nl:tapioca zetmeel
 pl:Tapioka
-sv:tapiokastärkelse
+sv:tapiokastärkelse, tapioka
 wikipedia:en: https://en.wikipedia.org/wiki/Tapioca
 
 < en:Starch
@@ -65804,7 +68515,7 @@ da:Hvedestivelse
 de:Weizenstärke
 el:άμυλο σιταριού
 es:almidón de trigo
-fi:vehnätärkkelys
+fi:vehnätärkkelys, vehnätärkkelystä
 fr:amidon de froment, amidon de blé
 hu:búzakeményítő
 it:amido di frumento
@@ -65830,6 +68541,7 @@ fi:pastöroitu maito, pastöroidusta maidosta
 fr:lait pasteurisé
 hu:pasztőrözött tej, pasztörizált tej
 it:latte pastorizzato
+nb:pasteurisert melk
 nl:gepasteuriseerde melk
 pl:Mleko pasteryzowane
 pt:leite pasteurizado
@@ -65869,26 +68581,35 @@ wikidata:en: Q641656
 wikipedia:en: https://en.wikipedia.org/wiki/Volvariella_volvacea
 
 < en:Strawberry
-de:Erdbeerpulver
-
-< en:Strawberry
 en:strawberry filling
 de:Erdbeerfüllung
 fi:mansikkatäyte
 fr:nappage à la fraise
 
 < en:Strawberry
+en:strawberry pieces
+fr:morceaux de fraise
+
+< en:Strawberry
+en:strawberry powder
+de:Erdbeerpulver
+et:maasikapulber
+fi:mansikkajauhe
+fr:poudre de fraise
+ro:pudră de căpșuni
+
+< en:Strawberry
 fr:fraises lyophilisées
 de:Erdbeeren gefriergetrocknet
-fi:pakastekuivattu manskikka
+fi:pakkaskuivattu mansikka, pakastekuivattu mansikka
 it:fragole liofilizzate
 
 < en:Fruit juice
 < en:Strawberry
-fr:jus de fraise à base de concentré
-de:Erdbeersaft aus Konzentrat
-fi:mansikkamehu tiivisteestä
-nl:geconcentreerd aardbeiensap
+en:strawberry juice
+fi:mansikkamehu
+fr:jus de fraise
+sv:jordgubbsjuice, jordgubbssaft
 
 < en:Fruit juice
 < en:Grape
@@ -65900,11 +68621,12 @@ fi:mansikoista valmistettu mehu ja viinirypäleet
 en:strawberry puree
 de:Erdbeerpüree
 es:puré de fresa
-fi:mansikkapyree, mansikkasose
+fi:mansikkapyree, mansikkasose, mansikkapyre
 fr:purée de fraise, purée de fraises
 it:purea di fragola
 nl:aardbeienpuree
 ru:Клубничное пюре
+sv:jordgubbspuré
 
 < en:Natural flavouring
 < en:Strawberry flavouring
@@ -65915,6 +68637,19 @@ fi:luontainen mansikka-aromi
 fr:arôme naturel de fraise
 hu:természetes eper aroma
 nl:natuurlijk aardbeienaroma
+
+< en:Strawberry juice
+en:strawberry juice concentrate, concentrated strawberry juice
+de:erdbeersaftkonzentrat
+fi:mansikkamehutiiviste, mansikkatäysmehutiiviste
+fr:concentré de jus de fraise
+
+< en:Strawberry juice concentrate
+en:strawberry juice from concentrate
+de:Erdbeersaft aus Konzentrat
+fi:mansikkamehu tiivisteestä, tiivisteestä valmistettu mansikkatäysmehu
+fr:jus de fraise à base de concentré
+nl:geconcentreerd aardbeiensap
 
 < en:Strawberry puree
 en:concentrated strawberry puree
@@ -65946,7 +68681,7 @@ de:Zucker
 el:Ζάχαρη
 eo:Sukero
 es:azúcar, azúcares
-et:Suhkrud
+et:suhkur, suhkrud
 eu:Azukre
 fa:شکر
 fi:sokeri, sokeria
@@ -65961,7 +68696,7 @@ hi:शर्करा
 hr:Šećeri
 ht:Sik
 hu:cukor
-is:Matarsykur
+is:sykur, matarsykur
 it:zucchero
 iu:ᓱᑲᒃ
 ja:砂糖
@@ -66048,7 +68783,7 @@ en:brown sugar
 ar:سكر بني
 az:Qəhvəyi şəkər
 ca:sucre morè
-da:farin
+da:farin, brun farin
 de:Brauner Zucker, Farinzucker
 eo:Bruna sukero
 es:azúcar morena, azúcar moreno
@@ -66068,6 +68803,7 @@ ja:粗糖
 ko:흑설탕
 ml:ബ്രൗൺ ഷുഗർ
 ms:Gula perang
+nb:brunt sukker
 nl:basterdsuiker, bruine suiker
 pl:Brązowy cukier
 pt:açúcar mascavo
@@ -66085,7 +68821,7 @@ en:cane sugar
 bg:захар от захарна тръстика
 ca:Sucre de canya
 cs:třtinový cukr
-da:rörsocker
+da:rørsukker
 de:Rohrzucker
 el:ζάχαρη από ζαχαροκάλαμο
 es:azúcar de caña
@@ -66115,13 +68851,15 @@ wikipedia:en: https://en.wikipedia.org/wiki/Sucrose#Cane
 
 < en:Sugar
 en:caramelised sugar
+da:karamelliseret sukker
 de:Karamellzucker, karamellisierter Zucker
 es:azúcar caramelizado
-fi:karamellisokeri
+fi:karamellisoitu sokeri, karamellisoitua sokeria, karamellisokeri
 fr:sucre brun, sucre caramel, sucre caramélisé
 hu:karamellizált cukor
 it:zucchero caramellato
 nl:gekarameliseerde suiker
+pl:cukier karmelizowany
 ro:zahăr caramelizat
 sv:karamelliserat socker
 
@@ -66137,12 +68875,15 @@ nl:poedersuiker, Kristalsuiker
 
 < en:Sugar
 en:grape sugar, raisin sugar
+da:druesukker
 de:Traubenzucker
 es:azúcar de uva
 fi:rypälesokeri
 fr:sucre de raisin
 hu:mazsolacukor
 it:zucchero d'uva
+nb:druesukker
+sv:druvsocker
 
 < en:Sugar
 en:icing sugar
@@ -66151,10 +68892,12 @@ fi:tomusokeri
 fr:sucre glace
 it:zucchero a velo
 nl:glazuursuiker
+sv:florsocker
 
 < en:Sugar
 en:invert sugar, inverted sugar
 ca:sucre invertit
+da:invertsukker
 de:Invertzucker
 es:azúcar invertido, azucar liquido invertido
 fi:inverttisokeri
@@ -66165,6 +68908,7 @@ nl:Invertsuiker
 pl:Cukier inwertowany
 pt:açúcar invertido
 ro:zahăr invertit, zahar invertit
+sv:invertsocker
 wikipedia:en: https://en.wikipedia.org/wiki/Inverted_sugar_syrup
 
 < en:Sugar
@@ -66174,6 +68918,7 @@ es:Azúcar liquido
 fi:nestesokeri
 fr:sucre liquide
 hu:folyékony cukor
+sv:sockerlösning
 
 < en:Sugar
 en:maltose
@@ -66252,7 +68997,7 @@ eo:melaso
 es:melaza
 eu:Melaza
 fa:ملاس
-fi:Melassi
+fi:Melassi, melassia, melassisiirappi
 fr:mélasse, mélasses
 ga:Molás
 gn:Eíra
@@ -66284,7 +69029,7 @@ sh:Melasa
 sk:Melasa
 sn:Melaza
 sr:Меласа
-sv:melass
+sv:melass, melass sirap
 th:กากน้ำตาล
 tl:Pulot
 tr:Melas
@@ -66311,6 +69056,12 @@ fi:Palmusokeri
 fr:sucre de palme
 it:Zucchero di palma
 pl:Cukier palmowy
+
+< en:Sugar
+en:partially inverted sugar syrup
+fi:osittain invertoitu sokerisiirappi
+fr:sirop de sucre partiellement inverti
+sv:delvis inverterad sockersirap
 
 < en:Sugar
 en:sucrose
@@ -66370,7 +69121,7 @@ sl:Saharoza
 sq:Sakaroza
 sr:сахароза
 su:Sukrosa
-sv:Sackaros
+sv:Sackaros, sukros
 ta:சுக்கிரோசு
 te:సుక్రోజ్
 th:ซูโครส
@@ -66426,9 +69177,34 @@ wikipedia:en: https://en.wikipedia.org/wiki/Trehalose
 en:unrefined sugar, raw sugar
 de:unraffinierter Zucker
 es:Azúcar sin refinar, azucar integral
-fi:ruokosokeri
+fi:raakasokeri
 fr:sucre non raffiné, sucre brut, sucre complet
 nl:ongeraffineerde suiker, ruwe suiker
+sv:råsocker
+
+< en:Sugar
+en:vanilla sugar
+bs:vanilin šećer
+da:vaniljesukker
+de:vanillezucker
+es:azúcar vainillada
+fi:vaniljasokeri
+fr:sucre vanillé
+hu:vaníliás cukor
+it:zucchero vanigliato
+kk:ванильді қант
+nb:vaniljesukker
+pl:cukier waniliowy
+sv:vaniljsocker
+uk:ванільний цукор
+wikidata:en: Q3492989
+wikipedia:en: https://en.wikipedia.org/wiki/Vanilla_sugar
+
+< en:Sugar
+en:wheat syrup
+da:hvedesirup
+fi:vehnäsiirappi
+fr:sirop de blé
 
 < en:Sugar
 en:white sugar
@@ -66440,17 +69216,16 @@ hu:fehér cukor
 it:Zucchero bianco
 
 < en:Sugar
-fr:sirop de blé
+fr:mélasse de canne
+fi:ruokomelassi
 
 < en:Sugar
 fr:sirop de sucre de canne
+de:rohrzuckersirup
 fi:ruokosokerisiirappi
 
 < en:Sugar
 fr:sirop de sucre mélassé
-
-< en:Sugar
-fr:sirop de sucre partiellement inverti
 
 < en:Sugar
 fr:sucre blond
@@ -66474,9 +69249,6 @@ fr:sucre perlé
 fr:sucre semoule
 
 < en:Sugar
-fr:sucre vanillé
-
-< en:Sugar
 fr:sucre vanilline
 fi:vanilliinisokeri
 
@@ -66489,7 +69261,7 @@ nl:Arenga bossuiker
 en:sugar syrup
 de:Zuckersirup
 es:Sirope de azucar, jarabe de azucar
-fi:sokerisiirappi
+fi:sokerisiirappi, sokeriliemi
 fr:sirop de sucre
 hu:cukorszirup
 it:sciroppo di zucchero
@@ -66498,20 +69270,30 @@ pl:Syrop cukrowy
 pt:Xaropa de açúcar
 ro:sirop de zahăr, sirop de zahar
 ru:Сахарный сироп
+sv:sockersirap
 vegan:en: yes
 vegetarian:en: yes
 
+< en:Sugar syrup
+en:brown sugar syrup
+da:mørk sirup
+de:brauner zuckersirup
+fi:ruskea sokerisiirappi
+nb:mørk sirup
+sv:mörk sirap
+
 < en:Invert sugar
 < en:Sugar syrup
-en:invert sugar syrup, invert syrup, liquid invert syrup
+en:invert sugar syrup, invert syrup, liquid invert syrup, inverted syrup
 de:Invertzuckersirup
 es:Jarabe de azúcar invertido
-fi:inverttisokerisiirappi
+fi:inverttisokerisiirappi, inverttisokerisiirappia
 fr:sirop de sucre inverti, sucre liquide inverti, sirop de sucre inverti cristallisé
 hu:invert cukorszirup, invertcukor-szirup, glükóz-fruktóz szirup, fruktóz-glükóz-szirup
 it:sciroppo di zucchero invertito
 nl:Invertsuikerstroop
 ro:sirop de zahăr invertit, sirop de zahar invertit
+sv:invertsockersirap
 
 en:sulfite, Sulphites, sulphite, sulfites
 af:Sulfiet
@@ -66569,18 +69351,19 @@ fr:pétales de tournesol
 < en:Sunflower
 en:sunflower seed, sunflower seeds, sunflower kernels
 ca:llavors de gira-sol, pipes de gira-sol
-da:Solsikkekerner
+da:Solsikkekerner, solsikkefrø
 de:Sonnenblumenkerne
 es:semillas de girasol, pipas de girasol
-fi:auringonkukansiemen, auringonkukansiemenet
+fi:auringonkukansiemen, auringonkukansiemenet, auringonkukansiemeniä
 fr:graines de tournesol
 hu:napraforgómag
 it:semi di girasole
+nb:solsikkekjerner
 nl:zonnebloempitten
 nn:solsikkefrø
 pl:Nasiona słonecznika
 ru:Семена Подсолнечника
-sv:solrosfrön
+sv:solrosfrön, solrosfrö, solroskärna, solroskärnor
 nutriscore_fruits_vegetables_nuts:en: no
 
 < en:Sunflower lecithin
@@ -66659,12 +69442,13 @@ fi:kovettamaton auringonkukkaöljy, hydrogenoimaton auringonkukkaöljy
 fr:huile de tournesol non hydrogénée, huile végétale de tournesol non hydrogénée
 hu:nem hidrogénezett napraforgóolaj
 nl:zonnebloemolie ongehard
+sv:ohärdad solrosolja
 
 < en:Sunflower oil
 en:organic sunflower oil
 da:økologisk solsikkeolie
 de:biologische Sonnenblumöl
-fi:luomu auringonkukkaöljy
+fi:luomuauringonkukkaöljy, luomu auringonkukkaöljy
 fr:huile de tournesol bio
 hu:bio napraforgóolaj
 nl:olie van biologische zonnebloempitten, olie van biologisch zonnebloempitten, biozonnebloemolie, bio zonnebloemolie
@@ -66695,6 +69479,13 @@ fr:huile de tournesol vierge, huile de tournesol vierge première pression à fr
 
 < en:Sunflower oil
 fr:oléisol®
+
+< en:Flour
+< en:Sunflower seed
+en:sunflower seed flour
+fi:auringonkukansiemenjauho
+fr:farine de graines de tournesol
+sv:solrosfrömjöl
 
 < en:Sunflower seed
 en:shelled sunflower seeds
@@ -66735,10 +69526,18 @@ fr:bigarreaux confits
 en:sweet whey powder
 de:Süßmolkepulver, Süssmolkepulver, Sussmolkenpulver, Süssmolkenpulver, Süßmolkenpulver, Sußmolkenpulver
 es:suero de leche azucarado en polvo, lactosuero azucarado en polvo
+et:magus vadakupulber
 fi:makea herajauhe, makeutettu herajauhe
 fr:lactosérum doux en poudre, poudre de lactosérum sucré, petit-lait doux en poudre
-it:siero di latte in polvere
+it:siero di latte in polvere, siero di latte polvere
 nl:Zoete weipoeder
+ro:zer pudră îndulcit
+
+< en:Corn kernel
+< en:Sweetcorn
+fr:maïs doux en grains
+nl:zoete maïskorrels
+pt:milho doce em grão
 
 < en:Sweetened condensed milk
 en:sweetened condensed semi-skimmed milk
@@ -66771,7 +69570,7 @@ en:Sweetener, bulk sweetener, intense sweetener
 bg:Подсладител
 ca:Edulcorant, esdulcorants
 cs:Sladidlo
-da:Sødestoffer, sødemiddel
+da:Sødestof, Sødestoffer, Kunstigt sødemiddel, sødemiddel
 de:Süßungsmittel
 el:Γλυκαντικό
 es:Edulcorante, Endulzante, edulcorante intenso, edulcorante masivo, edulcorantes, endulzantes
@@ -66784,6 +69583,7 @@ it:Edulcorante, edulcoranti, dolcificante, dolcificanti
 lt:Saldiklis
 lv:Saldinātājs
 mt:Dolċifikant
+nb:Søtstoff
 nl:Zoetstof, Zoetstoffen
 pl:Substancja słodząca, Substancje słodzące
 pt:Edulcorante
@@ -66878,6 +69678,7 @@ ko:시럽
 la:Sirupus
 li:Sjroap
 lt:Sirupas
+nb:sirup
 nl:stroop, siroop
 nn:sirup
 pl:syrop
@@ -66899,11 +69700,37 @@ vegetarian:en: yes
 wikidata:en: Q6584340
 wikipedia:en: https://en.wikipedia.org/wiki/Syrup
 
+< en:Barley malt extract
+< en:Syrup
+en:barley malt syrup
+bn:বার্লি মল্ট সিরাপ
+cy:surop heiddfrag
+da:bygmaltsirup
+fa:شربت مالت جو
+fi:ohramallassiirappi
+fr:sirop d'orge malté
+wikidata:en: Q3485291
+wikipedia:en: https://en.wikipedia.org/wiki/Barley_malt_syrup
+
 < en:Rye
 < en:Syrup
 en:rye sirup
 et:odrasiirup
 hu:rozsszirup
+
+< en:Syrup
+en:sugar beet syrup
+de:Zuckerrübensirup
+fi:sokerijuurikassiirappi
+fr:sirop de betterave
+sv:sockerbetssirap
+
+< en:Tagliatelle
+en:cooked tagliatelle
+de:Tagliatelle gekocht, Bandnudeln gekocht
+fi:kypsennetty tagliatelle
+fr:tagliatelles cuites
+it:tagliatelle cotte
 
 en:tamarind
 af:Tamarinde
@@ -66976,16 +69803,21 @@ wikidata:en: Q28178875
 wikipedia:en: https://en.wikipedia.org/wiki/Tamarind
 
 < en:Tamarind
-nl:tamarindepuree, tamarinde-extract
+en:tamarind extract
 de:Tamarindenextrakt
 es:Extracto de tamarinado
 fi:tamarindiuute
 fr:extrait de tamarin
+nl:tamarinde-extract
+sv:tamarindextrakt
+
+< en:Tamarind
+nl:tamarindepuree
 
 < en:Modified starch
 < en:Tapioca starch
 en:modified tapioca starch, modified manioc starch
-da:Tapiocastivelse
+da:modificeret tapiokastivelse
 de:modifizierte Tapiokastärke
 es:almidón modificado de tapioca
 fi:muunnettu tapiokatärkkelys
@@ -66995,6 +69827,7 @@ it:amido modificato di tapioca
 nl:gemodificeerd tapiocazetmeel
 pl:Skrobia modyfikowana z tapioki
 pt:amido modificado de tapioca
+sv:modifierad tapiokastärkelse, modifierad tapioka stärkelse
 
 en:tapioca syrup
 fr:sirop de tapioca
@@ -67184,12 +70017,14 @@ wikipedia:en: https://en.wikipedia.org/wiki/Green_tea
 < en:Tea
 en:tea extract
 af:swart tee
+da:te-ekstrakt
 de:Tee-Extrakt
 es:Extracto de té
 fi:teeuute
 fr:extrait de thé, extraits de thé
 it:estratto di tè
-sr:ekstrakt čaja # sr-el:ekstrakt čaja
+sr:ekstrakt čaja
+sv:te-extrakt
 
 < en:Tea
 en:tea from Ceylon
@@ -67215,6 +70050,7 @@ en:Hom Mali rice, thai hom mali rice
 de:Hom Mali
 fr:riz thaï Hom Mali, Hom Mali
 nl:Hom Mali
+sv:thai hom mali
 
 < en:Thai long grain rice
 en:organic Thai long grain white rice
@@ -67239,6 +70075,7 @@ fi:pitkäjyväinen jasmiiniriisi
 fr:riz thai long grain, riz long grain thai, riz long thai, Riz long grain de Thailande
 hu:hosszú szemű jázminrizs, hosszú szemű jázmin rizs
 nl:Langkorrelige Thaise rijst
+sv:långkornigt jasminris
 
 < en:Thai rice
 fr:riz rouge complet thaï au jasmin
@@ -67370,12 +70207,12 @@ en:Thickener, bodying agent, texturizing agent, thickener synergist
 bg:Сгъстител
 ca:Espessidor, texturitzant, espessidors, agent espessidor, agents espessidors, espessant, espessants
 cs:Zahušťovadlo
-da:Sødestof, fortykningsmiddel, fortykningsmidler
+da:Fortykningsmiddel, Fortykningsmidler
 de:Verdickungsmittel
 el:Πυκνωτικό μέσο
 es:Espesante, agente de soporte, agente texturizador, agentes texturizadores, aglutinante, sinergista espesante, espesantes, agente espesante, agentes espesantes
 et:Paksendaja, Paksendajad
-fi:Sakeuttamisaine, Sakeuttamisainetta, Sakeuttamisaineet, Sakeuttamisaineita
+fi:Sakeuttamisaine, Sakeuttamisainetta, Sakeuttamisaineet, Sakeuttamisaineita, luonnollinen sakeutusaine
 fr:Épaississant, agent de texture, épaississan synergiste, raffermissant, agent épaississant, agents épaississants
 ga:Tiúsóir
 hu:Sűrítőanyag
@@ -67383,6 +70220,7 @@ it:Addensante, addensanti, agente addensante, agenti addensanti
 lt:Tirštiklis
 lv:Biezinātājs
 mt:Aġent li jgħaqqad
+nb:Fortykningsmiddel
 nl:Verdikkingsmiddel, Verdikkingsmiddelen
 pl:Substancja zagęszczająca, Substancje zagęszczające
 pt:Espessante
@@ -67390,7 +70228,7 @@ ro:Agent de îngroșare
 ru:Загуститель
 sk:Zahusťovadlo
 sl:Sladilo
-sv:Förtjockningsmedel
+sv:Förtjockningsmedel, naturlig förtjockningsmedel
 description:cs: Zahušťovadly se rozumějí látky, které zvyšují viskozitu potraviny.
 description:da: Fortykningsmidler: stoffer, der øger en fødevares viskositet.
 description:de: Verdickungsmittel sind Stoffe, die die Viskosität eines Lebensmittels erhöhen.
@@ -67544,7 +70382,7 @@ it:pomodorini, pomodorini ciliegia
 nl:kerstomaatjes, cherry tomaat, cheryytomaatjes, cherrytomaten
 nn:cocktailtomater
 pt:tomates cerejas, tomates cereja
-sv:cherrytomater, cocktailtomater
+sv:körsbärstomater, cherrytomater, cocktailtomater
 
 < en:Tomato
 en:chopped tomatoes
@@ -67556,6 +70394,7 @@ fi:pilkottu tomaatti, pilkotut tomaatit
 fr:tomate concassée, tomates concassées, concassé de tomates
 hu:szeletelt paradicsom
 it:pomodori tritati
+nb:hakkede tomater
 nl:Gehakte tomaten
 pl:krojane pomidory
 sk:krájané rajčiny
@@ -67631,6 +70470,7 @@ fi:tomaattimehu, tomaattitäysmehu
 fr:jus de tomate, Jus de tomates
 hu:paradicsomlé
 it:succo di pomodoro
+nb:tomatjuice
 nl:tomatensap
 pl:Sok pomidorowy
 ru:Томатный сок
@@ -67647,24 +70487,26 @@ fi:tomaattijauhe, tomaattijauhetta, tomaattisosejauhe
 fr:tomate en poudre, tomates en poudre, tomate déshydratée, poudre de tomate, poudre de tomates
 it:pomodoro en polvere
 nl:tomatenpoeder
-sv:tomatpulver
+sv:tomatpulver, tomatpurépulver
 
 < en:Tomato
 en:tomato purée, tomato paste, tomato concentrate
 ca:Llet en pols
-da:tomatpuré, tomatkoncentrat
+da:tomatpuré, tomatpure, tomatkoncentrat
 de:Tomatenmark, konzentriertes Tomatenpüree, Tomatenkonzentrat, Tomatenmarkkonzentrat, Tomatenpüree
 es:concentrado de tomate, pasta de tomate
-fi:tomaattipyree, tomaattipyre, tomaattitahna, tomaattitiiviste
+et:tomatipüree
+fi:tomaattipyree, tomaattipyre, tomaattitahna, tomaattitiiviste, tomaattisose
 fr:Purée de tomate, concentré de tomate, concentré de tomates, pâte de tomate, purée de tomates
 he:מחית עגבניות
 hu:paradicsompüré, paradicsomszósz
 it:passata di pomodoro, concentrato di pomodoro
+nb:tomatpuré
 nl:tomatenpurée, tomatenconcentraat, tomatenpuree
 pl:koncentrat pomidorowy
 pt:concentrado de tomate
-ru:Томатная паста
-sv:tomatpuré
+ru:Томатная паста, томатный концентрат
+sv:tomatpuré, tomatpyré, tomatpure, tomatkoncentrat, mosade tomater
 carbon_footprint_fr_foodges_ingredient:fr: Sauce tomate
 carbon_footprint_fr_foodges_value:fr: 2.9
 
@@ -67672,6 +70514,7 @@ carbon_footprint_fr_foodges_value:fr: 2.9
 fr:coulis de tomates, coulis de tomate
 de:Passierte Tomaten
 es:tomates tamizados
+fi:Tomaattikastike
 it:passata di pomodoro, concentrato di pomodoro
 nl:gezeefde tomaten
 nn:mosede tomater
@@ -67713,14 +70556,14 @@ fr:pulpe de tomates avec morceaux et purée de tomates
 en:concentrated tomato purée
 de:konzentriertes Tomatenmark, Tomatenpüreekonzentrat
 es:tomate-concentrado
-fi:tiivistetty tomaattipyree
+fi:tiivistetty tomaattipyree, tiivistettyä tomaattipyreetä
 fr:purée de tomate concentrée, purée de tomates concentrée, purée de tomates concentrées
 hu:sűrített paradicsompüré, sűrített paradicsom, paradicsom (sűrítmény), paradicsom (sűrítményből)
 sv:koncentrerad tomatpuré
 
 < en:Tomato purée
 en:double concentrated tomato
-da:dobbelt koncentreret tomatpuré
+da:dobbelt tomatkoncentrat, dobbelt koncentreret tomatpuré
 de:Tomatenkonzentrat zweifach konzentriert, Tomatenmark doppelt konzentriert
 es:tomate doble concentrado, concentrado doble de tomate
 fi:tuplatiivistetty tomaattipyree
@@ -67811,6 +70654,50 @@ carbon_footprint_fr_foodges_ingredient:fr: Truite d'élevage, entière
 carbon_footprint_fr_foodges_value:fr: 4.9
 wikidata:en: Q187986
 wikipedia:en: https://en.wikipedia.org/wiki/Rainbow_trout
+
+< en:Truffle
+en:black truffle
+ca:tòfona negra
+cy:Cloronen Ffrengig
+de:Schwarze Trüffel
+es:trufa negra
+eu:Boilur beltz
+fi:mustatryffeli
+fr:truffe noire, truffes noires
+hu:Francia szarvasgomba
+it:Tartufo nero
+kk:Жерқұлақ
+nl:zwarte truffel
+pl:trufla czarnozarodnikowa
+ro:Trufă neagră franceză
+ru:Трюфель чёрный
+sr:Crna gomoljača
+sv:Perigordtryffel
+tr:Perigord trüfü
+zh:黑松露
+
+< en:Truffle
+en:summer truffle
+az:Yay dombalanı
+be:Труфля летняя
+bg:Летен трюфел
+cs:lanýž letní
+cy:Cloren foch
+de:Sommer-trüffel
+et:Suvetrühvel
+eu:Udako boilur
+fi:kesätryffeli
+fr:truffle d'été, tuber aestivum
+hu:Nyári szarvasgomba
+it:Tartufo Scorzione
+lt:Vasarinis trumas
+nl:Zomertruffel
+pl:trufla letnia
+ru:Трюфель летний
+sv:Sommartryffel
+uk:Трюфель літній
+wikidata:en: Q74692
+wikipedia:en: https://en.wikipedia.org/wiki/Tuber_aestivum
 
 < en:Tub gurnard
 en:Trigla lucerna
@@ -67977,13 +70864,15 @@ fr:viande séparée mécaniquement de dinde
 it:carne di tacchino separata meccanicamente
 
 < en:Turkey meat
-en:turkey breast, turkey fillet
+en:turkey breast, turkey fillet, turkey breast meat
+da:kalkunbryst
 de:Putenfilet
 es:pechuga de pavo
-fi:kalkkunanfilee, kalkkunan filee
+fi:kalkkunanfilee, kalkkunan filee, kalkkuna filee, kalkkunanrinta, kalkkunan rintaliha
 fr:filet de dinde, filets de dinde, blanc de dinde, blancs de dinde
 it:Filetto di tacchino
 nl:Kalkoenfilet
+sv:kalkonbröst
 carbon_footprint_fr_foodges_ingredient:fr: Blanc de dinde
 carbon_footprint_fr_foodges_value:fr: 6.5
 
@@ -68029,6 +70918,15 @@ en:Paratapes undulatus
 de:Paratapes undulatus
 fr:Paratapes undulatus
 la:Paratapes undulatus, Paphia undulata
+
+< en:Unrefined cane sugar
+en:demerara sugar
+ca:sucre demerara
+de:demerara-zucker, demerera-zucker
+fi:demerarasokeri
+fr:sucre demerara
+sv:demerarasocker
+wikidata:en: Q837194
 
 < en:Unrefined cane sugar
 fr:sucre roux de canne en poudre, Cassonade Pure Canne, Sucre de canne complet en poudre, sucre en poudre pur canne
@@ -68105,7 +71003,7 @@ it:vaniglia Bourbon
 en:vanilla extract
 ca:extracte de vainilla
 cs:Vanilkový výtažek
-da:Vaniljeessens
+da:vaniljeekstrakt, vaniljeessens
 de:Vanilleextrakt, Vanille Extrakt
 es:extracto de vainilla
 fi:vaniljauute
@@ -68120,14 +71018,16 @@ sv:vaniljextrakt
 
 < en:Vanilla
 en:vanilla pod, vanilla pods
+da:vaniljestang, vaniljestænger
 de:Vanilleschoten
 es:vainas de vainilla, vaina de vainilla
-fi:vaniljatanko
+fi:vaniljatanko, vaniljapapu
 fr:gousse de vanille, gousses de vanille, écorce de vanille
 it:baccelli di vaniglia
 nl:vanillestokje, vanillestokjes
+pl:laski wanilii
 pt:vagem de baunilha
-sv:vaniljstång
+sv:vaniljstång, vaniljböna
 carbon_footprint_fr_foodges_ingredient:fr: Gousse de Vanille
 carbon_footprint_fr_foodges_value:fr: 2.6
 
@@ -68145,11 +71045,13 @@ sv:vaniljpulver
 
 < en:Vanilla
 en:vanilla seeds
+da:vaniljekorn
 de:Vanilleschoten
 es:Semillas de vainilla
-fi:vaniljan siemenet
+fi:vaniljansiemen, vaniljan siemenet
 fr:graines de vanille
 it:semi di vaniglia
+sv:vaniljfrö
 
 < en:Vanilla
 fr:vanille naturelle
@@ -68157,7 +71059,7 @@ fi:luontainen vanilja
 
 < en:Bourbon vanilla
 < en:Vanilla extract
-en:Bourbon Vanille Extrakt
+en:bourbon vanilla extract
 cs:extrakt z burbonské vanilky
 da:bourbon vaniljeekstrakt
 de:Bourbon Vanille Extrakt, Vanille-Extrakt Bourbon, Bourbon Vanilleextrakt, Bourbonvanilleextrakt
@@ -68205,9 +71107,9 @@ hu:természetes vanília aroma
 it:aroma naturale di vaniglia, aroma naturale vaniglia
 nb:naturlig vanilijarom
 nl:natuurlijk vanillearoma
-pl:naturalny aromat wanilii
+pl:naturalny aromat wanilii, naturalny aromat waniliowy
 pt:aroma de baunilha natural, aromatizante de baunilha natural
-sv:naturlig vanilijarom
+sv:naturlig vaniljarom, naturlig vanilijarom
 vegan:en: yes
 vegetarian:en: yes
 
@@ -68224,11 +71126,13 @@ de:Vanilleschotenpulver
 
 < en:Vanilla pod
 en:ground vanilla beans, vanilla bean pieces
+da:formalede vaniljestænger
 de:Vanilleschoten gemahlen, Vannileschoten gemahlen, vermahlene Vanilleschoten
 fi:vaniljatangon palat, vaniljakodat
 fr:gousses de vanille moulues, gousses de vanille broyées
 it:semi di vaniglia macinat
-sv:vaniljstångbitar
+pl:kawałki wanilii
+sv:mald vaniljstång, vaniljstångbitar
 
 < en:Vanilla pod
 fr:gousse de vanille épuisée, gousses de vanille épuisées
@@ -68260,7 +71164,7 @@ eo:Vanilino
 es:vainillina
 eu:Bainilina
 fa:وانیلین
-fi:Vanilliini
+fi:vanilliini, vaniliini
 fr:vanilline, arôme vanilline
 he:ונילין
 hu:vanillin, vanillin aroma
@@ -68884,11 +71788,13 @@ fr:Muscat sec
 < en:Meat
 < en:Veal
 en:veal meat
+da:kalvekød
 de:Kalbsfleisch
 es:carne de ternera
 fi:vasikanliha
 fr:viande de veau
 hu:borjúhús
+sv:kalvkött
 carbon_footprint_fr_foodges_ingredient:fr: Viande de veau France
 carbon_footprint_fr_foodges_value:fr: 20.5
 
@@ -68898,7 +71804,7 @@ cs:Zelenina
 da:Grøntsag
 de:Gemüse
 es:verduras, hortalizas, vegetal, vegetales
-fi:kasvis
+fi:vihannes, kasvis, kasvikset
 fr:légume, légumes
 he:ירק
 hr:Povrće
@@ -69251,6 +72157,7 @@ pl:Awokado
 pt:abacate
 ru:авокадо
 sk:avokádo
+sv:avokado
 te:అవోకాడో
 vo:Avokaado
 carbon_footprint_fr_foodges_ingredient:fr: Avocat
@@ -69365,7 +72272,7 @@ an:Pimiento
 ar:فلفل حلو
 ca:Pebrot morro de bou
 cs:kapie
-da:paprika
+da:paprika, peberfrugt
 de:peberfrugt, Paprika
 eo:Kapsiko
 es:Pimiento, morrón, Pimiento morrón
@@ -69514,7 +72421,7 @@ ca:Col
 da:kål
 de:Kohl
 es:Col, repollo, berza
-fi:kaali
+fi:kaali, keräkaali
 fr:chou, choux
 hu:fejeskáposzta
 it:cavolo
@@ -69544,6 +72451,7 @@ it:cavolfiore
 nl:bloemkool
 pl:kalafior
 ru:цветная капуста
+sv:blomkål
 te:గోబీ పుష్పం
 zh:花椰菜
 carbon_footprint_fr_foodges_ingredient:fr: Chou-Fleur
@@ -69565,7 +72473,7 @@ bs:Celer
 ca:Api
 cs:Miřík celer, celer
 cy:Seleri
-da:selleri
+da:selleri, sellerie
 de:Sellerie, Staudensellerie
 el:Σέλινο
 eo:celerio
@@ -69648,7 +72556,7 @@ eo:Folibeto
 es:Acelgas
 eu:Zerba
 fa:برگ چغندر
-fi:mangoldi, lehtimangoldi
+fi:mangoldi, lehtimangoldi, lehtijuurikas
 fr:blette, Blettes
 ga:Biatas bán
 gl:Acelga
@@ -69699,10 +72607,10 @@ de:Peperoni, chilischoten, Pfefferoni, Chili, Piment
 el:Τσίλι
 eo:Kapsiketo
 es:guindilla, ají, chile, pimenton picante, pimiento picante
-et:tšilli
+et:tšilli, tšillipipar
 eu:Pipermin
 fa:فلفل تند
-fi:chili
+fi:chili, chilipippuri, chilipaprika
 fr:chili, piment du chili, piment, piments
 gl:Chile
 gn:Ky'ỹi
@@ -69756,7 +72664,7 @@ so:Besbaas
 sq:specë e djegëst
 sr:Čili
 su:Cabé
-sv:chilipeppar
+sv:chilipeppar, fefferoni
 ta:பச்சை மிளகாய்
 te:మిరపకాయ
 th:พริก
@@ -69788,7 +72696,7 @@ es:calabacín, cucurbita pepo
 et:puhmik-õlikõrvits
 eu:kuiatxo
 fa:کدو تخم پوست کاغذی
-fi:kesäkurpitsaa
+fi:kesäkurpitsa, kesäkurpitsaa
 fr:courgette
 ga:cúirséad
 ha:kabewa
@@ -69853,7 +72761,7 @@ ar:الخيار
 bg:краставица, Корнишон
 ca:cogombre
 cs:Okurek
-da:agurk
+da:agurk, agurker
 de:Gurke
 el:Αγγούρι
 eo:serpentkukumo
@@ -69870,7 +72778,7 @@ nb:agurk
 nl:komkommer, komkommers
 nn:agurk
 nv:Taʼneeskʼání áłtsʼóózígíí
-pl:Ogórek
+pl:Ogórek, ogórki
 pt:pepino
 ro:Castravete
 ru:огурец
@@ -69944,10 +72852,6 @@ pl:Endywia kędzierzawa
 sv:Frisésallat
 wikidata:en: Q2963415
 wikipedia:fr: https://fr.wikipedia.org/wiki/Chicorée_frisée
-
-< en:Fruit
-< en:Vegetable
-fr:fruits et légumes concentrés, concentrés de fruits et de légumes
 
 < en:Vegetable
 en:green tomato
@@ -70076,7 +72980,7 @@ ca:Radicchio
 da:radicchio
 de:Chicorée rot, Radicchio
 eo:salatcikorio
-fi:punasikuri
+fi:punasikuri, punasalaatti
 fr:chicorée rouge, Radicchio, trévise, salade trévise
 hu:Vörös cikória
 it:Radicchio
@@ -70086,8 +72990,9 @@ nl:Roodlof
 pt:Radicchio
 ru:радиккьо
 sh:Radiccio di Treviso
-sv:Radicchiosallad
+sv:Radicchiosallad, rosensallat, rosésallat
 wikidata:en: Q767765
+wikipedia:en: https://en.wikipedia.org/wiki/Radicchio
 
 < en:Vegetable
 en:Red kuri squash
@@ -70185,7 +73090,7 @@ en:salad
 da:Salat
 de:Salat
 es:Ensalada
-fi:salaatti
+fi:salaatti, salaatit
 fr:salade
 hu:saláta, kerti saláta
 it:Insalata
@@ -70316,6 +73221,7 @@ iu:ᒥᓗᑦᓱᑳᒐᖅ
 ln:Tomáti
 mg:Voatabia
 ml:തക്കാളി
+nb:tomat, tomater
 nl:tomaat, tomaten
 nn:tomat, tomater
 oc:Tomata
@@ -70342,15 +73248,30 @@ carbon_footprint_fr_foodges_value:fr: 0.5
 wikidata:en: Q20638126
 
 < en:Vegetable
+en:vegetable blend, vegetable mix
+fi:vihannessekoitus, kasvissekoitus
+fr:mélange de légumes
+sv:grönsaksmix
+
+< en:Vegetable
+en:vegetable concentrate, vegetable concentrates
+da:grøntsagskoncentrat
+fi:kasvistiiviste, kasvistiivisteet
+fr:concentré de légumes, concentrés de légumes
+sv:grönsakskoncentrat
+
+< en:Vegetable
 en:vegetable juice
-da:Grøntsagsjuice
+da:Grøntsagsjuice, grøntsagssaft
 de:Gemüsesaft
 es:Zumo vegetal, caldo vegetal
 fi:kasvismehu
 fr:Jus de légumes
 it:succo di verdura
+nb:grønnsaksjuice
 nl:Groentensap
 ru:Овощной сок
+sv:grönsaksjuice
 
 < en:Vegetable
 en:vegetables in variable proportion
@@ -70385,23 +73306,20 @@ zh:西洋菜
 wikipedia:en: https://en.wikipedia.org/wiki/Watercress
 
 < en:Vegetable
-fr:concentré de légumes
-
-< en:Vegetable
-fr:concentrés de légumes
-fi:kasvitiiviste
-
-< en:Vegetable
 fr:extrait de légumes, extraits de légumes
-fi:kasviuute, kasviuutteet
+fi:vihannesuute, kasvisuute
 
 < en:Vegetable
 fr:jus de légumes concentrés
-fi:kasvimehutiiviste
+da:grøntsagssaftkoncentrat
+fi:vihannesmehutiiviste, kasvimehutiiviste, kasvismehutiivisteet
+nb:grønnsaksjuicekonsentrat
+sv:grönsaksjuicekoncentrat
 
 < en:Vegetable
 fr:légume déshydraté, légumes déshydratés, légumes séchés
-fi:kuivatut kasvikset
+fi:kuivatut vihannekset, kuivatut kasvikset
+sv:torkade grönsaker
 
 < en:Vegetable
 fr:légumes et jus de cuisson de légumes
@@ -70412,8 +73330,16 @@ fr:légumes frais
 < en:Vegetable
 fr:légumes verts
 
-< en:Vegetable
-fr:mélange de légumes
+< en:Fruit concentrates
+< en:Vegetable concentrate
+en:fruit and vegetable concentrates, vegetable and fruit concentrates
+da:frugt- og grøntsagskoncentrater
+de:obst- und gemüsekonzentrate
+es:concentrados de frutas y vegetales
+fi:hedelmä- ja kasvistiivisteet, kasvis- ja hedelmätiivisteet
+fr:fruits et légumes concentrés, concentrés de fruits et de légumes
+nl:groente- en fruitconcentraten
+sv:frukt- och grönsakskoncentrat
 
 < en:Vegetable extract
 fr:extraits végétaux à pouvoir colorant
@@ -70426,15 +73352,18 @@ es:Grasa vegetal hidrogenada
 fi:kovetettu kasvirasva, hydrogenoitu kasvirasva
 fr:graisse végétale hydrogénée, matière grasse végétale hydrogénée, graisses végétales hydrogénées
 hu:hidrogénezett növényi zsír
+sv:härdat vegetabiliskt fett
 
 < en:Vegetable fat
 en:coconut fat
+da:kokosfedt
 de:Kokosfett
 es:Grasa de coco, grasa vegetal de coco, manteca de coco
-fi:kookosrasva
+fi:kookosrasva, kookosrasvaa
 fr:matière grasse de noix de coco, graisse de noix de coco, graisse de coco, matière grasse végétale de coprah, matière grasse de coprah
 hu:kókuszzsír
 it:grasso di cocco
+sv:kokosfett
 from_palm_oil:en: no
 
 < en:Vegetable fat
@@ -70453,9 +73382,10 @@ en:non-hydrogenated vegetable fats, non-hydrogenated vegetable fat
 de:ungehärtete Pflanzenfette
 fi:kovettamattomat kasvirasvat, kovettamaton kasvirasva, hydrogenoimattomat kasvirasvat, hydrogenoimaton kasvirasva
 fr:matières grasses végétales non hydrogénées, matière grasse végétale non hydrogénée, graisses végétales non hydrogénées
+sv:ej härdade vegetabilisk fetter
 
 < en:Vegetable fat
-en:shea butter
+en:shea butter, shea
 ak:Nkuto
 ar:زبدة الشيا
 bg:Масло от ший
@@ -70463,7 +73393,7 @@ de:Shea Butter, Sheabutter, Shea
 el:λίπος shea
 eo:karitea butero
 es:manteca de karité, grasa de karite, karite
-fi:karitevoi, sheavoi, shea
+fi:karitevoi, sheavoi, shea, karite, sheaydin
 fr:beurre de karité, matière grasse de karité, karité, graisses végétales de karité, huile de karité, huile végétale de karité, huiles végétales de karité
 he:חמאת שיאה
 hr:shea maslac
@@ -70479,7 +73409,7 @@ ro:unt de shea
 ru:Масло дерева ши
 sk:Bambucké maslo
 sl:Karitejevo maslo
-sv:Sheasmör
+sv:Sheasmör, shea
 th:เนยเชีย
 zh:乳木果油
 from_palm_oil:en: no
@@ -70499,6 +73429,8 @@ fr:matières grasses végétales de colza, matières grasses de colza
 
 < en:Vegetable fat
 fr:préparation de matières grasses végétales
+fi:kasvirasvavalmiste
+sv:vegetabilisk fettprodukt
 
 < en:Apple
 < en:Vegetable fiber
@@ -70529,13 +73461,13 @@ nl:erwtenvezel
 ro:fibre de mazare
 
 < en:Vegetable fiber
-en:Psyllium, plantago
+en:Psyllium, plantago, psyllium fibre
 ar:بزر قطونة
 da:Psyllium
 de:Psyllium
 es:Psilio, plantago
 fa:بارهنگ کتانی
-fi:Psyllium
+fi:psyllium, psylliumkuitu
 fr:fibres de psyllium, psyllium
 he:פסיליום
 hi:isabgol
@@ -70545,21 +73477,33 @@ pl:Babka
 ro:Psyllium
 ru:Подорожник
 sd:اسپنگر
-sv:Loppfrö
+sv:Loppfrö, psylliumfiber
 ta:Isabgol
 uk:Подорожник
 ur:اسپغول
 wikidata:en: Q15258700
 wikipedia:en: https://en.wikipedia.org/wiki/Psyllium
 
+< en:Vegetable fiber
+en:sugar beet fibre, sugar beet fiber
+da:sukkerroefiber
+de:zuckerrübenfaser
+fi:sokerijuurikaskuitu
+fr:fibre de betterave sucrière
+it:fibra de barbabietola
+nb:sukkerbetefiber
+nl:suikerbietvezel
+sv:sockerbetsfiber
+
 < en:Vegetable
 < en:Vegetable fiber
 fr:fibres de légume
-fi:kasvikuitu, kasvikuidut
+fi:kasviskuitu
 
 < en:Vegetable fiber
 < en:Wheat
 en:wheat fiber
+da:hvedefibre
 de:Weizenfasern
 es:fibras de trigo
 fi:vehnäkuitu
@@ -70569,7 +73513,7 @@ it:fibre di frumento
 nl:tarwevezel
 pt:fibras de trigo
 ru:Пшеничные волокна
-sv:Vete fiber
+sv:vetefiber, Vete fiber
 
 < en:Lemon
 < en:Vegetable fiber
@@ -70593,6 +73537,7 @@ hu:zabrost
 it:fibra d'avena
 nl:havervezel
 pt:fibra de aveia
+sv:havrefiber
 
 < en:Pineapple
 < en:Vegetable fiber
@@ -70604,6 +73549,7 @@ fr:fibres d'ananas
 hu:ananászrost
 it:fibre d'ananas, fibre di ananas
 nl:ananasvezels
+sv:ananasfiber
 
 < en:Carrot
 < en:Vegetable juice
@@ -70629,6 +73575,7 @@ ru:морковный сок
 sa:गृञ्जनकरसः
 sl:Korenčkov sok
 sq:leng me karrota
+sv:morotsjuice
 ta:கேரட் சாறு
 th:น้ำแคร์รอต
 zh:胡萝卜汁
@@ -70694,6 +73641,7 @@ hi:नारियल तेल
 hr:Kokosovo ulje
 hu:kókuszolaj
 id:Minyak kelapa
+is:kókosolía
 it:olio di cocco
 ja:ヤシ油
 kn:ಕೊಬ್ಬರಿ ಎಣ್ಣೆ
@@ -70858,7 +73806,7 @@ pt:óleo de linhaça
 ro:Ulei de in
 ru:Льняное масло
 sl:Laneno olje
-sv:Linolja
+sv:Linolja, linfröolja
 te:అవిసె నూనె
 th:น้ำมันเมล็ดฝ้าย
 tr:Keten yağı
@@ -71116,6 +74064,11 @@ en:Shorea robusta seed oil, Shorea robusta oil, Sal tree oil, Sal oil
 es:Aceite de shorea robusta, aceite de sal
 fr:Huile de sal, huile végétale de sal
 it:Olio di shorea robusta
+kn:ಅಶ್ವಕರ್ಣ ಎಣ್ಣೆ
+te:సాల్‌సీడ్ నూనె
+from_palm_oil:en: no
+wikidata:en: Q15087371
+wikipedia:en: https://en.wikipedia.org/wiki/Shorea_robusta_seed_oil
 
 < en:Vegetable oil
 en:soya oil, Soybean oil, soy oil
@@ -71146,7 +74099,7 @@ nl:sojaolie
 pl:olej sojowy
 pt:óleo de soja
 ru:Соевое масло
-sv:Sojaolja
+sv:Sojaolja, sojaböns olja
 uk:Соєва олія
 zh:大豆油
 from_palm_oil:en: no
@@ -71168,7 +74121,7 @@ es:aceite de girasol, aceite vegetal de girasol, aceite de semillas de girasol
 et:Päevalilleõli
 eu:ekilore-olio
 fa:روغن آفتاب‌گردان
-fi:auringonkukkaöljy
+fi:auringonkukkaöljy, auringonkukkaöljyä
 fr:huile de tournesol, huile de graines de tournesol, huile tournesol, huile végétale de tournesol, graisses végétales de tournesol
 gl:Aceite de xirasol
 he:שמן חמניות
@@ -71183,6 +74136,7 @@ ko:해바라기 기름
 lt:Saulėgrąžų aliejus
 mk:Сончогледово масло
 mr:Minyak bunga matahari
+nb:solsikkeolje
 nl:zonnebloemolie
 nn:solsikkeolje
 pl:Olej słonecznikowy
@@ -71282,7 +74236,9 @@ fi:rapsiöljy, rapsirasva, rapsiöljy ja -rasva
 fr:Huile de colza ou canola
 he:שמן לפתית
 hu:repcemagolajak, repcemagzsír
+is:repjuolía
 it:Olio di colza
+nb:rapsolje
 nl:Koolzaadolie, plantaardige koolzaadolie, raapzaad, raap
 pl:Olej rzepakowy, olej roślinny rzepakowy
 ru:Рапсовое масло
@@ -71297,18 +74253,22 @@ da:vegetabilsk fedt
 de:pflanzliche Fette, pflanzliches Fett
 el:φυτικά λίπη
 es:grasas vegetales, grasa vegetal
-fi:kasvirasva, kasvirasvat, kasvisrasva, kasvisrasvat
-fr:matière grasse végétale, matières grasses végétales, matière graisse végétale, graisse végétale, graisses végétales
+fi:kasvirasva, kasvirasvat, kasvisrasva, kasvisrasvat, kasvisrasvoja, kasvirasvoja, kasvisrasvasta
+fr:matière grasse végétale, matières grasses végétales, matière graisse végétale, graisse végétale, graisses végétales, grasse végétale
 hu:növényi zsír, növényi zsírok
-is:jurtafeiti
+is:jurtafeiti, jurtafeta
 it:grassi vegetali
+lt:augaliniai riebalai
+lv:augu tauki
+nb:vegetabilsk fett, vegetabilskt fett
 nl:plantaardige vetten
 nn:vegetabilisk fett
-pl:Tłuszcz roślinny
+pl:tłuszcz roślinny, tłuszcze roślinne
 pt:gordura vegetal, gorduras vegetais, matérias gordas vegetais
 ro:grăsime vegetală
 ru:растительные жиры
-sv:vegetabiliska fetter
+sk:rastlinný tuk
+sv:vegetabiliska fetter, vegetabiliskt fett, vegetabilsk fett, vegetabilisk fett
 
 < en:Vegetable oil and fat
 en:vegetable oil, vegetal oil, vegetal oils, vegetable oils
@@ -71319,14 +74279,14 @@ be:Алеі
 bg:Растително масло
 ca:Oli vegetal
 cs:Rostlinný olej
-da:vegetabilisk olie
+da:vegetabilsk olie, vegetabilisk olie, vegetabilske olier
 de:Pflanzenöle, pflanzliche Öle, pflanzliches Öl
 eo:Legoma oleo
 es:Aceite vegetal, aceites vegetales
 et:Taimeõli
 eu:Landare-olio
 fa:دانه‌های روغنی
-fi:kasviöljy, kasviöljyt
+fi:kasviöljy, kasviöljyt, kasviöljyjä
 fr:huile végétale, huiles végétales, huiles végétale, huile végétales
 gl:Aceite vexetal
 he:שמן מן הצומח
@@ -71341,6 +74301,7 @@ ky:Өсүмдүк майлары
 ml:സസ്യ എണ്ണകൾ
 mr:वनस्पती तूप
 ms:Minyak sayur
+nb:vegetabilsk olje, vegetabilisk olje
 nl:plantaardige olie, Spijsolie
 nn:vegetabilisk olie
 pl:Oleje roślinne
@@ -71349,7 +74310,7 @@ ro:Ulei vegetal, uleiuri vegetale
 ru:растительные масла, Растительное масло
 sh:Biljno ulje
 sr:Биљно уље
-sv:
+sv:vegetabilisk olja, vegetabiliska oljor
 th:น้ำมันพืช
 tr:Bitkisel yağ
 uk:Рослинні жири й олії
@@ -71361,15 +74322,31 @@ wikipedia:en: https://en.wikipedia.org/wiki/Vegetable_oil
 de:Eiweißpulver aus Sonnenblumenkernen
 
 < en:Vegetable protein
+en:broad bean protein
+fi:härkäpapuproteiini
+fr:protéine de fèves, protéines de fèves
+sv:protein från bondböna
+
+< en:Vegetable protein
 en:hydrolysed vegetable protein, HVP, vegetable hydrolysed proteins
-de:hydrolysiertes Pflanzenprotein
-es:Proteina vegetal hidrolizada
-fi:kasviproteiinihydrosylaatti
+da:hydrolyseret vegetabllsk protein. hydrolysert vegetabilsk protein
+de:hydrolysiertes Pflanzenprotein, aufgeschlossenes Pflanzeneiweiß
+es:Proteina vegetal hidrolizada, hidrolizado de proteína vegetal
+fi:hydrolysoitu kasviproteiini, kasviproteiinihydrosylaatti
 fr:protéine végétale hydrolysée, protéines végétales hydrolysées
 hu:hidrolizált növényi fehérjék, hidolizált növényi fehérje
-nl:gehydroliseerde plantaardige eiwit
+nb:hydrolysert vegetabilsk protein
+nl:gehydroliseerde plantaardige eiwit, gehydroliseerd plantaardig eiwit
 pl:Hydrolizowane białko roślinne
+sv:hydrolyserat vegetabiliskt protein, hydroliserat vegetabiliskt protein
 zh:酸水解植物蛋白
+
+< en:Vegetable protein
+en:oat protein
+de:haferprotein
+fi:kauraproteiini
+fr:protéine d'avoine, protéines d'avoine
+sv:havreprotein
 
 < en:Vegetable protein
 en:pea protein
@@ -71383,7 +74360,19 @@ it:proteine di piselli
 nl:boneneiwit
 pl:Białko grochu
 ru:Гороховый протеин
-sv:Ärtprotein
+sv:Ärtprotein, protein från ärtor
+
+< en:Vegetable protein
+en:potato protein
+de:kartoffelprotein
+fi:perunaproteiini
+fr:protéine de pomme de terre, protéines de pomme de terre
+
+< en:Vegetable protein
+en:rapeseed protein
+fi:rapsiproteiini
+fr:protéine de colza, protéines de colza
+sv:rapsprotein
 
 < en:Vegetable protein
 en:wheat protein
@@ -71395,6 +74384,7 @@ hu:búzafehérje
 it:proteine del grano
 nl:graneneiwit
 pt:proteína de trigo
+sv:veteprotein
 
 < en:Vegetable protein
 fr:protéines de blé
@@ -71402,6 +74392,14 @@ fr:protéines de blé
 < en:Vegetable protein
 fr:protéines végétales réhydratées
 hu:rehidratált növényi fehérjék
+
+< en:Reindeer
+< en:Venison
+en:reindeer meat, caribou meat
+fi:poronliha
+fr:viande de renne
+sv:renkött
+wikidata:en: Q10650944
 
 < en:Verbena
 en:organic verbena
@@ -71436,7 +74434,7 @@ it:foglie di vite
 vegan:en: yes
 vegetarian:en: yes
 
-en:vinegar
+en:vinegar, white vinegar
 af:Asyn
 an:Vinagre
 ar:خل
@@ -71596,6 +74594,7 @@ fi:mallasetikka
 fr:vinaigre de malt
 hu:malátaecet
 nl:Moutazijn
+sv:maltvinäger
 
 < en:Vinegar
 en:red wine vinegar
@@ -71607,6 +74606,7 @@ fr:vinaigre de vin rouge
 hu:vörösborecet
 it:aceto di vino rosso
 nl:rode wijnazijn
+sv:rödvinsvinäger
 
 < en:Vinegar
 en:rice vinegar
@@ -71615,7 +74615,7 @@ de:Reisessig
 el:ξύδι ρυζιού
 eo:rizvinagro
 es:vinagre de arroz
-fi:riisietikka
+fi:riisiviinietikka, riisietikka
 fr:vinaigre de riz
 gl:Vinagre de arroz
 he:חומץ אורז
@@ -71627,6 +74627,7 @@ ko:쌀식초
 nl:rijstazijn
 pl:Ocet ryżowy
 ru:Рисовый уксус
+sv:risvinäger, risvinvinäger
 uk:Рисовий оцет
 zh:米醋
 wikidata:en: Q1849012
@@ -71655,13 +74656,19 @@ it:aceto da tavola
 nl:tafelazijn
 
 < en:Vinegar
+en:tarragon vinegar
+da:estragoneddike
+de:estragonessig
+fi:rakuunaetikka
+fr:vinaigre à l'estragon
+sv:dragonvinäger
+
+< en:Vinegar
 en:vinegar powder
 de:Essigpulver
 es:vinagre en polvo
+fi:etikkajauhe
 fr:Poudre de vinaigre
-
-< en:Vinegar
-en:white vinegar
 
 < en:Vinegar
 en:wine vinegar
@@ -71677,7 +74684,7 @@ nl:wijnazijn
 pl:Ocet winny
 pt:vinagre de vinho
 ru:Винный уксус
-sv:vinsvinäger
+sv:vinsvinäger, vinättika, vinäger av vin
 carbon_footprint_fr_foodges_ingredient:fr: Vinaigre de vin
 carbon_footprint_fr_foodges_value:fr: 4.2
 
@@ -71698,14 +74705,15 @@ fr:huile de coco vierge biologique, huile vierge de noix de coco bio
 < en:Virgin olive oil
 en:extra virgin olive oil
 ca:Oli d'oliva verge extra, oli OVE
-da:ekstra jomfruolivenolie
+da:ekstra jomfruolivenolie, ekstra jomfru olivenolie
 de:natives Olivenöl Extra, Olivenöl nativ extra
 es:aceite de oliva virgen extra
-fi:ekstra-neitsytoliiviöljy
+fi:ekstra-neitsytoliiviöljy, ekstraneitsytoliiviöljy
 fr:huile d'olive extra vierge, huile d'olive vierge extra, huile d'olive vierge extra extraite à froid, huile d'olive de catégorie supérieure obtenue directement des olives et uniquement par des procédés mécaniques, huile extra vierge d'olive
 hu:extra szűz olívaolaj, extraszűz olívaolaj
 it:olio d'oliva extra vergine, olio extravergine di oliva, olio di oliva extra vergine, olio extra vergine di oliva, olio extra vergine d'oliva
 nl:olijfolie extra vierge, extra olijfolie van de eerste persing
+sv:extra jungfru olivolja, olivolja extra virgin, extra jungfruolja, extra fin olivolja, extra virgin olivolja, extra jungfruolivolja
 
 < en:Vitamin A
 en:retinol
@@ -71850,7 +74858,7 @@ cs:kyanokobalamin
 el:κυανοκοβαλαμίνη
 es:cianocobalamina
 et:tsüanokobalamiin
-fi:syaanikobalamiini
+fi:syanokobalamiini
 fr:cyanocobalamine
 hu:cianokobalamin
 it:cianocobalamina
@@ -72003,7 +75011,7 @@ lv:holekalciferols, D3 vitamīns
 mn:Д3 витамин
 ms:Kolekalsiferol, Vitamin D3
 mt:kolekalċiferol
-nb:vitamin D3
+nb:kolekalsiferol, vitamin D3
 nl:Cholecalciferol, vitamine D3
 nn:kolekalciferol, kolekalsiferol, vitamin D3, D3-vitamin
 oc:Cholecalciferol, Vitamina D3
@@ -72538,6 +75546,7 @@ bs:Vitamin B5
 ca:àcid pantotènic, vitamina B5, B5
 cs:Kyselina pantothenová, vitamín B5, B5
 cy:Asid pantothenig, Fitamin B5, B5
+da:Pantotensyre, Pantothensyre
 de:Pantothensäure, Vitamin B5, B5
 dv:ވިޓަމިން ބީ5
 el:Παντοθενικό οξύ
@@ -72878,7 +75887,7 @@ sl:Vitamin D
 sq:Vitamina D
 sr:витамин Д
 su:Vitamin D
-sv:vitamin D
+sv:D-vitamin, vitamin D
 ta:உயிர்ச்சத்து டி
 te:విటమిన్ డి
 tg:Витамини D
@@ -73074,7 +76083,7 @@ et:Vesi
 eu:Ur
 fa:آب
 ff:Ndiyam
-fi:Vesi
+fi:vesi, vettä
 fo:Vatn
 fr:eau
 fy:Wetter
@@ -73206,7 +76215,7 @@ ee:Gaseeritud vesi, karboniseeritud vesi, mulliga vesi
 el:Σόδα
 eo:Karbonata akvo
 es:Agua carbonatada
-fi:Soodavesi
+fi:soodavesi, hiilihapotettu vesi
 fr:Eau gazeuse, eau acidulée, eau effervescente, eau pétillante, eau gazéifiée, soda club, soda nature, eau gazéifié, eau gazéfiée
 he:מי סודה
 hr:Gazirana voda
@@ -73232,7 +76241,7 @@ ro:Sifon, Apa carbonatată, apa gazoasă, sifonul
 ru:Газированная вода
 si:Sifon, Apa carbonatată, apa gazoasă, sifonul
 sr:Сода вода
-sv:Bordsvatten
+sv:Bordsvatten, kolsyrat vatten
 ta:சோடா நீர்
 th:โซดา
 tr:Soda, sodalı su, karbonatlı su
@@ -73384,7 +76393,7 @@ eo:Mineralakvo
 es:Agua mineral
 et:Mineraalvesi
 fa:آب معدنی
-fi:Kivennäisvesi
+fi:kivennäisvesi, mineraalivesi
 fr:eau minérale
 ga:Uiscí mianraí
 gl:Auga mineral
@@ -73608,6 +76617,7 @@ it:Semolina
 nl:gries
 oc:Semola
 pl:Kasza manna
+sv:semolinagryn
 vegan:en: yes
 vegetarian:en: yes
 
@@ -73619,20 +76629,25 @@ fi:vehnälese
 fr:son de blé, son de froment
 hu:búzakorpa
 it:crusca di frumento
+nb:hvetekli
 nl:tarwezemelen
 pt:farelo de trigo
+sv:vetekli
 
 < en:Wheat
 en:wheat flakes
 ca:flocs de blat
 de:Weizenflocken
 es:copos de trigo
+et:nisuhelbed
 fi:vehnähiutale
 fr:flocons de blé, flocon de blé
 hu:búzapelyhek
 it:fiocchi di frumento
+nb:hveteflak
 nl:tarwevlokken
 pl:płatki pszenne
+sv:veteflingor
 
 < en:Wheat
 en:wheat germ, wheatgerm
@@ -73642,13 +76657,16 @@ fi:vehnänalkio
 fr:germe de blé, germes de blé
 hu:búzacsíra
 it:germi di frumento
+nb:hvetekim
 nl:tarwekiem
 pl:kielki pszenicy
 pt:gérmen de trigo
+sv:vetegroddar
 wikipedia:en: https://en.wikipedia.org/wiki/Cereal_germ#Wheat_germ
 
 < en:Wheat
 en:whole wheat, whole grain wheat
+da:fuldkornshvede
 de:Vollkornweizen
 el:Σίτος ολικής αλέσεως
 es:trigo integral
@@ -73656,9 +76674,11 @@ fi:täysjyvävehnä
 fr:blé complet
 hu:teljes kiőrlésű búza
 it:frumento integrale
+nb:sammalt hvete
 nl:volkorentarwe
 pl:pszenica z pełnego przemiału
 pt:trigo integral
+sv:fullkornsvete
 zh:全麥小麥
 
 < en:Wheat
@@ -73704,6 +76724,11 @@ ro:făină albă
 de:Weizenquellmehl
 
 < en:Wheat flour
+en:dark wheat flour, yeast bread wheat flour
+fi:hiivaleipäjauho, tumma vehnäjauho, hiivaleipävehnäjauho, vehnähiivaleipäjauho
+sv:jästbrödsvetemjöl, vetejästbrödmjöl
+
+< en:Wheat flour
 en:dextrinated wheat flour
 de:dextriniertes Weizenmehl
 es:harina de trigo dextrinada
@@ -73720,27 +76745,30 @@ fr:farine de blé dur
 hu:durumbúzaliszt
 it:farina di grano duro
 nl:durum tarwemeel
-sv:durumvetemjöl
+sv:durumvetemjöl, mjöl av durumvete
 
 < en:Wheat flour
 en:fortified wheat flour, enriched wheat flour
 de:angereichertes Weizenmehl
 es:Harina de trigo fortificada
-fi:rikastettu vehnäjauho
+fi:rikastettu vehnäjauho, vitaminoitu vehnäjauho
 fr:farine de blé enrichie
 it:farina di frumento fortificada
 nl:verrijkt tarwebloem
 pl:Wzbogacona mąka pszenna
+sv:berikat vetemjöl
 
 < en:Wheat flour
 en:malted wheat flour
+da:hvedemaltmel
 de:gemaltzen Weizenmehl, Weizenmalzmehl, Weizenrostmalzmehl
 es:harina de trigo malteada
-fi:mallastettu vehnäjauho
-fr:farine de blé maltée, fr:farine de blé fermenté, farine de blé malté, farine de malt, farine de malt de froment
+fi:vehnämallasjauho, mallastettu vehnäjauho
+fr:farine de blé maltée, farine de blé fermenté, farine de blé malté, farine de malt de froment
 hu:búzamaláta liszt
 it:farina di grano maltato
 nl:gemout tarwemeel
+sv:vetemaltmjöl
 
 < en:Wheat flour
 en:wheat flour type 0, flour type 0
@@ -73783,7 +76811,7 @@ fr:farine mi-blanche
 < en:Wholemeal flour
 en:whole wheat flour
 ca:farina integral
-da:Fuldkornsmel
+da:hvedefuldkornsmel
 de:Vollkornweizenmehl, Weizenvollkornmehl
 es:harina de trigo integral, harina integral de trigo
 fi:täysjyvävehnäjauho
@@ -73792,7 +76820,7 @@ hu:teljes kiőrlélsű búzaliszt
 it:farina integrale di frumento, farina di frumento integrale
 nl:volkorentarwemeel
 pt:farinha de trigo integral, farinha integral de trigo
-sv:fullkornsvetemjöl
+sv:fullkornsvetemjöl, grahamsmjöl av vete
 
 < en:Wheat gluten
 fr:gluten vital de blé
@@ -73814,8 +76842,27 @@ fr:protéine de blé hydrolysée, protéines de blé hydrolysées
 hu:hidrolizált búzafehérje
 nl:gehydroliseerd tarwe-eiwit
 
+< en:Wheat protein
+en:rehydrated wheat protein
+fi:vedellä turvotettu vehnäproteiini
+fr:protéines de blé réhydratees, protéine de blé réhydratees
+sv:rehydrerat veteprotein
+
+< en:Wheat protein
+en:textured wheat protein
+da:textureret hvedeprotein
+fr:protéines de blé texturées
+
 < en:Wheat semolina
 fr:semoule de blé tendre
+
+< en:Wheat sourdough
+fr:levain de blé déshydraté
+es:masa madre deshidratada de trigo
+fi:kuivattu vehnätaikinanjuuri
+
+< en:Wheat sourdough
+fr:levain de blé dévitalisé
 
 < en:Modified starch
 < en:Wheat starch
@@ -73827,6 +76874,7 @@ fr:amidon modifié de blé, amidon transformé de blé
 hu:módosított búzakeményítő
 it:amido modificato de fromento
 nl:gemodificeerd tarwezetmeel
+sv:modifierad vetestärkelse
 
 < en:Modified starch
 < en:Wheat starch
@@ -73853,11 +76901,16 @@ en:Concentrated whey
 ca:sèrum de la llet concentrat
 de:konzentrierte Molke
 es:lactosuero concentrado, suero de la leche concentrado
-fi:heratiiviste
+fi:heratiiviste, herakonsentraatti
 fr:lactosérum concentré
 hu:sűrített tejsavó
 it:siero di latte concentrato
 nl:Geconcentreerde wei
+sv:vasslekoncentrat
+
+< en:Whey
+en:condensed whey
+fi:kondensoitu hera
 
 < en:Whey
 en:Demineralised whey
@@ -73887,21 +76940,28 @@ es:permeado de suero
 fi:herapermeaatti, maitopermeaatti
 fr:perméat de petit lait
 nl:melkweipermeaat
+sv:vasslepermeat
 
 < en:Whey
 en:whey powder, powdered whey
 ca:Xerigot en pols, sèrum en pols
-da:Vallepulver
+cs:sušená syrovátka
+da:Vallepulver, vallepulver af mælk
 de:Molkenpulver, Molkepulver
 es:suero de leche en polvo
-fi:herajauhe
+et:vadakupulber
+fi:herajauhe, herajauhetta, herajauho
 fr:lactosérum en poudre, petit-lait en poudre, sérum de lait en poudre, poudre de lactosérum
 hu:tejsavópor, savópor, étkezési savópor
-it:siero di latte in polvere
+is:mysuduft
+it:siero di latte in polvere, siero di latte polvere
+nb:mysepulver, mysepulver av melk
 nl:weipoeder, wei poeder
-pl:Serwatka w proszku
+pl:Serwatka w proszku, preparat serwatkowy
 pt:soro de leite em pó
-sv:vasslepulver
+ru:сухая молочная сыворотка
+sk:sušená srvátka
+sv:vasslepulver, vasslepulver från mjölk
 vegan:en: no
 vegetarian:en: maybe
 
@@ -73958,6 +77018,7 @@ de:konzentriertes Molkeprotein
 fi:heraproteiinikonsentraatti
 fr:concentré de protéines de lactosérum, concentré de protéines de sérum
 hu:sűrített savófehérje, sűrített tejsavófehérje
+sv:vassleproteinkoncentrat
 
 < en:Whey protein
 en:whey protein isolate, whey isolate
@@ -73967,6 +77028,11 @@ fi:heraproteiini-isolaatti
 fr:Isolat de protéine de lactosérum
 hu:izolált savófehérje, izolált tejsavófehérje, savófehérje izolátum, tejsavófehérje izolátum
 wikidata:en: Q7993541
+
+< en:Whipping cream
+en:pasteurized whipping cream
+fi:pastöroitu kuohukerma
+sv:pastöriserad vispgrädde
 
 < en:Whiskey
 en:Irish whiskey
@@ -74083,6 +77149,7 @@ es:pimienta blanca molida
 fi:valkopippurijauhe, jauhettu valkopippuri
 fr:poivre blanc moulu
 nl:gemalen witte peper
+sv:mald vitpeppar, vitpepparpulver
 
 < en:Red quinoa
 < en:White quinoa
@@ -74147,6 +77214,7 @@ fi:valkoviiniuute
 fr:extrait de vin blanc
 hu:fehérbor kivonat
 it:estratto di vino bianco
+sv:vitvinsextrakt
 
 < en:White wine
 en:white wine from cava
@@ -74348,8 +77416,10 @@ nl:kipheeleipoeder
 
 < en:Whole wheat
 en:whole wheat groats
-fi:täysjyvävehnärouhe
+da:groftmalet fuldkornshvedemel
+fi:täysjyvävehnärouhe, täysjyvävehnärouhetta
 hu:teljes kiőrlésű búzadara
+sv:fullkornsvetekross
 
 < en:Mild yogurt
 < en:Whole yogurt
@@ -74357,19 +77427,44 @@ en:mild whole yogurt
 de:Sahnejoghurt mild, Rahmjoghurt mild
 fr:yaourt doux entier
 
+< en:Wholemeal barley
+en:whole grain barley flakes, wholegrain barley flakes
+de:vollkorn-gerstenflocken, vollkorngerstenflocken
+fi:täysjyväohrahiutale
+fr:flocons d'orge complète
+sv:fullkornskornflingor
+
+< de:Getreideflocken
+< en:Wholemeal cereal
+en:wholemeal cereal flakes
+fi:täysjyvähiutaleet, täysjyvähiutale
+fr:flocons de céréales complètes
+sv:fullkornsflingor
+
 < en:Rye flour
 < en:Wholemeal flour
-en:wholemeal rye flour
+en:wholemeal rye flour, wholegrain rye flour
+da:fuldkornsrugmel, fullkornsrugmel
 de:Roggenvollkornmehl
 es:flor de harina integral de centeno, harina integral de centeno
 fi:täysjyväruisjauho, täysjyväruisjauhoa
 fr:farine de seigle complète, farine complète de seigle
 hu:teljes kiőrlésű rozsliszt
+it:farina di segale integrale
+nb:fullkornsrugmel
 nl:volkoren roggemeel
+pt:farinha integral de centeio
+sv:fullkornsrågmjöl, fullkornsmjöl av råg
 
 < en:Wholemeal rye
 de:Roggenvollkornschrot, Roggenvollkornflocken
 fi:täysjyväruishiutale
+
+< en:Wholemeal rye
+en:wholemeal rye groats
+da:groftmalet fuldkornsrugmel
+fi:täysjyväruisrouhe, täysjyväruisrouhetta
+sv:fullkornsrågkross
 
 < en:Malt
 < en:Wholemeal rye flour
@@ -74472,7 +77567,7 @@ ru:красное вино
 sh:Crno vino
 sk:víno červené
 sr:Црно вино
-sv:Rött vin
+sv:rödvin, rött vin
 ta:திராட்சைச் செங்கள்
 tr:Kırmızı şarap
 uk:Червоне вино
@@ -74652,9 +77747,10 @@ sv:vitvinsvinäger
 < en:With other natural flavouring
 fr:arômes naturels d'orange avec autres arômes naturels, arôme naturel d'orange avec autres arômes naturels
 de:natürliches Orangenaroma mit anderen natürlichen Aromen
-fi:luontainen appelsiiniaromi ja muut luontaiset aromit
+fi:luontainen appelsiiniaromi ja muita luontaisia aromeja, luontainen appelsiiniaromi ja muut luontaiset aromit, luontainen appelsiiniaromi joka sisältää muita luontaisia aromeja
 nl:natuurlijk sinaasappelaroma met andere natuurlijke aroma's
 pl:naturalny aromat pomarańczowy z innymi naturalnymi aromatami
+sv:naturlig apelsinarom med andra naturliga aromer
 
 en:yeast
 af:Gis
@@ -74669,7 +77765,7 @@ bs:Kvasci
 ca:Rent, llevat
 cs:Kvasinky
 cy:Burum
-da:Gærsvamp
+da:gær, gærsvamp
 de:Hefe, Hefen
 el:Ζυμομύκητες
 eo:Gisto
@@ -74735,11 +77831,6 @@ wikidata:en: Q45422
 wikipedia:en: https://en.wikipedia.org/wiki/Yeast
 
 < en:Yeast
-de:Nährhefe
-fr:levure alimentaire
-it:lievito alimentare
-
-< en:Yeast
 de:Trockenhefe
 fr:levure sèche
 it:lievito secco
@@ -74802,6 +77893,23 @@ fr:levure naturelle
 it:naturale-fermento, lievito naturale
 
 < en:Yeast
+en:nutritional yeast
+ar:رقائق الخميرة المغذية
+de:nährhefe
+eo:nutra gisto
+fi:ravintohiiva
+fr:levure alimentaire
+id:ragi nutrisional
+it:lievito alimentare
+nl:edelgist
+pl:drożdże odżywcze
+ru:пищевые дрожжи
+sv:näringsjäst, bjäst
+uk:харчові дріжджі
+wikidata:en: Q1786540
+wikipedia:en: https://en.wikipedia.org/wiki/Nutritional_yeast
+
+< en:Yeast
 en:yeast extract
 bs:ekstrakt kvasca
 ca:Extracte de llevat
@@ -74818,9 +77926,10 @@ hu:élesztőkivonat
 it:estratto di lievito
 ja:酵母エキス
 lt:mieliu ekstraktas
+nb:gjærekstrakt
 nl:gistextract
 nn:gjærekstrakt
-pl:ekstrakt drożdżowy
+pl:ekstrakt drożdżowy, ekstrakt z drożdży
 pt:extrato de levedura
 ro:extract de drojdie
 ru:Дрожжевой экстракт
@@ -74834,11 +77943,11 @@ wikipedia:en: https://en.wikipedia.org/wiki/Yeast_extract
 
 < en:Yeast
 en:yeast powder, raising powder
-da:Tørret gær
+da:tørgær, tørret gær
 de:Hefepulver
 el:μαγιά σκόνη
 es:levadura en polvo
-fi:hiivajauhe
+fi:kuivahiiva, hiivajauhe
 fr:poudre de levure, levure en poudre, poudres levantes, poudres à lever, poudre levante
 hu:porélesztő, élesztőpor
 it:lievito in polvere
@@ -74846,7 +77955,7 @@ nl:gistpoeder
 pl:Drożdże w proszku
 pt:levedura em pó
 ru:Дрожжевой порошок
-sv:jästpulver
+sv:torrjäst, jästpulver
 
 < en:Yeast extract
 en:yeast extract powder
@@ -74879,6 +77988,7 @@ es:yogur en polvo
 fi:jogurttijauhe
 fr:yaourt en poudre
 hu:joghurtpor
+sv:yoghurtpulver
 
 < en:Yogurt
 en:mild yogurt
@@ -75190,6 +78300,10 @@ zh:硫酸锌
 fr:sirop d'agave concentré biologique
 es:jarabe de ágave concentrado ecológico
 
+fi:omenavalmiste
+fr:préparation à base de pommes
+sv:äpple preparat
+
 fr:additifs alimentaires
 
 fr:agent crémeux
@@ -75198,8 +78312,10 @@ fr:agent crémeux
 < fr:Ail séché
 en:rehydrated garlic
 de:Rehydrierter Knoblauch
+fi:rekombinoitu valkosipuli
 fr:ail réhydraté
 it:Aglio reidrataro
+sv:rehydrerad vitlök
 
 < en:Modified starch
 < fr:Amidon de maïs cireux
@@ -75268,15 +78384,6 @@ fr:compote de pommes allégée en sucres
 < fr:Concentré de carotte et de citrouille
 de:Färbende Konzentrate Karotte und Kürbis
 
-< fr:Concentrés de fruits
-en:fruit and plant concentrates
-de:Frucht- und Pflanzenkonzentrate
-es:Concentrado de frutas y plantas
-fi:hedelmä- ja kasvitiiviste, hedelmä- ja kasvitiivisteet
-fr:concentré de fruits et de plantes, concentrés de fruits et de plantes
-it:concentrati di frutta e plante
-nl:vruchten- en plantenconcentraten
-
 fr:confiserie
 
 fr:conservateur de surface
@@ -75293,6 +78400,7 @@ fr:crème pâtissière
 < en:Turkey meat
 < fr:Cuisse de dinde
 fr:viande de cuisse de dinde
+de:putenoberkeulenfleisch
 
 fr:d'élevage en plein air
 de:aus Freilandhaltung
@@ -75328,6 +78436,7 @@ nl:Koolzuurhoudend Spa natuurlijk mineraalwater
 
 fr:éclats de caramel
 de:Caramelstücke
+fi:toffeepala
 
 fr:éclats de caramel au beurre salé
 
@@ -75337,6 +78446,7 @@ it:fiocchi di Hüppen
 
 < fr:Éclats de noisettes
 fr:éclats de noisettes caramélisés
+fi:karamellisoidut hasselpähkinät
 
 
 fr:extrait de bœuf
@@ -75348,21 +78458,7 @@ fr:préparation à base de filets de poulet traités en salaison
 
 fr:filets de maquereaux cuits au court-bouillon
 
-< en:Malt
-< fr:Flocons de seigle
-fr:flocons de seigle malté
-
 fr:foie
-
-< fr:Foie de boeuf
-en:calf's liver
-ca:fetge de vedella, foie de vedella
-de:kalbsleber
-es:higado de ternera, foie de ternera
-fi:vasikanmaksa
-fr:foie de veau
-hu:borjúmáj
-it:fegato di maiale
 
 < fr:Foie gras de canard
 fr:foie gras de canard du sud-ouest
@@ -75374,6 +78470,82 @@ fi:pakastekuivattu mansikka paloina
 
 fr:friture
 
+< en:Berries
+< en:Fruit
+< fr:Fruits des bois
+en:blackcurrant
+da:solbær
+de:schwarze Johannisbeere, schwarze Johannisbeeren
+es:grosella negra, grosellas negras
+fi:mustaherukka, mustaherukkaa, mustaviinimarja, mustaviinimarjaa
+fr:cassis
+hu:fekete ribizli
+it:ribes nero, ribes neri
+nb:solbær
+nl:zwarte bes, cassisbessen
+pt:groselha negra
+sv:svarta vinbär, svartvinbär, svart vinbär
+zh:黑加伦
+wikidata:en: Q146604
+wikipedia:en: https://en.wikipedia.org/wiki/Blackcurrant
+
+< en:Berries
+< en:Fruit
+< fr:Fruits des bois
+en:raspberry, raspberries
+af:Framboos
+an:Chordón
+ar:عليق
+br:Flamboez
+bs:Malina
+ca:Gerd
+cs:Malina
+cy:Mafon cochion
+da:hindbær
+de:Himbeeren, Himbeere
+eo:Frambo
+es:frambuesa
+fa:تمشک
+fi:vadelma
+fr:framboise
+ga:Sú craobh
+gd:Sùbh-craoibh
+hi:रसभरी
+ht:Franbwaz
+hu:málna
+hy:Ազնվամորի
+io:Frambo
+it:lamponi, lampone
+ja:ラズベリー
+kk:Таңқурай
+kn:ರಾಸ್‍ಬೆರಿ
+ko:라즈베리
+kv:Ӧмидз
+lo:ໝາກຟະລຳບວດ
+lt:Avietė
+mk:Малина
+mr:रास्पबेरी
+ms:Raspberi
+mt:Lampuna
+nl:framboos, frambozen
+nn:bringebær
+nv:Dzidzé łikaní dinilchííʼígíí
+pl:maliny
+pt:framboesas
+ru:Малина
+sd:راسپ بيري
+sk:Malina
+sr:Малина
+sv:hallon
+sw:Mrasiberi
+ta:ராஸ்பெரி
+te:కోరిందపండు
+th:แรสเบอร์รี
+tl:Prambuwesas
+ty:Rahipere
+uz:Malina
+zh:樹莓
+
 < en:Elder
 < fr:Fruits des bois
 en:elderberry
@@ -75384,6 +78556,7 @@ fi:seljanmarja
 fr:baie de sureau, baies de sureau
 it:sambuco
 nl:vlierbes
+sv:fläderbär
 
 < fr:Fumet de poisson
 fr:fumet de poisson aromatisé
@@ -75411,15 +78584,6 @@ de:gemahlene extrahierte Vanilleschoten, extrahierte gemahlene Vanilleschoten
 it:baccelli di vaniglia curati macinati
 nl:gemalen geëxtraheerde vanillestokjes
 
-< fr:Grains de maïs
-fr:grains de maïs à éclater
-
-< en:Sweetcorn
-< fr:Grains de maïs
-fr:maïs doux en grains
-nl:zoete maïskorrels
-pt:milho doce em grão
-
 fr:Gratinage
 
 < fr:Haricot mungo
@@ -75431,6 +78595,14 @@ fr:haricots mogettes de Vendée, mogettes de Vendée
 < fr:Haricots verts coupés
 < fr:Haricots verts très fins
 fr:haricots vertes très fins coupés, haricots verts extra fines coupés
+
+< fr:Huile végétale hydrogénée
+en:fully hydrogenated vegetable oils
+da:helt hærdet vegetabilsk olie
+fi:kokonaan kovetetut kasviöljyt
+fr:huiles végétales totalement hydrogénées
+nb:fullherdet vegetabilske oljer
+sv:fullhärdade vegetabiliska oljor
 
 fr:Ile flottante sur lit de crème anglaise
 
@@ -75462,33 +78634,12 @@ fi:mandariinimehutiiviste, mandariinitäysmehutiiviste
 fr:Jus de mandarine concentré
 ru:Концентрированный мандариновый сок
 
-< fr:Jus de sureau
-fr:jus de sureau concentré, jus concentré de sureau
-de:konzentrierter Holundersaft
-
-< fr:Jus de sureau concentré
-fr:jus de sureau à base de concentré
-de:Holundersaft aus Konzentrat
-fi:seljanmarjamehu tiivisteestä
-it:succo di sambuco a base di concentrato
-
-< fr:Lait de noix de coco en poudre
-fr:lait de coco reconstitué
-
 < fr:Lait demi écrémé uht
 fr:lait de montagne demi écrémé stérilisé uht
 
 ca:llet en pols condensada, llet condensada en pols
 es:leche en polvo condensada, leche condensada en polvo
 nl:gecondenseerde magere poedermelk
-
-< fr:Levain de blé
-fr:levain de blé déshydraté
-es:masa madre deshidratada de trigo
-fi:kuivattu vehnätaikinanjuuri
-
-< fr:Levain de blé
-fr:levain de blé dévitalisé
 
 < fr:Longe de porc
 fr:longe de porc traitée en salaison
@@ -75529,8 +78680,9 @@ fr:matière grasse de lait anhydre
 < fr:Mélange de salades
 fr:salade mélangée verte et rouge
 
-fr:mélasse de sucre de canne, mélasse de canne
-fi:ruokomelassi
+fr:mélasse de sucre de canne
+fi:ruokosokerimelassi
+sv:rörsockermelass
 
 
 < fr:Miel crémeux
@@ -75609,9 +78761,8 @@ fr:oeufs de lompe noirs
 < fr:Œufs de lompe
 fr:oeufs de lompe rouges
 
-< en:Category A eggs
 < fr:Œufs de poules élevées en cage
-fr:oeufs de poules élevées en cage de categorie a
+fi:virikehäkkikanan muna, virikehäkkikanojen munia
 
 < fr:Œufs de poules élevées en cage
 fr:Oeufs frais datés du jour de ponte de poules élevées en cage
@@ -75638,6 +78789,7 @@ fi:täysjyvävehnähiutale
 fr:pétales de blé complet
 hu:teljes kiőrlésű búzapehely
 pt:flocos de trigo integral
+sv:fullkornsveteflingor, fullkorn veteflinga
 
 < fr:Petits pois doux
 fr:petits pois doux extra fins
@@ -75716,9 +78868,6 @@ fr:sirop d'amidon
 < fr:Sirop d'amidon
 fr:sirop d'amidon de maïs
 
-< fr:Sirop d'orge malté
-fr:sirop de malt d'orge déshydraté
-
 fr:sirop de candi, sirop de sucre candi
 
 fr:sous-produit du boeuf
@@ -75726,7 +78875,10 @@ fr:sous-produit du boeuf
 < fr:Steak haché
 fr:Steak haché pur boeuf, pure viande de boeuf hachée, viande hachée pur bœuf
 ca:stick tartar de vedella, stick tartar de res, filet mòlt de vedella, filet mòlt de res
+da:pandebøf
 es:stick tartar de ternera, stick tartar de res, filete picado de ternera, filete picado de res
+fi:naudan jauhelihapihvi
+sv:pannbiff
 
 fr:substitut du sel
 de:Speisesalzersatz
@@ -75764,11 +78916,6 @@ es:cerdo curado y precocido
 
 < fr:Viande de poulet traitée en salaison
 fr:viande de poulet traitée en salaison et précuite
-
-< fr:Viande hachée de bœuf
-fr:préparation viande hachée de boeuf
-ca:preparació de carn molta de res
-es:preparación de carne molida de res
 
 < nl:Vegetarisch weipoeder
 nl:gezoet vegetarisch weipoeder

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -25185,7 +25185,7 @@ da:Quinoa
 de:Quinoa
 el:Κινόα
 eo:Kvinoo
-es:quinua, quinoa real
+es:Quinoa, quinua, quinoa real
 et:kinoa, Tšiili hanemalts
 eu:Kinoa
 fa:کینوآ

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -41056,7 +41056,7 @@ fr:Jus concentré d'aronia
 
 <en:fruit
 en:acerola
-de:Acerolakirschen
+de:Acerolakirschen, acerola
 es:acerola
 fi:akerola, acerola
 fr:acérola


### PR DESCRIPTION
We have been historically quite aggressive when matching tags: if it did not match in the target language, we tried in some other languages. The risk of false positives was low, but as we have now very extended taxonomies, the risk of false positives is higher (and it is less useful because our data is cleaner).

This issue is to introduce stricter rules, so that we specify which site tries which language for only a very limited set of taxonomies:

"la" is Latin, it's quite useful for species in ingredients, and the mysterious "aqua" ingredient in beauty products :)

```perl
				if ($options{product_type} eq "food") {
				
					if ($tagtype eq "ingredients") {
						@test_languages = ("la");
					}
					elsif ($tagtype eq "additives") {
						@test_languages = ("en");
					}				
				}
				elsif ($options{product_type} eq "beauty") {
				
					# Beauty products ingredients are often in English
					if ($tagtype eq "ingredients") {
						@test_languages = ("en", "la");
					}
					elsif ($tagtype eq "additives") {
						@test_languages = ("en");
					}				
				}