### PR TITLE
Categories fix

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -69347,7 +69347,9 @@ ciqual_food_code:en:40601
 ciqual_food_name:en:Offal, cooked (average)
 ciqual_food_name:fr:Abat, cuit (aliment moyen)
 
-<en:Offals
+<en:offals
+en:kidneys
+
 <en:kidneys
 en:Cooked kidneys, Cooked kidney
 fr:Rognons cuits, Rognon cuit


### PR DESCRIPTION
Errors in the categories taxonomy definition:
3618
ERROR - en:cooked-rabbit-meat is a parent of itself
3619
ERROR - en:cooked-kidneys is a parent of itself
3620
ERROR - en:salad-without-dressing has an undefined parent
3621
Errors in the categories taxonomy definition at lib/ProductOpener/Tags.pm line 1608.
3622
[categories] child process exited with code 25