### PR TITLE
better percent parsing, fixes #3667

### DIFF
--- a/t/ingredients_percent.t
+++ b/t/ingredients_percent.t
@@ -411,8 +411,45 @@ my @tests = (
   }
 ]
 
-]
+],
 
+	[ { lc=>"es", ingredients_text=>"Leche. Cacao: 27% mínimo"},
+[
+  {
+    'id' => 'en:milk',
+    'percent_max' => 73,
+    'percent_min' => 73,
+    'text' => 'Leche'
+  },
+  {
+    'id' => 'en:cocoa',
+    'percent' => '27',
+    'percent_max' => 27,
+    'percent_min' => 27,
+    'text' => 'Cacao'
+  }
+]
+],
+
+	[ { lc=>"es", ingredients_text=>"Leche min 12.2%, Cacao: min 7%, Avellanas (mínimo 3%)"},
+[
+  {
+    'id' => 'en:milk',
+    'percent' => '12.2',
+    'text' => 'Leche'
+  },
+  {
+    'id' => 'en:cocoa',
+    'percent' => '7',
+    'text' => 'Cacao'
+  },
+  {
+    'id' => 'en:hazelnut',
+    'percent' => '3',
+    'text' => 'Avellanas'
+  }
+]
+],
 
 );
 


### PR DESCRIPTION
- Support for "some ingredient: min 10%" (previously we matched only "some ingredient: 10% min"
- Made a $percent_regexp to avoid repeating the same complex regexp 10 times
- Added some support for Spanish (e.g. "Cacao: 57% mínimo.")