### PR TITLE
Fix add_tags_to_field()

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -286,8 +286,6 @@ else {
 			add_tags_to_field($product_ref, $lc, $field, $additional_fields);
 
 			$log->debug("add_field", { field => $field, code => $code, additional_fields => $additional_fields, existing_value => $product_ref->{$field} }) if $log->is_debug();
-
-			compute_field_tags($product_ref, $lc, $field);
 		}
 
 		elsif (defined param($field)) {

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1196,7 +1196,6 @@ sub parse_ingredients_text($) {
 						if (exists_taxonomy_tag("labels", $label_id)) {
 							# Add the label to the product
 							add_tags_to_field($product_ref, $product_lc, "labels", $label_id);
-							compute_field_tags($product_ref, $product_lc, "labels");
 							$skip_ingredient = 1;
 							$ingredient_recognized = 1;
 						}

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -950,7 +950,6 @@ sub compute_data_sources($) {
 
 	if ((scalar keys %data_sources) > 0) {
 		add_tags_to_field($product_ref, "en", "data_sources", join(',', sort keys %data_sources));
-		compute_field_tags($product_ref, "en", "data_sources");
 	}
 }
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3407,14 +3407,15 @@ sub add_tags_to_field($$$$) {
 			$value = $product_ref->{$field};
 		}
 		(defined $value) or $value = "";
-
+		
 		$product_ref->{$field} = $value . ", " . join(", ", @added_tags);
+		
+		if ($product_ref->{$field} =~ /^, /) {
+			$product_ref->{$field} = $';
+		}
+		
+		compute_field_tags($product_ref, $tag_lc, $field);
 	}
-
-	if ($product_ref->{$field} =~ /^, /) {
-		$product_ref->{$field} = $';
-	}
-
 }
 
 

--- a/t/tags.t
+++ b/t/tags.t
@@ -547,4 +547,29 @@ is_deeply($product_ref->{categories_tags}, [
      'en:strawberries'
 ]) or diag explain $product_ref;
 
+$product_ref = {
+'categories' => "Plats pr\x{e9}par\x{e9}s, Plats pr\x{e9}par\x{e9}s au poisson, Plats \x{e0} base de p\x{e2}tes, Lasagnes pr\x{e9}par\x{e9}es, Plats au saumon, Lasagnes au saumon",
+'categories_lc' => 'fr',
+         'categories_tags' => [
+                                 'en:meals',
+                                 'en:pasta-dishes',
+                                 'en:prepared-lasagne',
+                                 'en:meals-with-fish',
+                                 'en:meals-with-salmon',
+                                 'en:salmon-lasagne'
+                               ],
+
+lc => 'fr',
+lang => 'fr',
+
+};
+
+add_tags_to_field($product_ref, "en", "categories", "Meals,Pasta dishes,Prepared lasagne,Meals with fish,Meals with salmon,Salmon lasagne");
+
+diag explain $product_ref;
+
+compute_field_tags($product_ref, "en", "categories");
+
+diag explain $product_ref;
+
 done_testing();

--- a/t/tags.t
+++ b/t/tags.t
@@ -524,5 +524,27 @@ is_deeply($product_ref->{categories_tags},  [
    ],
 ) or diag explain $product_ref;
 
+$product_ref = {
+	lc => "fr",
+	categories => "pommes, bananes, en:pears, fr:fraises, es:limones",
+};
+
+compute_field_tags($product_ref, "fr", "categories");
+
+is_deeply($product_ref->{categories_tags}, [
+     'en:plant-based-foods-and-beverages',
+     'en:plant-based-foods',
+     'en:fruits-and-vegetables-based-foods',
+     'en:fruits-based-foods',
+     'en:fruits',
+     'en:apples',
+     'en:berries',
+     'en:citrus',
+     'en:tropical-fruits',
+     'en:bananas',
+     'en:lemons',
+     'en:pears',
+     'en:strawberries'
+]) or diag explain $product_ref;
 
 done_testing();

--- a/t/tags.t
+++ b/t/tags.t
@@ -66,7 +66,29 @@ add_tags_to_field($product_ref, "fr", "categories", "pommes, bananes");
 is_deeply($product_ref,
 {
    'categories' => 'pommes, bananes',
-   'lc' => 'fr'
+   'lc' => 'fr',
+   'categories_hierarchy' => [
+     'en:plant-based-foods-and-beverages',
+     'en:plant-based-foods',
+     'en:fruits-and-vegetables-based-foods',
+     'en:fruits-based-foods',
+     'en:fruits',
+     'en:apples',
+     'en:tropical-fruits',
+     'en:bananas'
+   ],
+   'categories_lc' => 'fr',
+   'categories_tags' => [
+     'en:plant-based-foods-and-beverages',
+     'en:plant-based-foods',
+     'en:fruits-and-vegetables-based-foods',
+     'en:fruits-based-foods',
+     'en:fruits',
+     'en:apples',
+     'en:tropical-fruits',
+     'en:bananas'
+   ],
+
 }
 ) or diag explain $product_ref;
 
@@ -137,6 +159,7 @@ is_deeply($product_ref->{categories_tags},
    'en:bananas',
    'en:plums',
    'en:raspberries',
+   'en:strawberries',
  ]
 
 ) or diag explain $product_ref->{categories_tags};
@@ -161,11 +184,12 @@ is_deeply($product_ref->{categories_tags},
    'en:oranges',
    'en:plums',
    'en:raspberries',
+   'en:strawberries',
  ]
 
 ) or diag explain $product_ref->{categories_tags};
 
-is($product_ref->{categories}, "Alimentos y bebidas de origen vegetal, Alimentos de origen vegetal, Frutas y verduras y sus productos, Frutas y sus productos, Frutas, Manzanas, Frutas del bosque, Frutas tropicales, Plátanos, Ciruelas, Frambuesas, naranjas, limones");
+is($product_ref->{categories}, "Alimentos y bebidas de origen vegetal, Alimentos de origen vegetal, Frutas y verduras y sus productos, Frutas y sus productos, Frutas, Manzanas, Frutas del bosque, Frutas tropicales, Plátanos, Ciruelas, Frambuesas, Fresas, naranjas, limones");
 
 add_tags_to_field($product_ref, "it", "categories", "bogus, mele");
 compute_field_tags($product_ref, "it", "categories");
@@ -186,6 +210,7 @@ is_deeply($product_ref->{categories_tags},
    'en:oranges',
    'en:plums',
    'en:raspberries',
+   'en:strawberries',
    'it:bogus',
  ]
 
@@ -202,7 +227,30 @@ add_tags_to_field($product_ref, "fr", "countries", "france, en:spain, deutschlan
 is_deeply($product_ref,
 {
    'countries' => 'france, en:spain, deutschland, fr:bolivie, italie, de:suisse, colombia, bidon',
-   'lc' => 'fr'
+   'lc' => 'fr',
+   'countries_hierarchy' => [
+     'en:bolivia',
+     'en:colombia',
+     'en:france',
+     'en:italy',
+     'en:spain',
+     'en:switzerland',
+     'fr:bidon',
+     'fr:deutschland'
+   ],
+   'countries_lc' => 'fr',
+   'countries_tags' => [
+     'en:bolivia',
+     'en:colombia',
+     'en:france',
+     'en:italy',
+     'en:spain',
+     'en:switzerland',
+     'fr:bidon',
+     'fr:deutschland'
+   ],
+
+
 }) or diag explain($product_ref);
 
 
@@ -249,6 +297,11 @@ add_tags_to_field($product_ref, "fr", "brands", "Baba, Bobo");
 is_deeply($product_ref,
 {
    'brands' => 'Baba, Bobo',
+  'brands_tags' => [
+     'baba',
+     'bobo'
+   ],
+
    'lc' => 'fr'
 }) or diag explain($product_ref);
 
@@ -271,7 +324,8 @@ is_deeply($product_ref,
    'brands' => 'Baba, Bobo, Bibi',
    'brands_tags' => [
      'baba',
-     'bobo'
+     'bobo',
+     'bibi',
    ],
 
    'lc' => 'fr'
@@ -548,7 +602,7 @@ is_deeply($product_ref->{categories_tags}, [
 ]) or diag explain $product_ref;
 
 $product_ref = {
-'categories' => "Plats pr\x{e9}par\x{e9}s, Plats pr\x{e9}par\x{e9}s au poisson, Plats \x{e0} base de p\x{e2}tes, Lasagnes pr\x{e9}par\x{e9}es, Plats au saumon, Lasagnes au saumon",
+'categories' => "Plats pr\x{e9}par\x{e9}s, Plats pr\x{e9}par\x{e9}s au poisson, Plats \x{e0} base de p\x{e2}tes, Lasagnes pr\x{e9}par\x{e9}es, Plats au saumon",
 'categories_lc' => 'fr',
          'categories_tags' => [
                                  'en:meals',
@@ -556,7 +610,6 @@ $product_ref = {
                                  'en:prepared-lasagne',
                                  'en:meals-with-fish',
                                  'en:meals-with-salmon',
-                                 'en:salmon-lasagne'
                                ],
 
 lc => 'fr',
@@ -564,12 +617,17 @@ lang => 'fr',
 
 };
 
-add_tags_to_field($product_ref, "en", "categories", "Meals,Pasta dishes,Prepared lasagne,Meals with fish,Meals with salmon,Salmon lasagne");
+add_tags_to_field($product_ref, "en", "categories", "Meals,Pasta dishes,Prepared lasagne,Meals with fish,Meals with salmon");
 
-diag explain $product_ref;
+is_deeply($product_ref->{categories_tags}, 
+[
+     'en:meals',
+     'en:pasta-dishes',
+     'en:prepared-lasagne',
+     'en:meals-with-fish',
+     'en:meals-with-salmon',
 
-compute_field_tags($product_ref, "en", "categories");
-
-diag explain $product_ref;
+]
+) or diag explain $product_ref;
 
 done_testing();

--- a/t/tags.t
+++ b/t/tags.t
@@ -487,5 +487,34 @@ is_deeply(canonicalize_taxonomy_tag("fr", "labels", "pur jus"), "en:pure-juice")
 # should not be matched to "pur jus" in French and return "en:pure-juice"
 is_deeply(canonicalize_taxonomy_tag("en", "labels", "au jus"), "en:au jus");
 
+# Test add_tags_to_field
+
+$product_ref = {
+	lc => "fr",
+          'categories_hierarchy' => [
+                                 'en:meals',
+                               ],
+};
+
+
+add_tags_to_field($product_ref, "fr", "categories", "pommes");
+compute_field_tags($product_ref, "fr", "categories");
+
+add_tags_to_field($product_ref, "en", "categories", "bananas");
+compute_field_tags($product_ref, "en", "categories");
+
+is_deeply($product_ref->{categories_tags},  [
+     'en:plant-based-foods-and-beverages',
+     'en:plant-based-foods',
+     'en:fruits-and-vegetables-based-foods',
+     'en:meals',
+     'en:fruits-based-foods',
+     'en:fruits',
+     'en:apples',
+     'en:tropical-fruits',
+     'en:bananas'
+   ],
+) or diag explain $product_ref;
+
 
 done_testing();

--- a/t/tags.t
+++ b/t/tags.t
@@ -503,6 +503,12 @@ compute_field_tags($product_ref, "fr", "categories");
 add_tags_to_field($product_ref, "en", "categories", "bananas");
 compute_field_tags($product_ref, "en", "categories");
 
+add_tags_to_field($product_ref, "en", "categories", "en:pears");
+compute_field_tags($product_ref, "en", "categories");
+
+add_tags_to_field($product_ref, "es", "categories", "en:peaches");
+compute_field_tags($product_ref, "es", "categories");
+
 is_deeply($product_ref->{categories_tags},  [
      'en:plant-based-foods-and-beverages',
      'en:plant-based-foods',
@@ -511,8 +517,10 @@ is_deeply($product_ref->{categories_tags},  [
      'en:fruits-based-foods',
      'en:fruits',
      'en:apples',
+     'en:peaches',
      'en:tropical-fruits',
-     'en:bananas'
+     'en:bananas',
+     'en:pears',
    ],
 ) or diag explain $product_ref;
 


### PR DESCRIPTION
Fixed add_tags_to_field to prevent mix up of languages when all the fields added are already there.
Call compute_field_tags() directly from add_tags_to_field, only when fields have changed.

See #3675 for details.

Adding more tests to verify that the add_tags_to_field() function works correctly.