### PR TITLE
Try to reduce memory used by Docker: start only 1 Apache server

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -55,6 +55,10 @@ FROM modperl AS runnable
 # Prepare Apache to include our custom config
 RUN rm /etc/apache2/sites-enabled/000-default.conf
 
+# Reduce the number of Apache processes
+RUN sed -i 's/StartServers\s*2/StartServers 1/' /etc/apache2/mods-enabled/mpm_event.conf
+RUN sed -i 's/MaxRequestWorkers\s*150/MaxRequestWorkers 25/' /etc/apache2/mods-enabled/mpm_event.conf
+
 # Copy Perl libraries from the builder image
 COPY --from=builder /tmp/local/ /opt/perl/local/
 ENV PERL5LIB /opt/perl/local/lib/perl5/


### PR DESCRIPTION
@areeshatariq is running into issues with docker, the Apache container sometimes fails because there isn't enough memory. (on a 12 Gb machine).

This is to change the Apache config to start only one server process (instead of 2), in the hope that it will reduce memory (although as some memory is shared, I'm not sure how much is actually saved).

This is what I get in top with this change:

``Tasks:   5 total,   1 running,   4 sleeping,   0 stopped,   0 zombie
%Cpu(s):  7.5 us,  2.1 sy,  0.0 ni, 89.8 id,  0.1 wa,  0.0 hi,  0.6 si,  0.0 st
MiB Mem :  15899.2 total,    187.0 free,  13855.0 used,   1857.2 buff/cache
MiB Swap:   2048.0 total,      0.1 free,   2047.9 used.   1016.4 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                      
      1 root      20   0    2384    692    624 S   0.0   0.0   0:00.26 apache2ctl                   
      8 root      20   0    3864   2884   2456 S   0.0   0.0   0:00.24 bash                         
     15 root      20   0    8044   2976   2540 R   0.0   0.0   0:00.02 top                          
     20 root      20   0 2690500   2.5g  15936 S   0.0  16.2   0:29.29 /usr/sbin/apach              
     25 www-data  20   0 4616416   2.5g   8296 S   0.0  16.2   0:00.28 /usr/sbin/apach   

Without it, there is a 3rd 2.5g Apache process.

Something else we could try is to make smaller versions of taxonomy files (especially ingredients and categories).