### PR TITLE
always match tags in English, fixes #3679

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2673,34 +2673,24 @@ sub canonicalize_taxonomy_tag($$$)
 		}
 		else {
 
-			# try matching in other languages
-			my @test_languages = ();
-			
-			if (($tagtype eq "countries") or ($tagtype eq "languages")
-				or ($tagtype eq "labels") or ($tagtype eq "origins")) {
-				@test_languages = ("en");
-			}
+			# try matching in other languages (by default, in English)
+			my @test_languages = ("en");
 			
 			if (defined $options{product_type}) {
 				
 				if ($options{product_type} eq "food") {
 				
+					# Latin animal species (e.g. for fish)
 					if ($tagtype eq "ingredients") {
 						@test_languages = ("la");
-					}
-					elsif (($tagtype eq "additives") or ($tagtype eq "minerals")) {
-						@test_languages = ("en");
-					}				
+					}			
 				}
 				elsif ($options{product_type} eq "beauty") {
 				
-					# Beauty products ingredients are often in English
+					# Beauty products ingredients are often in English or Latin
 					if ($tagtype eq "ingredients") {
 						@test_languages = ("en", "la");
-					}
-					elsif ($tagtype eq "additives") {
-						@test_languages = ("en");
-					}				
+					}			
 				}
 			}
 


### PR DESCRIPTION
It's probably a good idea to keep matching tags in English when they don't match the local language. Fixes #3679 

Bug introduced by #3638 