### PR TITLE
match E-number + name, fixes #3694

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2646,6 +2646,26 @@ sub canonicalize_taxonomy_tag($$$)
 		# check E + 1 digit in order to not convert Erythorbate-de-sodium to Erythorbate
 		$tagid =~ s/^e(\d.*?)-(.*)$/e$1/i;
 	}
+	elsif ($tagtype eq "ingredients") {
+		# convert E-number + name to E-number only if the number match the name
+		my $additive_tagid;
+		my $name;
+		if ($tagid =~ /^(e\d.*?)-(.*)$/i) {
+			$additive_tagid = $1;
+			$name = $2;
+		}
+		elsif ($tagid =~ /^(.*)-(e\d.*?)$/i) {
+			$name = $1;
+			$additive_tagid = $2;
+		}
+		if (defined $name) {
+			my $name_id = canonicalize_taxonomy_tag($tag_lc, "additives", $name);
+			# caramelo e150c -> name_id is e150
+			if (("en:" . $additive_tagid) =~ /^$name_id/) {
+				return "en:" . $additive_tagid;
+			}			
+		}
+	}
 
 
 	if ((defined $synonyms{$tagtype}) and (defined $synonyms{$tagtype}{$tag_lc}) and (defined $synonyms{$tagtype}{$tag_lc}{$tagid})) {

--- a/t/ingredients_tags.t
+++ b/t/ingredients_tags.t
@@ -108,6 +108,20 @@ my @tests = (
 	# Spanish and is "e" before "i" or "hi"
 	[ { lc => "es", ingredients_text => "agua de coco e hielo"} , ['en:coconut-water', 'en:ice']],
 
+	# Additive number + name
+	[ { lc => "fr", ingredients_text => "acide citrique E330"} , ["en:e330"]],
+	[ { lc => "fr", ingredients_text => "E330 acide citrique"} , ["en:e330"]],
+	[ { lc => "en", ingredients_text => "E-330 citric acid"} , ["en:e330"]],
+	# citric acid E-330 does not work, as "acid" is an additive class
+	# and it currently gets turned into citric acid: E-330
+	# (which is not that bad)
+	#[ { lc => "en", ingredients_text => "citric acid E-330"} , ["en:e330"]],
+	[ { lc => "en", ingredients_text => "tartrazine E-102"} , ["en:e102"]],
+	# caramel: e150, match e150c
+	[ { lc => "es", ingredients_text => "caramelo E-150c"} , ["en:e150c"]],
+	# mismatch between name and number
+	[ { lc => "fr", ingredients_text => "acide citrique E120"} , ["fr:acide citrique e120"]],
+
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
this is to match things like "E330 citric acid" and "citric acid E330" where we have both the E-number and one of the additives names / synonyms.