### PR TITLE
separate ingredients cutting from cleaning, bug #2239 (and needed for Equadis import)

### DIFF
--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -758,7 +758,9 @@ sub clean_fields($) {
 	foreach my $field (keys %$product_ref) {
 
 		# Split the generic name from the ingredient list
-		if ($field =~ /^ingredients_text_(\w\w)/) {
+		# Warning: this should be done only once, on the producers platform, when we import product data from a producer
+		# It should not be done again when we import product data from the producers platform to the public database
+		if (($server_options{producers_platform}) and ($field =~ /^ingredients_text_(\w\w)/)) {
 			my $ingredients_lc = $1;
 			split_generic_name_from_ingredients($product_ref, $ingredients_lc);
 		}

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -64,8 +64,8 @@ msgid "Join us on Slack"
 msgstr "Join us on Slack"
 
 msgctxt "add_user_join_the_project"
-msgid "%s is a collaborative project to which you can bring much more than new products: your energy, enthusiasm and ideas!'
-msgstr "%s is a collaborative project to which you can bring much more than new products: your energy, enthusiasm and ideas!'
+msgid "%s is a collaborative project to which you can bring much more than new products: your energy, enthusiasm and ideas!"
+msgstr "%s is a collaborative project to which you can bring much more than new products: your energy, enthusiasm and ideas!"
 
 msgctxt "add_user_join_us_on_slack"
 msgid "We use a discussion system called Slack where all project participants can exchange and collaborate. Please join! We would be happy to know you!"

--- a/t/additives.t
+++ b/t/additives.t
@@ -52,8 +52,9 @@ extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
 	"en:e330",
+	"en:e570", # detected wrongly because of the bogus data after the ingredients list	
                               ],
-);
+) or diag explain $product_ref;
 
 
 # Make sure 100% is not recognized as E-100

--- a/t/ingredients_clean.t
+++ b/t/ingredients_clean.t
@@ -14,6 +14,7 @@ use ProductOpener::Tags qw/:all/;
 use ProductOpener::TagsEntries qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::ImportConvert qw/:all/;
+use ProductOpener::Config qw/:all/;
 
 ProductOpener::Ingredients::validate_regular_expressions();
 
@@ -32,15 +33,15 @@ my @tests = (
 
 	["fr",
 	"Ingrédients: viande de porc 72 %. gras de porc, eau, farine (BLE), conservateur E325, épices et arornales, sel cle Guérarandes 1.1%. lactose (LAIT), acidifiant :E 262, conservateurs:E250 E316, arormes, arome naturel. A consommer cuit à coeur. Conditionné sous atmosphère protectrice ALLERGENES: GLUTEN,LAIT. Valeurs nutritionnelles pour 100 g: Energie: 1306 kJ ou 316 kcal Matières grasses 27.8 g donl acides gras saturés : 11.1 g Glucides: 3.1 g dont sucres 2.1 g Protéines 13.3 g Sel 1.4 g LOT 2530187431",
-	"viande de porc 72 %. gras de porc, eau, farine (BLE), conservateur E325, épices et arornales, sel cle Guérarandes 1.1%. lactose (LAIT), acidifiant :E 262, conservateurs:E250 E316, arormes, arome naturel."],
+	"Viande de porc 72 %. gras de porc, eau, farine (BLE), conservateur E325, épices et arornales, sel cle Guérarandes 1.1%. lactose (LAIT), acidifiant :E 262, conservateurs:E250 E316, arormes, arome naturel."],
 
 	["fr",
 	"CERVITA NATURE VOUS APPORTE Valeurs nutritionnelles moyennes pour 100 g en % des RNJ* par pot INGRÉDIENTS: fromage blanc à 3,6% de matière grasse (75,3%), crème fouettée stérilisée (24,6%), gélatine, ferments lactiques. Valeur énergétique Proteines 561 k] 135 kcal 6,9g 3,8 g 3,7 9 10,3g 14 Glucides dont Sucres Lipides 15 35 dont Acides gras satures Fibres 6,9 g 0 9 0,03g allimentaires Sodium Repères Nutritionnels Journaliers pour un adulte avec un apport moyen de 2000 kcal. Ces valeurs et les portions peuvent varier vius ",
-	"fromage blanc à 3,6% de matière grasse (75,3%), crème fouettée stérilisée (24,6%), gélatine, ferments lactiques."],
+	"Fromage blanc à 3,6% de matière grasse (75,3%), crème fouettée stérilisée (24,6%), gélatine, ferments lactiques."],
 
 	["fr",
 	"INGREDIENTS lait entier (55,4%), crème (lait), sucre (9,7%), myrtille (8%), lait écrémé concentré, épaississants : amidon transformé, farine de graines de caroube, protéines de lait, extrait de carotte pourpre et d'hibiscus, correcteurs d'acidité : citrates de sodium, acide citrique, arôme naturel, ferments lactiques (lait). ",
-	"lait entier (55,4%), crème (lait), sucre (9,7%), myrtille (8%), lait écrémé concentré, épaississants : amidon transformé, farine de graines de caroube, protéines de lait, extrait de carotte pourpre et d'hibiscus, correcteurs d'acidité : citrates de sodium, acide citrique, arôme naturel, ferments lactiques (lait)."],
+	"Lait entier (55,4%), crème (lait), sucre (9,7%), myrtille (8%), lait écrémé concentré, épaississants : amidon transformé, farine de graines de caroube, protéines de lait, extrait de carotte pourpre et d'hibiscus, correcteurs d'acidité : citrates de sodium, acide citrique, arôme naturel, ferments lactiques (lait)."],
 
 	["fr", "Pomme*, fraise*. *: ingrédients issus de l'agriculture biologique",
 	"Pomme*, fraise*. *: ingrédients issus de l'agriculture biologique"],
@@ -73,7 +74,7 @@ crème fraîche
 
 	["fi",
 	"Ainesosat: sitruunajauhe, maustamisvalmiste (vesi, suola, glukoosisiirappi, valkopippuri), rapsiöljy. Valmistus pannulla: Paista jäisiä leikkeitä kuumalla pannulla runsaassa öljyssä kummaltakin puolelta n. 3 minuuttia. Sulanutta tuotetta ei saa jäädyttää uudelleen. Kuumennettava läpikotaisin ennen tarjoilua.",
-	"sitruunajauhe, maustamisvalmiste (vesi, suola, glukoosisiirappi, valkopippuri), rapsiöljy."],
+	"Sitruunajauhe, maustamisvalmiste (vesi, suola, glukoosisiirappi, valkopippuri), rapsiöljy."],
 
 	["fi",
 	"Cornflakes - Maissihiutaleet INGREDIENSER: Majs 92% (EU), socker, kornmaltextrakt, salt. Kan innehälla spär av vete, räg, havre, mjölk och soja. FÖRVARING: Torrt och inte för varmt. AINESOSAT: Maissi 92% (EU), sokeri, ohramallasuute, suola. PARASTA ENNEN: Katso pakkauksen yläosa.",
@@ -113,21 +114,17 @@ Edit ingredients (en)",
 	["pl",
 	"jogurt*, cukier, owoce 7%, (maliny 2,3%, ananasy 1,8%, sok ananasowy z koncentratu 1,6%, sok malinowy z koncentratu 1,3%), musli 2,5% (otręby pszenne, płatki owsiane, pszenica, siemię lniane, ziarno słonecznika,orzechy laskowe), koncentrat soku z buraków czerwonych - aromat. *zawiera składniki pochodzące z mleka oraz żywe kultury bakterii.",
 	"jogurt*, cukier, owoce 7%, (maliny 2,3%, ananasy 1,8%, sok ananasowy z koncentratu 1,6%, sok malinowy z koncentratu 1,3%), musli 2,5% (otręby pszenne, płatki owsiane, pszenica, siemię lniane, ziarno słonecznika,orzechy laskowe), koncentrat soku z buraków czerwonych - aromat. *zawiera składniki pochodzące z mleka oraz żywe kultury bakterii."],
+	
+	["fr","INGREDIENTS : badiane* (Illicium verum) 30%, anis vert* (Pimpinella anisum) 30%, fenouil* (Foeniculum vulgare) 30%, racine de réglisse* (Glycyrrhiza glabra). *Produits issus de l'agriculture biologique. INGREDIENTS: star anise* 30%, green anise* 30%, fennel* 30%, liquorice*. *Organically grown products. INGREDIËNTEN: steranijs* 30%, groene anijs* 30%, venkel* 30%, zoethout*. *Biologisch geteelde producten.",
+"Badiane* (Illicium verum) 30%, anis vert* (Pimpinella anisum) 30%, fenouil* (Foeniculum vulgare) 30%, racine de réglisse* (Glycyrrhiza glabra). *Produits issus de l'agriculture biologique. INGREDIENTS: star anise* 30%, green anise* 30%, fennel* 30%, liquorice*. *Organically grown products. INGREDIËNTEN: steranijs* 30%, groene anijs* 30%, venkel* 30%, zoethout*. *Biologisch geteelde producten."],
 
+	["de", "ZUTATEN: 67% Pizzateig: Weizenmehl, Trinkwasser. ZUTATEN: 33% zubereitete Tomatensosse: 92,7 % Tomatenpüree mit kleinen Tomatenstückchen.", "67% Pizzateig: Weizenmehl, Trinkwasser. ZUTATEN: 33% zubereitete Tomatensosse: 92,7 % Tomatenpüree mit kleinen Tomatenstückchen."],
 
 );
 
 foreach my $test_ref (@tests) {
 
-	my $ingredients_lc = "ingredients_text_" . $test_ref->[0];
-
-	my $product_ref = { lc => $test_ref->[0],
-		$ingredients_lc => $test_ref->[1] };
-
-	compute_languages($product_ref);
-	clean_ingredients_text($product_ref);
-
-	is($product_ref->{$ingredients_lc}, $test_ref->[2]);
+	is(cut_ingredients_text_for_lang($test_ref->[1], $test_ref->[0]), $test_ref->[2]);
 
 }
 
@@ -151,14 +148,22 @@ foreach my $test_ref (@tests) {
 	["en", "Natural pasteurized cow milk - Natural milk fat", "Natural pasteurized cow milk - Natural milk fat"],
 	["en", "NA.", ""],
 
-	# 4 arguments: call clean_ingredients_text_for_field instead of clean_fields
-	# e.g. for OCR, we call clean_ingredients_text_for_field instead of clean_fields
-	["de", "ZUTATEN: 67% Pizzateig: Weizenmehl, Trinkwasser. ZUTATEN: 33% zubereitete Tomatensosse: 92,7 % Tomatenpüree mit kleinen Tomatenstückchen.", "", "67% Pizzateig: Weizenmehl, Trinkwasser. ZUTATEN: 33% zubereitete Tomatensosse: 92,7 % Tomatenpüree mit kleinen Tomatenstückchen."],
 
 	# HTML entities
 	["fr", "P&acirc;tes alimentaires cuites aromatis&eacute;es au curcuma", "Pâtes alimentaires cuites aromatisées au curcuma"],
 
+	# The clean_fields function should remove "Ingrédients:" only when at the very beginning
+	["fr","eau, sel, sucre - Garniture - Ingrédients: Chocolat, sucre",
+		"Eau, sel, sucre - Garniture - Ingrédients: Chocolat, sucre"],
+	["fr","Ingrédients: eau, sel, sucre - Garniture - Ingrédients: Chocolat, sucre",
+		"Eau, sel, sucre - Garniture - Ingrédients: Chocolat, sucre"],
+
 );
+
+# Results of some tests are different on the producers platform (on purpose)
+
+my $producers_platform = $server_options{producers_platform};
+$server_options{producers_platform} = 0;
 
 foreach my $test_ref (@tests) {
 
@@ -169,19 +174,14 @@ foreach my $test_ref (@tests) {
 		$ingredients_lc => $test_ref->[1],
 	};
 
-	if (not defined $test_ref->[3]) {
-		clean_fields($product_ref);
-		is($product_ref->{$ingredients_lc}, $test_ref->[2]);
-	}
-	else {
-		$product_ref->{$ingredients_lc} = clean_ingredients_text_for_lang($product_ref->{$ingredients_lc}, $test_ref->[0]);
-		is($product_ref->{$ingredients_lc}, $test_ref->[3]);
-	}
-
+	clean_fields($product_ref);
+	is($product_ref->{$ingredients_lc}, $test_ref->[2]);
 }
 
-# split_generic_name_from_ingredients() tests
+$server_options{producers_platform} = $producers_platform;
 
+
+# split_generic_name_from_ingredients() tests
 
 @tests = (
 

--- a/t/ingredients_clean.t
+++ b/t/ingredients_clean.t
@@ -162,7 +162,6 @@ foreach my $test_ref (@tests) {
 
 # Results of some tests are different on the producers platform (on purpose)
 
-my $producers_platform = $server_options{producers_platform};
 $server_options{producers_platform} = 0;
 
 foreach my $test_ref (@tests) {
@@ -178,7 +177,7 @@ foreach my $test_ref (@tests) {
 	is($product_ref->{$ingredients_lc}, $test_ref->[2]);
 }
 
-$server_options{producers_platform} = $producers_platform;
+$server_options{producers_platform} = 1;
 
 
 # split_generic_name_from_ingredients() tests


### PR DESCRIPTION
Fixes #2239 

Separating ingredients cutting from cleaning is necessary because ingredients cutting needs to happen only once (just after we do OCR).

Cleaning on the other hand could be done multiple times (e.g. if we improve the cleaning).

This will make it also easier to integrate ingredients spelling. cc @raphael0202 