### PR TITLE
add --mark-as-obsolete-since-date , fixes #3874

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -533,6 +533,8 @@ improvements
 	preparation
 	warning
 	data_sources
+	obsolete
+	obsolete_since_date
 );
 
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -267,7 +267,8 @@ sub normalize_code($) {
 sub split_code($) {
 
 	my $code = shift;
-	if ($code !~ /^\d{8,24}$/) {
+	# Require at least 4 digits (some stores use very short internal barcodes, they are likely to be conflicting)
+	if ($code !~ /^\d{4,24}$/) {
 
 		$log->info("invalid code", { code => $code }) if $log->is_info();
 		return "invalid";

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -37,6 +37,7 @@ it is likely that the MongoDB cursor of products to be updated will expire, and 
 --count		do not do any processing, just count the number of products matching the --query options
 --just-print-codes	do not do any processing, just print the barcodes
 --query some_field=some_value (e.g. categories_tags=en:beers)	filter the products
+--query some_field=-some_value	match products that don't have some_value for some_field
 --process-ingredients	compute allergens, additives detection
 --clean-ingredients	remove nutrition facts, conservation conditions etc.
 --compute-nutrition-score	nutriscore
@@ -113,6 +114,7 @@ my $assign_category_properties = '';
 my $restore_values_deleted_by_user = '';
 my $delete_debug_tags = '';
 my $all_owners = '';
+my $mark_as_obsolete_since_date = '';
 my $reassign_energy_kcal = '';
 
 my $query_ref = {};	# filters for mongodb query
@@ -141,7 +143,7 @@ GetOptions ("key=s"   => \$key,      # string
 			"fix-missing-lc" => \$fix_missing_lc,
 			"fix-zulu-lang" => \$fix_zulu_lang,
 			"fix-rev-not-incremented" => \$fix_rev_not_incremented,
-			"user_id=s" => \$User_id,
+			"user-id=s" => \$User_id,
 			"comment=s" => \$comment,
 			"run-ocr" => \$run_ocr,
 			"autorotate" => \$autorotate,
@@ -153,6 +155,7 @@ GetOptions ("key=s"   => \$key,      # string
 			"team=s" => \$team,
 			"restore-values-deleted-by-user=s" => \$restore_values_deleted_by_user,
 			"delete-debug-tags" => \$delete_debug_tags,
+			"mark-as-obsolete-since-date=s" => \$mark_as_obsolete_since_date,
 			"all-owners" => \$all_owners,
 			)
   or die("Error in command line arguments:\n\n$usage");
@@ -197,6 +200,7 @@ if ((not $process_ingredients) and (not $compute_nutrition_score) and (not $comp
 	and (not $compute_sort_key)
 	and (not $remove_team) and (not $remove_label) and (not $remove_nutrient)
 	and (not $assign_category_properties) and (not $restore_values_deleted_by_user) and not ($delete_debug_tags)
+	and (not $mark_as_obsolete_since_date)
 	and (not $compute_codes) and (not $compute_carbon) and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)) {
 	die("Missing fields to update or --count option:\n$usage");
 }
@@ -219,6 +223,9 @@ foreach my $field (sort keys %$query_ref) {
 	elsif ($query_ref->{$field} eq 'exists') {
 		$query_ref->{$field} = { '$exists' => true };
 	}
+	elsif ($query_ref->{$field} =~ /^-/) {
+		$query_ref->{$field} = { '$ne' => $' };
+	}	
 	elsif ($field =~ /_t$/) {	# created_t, last_modified_t etc.
 		$query_ref->{$field} += 0;
 	}
@@ -914,6 +921,14 @@ while (my $product_ref = $cursor->next) {
 
 		if ($compute_sort_key) {
 			compute_sort_keys($product_ref);
+		}
+		
+		if ($mark_as_obsolete_since_date) {
+			if ((not defined $product_ref->{obsolete}) or (not $product_ref->{obsolete})) {
+				$product_ref->{obsolete} = "on";
+				$product_ref->{obsolete_since_date} = $mark_as_obsolete_since_date;
+				$product_values_changed = 1;
+			}		
 		}
 
 		if (not $pretend) {


### PR DESCRIPTION
Add a way to mark products matching a given query as obsolete using the update_all_products.pl script. Details: #3874 