### PR TITLE
override csv separator for FR

### DIFF
--- a/scripts/update_packager_codes.pl
+++ b/scripts/update_packager_codes.pl
@@ -107,6 +107,9 @@ if (opendir (DH, "$data_root/packager-codes")) {
 			if ($extension eq 'tsv') {
 				$separator = $tsv_separator;
 			}
+			if ($country eq "fr") {
+				$separator = ',';
+			}
 
 			my $key = $packager_code_key{$country};
 


### PR DESCRIPTION
The French file is generated with , instead of ; as separator.

This is an ugly fix, at some point we will have to improve the script so that it uses Text::CSV to load csv files.
