### PR TITLE
fix for short barcodes

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -76,7 +76,7 @@ my $original_code = $code;
 
 $code = normalize_code($code);
 
-if ($code !~ /^\d{8,24}$/) {
+if ($code !~ /^\d{4,24}$/) {
 
 	$log->info("invalid code", { code => $code, original_code => $original_code }) if $log->is_info();
 	$response{status} = 0;

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -85,7 +85,7 @@ if ($type eq 'search_or_add') {
 	if ((not defined $code) or ($code eq "")) {
 		$code = process_search_image_form(\$filename);
 	}
-	elsif ($code !~ /^\d{8,24}$/) {
+	elsif ($code !~ /^\d{4,24}$/) {
 		display_error($Lang{invalid_barcode}{$lang}, 403);
 	}	
 
@@ -173,7 +173,7 @@ else {
 	if ((not defined $code) or ($code eq '')) {
 		display_error($Lang{missing_barcode}{$lang}, 403);
 	}
-	elsif ($code !~ /^\d{8,24}$/) {
+	elsif ($code !~ /^\d{4,24}$/) {
 		display_error($Lang{invalid_barcode}{$lang}, 403);
 	}
 	else {

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -107,7 +107,7 @@ if ((not defined $search_terms) or ($search_terms eq '')) {
 if ((not defined param('json')) and (not defined param('jsonp')) and
 	(not defined param('jqm')) and (not defined param('jqm_loadmore')) and
 	(not defined param('xml')) and (not defined param('rss')) and
-	($search_terms =~ /^(\d{8,24})$/)) {
+	($search_terms =~ /^(\d{4,24})$/)) {
 
 		my $code = normalize_code($search_terms);
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4233,6 +4233,7 @@ sub search_and_display_products($$$$$) {
 								}
 							}
 						}
+
 					}
 
 					elsif (defined $product_ref->{$field}) {
@@ -7279,7 +7280,7 @@ sub display_product($)
 	my $code = normalize_code($request_code);
 	local $log->context->{code} = $code;
 	
-	if ($code !~ /^\d{8,24}$/) {
+	if ($code !~ /^\d{4,24}$/) {
 		display_error($Lang{invalid_barcode}{$lang}, 403);
 	}		
 
@@ -9774,7 +9775,7 @@ sub display_product_api($)
 	$response{code} = $code;
 	my $product_ref = retrieve_product($product_id);
 	
-	if ($code !~ /^\d{8,24}$/) {
+	if ($code !~ /^\d{4,24}$/) {
 
 		$log->info("invalid code", { code => $code, original_code => $request_ref->{code} }) if $log->is_info();
 		$response{status} = 0;

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -802,7 +802,7 @@ sub change_product_server_or_code($$$) {
 	}
 
 	$new_code = normalize_code($new_code);
-	if ($new_code !~ /^\d{8,24}$/) {
+	if ($new_code !~ /^\d{4,24}$/) {
 		display_error($Lang{invalid_barcode}{$lang}, 403);
 	}
 	else {


### PR DESCRIPTION
I was a bit too aggressive in banning barcodes with less than 8 digits, we actually have some with less digits (e.g. 4 or 6) mostly used in small stores.

The barcodes now require at least 4 digits (3 digits and less cause problems in the current path structure)