### PR TITLE
fix regexp, remove warnings

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2773,7 +2773,7 @@ fr => [
 # phrases that can be removed
 my %ignore_phrases = (
 de => [
-"\d\d?\s?%\sFett\si(\.|,)\s?Tr(\.|,)?", # 45 % Fett i.Tr.
+'\d\d?\s?%\sFett\si(\.|,)\s?Tr(\.|,)?', # 45 % Fett i.Tr.
 "inklusive",
 ],
 en => [


### PR DESCRIPTION
in Perl strings between "" are interpreted (e.g. escape sequences). Here we don't want to interpret them, so we need to use single quotes.