### PR TITLE
Removed template initialization from CGI Scripts

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -42,18 +42,6 @@ use Storable qw/dclone/;
 use Encode;
 use JSON::PP;
 use Log::Any qw($log);
-use Template;
-use Data::Dumper;
-
-# Initialize the Template module
-my $tt = Template->new({
-	INCLUDE_PATH => $data_root . '/templates',
-	INTERPOLATE => 1,
-	EVAL_PERL => 1,
-	STAT_TTL => 60,	# cache templates in memory for 1 min before checking if the source changed
-	COMPILE_EXT => '.ttc',	# compile templates to Perl code for much faster reload
-	COMPILE_DIR => $data_root . '/tmp/templates',
-});
 
 # Passing values to the template
 my $template_data_ref = {

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -38,22 +38,8 @@ use URI::Escape::XS;
 use Storable qw/dclone/;
 use Log::Any qw($log);
 
-use Template;
-use Data::Dumper;
-
 my $type = param('type') || 'add';
 my $action = param('action') || 'display';
-
-
-# Initialize the Template module
-my $tt = Template->new({
-	INCLUDE_PATH => $data_root . '/templates',
-	INTERPOLATE => 1,
-	EVAL_PERL => 1,
-	STAT_TTL => 60,	# cache templates in memory for 1 min before checking if the source changed
-	COMPILE_EXT => '.ttc',	# compile templates to Perl code for much faster reload
-	COMPILE_DIR => $data_root . '/tmp/templates',
-});
 
 # Passing values to the template
 my $template_data_ref = {


### PR DESCRIPTION
**Description:**
Since $tt is now an exported variable, we don't need to initialize it separately in CGI Scripts

**Related issues and discussion:**
@stephanegigandet and @hangy suggested in PR #3897 
$tt is made an exported variable in PR #3985
