### PR TITLE
set sonar.sources to remove bogus failing tests from sonarcloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.sources=cgi,docker,lib,scripts,templates,scss,html/css,html/js


### PR DESCRIPTION
I don't know why but sonarcloud makes some tests fail for PRs that did not touch the failing files, and we can't merge the branches. :(

e.g. https://github.com/openfoodfacts/openfoodfacts-server/pull/3996