### PR TITLE
Preparse fi organic label from compound words

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3348,6 +3348,12 @@ sub preparse_ingredients_text($$) {
 		$text =~  s/\bsal \(shorea robusta\)/shorea robusta/ig;
 		$text =~  s/\bshorea robusta \(sal\)/shorea robusta/ig;
 	}
+	elsif ( $product_lc eq 'fi' ) {
+
+		# Organic label can appear as a part of a longer word.
+		# Separate it so it can be detected
+		$text =~ s/\b(luomu)\B/$1 /ig;
+	}
 	elsif ($product_lc eq 'fr') {
 
 		# huiles de palme et de

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -1616,7 +1616,7 @@ delete $product_ref->{ingredients_percent_analysis};
 
 is($product_ref->{ingredients_n}, 19);
 
-my $expected_product_ref =
+$expected_product_ref =
  {
    'ingredients' => [
      {

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -2185,6 +2185,47 @@ is_deeply ($product_ref->{ingredients},
    ],
 ) or diag explain $product_ref;
 
+# FI - organic label as part of the ingredient
+
+$product_ref = {
+	lc => "fi",
+	ingredients_text => "vihreä luomutee, luomumaito, luomu ohramallas",
+};
+
+extract_ingredients_from_text($product_ref);
+
+delete_ingredients_percent_values($product_ref->{ingredients});
+delete $product_ref->{ingredients_percent_analysis};
+
+is ($product_ref->{labels}, undef) or diag explain $product_ref->{labels};
+is_deeply ($product_ref->{labels_tags}, undef) or diag explain $product_ref->{labels_tags};
+
+is_deeply(
+	$product_ref->{ingredients},
+	[   {   'id'         => 'en:green-tea',
+			'labels'     => 'en:organic',
+			'rank'       => 1,
+			'text'       => "vihre\x{e4} tee",
+			'vegan'      => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{   'id'         => 'en:milk',
+			'labels'     => 'en:organic',
+			'rank'       => 2,
+			'text'       => 'maito',
+			'vegan'      => 'no',
+			'vegetarian' => 'yes'
+		},
+		{   'id'         => 'en:malted-barley',
+			'labels'     => 'en:organic',
+			'rank'       => 3,
+			'text'       => 'ohramallas',
+			'vegan'      => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
+) or diag explain $product_ref;
+
 
 $product_ref = {
         lc => "fr",

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -141,6 +141,7 @@ my @lists =(
 	["fi","omenamehu, vesi, sokeri. jossa käsitellään myös maitoa.","omenamehu, vesi, sokeri. jäämät : maitoa."],
 	["fi","omenamehu, vesi, sokeri. Saattaa sisältää pieniä määriä selleriä, sinappia ja vehnää.","omenamehu, vesi, sokeri. jäämät : selleriä, jäämät : sinappia, jäämät : vehnää."],
 	["fi","omenamehu, vesi, sokeri. Saattaa sisältää pienehköjä määriä selleriä, sinappia ja vehnää.","omenamehu, vesi, sokeri. jäämät : selleriä, jäämät : sinappia, jäämät : vehnää."],
+	["fi","luomurypsiöljy, luomu kaura, vihreä luomutee", "luomu rypsiöljy, luomu kaura, vihreä luomu tee"],
 
 
 	["fr","arôme naturel de citron-citron vert et d'autres agrumes", "arôme naturel de citron, arôme naturel de citron vert, arôme naturel d'agrumes"],


### PR DESCRIPTION
**Description:**

As a special case of a label, Finnish organic label often appears at the start of a compound word ingredient ([There's plenty of these](https://fi.openfoodfacts.org/ingredients?status=unknown&filter=luomu)). This change separates it as a separate word during preparsing so it will be properly detected later. Desired result:
`luomumaito` -> `luomu maito` -> `'id' => 'en:milk', 'labels'  => 'en:organic'` 