### PR TITLE
revert bad commit aeeca45 - add back agribalyse_food_code to categories taxonomy

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1314,7 +1314,6 @@ sub parse_ingredients_text($) {
 							'nl' => [
 								'in wisselende verhoudingen',
 								'harde fractie',
-								'o.a.',
 							],
 
 							'sv' => [ 'varierande proportion', ],

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1997,7 +1997,8 @@ lt:E160a(i), Beta karotenas
 lv:E160a(i), Beta-karotīns
 mt:E160a(i), Beta-karotên
 nb:E160a(i), Betakaroten
-nl:E160a(i), Bèta-caroteen, betacaroteen
+nl:E160a(i), Bèta-caroteen
+nl_be:E160a(i), Bèta-caroteen
 pl:E160a(i), Beta-karoten
 pt:E160a(i), Beta-caroteno
 ro:E160a(i), Beta-caroten

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -246,6 +246,7 @@ ciqual_food_name:fr:Boisson infantile céréales lactées (aliment moyen)
 <en:Milky cereal-based beverages
 en:Dairy cereal-based beverage for baby's breakfast
 fr:Boisson lactée pour petit-déjeuner bébé avec céréales
+agribalyse_food_code:en:13173
 ciqual_food_code:en:13173
 ciqual_food_name:en:Dairy cereal-based beverage for baby's breakfast
 ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeuner
@@ -254,6 +255,7 @@ ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeune
 <en:From 4 months
 en:Dairy cereal-based beverage with fruits for baby's snack from 4/6 months
 fr:Boisson lactée pour goûter bébé dès 4/6 mois avec céréales et fruits
+agribalyse_food_code:en:13162
 ciqual_food_code:en:13162
 ciqual_food_name:en:Dairy cereal-based beverage with fruits for baby's snack from 4/6 months
 ciqual_food_name:fr:Boisson infantile céréales lactées aux fruits pour le goûter dès 4/6 mois
@@ -262,6 +264,7 @@ ciqual_food_name:fr:Boisson infantile céréales lactées aux fruits pour le go�
 <en:From 4 months
 en:Dairy cereal-based beverage with vegetables for baby's dinner from 4/6 months
 fr:Boisson lactée pour dîner bébé dès 4/6 mois avec céréales et légumes
+agribalyse_food_code:en:13161
 ciqual_food_code:en:13161
 ciqual_food_name:en:Dairy cereal-based beverage with vegetables for baby's dinner from 4/6 months
 ciqual_food_name:fr:Boisson infantile céréales lactées aux légumes pour dîner dès 4/6 mois
@@ -270,6 +273,7 @@ ciqual_food_name:fr:Boisson infantile céréales lactées aux légumes pour dîn
 <en:From 4 months
 en:Dairy cereal-based beverage for baby's breakfast from 4/6 months
 fr:Boisson lactée pour petit-déjeuner bébé dès 4/6 mois avec céréales
+agribalyse_food_code:en:13163
 ciqual_food_code:en:13163
 ciqual_food_name:en:Dairy cereal-based beverage for baby's breakfast from 4/6 months
 ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeuner dès 4/6 mois
@@ -278,6 +282,7 @@ ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeune
 <en:From 6 months
 en:Fruit-based beverages for baby from 4/6 months
 fr:Boissons aux fruits pour bébé dès 4/6 mois
+agribalyse_food_code:en:13159
 ciqual_food_code:en:13159
 ciqual_food_name:en:Fruit-based beverage for baby from 4/6 months
 ciqual_food_name:fr:Boisson aux fruits pour bébé dès 4/6mois
@@ -286,6 +291,7 @@ ciqual_food_name:fr:Boisson aux fruits pour bébé dès 4/6mois
 <en:From 8 months
 en:Dairy cereal-based beverage for baby's breakfast from 8/9 months
 fr:Boisson lactée pour petit-déjeuner bébé dès 8/9 mois avec céréales
+agribalyse_food_code:en:13169
 ciqual_food_code:en:13169
 ciqual_food_name:en:Dairy cereal-based beverage for baby's breakfast from 8/9 months
 ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeuner dès 8/9 mois
@@ -294,6 +300,7 @@ ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeune
 <en:From 12 months old
 en:Dairy cereal-based beverage for baby's breakfast from 12 months
 fr:Boisson lactée pour petit-déjeuner bébé dès 12 mois avec céréales
+agribalyse_food_code:en:13170
 ciqual_food_code:en:13170
 ciqual_food_name:en:Dairy cereal-based beverage for baby's breakfast from 12 months
 ciqual_food_name:fr:Boisson infantile céréales lactées pour le petit déjeuner dès 12 mois
@@ -322,6 +329,7 @@ ro:Deserturi cu lactate pentru bebeluși, Deserturi cu lactate bebeluși
 <en:Snacks and desserts for babies
 en:Dairy dessert for baby with custard
 fr:Dessert lacté pour bébé, Crème dessert pour bébé
+agribalyse_food_code:en:13164
 ciqual_food_code:en:13164
 ciqual_food_name:en:Dairy dessert for baby, custard type
 ciqual_food_name:fr:Dessert lacté infantile type crème dessert
@@ -329,6 +337,7 @@ ciqual_food_name:fr:Dessert lacté infantile type crème dessert
 <en:Snacks and desserts for babies
 en:Dairy dessert for baby with rice, Dairy dessert for baby with semolina
 fr:Dessert lacté pour bébé au riz, Dessert lacté pour bébé à la semoule
+agribalyse_food_code:en:13165
 ciqual_food_code:en:13165
 ciqual_food_name:en:Dairy dessert for baby, with rice or semolina
 ciqual_food_name:fr:Dessert lacté infantile au riz ou à la semoule
@@ -336,6 +345,7 @@ ciqual_food_name:fr:Dessert lacté infantile au riz ou à la semoule
 <en:Snacks and desserts for babies
 en:Plain dairy dessert for baby with sugar, Dairy dessert for baby with sugar and fruits
 fr:Dessert lacté pour bébé nature sucré, Dessert lacté pour bébé sucré aux fruits
+agribalyse_food_code:en:13166
 ciqual_food_code:en:13166
 ciqual_food_name:en:Dairy dessert for baby, plain with sugar or with fruits
 ciqual_food_name:fr:Dessert lacté infantile nature sucré ou aux fruits
@@ -365,6 +375,7 @@ ro:Formula pentru bebeluși, Formula bebeluși, Formula bebelusi, Formula pentru
 <en:Infant formulas
 en:Ready to feed baby first milk
 fr:Laits 1er âge prêts à consommer, Laits premier âge prêts à consommer
+agribalyse_food_code:en:19013
 ciqual_food_code:en:19013
 ciqual_food_name:en:Baby milk, first milk, ready to feed
 ciqual_food_name:fr:Lait 1er âge, prêt à consommer (préparation pour nourrissons)
@@ -384,6 +395,7 @@ nl:Baby-startmelk vanaf 10 maanden
 <en:Infant formulas
 en:First age baby milk powder, First milk powder, First infant milk formula in powder
 fr:Lait 1er âge en poudre soluble, Lait premier âge en poudre soluble, Préparation pour nourrissons en poudre soluble
+agribalyse_food_code:en:3000
 ciqual_food_code:en:3000
 ciqual_food_name:en:Baby milk, first age, powder
 ciqual_food_name:fr:Lait 1er âge, poudre soluble (préparation pour nourrissons)
@@ -398,6 +410,7 @@ nl:Baby-opvolgmelk
 <en:Baby follow-on milk from 5 months
 en:Second age baby milk powder, Second milk powder, Second infant milk formula in powder
 fr:Lait 2ème âge en poudre soluble, Lait deuxième âge en poudre soluble, Préparation de suite en poudre soluble
+agribalyse_food_code:en:3002
 ciqual_food_code:en:3002
 ciqual_food_name:en:Baby milk, second age, powder
 ciqual_food_name:fr:Lait 2e âge, poudre soluble (préparation de suite)
@@ -405,6 +418,7 @@ ciqual_food_name:fr:Lait 2e âge, poudre soluble (préparation de suite)
 <en:Baby follow-on milk from 5 months
 en:Ready to feed baby follow on milk
 fr:Lait 2e âge prêt à consommer, Lait deuxième âge prêt à consommer
+agribalyse_food_code:en:19014
 ciqual_food_code:en:19014
 ciqual_food_name:en:Baby milk, follow on milk, ready to feed
 ciqual_food_name:fr:Lait 2e âge, prêt à consommer (préparation pour nourrissons)
@@ -436,6 +450,7 @@ nl:Peutermelk
 <en:Growth milks
 en:Ready to feed baby growing up milk
 fr:Lait de croissance pour enfants en bas âge, Aliment lacté liquide destiné aux enfants en bas âge
+agribalyse_food_code:en:19012
 ciqual_food_code:en:19012
 ciqual_food_name:en:Baby milk, growing up milk, ready to feed
 ciqual_food_name:fr:Lait de croissance infantile, liquide (aliment lacté destiné aux enfants en bas âge)
@@ -508,6 +523,7 @@ nl:Babypotjes, Babypotje
 <en:Main meals for babies
 en:Baby food jar with vegetables from 4-6 months
 fr:Petits pots aux légumes pour bébés dès 4-6 mois
+agribalyse_food_code:en:20246
 ciqual_food_code:en:20246
 ciqual_food_name:en:Baby food jar with vegetables, from 4-6 months
 ciqual_food_name:fr:Petit pot légumes, dès 4-6 mois
@@ -516,6 +532,7 @@ ciqual_food_name:fr:Petit pot légumes, dès 4-6 mois
 <en:From 4 months
 en:Baby food jar with vegetables and starch from 4-6 months
 fr:Petit pots aux légumes avec féculents pour bébés dès 4/6 mois
+agribalyse_food_code:en:20247
 ciqual_food_code:en:20247
 ciqual_food_name:en:Baby food jar with vegetables and starch, from 4-6 months
 ciqual_food_name:fr:Petit pot légumes, avec féculent, dès 4/6 mois
@@ -523,6 +540,7 @@ ciqual_food_name:fr:Petit pot légumes, avec féculent, dès 4/6 mois
 <en:Main meals for babies
 en:Baby food jar with banana
 fr:Petits pots aux fruits avec bananes pour bébé
+agribalyse_food_code:en:13157
 ciqual_food_code:en:13157
 ciqual_food_name:en:Baby food jar with banana
 ciqual_food_name:fr:Petit pot fruit avec banane pour bébé
@@ -530,6 +548,7 @@ ciqual_food_name:fr:Petit pot fruit avec banane pour bébé
 <en:Main meals for babies
 en:Baby food jar without banana
 fr:Petits pots aux fruits sans banane pour bébé
+agribalyse_food_code:en:13158
 ciqual_food_code:en:13158
 ciqual_food_name:en:Baby food jar without banana
 ciqual_food_name:fr:Petit pot fruit sans banane pour bébé
@@ -545,6 +564,7 @@ nl:Babysoepen, Babysoep
 <en:From 4 months
 en:Instant cereal powder to be reconstituted for baby from 4/6 months
 fr:Céréales instantanées en poudre pour bébé dès 4/6 mois
+agribalyse_food_code:en:13167
 ciqual_food_code:en:13167
 ciqual_food_name:en:Instant cereal (powder to be reconstituted) for baby from 4/6 months
 ciqual_food_name:fr:Céréales instantanées, poudre à reconstituer, dès 4/6 mois
@@ -553,6 +573,7 @@ ciqual_food_name:fr:Céréales instantanées, poudre à reconstituer, dès 4/6 m
 <en:From 6 months
 en:Instant cereal powder to be reconstituted for baby from 6 months
 fr:Céréales instantanées en poudre pour bébé dès 6 mois
+agribalyse_food_code:en:13168
 ciqual_food_code:en:13168
 ciqual_food_name:en:Instant cereal (powder to be reconstituted) for baby from 6 months
 ciqual_food_name:fr:Céréales instantanées, poudre à reconstituer, dès 6 mois
@@ -560,6 +581,7 @@ ciqual_food_name:fr:Céréales instantanées, poudre à reconstituer, dès 6 moi
 <en:Main meals for babies
 en:Soup for baby with vegetables and cereals and milk
 fr:Soupe pour bébé aux légumes aux céréales et au lait
+agribalyse_food_code:en:20253
 ciqual_food_code:en:20253
 ciqual_food_name:en:Soup for baby, with vegetables, cereals and milk
 ciqual_food_name:fr:Soupe pour bébé légumes, céréales et lait
@@ -567,6 +589,7 @@ ciqual_food_name:fr:Soupe pour bébé légumes, céréales et lait
 <en:Main meals for babies
 en:Soup for baby with vegetables and potatoes
 fr:Soupe pour bébé aux légumes et aux pommes de terre
+agribalyse_food_code:en:20252
 ciqual_food_code:en:20252
 ciqual_food_name:en:Soup for baby, with vegetables and potatoes
 ciqual_food_name:fr:Soupe pour bébé légumes et pomme de terre
@@ -575,6 +598,7 @@ ciqual_food_name:fr:Soupe pour bébé légumes et pomme de terre
 <en:From 6 months
 en:Vegetable dish for baby with starch and meat or fish
 fr:Plat avec légumes et féculents et viande ou poisson
+agribalyse_food_code:en:42603
 ciqual_food_code:en:42603
 ciqual_food_name:en:Vegetable dish for baby, w meat/fish and starch, from 6-8 months
 ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 6-8 mois
@@ -583,6 +607,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 6-8 mo
 <en:From 6 months
 en:Vegetable dish for baby with milk and starch from 6-8 months, Vegetable dish for baby with cream and starch from 6-8 months
 fr:Plat de légumes et féculents avec lait pour bébé dès 6-8 mois, Plat de légumes et féculents avec crème pour bébé dès 6-8 mois
+agribalyse_food_code:en:20249
 ciqual_food_code:en:20249
 ciqual_food_name:en:Vegetable dish for baby, with milk/cream and starch, from 6-8 months
 ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 6-8 mois
@@ -591,6 +616,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 6-8 mois
 <en:From 6 months
 en:Vegetable dish for baby with starch from 6-8 months
 fr:Plat de légumes et féculents dès 6-8 mois
+agribalyse_food_code:en:20248
 ciqual_food_code:en:20248
 ciqual_food_name:en:Vegetable dish for baby, with starch, from 6-8 months
 ciqual_food_name:fr:Plat légumes, avec féculent, dès 6-8 mois
@@ -599,6 +625,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent, dès 6-8 mois
 <en:From 8 months
 en:Vegetable dish for baby with starch and meat or fish
 fr:Plat avec légumes et féculents et viande ou poisson
+agribalyse_food_code:en:42604
 ciqual_food_code:en:42604
 ciqual_food_name:en:Vegetable dish for baby, w meat/fish and starch, from 8-12 months
 ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 8-12 mois
@@ -607,6 +634,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 8-12 m
 <en:From 8 months
 en:Vegetable dish for baby with milk and starch from 8-12 months, Vegetable dish for baby with cream and starch from 8-12 months
 fr:Plat de légumes et féculents avec lait pour bébé dès 8-12 mois, Plat de légumes et féculents avec crème pour bébé dès 8-12 mois
+agribalyse_food_code:en:20250
 ciqual_food_code:en:20250
 ciqual_food_name:en:Vegetable dish for baby, with milk/cream and starch, from 8-12 months
 ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 8-12 mois
@@ -615,6 +643,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 8-12 mois
 <en:From 12 months old
 en:Vegetable dish for baby with starch and meat or fish
 fr:Plat avec légumes et féculents et viande ou poisson
+agribalyse_food_code:en:42605
 ciqual_food_code:en:42605
 ciqual_food_name:en:Vegetable dish for baby, w meat/fish and starch, from 12 months
 ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 12 mois
@@ -623,6 +652,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 12 moi
 <en:From 12 months old
 en:Vegetable dish for baby with milk and starch from 12 months, Vegetable dish for baby with cream and starch from 12 months
 fr:Plat de légumes et féculents avec lait pour bébé dès 12 mois, Plat de légumes et féculents avec crème pour bébé dès 12 mois
+agribalyse_food_code:en:20251
 ciqual_food_code:en:20251
 ciqual_food_name:en:Vegetable dish for baby, with milk/cream and starch, from 12 months
 ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 12 mois
@@ -631,6 +661,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 12 mois
 <en:From 18 months
 en:Vegetable dish for baby with starch and meat or fish
 fr:Plat avec légumes et féculents et viande ou poisson
+agribalyse_food_code:en:42606
 ciqual_food_code:en:42606
 ciqual_food_name:en:Vegetable dish for baby, w meat/fish and starch, from 18 months
 ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 18 mois
@@ -639,6 +670,7 @@ ciqual_food_name:fr:Plat légumes, avec féculent et viande/poisson, dès 18 moi
 <en:From 18 months
 en:Vegetable dish for baby with milk and starch from 18 months, Vegetable dish for baby with cream and starch from 18 months
 fr:Plat de légumes et féculents avec lait pour bébé dès 18 mois, Plat de légumes et féculents avec bébé pour enfant dès 18 mois
+agribalyse_food_code:en:20254
 ciqual_food_code:en:20254
 ciqual_food_name:en:Vegetable dish for baby, with milk/cream and starch, from 18 months
 ciqual_food_name:fr:Plat légumes, avec féculent et lait/crème, dès 18 mois
@@ -910,6 +942,7 @@ nova:en:3
 <en:Alcoholic beverages
 en:Sangria
 fr:Sangria
+agribalyse_food_code:en:1017
 ciqual_food_code:en:1017
 ciqual_food_name:en:Sangria
 ciqual_food_name:fr:Sangria
@@ -919,6 +952,7 @@ fr:Pastis
 de:Pastis
 nl:Pastis, Anijsdranken
 ro:Pastis
+agribalyse_food_code:en:1000
 ciqual_food_code:en:1000
 ciqual_food_name:en:Pastis (anise-flavoured spirit)
 
@@ -931,12 +965,14 @@ ja:日本酒, にほんしゅ
 nl:Saké
 ro:Sake
 wikidata:en:Q170219
+agribalyse_food_code:en:1026
 ciqual_food_code:en:1026
 ciqual_food_name:en:Sake or rice wine
 
 <en:Alcoholic beverages
 en:Shandy, Beer with lemonade
 fr:Panaché, Limonade et bière
+agribalyse_food_code:en:5004
 ciqual_food_code:en:5004
 ciqual_food_name:en:Shandy (beer + lemonade)
 ciqual_food_name:fr:Panaché (limonade et bière)
@@ -944,6 +980,7 @@ ciqual_food_name:fr:Panaché (limonade et bière)
 <en:Alcoholic beverages
 en:Shandy with less than 1° of alcohol
 fr:Panaché à moins de 1° d'alcool
+agribalyse_food_code:en:5005
 ciqual_food_code:en:5005
 ciqual_food_name:en:Shandy, prepacked (<1° alcohol)
 ciqual_food_name:fr:Panaché préemballé (<1° alc.)
@@ -1097,9 +1134,10 @@ jbo:birje
 krc:Сыра
 wikidata:en:Q44
 nova:en:3
-agribalyse_proxy_food_code:en:5000
-agribalyse_proxy_food_name:en:Beer, dark
-agribalyse_proxy_food_name:fr:Bière brune
+# TODO: exclude non French beers ?
+agribalyse_proxy_food_code:en:5002
+agribalyse_proxy_food_name:en:Beer, strong (>8° alcohol)
+agribalyse_proxy_food_name:fr:Bière forte (>8° alcool)
 
 <en:Beers
 en:Abbey beer, Abbey ale, Abbey beers
@@ -1108,6 +1146,7 @@ fi:luostariolut
 fr:Bières d'abbayes, Bières d'abbaye, Bières d'abbayes régionales
 hu:Apátsági sör
 nl:Abdijbieren
+agribalyse_food_code:en:5011
 ciqual_food_code:en:5011
 ciqual_food_name:en:Beer, specialty, from abbey or regional (varying alcohol content)
 ciqual_food_name:fr:Bière de spécialités ou d'abbaye, régionales ou d'une brasserie (degré d'alcool variable)
@@ -1117,6 +1156,7 @@ en:American beers, Beers from the USA
 fr:Bières américaines, Bières des Etats-Unis, Bières des USA
 it:Birre americane, Birre dagli USA, Birre dagli Stati Uniti d'America
 nl:Bier uit de Verenigde Staten van Amerika, Amerikaanse bieren
+origins:en: en:United States
 
 <en:Beers
 en:French beers, Beers from France
@@ -1128,6 +1168,7 @@ hu:Francia sörök
 it:Birre francesi, birre dalla Francia
 nl:Franse bieren, Bieren uit Frankrijk
 ro:Beri franțuzești, Beri frantuzesti, Bere franțuzească, Bere frantuzeasca, Bere franta, Bere franța
+origins:en: en:France
 
 <en:French beers
 en:Corsican beers
@@ -1135,6 +1176,7 @@ de:Korsikanische Biere, Korsische Biere
 fr:Bières corses
 hu:Korzikai sörök
 nl:Corsicaanse bieren, Bieren uit Corsica
+origins:en: en:Corsica
 
 <en:Beers
 en:Organic beers
@@ -1152,6 +1194,7 @@ en:Brittany Beers
 de:Bretonische Biere
 fr:Bières bretonnes, Bières de bretagne
 nl:Bretonse bieren
+origins:en: fr:Bretagne
 
 <en:Beers
 en:Beers from Ireland, Irish beers
@@ -1160,6 +1203,7 @@ fr:Bières irlandaises
 hu:Ír sörök
 nl:Ierse bieren
 ro:Beri irlandeze, Beri irlanda, Bere irlandeză, Bere irlanda, Bere irlandeza
+origins:en: en:Ireland
 
 <en:Beers
 en:Italian beers, Beers from Italy
@@ -1169,6 +1213,7 @@ hu:Olasz sörök, Olaszországi sörök
 it:Birre italiane, birre dall'italia
 nl:Italiaanse bieren
 ro:Beri italiene, Beri italia, Bere italia, Bere italiana, Bere italiană
+origins:en: en:Italy
 
 <en:Beers
 en:Double beer
@@ -1203,6 +1248,7 @@ fr:Bières belges, Bières de Belgique
 hu:Belga sörök, Sörök belgumból
 nl:Belgische bieren, Bieren uit België
 ro:Beri belgiene, Beri Belgia, Bere Belgiană, Bere Belgia, Bere Belgiana
+origins:en: en:Belgium
 
 <en:Belgian beers
 fr:Lambic, Gueuze-Lambic, Gueuze, Lambiek, Geuze-Lambiek, Geuze
@@ -1236,6 +1282,7 @@ origins:en: en:Belgium
 
 <en:Beers
 en:Bulgarian beers
+origins:en: en:Bulgaria
 
 <en:Bulgarian beers
 bg:Българско розово масло, Bulgarsko rozovo maslo
@@ -1249,6 +1296,7 @@ de:Tschechische Biere
 fr:Bières de République tchèque
 hu:Cseh sörök, Sörök csehországból
 nl:Tsjechische bieren
+origins:en: en:Czech Republic
 
 <en:Beers from Czech republic
 cz:Březnický ležák
@@ -1479,6 +1527,7 @@ hu:Lágerek, Világos sörök
 nl:Lagers, Lager, Blonde bieren
 ro:Beri blonde, Bere blondă, Bere blonda
 wikidata:en:Q2792509
+agribalyse_food_code:en:5001
 ciqual_food_code:en:5001
 
 <en:Beers
@@ -1489,6 +1538,7 @@ fr:Bières brunes, bière brune
 nl:Stout
 zh:烈性黑啤酒
 wikidata:en:Q2905033
+agribalyse_food_code:en:5000
 ciqual_food_code:en:5000
 ciqual_food_name:en:Beer, dark
 ciqual_food_name:fr:Bière brune
@@ -1508,6 +1558,7 @@ fi:vahvat oluet
 fr:Bières fortes, Bières à 8% ou plus, Bières à 8° alcool ou plus
 hu:Erős sörök
 nl:Sterke bieren
+agribalyse_food_code:en:5002
 ciqual_food_code:en:5002
 ciqual_food_name:en:Beer, strong (>8° alcohol)
 ciqual_food_name:fr:Bière forte (>8° alcool)
@@ -1531,6 +1582,7 @@ it:Birre senza glutine
 <en:Beers
 en:Special beers, Special beers with 5° alcohol, Special beers with 6° alcohol
 fr:Bières spéciales à 5° d'alcool, Bières spéciales à 6° d'alcool
+agribalyse_food_code:en:5010
 ciqual_food_code:en:5010
 ciqual_food_name:en:Beer, special (5-6° alcohol)
 ciqual_food_name:fr:Bière spéciale (5-6° alcool)
@@ -1538,6 +1590,7 @@ ciqual_food_name:fr:Bière spéciale (5-6° alcool)
 <en:Beers
 en:5% beer, Beer with 5° alcohol, Beer with 4° alcohol
 fr:Bière à 4-5° d'alcool, Bière à 4%, Bière à 5%
+agribalyse_food_code:en:5001
 ciqual_food_code:en:5001
 ciqual_food_name:en:Beer, regular (4-5° alcohol)
 ciqual_food_name:fr:Bière coeur de marché (4-5° alcool)
@@ -1545,6 +1598,7 @@ ciqual_food_name:fr:Bière coeur de marché (4-5° alcool)
 <en:Beers
 en:Beers with low alcohol-content, 3% beers, Beers with 3° alcohol
 fr:Bières faiblement alcoolisées, Bières à 3° d'alcool, Bières à 3%
+agribalyse_food_code:en:5008
 ciqual_food_code:en:5008
 ciqual_food_name:en:Beer, low alcohol-content (3° alcohol)
 ciqual_food_name:fr:Bière faiblement alcoolisée (3° alcool)
@@ -1552,6 +1606,7 @@ ciqual_food_name:fr:Bière faiblement alcoolisée (3° alcool)
 <en:Non-Alcoholic beverages
 en:Alcohol-free juice and syrup-based cocktails
 fr:Cocktail sans alcool à base de jus de fruits et de sirop
+agribalyse_food_code:en:2008
 ciqual_food_code:en:2008
 ciqual_food_name:en:Cocktail, alcohol-free (juices and syrup-based cocktail)
 ciqual_food_name:fr:Cocktail sans alcool (à base de jus de fruits et de sirop)
@@ -1569,6 +1624,7 @@ pl:Piwo bezalkoholowe
 ro:Beri fără alcool, Bere fără alcool, Bere nealcoolizată, Bere nealcoolizata
 zh:无酒精啤酒
 wikidata:en:Q524679
+agribalyse_food_code:en:5030
 ciqual_food_code:en:5030
 ciqual_food_name:en:Beer, alcohol-free (<1,2° alcohol)
 ciqual_food_name:fr:Bière sans alcool (<1,2° alcool)
@@ -1606,6 +1662,7 @@ wikidata:en:Q2832208
 <en:Alcoholic beverages
 en:Pure alcohol
 fr:Alcool pur
+agribalyse_food_code:en:1014
 ciqual_food_code:en:1014
 ciqual_food_name:en:Pure alcohol
 
@@ -1674,6 +1731,7 @@ fr:Eaux-de-vie, Eau-de-vie
 de:Eau de vie, Branntwein
 nl:Vruchtendistillaten
 wikidata:en:Q2166541
+agribalyse_food_code:en:1001
 ciqual_food_code:en:1001
 ciqual_food_name:en:Clear fruit brandy or eau-de-vie
 
@@ -1741,6 +1799,7 @@ it:Whisky, whiskey
 nl:Whiskey, Whisky
 ro:Whisky, whiskey
 wikidata:en:Q281
+agribalyse_food_code:en:1005
 ciqual_food_code:en:1005
 ciqual_food_name:en:Whisky
 
@@ -1784,6 +1843,7 @@ fr:Whisky américain
 nl:Amerikaanse whiskies
 ro:Whisky american, whiskey american
 wikidata_category:en:Q8126582
+origins:en: en:United States
 
 <en:American whiskeys
 en:Bourbon whiskeys, Bourbon whiskey
@@ -1806,6 +1866,7 @@ en:Belgian Whisky
 de:Belgische Whiskys
 fr:Whisky belge
 nl:Belgische whiskies
+origins:en: en:Belgium
 
 <en:Whisky
 en:Canadian whiskeys
@@ -1815,6 +1876,7 @@ nl:Canadese whiskies
 zh:加拿大威士忌
 wikidata:en:Q536976
 wikipediacategory:en:Q8340945
+origins:en: en:Canada
 
 <en:Whisky
 en:Scotch whisky
@@ -1835,6 +1897,7 @@ en:Blended scotch whisky
 de:Schottische Blended Whiskys
 fr:Blend écossais, Blends écossais
 nl:Schotse blended whiskies, Schotse blended whisky
+origins:en: en:Scotland, en:United Kingdom
 
 <en:Whisky
 en:French Whisky
@@ -1842,7 +1905,8 @@ de:Französische Whiskys
 fr:Whisky français
 nl:Franse whiskies
 zh:法国威士忌
-wikipediacategory:en:Q15975338
+wikidata_wikipedia_category:en:Q15975338
+origins:en: en:France
 
 <en:French Whisky
 en:Alsatian whiskey
@@ -1850,30 +1914,35 @@ de:Whisky aus dem Elsass
 fr:Whisky alsacien
 nl:Elzasser whiskies
 zh:阿尔萨斯威士忌
+origins:en: fr:Alsace
 
 <en:French Whisky
 en:Breton whiskey
 de:Whisky aus der Bretagne
 fr:Whisky breton
 nl:Bretonse whiskies
+origins:en: fr:Bretagne
 
 <en:French Whisky
 en:Corsican whiskey
 de:Whisky aus Korsika
 fr:Whisky corse
 nl:Corsicaanse whiskies
+origins:en: en:Corsica
 
 <en:French Whisky
 en:Whisky from Lorraine
 de:Whisky aus Lothringen
 fr:Whisky lorrain
 nl:Lotharingse whiskies
+origins:en: fr:Lorraine
 
 <en:French Whisky
 en:Norman Whisky, Whisky from Normandy
 de:Whisky aus der Normandie
 fr:Whisky normand
 nl:Normandische whiskies
+origins:en: fr:Normandie
 
 <en:Whisky
 en:Welsh Whisky
@@ -1881,6 +1950,7 @@ de:Whisky aus Wales
 fr:Whisky gallois
 nl:Welshe whiskies
 wikidata:en:Q7982042
+origins:en: en:United Kingdom, en:Wales
 
 <en:Whisky
 en:Irish whiskey
@@ -1889,6 +1959,7 @@ es:Whiskies irlandeses
 fr:Whisky irlandais
 nl:Ierse whiskies
 wikidata:en:Q909747
+origins:en: en:Ireland
 
 <en:Whisky
 en:Japanese whiskey
@@ -1896,6 +1967,7 @@ de:Japanische Whiskys
 fr:Whisky japonais
 nl:Japanse whiskies
 wikidata:en:Q901367
+origins:en: en:Japan
 
 <en:Whisky
 en:German Whiskeys, German Whisky, German Whiskey, German Whiskys
@@ -1913,18 +1985,20 @@ fr:Armagnacs, Armagnac
 de:Armagnac, Branntwein aus de Gascogne
 nl:Armagnacs, Armagnac
 wikidata_category:en:Q9469550
+origins:en: en:France, fr:Gascogne
 
 <fr:Armagnacs
 fr:Armagnac-Ténarèze
 de:Armagnac aus dem Anbaugebiet Ténarèze
 nl:Armagnac uit Ténarèze
-country:en:France
+origins:en: en:France, fr:Gascogne
 
 <fr:Armagnacs
 fr:Bas-Armagnac
 de:Armagnac aus dem Anbaugebiet Bas-Armagnac
 country:en:France
 wikidata:en:Q2201024
+origins:en: en:France, fr:Gascogne
 
 <fr:Armagnacs
 fr:Blanche Armagnac
@@ -1940,6 +2014,7 @@ nl:Calvados
 country:en:France
 instanceof:fr:IGP
 wikidata:en:Q3268
+origins:en: en:France, fr:Calvados
 
 <fr:Eaux-de-vie
 fr:Cognac
@@ -1971,12 +2046,14 @@ fr:Eau-de-vie de cidre de Normandie
 de:Apfelbrand aus der Normandie
 nl:Normandische cider eau-de-vies
 country:en:France
+origins:en: en:France, fr:Normandie
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de cidre du Maine
 de:Apfelbrand aus Maine
 nl:Eau-de-vies uit de Maine-streek
 country:en:France
+origins:en: en:France, fr:Maine
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de Cognac
@@ -1989,84 +2066,98 @@ fr:Eau-de-vie de Jura
 de:Branntwein aus dem Jura
 nl:Eau-devies uit de Jura
 country:en:France
+origins:en: en:France, fr:Jura
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de poiré de Bretagne
 de:Birnenbrand aus der Bretagne
 nl:Peren eau-de-vies uit Bretagne
 country:en:France
+origins:en: en:France, fr:Bretagne
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de poiré de Normandie
 de:Birnenbrand aus der Normandie
 nl:Peren eau-de-vies uit Normandië
 country:en:France
+origins:en: en:France, fr:Normandie
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de poiré du Maine
 de:Birnenbrand aus Maine
 nl:Peren-eau-de-vies uit de Maine-streek
 country:en:France
+origins:en: en:France, fr:Maine
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin de Bourgogne
 de:Branntwein aus der Bourgogne
 nl:Wijn-eau-de-vies uit de Bourgogne
 country:en:France
+origins:en: en:France, fr:Bourgogne
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin de la Marne
 de:Branntwein aus Marne, Branntwein aus dem Marne Tal
 nl:Wijn-eau-de-vies uit de Marne
 country:en:France
+origins:en: en:France, fr:Marne
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin de Savoie
 de:Branntwein aus Savoie, Branntwein aus Savoyen
 nl:Wijn eau-de-vies uit de Savoie
 country:en:France
+origins:en: en:France, fr:Savoie
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin des Côtes-du-Rhone
 de:Branntwein aus dem Rhône Tal, Branntwein aus Côtes-du-Rhône
 nl:Wijn-eau-de-vies uit de Côtes-du-Rhône
 country:en:France
+origins:en: en:France, fr:Côtes-du-Rhône
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire d'Aquitaine
 de:Branntwein aus Aquitaine, Branntwein aus Aquitanien
 nl:Wijn-eau-de-vies uit Aquitaine
 country:en:France
+origins:en: en:France, fr:Aquitaine
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire de Franche-Comté
 de:Branntwein aus der Freigrafschaft Burgund, Branntwein aus Franche-Comté
 nl:Wijn eau-de-vies uit de Franche-Comté
 country:en:France
+origins:en: en:France, fr:Franche-Comté
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire de Provence
 de:Branntwein aus der Provence
 nl:Wijn-eau-de-vies uit de Provence
 country:en:France
+origins:en: en:France, fr:Provence
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire des Coteaux de la Loire
 de:Branntwein aus dem Loire Tal, Branntwein aus Coteaux de la Loire
 nl:Wijn-eau-de-vies uit de Coteaux de la Loire
 country:en:France
+origins:en: en:France, fr:Coteaux de la Loire
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire du Bugey
 de:Branntwein aus dem Bugey
 nl:Wijn-eau-de-vies uit de Bugey
 country:en:France
+origins:en: en:France, fr:Bugey
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire du Centre-Est
 de:Branntwein aus Centre-Est
 nl:Wijn eau-de-vies uit de Centre-Est
 country:en:France
+origins:en: en:France, fr:Centre-Est
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie de vin originaire du Languedoc
@@ -2075,13 +2166,14 @@ nl:Wijn eau-de-vies uit de Languedoc
 country:en:France
 protected_name_file_number_en: PGI-FR-02067
 protected_name_type:en: gi
-origins:en: en:France
+origins:en: en:France, fr:Languedoc
 
 <en:French Eaux-de-vie
 fr:Eau-de-vie des Charentes
 de:Branntwein aus Charente
 nl:Eau-de-vies uit de Charante
 country:en:France
+origins:en: en:France, fr:Charentes
 
 <en:Swiss Eaux-de-vie
 fr:Abricotine
@@ -2093,6 +2185,7 @@ wikidata:en:Q10216
 fr:Damassine
 de:Eau de Damassine, Pflaumenbrand aus der Schweiz
 nl:Damasinnes, Damasinne
+origins:en: en:France, fr:Suisse
 
 <en:Swiss Eaux-de-vie
 fr:Williamine
@@ -2105,6 +2198,7 @@ en:Tunisian Eaux-de-vie
 de:Branntwein aus Tunesien
 fr:Eaux-de-vie tunisiennes, Eau-de-vie tunisienne, Eaux-de-vie de Tunisie, Eau-de-vie de Tunisine
 nl:Tunesische eau-de-vies
+origins:en: en:Tunisia
 
 <en:Tunisian Eaux-de-vie
 fr:Boukha
@@ -2159,6 +2253,7 @@ fr:Raki, Rakı
 de:Raki, Anisbrand aus der Türkei
 nl:Raki
 wikidata:en:Q638290
+origins:en: en:Turkey
 
 <fr:Eaux-de-vie
 en:Rums
@@ -2224,6 +2319,7 @@ zh:朗姆酒
 arz:روم
 yue:冧酒
 wikidata:en:Q83376
+agribalyse_food_code:en:1004
 ciqual_food_code:en:1004
 ciqual_food_name:en:Rum
 
@@ -2241,6 +2337,7 @@ en:Barbadian rum
 de:Rum aus Barbados
 fr:Rhums barbadiens, Rhum barbadien
 nl:Barbados rums, Barbados-rum, Barbados rum
+origins:en: en:Barbados
 
 <en:Rums
 en:Cuban rums, Rums from Cuba
@@ -2248,12 +2345,14 @@ de:Kubanische Rums
 fr:Rhums cubains,Rhum cubain
 nl:Cubaanse rums, Rum uit Cuba
 ro:Rom cubanez, Rom Cuba
+origins:en: en:Cuba
 
 <en:Rums
 en:Dominican rums
 de:Dominikanische Rums
 fr:Rhums dominicains,Rhum dominicain
 nl:Dominicaanse rums, Dominicaanse rum
+origins:en: en:Dominican republic
 
 <en:Rums
 en:French rums
@@ -2308,6 +2407,7 @@ en:Haitian rums, Rums from Haiti
 de:Haitianische Rums
 fr:Rhums haïtiens
 nl:Haitiaanse rums, Rum uit Haïti
+origins:en: en:Haiti
 
 <en:Rums
 en:Jamaican rum, Rums from Jamaica
@@ -2315,6 +2415,7 @@ de:Jamaikanische Rums
 fr:Rhums jamaïcains
 nl:Jamaicaanse rums, Rum uit Jamaica
 ro:Rom jamaican, Rom Jamaica
+origins:en: en:Jamaica
 
 <en:Rums
 en:Agricultural rums, rhums agricoles
@@ -2366,6 +2467,7 @@ ro:Vodcă, Vodka
 ru:Водка
 zh:伏特加
 wikidata:en:Q374
+agribalyse_food_code:en:1008
 ciqual_food_code:en:1008
 ciqual_food_name:en:Vodka
 
@@ -2378,6 +2480,7 @@ en:Polish vodkas
 de:Polnische Wodkas
 fr:Vodkas polonaises
 nl:Poolse wodkas, Poolse wodka
+origins:en: en:Poland
 
 <en:Polish vodkas
 en:Herbal vodka from the North Podlasie Lowland aromatised with an extract of bison grass
@@ -2402,6 +2505,7 @@ en:Ukrainian vodkas
 de:Ukraninische Wodkas
 fr:Vodkas ukrainiennes
 nl:Ukraïnse wodkas
+origins:en: en:Ukraine
 
 <en:Vodka
 en:Estonian vodkas
@@ -2417,12 +2521,14 @@ en:Latvian vodkas
 de:Litauische Wodkas
 fr:Vodkas lettones
 nl:Letse wodkas
+origins:en: en:Latvia
 
 <en:Vodka
 en:Lettische vodkas
 de:Lettischer Wodka
 fr:Vodkas lithuaniennes
 nl:Litouwse wodkas
+origins:en: en:Lithuania
 
 <en:Vodka
 no:Norsk Vodka, Norwegian Vodka
@@ -2435,6 +2541,7 @@ en:Czech vodkas
 de:Tschechische Wodkas
 fr:Vodkas tchèques
 nl:Tsjechische wodkas
+origins:en: en:Czech Republic
 
 <en:Vodka
 sv:Svensk Vodka, Swedish Vodka
@@ -2456,6 +2563,7 @@ fr:Gins, Gin
 nl:Gins
 ro:Gin
 wikidata:en:Q959362
+agribalyse_food_code:en:1002
 ciqual_food_code:en:1002
 ciqual_food_name:en:Gin
 
@@ -2474,12 +2582,14 @@ fr:Cocktails spritz
 <en:Alcoholic beverages
 en:Whiskey-based cocktail
 fr:Cocktail à base de whisky
+agribalyse_food_code:en:1013
 ciqual_food_code:en:1013
 ciqual_food_name:en:Whiskey-based cocktail
 
 <en:Wine-based drinks
 en:Vermouth
 fr:Vermouth
+agribalyse_food_code:en:1007
 ciqual_food_code:en:1007
 ciqual_food_name:en:Wine-based aperitif
 ciqual_food_name:fr:Apéritif à base de vin ou vermouth
@@ -2525,6 +2635,7 @@ fr:Cidres bruts, Cidre brut
 de:Cidre halbtrocken
 nl:Halfdroge ciders
 en:Dry ciders
+agribalyse_food_code:en:5006
 ciqual_food_code:en:5006
 ciqual_food_name:en:Cider, dry
 ciqual_food_name:fr:Cidre brut
@@ -2532,6 +2643,7 @@ ciqual_food_name:fr:Cidre brut
 <en:Ciders
 fr:Cidres demi-secs, Cidre demi-sec, Cidres bouchés demi-secs, Cidre bouché demi-sec
 en:Half-dry ciders
+agribalyse_food_code:en:5021
 ciqual_food_code:en:5021
 ciqual_food_name:en:Cider, half-dry
 ciqual_food_name:fr:Cidre bouché demi-sec
@@ -2542,6 +2654,7 @@ de:Süße Apfelweine
 fi:makeat siiderit
 fr:Cidres doux, Cidre doux
 nl:Zoete ciders
+agribalyse_food_code:en:5007
 ciqual_food_code:en:5007
 ciqual_food_name:en:Cider, sweet
 ciqual_food_name:fr:Cidre doux
@@ -2555,6 +2668,7 @@ nl:Roséciders
 <en:Ciders
 en:Flavoured ciders
 fr:Cidres aromatisés framboise, Cidres aromatisés à la framboise
+agribalyse_food_code:en:5022
 ciqual_food_code:en:5022
 ciqual_food_name:en:Flavoured cider
 ciqual_food_name:fr:Cidre aromatisé (framboise)
@@ -2564,6 +2678,7 @@ en:Traditional ciders
 de:Traditioneller Cidre
 fr:Cidres traditionnels
 nl:Traditionele ciders, Appelwijnen
+agribalyse_food_code:en:5020
 ciqual_food_code:en:5020
 ciqual_food_name:en:Cider
 ciqual_food_name:fr:Cidre traditionnel
@@ -2583,6 +2698,7 @@ origins:en: en:France, fr:Normandie
 <en:Alcoholic beverages
 en:Champagne kir, Cocktail of champagne with red fruit liqueur
 fr:Kir royal, Kir au champagne, Kir royal au champagne
+agribalyse_food_code:en:1019
 ciqual_food_code:en:1019
 ciqual_food_name:en:Champagne kir (Cocktail of champagne with red fruit liqueur)
 ciqual_food_name:fr:Kir royal (au champagne)
@@ -2590,6 +2706,7 @@ ciqual_food_name:fr:Kir royal (au champagne)
 <en:Alcoholic beverages
 en:Kir, Cocktail of white wine with red fruit liqueur
 fr:Kir au vin blanc
+agribalyse_food_code:en:1018
 ciqual_food_code:en:1018
 ciqual_food_name:en:Kir (Cocktail of white wine with red fruit liqueur)
 ciqual_food_name:fr:Kir (au vin blanc)
@@ -2604,6 +2721,7 @@ wikidata:en:Q1815494
 <en:Alcoholic beverages
 en:Punch cocktail with 16% alcohol, Punch with 16% alcohol
 fr:Cocktail type punch à 16% d'alcool, Punch à 16% d'alcool
+agribalyse_food_code:en:1022
 ciqual_food_code:en:1022
 ciqual_food_name:en:Cocktail, punch type, 16% alcohol
 ciqual_food_name:fr:Cocktail type punch, 16% alcool
@@ -2611,6 +2729,7 @@ ciqual_food_name:fr:Cocktail type punch, 16% alcool
 <en:Alcoholic beverages
 en:Rum-based cocktail
 fr:Cocktail à base de rhum
+agribalyse_food_code:en:1012
 ciqual_food_code:en:1012
 ciqual_food_name:en:Rum-based cocktail
 ciqual_food_name:fr:Cocktail à base de rhum
@@ -2625,6 +2744,7 @@ fr:Liqueurs, liqueur
 nl:Likeuren
 ro:Lichior
 wikidata:en:Q178780
+agribalyse_food_code:en:1003
 ciqual_food_code:en:1003
 ciqual_food_name:en:Liqueur
 
@@ -2705,6 +2825,7 @@ origins:en: en:Spain
 fr:Crèmes de cassis
 en:Blackcurrant liqueur
 wikidata:en:Q968019
+agribalyse_food_code:en:1021
 ciqual_food_code:en:1021
 ciqual_food_name:en:Blackcurrant liqueur
 ciqual_food_name:fr:Crème de cassis
@@ -2748,6 +2869,7 @@ wikidata:en:Q496934
 
 <en:liqueur
 en:Austrian liqueur
+origins:en: en:Austria
 
 <en:Austrian liqueur
 de:Jägertee, Jagertee, Jagatee
@@ -2776,6 +2898,7 @@ origins:en: en:Austria
 <en:Beverages
 en:Still fruit soft drink with less than 10% of fruit juice without sugar and with artificial sweeteners
 fr:Boisson plate aux fruits non sucrée avec édulcorants et moins de 10% de jus
+agribalyse_food_code:en:18021
 ciqual_food_code:en:18021
 ciqual_food_name:en:Fruit soft drink, still (less than 10% of fruit juice), without sugar and with artificial sweetener(s)
 ciqual_food_name:fr:Boisson plate aux fruits, (à moins de 10% de jus), non sucrée, avec édulcorants
@@ -2783,6 +2906,7 @@ ciqual_food_name:fr:Boisson plate aux fruits, (à moins de 10% de jus), non sucr
 <en:Beverages
 en:Still fruit soft drink with sugar
 fr:Boisson plate aux fruits sucrée
+agribalyse_food_code:en:18309
 ciqual_food_code:en:18309
 ciqual_food_name:en:Fruit soft drink, still (fruit juice content unspecified), with sugar
 ciqual_food_name:fr:Boisson plate aux fruits (teneur en jus non spécifiée), sucrée
@@ -2790,6 +2914,7 @@ ciqual_food_name:fr:Boisson plate aux fruits (teneur en jus non spécifiée), su
 <en:Beverages
 en:Still fruit soft drink with sugar and with less than 10% of fruit juice
 fr:Boisson plate aux fruits sucrée avec moins de 10% de jus
+agribalyse_food_code:en:18023
 ciqual_food_code:en:18023
 ciqual_food_name:en:Fruit soft drink, still (less than 10% of fruit juice), with sugar
 ciqual_food_name:fr:Boisson plate aux fruits (à moins de 10% de jus), sucrée
@@ -2797,6 +2922,7 @@ ciqual_food_name:fr:Boisson plate aux fruits (à moins de 10% de jus), sucrée
 <en:Beverages
 en:Still fruit soft drink with reduced sugar and with 10-50% of fruit juice
 fr:Boisson plate aux fruits avec 10 à 50% de jus à teneur réduite en sucres
+agribalyse_food_code:en:18304
 ciqual_food_code:en:18304
 ciqual_food_name:en:Fruit soft drink, still (10-50% of fruit juice), reduced sugar
 ciqual_food_name:fr:Boisson plate aux fruits (10 à 50% de jus), à teneur réduite en sucres
@@ -2804,6 +2930,7 @@ ciqual_food_name:fr:Boisson plate aux fruits (10 à 50% de jus), à teneur rédu
 <en:Beverages
 en:Still fruit soft drink with sugar and with 10-50% of fruit juice
 fr:Boisson plate aux fruits sucrée avec 10 à 50% de jus
+agribalyse_food_code:en:18339
 ciqual_food_code:en:18339
 ciqual_food_name:en:Fruit soft drink, still (10-50% of fruit juice), with sugar
 ciqual_food_name:fr:Boisson plate aux fruits (10 à 50% de jus), sucrée
@@ -2848,6 +2975,7 @@ nova:en:3
 <en:Carbonated drinks
 en:Carbonated soft drinks without fruit juice with sugar
 fr:Boissons gazeuses sucrées sans jus de fruit
+agribalyse_food_code:en:18026
 ciqual_food_code:en:18026
 ciqual_food_name:en:Soft drink, carbonated, without fruit juice, with sugar
 ciqual_food_name:fr:Boisson gazeuse, sans jus de fruit, sucrée
@@ -2856,6 +2984,7 @@ ciqual_food_name:fr:Boisson gazeuse, sans jus de fruit, sucrée
 <en:Diet beverages
 en:Carbonated soft drinks without fruit juice with reduced sugar
 fr:Boissons gazeuses sans jus de fruit à teneur réduite en sucres
+agribalyse_food_code:en:18032
 ciqual_food_code:en:18032
 ciqual_food_name:en:Soft drink, carbonated, without fruit juice, reduced sugar
 ciqual_food_name:fr:Boisson gazeuse, sans jus de fruit, à teneur réduite en sucres
@@ -2863,6 +2992,7 @@ ciqual_food_name:fr:Boisson gazeuse, sans jus de fruit, à teneur réduite en su
 <en:Carbonated drinks
 en:Carbonated soft drinks without fruit juice with sugar and artificial sweeteners
 fr:Boissons gazeuses sans jus de fruit sucrées avec édulcorants
+agribalyse_food_code:en:18078
 ciqual_food_code:en:18078
 ciqual_food_name:en:Soft drink, carbonated, without fruit juice, with sugar and artificial sweetener(s)
 ciqual_food_name:fr:Boisson gazeuse, sans jus de fruit, sucrée, avec édulcorants
@@ -2884,6 +3014,7 @@ ciqual_food_name:fr:Boisson gazeuse aux fruits (teneur en jus non spécifiée), 
 <en:Carbonated drinks
 en:Carbonated fruit soft drink with less than 10% of fruit juice without sugar and with artificial sweeteners
 fr:Boisson gazeuse aux fruits avec moins de 10% de jus non sucrée avec édulcorants
+agribalyse_food_code:en:18340
 ciqual_food_code:en:18340
 ciqual_food_name:en:Fruit soft drink, carbonated (less than 10% of fruit juice), without sugar and with artificial sweetener(s)
 ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), non sucrée, avec édulcorants
@@ -2891,6 +3022,7 @@ ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), non suc
 <en:Carbonated drinks
 en:Carbonated fruit soft drinks with sugar with 10-50% of fruit juice
 fr:Boissons gazeuses non sucrées aux fruits avec 10 à 50% de jus
+agribalyse_food_code:en:18019
 ciqual_food_code:en:18019
 ciqual_food_name:en:Fruit soft drink, carbonated (10-50% of fruit juice), with sugar
 ciqual_food_name:fr:Boisson gazeuse aux fruits (de 10 à 50% de jus), sucrée
@@ -2898,6 +3030,7 @@ ciqual_food_name:fr:Boisson gazeuse aux fruits (de 10 à 50% de jus), sucrée
 <en:Carbonated drinks
 en:Carbonated fruit soft drink with sugar and artificial sweeteners and with less than 10% of fruit juice
 fr:Boisson gazeuse aux fruits sucrée avec édulcorants et moins de 10% de jus
+agribalyse_food_code:en:18033
 ciqual_food_code:en:18033
 ciqual_food_name:en:Fruit soft drink, carbonated (less than 10% of fruit juice), with sugar and artificial sweetener(s)
 ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), sucrée, avec édulcorants
@@ -2905,6 +3038,7 @@ ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), sucrée
 <en:Carbonated drinks
 en:Carbonated fruit soft drink with sugar and less than 10% of fruit juice
 fr:Boisson gazeuse aux fruits sucrée avec moins de 10% de jus
+agribalyse_food_code:en:18049
 ciqual_food_code:en:18049
 ciqual_food_name:en:Fruit soft drink, carbonated (less than 10% of fruit juice), with sugar
 ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), sucrée
@@ -2912,6 +3046,7 @@ ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), sucrée
 <en:Carbonated drinks
 en:Carbonated fruit soft drink with less than 10% of fruit juice without sugar and artificial sweeteners
 fr:Boisson gazeuse aux fruits avec moins de 10% de jus non sucrée sans édulcorant
+agribalyse_food_code:en:18345
 ciqual_food_code:en:18345
 ciqual_food_name:en:Fruit soft drink, carbonated (less than 10% of fruit juice), without sugar and artificial sweetener(s)
 ciqual_food_name:fr:Boisson gazeuse aux fruits (à moins de 10% de jus), non sucrée, sans édulcorant
@@ -2934,6 +3069,7 @@ agribalyse_proxy_food_name:fr:Tonic ou bitter, sucré
 <en:Tonic water
 en:Tonic drink with sugar
 fr:Tonic sucré, Bitter sucré
+agribalyse_food_code:en:18344
 ciqual_food_code:en:18344
 ciqual_food_name:en:Tonic drink, with sugar
 ciqual_food_name:fr:Tonic ou bitter, sucré
@@ -2941,6 +3077,7 @@ ciqual_food_name:fr:Tonic ou bitter, sucré
 <en:Tonic water
 en:Tonic drink without sugar with artificial sweeteners
 fr:Tonic non sucré avec édulcorants, Bitter non sucré avec édulcorants
+agribalyse_food_code:en:18013
 ciqual_food_code:en:18013
 ciqual_food_name:en:Tonic drink, without sugar, with artificial sweetener(s)
 ciqual_food_name:fr:Tonic ou bitter, non sucré, avec édulcorants
@@ -2948,6 +3085,7 @@ ciqual_food_name:fr:Tonic ou bitter, non sucré, avec édulcorants
 <en:Tonic water
 en:Tonic drink with sugar and artificial sweeteners
 fr:Tonic sucré avec édulcorants, Bitter sucré avec édulcorants
+agribalyse_food_code:en:18014
 ciqual_food_code:en:18014
 ciqual_food_name:en:Tonic drink, with sugar and artificial sweetener(s)
 ciqual_food_name:fr:Tonic ou bitter, sucré, avec édulcorants
@@ -2992,6 +3130,7 @@ fi:Dieettikola
 fr:Sodas au cola light, colas light, cola light, Cola non sucré avec édulcorants
 nl:Light cola's
 ro:Cola light
+agribalyse_food_code:en:18060
 ciqual_food_code:en:18060
 ciqual_food_name:en:Cola, without sugar and with artificial sweetener(s)
 ciqual_food_name:fr:Cola, non sucré, avec édulcorants
@@ -3000,6 +3139,7 @@ ciqual_food_name:fr:Cola, non sucré, avec édulcorants
 <en:Colas
 en:Cola without sugar with artificial sweeteners and with caffeine
 fr:Cola non sucré avec édulcorants sans caféine
+agribalyse_food_code:en:18068
 ciqual_food_code:en:18068
 ciqual_food_name:en:Cola, without sugar, with artificial sweetener(s) and with caffeine
 ciqual_food_name:fr:Cola, non sucré, avec édulcorants, sans caféine
@@ -3073,6 +3213,7 @@ wikidata_category:en:Q7214078
 <en:Energy drinks
 en:Energy drink with sugar
 fr:Boisson énergisante sucrée
+agribalyse_food_code:en:18352
 ciqual_food_code:en:18352
 ciqual_food_name:en:Energy drink, with sugar
 ciqual_food_name:fr:Boisson énergisante, sucrée
@@ -3080,6 +3221,7 @@ ciqual_food_name:fr:Boisson énergisante, sucrée
 <en:Energy drinks
 en:Energy drink without sugar and with artificial sweeteners
 fr:Boisson énergisante non sucrée avec édulcorants
+agribalyse_food_code:en:18353
 ciqual_food_code:en:18353
 ciqual_food_name:en:Energy drink, without sugar and with artificial sweetener(s)
 ciqual_food_name:fr:Boisson énergisante, non sucrée, avec édulcorants
@@ -3165,6 +3307,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lemonade
 <en:Lemonades
 en:Lemonade with sugar
 fr:Limonade sucrée
+agribalyse_food_code:en:18010
 ciqual_food_code:en:18010
 ciqual_food_name:en:Lemonade, with sugar
 ciqual_food_name:fr:Limonade, sucrée
@@ -3172,6 +3315,7 @@ ciqual_food_name:fr:Limonade, sucrée
 <en:Lemonades
 en:Lemonade with sugar and artificial sweeteners
 fr:Limonade sucrée avec édulcorants
+agribalyse_food_code:en:18016
 ciqual_food_code:en:18016
 ciqual_food_name:en:Lemonade, with sugar and artificial sweetener(s)
 ciqual_food_name:fr:Limonade, sucrée, avec édulcorants
@@ -3179,6 +3323,7 @@ ciqual_food_name:fr:Limonade, sucrée, avec édulcorants
 <en:Lemonades
 en:Lemonade without sugar with artificial sweeteners
 fr:Limonade non sucrée avec édulcorants
+agribalyse_food_code:en:18035
 ciqual_food_code:en:18035
 ciqual_food_name:en:Lemonade, without sugar, with artificial sweetener(s)
 ciqual_food_name:fr:Limonade, non sucrée, avec édulcorants
@@ -3186,6 +3331,7 @@ ciqual_food_name:fr:Limonade, non sucrée, avec édulcorants
 <en:Lemonades
 en:Lemonade with flavoured syrup
 fr:Diabolo, Limonade et sirop
+agribalyse_food_code:en:18039
 ciqual_food_code:en:18039
 ciqual_food_name:en:Lemonade with a flavoured syrup
 ciqual_food_name:fr:Diabolo (limonade et sirop)
@@ -3211,6 +3357,7 @@ ciqual_food_name:fr:Cola, teneur en sucre et édulcorant inconnue (aliment moyen
 <en:Colas
 en:Cola with sugar
 fr:Cola sucré
+agribalyse_food_code:en:18018
 ciqual_food_code:en:18018
 ciqual_food_name:en:Cola, with sugar
 ciqual_food_name:fr:Cola, sucré
@@ -3218,6 +3365,7 @@ ciqual_food_name:fr:Cola, sucré
 <en:Colas
 en:Cola with sugar and artificial sweetener(s)
 fr:Cola sucré avec édulcorants
+agribalyse_food_code:en:18037
 ciqual_food_code:en:18037
 ciqual_food_name:en:Cola, with sugar and artificial sweetener(s)
 ciqual_food_name:fr:Cola, sucré, avec édulcorants
@@ -3225,6 +3373,7 @@ ciqual_food_name:fr:Cola, sucré, avec édulcorants
 <en:Colas
 en:Cola with sugar and without caffeine
 fr:Cola sucré sans caféine
+agribalyse_food_code:en:18067
 ciqual_food_code:en:18067
 ciqual_food_name:en:Cola, with sugar and without caffeine
 ciqual_food_name:fr:Cola, sucré, sans caféine
@@ -3327,6 +3476,7 @@ es:Bebidas de fruta y leche
 fi:Mehu-maitojuomat
 fr:Boissons au lait et au jus de fruits, jus de fruits au lait, jus de fruits lactés, Boissons au jus de fruit et au lait
 nl:Fruit- en melksap
+agribalyse_food_code:en:18343
 ciqual_food_code:en:18343
 ciqual_food_name:en:Fruit juice with milk
 ciqual_food_name:fr:Boisson au jus de fruit et au lait
@@ -3348,6 +3498,7 @@ hu:Gyümölcsturmixok
 nl:Smoothies
 nl_be:Smoothies
 wikidata:en:Q13290
+agribalyse_food_code:en:2500
 ciqual_food_code:en:2500
 ciqual_food_name:en:Smoothie
 ciqual_food_name:fr:Smoothie
@@ -3488,6 +3639,7 @@ es:Zumos de manzana exprimidos no refrigerados, Zumos de manzana exprimidos, Zum
 fi:puristetut omenamehut
 fr:Jus de pommes pur jus, jus de pomme pur jus, jus de pommes 100% pur jus, jus de pomme 100% pur jus, pur jus de pomme, pur jus de pommes
 nl:Appelsappen, Appelsap
+agribalyse_food_code:en:2074
 ciqual_food_code:en:2074
 ciqual_food_name:en:Apple juice, pure juice
 ciqual_food_name:fr:Jus de pomme, pur jus
@@ -3690,6 +3842,7 @@ pl:Soki wieloowocowe
 <en:Multifruit juices
 en:Mixed fruits pure multivitamin juice
 fr:Jus multifruit pur jus multivitaminé
+agribalyse_food_code:en:2002
 ciqual_food_code:en:2002
 ciqual_food_name:en:Mixed fruits juice, pure juice, multivitamin
 ciqual_food_name:fr:Jus multifruit, pur jus, multivitaminé
@@ -3697,6 +3850,7 @@ ciqual_food_name:fr:Jus multifruit, pur jus, multivitaminé
 <en:Multifruit juices
 en:Multivitamin mixed fruits juice reconstituted from a concentrate
 fr:Jus multifruit à base de concentré
+agribalyse_food_code:en:2069
 ciqual_food_code:en:2069
 ciqual_food_name:en:Mixed fruits juice, reconstituted from a concentrate, multivitamin
 ciqual_food_name:fr:Jus multifruit, à base de concentré, standard
@@ -3704,6 +3858,7 @@ ciqual_food_name:fr:Jus multifruit, à base de concentré, standard
 <en:Multifruit juices
 en:Orange based mixed fruits multivitamin juice
 fr:Jus multifruit multivitaminé à base d'orange
+agribalyse_food_code:en:2011
 ciqual_food_code:en:2011
 ciqual_food_name:en:Mixed fruits juice, orange based, multivitamin
 ciqual_food_name:fr:Jus multifruit - base orange, multivitaminé
@@ -3722,6 +3877,7 @@ nl:Multivruchtensappen uit concentraat, Multivruchtensap uit concentraat
 en:Squeezed multifruit juices, Mixed fruits pure juices
 fi:puristetut monihedelmämehut
 fr:Jus multifruits pur jus
+agribalyse_food_code:en:2035
 ciqual_food_code:en:2035
 ciqual_food_name:en:Mixed fruits juice, pure juice
 ciqual_food_name:fr:Jus multifruit, pur jus, standard
@@ -3756,6 +3912,7 @@ pl:Soki pomarańczowe
 pt:Sumos de laranja
 zh:橙子汁, 橙汁
 wikidata:en:Q1781317
+agribalyse_food_code:en:2013
 ciqual_food_code:en:2013
 ciqual_food_name:en:Orange juice, home-made
 ciqual_food_name:fr:Jus d'orange, maison
@@ -4175,6 +4332,7 @@ fi:monihedelmänektarit
 fr:Nectars multifruits
 nl:Multivruchtennectars, Multivruchtennectar
 zh:多果子花蜜, 多果蜜
+agribalyse_food_code:en:2061
 ciqual_food_code:en:2061
 ciqual_food_name:en:Mixed fruits nectar
 ciqual_food_name:fr:Nectar multifruit, standard
@@ -4182,6 +4340,7 @@ ciqual_food_name:fr:Nectar multifruit, standard
 <en:Fruit nectars
 en:Multivitamin mixed fruits nectars
 fr:Nectars multifruits multivitaminés
+agribalyse_food_code:en:2060
 ciqual_food_code:en:2060
 ciqual_food_name:en:Mixed fruits nectar, multivitamin
 ciqual_food_name:fr:Nectar multifruit, multivitaminé
@@ -4390,6 +4549,7 @@ de:Passierte Tomaten
 fr:Coulis de tomates, coulis de tomate, Coulis de tomate appertisé mi-réduit à 11%, Purée de tomates appertisée mi-réduite à 11%
 it:Passata
 nl:Gezeefde tomaten, Passata, Tomatencoulis
+agribalyse_food_code:en:20260
 ciqual_food_code:en:20260
 ciqual_food_name:en:Tomato coulis, canned (tomato puree semi-reduced 11%)
 ciqual_food_name:fr:Tomate, coulis, appertisé (purée de tomates mi-réduite à 11%)
@@ -4525,6 +4685,7 @@ la:Taraxacum officinale
 nl:Paardenbloem, Paardebloem
 ro:Păpădie
 wikidata:en:Q131219
+agribalyse_food_code:en:20038
 ciqual_food_code:en:20038
 ciqual_food_name:en:Dandelion, raw
 ciqual_food_name:fr:Pissenlit, cru
@@ -5025,6 +5186,7 @@ wikidata:en:Q203415
 <en:Black teas
 en:Brewed black tea without sugar
 fr:Thé noir infusé non sucré
+agribalyse_food_code:en:18154
 ciqual_food_code:en:18154
 ciqual_food_name:en:Black tea, brewed, without sugar
 ciqual_food_name:fr:Thé noir, infusé, non sucré
@@ -5113,6 +5275,7 @@ wikidata:en:Q484083
 <en:Green teas
 en:Brewed green tea without sugar
 fr:Thé vert infusé non sucré
+agribalyse_food_code:en:18155
 ciqual_food_code:en:18155
 ciqual_food_name:en:Green tea, brewed, without sugar
 ciqual_food_name:fr:Thé vert, infusé, non sucré
@@ -5249,6 +5412,7 @@ wikidata:en:Q231587
 <en:Teas
 en:Brewed oolong tea without sugar
 fr:Thé oolong infusé non sucré
+agribalyse_food_code:en:18156
 ciqual_food_code:en:18156
 ciqual_food_name:en:Oolong tea, brewed, without sugar
 ciqual_food_name:fr:Thé oolong, infusé, non sucré
@@ -5392,6 +5556,7 @@ wikidata:en:Q25408
 <en:Teas
 en:Brewed tea without sugar
 fr:Thé infusé non sucré
+agribalyse_food_code:en:18020
 ciqual_food_code:en:18020
 ciqual_food_name:en:Tea, brewed, without sugar
 ciqual_food_name:fr:Thé infusé, non sucré
@@ -5519,6 +5684,7 @@ fr:Cafés moulus, café moulu
 nl:Gemalen koffies, Filterkoffies, Gemalen koffie, Filterkoffie
 ru:Кофе молотый, Молотый кофе
 zh:研磨咖啡
+agribalyse_food_code:en:18003
 ciqual_food_code:en:18003
 ciqual_food_name:en:Coffee, ground
 ciqual_food_name:fr:Café, moulu
@@ -5552,6 +5718,7 @@ nl:Oploskoffies, Oploskoffie
 ru:Растворимый кофе, кофе растворимый
 zh:速溶咖啡, 即时咖啡
 wikidata:en:Q858049
+agribalyse_food_code:en:18005
 ciqual_food_code:en:18005
 ciqual_food_name:en:Coffee, powder, instant
 ciqual_food_name:fr:Café, poudre soluble
@@ -5559,6 +5726,7 @@ ciqual_food_name:fr:Café, poudre soluble
 <en:Coffees
 en:Ready-to-drink coffee without sugar
 fr:Café non sucré prêt à boire
+agribalyse_food_code:en:18004
 ciqual_food_code:en:18004
 ciqual_food_name:en:Not instant coffee, without sugar, ready-to-drink
 ciqual_food_name:fr:Café, non instantané, non sucré, prêt à boire
@@ -5566,6 +5734,7 @@ ciqual_food_name:fr:Café, non instantané, non sucré, prêt à boire
 <en:Coffees
 en:Ready-to-drink espresso coffee without sugar
 fr:Café expresso non sucré prêt à boire
+agribalyse_food_code:en:18071
 ciqual_food_code:en:18071
 ciqual_food_name:en:Espresso coffee, not instant coffee, without sugar, ready-to-drink
 ciqual_food_name:fr:Café expresso, non instantané, non sucré, prêt à boire
@@ -5573,6 +5742,7 @@ ciqual_food_name:fr:Café expresso, non instantané, non sucré, prêt à boire
 <en:Coffees
 en:Ready-to-drink coffee with milk without sugar, Ready-to-drink white coffee without sugar, Ready-to-drink cappuccino without sugar
 fr:Café au lait non sucré prêt à boire, Café crème non sucré prêt à boire, Cappuccino non sucré prêt à boire
+agribalyse_food_code:en:18151
 ciqual_food_code:en:18151
 ciqual_food_name:en:Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_name:fr:Café au lait, café crème ou cappuccino, instantané ou non, non sucré, prêt à boire
@@ -5593,6 +5763,7 @@ fi:kofeiinittomat pikakahvit
 fr:Cafés en poudre décaféinés, Cafés instantanés décaféinés, Cafés solubles décaféinés, Café décaféiné en poudre soluble
 nl:Cafeïnevrije oploskoffies, Cafeïnevrije oploskoffie
 ru:растворимый кофе без кофеина, декофеинизированный растворимый кофе
+agribalyse_food_code:en:18069
 ciqual_food_code:en:18069
 ciqual_food_name:en:Decaffeinated coffee, powder, instant
 ciqual_food_name:fr:Café, décaféiné, poudre soluble
@@ -5601,6 +5772,7 @@ ciqual_food_name:fr:Café, décaféiné, poudre soluble
 <en:Decaffeinated coffees
 en:Ready-to-drink instant decaffeinated coffee without sugar
 fr:Café décaféiné non sucré instantané prêt à boire
+agribalyse_food_code:en:18072
 ciqual_food_code:en:18072
 ciqual_food_name:en:Decaffeinated instant coffee, without sugar, ready-to-drink
 ciqual_food_name:fr:Café décaféiné, instantané, non sucré, prêt à boire
@@ -5608,6 +5780,7 @@ ciqual_food_name:fr:Café décaféiné, instantané, non sucré, prêt à boire
 <en:Decaffeinated coffees
 en:Ready-to-drink decaffeinated coffee without sugar
 fr:Café décaféiné non sucré prêt à boire
+agribalyse_food_code:en:18070
 ciqual_food_code:en:18070
 ciqual_food_name:en:Decaffeinated not instant coffee, without sugar, ready-to-drink
 ciqual_food_name:fr:Café décaféiné, non instantané, non sucré, prêt à boire
@@ -5615,6 +5788,7 @@ ciqual_food_name:fr:Café décaféiné, non instantané, non sucré, prêt à bo
 <en:Instant coffees
 en:Ready-to-drink instant coffee without sugar
 fr:Café instantané non sucré prêt à boire
+agribalyse_food_code:en:18073
 ciqual_food_code:en:18073
 ciqual_food_name:en:Instant coffee, without sugar, ready-to-drink
 ciqual_food_name:fr:Café, instantané, non sucré, prêt à boire
@@ -5622,6 +5796,7 @@ ciqual_food_name:fr:Café, instantané, non sucré, prêt à boire
 <en:Instant coffees
 en:Instant powder for coffee with milk, Instant powder for cappuccino with chocolate
 fr:Café au lait en poudre soluble, Cappuccino au chocolat en poudre soluble
+agribalyse_food_code:en:18163
 ciqual_food_code:en:18163
 ciqual_food_name:en:Coffee with milk or Cappuccino with chocolate, powder, instant
 ciqual_food_name:fr:Café au lait ou cappuccino au chocolat, poudre soluble
@@ -5629,6 +5804,7 @@ ciqual_food_name:fr:Café au lait ou cappuccino au chocolat, poudre soluble
 <en:Instant coffees
 en:Instant powder for coffee with milk, Instant powder for cappuccino
 fr:Café au lait en poudre soluble, Cappuccino en poudre soluble
+agribalyse_food_code:en:18160
 ciqual_food_code:en:18160
 ciqual_food_name:en:Coffee with milk or Cappuccino, powder, instant
 ciqual_food_name:fr:Café au lait ou cappuccino, poudre soluble
@@ -5647,6 +5823,7 @@ en:Instant chicory, Instant chicory powder
 fr:Chicorée soluble, chicorée en poudre, Chicorée en poudre soluble
 nl:Oploscichorei
 ru:Цикорий растворимый, растворимый цикорий
+agribalyse_food_code:en:18152
 ciqual_food_code:en:18152
 ciqual_food_name:en:Chicory, powder, instant
 ciqual_food_name:fr:Chicorée, poudre soluble
@@ -5655,6 +5832,7 @@ ciqual_food_name:fr:Chicorée, poudre soluble
 <en:Plant-based beverages
 en:Instant mix of chicory and coffee powder
 fr:Chicorée et café en poudre soluble
+agribalyse_food_code:en:18150
 ciqual_food_code:en:18150
 ciqual_food_name:en:Mix of chicory and coffee, powder, instant
 ciqual_food_name:fr:Chicorée et café, poudre soluble
@@ -5662,6 +5840,7 @@ ciqual_food_name:fr:Chicorée et café, poudre soluble
 <en:Instant chicory
 en:Sugar free ready-to-drink instant chicory with artificial sweeteners reconstituted with standard semi-skimmed milk
 fr:Chicorée instantanée non sucrée prête à boire reconstituée avec du lait demi-écrémé standard
+agribalyse_food_code:en:18161
 ciqual_food_code:en:18161
 ciqual_food_name:en:Instant chicory, without sugar and artificial sweeteners, ready-to-drink (reconstituted with standard semi-skimmed milk)
 ciqual_food_name:fr:Chicorée, instantanée, non sucrée, prête à boire (reconstituée avec du lait demi-écrémé standard)
@@ -5672,6 +5851,7 @@ en:Instant chicory with water
 fr:Chicorée soluble, chicorée en poudre
 nl:Oploscichorei
 ru:Цикорий растворимый, растворимый цикорий
+agribalyse_food_code:en:18162
 ciqual_food_code:en:18162
 ciqual_food_name:en:Mix of chicory and coffee, instant, without sugar, ready-to-drink (reconstituted with water)
 
@@ -5679,6 +5859,7 @@ ciqual_food_name:en:Mix of chicory and coffee, instant, without sugar, ready-to-
 <en:Plant-based beverages
 en:Mix of chicory and coffee instant without sugar ready-to-drink (reconstituted with standard semi-skimmed milk)
 fr:Chicorée et café instantané non sucré prête à boire (reconstituée avec du lait demi-écrémé standard)
+agribalyse_food_code:en:18153
 ciqual_food_code:en:18153
 ciqual_food_name:en:Mix of chicory and coffee, instant, without sugar, ready-to-drink (reconstituted with standard semi-skimmed milk)
 
@@ -5724,6 +5905,7 @@ ciqual_food_name:en:Water, bottled (average)
 ciqual_food_name:fr:Eau de source, embouteillée (aliment moyen)
 
 <en:Waters
+agribalyse_food_code:en:18430
 ciqual_food_code:en:18430
 ciqual_food_name:en:Water, bottled
 ciqual_food_name:fr:Eau embouteillée de source
@@ -5774,6 +5956,9 @@ wikidata:en:Q178921
 ciqual_food_code:en:18044
 ciqual_food_name:en:Water, mineral, bottled (average)
 ciqual_food_name:fr:Eau minérale (aliment moyen)
+agribalyse_proxy_food_code:en:76000
+agribalyse_proxy_food_name:en:Mineral still water (Abatilles), bottled, lightly mineralized
+agribalyse_proxy_food_name:fr:Eau minérale Abatilles, embouteillée, non gazeuse, faiblement minéralisée (Arcachon, 33)
 
 <en:Mineral waters
 en:Low mineral bottled waters, Bottled waters with low mineralization levels
@@ -5781,6 +5966,8 @@ fr:Eau minérale embouteillée faiblement minéralisée
 ciqual_food_code:en:18009
 ciqual_food_name:en:Water, bottled, low mineral (average)
 ciqual_food_name:fr:Eau minérale, embouteillée, faiblement minéralisée (aliment moyen)
+
+
 
 <en:Carbonated waters
 <en:Mineral waters
@@ -5808,6 +5995,7 @@ zh:天然矿泉水, 天然矿物质水
 <en:Mineral waters
 en:Bottled water flavoured with sugar
 fr:Boisson à l'eau minérale aromatisée sucrée, Boisson à l'eau de source aromatisée sucrée
+agribalyse_food_code:en:18012
 ciqual_food_code:en:18012
 ciqual_food_name:en:Bottled water, flavoured, w sugar
 ciqual_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, sucrée
@@ -5815,6 +6003,7 @@ ciqual_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, sucré
 <en:Mineral waters
 en:Bottled water flavoured without sugar or artificial sweeteners
 fr:Boisson à l'eau minérale aromatisée non sucrée sans édulcorant, Boisson à l'eau de source aromatisée non sucrée sans édulcorant
+agribalyse_food_code:en:18028
 ciqual_food_code:en:18028
 ciqual_food_name:en:Bottled water, flavoured, without sugar and artificial sweeteners
 ciqual_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, non sucrée, sans édulcorant
@@ -5822,6 +6011,7 @@ ciqual_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, non su
 <en:Mineral waters
 en:Bottled water flavoured without sugar and with artificial sweeteners
 fr:Boisson à l'eau minérale ou de source aromatisée non sucrée avec édulcorants
+agribalyse_food_code:en:18030
 ciqual_food_code:en:18030
 ciqual_food_name:en:Bottled water, flavoured, without sugar and with artificial sweeteners
 ciqual_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, non sucrée, avec édulcorants
@@ -5829,6 +6019,7 @@ ciqual_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, non su
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Abatilles
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Abatilles Arcachon 33
+agribalyse_food_code:en:76000
 ciqual_food_code:en:76000
 ciqual_food_name:en:Mineral still water (Abatilles), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Abatilles, embouteillée, non gazeuse, faiblement minéralisée (Arcachon, 33)
@@ -5836,6 +6027,7 @@ ciqual_food_name:fr:Eau minérale Abatilles, embouteillée, non gazeuse, faiblem
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Avra
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Avra Grèce
+agribalyse_food_code:en:76062
 ciqual_food_code:en:76062
 ciqual_food_name:en:Mineral still water (Avra), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Avra, embouteillée, non gazeuse, faiblement minéralisée (Grèce)
@@ -5843,6 +6035,7 @@ ciqual_food_name:fr:Eau minérale Avra, embouteillée, non gazeuse, faiblement m
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Beckerich
 fr:Eau minérale Beckerich embouteillée non gazeuse faiblement minéralisée Luxembourg
+agribalyse_food_code:en:76063
 ciqual_food_code:en:76063
 ciqual_food_name:en:Mineral still water (Beckerich), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Beckerich, embouteillée, non gazeuse, faiblement minéralisée (Luxembourg)
@@ -5850,6 +6043,7 @@ ciqual_food_name:fr:Eau minérale Beckerich, embouteillée, non gazeuse, faiblem
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized still water Caramulo
 fr:Eau minérale embouteillée non gazeuse très faiblement minéralisée Caramulo Portugal
+agribalyse_food_code:en:76064
 ciqual_food_code:en:76064
 ciqual_food_name:en:Mineral still water (Caramulo), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Caramulo, embouteillée, non gazeuse, très faiblement minéralisée (Portugal)
@@ -5857,6 +6051,7 @@ ciqual_food_name:fr:Eau minérale Caramulo, embouteillée, non gazeuse, très fa
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Chaudfontaine
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Chaudfontaine Belgique
+agribalyse_food_code:en:76065
 ciqual_food_code:en:76065
 ciqual_food_name:en:Mineral still water (Chaudfontaine), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Chaudfontaine, embouteillée, non gazeuse, faiblement minéralisée (Belgique)
@@ -5864,6 +6059,7 @@ ciqual_food_name:fr:Eau minérale Chaudfontaine, embouteillée, non gazeuse, fai
 <en:Mineral waters
 en:Bottled averagely mineralized still water Christinen Brunnen
 fr:Eau minérale embouteillée non gazeuse moyennement minéralisée Christinen Brunnen Allemagne
+agribalyse_food_code:en:76066
 ciqual_food_code:en:76066
 ciqual_food_name:en:Mineral still water (Christinen Brunnen), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Christinen Brunnen, embouteillée, non gazeuse, moyennement minéralisée (Allemagne)
@@ -5871,6 +6067,7 @@ ciqual_food_name:fr:Eau minérale Christinen Brunnen, embouteillée, non gazeuse
 <en:Mineral waters
 en:Bottled strongly mineralized still water Courmayer
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Courmayeur Italie
+agribalyse_food_code:en:76067
 ciqual_food_code:en:76067
 ciqual_food_name:en:Mineral still water (Courmayer), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Courmayeur, embouteillée, non gazeuse, fortement minéralisée (Italie)
@@ -5878,6 +6075,7 @@ ciqual_food_name:fr:Eau minérale Courmayeur, embouteillée, non gazeuse, fortem
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Highland spring
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Highland spring Écosse
+agribalyse_food_code:en:76068
 ciqual_food_code:en:76068
 ciqual_food_name:en:Mineral still water (Highland spring), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Highland spring, embouteillée, non gazeuse, faiblement minéralisée (Écosse)
@@ -5885,6 +6083,7 @@ ciqual_food_name:fr:Eau minérale Highland spring, embouteillée, non gazeuse, f
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Levissima
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Levissima Italie
+agribalyse_food_code:en:76069
 ciqual_food_code:en:76069
 ciqual_food_name:en:Mineral still water (Levissima), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Levissima, embouteillée, non gazeuse, faiblement minéralisée (Italie)
@@ -5892,6 +6091,7 @@ ciqual_food_name:fr:Eau minérale Levissima, embouteillée, non gazeuse, faiblem
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized still water Luso
 fr:Eau minérale embouteillée non gazeuse très faiblement minéralisée Luso Portugal
+agribalyse_food_code:en:76070
 ciqual_food_code:en:76070
 ciqual_food_name:en:Mineral still water (Luso), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Luso, embouteillée, non gazeuse, très faiblement minéralisée (Portugal)
@@ -5899,6 +6099,7 @@ ciqual_food_name:fr:Eau minérale Luso, embouteillée, non gazeuse, très faible
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Néro
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Néro Grèce
+agribalyse_food_code:en:76071
 ciqual_food_code:en:76071
 ciqual_food_name:en:Mineral still water (Néro), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Néro, embouteillée, non gazeuse, faiblement minéralisée (Grèce)
@@ -5906,6 +6107,7 @@ ciqual_food_name:fr:Eau minérale Néro, embouteillée, non gazeuse, faiblement 
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized still water Penacova
 fr:Eau minérale embouteillée non gazeuse très faiblement minéralisée Penacova Portugal
+agribalyse_food_code:en:76072
 ciqual_food_code:en:76072
 ciqual_food_name:en:Mineral still water (Penacova), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Penacova, embouteillée, non gazeuse, très faiblement minéralisée (Portugal)
@@ -5913,6 +6115,7 @@ ciqual_food_name:fr:Eau minérale Penacova, embouteillée, non gazeuse, très fa
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized water San Benedetto
 fr:Eau minérale embouteillée faiblement minéralisée San Benedetto Italie
+agribalyse_food_code:en:76073
 ciqual_food_code:en:76073
 ciqual_food_name:en:Mineral water (San Benedetto), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale San Benedetto, embouteillée, faiblement minéralisée (Italie)
@@ -5920,6 +6123,7 @@ ciqual_food_name:fr:Eau minérale San Benedetto, embouteillée, faiblement miné
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Aix-les-Bains
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Aix-les-Bains 73
+agribalyse_food_code:en:76001
 ciqual_food_code:en:76001
 ciqual_food_name:en:Mineral still water (Aix-les-Bains), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Aix-les-Bains, embouteillée, non gazeuse, faiblement minéralisée (Aix-les-Bains, 73)
@@ -5927,6 +6131,7 @@ ciqual_food_name:fr:Eau minérale Aix-les-Bains, embouteillée, non gazeuse, fai
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized water San Bernardo
 fr:Eau minérale embouteillée très faiblement minéralisée San Bernardo Italie
+agribalyse_food_code:en:76074
 ciqual_food_code:en:76074
 ciqual_food_name:en:Mineral water (San Bernardo), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale San Bernardo, embouteillée, très faiblement minéralisée (Italie)
@@ -5934,6 +6139,7 @@ ciqual_food_name:fr:Eau minérale San Bernardo, embouteillée, très faiblement 
 <en:Mineral waters
 en:Bottled averagely mineralized still water Spa-Reine
 fr:Eau minérale embouteillée moyennement minéralisée Spa-Reine Belgique
+agribalyse_food_code:en:76076
 ciqual_food_code:en:76076
 ciqual_food_name:en:Mineral still water (Spa-Reine), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Spa-Reine, embouteillée, gazeuse ou non non gazeuse, moyennement minéralisée (Belgique)
@@ -5941,6 +6147,7 @@ ciqual_food_name:fr:Eau minérale Spa-Reine, embouteillée, gazeuse ou non non g
 <en:Mineral waters
 en:Bottled strongly mineralized still water Talians
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Talians Italie
+agribalyse_food_code:en:76077
 ciqual_food_code:en:76077
 ciqual_food_name:en:Mineral still water (Talians), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Talians, embouteillée, non gazeuse, fortement minéralisée (Italie)
@@ -5948,6 +6155,7 @@ ciqual_food_name:fr:Eau minérale Talians, embouteillée, non gazeuse, fortement
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Valvert
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Valvert Belgique
+agribalyse_food_code:en:76078
 ciqual_food_code:en:76078
 ciqual_food_name:en:Mineral still water (Valvert), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Valvert, embouteillée, non gazeuse, faiblement minéralisée (Belgique)
@@ -5955,6 +6163,7 @@ ciqual_food_name:fr:Eau minérale Valvert, embouteillée, non gazeuse, faiblemen
 <en:Mineral waters
 en:Bottled strongly mineralized still water Appollinaris
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Appollinaris Allemagne
+agribalyse_food_code:en:76079
 ciqual_food_code:en:76079
 ciqual_food_name:en:Mineral still water (Appollinaris), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Appollinaris, embouteillée, non gazeuse, fortement minéralisée (Allemagne)
@@ -5962,6 +6171,7 @@ ciqual_food_name:fr:Eau minérale Appollinaris, embouteillée, non gazeuse, fort
 <en:Mineral waters
 en:Bottled spring still water Cristaline
 fr:Eau de source embouteillée non gazeuse Cristaline
+agribalyse_food_code:en:76080
 ciqual_food_code:en:76080
 ciqual_food_name:en:Spring still water (Cristaline), bottled
 ciqual_food_name:fr:Eau de source Cristaline, embouteillée, non gazeuse
@@ -5969,6 +6179,7 @@ ciqual_food_name:fr:Eau de source Cristaline, embouteillée, non gazeuse
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Biovive
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Biovive Dax 40
+agribalyse_food_code:en:76081
 ciqual_food_code:en:76081
 ciqual_food_name:en:Mineral still water (Biovive), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Biovive, embouteillée, non gazeuse, faiblement minéralisée (Dax, 40)
@@ -5976,6 +6187,7 @@ ciqual_food_name:fr:Eau minérale Biovive, embouteillée, non gazeuse, faiblemen
 <en:Mineral waters
 en:Bottled strongly mineralized still water La Cairolle
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée La Cairolle Les Aires 34
+agribalyse_food_code:en:76082
 ciqual_food_code:en:76082
 ciqual_food_name:en:Mineral still water (La Cairolle), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale La Cairolle, embouteillée, non gazeuse, fortement minéralisée (Les Aires, 34)
@@ -5983,6 +6195,7 @@ ciqual_food_name:fr:Eau minérale La Cairolle, embouteillée, non gazeuse, forte
 <en:Mineral waters
 en:Bottled strongly mineralized still water La Française
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée La Française Propiac 26
+agribalyse_food_code:en:76085
 ciqual_food_code:en:76085
 ciqual_food_name:en:Mineral still water (La Française), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale La Française, embouteillée, non gazeuse, fortement minéralisée (Propiac, 26)
@@ -5990,6 +6203,7 @@ ciqual_food_name:fr:Eau minérale La Française, embouteillée, non gazeuse, for
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized still water Montcalm
 fr:Eau minérale embouteillée non gazeuse très faiblement minéralisée Montcalm Auzat 09
+agribalyse_food_code:en:76086
 ciqual_food_code:en:76086
 ciqual_food_name:en:Mineral still water (Montcalm), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Montcalm, embouteillée, non gazeuse, très faiblement minéralisée (Auzat, 09)
@@ -5997,6 +6211,7 @@ ciqual_food_name:fr:Eau minérale Montcalm, embouteillée, non gazeuse, très fa
 <en:Low mineral bottled waters
 en:Mineral still water bottled lightly mineralized Montclar
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée (Montclar 04)
+agribalyse_food_code:en:76087
 ciqual_food_code:en:76087
 ciqual_food_name:en:Mineral still water (Montclar), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Montclar, embouteillée, non gazeuse, faiblement minéralisée (Montclar, 04)
@@ -6004,6 +6219,7 @@ ciqual_food_name:fr:Eau minérale Montclar, embouteillée, non gazeuse, faibleme
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Ogeu
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Ogeu-les-Bains 64
+agribalyse_food_code:en:76090
 ciqual_food_code:en:76090
 ciqual_food_name:en:Mineral still water (Ogeu), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Ogeu, embouteillée, non gazeuse, faiblement minéralisée (Ogeu-les-Bains, 64)
@@ -6011,6 +6227,7 @@ ciqual_food_name:fr:Eau minérale Ogeu, embouteillée, non gazeuse, faiblement m
 <en:Mineral waters
 en:Bottled strongly mineralized still water Prince Noir
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Prince Noir St-Antonin-Noble-Val 82
+agribalyse_food_code:en:76091
 ciqual_food_code:en:76091
 ciqual_food_name:en:Mineral still water (Prince Noir), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Prince Noir, embouteillée, non gazeuse, fortement minéralisée (St-Antonin-Noble-Val, 82)
@@ -6018,6 +6235,7 @@ ciqual_food_name:fr:Eau minérale Prince Noir, embouteillée, non gazeuse, forte
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized still water Treignac
 fr:Eau minérale embouteillée non gazeuse très faiblement minéralisée Treignac 19
+agribalyse_food_code:en:76095
 ciqual_food_code:en:76095
 ciqual_food_name:en:Mineral still water (Treignac), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Treignac, embouteillée, non gazeuse, très faiblement minéralisée (Treignac, 19)
@@ -6025,6 +6243,7 @@ ciqual_food_name:fr:Eau minérale Treignac, embouteillée, non gazeuse, très fa
 <en:Mineral waters
 en:Bottled averagely mineralized still water Vauban
 fr:Eau minérale embouteillée non gazeuse moyennement minéralisée Vauban St-Amand-les-Eaux 59
+agribalyse_food_code:en:76097
 ciqual_food_code:en:76097
 ciqual_food_name:en:Mineral still water (Vauban), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Vauban, embouteillée, non gazeuse, moyennement minéralisée (St-Amand-les-Eaux, 59)
@@ -6032,6 +6251,7 @@ ciqual_food_name:fr:Eau minérale Vauban, embouteillée, non gazeuse, moyennemen
 <en:Mineral waters
 en:Mineral water Carola
 fr:Eau minérale embouteillée moyennement minéralisée Carola Ribeauville 68
+agribalyse_food_code:en:76100
 ciqual_food_code:en:76100
 ciqual_food_name:en:Water, mineral, carbonated ou non-carbonated, CAROLA
 ciqual_food_name:fr:Eau minérale Carola, embouteillée, gazeuse ou non gazeuse, moyennement minéralisée (Ribeauville, 68)
@@ -6039,6 +6259,7 @@ ciqual_food_name:fr:Eau minérale Carola, embouteillée, gazeuse ou non gazeuse,
 <en:Non-carbonated natural mineral waters
 en:Non-carbonated mineral water Mont-Blanc
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Mont-Blanc Italie
+agribalyse_food_code:en:76101
 ciqual_food_code:en:76101
 ciqual_food_name:en:Water, mineral, non-carbonated, MONT-BLANC
 ciqual_food_name:fr:Eau minérale Mont-Blanc, embouteillée, non gazeuse, faiblement minéralisée (Italie)
@@ -6046,6 +6267,7 @@ ciqual_food_name:fr:Eau minérale Mont-Blanc, embouteillée, non gazeuse, faible
 <en:Non-carbonated natural mineral waters
 en:Non-carbonated mineral water Eden
 fr:Eau minérale Eden embouteillée non gazeuse faiblement minéralisée La Goa Suisse
+agribalyse_food_code:en:76102
 ciqual_food_code:en:76102
 ciqual_food_name:en:Water, mineral, non-carbonated, EDEN
 ciqual_food_name:fr:Eau minérale Eden (La Goa), embouteillée, non gazeuse, faiblement minéralisée (Suisse)
@@ -6054,6 +6276,7 @@ ciqual_food_name:fr:Eau minérale Eden (La Goa), embouteillée, non gazeuse, fai
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water Nessel
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Nessel Soultzmatt 68
+agribalyse_food_code:en:76088
 ciqual_food_code:en:76088
 ciqual_food_name:en:Mineral sparkling water (Nessel), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Nessel, embouteillée, gazeuse, moyennement minéralisée (Soultzmatt, 68)
@@ -6062,6 +6285,7 @@ ciqual_food_name:fr:Eau minérale Nessel, embouteillée, gazeuse, moyennement mi
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water Vals
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Vals-les-Bains 07
+agribalyse_food_code:en:76096
 ciqual_food_code:en:76096
 ciqual_food_name:en:Mineral sparkling water (Vals), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Vals, embouteillée, gazeuse, moyennement minéralisée (Vals-les-Bains, 07)
@@ -6070,6 +6294,7 @@ ciqual_food_name:fr:Eau minérale Vals, embouteillée, gazeuse, moyennement min�
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water St-Alban
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée (St-Alban 42)
+agribalyse_food_code:en:76092
 ciqual_food_code:en:76092
 ciqual_food_name:en:Mineral sparkling water (St-Alban), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale St-Alban, embouteillée, gazeuse, moyennement minéralisée (St-Alban, 42)
@@ -6078,6 +6303,7 @@ ciqual_food_name:fr:Eau minérale St-Alban, embouteillée, gazeuse, moyennement 
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water St-Géron
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée St-Géron 43
+agribalyse_food_code:en:76093
 ciqual_food_code:en:76093
 ciqual_food_name:en:Mineral sparkling water (St-Géron), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale St-Géron, embouteillée, gazeuse, moyennement minéralisée (St-Géron, 43)
@@ -6086,6 +6312,7 @@ ciqual_food_name:fr:Eau minérale St-Géron, embouteillée, gazeuse, moyennement
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water St-Michel-de-Mourcairol
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée St-Michel-de-Mourcairol Les Aires 34
+agribalyse_food_code:en:76094
 ciqual_food_code:en:76094
 ciqual_food_name:en:Mineral sparkling water (St-Michel-de-Mourcairol), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale St-Michel-de-Mourcairol, embouteillée, gazeuse, moyennement minéralisée (Les Aires, 34)
@@ -6094,6 +6321,7 @@ ciqual_food_name:fr:Eau minérale St-Michel-de-Mourcairol, embouteillée, gazeus
 <en:Carbonated waters
 en:Bottled lightly mineralized sparkling water Ogeu
 fr:Eau minérale embouteillée gazeuse faiblement minéralisée Ogeu-les-Bains 64
+agribalyse_food_code:en:76089
 ciqual_food_code:en:76089
 ciqual_food_name:en:Mineral sparkling water (Ogeu), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Ogeu, embouteillée, gazeuse, faiblement minéralisée (Ogeu-les-Bains, 64)
@@ -6102,6 +6330,7 @@ ciqual_food_name:fr:Eau minérale Ogeu, embouteillée, gazeuse, faiblement miné
 <en:Carbonated waters
 en:Bottled strongly mineralized sparkling water Cilaos
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Cilaos 974
+agribalyse_food_code:en:76083
 ciqual_food_code:en:76083
 ciqual_food_name:en:Mineral sparkling water (Cilaos), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Cilaos, embouteillée, gazeuse, fortement minéralisée (Cilaos, 974)
@@ -6110,6 +6339,7 @@ ciqual_food_name:fr:Eau minérale Cilaos, embouteillée, gazeuse, fortement min�
 <en:Carbonated waters
 en:Bottled lightly mineralized sparkling water Aziac
 fr:Eau minérale embouteillée gazeuse faiblement minéralisée Aizac 07
+agribalyse_food_code:en:76002
 ciqual_food_code:en:76002
 ciqual_food_name:en:Mineral sparkling water (Aziac), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Aizac, embouteillée, gazeuse, faiblement minéralisée (Aizac, 07)
@@ -6118,6 +6348,7 @@ ciqual_food_name:fr:Eau minérale Aizac, embouteillée, gazeuse, faiblement min�
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water San Pellegrino
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée San Pellegrino Italie
+agribalyse_food_code:en:76075
 ciqual_food_code:en:76075
 ciqual_food_name:en:Mineral sparkling water (San Pellegrino), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale San Pellegrino, embouteillée, gazeuse, moyennement minéralisée (Italie)
@@ -6126,6 +6357,7 @@ ciqual_food_name:fr:Eau minérale San Pellegrino, embouteillée, gazeuse, moyenn
 <en:Carbonated waters
 en:Bottled averagely mineralized sparkling water Badoit
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Badoit St-Galmier 42
+agribalyse_food_code:en:76061
 ciqual_food_code:en:76061
 ciqual_food_name:en:Mineral sparkling water (Badoit), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Badoit, embouteillée, gazeuse, moyennement minéralisée (St-Galmier, 42)
@@ -6134,6 +6366,7 @@ ciqual_food_name:fr:Eau minérale Badoit, embouteillée, gazeuse, moyennement mi
 <en:Carbonated waters
 en:Bottled lightly mineralized sparkling water Perrier
 fr:Eau minérale embouteillée gazeuse faiblement minéralisée Perrier Vergèse 30
+agribalyse_food_code:en:76060
 ciqual_food_code:en:76060
 ciqual_food_name:en:Mineral sparkling water (Perrier), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Perrier, embouteillée, gazeuse, faiblement minéralisée (Vergèse, 30)
@@ -6141,6 +6374,7 @@ ciqual_food_name:fr:Eau minérale Perrier, embouteillée, gazeuse, faiblement mi
 <en:Natural mineral waters
 en:Bottled strongly mineralized still water Amanda
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée St-Amand 59
+agribalyse_food_code:en:76004
 ciqual_food_code:en:76004
 ciqual_food_name:en:Mineral still water (Amanda), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Amanda, embouteillée, non gazeuse, fortement minéralisée (St-Amand, 59)
@@ -6149,6 +6383,7 @@ ciqual_food_name:fr:Eau minérale Amanda, embouteillée, non gazeuse, fortement 
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Arcens
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Arcens 07
+agribalyse_food_code:en:76006
 ciqual_food_code:en:76006
 ciqual_food_name:en:Mineral sparkling water (Arcens), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Arcens, embouteillée, gazeuse, moyennement minéralisée (Arcens, 07)
@@ -6157,6 +6392,7 @@ ciqual_food_name:fr:Eau minérale Arcens, embouteillée, gazeuse, moyennement mi
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Ardesy
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Ardesy Ardes 63
+agribalyse_food_code:en:76007
 ciqual_food_code:en:76007
 ciqual_food_name:en:Mineral sparkling water (Ardesy), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Ardesy, embouteillée, gazeuse, fortement minéralisée (Ardes, 63)
@@ -6165,6 +6401,7 @@ ciqual_food_name:fr:Eau minérale Ardesy, embouteillée, gazeuse, fortement min�
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Auvergne
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Auvergne Cornillon 38
+agribalyse_food_code:en:76008
 ciqual_food_code:en:76008
 ciqual_food_name:en:Mineral sparkling water (Auvergne), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Auvergne, embouteillée, gazeuse, fortement minéralisée (Cornillon, 38)
@@ -6173,6 +6410,7 @@ ciqual_food_name:fr:Eau minérale Auvergne, embouteillée, gazeuse, fortement mi
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized still water Celtic
 fr:Eau minérale embouteillée très faiblement minéralisée Celtic Niederbronn 67
+agribalyse_food_code:en:76010
 ciqual_food_code:en:76010
 ciqual_food_name:en:Mineral still water (Celtic), bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Celtic, embouteillée, gazeuse ou non gazeuse, très faiblement minéralisée (Niederbronn, 67)
@@ -6181,6 +6419,7 @@ ciqual_food_name:fr:Eau minérale Celtic, embouteillée, gazeuse ou non gazeuse,
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Chambon
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Chambon 45
+agribalyse_food_code:en:76011
 ciqual_food_code:en:76011
 ciqual_food_name:en:Mineral still water (Chambon), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Chambon, embouteillée, non gazeuse, faiblement minéralisée (Chambon, 45)
@@ -6189,6 +6428,7 @@ ciqual_food_name:fr:Eau minérale Chambon, embouteillée, non gazeuse, faiblemen
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Chantemerle
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Chantemerle Le Pestrin 07
+agribalyse_food_code:en:76012
 ciqual_food_code:en:76012
 ciqual_food_name:en:Mineral still water (Chantemerle), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Chantemerle, embouteillée, non gazeuse, faiblement minéralisée (Le Pestrin, 07)
@@ -6196,6 +6436,7 @@ ciqual_food_name:fr:Eau minérale Chantemerle, embouteillée, non gazeuse, faibl
 <en:Natural mineral waters
 en:Bottled strongly mineralized still water Contrex
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Contrex Contrexéville 88
+agribalyse_food_code:en:76016
 ciqual_food_code:en:76016
 ciqual_food_name:en:Mineral still water (Contrex), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Contrex, embouteillée, non gazeuse, fortement minéralisée (Contrexéville, 88)
@@ -6203,6 +6444,7 @@ ciqual_food_name:fr:Eau minérale Contrex, embouteillée, non gazeuse, fortement
 <en:Natural mineral waters
 en:Bottled averagely mineralized still water Dax
 fr:Eau minérale embouteillée non gazeuse moyennement minéralisée Dax 40
+agribalyse_food_code:en:76017
 ciqual_food_code:en:76017
 ciqual_food_name:en:Mineral still water (Dax), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Dax, embouteillée, non gazeuse, moyennement minéralisée (Dax, 40)
@@ -6210,6 +6452,7 @@ ciqual_food_name:fr:Eau minérale Dax, embouteillée, non gazeuse, moyennement m
 <en:Natural mineral waters
 en:Bottled strongly mineralized still water Didier
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Didier Martinique
+agribalyse_food_code:en:76019
 ciqual_food_code:en:76019
 ciqual_food_name:en:Mineral still water (Didier), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Didier, embouteillée non gazeuse, fortement minéralisée (Martinique)
@@ -6218,6 +6461,7 @@ ciqual_food_name:fr:Eau minérale Didier, embouteillée non gazeuse, fortement m
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Evian
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Evian 74
+agribalyse_food_code:en:76020
 ciqual_food_code:en:76020
 ciqual_food_name:en:Mineral still water (Evian), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Evian, embouteillée, non gazeuse, faiblement minéralisée (Evian, 74)
@@ -6225,6 +6469,7 @@ ciqual_food_name:fr:Eau minérale Evian, embouteillée, non gazeuse, faiblement 
 <en:Natural mineral waters
 en:Bottled strongly mineralized still water Hépar
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Hépar Vittel 88
+agribalyse_food_code:en:76022
 ciqual_food_code:en:76022
 ciqual_food_name:en:Mineral still water (Hépar), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Hépar, embouteillée, non gazeuse, fortement minéralisée (Vittel, 88)
@@ -6232,6 +6477,7 @@ ciqual_food_name:fr:Eau minérale Hépar, embouteillée, non gazeuse, fortement 
 <en:Natural mineral waters
 en:Bottled averagely mineralized still water Vittel
 fr:Eau minérale embouteillée non gazeuse moyennement minéralisée Vittel 88
+agribalyse_food_code:en:76056
 ciqual_food_code:en:76056
 ciqual_food_name:en:Mineral still water (Vittel), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Vittel, embouteillée, non gazeuse, moyennement minéralisée (Vittel, 88)
@@ -6240,6 +6486,7 @@ ciqual_food_name:fr:Eau minérale Vittel, embouteillée, non gazeuse, moyennemen
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Volvic
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Volvic 63
+agribalyse_food_code:en:76057
 ciqual_food_code:en:76057
 ciqual_food_name:en:Mineral still water (Volvic), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Volvic, embouteillée, non gazeuse, faiblement minéralisée (Volvic, 63)
@@ -6248,6 +6495,7 @@ ciqual_food_name:fr:Eau minérale Volvic, embouteillée, non gazeuse, faiblement
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Luchon
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Luchon 31
+agribalyse_food_code:en:76025
 ciqual_food_code:en:76025
 ciqual_food_name:en:Mineral still water (Luchon), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Luchon, embouteillée, non gazeuse, faiblement minéralisée (Luchon, 31)
@@ -6256,6 +6504,7 @@ ciqual_food_name:fr:Eau minérale Luchon, embouteillée, non gazeuse, faiblement
 <en:Low mineral bottled waters
 en:Bottled very lightly mineralized water Mont-Roucous
 fr:Eau minérale embouteillée très faiblement minéralisée Mont-Roucous Lacaune 81
+agribalyse_food_code:en:76027
 ciqual_food_code:en:76027
 ciqual_food_name:en:Mineral water (Mont-Roucous, bottled, very lightly mineralized
 ciqual_food_name:fr:Eau minérale Mont-Roucous, embouteillée, très faiblement minéralisée (Lacaune, 81)
@@ -6264,6 +6513,7 @@ ciqual_food_name:fr:Eau minérale Mont-Roucous, embouteillée, très faiblement 
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized spring water Ogeu
 fr:Eau de source embouteillée faiblement minéralisée Ogeu 64
+agribalyse_food_code:en:76028
 ciqual_food_code:en:76028
 ciqual_food_name:en:Spring water (Ogeu), bottled, lightly mineralized
 ciqual_food_name:fr:Eau de source Ogeu, embouteillée, faiblement minéralisée (Ogeu, 64)
@@ -6271,6 +6521,7 @@ ciqual_food_name:fr:Eau de source Ogeu, embouteillée, faiblement minéralisée 
 <en:Natural mineral waters
 en:Bottled averagely mineralized still water Orée du bois
 fr:Eau minérale embouteillée non gazeuse moyennement minéralisée Orée du bois St-Amand 59
+agribalyse_food_code:en:76029
 ciqual_food_code:en:76029
 ciqual_food_name:en:Mineral still water (Orée du bois), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Orée du bois, embouteillée, non gazeuse, moyennement minéralisée (St-Amand, 59)
@@ -6279,6 +6530,7 @@ ciqual_food_name:fr:Eau minérale Orée du bois, embouteillée, non gazeuse, moy
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Plancoet
 fr:Eau minérale embouteillée faiblement minéralisée Plancoet 22
+agribalyse_food_code:en:76032
 ciqual_food_code:en:76032
 ciqual_food_name:en:Mineral still water (Plancoet), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Plancoet, embouteillée, gazeuse ou non gazeuse, faiblement minéralisée (Plancoet, 22)
@@ -6286,6 +6538,7 @@ ciqual_food_name:fr:Eau minérale Plancoet, embouteillée, gazeuse ou non gazeus
 <en:Natural mineral waters
 en:Bottled strongly mineralized still water Propiac
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée Propiac 26
+agribalyse_food_code:en:76033
 ciqual_food_code:en:76033
 ciqual_food_name:en:Mineral still water (Propiac), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Propiac, embouteillée, non gazeuse, fortement minéralisée (Propiac, 26)
@@ -6294,6 +6547,7 @@ ciqual_food_name:fr:Eau minérale Propiac, embouteillée, non gazeuse, fortement
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Sail-les-Bains
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Sail-les-Bains 42
+agribalyse_food_code:en:76038
 ciqual_food_code:en:76038
 ciqual_food_name:en:Mineral still water (Sail-les-Bains), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Sail-les-Bains, embouteillée, non gazeuse, faiblement minéralisée (Sail-les-Bains, 42)
@@ -6302,6 +6556,7 @@ ciqual_food_name:fr:Eau minérale Sail-les-Bains, embouteillée, non gazeuse, fa
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Wattwiller
 fr:Eau minérale embouteillée faiblement minéraliséee Wattwiller 68
+agribalyse_food_code:en:76059
 ciqual_food_code:en:76059
 ciqual_food_name:en:Mineral still water (Wattwiller), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Wattwiller, embouteillée, gazeuse ou non gazeuse, faiblement minéraliséee (Wattwiller, 68)
@@ -6309,6 +6564,7 @@ ciqual_food_name:fr:Eau minérale Wattwiller, embouteillée, gazeuse ou non gaze
 <en:Natural mineral waters
 en:Bottled averagely mineralized still water St-Amand
 fr:Eau minérale embouteillée moyennement minéralisée St-Amand 59
+agribalyse_food_code:en:76043
 ciqual_food_code:en:76043
 ciqual_food_name:en:Mineral still water (St-Amand), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale St-Amand, embouteillée, gazeuse ou non gazeuse, moyennement minéralisée (St-Amand, 59)
@@ -6316,6 +6572,7 @@ ciqual_food_name:fr:Eau minérale St-Amand, embouteillée, gazeuse ou non gazeus
 <en:Natural mineral waters
 en:Bottled strongly mineralized still water St-Antonin
 fr:Eau minérale embouteillée non gazeuse fortement minéralisée St-Antonin-Noble-Val 82
+agribalyse_food_code:en:76044
 ciqual_food_code:en:76044
 ciqual_food_name:en:Mineral still water (St-Antonin), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale St-Antonin, embouteillée, non gazeuse, fortement minéralisée (St-Antonin-Noble-Val, 82)
@@ -6324,6 +6581,7 @@ ciqual_food_name:fr:Eau minérale St-Antonin, embouteillée, non gazeuse, fortem
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized still water Thonon
 fr:Eau minérale embouteillée non gazeuse faiblement minéralisée Thonon 74
+agribalyse_food_code:en:76050
 ciqual_food_code:en:76050
 ciqual_food_name:en:Mineral still water (Thonon), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Thonon, embouteillée, non gazeuse, faiblement minéralisée (Thonon, 74)
@@ -6332,6 +6590,7 @@ ciqual_food_name:fr:Eau minérale Thonon, embouteillée, non gazeuse, faiblement
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water St-Diéry
 fr:Eau minérale embouteillée gazeuse fortement minéralisée St-Diéry 63
+agribalyse_food_code:en:76046
 ciqual_food_code:en:76046
 ciqual_food_name:en:Mineral sparkling water (St-Diéry), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale St-Diéry, embouteillée, gazeuse, fortement minéralisée (St-Diéry, 63)
@@ -6341,6 +6600,7 @@ ciqual_food_name:fr:Eau minérale St-Diéry, embouteillée, gazeuse, fortement m
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized sparkling water Ventadour
 fr:Eau minérale embouteillée gazeuse faiblement minéralisée Ventadour Le Pestrin 07
+agribalyse_food_code:en:76053
 ciqual_food_code:en:76053
 ciqual_food_name:en:Mineral sparkling water (Ventadour), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Ventadour, embouteillée, gazeuse, faiblement minéralisée (Le Pestrin, 07)
@@ -6350,6 +6610,7 @@ ciqual_food_name:fr:Eau minérale Ventadour, embouteillée, gazeuse, faiblement 
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized sparkling water Vernet
 fr:Eau minérale embouteillée gazeuse faiblement minéralisée Vernet Prades 07
+agribalyse_food_code:en:76054
 ciqual_food_code:en:76054
 ciqual_food_name:en:Mineral sparkling water (Vernet), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Vernet, embouteillée, gazeuse, faiblement minéralisée (Prades, 07)
@@ -6358,6 +6619,7 @@ ciqual_food_name:fr:Eau minérale Vernet, embouteillée, gazeuse, faiblement min
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Vichy Célestins
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Vichy Célestins Saint-Yorre 03
+agribalyse_food_code:en:76055
 ciqual_food_code:en:76055
 ciqual_food_name:en:Mineral sparkling water (Vichy Célestins), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Vichy Célestins, embouteillée, gazeuse, fortement minéralisée (Saint-Yorre, 03)
@@ -6366,6 +6628,7 @@ ciqual_food_name:fr:Eau minérale Vichy Célestins, embouteillée, gazeuse, fort
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Ste-Marguerite
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Ste-Marguerite St-Maurice 63
+agribalyse_food_code:en:76047
 ciqual_food_code:en:76047
 ciqual_food_name:en:Mineral sparkling water (Ste-Marguerite), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Ste-Marguerite, embouteillée, gazeuse, moyennement minéralisée (St-Maurice, 63)
@@ -6374,6 +6637,7 @@ ciqual_food_name:fr:Eau minérale Ste-Marguerite, embouteillée, gazeuse, moyenn
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water St-Yorre
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Saint-Yorre 03
+agribalyse_food_code:en:76049
 ciqual_food_code:en:76049
 ciqual_food_name:en:Mineral sparkling water (St-Yorre), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale St-Yorre, embouteillée, gazeuse, fortement minéralisée (Saint-Yorre, 03)
@@ -6383,6 +6647,7 @@ ciqual_food_name:fr:Eau minérale St-Yorre, embouteillée, gazeuse, fortement mi
 <en:Low mineral bottled waters
 en:Bottled lightly mineralized sparkling water Volvic active
 fr:Eau minérale active embouteillée gazeuse faiblement minéralisée Volvic 63
+agribalyse_food_code:en:76058
 ciqual_food_code:en:76058
 ciqual_food_name:en:Mineral sparkling water (Volvic active), bottled, lightly mineralized
 ciqual_food_name:fr:Eau minérale Volvic active, embouteillée, gazeuse, faiblement minéralisée (Volvic, 63)
@@ -6391,6 +6656,7 @@ ciqual_food_name:fr:Eau minérale Volvic active, embouteillée, gazeuse, faiblem
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Salvetat
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée La Salvetat 34
+agribalyse_food_code:en:76039
 ciqual_food_code:en:76039
 ciqual_food_name:en:Mineral sparkling water (Salvetat), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Salvetat, embouteillée, gazeuse, moyennement minéralisée (La Salvetat, 34)
@@ -6399,6 +6665,7 @@ ciqual_food_name:fr:Eau minérale Salvetat, embouteillée, gazeuse, moyennement 
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Soultzmatt
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Soultzmatt 68
+agribalyse_food_code:en:76040
 ciqual_food_code:en:76040
 ciqual_food_name:en:Mineral sparkling water (Soultzmatt), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Soultzmatt , embouteillée, gazeuse, moyennement minéralisée ( Soultzmatt, 68)
@@ -6407,6 +6674,7 @@ ciqual_food_name:fr:Eau minérale Soultzmatt , embouteillée, gazeuse, moyenneme
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Puits St Georges
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Puits St-Georges St-Romain-le-Puy 42
+agribalyse_food_code:en:76034
 ciqual_food_code:en:76034
 ciqual_food_name:en:Mineral sparkling water (Puits St Georges), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Puits St-Georges, embouteillée, gazeuse, moyennement minéralisée (St-Romain-le-Puy, 42)
@@ -6415,6 +6683,7 @@ ciqual_food_name:fr:Eau minérale Puits St-Georges, embouteillée, gazeuse, moye
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Quézac
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Quézac 48
+agribalyse_food_code:en:76035
 ciqual_food_code:en:76035
 ciqual_food_name:en:Mineral sparkling water (Quézac), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Quézac, embouteillée, gazeuse, moyennement minéralisée (Quézac, 48)
@@ -6423,6 +6692,7 @@ ciqual_food_name:fr:Eau minérale Quézac, embouteillée, gazeuse, moyennement m
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Reine des basaltes
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Reine des basaltes Asperjoc 07
+agribalyse_food_code:en:76036
 ciqual_food_code:en:76036
 ciqual_food_name:en:Mineral sparkling water (Reine des basaltes), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Reine des basaltes, embouteillée, gazeuse, moyennement minéralisée (Asperjoc, 07)
@@ -6431,6 +6701,7 @@ ciqual_food_name:fr:Eau minérale Reine des basaltes, embouteillée, gazeuse, mo
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Rozana
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Rozana Beauregard 63
+agribalyse_food_code:en:76037
 ciqual_food_code:en:76037
 ciqual_food_name:en:Mineral sparkling water (Rozana), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Rozana, embouteillée, gazeuse, fortement minéralisée (Beauregard, 63)
@@ -6439,6 +6710,7 @@ ciqual_food_name:fr:Eau minérale Rozana, embouteillée, gazeuse, fortement min�
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Orezza
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Orezza Rapaggio 20B
+agribalyse_food_code:en:76030
 ciqual_food_code:en:76030
 ciqual_food_name:en:Mineral sparkling water (Orezza), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Orezza, embouteillée, gazeuse, moyennement minéralisée (Rapaggio, 20B)
@@ -6447,6 +6719,7 @@ ciqual_food_name:fr:Eau minérale Orezza, embouteillée, gazeuse, moyennement mi
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Parot
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Parot St-Romain-le-Puy 42
+agribalyse_food_code:en:76031
 ciqual_food_code:en:76031
 ciqual_food_name:en:Mineral sparkling water (Parot), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Parot, embouteillée, gazeuse, moyennement minéralisée (St-Romain-le-Puy, 42)
@@ -6455,6 +6728,7 @@ ciqual_food_name:fr:Eau minérale Parot, embouteillée, gazeuse, moyennement min
 <en:Natural mineral waters
 en:Bottled averagely mineralized sparkling water Vernière
 fr:Eau minérale embouteillée gazeuse moyennement minéralisée Vernière Les Aires 34
+agribalyse_food_code:en:76024
 ciqual_food_code:en:76024
 ciqual_food_name:en:Mineral sparkling water (Vernière), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Vernière, embouteillée, gazeuse, moyennement minéralisée (Les Aires, 34)
@@ -6463,6 +6737,7 @@ ciqual_food_name:fr:Eau minérale Vernière, embouteillée, gazeuse, moyennement
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Didier
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Didier Martinique
+agribalyse_food_code:en:76018
 ciqual_food_code:en:76018
 ciqual_food_name:en:Mineral sparkling water (Didier), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Didier, embouteillée, gazeuse, fortement minéralisée (Martinique)
@@ -6471,6 +6746,7 @@ ciqual_food_name:fr:Eau minérale Didier, embouteillée, gazeuse, fortement min�
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Chateauneuf
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Chateauneuf 63
+agribalyse_food_code:en:76013
 ciqual_food_code:en:76013
 ciqual_food_name:en:Mineral sparkling water (Chateauneuf), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Chateauneuf, embouteillée, gazeuse, fortement minéralisée (Chateauneuf, 63)
@@ -6479,6 +6755,7 @@ ciqual_food_name:fr:Eau minérale Chateauneuf, embouteillée, gazeuse, fortement
 <en:Natural mineral waters
 en:Bottled strongly mineralized sparkling water Chateldon
 fr:Eau minérale embouteillée gazeuse fortement minéralisée Chateldon 63
+agribalyse_food_code:en:76014
 ciqual_food_code:en:76014
 ciqual_food_name:en:Mineral sparkling water (Chateldon), bottled, strongly mineralized
 ciqual_food_name:fr:Eau minérale Chateldon, embouteillée, gazeuse, fortement minéralisée (Chateldon, 63)
@@ -6487,6 +6764,7 @@ ciqual_food_name:fr:Eau minérale Chateldon, embouteillée, gazeuse, fortement m
 <en:Natural mineral waters
 en:Bottled averagely mineralized still water Clos de l'Abbaye
 fr:Eau minérale embouteillée non gazeuse moyennement minéralisée Clos de l'Abbaye St-Amand 59
+agribalyse_food_code:en:76015
 ciqual_food_code:en:76015
 ciqual_food_name:en:Mineral still water (Clos de l'Abbaye), bottled, averagely mineralized
 ciqual_food_name:fr:Eau minérale Clos de l'Abbaye, embouteillée, non gazeuse, moyennement minéralisée (St-Amand, 59)
@@ -6714,6 +6992,9 @@ nl:Rode wijnen, Rode wijn
 pt:Vinhos tintos, vinho tinto
 zh:红葡萄酒, 红酒
 wikidata:en:Q1827
+agribalyse_proxy_food_code:en:5204
+agribalyse_proxy_food_name:en:Wine, red, 11°
+agribalyse_proxy_food_name:fr:Vin rouge 11°
 
 <en:Red wines
 en:Organic red wines
@@ -6724,6 +7005,7 @@ zh:有机红葡萄酒, 有机红酒
 <en:Red wines
 en:10% red wine
 fr:Vin rouge à 10°, Vin rouge à 10 degrés
+agribalyse_food_code:en:5203
 ciqual_food_code:en:5203
 ciqual_food_name:en:Wine, red, 10°
 ciqual_food_name:fr:Vin rouge 10°
@@ -6731,6 +7013,7 @@ ciqual_food_name:fr:Vin rouge 10°
 <en:Red wines
 en:11% red wine
 fr:Vin rouge à 11°, Vin rouge à 11 degrés
+agribalyse_food_code:en:5204
 ciqual_food_code:en:5204
 ciqual_food_name:en:Wine, red, 11°
 ciqual_food_name:fr:Vin rouge 11°
@@ -6738,6 +7021,7 @@ ciqual_food_name:fr:Vin rouge 11°
 <en:Red wines
 en:12% red wine
 fr:Vin rouge à 12°, Vin rouge à 12 degrés
+agribalyse_food_code:en:5205
 ciqual_food_code:en:5205
 ciqual_food_name:en:Wine, red, 12°
 ciqual_food_name:fr:Vin rouge 12°
@@ -6745,6 +7029,7 @@ ciqual_food_name:fr:Vin rouge 12°
 <en:Red wines
 en:13% red wine
 fr:Vin rouge à 13°, Vin rouge à 13 degrés
+agribalyse_food_code:en:5208
 ciqual_food_code:en:5208
 ciqual_food_name:en:Wine, red, 13°
 ciqual_food_name:fr:Vin rouge 13°
@@ -6781,6 +7066,9 @@ zh:白葡萄酒
 als:Weisswein
 zh_yue:白葡萄酒
 wikidata:en:Q10210
+agribalyse_proxy_food_code:en:5200
+agribalyse_proxy_food_name:en:Wine, white, 11°
+agribalyse_proxy_food_name:fr:Vin blanc 11°
 
 <en:Wines
 en:Dessert wines
@@ -6824,18 +7112,21 @@ ciqual_food_name:fr:Boisson rafraîchissante sans alcool (aliment moyen)
 <en:Tea-based beverages
 en:Still soft drink with tea extract with sugar and artificial sweetener(s)
 fr:Boisson au thé aromatisée sucrée avec édulcorants
+agribalyse_food_code:en:18015
 ciqual_food_code:en:18015
 ciqual_food_name:en:Still soft drink with tea extract, with sugar and artificial sweetener(s)
 
 <en:Tea-based beverages
 en:Still soft drink with tea extract flavoured without sugar and with artificial sweeteners
 fr:Boisson au thé aromatisée non sucrée avec édulcorants
+agribalyse_food_code:en:18065
 ciqual_food_code:en:18065
 ciqual_food_name:en:Still soft drink with tea extract, flavoured, without sugar and with artificial sweeteners
 
 <en:Tea-based beverages
 en:Still soft drink with tea extract flavoured with sugar
 fr:Boisson au thé aromatisée sucrée
+agribalyse_food_code:en:18075
 ciqual_food_code:en:18075
 ciqual_food_name:en:Still soft drink with tea extract, flavoured, with sugar
 
@@ -18204,6 +18495,7 @@ en:Marsala wine
 fr:Marsala
 country:en:Italy
 #wikidata:en:
+agribalyse_food_code:en:1015
 ciqual_food_code:en:1015
 ciqual_food_name:en:Marsala wine
 ciqual_food_name:fr:Marsala
@@ -19394,6 +19686,7 @@ country:en:Luxembourg
 en:Wines from Malta
 fr:Vins de Malte, Vins maltais
 nl:Maltese wijnen, Maltese wijn, Wijn uit Malta
+country:en:Malta
 
 <en:Wines from Malta
 en:Gozo
@@ -21053,6 +21346,7 @@ fi:Samppanjat
 fr:Champagnes, champagne, vins de Champagne
 nl:Champagnes, Champagne
 wikidata:en:Q134862
+agribalyse_food_code:en:5207
 ciqual_food_code:en:5207
 ciqual_food_name:en:Champagne
 ciqual_food_name:fr:Champagne
@@ -21125,6 +21419,7 @@ fr:vins pétillant, vin pétillant, pétillant
 <en:Sparkling wines
 en:Sparkling fruit wine
 fr:Pétillant de fruits
+agribalyse_food_code:en:5100
 ciqual_food_code:en:5100
 ciqual_food_name:en:Sparkling fruit wine
 ciqual_food_name:fr:Pétillant de fruits
@@ -21185,6 +21480,7 @@ es:Vinos dulces
 fi:makeat viinit
 fr:Vins doux, Vin doux, Vins doux naturels, Vin doux naturel
 nl:Zoete wijnen, Zoete wijn
+agribalyse_food_code:en:1006
 ciqual_food_code:en:1006
 ciqual_food_name:en:Wine, white, sweet
 ciqual_food_name:fr:Vin doux
@@ -21192,6 +21488,7 @@ ciqual_food_name:fr:Vin doux
 <en:White wines
 en:11% white wine
 fr:Vin blanc à 11°, Vin blanc à 11% d'alcool
+agribalyse_food_code:en:5200
 ciqual_food_code:en:5200
 ciqual_food_name:en:Wine, white, 11°
 ciqual_food_name:fr:Vin blanc 11°
@@ -21199,6 +21496,7 @@ ciqual_food_name:fr:Vin blanc 11°
 <en:White wines
 en:11% dry white wine
 fr:Vin blanc sec à 11°, Vin blanc sec à 11% d'alcool
+agribalyse_food_code:en:5211
 ciqual_food_code:en:5211
 ciqual_food_name:en:Wine, white, dry, 11°
 ciqual_food_name:fr:Vin blanc sec 11°
@@ -21207,6 +21505,7 @@ ciqual_food_name:fr:Vin blanc sec 11°
 <en:Sparkling wines
 en:Sparkling white wine
 fr:Vin blanc mousseux
+agribalyse_food_code:en:5201
 ciqual_food_code:en:5201
 ciqual_food_name:en:Wine, white, sparkling
 ciqual_food_name:fr:Vin blanc mousseux
@@ -21215,6 +21514,7 @@ ciqual_food_name:fr:Vin blanc mousseux
 <en:Sparkling wines
 en:White sparkling flavoured wine
 fr:Vin blanc mousseux aromatisé
+agribalyse_food_code:en:5209
 ciqual_food_code:en:5209
 ciqual_food_name:en:Wine, white, sparkling, flavoured
 ciqual_food_name:fr:Vin blanc mousseux aromatisé
@@ -21320,6 +21620,7 @@ nl:Rosé wijnen, Rosé wijn, Rosé
 <en:Rosé wines
 en:11% rosé wine
 fr:Vin rosé 11°, Vin rosé 11 degrés
+agribalyse_food_code:en:5206
 ciqual_food_code:en:5206
 ciqual_food_name:en:Wine, rose, 11°
 ciqual_food_name:fr:Vin rosé 11°
@@ -21375,6 +21676,7 @@ wikidata:en:Q3411001
 <en:Mashed potatoes
 en:Potato puree made from flakes reconstituted with whole milk with added fat
 fr:Purée de pommes de terre à base de flocons reconstituée avec lait entier
+agribalyse_food_code:en:4017
 ciqual_food_code:en:4017
 ciqual_food_name:en:Potato puree, made from flakes, reconstituted with whole milk, with added fat
 ciqual_food_name:fr:Pomme de terre, purée à base de flocons, reconstituée avec lait entier, matière grasse
@@ -21383,6 +21685,7 @@ ciqual_food_name:fr:Pomme de terre, purée à base de flocons, reconstituée ave
 <en:Mashed potatoes
 en:Unsalted potato puree with milk and butter
 fr:Purée de pommes de terre non salée au lait et au beurre
+agribalyse_food_code:en:4018
 ciqual_food_code:en:4018
 ciqual_food_name:en:Potato puree, with milk and butter, unsalted
 ciqual_food_name:fr:Pomme de terre, purée, avec lait et beurre, non salée
@@ -21391,6 +21694,7 @@ ciqual_food_name:fr:Pomme de terre, purée, avec lait et beurre, non salée
 <en:Mashed potatoes
 en:Unsalted Potato puree made from flakes reconstituted with semi-skimmed milk and water
 fr:Purée de pommes de terre non salée à base de flocons reconstituée avec lait demi-écrémé et eau
+agribalyse_food_code:en:4019
 ciqual_food_code:en:4019
 ciqual_food_name:en:Potato puree, made from flakes, reconstituted with semi-skimmed milk and water, unsalted
 ciqual_food_name:fr:Pomme de terre, purée à base de flocons, reconstituée avec lait demi-écrémé et eau, non salée
@@ -21399,6 +21703,7 @@ ciqual_food_name:fr:Pomme de terre, purée à base de flocons, reconstituée ave
 <en:Mashed potatoes
 en:Dehydrated potato flakes with milk, Dehydrated potato flakes with cream
 fr:Purée de pommes de terre en flocons déshydratés au lait, Purée de pommes de terre en flocons déshydratés à la crème
+agribalyse_food_code:en:4016
 ciqual_food_code:en:4016
 ciqual_food_name:en:Potato flakes, dehydrated, with milk or cream
 ciqual_food_name:fr:Pomme de terre, flocons déshydratés, au lait ou à la crème
@@ -21407,6 +21712,7 @@ ciqual_food_name:fr:Pomme de terre, flocons déshydratés, au lait ou à la crè
 <en:Mashed potatoes
 en:Sweet potato puree cooked with cream
 fr:Purée de patates douces cuisinée à la crème, Purée de patate douce cuisinée à la crème
+agribalyse_food_code:en:4103
 ciqual_food_code:en:4103
 ciqual_food_name:en:Sweet potato, puree, cooked with cream
 ciqual_food_name:fr:Patate douce, purée, cuisinée à la crème
@@ -21415,6 +21721,7 @@ ciqual_food_name:fr:Patate douce, purée, cuisinée à la crème
 <en:Sweet potatoes
 en:Cooked sweet potatoes
 fr:Patates douces cuites
+agribalyse_food_code:en:4102
 ciqual_food_code:en:4102
 ciqual_food_name:en:Sweet potato, cooked
 ciqual_food_name:fr:Patate douce, cuite
@@ -21422,6 +21729,7 @@ ciqual_food_name:fr:Patate douce, cuite
 <en:Sweet potatoes
 en:Raw sweet potatoes
 fr:Patates douces crues
+agribalyse_food_code:en:4101
 ciqual_food_code:en:4101
 ciqual_food_name:en:Sweet potato, raw
 ciqual_food_name:fr:Patate douce, crue
@@ -21528,6 +21836,7 @@ nl:limoensiropen, Limoensiroop
 <en:Flavoured syrups
 en:Lemon base for beverage without sugar to be diluted, Lime base for beverage without sugar to be diluted,
 fr:Citron à diluer pour boissons sans sucres ajoutés, Citron vert à diluer pour boissons sans sucres ajoutés
+agribalyse_food_code:en:18220
 ciqual_food_code:en:18220
 ciqual_food_name:en:Lemon or lime base, for beverage, without sugar (to be diluted)
 ciqual_food_name:fr:Citron ou Lime, spécialité à diluer pour boissons, sans sucres ajoutés
@@ -21680,6 +21989,7 @@ pnns_group_2:en:Teas and herbal teas and coffees
 <en:Herbal tea beverages
 en:Brewed infusions without sugar
 fr:Tisanes infusées non sucrées
+agribalyse_food_code:en:18022
 ciqual_food_code:en:18022
 ciqual_food_name:en:Infusion, brewed, without sugar
 ciqual_food_name:fr:Tisane infusée, non sucrée
@@ -21901,6 +22211,7 @@ hu:Csokoládés kekszek
 nl:Chocolade koekjes, Chocolade koekje
 ro:Prăjituri cu ciocolată
 zh:巧克力曲奇, 巧克力曲奇饼干
+agribalyse_food_code:en:24684
 ciqual_food_code:en:24684
 ciqual_food_name:en:Biscuit (cookie), with chocolate drops
 
@@ -21976,12 +22287,14 @@ fr:Barquettes
 <en:Biscuits
 en:Sponge cake biscuits wih fruits covering, Pre-packed sponge cake biscuit with fruits covering
 fr:Barquettes aux fruits, Biscuit sec avec nappage aux fruits, Génoise avec nappage aux fruits, Barquette avec nappage aux fruits
+agribalyse_food_code:en:24678
 ciqual_food_code:en:24678
 ciqual_food_name:en:Biscuit sponge cake with fruits covering, pre-packed
 ciqual_food_name:fr:Biscuit sec (génoise) nappage aux fruits, type barquette
 
 <fr:Barquettes
 fr:Barquettes au chocolat
+agribalyse_food_code:en:24051
 ciqual_food_code:en:24051
 ciqual_food_name:en:Biscuit sponge cake, with chocolate, pre-packed
 
@@ -21999,6 +22312,7 @@ wikidata:en:Q16545117
 en:Crêpes dentelle with chocolate, Wafer cookie with chocolate
 fr:Crêpes dentelle au chocolat
 oqali_family:en: fr:Biscuits et gateaux industriels - Crepes dentelles au chocolat
+agribalyse_food_code:en:24371
 ciqual_food_code:en:24371
 ciqual_food_name:en:Wafer cookie, with chocolate, prepacked
 
@@ -22103,6 +22417,7 @@ es:Palmeras, palmeritas
 fr:Palmiers, Palmiers feuilletés, Biscuit sec feuilleté, Palmier
 nl:Krakelingen
 wikidata:en:Q2096475
+agribalyse_food_code:en:24659
 ciqual_food_code:en:24659
 ciqual_food_name:en:Biscuit puff pastry
 ciqual_food_name:fr:Biscuit sec feuilleté, type palmier ou autres
@@ -22110,6 +22425,7 @@ ciqual_food_name:fr:Biscuit sec feuilleté, type palmier ou autres
 <en:Flaky biscuits
 en:Puff pastry biscuit from bakery, Palmier from bakery
 fr:Palmier artisanal
+agribalyse_food_code:en:24660
 ciqual_food_code:en:24660
 ciqual_food_name:en:Biscuit ( puff pastry), palmier, from bakery
 ciqual_food_name:fr:Palmier, artisanal
@@ -22122,6 +22438,7 @@ fi:kuivat keksit
 fr:Biscuits secs, biscuit sec
 hu:Száraz kekszek
 nl:Droge biscuits
+agribalyse_food_code:en:24000
 ciqual_food_code:en:24000
 ciqual_food_name:en:Biscuit (cookie)
 ciqual_food_name:fr:Biscuit sec, sans précision
@@ -22129,6 +22446,7 @@ ciqual_food_name:fr:Biscuit sec, sans précision
 <fr:Biscuits secs
 en:Plain biscuit, Plain cookie
 fr:Biscuit sec nature
+agribalyse_food_code:en:24001
 ciqual_food_code:en:24001
 ciqual_food_name:en:Biscuit (cookie), plain
 ciqual_food_name:fr:Biscuit sec nature
@@ -22136,6 +22454,7 @@ ciqual_food_name:fr:Biscuit sec nature
 <fr:Biscuits secs
 en:Biscuit with guaranteed vitamins and chemical elements content
 fr:Biscuit sec à teneur garantie en vitamines et minéraux
+agribalyse_food_code:en:24003
 ciqual_food_code:en:24003
 ciqual_food_name:en:Biscuit (cookie) vitamins and chemical elements content guaranteed
 ciqual_food_name:fr:Biscuit sec à teneur garantie en vitamines et minéraux
@@ -22143,6 +22462,7 @@ ciqual_food_name:fr:Biscuit sec à teneur garantie en vitamines et minéraux
 <fr:Biscuits secs
 en:Biscuit with guaranteed vitamins content
 fr:Biscuit sec à teneur garantie en vitamines
+agribalyse_food_code:en:24002
 ciqual_food_code:en:24002
 ciqual_food_name:en:Biscuit (cookie) vitamins content guaranteed
 ciqual_food_name:fr:Biscuit sec à teneur garantie en vitamines
@@ -22150,6 +22470,7 @@ ciqual_food_name:fr:Biscuit sec à teneur garantie en vitamines
 <fr:Biscuits secs
 en:Biscuit with vegetal fat, Cookie with vegetal fat
 fr:Biscuit sec avec matière grasse végétale
+agribalyse_food_code:en:24010
 ciqual_food_code:en:24010
 ciqual_food_name:en:Biscuit (cookie), with vegetal fat
 ciqual_food_name:fr:Biscuit sec, avec matière grasse végétale
@@ -22158,6 +22479,7 @@ ciqual_food_name:fr:Biscuit sec, avec matière grasse végétale
 <fr:Biscuits secs
 en:Breakfast biscuit, Breakfast cookie
 fr:Biscuit sec pour petit déjeuner
+agribalyse_food_code:en:24034
 ciqual_food_code:en:24034
 ciqual_food_name:en:Breakfast biscuit (cookie)
 ciqual_food_name:fr:Biscuit sec pour petit déjeuner
@@ -22166,6 +22488,7 @@ ciqual_food_name:fr:Biscuit sec pour petit déjeuner
 <fr:Biscuits secs
 en:Breakfast biscuit with reduced sugar, Breakfast cookie with reduced sugar
 fr:Biscuit sec pour petit déjeuner allégé en sucres
+agribalyse_food_code:en:24035
 ciqual_food_code:en:24035
 ciqual_food_name:en:Breakfast biscuit (cookie), reduced sugar
 ciqual_food_name:fr:Biscuit sec pour petit déjeuner, allégé en sucres
@@ -22173,6 +22496,7 @@ ciqual_food_name:fr:Biscuit sec pour petit déjeuner, allégé en sucres
 <fr:Biscuits secs
 en:Biscuit with reduced sugar, Cookie with reduced sugar
 fr:Biscuit sec pauvre en glucides
+agribalyse_food_code:en:24690
 ciqual_food_code:en:24690
 ciqual_food_name:en:Biscuit (cookie), reduced sugar
 ciqual_food_name:fr:Biscuit sec pauvre en glucides
@@ -22181,6 +22505,7 @@ ciqual_food_name:fr:Biscuit sec pauvre en glucides
 <fr:Biscuits secs
 en:Breakfast biscuit with cereals fortified with vitamins and chemical elements, Breakfast cookie with cereals fortified with vitamins and chemical elements
 fr:Biscuit aux céréales pour petit déjeuner enrichis en vitamines et minéraux
+agribalyse_food_code:en:24041
 ciqual_food_code:en:24041
 ciqual_food_name:en:Breakfast biscuit (cookie) with cereals, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Biscuit aux céréales pour petit déjeuner, enrichis en vitamines et minéraux
@@ -22191,6 +22516,7 @@ en:Sponge fingers biscuit, Lady fingers biscuit
 nl:Lange vingers
 wikidata:en:Q16533537
 oqali_family:en: fr:Biscuits et gateaux industriels - Boudoirs
+agribalyse_food_code:en:24430
 ciqual_food_code:en:24430
 ciqual_food_name:en:Biscuit (cookie), sponge fingers or Lady fingers
 ciqual_food_name:fr:Biscuit sec aux œufs à la cuillère (cuiller) ou Boudoir
@@ -22198,6 +22524,7 @@ ciqual_food_name:fr:Biscuit sec aux œufs à la cuillère (cuiller) ou Boudoir
 <fr:Biscuits secs
 en:Assortment of miniature sweets and biscuits
 fr:Assortiment de petits biscuits secs
+agribalyse_food_code:en:24011
 ciqual_food_code:en:24011
 ciqual_food_name:en:Biscuit (cookie), assortment of miniature sweets and biscuits
 ciqual_food_name:fr:Biscuit sec, petits fours en assortiment
@@ -22210,6 +22537,7 @@ fr:Florentins, Florentin, Biscuit florentin, Biscuits florentins, Biscuit sec su
 nl:Florentines
 wikidata:en:Q1429469
 oqali_family:en: fr:Biscuits et gateaux industriels - Florentins
+agribalyse_food_code:en:24056
 ciqual_food_code:en:24056
 ciqual_food_name:en:Florentine biscuit (chocolate sweet biscuit (cookie) with almonds)
 ciqual_food_name:fr:Florentin (biscuit sec sucré chocolaté aux amandes)
@@ -22237,6 +22565,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Petit-Beurre
 wikidata:en:Q19573669
 # ingredient/fr:petit-beurre has 20 products in french @2018-02-08
 # category/petit-beurre has 263 products @2018-05-19
+agribalyse_food_code:en:24015
 ciqual_food_code:en:24015
 ciqual_food_name:en:Butter biscuit (cookie)
 ciqual_food_name:fr:Biscuit sec petit beurre
@@ -22251,6 +22580,7 @@ ca:Galetes de mantega
 fr:Biscuits sablés, Biscuit sablé, Sablés, Sablé, Sablé pâtissier
 nl:Zandkoekjes, Zandkokje
 wikidata:en:Q2915670
+agribalyse_food_code:en:24071
 ciqual_food_code:en:24071
 ciqual_food_name:en:Shortbread pastry biscuit
 ciqual_food_name:fr:Sablé pâtissier
@@ -22258,30 +22588,35 @@ ciqual_food_name:fr:Sablé pâtissier
 <en:Biscuits
 en:Biscuit shortbread with butter and chocolate
 fr:sablé au chocolat
+agribalyse_food_code:en:24050
 ciqual_food_code:en:24050
 ciqual_food_name:en:Biscuit shortbread, with butter and chocolate
 
 <en:Biscuits
 en:Shortbread cookie with cocoa or chocolate or praline or other
 fr:sablé au cacao et au chocolat
+agribalyse_food_code:en:24080
 ciqual_food_code:en:24080
 ciqual_food_name:en:Shortbread cookie with cocoa or chocolate, or praline or other
 
 <en:Biscuits
 en:Biscuit shortbread with chocolate pre-packed
 fr:galette au chocolat
+agribalyse_food_code:en:24053
 ciqual_food_code:en:24053
 ciqual_food_name:en:Biscuit shortbread, with chocolate, pre-packed
 
 <en:Biscuits
 en:Biscuit (cookie) snack with dairy or vanilla filling
 fr:biscuit lait vanille
+agribalyse_food_code:en:24225
 ciqual_food_code:en:24225
 ciqual_food_name:en:Biscuit (cookie), snack with dairy or vanilla filling
 
 <en:Biscuits
 en:Shortbread cookie with coconut
 fr:Sablé à la noix de coco
+agribalyse_food_code:en:24070
 ciqual_food_code:en:24070
 ciqual_food_name:en:Shortbread cookie w coconut
 ciqual_food_name:fr:Sablé à la noix de coco
@@ -22289,6 +22624,7 @@ ciqual_food_name:fr:Sablé à la noix de coco
 <en:Biscuits
 en:Shortbread cookie with apple, Shortbread cookie with red berries
 fr:Sablé aux pommes, Sablé aux fruits rouges
+agribalyse_food_code:en:24072
 ciqual_food_code:en:24072
 ciqual_food_name:en:Shortbread cookie with fruit (apple, red berries, etc.)
 ciqual_food_name:fr:Sablé aux fruits (pomme, fruits rouges, etc.)
@@ -22296,6 +22632,7 @@ ciqual_food_name:fr:Sablé aux fruits (pomme, fruits rouges, etc.)
 <en:Biscuits
 en:Fruit shortbread cake
 fr:Gâteau sablé aux fruits
+agribalyse_food_code:en:23930
 ciqual_food_code:en:23930
 ciqual_food_name:en:Fruit shortbread cake, prepacked
 ciqual_food_name:fr:Gâteau sablé aux fruits, préemballé
@@ -22303,6 +22640,7 @@ ciqual_food_name:fr:Gâteau sablé aux fruits, préemballé
 <en:Biscuits
 en:Shortbread biscuit with fruits
 fr:Biscuit sec aux fruits, Sablé aux fruits, Galette aux fruits, Palet aux fruits
+agribalyse_food_code:en:24054
 ciqual_food_code:en:24054
 ciqual_food_name:en:Biscuit shortbread, with fruits
 ciqual_food_name:fr:Biscuit sec, sablé, galette ou palet, aux fruits
@@ -22310,6 +22648,7 @@ ciqual_food_name:fr:Biscuit sec, sablé, galette ou palet, aux fruits
 <en:Biscuits
 en:Shortbread biscuit with butter
 fr:Biscuit sec au beurre
+agribalyse_food_code:en:24049
 ciqual_food_code:en:24049
 ciqual_food_name:en:Biscuit shortbread, with butter
 ciqual_food_name:fr:Biscuit sec au beurre, sablé, galette ou palet
@@ -22325,6 +22664,7 @@ ru:Имбирное печенье и пряники
 sv:Pepparkakor, Pepparkaka
 wikidata:en:Q178600
 oqali_family:en: fr:Biscuits et gateaux industriels - Pains d_epices
+agribalyse_food_code:en:23200
 ciqual_food_code:en:23200
 ciqual_food_name:en:Gingerbread
 ciqual_food_name:fr:Pain d'épices
@@ -22332,6 +22672,7 @@ ciqual_food_name:fr:Pain d'épices
 <en:Biscuits and cakes
 en:Savoy-style sponge cake, Savoy cake, Savoy sponge cake
 fr:Biscuit de Savoie
+agribalyse_food_code:en:23050
 ciqual_food_code:en:23050
 ciqual_food_name:en:Savoy-style sponge cake
 ciqual_food_name:fr:Biscuit de Savoie
@@ -22384,6 +22725,7 @@ fr:Spéculoos, spéculos
 nl:Kandijkoekjes, Kandijkoekje, Speculoos
 wikidata:en:Q6591
 oqali_family:en: fr:Biscuits et gateaux industriels - Speculoos
+agribalyse_food_code:en:24009
 ciqual_food_code:en:24009
 ciqual_food_name:en:Speculoos biscuit
 ciqual_food_name:fr:Spéculoos
@@ -22440,6 +22782,7 @@ nl:Gepaneerde kazen, Gepaneerde kaas
 <en:Breaded products
 en:Cheese and ham breaded
 fr:Fromage pané au jambon
+agribalyse_food_code:en:25546
 ciqual_food_code:en:25546
 ciqual_food_name:en:Cheese and ham, breaded
 
@@ -22469,6 +22812,7 @@ ciqual_food_name:fr:Pain (aliment moyen)
 <en:Appetizers
 en:Filled fougasse
 fr:Fougasses, Fougasses garnies
+agribalyse_food_code:en:7812
 ciqual_food_code:en:7812
 ciqual_food_name:en:Fougasse, filled
 ciqual_food_name:fr:Fougasse, garnie
@@ -22481,6 +22825,7 @@ fr:Pains aux raisins, escargots aux raisins, escargot aux raisins, pain aux rais
 nl:Rozijnenbroden, Rozijnenbrood
 ro:Pâini cu stafide, Pâine cu stafide
 #Escargot aux raisin a subcategory?
+agribalyse_food_code:en:7720
 ciqual_food_code:en:7720
 ciqual_food_name:en:Raisin puff pastry (Viennese pastries)
 ciqual_food_name:fr:Pain aux raisins (viennoiserie)
@@ -22495,6 +22840,7 @@ nl:Baguettes, Baguette
 ro:Baghete
 zh:法式面包, 法式长棍面包
 wikidata:en:Q208172
+agribalyse_food_code:en:7001
 ciqual_food_code:en:7001
 ciqual_food_name:en:Bread, French bread, baguette
 ciqual_food_name:fr:Pain, baguette, courante
@@ -22507,6 +22853,7 @@ fr:Pains de tradition française, pain de tradition française, pains traditionn
 <fr:Pains de tradition française
 fr:Baguettes de tradition française, Baguette de tradition française, baguettes traditionnelles françaises, baguette traditionnelle française, baguettes traditionnelles de France, baguette traditionnelle de France, baguettes tradition, baguette tradition, Baguettes de pain de tradition française
 en:Unsalted French bread, Unsalted baguette
+agribalyse_food_code:en:7007
 ciqual_food_code:en:7007
 ciqual_food_name:en:Bread, French bread, baguette, unsalted
 ciqual_food_name:fr:Pain, baguette, de tradition française
@@ -22515,6 +22862,7 @@ ciqual_food_name:fr:Pain, baguette, de tradition française
 <fr:Pains de tradition française
 en:Country-style French baguette bread, Country-style French bread bread
 fr:Baguette de campagne, Boule de pain de campagne
+agribalyse_food_code:en:7100
 ciqual_food_code:en:7100
 ciqual_food_name:en:Country-style bread, French bread (baguette or ball)
 ciqual_food_name:fr:Pain, baguette ou boule, de campagne
@@ -22523,6 +22871,7 @@ ciqual_food_name:fr:Pain, baguette ou boule, de campagne
 <fr:Pains de tradition française
 en:Wholemeal bread made with flour type 150, Integral bread made with flour type 150
 fr:Pain complet à la farine T150, Pain intégral à la farine T150
+agribalyse_food_code:en:7110
 ciqual_food_code:en:7110
 ciqual_food_name:en:Bread, wholemeal or integral bread (made with flour type 150)
 ciqual_food_name:fr:Pain complet ou intégral (à la farine T150)
@@ -22531,6 +22880,7 @@ ciqual_food_name:fr:Pain complet ou intégral (à la farine T150)
 <fr:Pains de tradition française
 en:Country-style home-made bread with flour for bread making machine
 fr:Pain de campagne fait maison avec farine pour machine à pain
+agribalyse_food_code:en:7261
 ciqual_food_code:en:7261
 ciqual_food_name:en:Country-style bread, home-made (with flour for bread making machine)
 ciqual_food_name:fr:Pain de campagne maison (avec farine pour machine à pain)
@@ -22539,6 +22889,7 @@ ciqual_food_name:fr:Pain de campagne maison (avec farine pour machine à pain)
 <fr:Pains de tradition française
 en:Unsalted French bread, French bread without salt
 fr:Baguettes de pain sans sel
+agribalyse_food_code:en:7160
 ciqual_food_code:en:7160
 ciqual_food_name:en:Bread, French bread, without salt
 ciqual_food_name:fr:Pain, baguette, sans sel
@@ -22547,6 +22898,7 @@ ciqual_food_name:fr:Pain, baguette, sans sel
 <fr:Pains de tradition française
 en:French bread multigrain from bakery, French bread baguette multigrain from bakery, French bread ball multigrain from bakery
 fr:Pain artisanal aux céréales et graines, Baguette artisanale aux céréales et graines, Boule de pain artisanale aux céréales et graines
+agribalyse_food_code:en:7255
 ciqual_food_code:en:7255
 ciqual_food_name:en:Bread, French bread, (baguette or ball), multigrain, from bakery
 ciqual_food_name:fr:Pain, baguette ou boule, aux céréales et graines, artisanal
@@ -22555,6 +22907,7 @@ ciqual_food_name:fr:Pain, baguette ou boule, aux céréales et graines, artisana
 <fr:Pains de tradition française
 en:Brown bread baguette with flour type 80, Brown bread baguette with flour type 110, Brown bread ball with flour type 80, Brown bread ball with flour type 110
 fr:Baguettes de pain à la farine T80, Baguettes de pain à la farine T110, Boules de pain à la farine T80, Boules de pain à la farine T110
+agribalyse_food_code:en:7010
 ciqual_food_code:en:7010
 ciqual_food_name:en:Brown bread, French bread (baguette or ball), with flour type 80 or 110
 ciqual_food_name:fr:Pain, baguette ou boule, bis (à la farine T80 ou T110) 
@@ -22563,6 +22916,7 @@ ciqual_food_name:fr:Pain, baguette ou boule, bis (à la farine T80 ou T110)
 <fr:Pains de tradition française
 en:Baguette made with type T55-T110 flour, Bread ball made with type T55-T110 flour
 fr:Baguette de pains bio à la farine T55 jusqu'à T110, Boules de pain bio à la farine T55 jusqu'à T110
+agribalyse_food_code:en:7025
 ciqual_food_code:en:7025
 ciqual_food_name:en:Brear (baguette or ball), made with type T55-T110 flour
 ciqual_food_name:fr:Pain, baguette ou boule, bio (à la farine T55 jusqu'à T110)
@@ -22571,6 +22925,7 @@ ciqual_food_name:fr:Pain, baguette ou boule, bio (à la farine T55 jusqu'à T110
 <fr:Pains de tradition française
 en:French bread ball 400g
 fr:Pain français 400g, Boule de pain français 400g
+agribalyse_food_code:en:7012
 ciqual_food_code:en:7012
 ciqual_food_name:en:Bread, French bread, ball, 400g
 ciqual_food_name:fr:Pain courant français, 400g ou boule
@@ -22579,6 +22934,7 @@ ciqual_food_name:fr:Pain courant français, 400g ou boule
 <fr:Pains de tradition française
 en:French bread multigrain from bakery, French bread baguette multigrain from bakery, French bread ball multigrain from bakery
 fr:Pain artisanal aux céréales et graines, Baguette artisanale aux céréales et graines, Boule de pain artisanale aux céréales et graines
+agribalyse_food_code:en:7255
 ciqual_food_code:en:7255
 ciqual_food_name:en:Bread, French bread, (baguette or ball), multigrain, from bakery
 ciqual_food_name:fr:Pain, baguette ou boule, aux céréales et graines, artisanal
@@ -22587,6 +22943,7 @@ ciqual_food_name:fr:Pain, baguette ou boule, aux céréales et graines, artisana
 <fr:Pains de tradition française
 en:French baguette with yeast, French bread ball with yeast
 fr:Baguette de pain au levain, Boule de pain au levain
+agribalyse_food_code:en:7002
 ciqual_food_code:en:7002
 ciqual_food_name:en:Bread, French bread (baguette or ball), with yeast
 ciqual_food_name:fr:Pain, baguette ou boule, au levain
@@ -22667,6 +23024,7 @@ it:Grissini
 nl:Soepstengels, Soepstengel
 wikidata:en:Q514467
 oqali_family:en: fr:Aperitifs a croquer - Gressins
+agribalyse_food_code:en:7525
 ciqual_food_code:en:7525
 ciqual_food_name:en:Grissini or bread stick
 ciqual_food_name:fr:Gressins
@@ -22696,6 +23054,7 @@ wikidata:en:Q251981
 <en:Crispbreads
 en:Extruded and grilled crispbread
 fr:Tartines craquantes grillées, Tartines craquantes extrudées et grillées
+agribalyse_food_code:en:7410
 ciqual_food_code:en:7410
 ciqual_food_name:en:Crispbread, extruded and grilled
 ciqual_food_name:fr:Tartine craquante, extrudée et grillée
@@ -22703,6 +23062,7 @@ ciqual_food_name:fr:Tartine craquante, extrudée et grillée
 <en:Crispbreads
 en:Extruded and grilled biscuits with chocolate filling
 fr:Tartines craquantes grillées fourrées au chocolat, Tartines craquantes extrudées et grillées fourrées au chocolat
+agribalyse_food_code:en:7412
 ciqual_food_code:en:7412
 ciqual_food_name:en:Biscuit, extruded and grilled, chocolate filling
 ciqual_food_name:fr:Tartine craquante, extrudée et grillée, fourrée au chocolat
@@ -22710,6 +23070,7 @@ ciqual_food_name:fr:Tartine craquante, extrudée et grillée, fourrée au chocol
 <en:Crispbreads
 en:Extruded and grilled biscuits with fruits filling
 fr:Tartines craquantes grillées fourrées aux fruits, Tartines craquantes extrudées et grillées fourrées aux fruits
+agribalyse_food_code:en:7413
 ciqual_food_code:en:7413
 ciqual_food_name:en:Biscuit, extruded and grilled, fruits filling
 ciqual_food_name:fr:Tartine craquante, extrudée et grillée, fourrée aux fruits
@@ -22725,6 +23086,7 @@ it:Pani senza glutine
 nl:Glutenvrije broden, Glutenvrij brood, Broden zonder gluten
 pl:Pieczywo bezglutenowe
 ro:Pâini fără gluten, Pâine fără gluten
+agribalyse_food_code:en:7130
 ciqual_food_code:en:7130
 ciqual_food_name:en:Bread, gluten free
 ciqual_food_name:fr:Pain, sans gluten
@@ -22742,6 +23104,7 @@ en:Rusk, rusks
 fr:Biscotte
 it:Fette biscottate
 wikidata:en:Q5477096
+agribalyse_food_code:en:7300
 ciqual_food_code:en:7300
 ciqual_food_name:en:Rusk
 ciqual_food_name:fr:Biscotte classique
@@ -22757,6 +23120,7 @@ nl:Roggebroden, Roggebrood
 ro:Pâine de secară, Pâine cu faină de secară
 ru:Ржаной хлеб, хлеб ржаной, чёрный хлеб
 wikidata:en:Q3893120
+agribalyse_food_code:en:7125
 ciqual_food_code:en:7125
 ciqual_food_name:en:Rye bread, and wheat
 ciqual_food_name:fr:Pain de seigle, et froment
@@ -22788,6 +23152,7 @@ ru:Хлеб ржано-пшеничный, Ржано-пшеничный хле�
 <en:Breads
 en:Bran bread, Whole-grain bread
 fr:Pain au son
+agribalyse_food_code:en:7115
 ciqual_food_code:en:7115
 ciqual_food_name:en:Bran grain bread
 ciqual_food_name:fr:Pain au son
@@ -22813,6 +23178,7 @@ wikidata:en:Q10516678
 <en:Meals
 en:Corn tortilla wraps to be filled
 fr:Tortillas souples à base de maïs à garnir
+agribalyse_food_code:en:7813
 ciqual_food_code:en:7813
 ciqual_food_name:en:Corn tortilla wrap, to be filled
 ciqual_food_name:fr:Tortilla souple (à garnir), à base de maïs
@@ -22820,6 +23186,7 @@ ciqual_food_name:fr:Tortilla souple (à garnir), à base de maïs
 <en:Meals
 en:Wheat tortilla wraps to be filled
 fr:Tortillas souples à base de blé à garnir
+agribalyse_food_code:en:7815
 ciqual_food_code:en:7815
 ciqual_food_name:en:Wheat tortilla wrap, to be filled
 ciqual_food_name:fr:Tortilla souple (à garnir), à base de blé
@@ -22827,6 +23194,7 @@ ciqual_food_name:fr:Tortilla souple (à garnir), à base de blé
 <en:Meals
 en:Fajitas
 fr:Fajitas
+agribalyse_food_code:en:25460
 ciqual_food_code:en:25460
 ciqual_food_name:en:Fajitas
 ciqual_food_name:fr:Fajitas
@@ -22838,6 +23206,7 @@ fr:Ragoûts
 <en:Meals
 en:Boiled meat with vegetables
 fr:Pot-au-feu
+agribalyse_food_code:en:25013
 ciqual_food_code:en:25013
 ciqual_food_name:en:Boiled meat with vegetables
 ciqual_food_name:fr:Pot-au-feu
@@ -22872,6 +23241,7 @@ nl:Gesneden broden
 pt:Pães em fatías
 ru:Хлеб нарезанный, Хлеб в нарезке
 wikidata:en:Q134152
+agribalyse_food_code:en:7200
 ciqual_food_code:en:7200
 ciqual_food_name:en:Sandwich loaf
 ciqual_food_name:fr:Pain de mie, courant
@@ -22882,6 +23252,7 @@ de:Brot ohne Kruste
 es:Pan inglés sin corteza, Pan de molde sin corteza
 fr:Pains de mie sans croûte
 nl:Korsteloze broden
+agribalyse_food_code:en:7201
 ciqual_food_code:en:7201
 ciqual_food_name:en:Sandwich loaf, crust less, prepacked
 ciqual_food_name:fr:Pain de mie, sans croûte, préemballé
@@ -22893,6 +23264,7 @@ es:Panes de molde con cereales
 fi:viipaloidut siemenleivät
 fr:Pains de mie aux céréales, Pain de mie aux céréales, Pain de mie multicéréales
 nl:Gesneden Meergranenbroden
+agribalyse_food_code:en:7113
 ciqual_food_code:en:7113
 ciqual_food_name:en:Sandwich loaf, multigrain
 ciqual_food_name:fr:Pain de mie, multicéréale
@@ -22902,6 +23274,7 @@ en:Wholemeal English bread, Wholemeal sandwich loaf
 es:Panes de molde integrales
 fr:Pains de mie complet, Pain de mie complet
 nl:Gesneden volkorenbroden
+agribalyse_food_code:en:7111
 ciqual_food_code:en:7111
 ciqual_food_name:en:Sandwich loaf, wholemeal
 ciqual_food_name:fr:Pain de mie, complet
@@ -22909,6 +23282,7 @@ ciqual_food_name:fr:Pain de mie, complet
 <en:Sliced breads
 en:Brioche sandwich bread
 fr:Pains de mie briochés
+agribalyse_food_code:en:7210
 ciqual_food_code:en:7210
 ciqual_food_name:en:Brioche sandwich bread, prepacked
 ciqual_food_name:fr:Pain de mie brioché, préemballé
@@ -22916,6 +23290,7 @@ ciqual_food_name:fr:Pain de mie brioché, préemballé
 <en:Sliced breads
 en:Bran grain sandwich loaf
 fr:Pain de mie au son
+agribalyse_food_code:en:7112
 ciqual_food_code:en:7112
 ciqual_food_name:en:Sandwich loaf, bran grain
 ciqual_food_name:fr:Pain de mie, au son
@@ -22923,6 +23298,7 @@ ciqual_food_name:fr:Pain de mie, au son
 <en:Sliced breads
 en:Bran grain sandwich loaf
 fr:Pain de mie au son
+agribalyse_food_code:en:7112
 ciqual_food_code:en:7112
 ciqual_food_name:en:Sandwich loaf, bran grain
 ciqual_food_name:fr:Pain de mie, au son
@@ -22958,6 +23334,7 @@ nl:Zweedse toasts, Zweedse toast
 <en:Toasts
 en:Sliced rusk with eggs
 fr:Pain grillé brioché
+agribalyse_food_code:en:7403
 ciqual_food_code:en:7403
 ciqual_food_name:en:Rusk with eggs, sliced, prepacked
 ciqual_food_name:fr:Pain grillé brioché, tranché, préemballé
@@ -22965,6 +23342,7 @@ ciqual_food_name:fr:Pain grillé brioché, tranché, préemballé
 <en:Toasts
 en:Rusk with eggs
 fr:Biscottes briochées
+agribalyse_food_code:en:7301
 ciqual_food_code:en:7301
 ciqual_food_name:en:Rusk, w eggs
 ciqual_food_name:fr:Biscotte briochée
@@ -22972,6 +23350,7 @@ ciqual_food_name:fr:Biscotte briochée
 <en:Toasts
 en:Unsalted rusk
 fr:Biscotte sans adjonction de sel
+agribalyse_food_code:en:7310
 ciqual_food_code:en:7310
 ciqual_food_name:en:Rusk, unsalted
 ciqual_food_name:fr:Biscotte sans adjonction de sel
@@ -22990,6 +23369,7 @@ ciqual_food_name:fr:Biscotte multicéréale
 <en:Toasts
 en:Wholemeal rusk, High-fiber rusk
 fr:Biscottes complètes, Biscottes riches en fibres
+agribalyse_food_code:en:7340
 ciqual_food_code:en:7340
 ciqual_food_name:en:Rusk, wholemeal or rich in fibre
 ciqual_food_name:fr:Biscotte complète ou riche en fibres
@@ -22997,6 +23377,7 @@ ciqual_food_name:fr:Biscotte complète ou riche en fibres
 <en:Toasts
 en:Wheat swedish toast
 fr:Pain grillé suédois au froment
+agribalyse_food_code:en:7407
 ciqual_food_code:en:7407
 ciqual_food_name:en:Wheat swedish toast
 ciqual_food_name:fr:Pain grillé suédois au froment
@@ -23004,6 +23385,7 @@ ciqual_food_name:fr:Pain grillé suédois au froment
 <en:Toasts
 en:Swedish toast with linseeds
 fr:Pain grillé suédois aux graines de lin
+agribalyse_food_code:en:7409
 ciqual_food_code:en:7409
 ciqual_food_name:en:Swedish toast, with linseeds
 ciqual_food_name:fr:Pain grillé suédois aux graines de lin
@@ -23011,6 +23393,7 @@ ciqual_food_name:fr:Pain grillé suédois aux graines de lin
 <en:Toasts
 en:Wheat wholemeal Swedish toast
 fr:Pain grillé suédois au blé complet
+agribalyse_food_code:en:7420
 ciqual_food_code:en:7420
 ciqual_food_name:en:Wheat swedish toast, wholemeal
 ciqual_food_name:fr:Pain grillé suédois au blé complet
@@ -23018,6 +23401,7 @@ ciqual_food_name:fr:Pain grillé suédois au blé complet
 <en:Toasts
 en:Swedish toast with fruits
 fr:Pain grillé suédois aux fruits
+agribalyse_food_code:en:7421
 ciqual_food_code:en:7421
 ciqual_food_name:en:Swedish toast, with fruits
 ciqual_food_name:fr:Pain grillé suédois aux fruits
@@ -23025,6 +23409,7 @@ ciqual_food_name:fr:Pain grillé suédois aux fruits
 <en:Toasts
 en:Home-made toasted breads
 fr:Pain grillé fait-maison
+agribalyse_food_code:en:7004
 ciqual_food_code:en:7004
 ciqual_food_name:en:Toasted bread, home-made
 ciqual_food_name:fr:Pain grillé, domestique
@@ -23032,6 +23417,7 @@ ciqual_food_name:fr:Pain grillé, domestique
 <en:Toasts
 en:Wheat rusk slices
 fr:Pain grillé en tranches au froment
+agribalyse_food_code:en:7400
 ciqual_food_code:en:7400
 ciqual_food_name:en:Rusk, slice, wheat
 ciqual_food_name:fr:Pain grillé, tranches, au froment
@@ -23039,6 +23425,7 @@ ciqual_food_name:fr:Pain grillé, tranches, au froment
 <en:Toasts
 en:Multigrain rusk slice
 fr:Pain grillé en tranches multicéréale
+agribalyse_food_code:en:7425
 ciqual_food_code:en:7425
 ciqual_food_name:en:Rusk , slice, multigrain
 ciqual_food_name:fr:Pain grillé, tranches, multicéréale
@@ -23083,6 +23470,7 @@ ru:Хлеб белый из пшеничной муки высшего сорт�
 <en:White breads
 en:Home-made bread with flour for home-made bread preparation
 fr:Pain blanc maison avec farine pour machine à pain
+agribalyse_food_code:en:7260
 ciqual_food_code:en:7260
 ciqual_food_name:en:Bread, home-made, with flour for home-made bread preparation
 ciqual_food_name:fr:Pain blanc maison (avec farine pour machine à pain)
@@ -23125,6 +23513,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Crouton
 # ingredient/fr:croûtons has 107 products in 5 languages @2019-04-21
 # category/croutons has 166 products @2019-05-19
 # usage:en:croutons (wheat flour, vegetable fat, edible salt, maltodextrin, grape sugar, onions, herbs, yeast extract, dehydrated garlic, flavoring, yeast, spice extract)
+agribalyse_food_code:en:7430
 ciqual_food_code:en:7430
 ciqual_food_name:en:Croutons
 
@@ -23137,12 +23526,14 @@ ciqual_food_name:en:Croutons
 <en:Breads
 en:Croutons plain prepacked
 fr:Croûtons nature
+agribalyse_food_code:en:7432
 ciqual_food_code:en:7432
 ciqual_food_name:en:Croutons, plain, prepacked
 
 <en:Breads
 en:Crouton with garlic herbs or onions prepacked
 fr:Croûton à l'ail aux fines herbes
+agribalyse_food_code:en:38500
 ciqual_food_code:en:38500
 ciqual_food_name:en:Crouton with garlic, herbs or onions, prepacked
 
@@ -23232,6 +23623,7 @@ fr:Pains Muffins, pain Muffins, pain Muffin, pains Muffin, pains pour Muffins, p
 nl:Muffins, Muffin
 zh:英国松饼, 英式松饼
 wikidata:en:Q429483
+agribalyse_food_code:en:7257
 ciqual_food_code:en:7257
 ciqual_food_name:en:English muffin, prepacked
 ciqual_food_name:fr:Muffin anglais, petit pain spécial, préemballé
@@ -23239,6 +23631,7 @@ ciqual_food_name:fr:Muffin anglais, petit pain spécial, préemballé
 <en:Special breads
 en:Whole-wheat English muffins, Whole wheat English muffins
 fr:Muffins anglais au blé complet, Petit pains au blé complet
+agribalyse_food_code:en:7256
 ciqual_food_code:en:7256
 ciqual_food_name:en:English muffin, wholewheat flour, prepacked
 ciqual_food_name:fr:Muffin anglais, complet, petit pain spécial, préemballé
@@ -23251,6 +23644,7 @@ es:Panes para hamburguesas, Panes de hamburguesa
 fi:hampurilaissämpylät
 fr:Pains Burger, Pains pour hamburgers, pain pour hamburgers, Pain pour hamburger, Bun pour hamburger
 nl:Burgerbroodjes, Burgerbroodje
+agribalyse_food_code:en:7259
 ciqual_food_code:en:7259
 ciqual_food_name:en:Rolls for hamburger/hotdog (buns), prepacked
 ciqual_food_name:fr:Pain pour hamburger ou hot dog (bun), préemballé
@@ -23258,6 +23652,7 @@ ciqual_food_name:fr:Pain pour hamburger ou hot dog (bun), préemballé
 <en:Special breads
 en:Wholemeal rolls for hamburger buns, Wholemeal rolls for hotdog buns
 fr:Pain complet pour hamburger bun, Pain complet pour hot dog bun
+agribalyse_food_code:en:7262
 ciqual_food_code:en:7262
 ciqual_food_name:en:Rolls for hamburger/hotdog (buns), wholemeal, prepacked
 ciqual_food_name:fr:Pain pour hamburger ou hot dog (bun), complet, préemballé
@@ -23270,6 +23665,7 @@ fi:Hot dog -sämpylät
 fr:Pains Hot Dog, Pains Hot-dog, Pains Hot Dogs, Pains Hot-Dogs, Pain Hot-dog, Pain pour hotdog, Bun pour hotdog
 nl:Hotdog-broodjes, Hot-dog broodje
 wikidata:en:Q1047392
+agribalyse_food_code:en:7259
 ciqual_food_code:en:7259
 ciqual_food_name:en:Rolls for hamburger/hotdog (buns), prepacked
 ciqual_food_name:fr:Pain pour hamburger ou hot dog (bun), préemballé
@@ -23292,6 +23688,7 @@ fr:Pains Pita, Pains pitta, Pains pitas, pain pitas, pains pita, pains pour pita
 nl:Pittabroden, Pittabrood, Pitta
 ru:Пита
 wikidata:en:Q211340
+agribalyse_food_code:en:7180
 ciqual_food_code:en:7180
 ciqual_food_name:en:Pita bread
 ciqual_food_name:fr:Pain pita
@@ -23305,6 +23702,7 @@ nl:Kebab-broden, Kebab-brood
 <en:Special breads
 en:Panini breads
 fr:Pains panini, Pain panini
+agribalyse_food_code:en:7170
 ciqual_food_code:en:7170
 ciqual_food_name:en:Panini bread
 ciqual_food_name:fr:Pain panini
@@ -23317,6 +23715,7 @@ fi:Vesirinkelit, Bagelit, Bagel
 fr:Pains Bagel, Bagel, Pain bagel
 nl:Bagels, Bagel
 wikidata:en:Q272502
+agribalyse_food_code:en:7258
 ciqual_food_code:en:7258
 ciqual_food_name:en:Bagel
 ciqual_food_name:fr:Bagel
@@ -23382,6 +23781,7 @@ ro:Ciocolată caldă instant, Pudră de ciocolată
 <en:Cocoa and chocolate powders
 en:Cocoa powder for beverages with sugar, Chocolate powder for beverages with sugar
 fr:Poudre cacaotée pour boisson sucrée, Poudre au chocolat pour boisson sucrée
+agribalyse_food_code:en:18101
 ciqual_food_code:en:18101
 ciqual_food_name:en:Cocoa or chocolate powder, for beverages, with sugar
 ciqual_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée
@@ -23389,6 +23789,7 @@ ciqual_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée
 <en:Cocoa and chocolate powders
 en:Instant cocoa powder without sugar
 fr:Cacao non sucré en poudre soluble
+agribalyse_food_code:en:18100
 ciqual_food_code:en:18100
 ciqual_food_name:en:Cocoa powder, without sugar, powder, instant
 ciqual_food_name:fr:Cacao, non sucré, poudre soluble
@@ -23396,6 +23797,7 @@ ciqual_food_name:fr:Cacao, non sucré, poudre soluble
 <en:Cocoa and chocolate powders
 en:Cocoa powder for beverages with sugar fortified with vitamins and chemical elements, Chocolate powder for beverages with sugar fortified with vitamins and chemical elements
 fr:Poudre cacaotée sucrée pour boisson enrichie en vitamines et minéraux, Poudre au chocolat sucrée pour boisson enrichie en vitamines et minéraux
+agribalyse_food_code:en:18167
 ciqual_food_code:en:18167
 ciqual_food_name:en:Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Poudre cacaotée ou au chocolat sucrée pour boisson, enrichie en vitamines et minéraux
@@ -23403,6 +23805,7 @@ ciqual_food_name:fr:Poudre cacaotée ou au chocolat sucrée pour boisson, enrich
 <en:Cocoa and chocolate powders
 en:Cocoa powder for beverages with sugar fortified with vitamins, Chocolate powder for beverages with sugar fortified with vitamins
 fr:Poudre cacaotée pour boisson sucrée enrichie en vitamines, Poudre au chocolat pour boisson sucrée enrichie en vitamines
+agribalyse_food_code:en:18168
 ciqual_food_code:en:18168
 ciqual_food_name:en:Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins
 ciqual_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines
@@ -23417,6 +23820,7 @@ ciqual_food_name:fr:Poudre maltée, cacaotée ou au chocolat pour boisson, sucr�
 <en:Instant beverages
 en:Ready-to-drink instant cocoa with sugar reconstituted with standard semi-skimmed milk, Ready-to-drink instant chocolate beverage with sugar reconstituted with standard semi-skimmed milk
 fr:Boisson cacaotée instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé standard, Boisson au chocolat instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé standard
+agribalyse_food_code:en:18104
 ciqual_food_code:en:18104
 ciqual_food_name:en:Instant cocoa or chocolate beverage, with sugar, ready-to-drink (reconstituted with standard semi-skimmed milk)
 ciqual_food_name:fr:Boisson cacaotée ou au chocolat, instantanée, sucrée, prête à boire (reconstituée avec du lait demi-écrémé standard)
@@ -23424,6 +23828,7 @@ ciqual_food_name:fr:Boisson cacaotée ou au chocolat, instantanée, sucrée, pr�
 <en:Instant beverages
 en:Ready-to-drink instant cocoa with sugar fortified with vitamins and chemical elements reconstituted with standard semi-skimmed milk, Ready-to-drink instant chocolate beverage with sugar fortified with vitamins and chemical elements reconstituted with standard semi-skimmed milk
 fr:Boisson cacaotée instantanée sucrée enrichie en vitamines prête à boire reconstituée avec du lait demi-écrémé, Boisson au chocolat instantanée sucrée enrichie en vitamines prête à boire reconstituée avec du lait demi-écrémé
+agribalyse_food_code:en:18106
 ciqual_food_code:en:18106
 ciqual_food_name:en:Instant cocoa or chocolate beverage, with sugar, fortified with vitamins and chemical elements, ready-to-drink (reconstituted with standard semi-skimm
 ciqual_food_name:fr:Boisson cacaotée ou au chocolat, instantanée, sucrée, enrichie en vitamines, prête à boire (reconstituée avec du lait demi-écrémé standard)
@@ -23621,6 +24026,7 @@ fr:Forêt-noires, Forêts noires, Gâteau au chocolat type forêt noire, Génois
 it:Torta della Foresta Nera
 nl: Schwarzwälder Kirschtaarten
 wikidata:en:Q19028
+agribalyse_food_code:en:23006
 ciqual_food_code:en:23006
 ciqual_food_name:en:Sponge cake w chocolate w or wo cherry
 ciqual_food_name:fr:Gâteau au chocolat type forêt noire (génoise au chocolat et crème multi-couches, avec ou sans cerises)
@@ -23629,6 +24035,7 @@ ciqual_food_name:fr:Gâteau au chocolat type forêt noire (génoise au chocolat 
 <en:Desserts
 en:Plain soft cake, Plain sponge cake
 fr:Gâteau moelleux nature, Génoise
+agribalyse_food_code:en:23594
 ciqual_food_code:en:23594
 ciqual_food_name:en:Soft cake, plain, sponge cake type
 ciqual_food_name:fr:Gâteau moelleux nature type génoise
@@ -23637,6 +24044,7 @@ ciqual_food_name:fr:Gâteau moelleux nature type génoise
 <en:Desserts
 en:Dried sponge cake filled with fruits and covered with chocolate
 fr:Génoise sèche fourrée aux fruits et nappée de chocolat
+agribalyse_food_code:en:24686
 ciqual_food_code:en:24686
 ciqual_food_name:en:Dried sponge cake filled with fruits and covered with chocolate
 ciqual_food_name:fr:Génoise sèche fourrée aux fruits et nappée de chocolat
@@ -23645,6 +24053,7 @@ ciqual_food_name:fr:Génoise sèche fourrée aux fruits et nappée de chocolat
 <en:Desserts
 en:Sponge cake filled and covered with chocolate
 fr:Génoise fourrée et nappée au chocolat
+agribalyse_food_code:en:23940
 ciqual_food_code:en:23940
 ciqual_food_name:en:Sponge cake filled and covered with chocolate
 ciqual_food_name:fr:Génoise fourrée et nappée au chocolat
@@ -23653,6 +24062,7 @@ ciqual_food_name:fr:Génoise fourrée et nappée au chocolat
 <en:Desserts
 en:Soft cake filled with fruit paste and coated with sugar icing, Soft cake filled with fruit puree and coated with sugar icing
 fr:Biscuit moelleux fourré à l'orange et enrobé de sucre glace
+agribalyse_food_code:en:24680
 ciqual_food_code:en:24680
 ciqual_food_name:en:Soft cake, filled with fruit paste or fruit puree and sugar icing coated
 ciqual_food_name:fr:Biscuit moelleux fourré à l'orange et enrobé de sucre glace
@@ -23661,6 +24071,7 @@ ciqual_food_name:fr:Biscuit moelleux fourré à l'orange et enrobé de sucre gla
 <en:Desserts
 en:Chocolate soft cake
 fr:Gâteau moelleux au chocolat
+agribalyse_food_code:en:23586
 ciqual_food_code:en:23586
 ciqual_food_name:en:Chocolate soft cake, prepacked
 ciqual_food_name:fr:Gâteau moelleux au chocolat, préemballé
@@ -23669,6 +24080,7 @@ ciqual_food_name:fr:Gâteau moelleux au chocolat, préemballé
 <en:Desserts
 en:Soft cake filled with chocolate, Soft cake filled with chocolate drops, Soft cake filled with milk
 fr:Gâteau moelleux fourré au chocolat, Gâteau moelleux fourré aux pépites de chocolat, Gâteau moelleux fourré au lait
+agribalyse_food_code:en:23939
 ciqual_food_code:en:23939
 ciqual_food_name:en:Soft cake filled with chocolate or chocolate drops or milk
 ciqual_food_name:fr:Gâteau moelleux fourré au chocolat ou aux pépites de chocolat ou au lait
@@ -23679,6 +24091,7 @@ de:Marmorkuchen,
 fr:Gâteaux marbrés, gâteau marbré
 nl:Marmercakes, Marmercake
 oqali_family:en: fr:Biscuits et gateaux industriels - Gateaux marbres
+agribalyse_food_code:en:23925
 ciqual_food_code:en:23925
 ciqual_food_name:en:Marble cake
 ciqual_food_name:fr:Gâteau marbré
@@ -23741,6 +24154,7 @@ nl:Donuts, Donut
 <en:Doughnuts
 en:Plain doughnuts, Plain doughnut
 fr:Donuts nature saupoudrés de sucre, Beignets ronds moelleux sans fourrage saupoudrés de sucre
+agribalyse_food_code:en:23880
 ciqual_food_code:en:23880
 ciqual_food_name:en:Doughnut, plain
 ciqual_food_name:fr:Beignet rond moelleux, sans fourrage, saupoudré de sucre
@@ -23748,6 +24162,7 @@ ciqual_food_name:fr:Beignet rond moelleux, sans fourrage, saupoudré de sucre
 <en:Doughnuts
 en:Doughnuts filled with fruits
 fr:Beignet fourré aux fruits
+agribalyse_food_code:en:23884
 ciqual_food_code:en:23884
 ciqual_food_name:en:Doughnut filled with fruits, prepacked
 ciqual_food_name:fr:Beignet fourré aux fruits, préemballé
@@ -23755,6 +24170,7 @@ ciqual_food_name:fr:Beignet fourré aux fruits, préemballé
 <en:Doughnuts
 en:Jam doughnuts, Jelly doughnuts, Doughnuts filled with jam
 fr:Beignets à la confiture, Donuts à la confiture
+agribalyse_food_code:en:23881
 ciqual_food_code:en:23881
 ciqual_food_name:en:Doughnut filled with jam
 ciqual_food_name:fr:Beignet à la confiture
@@ -23762,6 +24178,7 @@ ciqual_food_name:fr:Beignet à la confiture
 <en:Doughnuts
 en:Doughnuts filled with chocolate
 fr:Beignets fourrés au chocolat
+agribalyse_food_code:en:23885
 ciqual_food_code:en:23885
 ciqual_food_name:en:Doughnut filled with chocolate, prepacked
 
@@ -23773,6 +24190,7 @@ nl:Bretons cakes
 <en:Breton cakes
 en:Breton pudding cake with prunes
 fr:Far aux pruneaux
+agribalyse_food_code:en:23121
 ciqual_food_code:en:23121
 ciqual_food_name:en:Breton pudding cake with prunes
 ciqual_food_name:fr:Far aux pruneaux
@@ -23786,6 +24204,7 @@ fr:Kouign-amann, Kouign amann, Kouign aman, Kouign Amann, Kouign-Amann
 it:Kouign-amann
 nl:Kouign-amann
 wikidata:en:Q548319
+agribalyse_food_code:en:23122
 ciqual_food_code:en:23122
 ciqual_food_name:en:Buttered and caramelized milk bread cake
 ciqual_food_name:fr:Kouign Amann
@@ -23809,6 +24228,7 @@ wikidata:en:Q1094707
 <en:Clafoutis
 en:Refrigerated fruits batter-pudding, Refrigerated fruit batter pudding
 fr:Clafoutis aux fruits rayon frais
+agribalyse_food_code:en:39216
 ciqual_food_code:en:39216
 ciqual_food_name:en:Fruits batter-pudding, refrigerated
 ciqual_food_name:fr:Clafoutis aux fruits, rayon frais
@@ -23863,6 +24283,7 @@ wikidata:en:Q4545971
 <en:Jelly desserts
 en:Refrigerated flavoured milk jelly covered with caramel
 fr:Lait gélifié aromatisé nappé caramel rayon frais
+agribalyse_food_code:en:19679
 ciqual_food_code:en:19679
 ciqual_food_name:en:Milk jelly, flavoured, covered with caramel, refrigerated
 ciqual_food_name:fr:Lait gélifié aromatisé, nappé caramel, rayon frais
@@ -23872,6 +24293,7 @@ ciqual_food_name:fr:Lait gélifié aromatisé, nappé caramel, rayon frais
 <en:Jelly desserts
 en:Refrigerated flavoured milk jelly with reduced fat and sugar
 fr:Lait gélifié aromatisé allégé en matière grasse et en sucre rayon frais
+agribalyse_food_code:en:19683
 ciqual_food_code:en:19683
 ciqual_food_name:en:Milk jelly, flavoured, reduced fat and sugar, refrigerated
 ciqual_food_name:fr:Lait gélifié aromatisé, allégé en matière grasse et en sucre, rayon frais
@@ -23880,6 +24302,7 @@ ciqual_food_name:fr:Lait gélifié aromatisé, allégé en matière grasse et en
 <en:Jelly desserts
 en:Refrigerated flavoured milk jelly
 fr:Lait gélifié aromatisé rayon frais
+agribalyse_food_code:en:19680
 ciqual_food_code:en:19680
 ciqual_food_name:en:Milk jelly, flavoured, refrigerated
 ciqual_food_name:fr:Lait gélifié aromatisé, rayon frais
@@ -23887,6 +24310,7 @@ ciqual_food_name:fr:Lait gélifié aromatisé, rayon frais
 <en:Jelly desserts
 en:Refrigerated flavoured milk jelly with reduced fat and sugar
 fr:Lait gélifié aromatisé allégé en matière grasse et en sucre rayon frais
+agribalyse_food_code:en:19683
 ciqual_food_code:en:19683
 ciqual_food_name:en:Milk jelly, flavoured, reduced fat and sugar, refrigerated
 ciqual_food_name:fr:Lait gélifié aromatisé, allégé en matière grasse et en sucre, rayon frais
@@ -23894,6 +24318,7 @@ ciqual_food_name:fr:Lait gélifié aromatisé, allégé en matière grasse et en
 <en:Jelly desserts
 en:Refrigerated flavoured milk jelly
 fr:Lait gélifié aromatisé rayon frais
+agribalyse_food_code:en:19680
 ciqual_food_code:en:19680
 ciqual_food_name:en:Milk jelly, flavoured, refrigerated
 ciqual_food_name:fr:Lait gélifié aromatisé, rayon frais
@@ -23914,6 +24339,7 @@ fi:juustokakut
 fr:Cheesecakes, Cheesecake rayon frais, Gâteau au fromage rayon frais
 nl:Cheesecakes, Cheesecake
 wikidata:en:Q215348
+agribalyse_food_code:en:19689
 ciqual_food_code:en:19689
 ciqual_food_name:en:Cheesecake, refrigerated
 ciqual_food_name:fr:Cheesecake ou Gâteau au fromage frais, rayon frais
@@ -23975,12 +24401,14 @@ nl:Chocoladecakes, Chocoladecake
 pt:Bolos de chocolate
 zh:巧克力蛋糕
 wikidata:en:Q30186
+agribalyse_food_code:en:23585
 ciqual_food_code:en:23585
 ciqual_food_name:en:Chocolate cake
 
 <en:Chocolate cakes
 fr:Moelleux au chocolat
 en:Chocolate cake with melting centre refrigerated
+agribalyse_food_code:en:39234
 ciqual_food_code:en:39234
 ciqual_food_name:en:Chocolate cake w melting centre, refrigerated
 
@@ -23995,6 +24423,7 @@ de:Brownies, Brownie
 nl:Brownies, Brownie
 wikidata:en:Q503129
 oqali_family:en: fr:Biscuits et gateaux industriels - Brownies au chocolat
+agribalyse_food_code:en:23032
 ciqual_food_code:en:23032
 ciqual_food_name:en:Brownie (chocolate cake)
 
@@ -24017,6 +24446,10 @@ fr:Riz au lait, Riz au lait rayon frais
 nl:Rijstepaps
 pl:Puddingi ryżowe
 wikidata:en:Q19029
+
+<en:Rice puddings
+en:Refrigerated rice puddings
+fr:Riz au lait rayon frais
 agribalyse_food_code:en:39212
 ciqual_food_code:en:39212
 ciqual_food_name:en:Rice pudding, refrigerated
@@ -24025,6 +24458,7 @@ ciqual_food_name:fr:Riz au lait, rayon frais
 <en:Rice puddings
 en:Refrigerated rice pudding with caramel sauce
 fr:Gâteau de riz au caramel rayon frais
+agribalyse_food_code:en:23536
 ciqual_food_code:en:23536
 ciqual_food_name:en:Rice pudding w caramel sauce, refrigerated
 ciqual_food_name:fr:Gâteau de riz au caramel, rayon frais
@@ -24032,6 +24466,7 @@ ciqual_food_name:fr:Gâteau de riz au caramel, rayon frais
 <en:Rice puddings
 en:Canned rice puddings
 fr:Gâteaux de riz appertisés
+agribalyse_food_code:en:39232
 ciqual_food_code:en:39232
 ciqual_food_name:en:Rice pudding, canned
 ciqual_food_name:fr:Gâteau de riz, appertisé
@@ -24051,6 +24486,7 @@ fr:Cakes aux fruits, cake aux fruits, cake aux fruits confits, cakes aux fruits 
 nl:Vruchtencakes
 wikidata:en:Q675987
 oqali_family:en: fr:Biscuits et gateaux industriels - Cakes aux fruits confits
+agribalyse_food_code:en:23909
 ciqual_food_code:en:23909
 ciqual_food_name:en:Fruit cake
 ciqual_food_name:fr:Cake aux fruits
@@ -24058,6 +24494,7 @@ ciqual_food_name:fr:Cake aux fruits
 <en:Cakes
 en:Soft fruit cakes
 fr:Gâteaux moelleux aux fruits
+agribalyse_food_code:en:23937
 ciqual_food_code:en:23937
 ciqual_food_name:en:Fruit soft cake
 ciqual_food_name:fr:Gâteau moelleux aux fruits
@@ -24065,6 +24502,7 @@ ciqual_food_name:fr:Gâteau moelleux aux fruits
 <en:Cakes
 en:Lemon cake
 fr:Gâteau au citron
+agribalyse_food_code:en:23103
 ciqual_food_code:en:23103
 ciqual_food_name:en:Lemon cake, all types
 ciqual_food_name:fr:Gâteau au citron, tout type
@@ -24074,6 +24512,7 @@ ciqual_food_name:fr:Gâteau au citron, tout type
 fr:Financiers, financier, visitandines, visitandine, financiers aux amandes, financier aux amandes
 wikidata:en:Q588378
 oqali_family:en: fr:Biscuits et gateaux industriels - Financiers
+agribalyse_food_code:en:24664
 ciqual_food_code:en:24664
 ciqual_food_name:en:Almond cake
 
@@ -24083,6 +24522,7 @@ de:Katzenzungen
 fr:Langues de chat, Langue de chat
 nl:Kattetongen
 wikidata:en:Q960635
+agribalyse_food_code:en:24441
 ciqual_food_code:en:24441
 ciqual_food_name:en:Biscuit (cookie), cat tongue type
 ciqual_food_name:fr:Biscuit sec type langue de chat ou cigarette russe
@@ -24093,6 +24533,7 @@ de:Katzenzungen
 fr:Biscuits cigarettes, cigarette russe, Cigarettes russes
 nl:Kattetongen
 wikidata:en:Q960635
+agribalyse_food_code:en:24441
 ciqual_food_code:en:24441
 ciqual_food_name:en:Biscuit (cookie), cat tongue type
 ciqual_food_name:fr:Biscuit sec type langue de chat ou cigarette russe
@@ -24108,6 +24549,7 @@ nl:Madeleines
 pt:Madalenas
 wikidata:en:Q604408
 en:Madeleine biscuit
+agribalyse_food_code:en:24632
 ciqual_food_code:en:24632
 ciqual_food_name:en:Madeleine biscuit (cookie)
 ciqual_food_name:fr:Madeleine ordinaire, préemballée
@@ -24116,6 +24558,7 @@ ciqual_food_name:fr:Madeleine ordinaire, préemballée
 en:Plain madeleines, Plain madeleines cakes
 fr:Madeleines natures, Madeleine traditionnelle pur beurre
 oqali_family:en: fr:Biscuits et gateaux industriels - Madeleines nature
+agribalyse_food_code:en:24630
 ciqual_food_code:en:24630
 ciqual_food_name:en:Madeleine cake, pure butter
 ciqual_food_name:fr:Madeleine traditionnelle, pur beurre
@@ -24139,6 +24582,7 @@ fi:Suklaiset Madeleine-leivokset
 fr:Madeleines au chocolat
 nl:Chocolade madeleines
 oqali_family:en: fr:Biscuits et gateaux industriels - Madeleines au chocolat
+agribalyse_food_code:en:24631
 ciqual_food_code:en:24631
 ciqual_food_name:en:Madeleine biscuit, with chocolate, prepacked
 
@@ -24149,6 +24593,7 @@ es:Bizcocho
 fr:Quatre-quarts, quatre-quart, Quatre-quarts, Barre pâtissière
 nl:Pondscake
 wikidata:en:Q29443
+agribalyse_food_code:en:23081
 ciqual_food_code:en:23081
 ciqual_food_name:en:Pound cake, prepacked
 ciqual_food_name:fr:Quatre-quarts ou barre pâtissière, préemballé
@@ -24245,6 +24690,7 @@ de:Calissons d'Aix, Calissons aus Aix-en-Provence
 fr:Calissons d'Aix, Calissons d'Aix en Provence
 it:Calissons d'Aix
 nl:Calissons d'Aix
+agribalyse_food_code:en:31092
 ciqual_food_code:en:31092
 ciqual_food_name:en:Melon and almond Candy on a unleavened bread layer
 ciqual_food_name:fr:Calissons d'Aix en Provence
@@ -24310,6 +24756,7 @@ agribalyse_proxy_food_code:en:31004
 <en:Milk chocolates
 en:Milk chocolate bar
 fr:Chocolat au lait en tablette
+agribalyse_food_code:en:31004
 ciqual_food_code:en:31004
 ciqual_food_name:en:Milk chocolate bar
 ciqual_food_name:fr:Chocolat au lait, tablette
@@ -24327,6 +24774,7 @@ nl:Melkchocola met zoetstoffen
 <en:Chocolates with sweeteners
 en:Milk chocolate bar without sugar with sweeteners
 fr:Chocolat au lait en tablette sans sucres ajoutés avec édulcorants
+agribalyse_food_code:en:31020
 ciqual_food_code:en:31020
 ciqual_food_name:en:Milk chocolate bar, without sugar, with sweeteners
 ciqual_food_name:fr:Chocolat au lait sans sucres ajoutés, avec édulcorants, tablette
@@ -24358,6 +24806,7 @@ en:Puffed cereal milk chocolates, Milk chocolate bar with puffed cereals, Milk c
 fr:Chocolats au lait aux céréales croustillantes, Chocolat au lait en tablette aux céréales croustillantes
 it:Cioccolato al latte con cereali
 nl:Melkchocola met granen
+agribalyse_food_code:en:31009
 ciqual_food_code:en:31009
 ciqual_food_name:en:Milk chocolate bar, with puffed/popped cereals
 ciqual_food_name:fr:Chocolat au lait aux céréales croustillantes, tablette
@@ -24365,6 +24814,7 @@ ciqual_food_name:fr:Chocolat au lait aux céréales croustillantes, tablette
 <en:Milk chocolates
 en:Milk chocolate with dried fruits
 fr:Chocolat au lait aux fruits secs
+agribalyse_food_code:en:31018
 ciqual_food_code:en:31018
 ciqual_food_name:en:Milk chocolate bar, with dried fruits (nuts, almonds, raisins, praline)
 ciqual_food_name:fr:Chocolat au lait aux fruits secs (noisettes, amandes, raisins, praline), tablette
@@ -24406,6 +24856,7 @@ sv:Choklad med mandlar, choklad med mandel
 <en:Chocolates
 en:Toblerone milk cholcolate bar w nougat
 fr:Barre chocolat au lait avec nougat
+agribalyse_food_code:en:31098
 ciqual_food_code:en:31098
 ciqual_food_name:en:Toblerone milk cholcolate bar w nougat
 
@@ -24450,6 +24901,7 @@ agribalyse_proxy_food_code:en:31010
 <en:White chocolates
 en:White chocolate bar
 fr:Chocolat blanc en tablette, Tablette de chocolat blanc
+agribalyse_food_code:en:31010
 ciqual_food_code:en:31010
 ciqual_food_name:en:White chocolate bar
 ciqual_food_name:fr:Chocolat blanc, tablette
@@ -24564,6 +25016,7 @@ de:Gefüllte Milchschokolade, Milchschokolade mit Füllung
 fi:täytetyt maitosuklaat
 fr:Chocolats au lait fourrés, Chocolat au lait fourré
 nl:Gevulde melkchocola
+agribalyse_food_code:en:31079
 ciqual_food_code:en:31079
 ciqual_food_name:en:Milk chocolate, filled
 ciqual_food_name:fr:Chocolat au lait fourré
@@ -24572,6 +25025,7 @@ ciqual_food_name:fr:Chocolat au lait fourré
 <en:Filled milk chocolates
 en:Milk chocolate filled with praline, Milk chocolate bar filled with praline
 fr:Chocolat au lait fourré au praliné, chocolat au lait en tablette fourré au praliné
+agribalyse_food_code:en:31084
 ciqual_food_code:en:31084
 ciqual_food_name:en:Milk chocolate bar, filled with praline
 ciqual_food_name:fr:Chocolat au lait fourré au praliné, tablette
@@ -24664,12 +25118,14 @@ nl:Pure chocola met sinaasappelschil
 <en:Dark chocolates
 en:Dark chocolate bar with fruits (orange raspberries pear)
 fr:Chocolat noir aux fruits
+agribalyse_food_code:en:31069
 ciqual_food_code:en:31069
 ciqual_food_name:en:Dark chocolate bar, with fruits (orange, raspberries, pear)
 
 <en:Dark chocolates
 en:Chocolate bar with dried fruits
 fr:Barre chocolatée aux fruits secs
+agribalyse_food_code:en:31071
 ciqual_food_code:en:31071
 ciqual_food_name:en:Chocolate bar with dried fruits
 
@@ -24690,6 +25146,7 @@ it:Cioccolato fondente con zenzero, cioccolato fondente allo zenzero
 <en:Dark chocolate
 en:Dark chocolate bar with less than 70% cocoa
 fr:Chocolat noir à moins de 70% de cacao en tablette à croquer
+agribalyse_food_code:en:31005
 ciqual_food_code:en:31005
 ciqual_food_name:en:Dark chocolate bar, less than 70% cocoa
 ciqual_food_name:fr:Chocolat noir à moins de 70% de cacao, à croquer, tablette
@@ -24698,6 +25155,7 @@ ciqual_food_name:fr:Chocolat noir à moins de 70% de cacao, à croquer, tablette
 <en:Chocolates with sweeteners
 en:Dark chocolate bar without sugar and with artificial sweeteners
 fr:Chocolat noir en tablette sans sucres ajoutés avec édulcorants
+agribalyse_food_code:en:31030
 ciqual_food_code:en:31030
 ciqual_food_name:en:Dark chocolate bar, without sugar and with artificial sweeteners
 ciqual_food_name:fr:Chocolat noir sans sucres ajoutés, avec édulcorants, en tablette
@@ -24705,6 +25163,7 @@ ciqual_food_name:fr:Chocolat noir sans sucres ajoutés, avec édulcorants, en ta
 <en:Dark chocolate
 en:Dark chocolate bar with dried fruits
 fr:Chocolat noir en tablette aux fruits secs
+agribalyse_food_code:en:31070
 ciqual_food_code:en:31070
 ciqual_food_name:en:Dark chocolate bar, with dried fruits (nuts, almonds, raisin, praline)
 ciqual_food_name:fr:Chocolat noir aux fruits secs (noisettes, amandes, raisins, praline), tablette
@@ -24713,6 +25172,7 @@ ciqual_food_name:fr:Chocolat noir aux fruits secs (noisettes, amandes, raisins, 
 <en:Filled chocolates
 en:Dark chocolate filled with mint confectionery
 fr:Chocolat noir fourrage confiseur à la menthe
+agribalyse_food_code:en:31072
 ciqual_food_code:en:31072
 ciqual_food_name:en:Dark chocolate, filled with mint confectionery
 ciqual_food_name:fr:Chocolat noir fourrage confiseur à la menthe
@@ -24720,6 +25180,7 @@ ciqual_food_name:fr:Chocolat noir fourrage confiseur à la menthe
 <en:Dark chocolate
 en:Dark chocolate bar with more than 70% cocoa
 fr:Chocolat noir en tablette extra dégustation à 70% de cacao minimum
+agribalyse_food_code:en:31074
 ciqual_food_code:en:31074
 ciqual_food_name:en:Dark chocolate bar, more than 70% cocoa
 ciqual_food_name:fr:Chocolat noir à 70% cacao minimum, extra, dégustation, tablette
@@ -24728,6 +25189,7 @@ ciqual_food_name:fr:Chocolat noir à 70% cacao minimum, extra, dégustation, tab
 <en:Filled chocolates
 en:Dark chocolate bar filled with praline
 fr:Chocolat noir en tablette fourré au praliné
+agribalyse_food_code:en:31080
 ciqual_food_code:en:31080
 ciqual_food_name:en:Dark chocolate bar, filled with praline
 ciqual_food_name:fr:Chocolat noir fourré praliné, tablette
@@ -24735,6 +25197,7 @@ ciqual_food_name:fr:Chocolat noir fourré praliné, tablette
 <en:Dark chocolate
 en:Dark chocolate bar for cooking with more than 40% cocoa
 fr:Chocolat noir pâtissier en tablette à 40% de cacao minimum
+agribalyse_food_code:en:31085
 ciqual_food_code:en:31085
 ciqual_food_name:en:Dark chocolate bar, more than 40% cocoa, for cooking
 ciqual_food_name:fr:Chocolat noir à 40% de cacao minimum, à pâtisser, tablette
@@ -24870,6 +25333,7 @@ fr:Barre chocolatée biscuitée type KitKat, Kitkat
 
 <en:Chocolate bars
 fr:Barres chocolatées à la noix de coco, barre chocolatée à la noix de coco type Bounty, Bounty
+agribalyse_food_code:en:31002
 ciqual_food_code:en:31002
 ciqual_food_name:en:Coconut bar, with chocolate coating
 
@@ -24921,6 +25385,7 @@ zh:巧克力糖果
 <en:Chocolate candies
 en:Sugar coated chocolate confectioneries
 fr:Confiseries au chocolat dragéifiées
+agribalyse_food_code:en:31041
 ciqual_food_code:en:31041
 ciqual_food_name:en:Chocolate confectionery, sugar coated
 ciqual_food_name:fr:Confiserie au chocolat dragéifiée
@@ -24972,6 +25437,7 @@ fr:Papillotes en chocolat
 <en:Bonbons
 en:Chocolate confectioneries filled with praline, chocolate and nut confectioneries filled with praline
 fr:Rochers au chocolat fourrés au praliné
+agribalyse_food_code:en:31066
 ciqual_food_code:en:31066
 ciqual_food_name:en:Chocolate and nut confectionery filled with praline
 ciqual_food_name:fr:Rocher chocolat fourré praliné
@@ -24979,6 +25445,7 @@ ciqual_food_name:fr:Rocher chocolat fourré praliné
 <en:Bonbons
 en:Chocolate confectioneries filled with wafer
 fr:Bonbons de chocolat fourrés aux gaufrettes, Bonbons au chocolat fourrés au biscuit, Bouchées au chocolat fourrées aux gaufrettes, Bouchées au chocolat fourrées au biscuit
+agribalyse_food_code:en:31091
 ciqual_food_code:en:31091
 ciqual_food_name:en:Chocolate confectionery, filled with wafer
 ciqual_food_name:fr:Bonbon / bouchée au chocolat fourrage gaufrettes / biscuit
@@ -25036,6 +25503,7 @@ de:Mit Schokolade überzogene Nüsse
 fi:Suklaapähkinät
 fr:Fruits à coques enrobés de chocolat, fruits à coque au chocolat, Bouchées au chocolat fourrées aux fruits à coques
 nl:Noten in chocolade
+agribalyse_food_code:en:31063
 ciqual_food_code:en:31063
 ciqual_food_name:en:Chocolate confectionery, filled with nuts and/or praline
 ciqual_food_name:fr:Bouchée chocolat fourrage fruits à coques et/ou praliné
@@ -25047,6 +25515,7 @@ fi:Suklaalla päällystetyt maapähkinät
 fr:Cacahuètes au chocolat, cacahuètes enrobées de chocolat, cacahuètes enrobées de chocolat type M&M's, Cacahuètes enrobées de chocolat dragéifiées
 hu:Csokoládéval bevont mogyoró
 nl:Chocopindas
+agribalyse_food_code:en:31042
 ciqual_food_code:en:31042
 ciqual_food_name:en:Sugar and chocolate coated peanut
 ciqual_food_name:fr:Cacahuètes enrobées de chocolat dragéifiées
@@ -25073,6 +25542,7 @@ sv:Godis, Sötsaker
 th:ลูกอม
 zh:糖果
 wikidata:en:Q185583
+agribalyse_food_code:en:31003
 ciqual_food_code:en:31003
 ciqual_food_name:en:Candies, all types
 ciqual_food_name:fr:Bonbons, tout type
@@ -25159,6 +25629,7 @@ zh:软心豆粒糖
 <en:Gelified candies
 en:Jelly candy
 fr:Bonbon gélifié
+agribalyse_food_code:en:31060
 ciqual_food_code:en:31060
 ciqual_food_name:en:Jelly candy
 ciqual_food_name:fr:Bonbon gélifié
@@ -25173,6 +25644,7 @@ nl:Lollies
 ru:Леденец
 zh:棒棒糖
 wikidata:en:Q217446
+agribalyse_food_code:en:31059
 ciqual_food_code:en:31059
 ciqual_food_name:en:Hard candy and lollipop
 ciqual_food_name:fr:Bonbon dur et sucette
@@ -25187,6 +25659,7 @@ nl:Lollies
 ru:Леденец
 zh:棒棒糖
 wikidata:en:Q217446
+agribalyse_food_code:en:31059
 ciqual_food_code:en:31059
 ciqual_food_name:en:Hard candy and lollipop
 ciqual_food_name:fr:Bonbon dur et sucette
@@ -25230,6 +25703,7 @@ nl:Vloeibare caramels
 <en:Caramels
 en:Soft caramel candy
 fr:Bonbon au caramel mou
+agribalyse_food_code:en:31081
 ciqual_food_code:en:31081
 ciqual_food_name:en:Soft caramel candy
 ciqual_food_name:fr:Bonbon au caramel, mou
@@ -25255,6 +25729,9 @@ wikidata:en:Q130878
 ciqual_food_code:en:31121
 ciqual_food_name:en:Chewing gum, sugar level unknown (average)
 ciqual_food_name:fr:Chewing-gum, teneur en sucre inconnue (aliment moyen)
+agribalyse_proxy_food_code:en:31007
+agribalyse_proxy_food_name:en:Chewing gum, with sugar
+agribalyse_proxy_food_name:fr:Chewing-gum, sucré
 
 <en:Chewing gum
 en:Sugar-free chewing gum, Chewing gum without sugar
@@ -25266,6 +25743,7 @@ nl:Suikervrije kauwgom
 pl:bezcukrowa guma do żucia
 ro:Gumă de mestecat fără zahăr
 zh:无糖口香糖
+agribalyse_food_code:en:31054
 ciqual_food_code:en:31054
 ciqual_food_name:en:Chewing gum, without sugar
 ciqual_food_name:fr:Chewing-gum, sans sucre
@@ -25273,6 +25751,7 @@ ciqual_food_name:fr:Chewing-gum, sans sucre
 <en:Chewing gum
 en:Chewing gum with sugar
 fr:Chewing-gum sucré
+agribalyse_food_code:en:31007
 ciqual_food_code:en:31007
 ciqual_food_name:en:Chewing gum, with sugar
 ciqual_food_name:fr:Chewing-gum, sucré
@@ -25361,6 +25840,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Nougat
 # category/nougats has 421 products @2019-05-18
 # ingredient/nougat has 52 products in 5 languages @2019-02-08
 # nougat (cane sugar , hazelnuts 33%, cocoa mass, cocoa butter)
+agribalyse_food_code:en:31033
 ciqual_food_code:en:31033
 ciqual_food_name:en:Nougat
 
@@ -25426,6 +25906,7 @@ fi:vaahtokarkit
 fr:Guimauves, pâtes de guimauves, Chamallows, Guimauve, Marshmallows, Marshmallow
 nl:Marshmallows, Zoete Spekjes, Marshmellows
 wikidata:en:Q272198
+agribalyse_food_code:en:31050
 ciqual_food_code:en:31050
 ciqual_food_name:en:Candies, marshmallows
 ciqual_food_name:fr:Guimauve, Marshmallow
@@ -25528,6 +26009,7 @@ nl:Kerstmischocola
 <en:Christmas foods and drinks
 en:Yule log, Christmas log cake
 fr:Bûches de Noël
+agribalyse_food_code:en:23030
 ciqual_food_code:en:23030
 ciqual_food_name:en:Christmas log cake
 
@@ -25595,6 +26077,7 @@ fi:drageet
 fr:Dragées
 nl:Dragees
 wikidata:en:Q1255306
+agribalyse_food_code:en:31036
 ciqual_food_code:en:31036
 ciqual_food_name:en:Sugar-coated almond
 ciqual_food_name:fr:Dragée amande
@@ -25722,6 +26205,7 @@ fi:mantelimassa
 fr:Pâtes d’amande
 nl:Amandelpasta
 wikidata:en:Q2631692
+agribalyse_food_code:en:15201
 ciqual_food_code:en:15201
 ciqual_food_name:en:Almond paste or marzipan, prepacked
 
@@ -25891,6 +26375,7 @@ es:Dulces de frutas, Pastas de frutas, Cremas de frutas
 fi:hedelmätahnat
 fr:Pâtes de fruits, Pâte de fruit, Pâtes de fruit, Pâte de fruits
 nl:Vruchtenpastas, Vruchtenpasta's, Vruchtenkaasjes
+agribalyse_food_code:en:31014
 ciqual_food_code:en:31014
 ciqual_food_name:en:Fruit jelly
 ciqual_food_name:fr:Pâte de fruits
@@ -26009,6 +26494,7 @@ ro:Conserve de ravioli
 <en:Canned raviolis
 en:Canned raviolis filled with meat in tomato sauce
 fr:Raviolis à la viande sauce tomate appertisés, Raviolis à la viande sauce tomate en conserve
+agribalyse_food_code:en:25019
 ciqual_food_code:en:25019
 ciqual_food_name:en:Ravioli filled with meat, in tomato sauce, canned
 ciqual_food_name:fr:Ravioli à la viande, sauce tomate, appertisé
@@ -26016,6 +26502,7 @@ ciqual_food_name:fr:Ravioli à la viande, sauce tomate, appertisé
 <en:Canned raviolis
 en:Canned ravioli filled with vegetables in tomato sauce
 fr:Raviolis aux légumes sauce tomate appertisés
+agribalyse_food_code:en:25192
 ciqual_food_code:en:25192
 ciqual_food_name:en:Ravioli filled with vegetables, in tomato sauce, canned
 ciqual_food_name:fr:Raviolis aux légumes, sauce tomate, appertisés
@@ -26073,6 +26560,7 @@ fi:espanjalaiset tortillat
 fr:Omelettes de pommes de terre, Omelettes espagnoles, Tortilla espagnole aux oignons, Omelette aux pommes de terre et oignons
 nl:Spaanse tortillas
 wikidata:en:Q281751
+agribalyse_food_code:en:22510
 ciqual_food_code:en:22510
 ciqual_food_name:en:Spanish-style tortilla with onions (omelette with potatoes and onions)
 ciqual_food_name:fr:Tortilla espagnole aux oignons (omelette aux pommes de terre et oignons)
@@ -26094,6 +26582,7 @@ ciqual_food_name:fr:Omelette, garnitures diverses : légumes, fromages, viandes.
 <en:Meals
 en:Herb omelette
 fr:Omelette aux fines herbes
+agribalyse_food_code:en:22509
 ciqual_food_code:en:22509
 ciqual_food_name:en:Omelette, with herbs
 ciqual_food_name:fr:Omelette aux fines herbes
@@ -26101,6 +26590,7 @@ ciqual_food_name:fr:Omelette aux fines herbes
 <en:Meals
 en:Omelette with lardoons
 fr:Omelette aux lardons
+agribalyse_food_code:en:22507
 ciqual_food_code:en:22507
 ciqual_food_name:en:Omelette, with lardoons
 ciqual_food_name:fr:Omelette aux lardons
@@ -26108,6 +26598,7 @@ ciqual_food_name:fr:Omelette aux lardons
 <en:Meals
 en:Omelette with mushrooms, Mushroom Omelette
 fr:Omelette aux champignons
+agribalyse_food_code:en:22508
 ciqual_food_code:en:22508
 ciqual_food_name:en:Omelette, with mushrooms
 ciqual_food_name:fr:Omelette aux champignons
@@ -26115,6 +26606,7 @@ ciqual_food_name:fr:Omelette aux champignons
 <en:Meals
 en:Omelette with cheese
 fr:Omelette au fromage
+agribalyse_food_code:en:22506
 ciqual_food_code:en:22506
 ciqual_food_name:en:Omelette, with cheese
 
@@ -26128,6 +26620,7 @@ de:Käsepfannkuchen, Käse Pfannkuchen, Pfannkuchen mit Käse
 <en:Meals
 en:Buckwheat crepe filled with mushrooms and bechamel sauce, Crepe filled with mushrooms and bechamel sauce
 fr:Galette fourrée à la béchamel et aux champignons, Crêpe fourrée à la béchamel et aux champignons
+agribalyse_food_code:en:25411
 ciqual_food_code:en:25411
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with mushrooms and bechamel sauce
 ciqual_food_name:fr:Crêpe ou Galette fourrée béchamel champignon
@@ -26135,12 +26628,14 @@ ciqual_food_name:fr:Crêpe ou Galette fourrée béchamel champignon
 <en:Meals
 en:Crepe or buckwheat crepe filled with egg ham and cheese
 fr:Crêpe ou Galette complète (œuf jambon fromage)
+agribalyse_food_code:en:25562
 ciqual_food_code:en:25562
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with egg, ham and cheese
 
 <en:Meals
 en:Crepe filled with cheese and bechamel sauce, buckwheat crepe filled with cheese and bechamel sauce
 fr:Crêpe ou Galette fourrée béchamel fromage
+agribalyse_food_code:en:25549
 ciqual_food_code:en:25549
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with cheese and bechamel sauce
 ciqual_food_name:fr:Crêpe ou Galette fourrée béchamel fromage
@@ -26148,6 +26643,7 @@ ciqual_food_name:fr:Crêpe ou Galette fourrée béchamel fromage
 <en:Meals
 en:Buckwheat crepe filled with cheese ham mushrooms and bechamel sauce, Crepe filled with cheese ham mushrooms and bechamel sauce
 fr:Crêpe fourrée béchamel jambon fromage champignon, Galette fourrée béchamel jambon fromage champignon
+agribalyse_food_code:en:25552
 ciqual_food_code:en:25552
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with cheese, ham, mushrooms and bechamel sauce
 ciqual_food_name:fr:Crêpe ou Galette fourrée béchamel jambon fromage champignon
@@ -26155,6 +26651,7 @@ ciqual_food_name:fr:Crêpe ou Galette fourrée béchamel jambon fromage champign
 <en:Meals
 en:Crepe filled with fish, Crepe filled with seafood, Buckwheat crepe filled with fish, Buckwheat crepe filled with seafood
 fr:Crêpe fourrée au poisson, Crêpe fourrée aux fruits de mer, Galette fourrée au poisson, Galette fourrée aux fruits de mer
+agribalyse_food_code:en:25625
 ciqual_food_code:en:25625
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with fish and/or seafood
 ciqual_food_name:fr:Crêpe ou Galette fourrée au poisson et / ou fruits de mer
@@ -26162,6 +26659,7 @@ ciqual_food_name:fr:Crêpe ou Galette fourrée au poisson et / ou fruits de mer
 <en:Meals
 en:Crepe filled with scallops, Buckwheat crepe with scallops
 fr:Crêpe aux noix de St Jacques, Galette aux noix de St Jacques
+agribalyse_food_code:en:25572
 ciqual_food_code:en:25572
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with scallops
 ciqual_food_name:fr:Crêpe ou Galette aux noix de St Jacques
@@ -26169,6 +26667,7 @@ ciqual_food_name:fr:Crêpe ou Galette aux noix de St Jacques
 <en:Meals
 en:Pork sausage stew with cabbage carrots and potatoes
 fr:Potée auvergnate avec chou et porc
+agribalyse_food_code:en:25071
 ciqual_food_code:en:25071
 ciqual_food_name:en:Pork sausage stew with cabbage, carrots and potatoes
 ciqual_food_name:fr:Potée auvergnate (chou et porc)
@@ -26177,6 +26676,7 @@ ciqual_food_name:fr:Potée auvergnate (chou et porc)
 <en:Meals
 en:Stuffed cabbage
 fr:Chou farci
+agribalyse_food_code:en:25106
 ciqual_food_code:en:25106
 ciqual_food_name:en:Stuffed cabbage
 ciqual_food_name:fr:Chou farci
@@ -26302,6 +26802,7 @@ fr:Ignames frais
 <en:Yam potatoes
 en:Peeled boiled yam potato, Peeled yam potato cooked in water, Peeled boiled Indian potato, Peeled Indian potato cooked in water
 fr:Igname épluchée bouillie, Igname épluchée cuite à l'eau
+agribalyse_food_code:en:53503
 ciqual_food_code:en:53503
 ciqual_food_name:en:Yam or Indian potato, peeled, boiled/cooked in water
 ciqual_food_name:fr:Igname, épluchée, bouillie/cuite à l'eau
@@ -26309,6 +26810,7 @@ ciqual_food_name:fr:Igname, épluchée, bouillie/cuite à l'eau
 <en:Yam potatoes
 en:Raw peeled yam potato, Raw peeled Indian potato
 fr:Igname épluchée crue
+agribalyse_food_code:en:53502
 ciqual_food_code:en:53502
 ciqual_food_name:en:Yam or Indian potato, peeled, raw
 ciqual_food_name:fr:Igname, épluchée, crue
@@ -26336,6 +26838,7 @@ fr:Gnocchi de pommes de terre, Gnocchi à la pomme de terre
 it:gnocchi di patate
 nl:Aardappelgnocchi
 pnns_group_2:en:Potatoes
+agribalyse_food_code:en:26264
 ciqual_food_code:en:26264
 ciqual_food_name:en:Gnocchi, from potato, raw
 ciqual_food_name:fr:Gnocchi à la pomme de terre, cru
@@ -26343,6 +26846,7 @@ ciqual_food_name:fr:Gnocchi à la pomme de terre, cru
 <en:Cooked gnocchis
 en:Cooked gnocchis from potato
 fr:Gnocchis à la pomme de terre cuits
+agribalyse_food_code:en:25510
 ciqual_food_code:en:25510
 ciqual_food_name:en:Gnocchi, from potato, cooked
 ciqual_food_name:fr:Gnocchi à la pomme de terre, cuit
@@ -26359,6 +26863,7 @@ pnns_group_2:en:Cereals
 <en:Cereals and their products
 en:Cooked gnocchis from semolina
 fr:Gnocchis à la semoule cuits
+agribalyse_food_code:en:25479
 ciqual_food_code:en:25479
 ciqual_food_name:en:Gnocchi, from semolina, cooked
 ciqual_food_name:fr:Gnocchi à la semoule, cuit
@@ -26367,6 +26872,7 @@ ciqual_food_name:fr:Gnocchi à la semoule, cuit
 <en:Cereals and their products
 en:Raw gnocchi from semolina
 fr:Gnocchi à la semoule cru
+agribalyse_food_code:en:26265
 ciqual_food_code:en:26265
 ciqual_food_name:en:Gnocchi, from semolina, raw
 ciqual_food_name:fr:Gnocchi à la semoule, cru
@@ -26418,6 +26924,7 @@ it:Amaranto
 la:Amaranthus
 nl:Amaranth
 wikidata:en:Q156344
+agribalyse_food_code:en:9345
 ciqual_food_code:en:9345
 ciqual_food_name:en:Amaranth, raw
 ciqual_food_name:fr:Amarante, crue
@@ -26446,6 +26953,7 @@ wikidata:en:Q12104
 <en:Avena
 en:Raw oat
 fr:Avoines crues
+agribalyse_food_code:en:9310
 ciqual_food_code:en:9310
 ciqual_food_name:en:Oat, raw
 ciqual_food_name:fr:Avoine, crue
@@ -26473,6 +26981,7 @@ wikidata:en:Q3057987
 <en:Barley
 en:Row whole barley
 fr:Orge entière crue
+agribalyse_food_code:en:9320
 ciqual_food_code:en:9320
 ciqual_food_name:en:Barley, whole, raw
 ciqual_food_name:fr:Orge entière, crue
@@ -26480,6 +26989,7 @@ ciqual_food_name:fr:Orge entière, crue
 <en:Barley
 en:Raw pearled barley
 fr:Orge perlée crue
+agribalyse_food_code:en:9321
 ciqual_food_code:en:9321
 ciqual_food_name:en:Pearled barley, raw
 ciqual_food_name:fr:Orge perlée, crue
@@ -26487,6 +26997,7 @@ ciqual_food_name:fr:Orge perlée, crue
 <en:Barley
 en:Unsalted boiled pearled barley, Unsalted pearled barley cooked in water
 fr:Orge perlée bouillie non salée, Orge perlée cuite à l'eau non salée
+agribalyse_food_code:en:9322
 ciqual_food_code:en:9322
 ciqual_food_name:en:Pearled barley, boiled/cooked in water, unsalted
 ciqual_food_name:fr:Orge perlée, bouilli/cuite à l'eau, non salée
@@ -26503,6 +27014,7 @@ nl:Boekweit
 ru:Гречиха посевная, Гречиха съедобная, Греча
 zh:荞麦
 wikidata:en:Q132734
+agribalyse_food_code:en:9380
 ciqual_food_code:en:9380
 ciqual_food_name:en:Buckwheat, whole, raw
 ciqual_food_name:fr:Sarrasin entier, cru
@@ -26517,6 +27029,7 @@ it:Chia
 la:Salvia hispanica
 nl:Chia
 wikidata:en:Q1071585
+agribalyse_food_code:en:15047
 ciqual_food_code:en:15047
 ciqual_food_name:en:Seeds, chia, dried
 ciqual_food_name:fr:Chia, graine, séchée
@@ -26573,6 +27086,7 @@ fr:Maïs doux frais
 <en:Corn
 en:Cooked sweet corn on the cob
 fr:Maïs doux en épis cuit
+agribalyse_food_code:en:20049
 ciqual_food_code:en:20049
 ciqual_food_name:en:Sweet corn, on the cob, cooked
 ciqual_food_name:fr:Maïs doux, en épis, cuit
@@ -26580,6 +27094,7 @@ ciqual_food_name:fr:Maïs doux, en épis, cuit
 <en:Corn
 en:Frozen raw sweet corn on the cob
 fr:Maïs doux en épis surgelé cru
+agribalyse_food_code:en:20108
 ciqual_food_code:en:20108
 ciqual_food_name:en:Sweet corn, on the cob, frozen, raw
 ciqual_food_name:fr:Maïs doux, en épis, surgelé, cru
@@ -26587,6 +27102,7 @@ ciqual_food_name:fr:Maïs doux, en épis, surgelé, cru
 <en:Corn
 en:Frozen raw sweet corn
 fr:Maïs doux surgelé cru
+agribalyse_food_code:en:20233
 ciqual_food_code:en:20233
 ciqual_food_name:en:Sweet corn, frozen, raw
 ciqual_food_name:fr:Maïs doux, surgelé, cru
@@ -26594,6 +27110,7 @@ ciqual_food_name:fr:Maïs doux, surgelé, cru
 <en:Corn
 en:Raw corn grain, Raw maize grain
 fr:Maïs entier cru
+agribalyse_food_code:en:9200
 ciqual_food_code:en:9200
 ciqual_food_name:en:Corn or maize grain, raw
 ciqual_food_name:fr:Maïs entier, cru
@@ -26655,6 +27172,7 @@ it:Lino
 la:Linum usitatissimum
 nl:Lijnzaad, Zaad van vlas
 wikidata:en:Q45108
+agribalyse_food_code:en:15034
 ciqual_food_code:en:15034
 ciqual_food_name:en:Flaxseed
 ciqual_food_name:fr:Lin, graine
@@ -26673,6 +27191,7 @@ de:braune Leinsamen, braune Leinsaaten, braune Leinsaat
 es:Lino marrón, Linaza marrón, Semillas de lino marrón
 fr:Graines de lin brun, Graines de lin brunes
 nl:Bruin lijnzaad
+agribalyse_food_code:en:15052
 ciqual_food_code:en:15052
 ciqual_food_name:en:Flaxseed, brown
 ciqual_food_name:fr:Lin, brun, graine
@@ -26716,6 +27235,7 @@ wikidata:en:Q259438
 <en:Millet
 en:Whole millet
 fr:Mil entier
+agribalyse_food_code:en:9330
 ciqual_food_code:en:9330
 ciqual_food_name:en:Millet, whole
 ciqual_food_name:fr:Mil entier, cru
@@ -26741,6 +27261,7 @@ wikidata:en:Q165196
 <en:Millet
 en:Unsalted cooked millet
 fr:Mil cuit non salé
+agribalyse_food_code:en:9331
 ciqual_food_code:en:9331
 ciqual_food_name:en:Millet, cooked, unsalted
 ciqual_food_name:fr:Mil, cuit, non salé
@@ -26761,6 +27282,7 @@ wikidata:en:Q139925
 <en:Quinoa
 en:Raw quinoa
 fr:Quinoa cru
+agribalyse_food_code:en:9340
 ciqual_food_code:en:9340
 ciqual_food_name:en:Quinoa, raw
 ciqual_food_name:fr:Quinoa, cru
@@ -26768,6 +27290,7 @@ ciqual_food_name:fr:Quinoa, cru
 <en:Quinoa
 en:Unsalted boiled quinoa, Unsalted quinoa cooked in water
 fr:Quinoa bouilli non salé, Quinoa cuit à l'eau non salé
+agribalyse_food_code:en:9341
 ciqual_food_code:en:9341
 ciqual_food_name:en:Quinoa, boiled/cooked in water, unsalted
 ciqual_food_name:fr:Quinoa, bouilli/cuit à l'eau, non salé
@@ -26807,6 +27330,7 @@ fr:Riz complet, riz cargo, riz brun, riz semi-complet, Riz complet cru
 it:Riso integrale
 nl:Volkoren rijst
 wikidata:en:Q1066624
+agribalyse_food_code:en:9102
 ciqual_food_code:en:9102
 ciqual_food_name:en:Rice, brown, raw
 ciqual_food_name:fr:Riz complet, cru
@@ -26814,6 +27338,7 @@ ciqual_food_name:fr:Riz complet, cru
 <en:Brown rices
 en:Unsalted cooked brown rices
 fr:Riz complet cuit non salé
+agribalyse_food_code:en:9103
 ciqual_food_code:en:9103
 ciqual_food_name:en:Rice, brown, cooked, unsalted
 ciqual_food_name:fr:Riz complet, cuit, non salé
@@ -26842,6 +27367,7 @@ fr:Riz blanc, riz usiné, riz blancho
 nl:Witte rijst
 pl:Ryż biały
 wikidata:en:Q2674257
+agribalyse_food_code:en:9100
 ciqual_food_code:en:9100
 ciqual_food_name:en:Rice, raw
 ciqual_food_name:fr:Riz blanc, cru
@@ -26850,6 +27376,7 @@ ciqual_food_name:fr:Riz blanc, cru
 <en:Parboiled rices
 en:Raw parboiled rice
 fr:Riz blanc étuvé cru
+agribalyse_food_code:en:9101
 ciqual_food_code:en:9101
 ciqual_food_name:en:Rice, parboiled, raw
 ciqual_food_name:fr:Riz blanc étuvé, cru
@@ -26857,6 +27384,7 @@ ciqual_food_name:fr:Riz blanc étuvé, cru
 <en:Parboiled rices
 en:Unsalted cooked parboiled rice
 fr:Riz blanc étuvé cuit non salé
+agribalyse_food_code:en:9105
 ciqual_food_code:en:9105
 ciqual_food_name:en:Rice, parboiled, cooked, unsalted
 ciqual_food_name:fr:Riz blanc étuvé, cuit, non salé
@@ -26943,6 +27471,7 @@ zh:寿司米
 <en:Rices
 en:Unsalted cooked red rice
 fr:Riz rouge cuit non salé
+agribalyse_food_code:en:9110
 ciqual_food_code:en:9110
 ciqual_food_name:en:Rice, red, cooked, unsalted
 ciqual_food_name:fr:Riz rouge, cuit, non salé
@@ -26950,6 +27479,7 @@ ciqual_food_name:fr:Riz rouge, cuit, non salé
 <en:Rices
 en:Raw red rice
 fr:Riz rouge cru
+agribalyse_food_code:en:9109
 ciqual_food_code:en:9109
 ciqual_food_name:en:Rice, red, raw
 ciqual_food_name:fr:Riz rouge, cru
@@ -26992,6 +27522,7 @@ it:Riso Basmati
 nl:Basmatirijsten, Basmatirijst
 pl:Ryż Basmati, ryż siewny indyjski
 wikidata:en:Q1649635
+agribalyse_food_code:en:9119
 ciqual_food_code:en:9119
 ciqual_food_name:en:Basmati rice, raw
 ciqual_food_name:fr:Riz thaï ou basmati, cru
@@ -27120,6 +27651,7 @@ de:Gemischter Reis
 es:Mezclas de arroces, Mezcla de arroces
 fr:Mélanges de riz, Riz mélange de variétés
 nl:Gemengde rijsten, Rijstmelanges, Gemengde rijst, Rijstmelange
+agribalyse_food_code:en:9121
 ciqual_food_code:en:9121
 ciqual_food_name:en:Rice, mix of species (white, wholegrain, wild, red,etc.), raw
 ciqual_food_name:fr:Riz, mélange de variétés (blanc, complet, rouge, sauvage, etc.), cru
@@ -27148,6 +27680,7 @@ wikidata:en:Q12099
 <en:Secale
 en:Whole raw rye
 fr:Seigle entier cru
+agribalyse_food_code:en:9390
 ciqual_food_code:en:9390
 ciqual_food_name:en:Rye, whole, raw
 ciqual_food_name:fr:Seigle entier, cru
@@ -27163,6 +27696,7 @@ la:Sesamum indicum
 nl:Sesamzaden, Sesamzaad
 zh:芝麻
 wikidata:en:Q2763698
+agribalyse_food_code:en:15010
 ciqual_food_code:en:15010
 ciqual_food_name:en:Sesame seed
 
@@ -27177,6 +27711,7 @@ zh:生芝麻
 <en:Sesame
 en:Sesame seed husked
 fr:graine de sésame décortiquée
+agribalyse_food_code:en:15035
 ciqual_food_code:en:15035
 ciqual_food_name:en:Sesame seed, husked
 
@@ -27187,6 +27722,7 @@ es:Semillas de sésamo tostadas
 fr:Sésame toasté, Graines de sésame toastées
 nl:Geroosterde sesamzaden, Geroosterde sesamzaad
 zh:烤芝麻
+agribalyse_food_code:en:15038
 ciqual_food_code:en:15038
 ciqual_food_name:en:Sesame seed, grilled, husked
 
@@ -27200,6 +27736,7 @@ la:Sorghum
 nl:Sorghum, Sorgho, Kafferkoren
 zh:高粱
 wikidata:en:Q12111
+agribalyse_food_code:en:9360
 ciqual_food_code:en:9360
 ciqual_food_name:en:Sorghum, whole, raw
 ciqual_food_name:fr:Sorgho entier, cru
@@ -27244,6 +27781,7 @@ it:Grano tenero
 la:Triticum aestivum, Triticum aestivum subsp. aestivum
 nl:Gewone tarwes, Gewone tarwe
 wikidata:en:Q161098
+agribalyse_food_code:en:9010
 ciqual_food_code:en:9010
 ciqual_food_name:en:Wheat, whole, raw
 ciqual_food_name:fr:Blé tendre entier ou froment, cru
@@ -27294,6 +27832,7 @@ it:Grano khorasan
 la:Triticum turanicum, Triticum turgidum subsp. turanicum
 nl:Khorasantarwe, Kamut
 wikidata:en:Q11163068
+agribalyse_food_code:en:9003
 ciqual_food_code:en:9003
 ciqual_food_name:en:Khorasan wheat
 ciqual_food_name:fr:Blé de Khorasan, cru
@@ -27311,6 +27850,7 @@ wikidata:en:Q158767
 <en:Wheats
 en:Raw spelt
 fr:Épeautre cru
+agribalyse_food_code:en:9001
 ciqual_food_code:en:9001
 ciqual_food_name:en:Spelt, raw
 ciqual_food_name:fr:Épeautre, cru
@@ -27324,6 +27864,7 @@ it:Riso selvatico
 la:Zizania
 nl:Wilde rijsten, Wilde rijst
 wikidata:en:Q831681
+agribalyse_food_code:en:9108
 ciqual_food_code:en:9108
 ciqual_food_name:en:Wild rice, raw
 ciqual_food_name:fr:Riz sauvage, cru
@@ -27339,6 +27880,7 @@ wikidata:en:Q6038850
 <en:Precooked rices
 en:White rice cooked with chicken
 fr:Riz blanc cuit au poulet
+agribalyse_food_code:en:25184
 ciqual_food_code:en:25184
 ciqual_food_name:en:White rice, cooked, with chicken
 ciqual_food_name:fr:Riz blanc, cuit, avec poulet
@@ -27346,6 +27888,7 @@ ciqual_food_name:fr:Riz blanc, cuit, avec poulet
 <en:Precooked rices
 en:White rice cooked with vegetables and meat
 fr:Riz blanc cuit avec légumes et viande
+agribalyse_food_code:en:25185
 ciqual_food_code:en:25185
 ciqual_food_name:en:White rice, cooked, with vegetables and meat
 ciqual_food_name:fr:Riz blanc, cuit, avec légumes et viande
@@ -27353,6 +27896,7 @@ ciqual_food_name:fr:Riz blanc, cuit, avec légumes et viande
 <en:Precooked rices
 en:Unsalted cooked rice
 fr:Riz blanc cuit non salé
+agribalyse_food_code:en:9104
 ciqual_food_code:en:9104
 ciqual_food_name:en:Rice, cooked, unsalted
 ciqual_food_name:fr:Riz blanc, cuit, non salé
@@ -27360,6 +27904,7 @@ ciqual_food_name:fr:Riz blanc, cuit, non salé
 <en:Precooked rices
 en:Unsalted cooked wild rice
 fr:Riz sauvage cuit non salé
+agribalyse_food_code:en:9111
 ciqual_food_code:en:9111
 ciqual_food_name:en:Wild rice, cooked, unsalted
 ciqual_food_name:fr:Riz sauvage, cuit, non salé
@@ -27395,6 +27940,7 @@ nl:Suikermaïs in blik
 <en:Canned corn
 en:Canned drained sweet corn
 fr:Maïs doux appertisé égoutté, Maïs doux en conserve égoutté
+agribalyse_food_code:en:20066
 ciqual_food_code:en:20066
 ciqual_food_name:en:Sweet corn, canned, drained
 ciqual_food_name:fr:Maïs doux, appertisé, égoutté
@@ -27403,6 +27949,7 @@ ciqual_food_name:fr:Maïs doux, appertisé, égoutté
 <en:White beans
 en:Canned drained haricot beans
 fr:Haricots blancs appertisés égouttés, Haricots blancs en conserve égouttés
+agribalyse_food_code:en:20511
 ciqual_food_code:en:20511
 ciqual_food_name:en:Haricot bean, canned, drained
 ciqual_food_name:fr:Haricot blanc, appertisé, égoutté
@@ -27514,6 +28061,7 @@ zh:马铃薯薯片
 wikidata:en:Q173265
 en:Potato crisps
 fr:Chips de pommes de terre
+agribalyse_food_code:en:4004
 ciqual_food_code:en:4004
 ciqual_food_name:en:Potato crisps
 ciqual_food_name:fr:Chips de pommes de terre, standard
@@ -27521,6 +28069,7 @@ ciqual_food_name:fr:Chips de pommes de terre, standard
 <en:Potato crisps
 en:Potato crisps à l'ancienne, Old-fashioned style potato crisps
 fr:Chips de pommes de terre à l'ancienne
+agribalyse_food_code:en:4037
 ciqual_food_code:en:4037
 ciqual_food_name:en:Potato crisps, à l'ancienne (old-fashioned style)
 ciqual_food_name:fr:Chips de pommes de terre, à l'ancienne
@@ -27542,6 +28091,7 @@ en:Light potato crisps, Potato crisps with reduced fat
 de:Leichte Kartoffelchips
 fr:Chips de pommes de terre allégées, Chips de pommes de terre allégées en matière grasse
 nl:Light aardappelchips
+agribalyse_food_code:en:4038
 ciqual_food_code:en:4038
 ciqual_food_name:en:Potato crisps and related, reduced fat
 ciqual_food_name:fr:Chips de pommes de terre et assimilés, allégées en matière grasse
@@ -27580,6 +28130,7 @@ en:Prawn cocktail crisps, Prawn crackers
 de:Garnelencocktail Chips
 fr:Chips cocktail de crevettes, Chips de crevette
 nl:Garnalen chips
+agribalyse_food_code:en:38104
 ciqual_food_code:en:38104
 ciqual_food_name:en:Prawn crackers
 ciqual_food_name:fr:Chips de crevette
@@ -27680,6 +28231,7 @@ nl:Rode aardappelchips
 <en:Crisps
 fr:Tuiles salées, tuile salée, Biscuit apéritif à base de pomme de terre, Tuile salée à base de pomme de terre
 en:Salty snacks made from potato
+agribalyse_food_code:en:38405
 ciqual_food_code:en:38405
 ciqual_food_name:en:Salty snacks, made from potato
 ciqual_food_name:fr:Biscuit apéritif à base de pomme de terre, type tuile salée
@@ -27694,6 +28246,7 @@ hu:Kukoricacsipsz
 nl:Tortillachips
 ro:Nachos, Chipsuri de porumb, Chipsuri din porumb
 oqali_family:en: fr:Aperitifs a croquer - Tortillas
+agribalyse_food_code:en:38105
 ciqual_food_code:en:38105
 ciqual_food_name:en:Corn chips or tortilla chips
 ciqual_food_name:fr:Chips de maïs ou tortilla chips
@@ -27771,6 +28324,7 @@ ru:Кисломолочные напитки
 <en:Fermented milk drinks
 en:Plain whole fermented milk drink
 fr:Lait fermenté à boire nature au lait entier
+agribalyse_food_code:en:19805
 ciqual_food_code:en:19805
 ciqual_food_name:en:Fermented milk drink, plain, whole milk
 ciqual_food_name:fr:Lait fermenté à boire, nature, au lait entier
@@ -27778,6 +28332,7 @@ ciqual_food_name:fr:Lait fermenté à boire, nature, au lait entier
 <en:Fermented milk drinks
 en:Plain fermented skimmed milk drink
 fr:Lait fermenté à boire nature maigre
+agribalyse_food_code:en:19801
 ciqual_food_code:en:19801
 ciqual_food_name:en:Fermented milk drink, plain, skimmed milk
 ciqual_food_name:fr:Lait fermenté à boire, nature, maigre
@@ -27796,7 +28351,7 @@ wikidata:en:Q185749
 ciqual_food_code:en:19865
 ciqual_food_name:en:Kefir
 ciqual_food_name:fr:Kéfir
-who_id:7
+who_id:en:7
 
 <en:Kefir
 en:Kefir 1 %
@@ -27973,7 +28528,7 @@ nova:en:3
 ciqual_food_code:en:12999
 ciqual_food_name:en:Cheese (average)
 ciqual_food_name:fr:Fromage (aliment moyen)
-who_id:8
+who_id:en:8
 
 <en:Cheeses
 fr:Fromages pour enfants
@@ -28009,6 +28564,7 @@ de:Französischer Blauschimmelkäse
 fi:ranskalaiset sinihomejuustot
 fr:Fromages à pâte persillée français, pâtes à moisissure interne français, bleus français, Fromage bleu au lait de vache
 nl:Franse blauwschimmelkazen
+agribalyse_food_code:en:12520
 ciqual_food_code:en:12520
 ciqual_food_name:en:Blue cheese, from cow's milk
 
@@ -28020,6 +28576,7 @@ de:Bleu d'Auvergne
 nl:Bleus d'Auvergne
 wikidata:en:Q883954
 country:en:France
+agribalyse_food_code:en:12521
 ciqual_food_code:en:12521
 ciqual_food_name:en:Auvergne blue cheese, from cow's milk
 
@@ -28028,6 +28585,7 @@ fr:Bleus de Gex, bleus du Haut-Jura, bleus de Septmoncel
 en:Gex blue cheese or Jura blue cheese or Septmoncel blue cheese from cow's milk
 de:Bleu du Haut Jura, Bleu de Gex
 wikidata:en:Q1231078
+agribalyse_food_code:en:12526
 ciqual_food_code:en:12526
 ciqual_food_name:en:Gex blue cheese, or Jura blue cheese or Septmoncel blue cheese, from cow's milk
 
@@ -28057,6 +28615,7 @@ fr:Fourme d'Ambert
 en:Fourme d'Ambert cheese from cow's milk
 wikidata:en:Q1245530
 country:en:France
+agribalyse_food_code:en:12522
 ciqual_food_code:en:12522
 ciqual_food_name:en:Fourme d'Ambert cheese, from cow's milk
 
@@ -28066,6 +28625,7 @@ fr:Fourme de Montbrison
 en:Fourme de Montbrison cheese
 wikidata:en:Q1245441
 country:en:France
+agribalyse_food_code:en:12519
 ciqual_food_code:en:12519
 ciqual_food_name:en:Fourme de Montbrison cheese
 
@@ -28084,6 +28644,7 @@ fr:Roqueforts, Roquefort
 wikidata:en:Q189221
 country:en:France
 oqali_family:en: fr:Fromages - Roquefort
+agribalyse_food_code:en:12500
 ciqual_food_code:en:12500
 ciqual_food_name:en:Roquefort cheese, from ewe's milk
 ciqual_food_name:fr:Roquefort
@@ -28095,12 +28656,14 @@ wikidata:en:Q3528329
 <en:French blue-veined cheeses
 en:Bresse blue cheese from cow's milk
 fr:Fromage bleu de Bresse
+agribalyse_food_code:en:12527
 ciqual_food_code:en:12527
 ciqual_food_name:en:Bresse blue cheese, from cow's milk
 
 <en:French blue-veined cheeses
 en:Bresse blue cheese from cow's milk reduced fat around 15% fat
 fr:Fromage bleu de Bresse allegé environ 15% MG
+agribalyse_food_code:en:12528
 ciqual_food_code:en:12528
 ciqual_food_name:en:Bresse blue cheese, from cow's milk, reduced fat, around 15% fat
 
@@ -28115,6 +28678,7 @@ it:Gorgonzola
 nl:Gorgonzolas, Gorgonzola
 country:en:Italy
 wikidata:en:Q209044
+agribalyse_food_code:en:12524
 ciqual_food_code:en:12524
 ciqual_food_name:en:Gorgonzola cheese, from cow's milk
 
@@ -28146,6 +28710,7 @@ it:Provolone
 nl:Provolone
 pt:Provolone
 sv:Provolone
+agribalyse_food_code:en:12716
 ciqual_food_code:en:12716
 ciqual_food_name:en:Provolone cheese, from cow's milk
 ciqual_food_name:fr:Provolone
@@ -28158,6 +28723,7 @@ en:Coulommiers cheese from cow's milk
 hu:Coulommiers sajt
 wikidata:en:Q774297
 oqali_family:en: fr:Fromages - Coulommiers
+agribalyse_food_code:en:12010
 ciqual_food_code:en:12010
 ciqual_food_name:en:Coulommiers cheese, from cow's milk
 
@@ -28166,6 +28732,7 @@ ciqual_food_name:en:Coulommiers cheese, from cow's milk
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened round cheese with bloomy rind around 11% fat Coulommiers-type cheese reduced fat
 fr:Fromage rond à pâte molle et croûte fleurie environ 11% MG type coulommiers allégé en matière grasse
+agribalyse_food_code:en:12012
 ciqual_food_code:en:12012
 ciqual_food_name:en:Soft-ripened round cheese with bloomy rind, around 11% fat, Coulommiers-type cheese, reduced fat
 
@@ -28180,6 +28747,7 @@ nl:Bries, Brie
 pl:Sery Brie, ser Brie
 wikidata:en:Q193411
 oqali_family:en: fr:Fromages - Brie
+agribalyse_food_code:en:12020
 ciqual_food_code:en:12020
 ciqual_food_name:en:Brie cheese, from cow's milk
 
@@ -28191,6 +28759,7 @@ fr:Saint-Félicien
 nl:Saint-Félicien
 wikidata:en:Q1237731
 oqali_family:en: fr:Fromages - Saint marcellin et assimiles
+agribalyse_food_code:en:12052
 ciqual_food_code:en:12052
 ciqual_food_name:en:Saint-Felicien cheese, from cow's milk
 
@@ -28204,6 +28773,7 @@ fr:Cheddars, Cheddar
 hu:Cheddar sajt
 nl:Cheddars, Cheddar
 wikidata:en:Q217525
+agribalyse_food_code:en:12726
 ciqual_food_code:en:12726
 ciqual_food_name:en:Cheddar cheese, from cow's milk
 
@@ -28253,6 +28823,7 @@ hu:Mimolettes sajtok
 nl:Mimolettes, Commissiekazen
 wikidata:en:Q749121
 oqali_family:en: fr:Fromages - Mimolette
+agribalyse_food_code:en:12740
 ciqual_food_code:en:12740
 ciqual_food_name:en:Mimolette cheese, from cow's milk
 ciqual_food_name:fr:Mimolette, sans précision
@@ -28275,6 +28846,7 @@ ru:Чечил копчёный
 en:Half-aged mimolettes
 fr:Mimolettes demi-vieilles
 nl:Belegen mimolette
+agribalyse_food_code:en:12737
 ciqual_food_code:en:12737
 ciqual_food_name:en:Mimolette cheese, half-old, from cow's milk
 
@@ -28282,6 +28854,7 @@ ciqual_food_name:en:Mimolette cheese, half-old, from cow's milk
 en:Extra old mimolettes
 fr:Mimolettes extra vieilles
 nl:Extra oude mimolette
+agribalyse_food_code:en:12742
 ciqual_food_code:en:12742
 ciqual_food_name:en:Mimolette cheese, extra old, from cow's milk
 
@@ -28289,6 +28862,7 @@ ciqual_food_name:en:Mimolette cheese, extra old, from cow's milk
 en:Young mimolettes
 fr:Mimolettes jeunes
 nl:Jonge mimolette
+agribalyse_food_code:en:12735
 ciqual_food_code:en:12735
 ciqual_food_name:en:Mimolette cheese, young, from cow's milk
 ciqual_food_name:fr:Mimolette jeune
@@ -28298,6 +28872,7 @@ en:Old mimolettes
 fr:Mimolettes vieilles
 nl:Oude mimolette
 wikidata:en:Q643697
+agribalyse_food_code:en:12738
 ciqual_food_code:en:12738
 ciqual_food_name:en:Mimolette cheese, old, from cow's milk
 
@@ -28314,6 +28889,7 @@ oqali_family:en: fr:Fromages - Munster
 <en:Cheeses
 en:Saint-Paulin cheese
 fr:Saint-Paulin
+agribalyse_food_code:en:12755
 ciqual_food_code:en:12755
 ciqual_food_name:en:Saint-Paulin cheese, from cow's milk (semi-hard cheese)
 ciqual_food_name:fr:Saint-Paulin (fromage à pâte pressée non cuite demi-ferme)
@@ -28355,6 +28931,7 @@ hu:Camembertek, camembert sajtok
 nl:Camemberts
 wikidata:en:Q131480
 oqali_family:en: fr:Fromages - Camembert
+agribalyse_food_code:en:12001
 ciqual_food_code:en:12001
 ciqual_food_name:en:Camembert cheese, from cow's milk
 
@@ -28365,6 +28942,7 @@ de:Camembert aus Rohmilch, Rohmilch-Camembert
 fi:Camembert raakamaidosta
 fr:Camemberts au lait cru, Camembert au lait cru
 nl:Rauwmelkse camemberts
+agribalyse_food_code:en:12006
 ciqual_food_code:en:12006
 ciqual_food_name:en:Camembert cheese, from cow's milk, from raw milk
 
@@ -28404,6 +28982,7 @@ wikidata:en:Q2934743
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened cheese with bloomy rind (Camembert-type cheese)
 fr:Fromage à pâte molle et croûte fleurie (type camembert)
+agribalyse_food_code:en:12003
 ciqual_food_code:en:12003
 ciqual_food_name:en:Soft-ripened cheese with bloomy rind (Camembert-type cheese)
 
@@ -28411,6 +28990,7 @@ ciqual_food_name:en:Soft-ripened cheese with bloomy rind (Camembert-type cheese)
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened round cheese with bloomy rind 5 to 11% fat Camembert-type cheese reduced fat
 fr:Fromage rond à pâte molle et croûte fleurie 5 à 11% MG type camembert allégé en matière grasse
+agribalyse_food_code:en:12009
 ciqual_food_code:en:12009
 ciqual_food_name:en:Soft-ripened round cheese with bloomy rind, 5 to 11% fat, Camembert-type cheese, reduced fat
 
@@ -28418,6 +28998,7 @@ ciqual_food_name:en:Soft-ripened round cheese with bloomy rind, 5 to 11% fat, Ca
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened cheese triple cream around 40% fat
 fr:Fromage à pâte molle triple crème environ 40% MG
+agribalyse_food_code:en:12033
 ciqual_food_code:en:12033
 ciqual_food_name:en:Soft-ripened cheese, triple cream, around 40% fat
 
@@ -28425,6 +29006,7 @@ ciqual_food_name:en:Soft-ripened cheese, triple cream, around 40% fat
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened washed-rind cheese reduced fat around 13% fat
 fr:Fromage à pâte molle et croûte lavée allégé environ 13% MG
+agribalyse_food_code:en:12035
 ciqual_food_code:en:12035
 ciqual_food_name:en:Soft-ripened washed-rind cheese, reduced fat, around 13% fat
 
@@ -28432,6 +29014,7 @@ ciqual_food_name:en:Soft-ripened washed-rind cheese, reduced fat, around 13% fat
 <en:Soft cheeses with bloomy rind
 en:Soft -ripened washed bloomy and coloured rind cheese
 fr:Fromage à pâte molle et croûte mixte (lavée et fleurie) colorée
+agribalyse_food_code:en:12050
 ciqual_food_code:en:12050
 ciqual_food_name:en:Soft -ripened washed, bloomy and coloured rind cheese
 
@@ -28439,6 +29022,7 @@ ciqual_food_name:en:Soft -ripened washed, bloomy and coloured rind cheese
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened cheese double cream around 30% fat
 fr:Fromage à pâte molle double crème environ 30% MG
+agribalyse_food_code:en:12008
 ciqual_food_code:en:12008
 ciqual_food_name:en:Soft-ripened cheese, double cream, around 30% fat
 
@@ -28446,6 +29030,7 @@ ciqual_food_name:en:Soft-ripened cheese, double cream, around 30% fat
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened round cheese with bloomy rind around 5% fat Camembert-type cheese reduced fat
 fr:Fromage rond à pâte molle et croûte fleurie environ 5% MG type camembert allégé en matière grasse
+agribalyse_food_code:en:12013
 ciqual_food_code:en:12013
 ciqual_food_name:en:Soft-ripened round cheese with bloomy rind, around 5% fat, Camembert-type cheese, reduced fat
 
@@ -28453,6 +29038,7 @@ ciqual_food_name:en:Soft-ripened round cheese with bloomy rind, around 5% fat, C
 <en:Soft cheeses with bloomy rind
 en:Soft-ripened washed-rind cheese from pasteurised milk (Vieux pané-type cheese)
 fr:Fromage à pâte molle à croûte lavée au lait pasteurisé (type Vieux Pané)
+agribalyse_food_code:en:12047
 ciqual_food_code:en:12047
 ciqual_food_name:en:Soft-ripened washed-rind cheese, from pasteurised milk (Vieux pané-type cheese)
 
@@ -28469,6 +29055,7 @@ it:Emmental, emmenthal, emmentaler
 nl:Emmentalers
 wikidata:en:Q932214
 oqali_family:en: fr:Fromages - Emmental
+agribalyse_food_code:en:12115
 ciqual_food_code:en:12115
 ciqual_food_name:en:Emmental cheese, from cow's milk
 ciqual_food_name:fr:Emmental ou emmenthal
@@ -28476,6 +29063,7 @@ ciqual_food_name:fr:Emmental ou emmenthal
 <en:Emmentaler
 en:Hard cheese emmental-type cheese reduced fat
 fr:fromage de type emmental
+agribalyse_food_code:en:12116
 ciqual_food_code:en:12116
 ciqual_food_name:en:Hard cheese, emmental-type cheese, reduced fat
 ciqual_food_name:fr:Fromage à pate pressée cuite type emmental ou emmenthal, allégé en matière grasse
@@ -28529,6 +29117,7 @@ de:Geriebener Emmentaler
 fi:raastettu emmental
 fr:Emmentals râpés, emmental râpé, emmenthal râpé
 nl:Gemalen emmentalers
+agribalyse_food_code:en:12118
 ciqual_food_code:en:12118
 ciqual_food_name:en:Emmental cheese, grated, from cow's milk
 
@@ -28564,6 +29153,7 @@ it:Pont-l'évêque
 nl:Pont-l'Évêque
 country:en:France
 wikidata:en:Q1233145
+agribalyse_food_code:en:12042
 ciqual_food_code:en:12042
 ciqual_food_name:en:Pont l'Evêque cheese, from cow's milk
 
@@ -28576,6 +29166,7 @@ de:Reblochon
 wikidata:en:Q543805
 country:en:France
 oqali_family:en: fr:Fromages - Reblochon
+agribalyse_food_code:en:12045
 ciqual_food_code:en:12045
 ciqual_food_name:en:Reblochon cheese, from cow's milk
 
@@ -28603,18 +29194,21 @@ fr:Fetan
 hu:Feta sajtok
 nl:Fetas, Feta's
 wikidata:en:Q182760
+agribalyse_food_code:en:12061
 ciqual_food_code:en:12061
 ciqual_food_name:en:Feta cheese, from ewe's milk
 
 <en:Greek cheeses
 en:Feta-type cheese from cow's milk
 fr:Fromage type feta au lait de vache
+agribalyse_food_code:en:12060
 ciqual_food_code:en:12060
 ciqual_food_name:en:Feta-type cheese from cow's milk
 
 <en:Greek cheeses
 en:Feta-type cheese from cow's milk in oil and spices
 fr:Fromage type feta au lait de vache à l'huile et aux aromates
+agribalyse_food_code:en:12063
 ciqual_food_code:en:12063
 ciqual_food_name:en:Feta-type cheese from cow's milk, in oil and spices
 
@@ -28864,6 +29458,7 @@ en:Valençay cheese
 fr:Valençay
 nl:Velençay kaas
 wikidata:en:Q659277
+agribalyse_food_code:en:12848
 ciqual_food_code:en:12848
 ciqual_food_name:en:Valençay cheese, from goat's milk
 
@@ -28882,7 +29477,6 @@ oqali_family:en: fr:Fromages - Crottin de chevre
 en:Selles-sur-Cher
 fr:Selles-sur-Cher
 wikidata:en:Q1249172
-country:en:France
 agribalyse_food_code:en:12845
 ciqual_food_code:en:12845
 ciqual_food_name:en:Selles-sur-Cher cheese, from goat's milk
@@ -28902,6 +29496,7 @@ ciqual_food_name:en:Corsica soft ripened cheese, from ewe's milk
 en:Abondance
 fr:Abondance
 country:en:France
+agribalyse_food_code:en:12112
 ciqual_food_code:en:12112
 ciqual_food_name:en:Abondance cheese, from cow's milk
 
@@ -28915,6 +29510,7 @@ country:en:France
 <en:Cooked pressed cheeses
 fr:Beaufort
 en:Beaufort
+agribalyse_food_code:en:12105
 ciqual_food_code:en:12105
 ciqual_food_name:en:Beaufort cheese, from cow's milk
 country:en:France
@@ -28923,6 +29519,7 @@ country:en:France
 fr:Bleu des Causses
 en:Causses blue cheese from cow's milk
 country:en:France
+agribalyse_food_code:en:12523
 ciqual_food_code:en:12523
 ciqual_food_name:en:Causses blue cheese, from cow's milk
 
@@ -28935,6 +29532,7 @@ country:en:France
 fr:Brie de Meaux, Bries de Meaux
 en:Brie de Meaux cheese from cow's milk
 country:en:France
+agribalyse_food_code:en:12021
 ciqual_food_code:en:12021
 ciqual_food_name:en:Brie de Meaux cheese, from cow's milk
 
@@ -28943,6 +29541,7 @@ ciqual_food_name:en:Brie de Meaux cheese, from cow's milk
 fr:Brie de Melun, Bries de Melun
 en:Brie de Melun cheese from cow's milk
 country:en:France
+agribalyse_food_code:en:12022
 ciqual_food_code:en:12022
 ciqual_food_name:en:Brie de Melun cheese, from cow's milk
 
@@ -28955,6 +29554,7 @@ origins:en: fr:Corse, en:France
 <en:Uncooked pressed cheeses
 <en:Cow cheeses
 fr:Cantal, fourme de Cantal, cantalet, Cantals
+agribalyse_food_code:en:12722
 ciqual_food_code:en:12722
 ciqual_food_name:en:Cantal cheese, half matured, from cow's milk
 ciqual_food_name:fr:Cantal entre-deux
@@ -28965,6 +29565,7 @@ country:en:France
 <en:French cheeses
 en:Cantal Salers
 fr:Cantal Salers
+agribalyse_food_code:en:12723
 ciqual_food_code:en:12723
 ciqual_food_name:en:Cantal, Salers or Laguiole cheese, from cow's milk
 ciqual_food_name:fr:Cantal, Salers ou Laguiole
@@ -28975,6 +29576,7 @@ country:en:France
 <en:French cheeses
 en:Laguiole
 fr:Laguiole
+agribalyse_food_code:en:12723
 ciqual_food_code:en:12723
 ciqual_food_name:en:Cantal, Salers or Laguiole cheese, from cow's milk
 ciqual_food_name:fr:Cantal, Salers ou Laguiole
@@ -28986,6 +29588,7 @@ country:en:France
 fr:Chabichous du Poitou, Chabichou du Poitou
 country:en:France
 oqali_family:en: fr:Fromages - Crottin de chevre
+agribalyse_food_code:en:12830
 ciqual_food_code:en:12830
 ciqual_food_name:en:Chabichou cheese, from goat's milk
 
@@ -28995,6 +29598,7 @@ ciqual_food_name:en:Chabichou cheese, from goat's milk
 fr:Chaource
 en:Chaource cheese from cow's milk
 country:en:France
+agribalyse_food_code:en:12028
 ciqual_food_code:en:12028
 ciqual_food_name:en:Chaource cheese, from cow's milk
 
@@ -29013,12 +29617,14 @@ country:en:France
 <en:Goat cheeses
 en:Crottin cheese from goat's milk
 fr:Crottin de chèvre
+agribalyse_food_code:en:12833
 ciqual_food_code:en:12833
 ciqual_food_name:en:Crottin cheese, from goat's milk
 
 <en:Crottin cheese from goat's milk
 en:Crottin cheese from goat's milk from raw milk
 fr:Crottin de chèvre au lait cru
+agribalyse_food_code:en:12832
 ciqual_food_code:en:12832
 ciqual_food_name:en:Crottin cheese, from goat's milk, from raw milk
 
@@ -29029,6 +29635,7 @@ en:Crottin de Chavignol cheese
 fr:Crottins de Chavignol, Crottin de Chavignol, Chavignol
 country:en:France
 wikidata:en:Q249873
+agribalyse_food_code:en:12834
 ciqual_food_code:en:12834
 ciqual_food_name:en:Crottin de Chavignol cheese, from goat's milk
 
@@ -29040,6 +29647,7 @@ fr:Époisses, Epoisses
 nl:Époisse uit de Bourgogne
 country:en:France
 wikidata:en:Q1231414
+agribalyse_food_code:en:12038
 ciqual_food_code:en:12038
 ciqual_food_name:en:Époisses cheese, from cow's milk
 
@@ -29052,6 +29660,7 @@ fr:Gruyères français, Gruyère français, Gruyères de France
 nl:Gruyère uit Frankrijk, Franse Gruyère
 country:en:France
 wikidata:en:Q3118260
+agribalyse_food_code:en:12114
 ciqual_food_code:en:12114
 ciqual_food_name:en:Gruyere cheese, from cow's milk
 
@@ -29061,6 +29670,7 @@ ciqual_food_name:en:Gruyere cheese, from cow's milk
 <en:French Gruyères
 en:Gruyere cheese France Protected Geographical Indication from cow's milk
 fr:Gruyère IGP France, Gruyères IGP
+agribalyse_food_code:en:12113
 ciqual_food_code:en:12113
 ciqual_food_name:en:Gruyere cheese, France, Protected Geographical Indication, from cow's milk
 ciqual_food_name:fr:Gruyère IGP France
@@ -29070,6 +29680,7 @@ ciqual_food_name:fr:Gruyère IGP France
 fr:Langres
 en:Langres cheese from cow's milk
 country:en:France
+agribalyse_food_code:en:12040
 ciqual_food_code:en:12040
 ciqual_food_name:en:Langres cheese, from cow's milk
 
@@ -29086,6 +29697,7 @@ fr:Morbiers
 en:Morbier cheese from cow's milk
 country:en:France
 wikidata:en:Q177727
+agribalyse_food_code:en:12743
 ciqual_food_code:en:12743
 ciqual_food_name:en:Morbier cheese, from cow's milk
 
@@ -29094,6 +29706,7 @@ fr:Munster, Munster-Géromé
 country:en:France
 en:Munster cheese from cow's milk
 fr:Munster
+agribalyse_food_code:en:12039
 ciqual_food_code:en:12039
 ciqual_food_name:en:Munster cheese, from cow's milk
 
@@ -29101,6 +29714,7 @@ ciqual_food_name:en:Munster cheese, from cow's milk
 en:Neufchâtel cheese from cow's milk
 fr:Neufchâtel
 country:en:France
+agribalyse_food_code:en:12031
 ciqual_food_code:en:12031
 ciqual_food_name:en:Neufchâtel cheese, from cow's milk
 
@@ -29111,6 +29725,7 @@ en:Ossau-Iraty cheeses, Ossau-Iraty cheeses from ewe's milk
 fr:Ossau-lraty
 country:en:France
 wikidata:en:Q520598
+agribalyse_food_code:en:12119
 ciqual_food_code:en:12119
 ciqual_food_name:en:Ossau-Iraty cheese, from ewe's milk
 ciqual_food_name:fr:Ossau-Iraty
@@ -29132,6 +29747,7 @@ fr:Picodon
 country:en:France
 wikidata:en:Q1245576
 oqali_family:en: fr:Fromages - Crottin de chevre
+agribalyse_food_code:en:12836
 ciqual_food_code:en:12836
 ciqual_food_name:en:Picodon cheese, from goat's milk
 
@@ -29142,6 +29758,7 @@ en:Pouligny-Saint-Pierre, Pouligny Saint-Pierre
 fr:Pouligny-Saint-Pierre, Pouligny Saint-Pierre
 country:en:France
 wikidata:en:Q640839
+agribalyse_food_code:en:12839
 ciqual_food_code:en:12839
 ciqual_food_name:en:Pouligny Saint-Pierre cheese, from goat's milk
 
@@ -29161,6 +29778,7 @@ fr:Rocamadour
 country:en:France
 wikidata:en:Q768189
 oqali_family:en: fr:Fromages - Crottin de chevre
+agribalyse_food_code:en:12847
 ciqual_food_code:en:12847
 ciqual_food_name:en:Rocamadour cheese, from goat's milk
 
@@ -29171,6 +29789,7 @@ en:Sainte-Maure de Touraine, Sainte Maure cheese
 fr:Sainte-Maure de Touraine
 country:en:France
 wikidata:en:Q652628
+agribalyse_food_code:en:12842
 ciqual_food_code:en:12842
 ciqual_food_name:en:Sainte Maure cheese, from goat's milk
 
@@ -29182,6 +29801,7 @@ ciqual_food_name:en:Sainte Maure cheese, from goat's milk
 <en:French cheeses
 en:Cheese from goat's milk
 fr:Fromage de chèvre lactique affiné (type bûchette crottin Sainte-Maure)
+agribalyse_food_code:en:12803
 ciqual_food_code:en:12803
 ciqual_food_name:en:Cheese, from goat's milk
 
@@ -29193,6 +29813,7 @@ en:Saint-Marcellin cheese from cow's milk
 country:en:France
 wikidata:en:Q510126
 oqali_family:en: fr:Fromages - Saint marcellin et assimiles
+agribalyse_food_code:en:12049
 ciqual_food_code:en:12049
 ciqual_food_name:en:Saint-Marcellin cheese, from cow's milk
 
@@ -29203,6 +29824,7 @@ en:Salers cheese
 fr:Salers
 country:en:France
 wikidata:en:Q1245627
+agribalyse_food_code:en:12725
 ciqual_food_code:en:12725
 ciqual_food_name:en:Salers cheese, from cow's milk
 
@@ -29213,6 +29835,7 @@ fr:Tome des Bauges
 en:Tomme cheese (PDO) from the French Bauges mountains
 country:en:France
 wikidata:en:Q524966
+agribalyse_food_code:en:12763
 ciqual_food_code:en:12763
 ciqual_food_name:en:Tomme cheese (PDO) from the French Bauges mountains
 
@@ -29224,6 +29847,7 @@ fr:Mont d'Or, vacherin du Haut-Doubs, Vacherin-Mont d'Or
 en:Vacherin cheese or Mont d'or cheese from cow's milk
 de:Mont d'Or
 wikidata:en:Q2147909
+agribalyse_food_code:en:12051
 ciqual_food_code:en:12051
 ciqual_food_name:en:Vacherin cheese or Mont d'or cheese, from cow's milk
 
@@ -29238,6 +29862,7 @@ en:Livarot cheese from cow's milk
 de:Livarot
 wikidata:en:Q1144668
 country:en:France
+agribalyse_food_code:en:12037
 ciqual_food_code:en:12037
 ciqual_food_name:en:Livarot cheese, from cow's milk
 
@@ -29266,6 +29891,7 @@ fr:Fromages à pâte fondue, snack à base de fromage fondu
 nl:Smeltkazen
 ru:Плавленый сыр
 wikidata:en:Q1570052
+agribalyse_food_code:en:12356
 ciqual_food_code:en:12356
 ciqual_food_name:en:Processed cheese snack w breadsticks, for children
 
@@ -29316,6 +29942,7 @@ wikidata:en:Q2926318
 fr:Faisselles
 en:Drained soft fresh cheese around 6% fat
 wikidata:en:Q3064619
+agribalyse_food_code:en:19641
 ciqual_food_code:en:19641
 ciqual_food_name:en:Drained soft fresh cheese, around 6% fat
 
@@ -29336,6 +29963,7 @@ en:Carré de l'Est cheese from cow's milk
 de:Carre de l'Est
 origins:en: en:France, fr:Lorraine
 wikidata:en:Q2726262
+agribalyse_food_code:en:12025
 ciqual_food_code:en:12025
 ciqual_food_name:en:Carré de l'Est cheese, from cow's milk
 #average_weight:en:330 g
@@ -29394,6 +30022,7 @@ fr:Maasdam
 nl:Maasdam
 wikidata:en:Q3273732
 oqali_family:en: fr:Fromages - Maasdam
+agribalyse_food_code:en:12705
 ciqual_food_code:en:12705
 ciqual_food_name:en:Firm cheese, around 14% fat, Maasdam-type cheese, reduced fat
 ciqual_food_name:fr:Fromage à pâte ferme environ 14% MG type Masdaam à teneur réduite en MG
@@ -29403,6 +30032,7 @@ ciqual_food_name:fr:Fromage à pâte ferme environ 14% MG type Masdaam à teneur
 <en:Cheeses of the Netherlands
 en:Firm cheese around 27% fat Maasdam-type cheese
 fr:fromage type Maasdam 27% MG
+agribalyse_food_code:en:12741
 ciqual_food_code:en:12741
 ciqual_food_name:en:Firm cheese, around 27% fat, Maasdam-type cheese
 ciqual_food_name:fr:Fromage à pâte ferme environ 27% MG type Maasdam
@@ -29416,6 +30046,7 @@ fr:Goudas
 nl:Goudse Kazen
 wikidata:en:Q593675
 oqali_family:en: fr:Fromages - Gouda
+agribalyse_food_code:en:12736
 ciqual_food_code:en:12736
 ciqual_food_name:en:Gouda cheese, from cow's milk
 
@@ -29481,6 +30112,7 @@ hu:Edámi sajt
 nl:Edam
 wikidata:en:Q597473
 oqali_family:en: fr:Fromages - Edam
+agribalyse_food_code:en:12729
 ciqual_food_code:en:12729
 ciqual_food_name:en:Edam cheese, from cow's milk
 
@@ -29491,24 +30123,30 @@ fr:Saint-nectaire, Saint-nectaires, Saints-nectaires
 en:Saint-Nectaire cheese
 de:Saint-Nectaire
 wikidata:en:Q548309
+agribalyse_food_code:en:12752
 ciqual_food_code:en:12752
 ciqual_food_name:en:Saint-Nectaire cheese, from cow's milk
+origins:en: en:France
 
 <en:Cow cheeses
 <en:Uncooked pressed cheeses
 <en:French cheeses
 en:Saint-Nectaire cheese from cow's milk milks collected in many farms
 fr:Saint-Nectaire laitier
+agribalyse_food_code:en:12748
 ciqual_food_code:en:12748
 ciqual_food_name:en:Saint-Nectaire cheese, from cow's milk, milks collected in many farms
+origins:en: en:France
 
 <en:Cow cheeses
 <en:Uncooked pressed cheeses
 <en:French cheeses
 en:Saint-Nectaire cheese from cow's milk milk collected in an unique farm
 fr:Saint-Nectaire fermier
+agribalyse_food_code:en:12751
 ciqual_food_code:en:12751
 ciqual_food_name:en:Saint-Nectaire cheese, from cow's milk, milk collected in an unique farm
+origins:en: en:France
 
 <en:Cheeses
 en:Unpasteurised cheeses
@@ -29552,6 +30190,7 @@ fr:Fromages blancs natures
 <fr:Fromages blancs
 en:Fat free plain fresh cream cheese
 fr:Fromage blanc nature à 0% de matières grasses
+agribalyse_food_code:en:19644
 ciqual_food_code:en:19644
 ciqual_food_name:en:Fresh cream cheese, plain, fat free
 ciqual_food_name:fr:Fromage blanc nature, 0% MG
@@ -29559,6 +30198,7 @@ ciqual_food_name:fr:Fromage blanc nature, 0% MG
 <fr:Fromages blancs
 en:Plain fresh cream cheese around 3% fat
 fr:Fromage blanc nature à 3% de matières grasses environ
+agribalyse_food_code:en:19646
 ciqual_food_code:en:19646
 ciqual_food_name:en:Fresh cream cheese, plain, around 3% fat
 ciqual_food_name:fr:Fromage blanc nature, 3% MG environ
@@ -29566,6 +30206,7 @@ ciqual_food_name:fr:Fromage blanc nature, 3% MG environ
 <fr:Fromages blancs
 en:Plain creamy fresh cream cheese around 8% fat
 fr:Fromage blanc nature gourmand à 8% de matières grasses environ
+agribalyse_food_code:en:19649
 ciqual_food_code:en:19649
 ciqual_food_name:en:Fresh cream cheese, plain, creamy, around 8% fat
 ciqual_food_name:fr:Fromage blanc nature, gourmand, 8% MG environ
@@ -29618,6 +30259,7 @@ wikidata:en:Q1411808
 wikipedia:en:https://en.wikipedia.org/wiki/Sheep_milk_cheese
 # ingredient/fr:fromage-de-brebis has 42 products @2018-10-27
 # category/Sheep-Cheeses has 868 products @2019-05-24
+agribalyse_food_code:en:12824
 ciqual_food_code:en:12824
 ciqual_food_name:en:Soft ripened cheese with bloomy rind, from ewe's milk, Camembert-type cheese
 
@@ -29626,30 +30268,35 @@ fr:Fondues, fondue, fondues de fromage, fondue de fromage
 nl:Fondus, Kaasfondus
 wikidata:en:Q190531
 en:Processed cheese in slices
+agribalyse_food_code:en:12300
 ciqual_food_code:en:12300
 ciqual_food_name:en:Processed cheese, in slices
 
 <en:Cheeses
 en:Processed cheese double cream around 31% fat
 fr:Fromage fondu double crème environ 31% MG
+agribalyse_food_code:en:12320
 ciqual_food_code:en:12320
 ciqual_food_name:en:Processed cheese, double cream, around 31% fat
 
 <en:Cheeses
 en:Processed cheese around 20% fat in wedges or cubes
 fr:Fromage fondu en portions ou en cubes environ 20% MG
+agribalyse_food_code:en:12310
 ciqual_food_code:en:12310
 ciqual_food_name:en:Processed cheese, around 20% fat, in wedges or cubes
 
 <en:Cheeses
 en:Uncured soft cheese spreadable around 25% fat in a tub
 fr:Spécialité fromagère non affinée environ 25% MG type fromage en barquette à tartiner ou coque fromagère
+agribalyse_food_code:en:12315
 ciqual_food_code:en:12315
 ciqual_food_name:en:Uncured soft cheese, spreadable, around 25% fat, in a tub
 
 <en:Cheeses
 en:Uncured soft cheese spreadable around 20% fat in a tub
 fr:Spécialité fromagère non affinée environ 20% MG type fromage en barquette à tartiner ou coque fromagère
+agribalyse_food_code:en:12340
 ciqual_food_code:en:12340
 ciqual_food_name:en:Uncured soft cheese, spreadable, around 20% fat, in a tub
 
@@ -29659,6 +30306,7 @@ fr:Fondues savoyardes, fondue savoyarde
 it:Fonduta savoiarda
 nl:Kaasfondue uit de Savoie
 wikidata:en:Q972682
+agribalyse_food_code:en:25509
 ciqual_food_code:en:25509
 ciqual_food_name:en:Savoy-style fondue (cheese wine and bread)
 
@@ -29679,6 +30327,7 @@ it:Formaggio di capra
 nl:Geitenkazen
 ru:Сыр из козьего молока
 wikidata:en:Q198815
+agribalyse_food_code:en:12814
 ciqual_food_code:en:12814
 ciqual_food_name:en:Soft-ripened cheese, from goat's milk, from pasteurised milk
 
@@ -29689,12 +30338,14 @@ ciqual_food_name:en:Soft-ripened cheese, from goat's milk, from pasteurised milk
 <en:Goat cheeses
 en:Cheese semi-dry from goat's milk
 fr:Fromage de chèvre demi-sec
+agribalyse_food_code:en:12810
 ciqual_food_code:en:12810
 ciqual_food_name:en:Cheese, semi-dry, from goat's milk
 
 <en:Goat cheeses
 en:Cheese dry from goat's milk
 fr:Fromage de chèvre sec
+agribalyse_food_code:en:12815
 ciqual_food_code:en:12815
 ciqual_food_name:en:Cheese, dry, from goat's milk
 
@@ -29702,32 +30353,38 @@ ciqual_food_name:en:Cheese, dry, from goat's milk
 es:Rulo de cabra, Rulo de queso de cabra
 fr:Bûche de chèvre
 en:Cheese buche from goat's milk
+agribalyse_food_code:en:12812
 ciqual_food_code:en:12812
 ciqual_food_name:en:Cheese, buche, from goat's milk
+agribalyse_food_code:en:12800
 ciqual_food_code:en:12800
 ciqual_food_name:en:Cheese, from goat's milk, fresh, from pasteurised milk
 
 <en:Goat cheeses
 en:Cheese buche from goat's milk light
 fr:bûche de chèvre allégée en matière grasse
+agribalyse_food_code:en:12813
 ciqual_food_code:en:12813
 ciqual_food_name:en:Cheese, buche, from goat's milk, light
 
 <en:Goat cheeses
 en:Cheese from goat's milk from pasteurised milk
 fr:Fromage de chèvre lactique affiné au lait pasteurisé (type bûchette ou crottin)
+agribalyse_food_code:en:12802
 ciqual_food_code:en:12802
 ciqual_food_name:en:Cheese, from goat's milk, from pasteurised milk
 
 <en:Goat cheeses
 en:Cheese from goat's milk fresh from raw milk
 fr:Fromage de chèvre frais au lait cru (type palet ou crottin frais)
+agribalyse_food_code:en:12804
 ciqual_food_code:en:12804
 ciqual_food_name:en:Cheese, from goat's milk, fresh, from raw milk
 
 <en:Goat cheeses
 en:Cheese from goat's milk fresh
 fr:Fromage de chèvre frais au lait pasteurisé ou cru (type crottin frais ou bûchette fraîche)
+agribalyse_food_code:en:12805
 ciqual_food_code:en:12805
 ciqual_food_name:en:Cheese, from goat's milk, fresh
 
@@ -30086,6 +30743,7 @@ fi:sulatettu juusto
 fr:Fromages fondus, Fromage fondu
 nl:Funduekazen
 wikidata:en:Q190531
+agribalyse_food_code:en:12355
 ciqual_food_code:en:12355
 ciqual_food_name:en:Processed cheese with fresh cream cheese and walnuts
 
@@ -30131,6 +30789,7 @@ fr:Asiago
 protected_name_file_number:en: PDO-IT-0001-AM02
 protected_name_type:en: pdo
 origins:en: en:Italy
+agribalyse_food_code:en:12761
 ciqual_food_code:en:12761
 ciqual_food_name:en:Asiago cheese, from cow's milk
 
@@ -30195,6 +30854,7 @@ country:en:Italy
 #wikidata:en:
 en:Fontina cheese from cow's milk
 fr:Fontina
+agribalyse_food_code:en:12121
 ciqual_food_code:en:12121
 ciqual_food_name:en:Fontina cheese, from cow's milk
 
@@ -30224,6 +30884,7 @@ nl:Grana Padano
 country:en:Italy
 wikidata:en:Q940319
 oqali_family:en: fr:Fromages - Parmesan et assimiles
+agribalyse_food_code:en:12123
 ciqual_food_code:en:12123
 ciqual_food_name:en:Grana Padano cheese, from cow's milk
 
@@ -30249,6 +30910,7 @@ nl:Mozzarella
 sv:Mozzarella
 wikidata:en:Q14088
 oqali_family:en: fr:Fromages - Mozzarella
+agribalyse_food_code:en:19590
 ciqual_food_code:en:19590
 ciqual_food_name:en:Mozzarella cheese, from cow's milk
 
@@ -30304,6 +30966,7 @@ wikidata:en:Q155922
 country:en:Italy
 wikidata:en:Q155922
 oqali_family:en: fr:Fromages - Parmesan et assimiles
+agribalyse_food_code:en:12120
 ciqual_food_code:en:12120
 ciqual_food_name:en:Parmesan cheese, from cow's milk
 
@@ -30468,7 +31131,7 @@ country:en:Italy
 <en:Italian cheeses
 it:Squacquerone di Romagna
 country:en:Italy
-#wikidata:en:
+wikidata:en:Q20009815
 
 <en:Italian cheeses
 it:Stelvio, Stilfser
@@ -30478,7 +31141,7 @@ country:en:Italy
 <en:Italian cheeses
 it:Strachitunt
 country:en:Italy
-#wikidata:en:
+wikidata:en:Q3974593
 
 #DOP italian cheese
 <en:Italian cheeses
@@ -30504,8 +31167,6 @@ protected_name_type:en: pdo
 origins:en: en:Italy
 #wikidata:en:
 
-
-
 <en:Italian cheeses
 it:Valtellina Casera
 country:en:Italy
@@ -30521,6 +31182,7 @@ en:Lithuanian cheeses, cheeses from Lithuania
 de:Litauischer Käse
 fr:Fromages lithuaniens, Fromages de Lithuanie
 nl:Litouwse kazen
+origins:en: en:Lithuania
 
 <en:Lithuanian cheeses
 lt:Lietuviškas varškės sūris
@@ -30535,6 +31197,7 @@ en:Polish cheeses, cheeses from Poland
 de:Polnischer Käse
 fr:Fromages polonais, Fromages de Pologne
 nl:Poolse kazen
+origins:en: en:Poland
 
 <en:Polish cheeses
 pl:Bryndza Podhalańska
@@ -30571,6 +31234,7 @@ en:Portuguese cheeses, cheeses from Portugual
 de:Portugisischer Käse
 fr:Fromages portugais, Fromages du Portugal
 nl:Portugese kazen
+origins:en: en:Portugal
 
 <en:Portuguese cheeses
 pt:Queijo de Azeitão
@@ -30667,6 +31331,7 @@ en:Slovakian cheeses, cheeses from Slovakia
 de:Slovakischer Käse
 fr:Fromages de Slovaquie, Fromages slovaques
 nl:Slowaakse kazen
+origins:en: en:Slovakia
 
 <en:Slovakian cheeses
 sk:Klenovecký syrec
@@ -30733,6 +31398,7 @@ en:Slovenian cheeses, cheeses from Slovenia
 de:Slovenischer Käse
 fr:Fromages slovènes, Fromages de Slovénie
 nl:Sloveense kazen
+origins:en: en:Slovenia
 
 <en:Slovenian cheeses
 si:Bovški sir
@@ -30753,6 +31419,7 @@ country:en:Slovenia
 <en:sheep's-milk cheeses
 en:Pyrénées cheeses, Pyrénées cheeses from ewe's milk
 fr:Fromage de brebis des Pyrénées
+agribalyse_food_code:en:12747
 ciqual_food_code:en:12747
 ciqual_food_name:en:Pyrénées cheese, from ewe's milk
 ciqual_food_name:fr:Fromage de brebis des Pyrénées
@@ -30760,6 +31427,7 @@ ciqual_food_name:fr:Fromage de brebis des Pyrénées
 <en:sheep's-milk cheeses
 en:Semi-hard cheeses, Semi-hard cheeses from ewe's milk
 fr:Fromage de brebis à pâte pressée
+agribalyse_food_code:en:12827
 ciqual_food_code:en:12827
 ciqual_food_name:en:Semi-hard cheese, from ewe's milk
 ciqual_food_name:fr:Fromage de brebis à pâte pressée
@@ -30846,6 +31514,7 @@ country:en:Spain
 en:Swedish cheeses, cheeses from Sweden
 de:Schwedischer Käse
 fr:Fromages suédois, Fromages de Suède
+origins:en: en:Sweden
 
 <en:Swedish cheeses
 sv:Vrigstad Hemost
@@ -30959,18 +31628,21 @@ fr:Maroilles, Marolles
 en:Maroilles
 country:en:France
 wikidata:en:Q734978
+agribalyse_food_code:en:12036
 ciqual_food_code:en:12036
 ciqual_food_name:en:Maroilles cheese, from cow's milk
 
 <en:French cheeses
 en:Maroilles laitier cheese
 fr:Maroilles laitier
+agribalyse_food_code:en:12029
 ciqual_food_code:en:12029
 ciqual_food_name:en:Maroilles laitier cheese
 
 <en:French cheeses
 en:Maroilles fermier cheese
 fr:Maroilles fermier
+agribalyse_food_code:en:12030
 ciqual_food_code:en:12030
 ciqual_food_name:en:Maroilles fermier cheese
 
@@ -30980,6 +31652,7 @@ en:Raclette cheese from cow's milk
 de:Raclettekäse, Raclette-Käse
 wikidata:en:Q20748
 oqali_family:en: fr:Fromages - Fromage a raclette
+agribalyse_food_code:en:12749
 ciqual_food_code:en:12749
 ciqual_food_name:en:Raclette cheese, from cow's milk
 
@@ -30993,6 +31666,7 @@ wikidata:en:Q585246
 <en:Petits suisses
 en:2-3% fat Petit-Suisse with fruits, 2-3% fat fresh cream cheese with fruits
 fr:Petit suisse aux fruits à 2-3% de matières grasses, Fromage frais aux fruits à 2-3% de matières grasses
+agribalyse_food_code:en:19661
 ciqual_food_code:en:19661
 ciqual_food_name:en:Petit-Suisse, fresh cream cheese type, with fruits, 2-3% fat
 ciqual_food_name:fr:Fromage frais type petit suisse, aux fruits, 2-3% MG
@@ -31000,6 +31674,7 @@ ciqual_food_name:fr:Fromage frais type petit suisse, aux fruits, 2-3% MG
 <en:Petits suisses
 en:2-3% fat Petit-Suisse with fruits fortified with calcium and vitamin D, 2-3% fat fresh cream cheese with fruits fortified with calcium and vitamin D
 fr:Fromage frais aux fruits à 2-3% de matières grasses enrichi en calcium et vitamine D, Petit suisse aux fruits à 2-3% de matières grasses enrichi en calcium et vitamine D
+agribalyse_food_code:en:19662
 ciqual_food_code:en:19662
 ciqual_food_name:en:Petit-Suisse, fresh cream cheese type, with fruits, 2-3% fat, fortified with calcium and vitamin D
 ciqual_food_name:fr:Fromage frais type petit suisse, aux fruits, 2-3% MG, enrichi en calcium et vitamine D
@@ -31007,6 +31682,7 @@ ciqual_food_name:fr:Fromage frais type petit suisse, aux fruits, 2-3% MG, enrich
 <en:Petits suisses
 en:2-3% fat Petit-Suisse fruits flavoured fortified with calcium and vitamin D, 2-3% fat fresh cream cheese fruits flavoured fortified with calcium and vitamin D
 fr:Fromage frais aromatisé aux fruits à 2-3% de matières grasses enrichi en calcium et vitamine D, Petit suisse aromatisé aux fruits à 2-3% de matières grasses enrichi en calcium et vitamine D
+agribalyse_food_code:en:19667
 ciqual_food_code:en:19667
 ciqual_food_name:en:Petit-Suisse, fresh cream cheese type, fruits flavoured, 2-3% fat, fortified with calcium and vitamin D
 ciqual_food_name:fr:Fromage frais type petit suisse, aromatisé aux fruits, 2-3% MG, enrichi en calcium et vitamine D
@@ -31014,6 +31690,7 @@ ciqual_food_name:fr:Fromage frais type petit suisse, aromatisé aux fruits, 2-3%
 <en:Petits suisses
 en:Fat free plain Petit-Suisse
 fr:Petit suisse nature à 0% de matières grasses
+agribalyse_food_code:en:19663
 ciqual_food_code:en:19663
 ciqual_food_name:en:Petit-Suisse, fresh cream cheese type, plain, fat free
 ciqual_food_name:fr:Fromage frais type petit suisse, nature, 0% MG
@@ -31021,6 +31698,7 @@ ciqual_food_name:fr:Fromage frais type petit suisse, nature, 0% MG
 <en:Petits suisses
 en:Plain Petit-Suisse around 4% fat, Plain fresh cream cheese around 4% fat
 fr:Fromage frais nature à 4% de matières grasses environ, Petit suisse nature à 4% de matières grasses environ
+agribalyse_food_code:en:19664
 ciqual_food_code:en:19664
 ciqual_food_name:en:Petit-Suisse, fresh cream cheese type, plain, around 4% fat
 ciqual_food_name:fr:Fromage frais type petit suisse, nature, 4% MG environ
@@ -31028,6 +31706,7 @@ ciqual_food_name:fr:Fromage frais type petit suisse, nature, 4% MG environ
 <en:Petits suisses
 en:Plain Petit-Suisse around 9% fat, Plain fresh cream cheese around 9% fat
 fr:Fromage frais nature à 10% de matières grasses environ, Petit suisse nature à 10% de matières grasses environ
+agribalyse_food_code:en:19666
 ciqual_food_code:en:19666
 ciqual_food_name:en:Petit-Suisse like fresh cream cheese, plain, around 9% fat
 ciqual_food_name:fr:Fromage frais type petit suisse, nature, 10% MG environ
@@ -31086,6 +31765,7 @@ nl:UHT room, UHT romen
 <fr:Crèmes sous pression
 en:Whipped cream under pressure UHT, Chantilly cream under pressure UHT
 fr:Crèmes sous pression UHT
+agribalyse_food_code:en:19420
 ciqual_food_code:en:19420
 ciqual_food_name:en:Whipped cream or Chantilly cream, under pressure, UHT
 ciqual_food_name:fr:Crème chantilly, sous pression, UHT
@@ -31139,6 +31819,7 @@ hu:Erjesztett krémek
 <en:Creams
 en:Refrigerated 30% fat thick cream
 fr:Crème de lait épaisse à 30% de matières grasses rayon frais
+agribalyse_food_code:en:19410
 ciqual_food_code:en:19410
 ciqual_food_name:en:Thick cream 30% fat, refrigerated
 ciqual_food_name:fr:Crème de lait, 30% MG, épaisse, rayon frais
@@ -31146,6 +31827,7 @@ ciqual_food_name:fr:Crème de lait, 30% MG, épaisse, rayon frais
 <en:UHT Creams
 en:Liquid 30% fat UHT cream
 fr:Crème de lait semi-épaisse à 30% de matières grasses UHT
+agribalyse_food_code:en:19415
 ciqual_food_code:en:19415
 ciqual_food_name:en:Liquid cream 30% fat, UHT
 ciqual_food_name:fr:Crème de lait, 30% MG, semi-épaisse, UHT
@@ -31153,6 +31835,7 @@ ciqual_food_name:fr:Crème de lait, 30% MG, semi-épaisse, UHT
 <en:UHT Creams
 en:Liquid 15-20% fat light cream UHT
 fr:Crème de lait légère semi-épaisse avec 15 à 20% de matières grasses UHT
+agribalyse_food_code:en:19430
 ciqual_food_code:en:19430
 ciqual_food_name:en:Liquid cream, light, 15-20% fat, UHT
 ciqual_food_name:fr:Crème de lait, 15 à 20% MG, légère, semi-épaisse, UHT
@@ -31160,6 +31843,7 @@ ciqual_food_name:fr:Crème de lait, 15 à 20% MG, légère, semi-épaisse, UHT
 <en:Creams
 en:Refrigerated 15-20% fat light thick cream
 fr:Crème de lait légère épaisse avec 15 à 20% de matières grasses rayon frais
+agribalyse_food_code:en:19431
 ciqual_food_code:en:19431
 ciqual_food_name:en:Thick cream, light, 15-20% fat, refrigerated
 ciqual_food_name:fr:Crème de lait, 15 à 20% MG, légère, épaisse, rayon frais
@@ -31167,6 +31851,7 @@ ciqual_food_name:fr:Crème de lait, 15 à 20% MG, légère, épaisse, rayon frai
 <en:Creams
 en:Liquid light cream with 4 to 8% fat, Thick light cream with 4 to 8% fat
 fr:Spécialité à base de crème légère fluide à 8% de matières grasses, Spécialité à base de crème légère épaisse à 8% de matières grasses
+agribalyse_food_code:en:19433
 ciqual_food_code:en:19433
 ciqual_food_name:en:cream, light, 4 to 8% fat, liquid or thick
 ciqual_food_name:fr:Spécialité à base de crème légère 8% MG, fluide ou épaisse
@@ -31267,6 +31952,7 @@ en:Soy-based creams for cooking, Soy cream preparations
 es:Natas vegetales a base de soja para cocinar
 fr:Crèmes végétales à base de soja pour cuisiner, Préparations culinaires à base de soja, Crèmes de soja
 nl:Plantaardige sojaromen
+agribalyse_food_code:en:11214
 ciqual_food_code:en:11214
 ciqual_food_name:en:Soy cream preparation
 ciqual_food_name:fr:Préparation culinaire à base de soja, type "crème de soja"
@@ -31302,6 +31988,8 @@ ro:Unt
 ru:масло сливочное, сливочное масло
 sv:Smör
 wikidata:en:Q34172
+agribalyse_proxy_food_code:en:16400
+agribalyse_proxy_food_name:en:Butter, 82% fat, unsalted
 
 <en:Butters
 fr:Beurres de baratte
@@ -31330,12 +32018,14 @@ ciqual_food_name:fr:Beurre à teneur en matière grasse inconnue (allégé ou no
 <en:Half-salted butter
 en:Butter 80% fat lightly salted
 fr:Beurre à 80% MG demi-sel
+agribalyse_food_code:en:16402
 ciqual_food_code:en:16402
 ciqual_food_name:en:Butter, 80% fat, lightly salted
 
 <en:Butters
 en:Butter 60-62% fat light lightly salted
 fr:Beurre à 60-62% MG à teneur réduite en matière grasse demi-sel
+agribalyse_food_code:en:16411
 ciqual_food_code:en:16411
 ciqual_food_name:en:Butter, 60-62% fat, light, lightly salted
 
@@ -31372,18 +32062,21 @@ ciqual_food_name:fr:Beurre ou assimilé à teneur en matière grasse inconnue, d
 <en:Unsalted butters
 en:Butter 82% fat unsalted
 fr:Beurre à 82% MG doux
+agribalyse_food_code:en:16400
 ciqual_food_code:en:16400
 ciqual_food_name:en:Butter, 82% fat, unsalted
 
 <en:Unsalted butters
 en:Butter 82% fat unsalted easy-to-spread
 fr:Beurre à 82% MG doux tendre
+agribalyse_food_code:en:16404
 ciqual_food_code:en:16404
 ciqual_food_name:en:Butter, 82% fat, unsalted, easy-to-spread
 
 <en:Unsalted butters
 en:Butter light 39-41% fat unsalted
 fr:Beurre à 39-41% MG léger doux
+agribalyse_food_code:en:16415
 ciqual_food_code:en:16415
 ciqual_food_name:en:Butter, light, 39-41% fat, unsalted
 
@@ -31405,12 +32098,14 @@ de:Salzbutter, gesalzene Butter
 fi:suolatut voit
 fr:Beurres salés, beurre salé
 nl:Gezouten roomboters
+agribalyse_food_code:en:16403
 ciqual_food_code:en:16403
 ciqual_food_name:en:Butter, 80% fat, salted
 
 <en:Butters
 en:Butter 60-62% fat light unsalted
 fr:Beurre à 60-62% MG à teneur réduite en matière grasse doux
+agribalyse_food_code:en:16410
 ciqual_food_code:en:16410
 ciqual_food_name:en:Butter, 60-62% fat, light, unsalted
 
@@ -31420,6 +32115,7 @@ de:Dreiviertelfettbutter
 
 <en:Butters
 en:Belgian butters
+origins:en: en:Belgium
 
 <en:Belgian butters
 fr:Beurre d'Ardenne
@@ -31429,6 +32125,7 @@ origins:en: en:Belgium
 
 <en:Butters
 en:French butters
+origins:en: en:France
 
 <en:French butters
 fr:Beurre de Bresse
@@ -31452,9 +32149,12 @@ origins:en: en:France
 <en:Cooked pressed cheeses
 fr:Comté
 en:Comté cheese from cow's milk
+protected_name_type:en: aoc
 country:en:France
+origins:en: en:France
 wikidata:en:Q249310
 oqali_family:en: fr:Fromages - Comte
+agribalyse_food_code:en:12110
 ciqual_food_code:en:12110
 ciqual_food_name:en:Comté cheese, from cow's milk
 
@@ -31607,7 +32307,7 @@ fr:Babeurres, Laits battus, Laits de beurre, Laits ribots
 it:Latticelli, Laticello
 nl:Karnemelken, Botermelken
 wikidata:en:Q106612
-who_id:7
+who_id:en:7
 
 <en:Dairies
 en:Eggnog without alcohol
@@ -31729,6 +32429,7 @@ ciqual_food_name:fr:Boisson lactée aromatisée (arôme inconnu), sucrée, au la
 <en:Flavoured milks
 en:Refrigerated flavoured renneted milks
 fr:Laits emprésurés aromatisés rayon frais
+agribalyse_food_code:en:19678
 ciqual_food_code:en:19678
 ciqual_food_name:en:Renneted milk, flavoured, refrigerated
 ciqual_food_name:fr:Lait emprésuré aromatisé, rayon frais
@@ -31750,6 +32451,7 @@ en:Partially skimmed chocolate milks
 <en:Partially skimmed chocolate milks
 en:Partially skimmed chocolate flavoured milk with sugar fortified with vitamins and chemicals elements
 fr:Boisson lactée aromatisée au chocolat sucrée au lait partiellement écrémé enrichie en vitamines et minéraux
+agribalyse_food_code:en:19122
 ciqual_food_code:en:19122
 ciqual_food_name:en:Chocolate flavoured milk, with sugar, partially skimmed, fortified with vitamins and chemicals elements
 ciqual_food_name:fr:Boisson lactée aromatisée au chocolat, sucrée, au lait partiellement écrémé, enrichie et/ou restaurée en vitamines et/ou minéraux
@@ -31768,6 +32470,7 @@ nl:Aardbeienmelk
 <en:Strawberry milks
 en:Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D
 fr:Boisson lactée aromatisée à la fraise sucrée au lait partiellement écrémé enrichie à la vitamine D
+agribalyse_food_code:en:19127
 ciqual_food_code:en:19127
 ciqual_food_name:en:Strawberry flavoured milk, with sugar, partially skimmed, fortified with vitamins D
 ciqual_food_name:fr:Boisson lactée aromatisée à la fraise, sucrée, au lait partiellement écrémé, enrichie à la vitamine D
@@ -31775,6 +32478,7 @@ ciqual_food_name:fr:Boisson lactée aromatisée à la fraise, sucrée, au lait p
 <en:Flavoured milks
 en:Milkshakes from fast foods restaurant, Milk-shakes from fast foods restaurant
 fr:Milkshakes de fast food, Milk-shakes de fast food
+agribalyse_food_code:en:39001
 ciqual_food_code:en:39001
 ciqual_food_name:en:Milkshake, from fast foods restaurant
 ciqual_food_name:fr:Milk-shake, provenant de fast food
@@ -31813,6 +32517,7 @@ nl:Biologische halfvolle melken
 <en:Semi-skimmed milks
 en:Semi-skimmed milk with reduced lactose
 fr:Laits demi-écrémés à teneur réduite en lactose
+agribalyse_food_code:en:19060
 ciqual_food_code:en:19060
 ciqual_food_name:en:Milk, semi-skimmed, reduced lactose
 ciqual_food_name:fr:Lait demi-écrémé, à teneur réduite en lactose
@@ -31821,6 +32526,7 @@ ciqual_food_name:fr:Lait demi-écrémé, à teneur réduite en lactose
 <en:UHT Milks
 en:Semi-skimmed milk UHT
 fr:Laits demi-écrémés UHT
+agribalyse_food_code:en:19041
 ciqual_food_code:en:19041
 ciqual_food_name:en:Milk, semi-skimmed, UHT
 ciqual_food_name:fr:Lait demi-écrémé, UHT
@@ -31829,6 +32535,7 @@ ciqual_food_name:fr:Lait demi-écrémé, UHT
 <en:UHT Milks
 en:Semi-skimmed UHT milk fortified with vitamins
 fr:Laits demi-écrémés UHT enrichis en vitamines
+agribalyse_food_code:en:19049
 ciqual_food_code:en:19049
 ciqual_food_name:en:Milk, semi-skimmed, vitamin fortified, UHT
 ciqual_food_name:fr:Lait demi-écrémé, UHT, enrichi en vitamines
@@ -31837,6 +32544,7 @@ ciqual_food_name:fr:Lait demi-écrémé, UHT, enrichi en vitamines
 <en:Pasteurised milks
 en:Semi-skimmed pasteurised milk
 fr:Laits demi-écrémés pasteurisés
+agribalyse_food_code:en:19042
 ciqual_food_code:en:19042
 ciqual_food_name:en:Milk, semi-skimmed, pasteurised
 ciqual_food_name:fr:Lait demi-écrémé, pasteurisé
@@ -31874,6 +32582,7 @@ agribalyse_proxy_food_name:fr:Lait de chèvre, entier, UHT
 <en:UHT Milks
 en:Whole goat milk UHT
 fr:Lait de chèvre entier UHT
+agribalyse_food_code:en:19200
 ciqual_food_code:en:19200
 ciqual_food_name:en:Goat milk, whole, UHT
 ciqual_food_name:fr:Lait de chèvre, entier, UHT
@@ -31883,6 +32592,7 @@ ciqual_food_name:fr:Lait de chèvre, entier, UHT
 <en:Semi-skimmed milks
 en:Half skimmed pasteurized goat milk UHT
 fr:Lait de chèvre demi-écrémé UHT
+agribalyse_food_code:en:19201
 ciqual_food_code:en:19201
 ciqual_food_name:en:Goat milk, half skimmed, UHT pasteurized
 ciqual_food_name:fr:Lait de chèvre, demi-écrémé, UHT
@@ -31890,6 +32600,7 @@ ciqual_food_name:fr:Lait de chèvre, demi-écrémé, UHT
 <en:Goat milks
 en:Raw whole goat milk
 fr:Lait de chèvre entier cru
+agribalyse_food_code:en:19202
 ciqual_food_code:en:19202
 ciqual_food_name:en:Goat milk, whole, raw
 ciqual_food_name:fr:Lait de chèvre, entier, cru
@@ -31902,6 +32613,7 @@ fr:Laits de brebis, Lait de brebis, Lait de brebis entier
 nl:Schapenmelk
 pt:Leites de ovelha
 sv:Fårmjölk
+agribalyse_food_code:en:19250
 ciqual_food_code:en:19250
 ciqual_food_name:en:Sheep milk, whole
 ciqual_food_name:fr:Lait de brebis, entier
@@ -31929,6 +32641,7 @@ wikidata:en:Q2352187
 <en:Skimmed milks
 en:Skimmed milks UHT
 fr:Laits écrémés UHT
+agribalyse_food_code:en:19050
 ciqual_food_code:en:19050
 ciqual_food_name:en:Milk, skimmed, UHT
 ciqual_food_name:fr:Lait écrémé, UHT
@@ -31937,6 +32650,7 @@ ciqual_food_name:fr:Lait écrémé, UHT
 <en:Skimmed milks
 en:Pasteurised skimmed milk
 fr:Lait écrémé pasteurisé
+agribalyse_food_code:en:19051
 ciqual_food_code:en:19051
 ciqual_food_name:en:Milk, skimmed, pasteurised
 ciqual_food_name:fr:Lait écrémé, pasteurisé
@@ -31962,6 +32676,7 @@ agribalyse_proxy_food_name:fr:Lait en poudre, écrémé
 <en:Whole milks
 en:Whole milk powder
 fr:Lait entier en poudre
+agribalyse_food_code:en:19021
 ciqual_food_code:en:19021
 ciqual_food_name:en:Milk, powder, whole
 ciqual_food_name:fr:Lait en poudre, entier
@@ -31970,6 +32685,7 @@ ciqual_food_name:fr:Lait en poudre, entier
 <en:Semi-skimmed milks
 en:Semi-skimmed milk powder
 fr:Lait en poudre demi-écrémé
+agribalyse_food_code:en:19044
 ciqual_food_code:en:19044
 ciqual_food_name:en:Milk, powder, semi-skimmed
 ciqual_food_name:fr:Lait en poudre, demi-écrémé
@@ -31978,6 +32694,7 @@ ciqual_food_name:fr:Lait en poudre, demi-écrémé
 <en:Skimmed milks
 en:Skimmed milk powder
 fr:Lait en poudre écrémé
+agribalyse_food_code:en:19054
 ciqual_food_code:en:19054
 ciqual_food_name:en:Milk, powder, skimmed
 ciqual_food_name:fr:Lait en poudre, écrémé
@@ -32003,6 +32720,7 @@ fr:Laits entiers stérilisés
 <en:Pasteurised milks
 en:Whole pasteurised milks
 fr:Laits entiers pasteurisés
+agribalyse_food_code:en:19024
 ciqual_food_code:en:19024
 ciqual_food_name:en:Milk, whole, pasteurised
 ciqual_food_name:fr:Lait entier, pasteurisé
@@ -32011,6 +32729,7 @@ ciqual_food_name:fr:Lait entier, pasteurisé
 <en:UHT Milks
 en:Whole milk UHT
 fr:Lait entier UHT
+agribalyse_food_code:en:19023
 ciqual_food_code:en:19023
 ciqual_food_name:en:Milk, whole, UHT
 ciqual_food_name:fr:Lait entier, UHT
@@ -32104,6 +32823,7 @@ nl:Gecondenseerde melken
 <en:Condensed milks
 en:Whole condensed milk without sugar
 fr:Lait concentré entier non sucré
+agribalyse_food_code:en:19026
 ciqual_food_code:en:19026
 ciqual_food_name:en:Condensed milk, without sugar, whole
 ciqual_food_name:fr:Lait concentré non sucré, entier
@@ -32111,6 +32831,7 @@ ciqual_food_name:fr:Lait concentré non sucré, entier
 <en:Condensed milks
 en:Whole condensed milk with sugar
 fr:Lait concentré entier sucré
+agribalyse_food_code:en:19027
 ciqual_food_code:en:19027
 ciqual_food_name:en:Condensed milk, with sugar, whole
 ciqual_food_name:fr:Lait concentré sucré, entier
@@ -32297,6 +33018,7 @@ it:Bevanda di avena
 nl:Havermoutmelken
 sv:Havredrycker, havredryck
 zh:燕麦奶
+agribalyse_food_code:en:18905
 ciqual_food_code:en:18905
 ciqual_food_name:en:Oat-based drink, plain
 ciqual_food_name:fr:Boisson à base d'avoine, nature
@@ -32327,6 +33049,7 @@ es:Bebidas de arroz naturales, Leches de arroz naturales
 fi:riisijuomat
 fr:Boissons végétales de riz nature, Laits de riz nature, Boissons à base de riz nature
 nl:Natuurlijke rijstdranken
+agribalyse_food_code:en:18904
 ciqual_food_code:en:18904
 ciqual_food_name:en:Rice-based drink, plain
 ciqual_food_name:fr:Boisson à base de riz, nature
@@ -32388,6 +33111,7 @@ fi:kookosjuomat
 fr:Laits de coco, lait de coco, Crèmes de coco, Crème de coco
 nl:Kokosnootdranken
 wikidata:en:Q841779
+agribalyse_food_code:en:18041
 ciqual_food_code:en:18041
 ciqual_food_name:en:Coconut milk or coconut cream
 ciqual_food_name:fr:Lait de coco ou Crème de coco
@@ -32422,6 +33146,7 @@ nl:Sojadranken
 pl:Napoje sojowe, napój sojowy
 sv:Sojadrycker, sojadryck
 wikidata:en:Q192199
+agribalyse_food_code:en:18900
 ciqual_food_code:en:18900
 ciqual_food_name:en:Soy drink, plain
 ciqual_food_name:fr:Boisson au soja, nature
@@ -32467,6 +33192,7 @@ nl:Koffiesojadranken
 <en:Soy milks
 en:Soy drinks flavoured with sugar
 fr:Boissons au soja aromatisées sucrées
+agribalyse_food_code:en:18902
 ciqual_food_code:en:18902
 ciqual_food_name:en:Soy drink, flavoured, with sugar
 ciqual_food_name:fr:Boisson au soja, aromatisée, sucrée
@@ -32474,6 +33200,7 @@ ciqual_food_name:fr:Boisson au soja, aromatisée, sucrée
 <en:Soy milks
 en:Plain soy drink fortified with calcium
 fr:Boisson au soja nature enrichie en calcium
+agribalyse_food_code:en:18901
 ciqual_food_code:en:18901
 ciqual_food_name:en:Soy drink, plain, fortified with calcium
 ciqual_food_name:fr:Boisson au soja, nature, enrichie en calcium
@@ -32481,6 +33208,7 @@ ciqual_food_name:fr:Boisson au soja, nature, enrichie en calcium
 <en:Soy milks
 en:Flavoured soy drinks enriched in calcium with sugar, Flavoured soy drinks enriched in calcium with fruit concentrate
 fr:Boissons au soja aromatisées sucrées enrichies en calcium
+agribalyse_food_code:en:18903
 ciqual_food_code:en:18903
 ciqual_food_name:en:Soy drink, flavoured, enriched in calcium, w sugar or fruit concentrate
 ciqual_food_name:fr:Boisson au soja, aromatisée, sucrée, enrichie en calcium
@@ -32520,6 +33248,7 @@ nl:Amandeldranken
 pl:Napoje migdałowe, napój migdałowy
 sv:Mandeldrycker, mandeldryck
 wikidata:en:Q975953
+agribalyse_food_code:en:18107
 ciqual_food_code:en:18107
 ciqual_food_name:en:Almond drink
 ciqual_food_name:fr:Boisson à l'amande
@@ -32596,11 +33325,12 @@ fr:Horchatas de chufa surgelés
 <en:Frozen vegetables
 en:Frozen peas and carrots
 fr:Petits pois et carottes surgelés
-nl:Diepvries doperwten en worteltjes
+nl:Diepries doperwten en worteltjes
 
 <en:Frozen vegetables
 en:Frozen cooked garden peas and carrots
 fr:Petits pois et carottes surgelés cuits
+agribalyse_food_code:en:20215
 ciqual_food_code:en:20215
 ciqual_food_name:en:Garden peas and carrots, frozen, cooked
 ciqual_food_name:fr:Petits pois et carottes, surgelés, cuits
@@ -32608,6 +33338,7 @@ ciqual_food_name:fr:Petits pois et carottes, surgelés, cuits
 <en:Frozen vegetables
 en:Frozen raw garden peas and carrots
 fr:Petits pois et carottes surgelés crus
+agribalyse_food_code:en:20214
 ciqual_food_code:en:20214
 ciqual_food_name:en:Garden peas and carrots, frozen, raw
 ciqual_food_name:fr:Petits pois et carottes, surgelés, crus
@@ -32615,6 +33346,7 @@ ciqual_food_name:fr:Petits pois et carottes, surgelés, crus
 <en:Frozen vegetables
 en:Frozen mixed vegetables for ratatouille
 fr:Légumes pour ratatouille surgelés
+agribalyse_food_code:en:20266
 ciqual_food_code:en:20266
 ciqual_food_name:en:Mixed vegetables for ratatouille, frozen
 ciqual_food_name:fr:Légumes pour ratatouille, surgelés
@@ -32622,6 +33354,7 @@ ciqual_food_name:fr:Légumes pour ratatouille, surgelés
 <en:Frozen vegetables
 en:Frozen raw mixed vegetables for couscous
 fr:Légumes pour couscous surgelés crus
+agribalyse_food_code:en:20496
 ciqual_food_code:en:20496
 ciqual_food_name:en:Mixed vegetables for couscous, frozen, raw
 ciqual_food_name:fr:Légumes pour couscous, surgelés, crus
@@ -32768,6 +33501,7 @@ nl:Smeerkazen
 <en:Cheeses
 fr:Fromages Ail et fines herbes, fromage ail et fines herbes type Boursin, Tartare
 en:Uncured soft cheese spreadable around 30-40% fat flavoured (ex : garlic and herbs)
+agribalyse_food_code:en:19530
 ciqual_food_code:en:19530
 ciqual_food_name:en:Uncured soft cheese, spreadable, around 30-40% fat, flavoured (ex : garlic and herbs)
 
@@ -32841,7 +33575,7 @@ wikidata:en:Q13317
 ciqual_food_code:en:19624
 ciqual_food_name:en:Yoghurt, plain or fruit (average)
 ciqual_food_name:fr:Yaourt ou spécialité laitière nature ou aux fruits (aliment moyen)
-who_id:7
+who_id:en:7
 
 <en:Yogurts
 en:Lactose-free yogurts
@@ -32860,6 +33594,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aromatisé
 <en:Fruit yogurts
 en:Fat free fermented milk yogurt with fruits and sweetener, Fat free dairy specialty with fruits and sweetener
 fr:Yaourt au lait fermenté aux fruits avec édulcorants à 0% de matières grasses, Spécialité laitière aux fruits avec édulcorants à 0% de matières grasses
+agribalyse_food_code:en:19581
 ciqual_food_code:en:19581
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, with fruits, with sweetener, fat free
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits, avec édulcorants, 0% MG
@@ -32867,6 +33602,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits
 <en:Fruit yogurts
 en:Fat free fermented milk yogurt with fruits and sweetener fortified with vitamin D, Fat free dairy specialty with fruits and sweetener fortified with vitamin D
 fr:Yaourt au lait fermenté aux fruits avec édulcorants à 0% de matières grasses enrichi en vitamine D, Spécialité laitière aux fruits avec édulcorants à 0% de matières grasses enrichie en vitamine D
+agribalyse_food_code:en:19582
 ciqual_food_code:en:19582
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, with fruits, with sweetener, fat free, fortified with vitamin D
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits, avec édulcorants, 0% MG, enrichi en vitamine D
@@ -32874,6 +33610,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits
 <en:Fruit yogurts
 en:Fermented milk yogurt with fruits and sugar and cream, Dairy specialty with fruits and sugar and cream
 fr:Yaourt sucré au lait fermenté aux fruits et à la crème, Spécialité laitière sucrée aux fruits et à la crème
+agribalyse_food_code:en:19589
 ciqual_food_code:en:19589
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, w fruits, with sugar, with cream
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits, sucré, à la crème
@@ -32881,6 +33618,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits
 <en:Fruit yogurts
 en:Fermented milk yogurt fortified with vitamin D with fruits and sugar, Dairy specialty fortified with vitamin D with fruits and sugar
 fr:Yaourt sucré au lait fermenté aux fruits enrichi en vitamine D, Spécialité laitière sucrée aux fruits enrichie en vitamine D
+agribalyse_food_code:en:19592
 ciqual_food_code:en:19592
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, with fruits, with sugar, fortified with vitamin D
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits, sucré, enrichi en vitamine D
@@ -32888,6 +33626,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits
 <en:Yogurts
 en:Plain fermented milk yogurt with sugar, Plain dairy specialty with sugar
 fr:Yaourt sucré au lait fermenté, Spécialité laitière nature sucrée
+agribalyse_food_code:en:19599
 ciqual_food_code:en:19599
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, plain, w sugar
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature, sucré
@@ -32895,6 +33634,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature, su
 <en:Yogurts
 en:Fat free plain fermented milk yogurt, Fat free plain dairy specialty
 fr:Yaourt nature au lait fermenté à 0% de matières grasses, Spécialité laitière à 0% de matières grasses
+agribalyse_food_code:en:19594
 ciqual_food_code:en:19594
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, plain, fat free
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature, 0% MG
@@ -32902,6 +33642,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature, 0%
 <en:Flavoured yogurts
 en:Fat free flavoured fermented milk yogurt with sweetener, Fat free flavoured dairy specialty with sweetener
 fr:Yaourt au lait fermenté avec édulcorants à 0% de matières grasses, Spécialité laitière aromatisée avec édulcorants à 0% de matières grasses
+agribalyse_food_code:en:19559
 ciqual_food_code:en:19559
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, flavoured, with sweetener, fat free
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aromatisé, avec édulcorants, 0% MG
@@ -32909,6 +33650,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aromatisé
 <en:Flavoured yogurts
 en:Fermented milk flavoured yogurt with sugar and cream, Flavoured dairy specialty with sugar and cream
 fr:Yaourt sucré aromatisé au lait fermenté et à la crème, Spécialité laitière aromatisée sucrée à la crème
+agribalyse_food_code:en:19577
 ciqual_food_code:en:19577
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, flavoured, w sugar, with cream
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aromatisé, sucré, à la crème
@@ -32923,6 +33665,9 @@ fi:Juotavat jogurtit
 fr:Yaourts à boire, Yaourts à boire aromatisés, Yaourts à boire sucrés
 hu:Ivójoghurtok, Iható joghurtok
 nl:Drinkyoghurts
+agribalyse_proxy_food_code:en:19508
+agribalyse_proxy_food_name:en:Dairy drink or fermented milk or yogurt, flavoured, with sugar
+agribalyse_proxy_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, aromatisé, sucré
 
 <en:Drinkable yogurts
 fr:Yaourts à boire goût fraise, Yaourts à boire fraise, Yaourts à boire saveur fraise
@@ -32937,6 +33682,7 @@ fr:Yaourts à boire sans sucres
 <en:Drinkable yogurts
 en:Flavoured dairy drinks with sugar, Flavoured fermented milks with sugar, Flavoured yogurts with sugar
 fr:Boissons lactées aromatisées sucrées au lait fermenté, Yaourts à boire aromatisés sucrés, Laits fermentés aromatisés sucrés
+agribalyse_food_code:en:19508
 ciqual_food_code:en:19508
 ciqual_food_name:en:Dairy drink or fermented milk or yogurt, flavoured, with sugar
 ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, aromatisé, sucré
@@ -32944,6 +33690,7 @@ ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, aromatis
 <en:Drinkable yogurts
 en:Dairy drinks with sugar and fruits, Fermented milks with sugar and fruits, Yogurts with sugar and fruits
 fr:Boisson lactée sucrée au lait fermenté et aux fruits, Yaourt à boire sucré aux fruits, Lait fermenté sucré aux fruits
+agribalyse_food_code:en:19535
 ciqual_food_code:en:19535
 ciqual_food_name:en:Dairy drink or fermented milk or yogurt, with fruits, with sugar
 ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, aux fruits, sucré
@@ -32951,6 +33698,7 @@ ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, aux frui
 <en:Drinkable yogurts
 en:Plain dairy drinks with sugar, Plain fermented milks with sugar, Plain yogurts with sugar
 fr:Boissons lactées nature sucrées au lait fermenté, Yaourts à boire nature sucrés, Laits fermentés nature sucrés
+agribalyse_food_code:en:19537
 ciqual_food_code:en:19537
 ciqual_food_name:en:Dairy drink or fermented milk or yogurt, plain, with sugar
 ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, nature, sucré
@@ -32958,6 +33706,7 @@ ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, nature, 
 <en:Drinkable yogurts
 en:Plain dairy drinks with sugar and L Casei, Plain fermented milks with sugar and L Casei, Plain yogurts with sugar and L Casei
 fr:Boissons lactées nature sucrées au lait fermenté et L Casei, Yaourts à boire nature sucrés au L Casei, Laits fermentés nature sucrés au L Casei
+agribalyse_food_code:en:19538
 ciqual_food_code:en:19538
 ciqual_food_name:en:Dairy drink or fermented milk or yogurt, plain, with sugar, with L Casei
 ciqual_food_name:fr:Boisson lactée, lait fermenté ou yaourt à boire, nature, sucré, au L Casei
@@ -32977,6 +33726,7 @@ fr:Yaourts au bifidus nature
 <en:Fruit yogurts
 en:Fruit bifidus yogurts, Yogurt type fermented milk with fruits with sugar with bifidus, Yogurt type dairy specialty with fruits with sugar with bifidus
 fr:Yaourts au bifidus aux fruits, Lait fermenté de type yaourt aux fruits sucré au bifidus, Spécialité laitière de type yaourt aromatisé aux fruits au bifidus
+agribalyse_food_code:en:19542
 ciqual_food_code:en:19542
 ciqual_food_name:en:Fermented milk or dairy specialty, yogurt type, with fruits, with sugar, with bifidus
 ciqual_food_name:fr:Lait fermenté ou spécialité laitière type yaourt, aux fruits, sucré, au bifidus
@@ -32985,6 +33735,7 @@ ciqual_food_name:fr:Lait fermenté ou spécialité laitière type yaourt, aux fr
 <en:Flavoured yogurts
 en:Flavoured bifidus yogurts, Yogurt type fermented flavoured milk with sugar with bifidus, Yogurt type flavoured dairy specialty with sugar with bifidus
 fr:Yaourts au bifidus aromatisés, Lait fermenté de type yaourt aromatisé sucré au bifidus, spécialité laitière de type yaourt aromatisé sucré au bifidus
+agribalyse_food_code:en:19539
 ciqual_food_code:en:19539
 ciqual_food_name:en:Fermented milk or dairy specialty, yogurt type, flavoured, with sugar, with bifidus
 ciqual_food_name:fr:Lait fermenté ou spécialité laitière type yaourt, aromatisé, sucré, au bifidus
@@ -32992,6 +33743,7 @@ ciqual_food_name:fr:Lait fermenté ou spécialité laitière type yaourt, aromat
 <en:Bifidus yogurts
 en:Sweetened plain bifidus yogurts, Yogurt type plain fermented milk with sugar with bifidus, Yogurt type plain dairy specialty with sugar with bifidus
 fr:Yaourts au bifidus sucrés natures, Lait fermenté de type yaourt nature sucré au bifidus, spécialité laitière de type yaourt nature sucré au bifidus
+agribalyse_food_code:en:19546
 ciqual_food_code:en:19546
 ciqual_food_name:en:Fermented milk or dairy specialty, yogurt type, plain, with bifidus
 ciqual_food_name:fr:Lait fermenté ou spécialité laitière type yaourt, nature, au bifidus
@@ -33005,6 +33757,7 @@ fr:Yaourts aromatisés, Yaourt aromatisé sucré au lait fermenté, Spécialité
 nl:Gearomatiseerde yoghurts
 pt:Iogurtes aromatizados
 zh:调味酸奶
+agribalyse_food_code:en:19575
 ciqual_food_code:en:19575
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, flavoured, with sugar
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aromatisé, sucré
@@ -33039,6 +33792,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aromatisé
 <en:Fruit yogurts
 en:Fermented milk yogurt with fruits and sugar, Dairy specialty with fruits and sugar
 fr:Yaourt sucré au lait fermenté et aux fruits, Spécialité laitière sucrée aux fruits
+agribalyse_food_code:en:19587
 ciqual_food_code:en:19587
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, w fruits, with sugar
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux fruits, sucré
@@ -33283,6 +34037,7 @@ hu:Csokoládés joghurtok
 it:Yogurt al cioccolato
 nl:Yoghurt met chocolade
 ro:Iaurturi cu ciocolată
+agribalyse_food_code:en:19580
 ciqual_food_code:en:19580
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, with chocolate shavings, with cream, with sugar
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux copeaux de chocolat, à la crème, sucré
@@ -33318,6 +34073,7 @@ nl:Griekse yoghurts
 pt:Iogurtes gregos
 ru:Греческий йогурт
 zh:希腊酸奶
+agribalyse_food_code:en:19860
 ciqual_food_code:en:19860
 ciqual_food_name:en:Yogurt, Greek-style, plain
 ciqual_food_name:fr:Yaourt à la grecque, nature
@@ -33325,12 +34081,14 @@ ciqual_food_name:fr:Yaourt à la grecque, nature
 <en:Greek yogurts
 en:Yogurt Greek-style ewe's milk
 fr:Yaourt à la grecque au lait de brebis
+agribalyse_food_code:en:19550
 ciqual_food_code:en:19550
 ciqual_food_name:en:Yogurt, Greek-style, ewe's milk
 
 <en:Yogurts
 en:Greek-style yogurt on a bed of fruits, Greek yogurt on a bed of fruits
 fr:Yaourt à la grecque sur lit de fruits, Yaourts à la grecque sur lit de fruits
+agribalyse_food_code:en:19552
 ciqual_food_code:en:19552
 ciqual_food_name:en:Yogurt, Greek-style, on a bed of fruits
 ciqual_food_name:fr:Yaourt à la grecque, sur lit de fruits
@@ -33384,6 +34142,7 @@ fr:Yaourts au lait de chèvre, Yaourts de chèvre
 it:Yogurt di capra
 nl:Geitenmelkyoghurts
 ro:Iaurturi din lapte de capră
+agribalyse_food_code:en:19556
 ciqual_food_code:en:19556
 ciqual_food_name:en:Yogurt, goat's milk, plain, around 5% fat
 
@@ -33450,6 +34209,9 @@ fr:Yaourts nature, Yaourt nature
 ciqual_food_code:en:19600
 ciqual_food_name:en:Yoghurt, plain (average)
 ciqual_food_name:fr:Yaourt ou spécialité laitière nature (aliment moyen)
+agribalyse_proxy_food_code:en:19593
+agribalyse_proxy_food_name:en:Yogurt, fermented milk or dairy specialty, plain
+agribalyse_proxy_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature
 
 <en:Plain yogurts
 en:Plain unsweetened yogurts, Plain fermented milk yogurt, Plain dairy specialty
@@ -33463,6 +34225,7 @@ nl:Naturelyoghurts
 pl:Jogurty naturalne, Jogurt naturalny
 pt:Iogurtes naturales, iogurte naturale
 ro:Iaurturi naturale
+agribalyse_food_code:en:19593
 ciqual_food_code:en:19593
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, plain
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature
@@ -33470,6 +34233,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature
 <en:Yogurts
 en:Plain fermented milk yogurt with cream, Plain dairy specialty with cream
 fr:Yaourt au lait fermenté à la crème, Spécialité laitière nature à la crème
+agribalyse_food_code:en:19598
 ciqual_food_code:en:19598
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, plain, w cream
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, nature, à la crème
@@ -33535,6 +34299,7 @@ zh:甜品, 甜点
 <en:Desserts
 fr:Bavarois aux fruits, Gâteau à la mousse de fruits sur génoise, Miroir aux fruits,
 en:Sponge cake with fruit mousse
+agribalyse_food_code:en:23007
 ciqual_food_code:en:23007
 ciqual_food_name:en:Sponge cake w fruit mousse
 ciqual_food_name:fr:Gâteau mousse de fruits sur génoise, type miroir, bavarois
@@ -33544,18 +34309,21 @@ en:Liégeois
 fr:Liégeois
 nl:Toetjes met roomlaag
 en:Custard topped with whipped cream (chocolate coffee caramel or vanilla custard) refrigerated
+agribalyse_food_code:en:19681
 ciqual_food_code:en:19681
 ciqual_food_name:en:Custard topped with whipped cream (chocolate, coffee, caramel or vanilla custard), refrigerated
 
 <en:Desserts
 en:Mousse (chocolate coffee caramel or vanilla) topped with whipped cream refrigerated
 fr:mousse liégoise
+agribalyse_food_code:en:39235
 ciqual_food_code:en:39235
 ciqual_food_name:en:Mousse (chocolate, coffee, caramel or vanilla) topped with whipped cream, refrigerated
 
 <en:Desserts
 en:Goblet of coffee ice cream topped with whipped cream
 fr:Coupe glacée au café, Café liégeois
+agribalyse_food_code:en:39532
 ciqual_food_code:en:39532
 ciqual_food_name:en:Goblet of ice cream, coffee or chocolate ice cream topped with whipped cream
 ciqual_food_name:fr:Coupe glacée type café ou chocolat liégeois
@@ -33563,6 +34331,7 @@ ciqual_food_name:fr:Coupe glacée type café ou chocolat liégeois
 <en:Desserts
 en:Goblet of chocolate ice cream topped with whipped cream
 fr:Coupe glace au chocolat, Chocolat liégeois
+agribalyse_food_code:en:39532
 ciqual_food_code:en:39532
 ciqual_food_name:en:Goblet of ice cream, coffee or chocolate ice cream topped with whipped cream
 ciqual_food_name:fr:Coupe glacée type café ou chocolat liégeois
@@ -33570,6 +34339,7 @@ ciqual_food_name:fr:Coupe glacée type café ou chocolat liégeois
 <en:Desserts
 en:Goblet of peach Melba ice cream, Goblet of Belle Helene pear ice cream
 fr:Coupe glacée parfum pêche Melba, Coupe glacée parfum poire Belle-Hélène
+agribalyse_food_code:en:39534
 ciqual_food_code:en:39534
 ciqual_food_name:en:Goblet of ice cream, peach Melba or Belle Helene pear type
 ciqual_food_name:fr:Coupe glacée parfum pêche Melba ou poire Belle-Hélène
@@ -33577,6 +34347,7 @@ ciqual_food_name:fr:Coupe glacée parfum pêche Melba ou poire Belle-Hélène
 <en:Desserts
 en:Fruit liegeois
 fr:Liégeois aux fruits
+agribalyse_food_code:en:39220
 ciqual_food_code:en:39220
 ciqual_food_name:en:Fruit liegeois
 ciqual_food_name:fr:Liégeois aux fruits
@@ -33611,6 +34382,7 @@ wikidata:en:Q1381277
 <en:Chocolate mousses
 en:Refrigerated milk-based chocolate mousses
 fr:Mousses au chocolat au lait rayon frais
+agribalyse_food_code:en:39206
 ciqual_food_code:en:39206
 ciqual_food_name:en:Chocolate mousse (milk-based), refrigerated
 ciqual_food_name:fr:Mousse au chocolat (base laitière), rayon frais
@@ -33618,6 +34390,7 @@ ciqual_food_name:fr:Mousse au chocolat (base laitière), rayon frais
 <en:Chocolate mousses
 en:Refrigerated chocolate mousses
 fr:Mousses au chocolat traditionnelles rayon frais
+agribalyse_food_code:en:39210
 ciqual_food_code:en:39210
 ciqual_food_name:en:Mousse, chocolate, refrigerated
 ciqual_food_name:fr:Mousse au chocolat traditionnelle, rayon frais
@@ -33692,6 +34465,7 @@ fr:Coulis de mangue
 <en:Fruits based foods
 en:Fruits desserts, Fruits dessert
 fr:Desserts de fruits, Dessert de fruits
+agribalyse_food_code:en:13152
 ciqual_food_code:en:13152
 ciqual_food_name:en:Fruits dessert, all types (fruits dessert's sugar content is less than fruits compote but more than fruits compote reduced sugar)
 ciqual_food_name:fr:Dessert de fruits, tout type de fruits (en taux de sucres : compotes allégées en sucres < desserts de fruits < compotes allégée)
@@ -33709,6 +34483,7 @@ it:Composte, composta
 nl:Compotes
 zh:蜜饯
 wikidata:en:Q635999
+agribalyse_food_code:en:13108
 ciqual_food_code:en:13108
 ciqual_food_name:en:Fruits compote, miscellaneous
 ciqual_food_name:fr:Compote, tout type de fruits
@@ -33717,6 +34492,7 @@ ciqual_food_name:fr:Compote, tout type de fruits
 <en:Fruits based foods
 en:Fruits compote with reduced sugar
 fr:Compote de fruits allégée en sucres
+agribalyse_food_code:en:13109
 ciqual_food_code:en:13109
 ciqual_food_name:en:Fruits compote, miscellaneous, reduced sugar
 ciqual_food_name:fr:Compote, tout type de fruits, allégée en sucres
@@ -33725,6 +34501,7 @@ ciqual_food_name:fr:Compote, tout type de fruits, allégée en sucres
 <en:Fruits based foods
 en:Refrigerated fruits compote with reduced sugar
 fr:Compote de fruits allégée en sucres rayon frais
+agribalyse_food_code:en:13129
 ciqual_food_code:en:13129
 ciqual_food_name:en:Fruits compote, miscellaneous, reduced sugar, refrigerated
 ciqual_food_name:fr:Compote, tout type de fruits, allégée en sucres, rayon frais
@@ -33733,6 +34510,7 @@ ciqual_food_name:fr:Compote, tout type de fruits, allégée en sucres, rayon fra
 <en:Fruits based foods
 en:Fruits puree without sugar added
 fr:Purée de fruits sans sucres ajoutés, Compote de fruits sans sucres ajoutés
+agribalyse_food_code:en:13153
 ciqual_food_code:en:13153
 ciqual_food_name:en:Fruits puree, without sugar added
 ciqual_food_name:fr:Purée de fruits, tout type de fruits, type ""compote sans sucres ajoutés""
@@ -33741,6 +34519,7 @@ ciqual_food_name:fr:Purée de fruits, tout type de fruits, type ""compote sans s
 <en:Fruits based foods
 en:Peach melba with vanilla ice cream and raspberry sauce, Peach melba
 fr:Pêche melba
+agribalyse_food_code:en:39401
 ciqual_food_code:en:39401
 ciqual_food_name:en:Peach melba (with vanilla ice cream and raspberry sauce)
 ciqual_food_name:fr:Pêche melba
@@ -33793,6 +34572,7 @@ it:Composte di mela
 nl:Appelcompotes
 sv:Äppelmos
 wikidata:en:Q618345
+agribalyse_food_code:en:13038
 ciqual_food_code:en:13038
 ciqual_food_name:en:Apple compote
 ciqual_food_name:fr:Compote de pomme
@@ -33999,6 +34779,7 @@ nl:Mousses op basis van melk
 en:Refrigerated chocolate custard dessert
 fr:Crèmes dessert chocolat, Crème dessert chocolat, Crèmes dessert au chocolat, Crème dessert au chocolat
 nl:Chocolade vla's
+agribalyse_food_code:en:39200
 ciqual_food_code:en:39200
 ciqual_food_name:en:Custard dessert, chocolate, refrigerated
 ciqual_food_name:fr:Crème dessert au chocolat, rayon frais
@@ -34007,6 +34788,7 @@ ciqual_food_name:fr:Crème dessert au chocolat, rayon frais
 <en:Canned custard desserts
 en:Canned chocolate custard dessert
 fr:Crème dessert au chocolat appertisée
+agribalyse_food_code:en:39506
 ciqual_food_code:en:39506
 ciqual_food_name:en:Custard dessert, chocolate, canned
 ciqual_food_name:fr:Crème dessert au chocolat, appertisée
@@ -34014,6 +34796,7 @@ ciqual_food_name:fr:Crème dessert au chocolat, appertisée
 <en:Canned custard desserts
 en:Canned vanilla custard dessert
 fr:Crème dessert à la vanille appertisée
+agribalyse_food_code:en:39214
 ciqual_food_code:en:39214
 ciqual_food_name:en:Custard dessert, vanilla, canned
 ciqual_food_name:fr:Crème dessert à la vanille, appertisée
@@ -34021,6 +34804,7 @@ ciqual_food_name:fr:Crème dessert à la vanille, appertisée
 <en:Refrigerated dessert creams
 en:Refrigerated custard dessert with reduced fat
 fr:Crème dessert allégée en matières grasses rayon frais
+agribalyse_food_code:en:19673
 ciqual_food_code:en:19673
 ciqual_food_name:en:Custard dessert, reduced fat, refrigerated
 ciqual_food_name:fr:Crème dessert, allégée en MG, rayon frais
@@ -34028,6 +34812,7 @@ ciqual_food_name:fr:Crème dessert, allégée en MG, rayon frais
 <en:Refrigerated dessert creams
 en:Refrigerated vanilla custard dessert
 fr:Crème dessert à la vanille rayon frais
+agribalyse_food_code:en:39229
 ciqual_food_code:en:39229
 ciqual_food_name:en:Custard dessert, vanilla, refrigerated
 ciqual_food_name:fr:Crème dessert à la vanille, rayon frais
@@ -34035,6 +34820,7 @@ ciqual_food_name:fr:Crème dessert à la vanille, rayon frais
 <en:Refrigerated dessert creams
 en:Refrigerated coffee custard dessert
 fr:Crème dessert au café rayon frais
+agribalyse_food_code:en:39246
 ciqual_food_code:en:39246
 ciqual_food_name:en:Custard dessert, coffee, refrigerated
 ciqual_food_name:fr:Crème dessert au café, rayon frais
@@ -34042,6 +34828,7 @@ ciqual_food_name:fr:Crème dessert au café, rayon frais
 <en:Refrigerated dessert creams
 en:Refrigerated caramel custard dessert
 fr:Crème dessert au caramel rayon frais
+agribalyse_food_code:en:39247
 ciqual_food_code:en:39247
 ciqual_food_name:en:Custard dessert, caramel, refrigerated
 ciqual_food_name:fr:Crème dessert au caramel, rayon frais
@@ -34049,12 +34836,14 @@ ciqual_food_name:fr:Crème dessert au caramel, rayon frais
 <fr:Crèmes dessert chocolat
 fr:Crèmes dessert chocolat noir, Crème dessert chocolat noir, Crèmes dessert au chocolat noir, Crème dessert au chocolat noir
 nl:Chocolade puur vla's
+agribalyse_food_code:en:39211
 ciqual_food_code:en:39211
 ciqual_food_name:en:Custard cream with eggs (a small jar of chocolate or vanilla cream or other flavour), refrigerated
 
 <en:Refrigerated dessert creams
 fr:Crèmes dessert vanille, Crème dessert vanille, Crèmes dessert à la vanille, Crème dessert à la vanille
 nl:vanilla vla's
+agribalyse_food_code:en:39211
 ciqual_food_code:en:39211
 ciqual_food_name:en:Custard cream with eggs (a small jar of chocolate or vanilla cream or other flavour), refrigerated
 
@@ -34128,6 +34917,7 @@ it:Panna cotta con coulis di fruttes
 <en:Panna cottas
 en:Refrigerated panna cotta
 fr:Panna cotta rayon frais
+agribalyse_food_code:en:19685
 ciqual_food_code:en:19685
 ciqual_food_name:en:Panna cotta, refrigerated
 ciqual_food_name:fr:Panna cotta, rayon frais
@@ -34169,6 +34959,7 @@ fr:Gâteaux de semoule, Gâteaux à la semoule, Gâteau de semoule, Gâteau à l
 <fr:Gâteaux de semoule
 en:Canned semolina puddings
 fr:Gâteaux de semoule appertisés
+agribalyse_food_code:en:23535
 ciqual_food_code:en:23535
 ciqual_food_name:en:Semolina pudding, canned
 ciqual_food_name:fr:Gâteau de semoule, appertisé
@@ -34176,6 +34967,7 @@ ciqual_food_name:fr:Gâteau de semoule, appertisé
 <fr:Gâteaux de semoule
 en:Refrigerated semolina pudding
 fr:Semoule au lait rayon frais
+agribalyse_food_code:en:39218
 ciqual_food_code:en:39218
 ciqual_food_name:en:Semolina pudding, refrigerated
 ciqual_food_name:fr:Semoule au lait, rayon frais
@@ -34183,6 +34975,7 @@ ciqual_food_name:fr:Semoule au lait, rayon frais
 <fr:Gâteaux de semoule
 en:Refrigerated semolina pudding with raisins and caramel sauce
 fr:Gâteau de semoule aux raisins et au caramel rayon frais
+agribalyse_food_code:en:23534
 ciqual_food_code:en:23534
 ciqual_food_name:en:Semolina pudding, with raisins and caramel sauce, refrigerated
 ciqual_food_name:fr:Gâteau de semoule aux raisins et caramel, rayon frais
@@ -34190,6 +34983,7 @@ ciqual_food_name:fr:Gâteau de semoule aux raisins et caramel, rayon frais
 <en:Dairy desserts
 en:Yogurt cake
 fr:Gâteau au yaourt
+agribalyse_food_code:en:23588
 ciqual_food_code:en:23588
 ciqual_food_name:en:Yogurt cake
 ciqual_food_name:fr:Gâteau au yaourt
@@ -34197,6 +34991,7 @@ ciqual_food_name:fr:Gâteau au yaourt
 <en:Dairy desserts
 en:Fresh cream cheese cake
 fr:Gâteau au fromage blanc
+agribalyse_food_code:en:23589
 ciqual_food_code:en:23589
 ciqual_food_name:en:Fresh cream cheese cake
 ciqual_food_name:fr:Gâteau au fromage blanc
@@ -34210,6 +35005,7 @@ fr:Tiramisu
 it:Tiramisù
 nl:Tiramisu
 wikidata:en:Q131582
+agribalyse_food_code:en:19698
 ciqual_food_code:en:19698
 ciqual_food_name:en:Tiramisu, refrigerated
 ciqual_food_name:fr:Tiramisu, rayon frais
@@ -34226,6 +35022,7 @@ fr:Tiramisu au café
 <en:Dairy desserts
 en:Dessert Opera cake type
 fr:opéra
+agribalyse_food_code:en:23008
 ciqual_food_code:en:23008
 ciqual_food_name:en:Dessert, Opera cake type
 
@@ -34245,6 +35042,7 @@ nl:Fruitsalade in siroop
 <en:Fruit salads in syrup
 en:Canned drained fruit cocktail in syrup, Canned drained fruit salad in syrup
 fr:Macédoine de fruits au sirop appertisée égouttée, Cocktail de fruits au sirop appertisé égoutté, Salade de fruits au sirop appertisée égouttée
+agribalyse_food_code:en:13706
 ciqual_food_code:en:13706
 ciqual_food_name:en:Fruit cocktail or salad, canned in syrup, drained
 ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop, appertisé, égoutté
@@ -34252,6 +35050,7 @@ ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop, appert
 <en:Fruit salads in syrup
 en:Canned drained fruit cocktail in light syrup, Canned drained fruit salad in light syrup
 fr:Macédoine de fruits au sirop léger appertisée égouttée, Cocktail de fruits au sirop léger appertisé égoutté, Salade de fruits au sirop léger appertisée égouttée
+agribalyse_food_code:en:13708
 ciqual_food_code:en:13708
 ciqual_food_name:en:Fruit cocktail or salad, canned in light syrup, drained
 ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop léger, appertisé, égoutté
@@ -34259,6 +35058,7 @@ ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop léger,
 <en:Fruit salads in syrup
 en:Canned fruit cocktail in light syrup, Canned fruit salad in light syrup
 fr:Macédoine de fruits au sirop léger appertisée, Cocktail de fruits au sirop léger appertisé, Salade de fruits au sirop léger appertisée
+agribalyse_food_code:en:13709
 ciqual_food_code:en:13709
 ciqual_food_name:en:Fruit cocktail or salad, canned in light syrup, not drained
 ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop léger, appertisé, non égoutté
@@ -34266,6 +35066,7 @@ ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop léger,
 <en:Fruit salads in syrup
 en:Canned fruit cocktail in syrup not drained, Canned fruit salad in syrup not drained
 fr:Macédoine de fruits au sirop appertisé non égoutté, Cocktail de fruits au sirop appertisé non égoutté, Salade de fruits au sirop appertisé non égoutté
+agribalyse_food_code:en:13707
 ciqual_food_code:en:13707
 ciqual_food_name:en:Fruit cocktail or salad, canned in syrup, not drained
 ciqual_food_name:fr:Macédoine ou cocktail ou salade de fruits, au sirop, appertisé, non égoutté
@@ -34278,6 +35079,7 @@ nl:Verse fruitsalade
 <en:Fruit salads
 en:Raw fruit salad
 fr:Salade de fruits crus
+agribalyse_food_code:en:13134
 ciqual_food_code:en:13134
 ciqual_food_name:en:Fruit salad, raw
 ciqual_food_name:fr:Salade de fruits, crue
@@ -34292,6 +35094,7 @@ wikidata:en:Q16636380
 <en:Flans
 en:Refrigerated flan with eggs
 fr:Flan aux œufs rayon frais
+agribalyse_food_code:en:19674
 ciqual_food_code:en:19674
 ciqual_food_name:en:Flan with eggs, refrigerated
 ciqual_food_name:fr:Flan aux œufs, rayon frais
@@ -34345,6 +35148,7 @@ fr:Desserts de soja au caramel
 <en:Soy desserts
 en:Refrigerated soy dessert with fruits
 fr:Dessert au soja aux fruits rayon frais
+agribalyse_food_code:en:19692
 ciqual_food_code:en:19692
 ciqual_food_name:en:Soy dessert, w fruits, refrigerated
 ciqual_food_name:fr:Dessert au soja, aux fruits, rayon frais
@@ -34352,6 +35156,7 @@ ciqual_food_name:fr:Dessert au soja, aux fruits, rayon frais
 <en:Soy desserts
 en:Refrigerated flavoured soy dessert
 fr:Dessert au soja aromatisé rayon frais
+agribalyse_food_code:en:20911
 ciqual_food_code:en:20911
 ciqual_food_name:en:Soy dessert, flavoured, refrigerated
 ciqual_food_name:fr:Dessert au soja aromatisé, rayon frais
@@ -34359,6 +35164,7 @@ ciqual_food_name:fr:Dessert au soja aromatisé, rayon frais
 <en:Soy desserts
 en:Refrigerated plain soy dessert
 fr:Dessert au soja nature rayon frais
+agribalyse_food_code:en:19693
 ciqual_food_code:en:19693
 ciqual_food_name:en:Soy dessert, plain, refrigerated
 ciqual_food_name:fr:Dessert au soja, nature, rayon frais
@@ -34606,6 +35412,7 @@ nl:Gepelde amandelen
 en:Whole almonds
 de:ganze Mandeln
 fr:Amandes entières
+agribalyse_food_code:en:15000
 ciqual_food_code:en:15000
 ciqual_food_name:en:Almond, (with peel)
 
@@ -34613,6 +35420,7 @@ ciqual_food_name:en:Almond, (with peel)
 <en:Whole almonds
 en:Almond peeled unpeeled or blanched
 fr:Amande mondée émondée blanchie
+agribalyse_food_code:en:15041
 ciqual_food_code:en:15041
 ciqual_food_name:en:Almond, peeled, unpeeled or blanched
 
@@ -34639,6 +35447,7 @@ nl:Gezouten amandelen
 <en:Grilled almonds
 fr:Amandes grillées et salées, Amande grillée salée
 en:Almond grilled salted
+agribalyse_food_code:en:15042
 ciqual_food_code:en:15042
 ciqual_food_name:en:Almond, grilled, salted
 
@@ -34687,12 +35496,14 @@ nl:Gepelde kastanjes
 <en:Chestnuts
 en:Chestnut boiled/cooked in water
 fr:Châtaigne bouillie/cuite à l'eau
+agribalyse_food_code:en:15020
 ciqual_food_code:en:15020
 ciqual_food_name:en:Chestnut, boiled/cooked in water
 
 <en:Chestnuts
 en:Grilled chestnut
 fr:Châtaigne grillée
+agribalyse_food_code:en:15021
 ciqual_food_code:en:15021
 ciqual_food_name:en:Chestnut, grilled
 ciqual_food_name:fr:Châtaigne, grillée
@@ -34700,6 +35511,7 @@ ciqual_food_name:fr:Châtaigne, grillée
 <en:Chestnuts
 en:Raw chestnut, Raw chestnuts
 fr:Châtaigne crue, Châtaignes crues
+agribalyse_food_code:en:15024
 ciqual_food_code:en:15024
 ciqual_food_name:en:Chestnut, raw
 ciqual_food_name:fr:Châtaigne, crue
@@ -34708,6 +35520,7 @@ ciqual_food_name:fr:Châtaigne, crue
 <en:Canned nuts
 en:Canned chestnut
 fr:Châtaigne en conserve, Châtaignes en conserve
+agribalyse_food_code:en:15039
 ciqual_food_code:en:15039
 ciqual_food_name:en:Chestnut, canned
 ciqual_food_name:fr:Châtaigne ou Marron, appertisé
@@ -34723,6 +35536,7 @@ nl:Hazelnoten
 sv:Hasselnötter, hasselnöt
 wikidata:en:Q578307
 season_in_country_fr:en: 9,10,11
+agribalyse_food_code:en:15004
 ciqual_food_code:en:15004
 ciqual_food_name:en:Hazelnut
 
@@ -34774,6 +35588,7 @@ de:geröstete Haselnüsse
 es:Avellanas tostadas
 fr:Noisettes grillées
 nl:Gebrande hazelnoten
+agribalyse_food_code:en:15033
 ciqual_food_code:en:15033
 ciqual_food_name:en:Hazelnut, grilled
 
@@ -34781,6 +35596,7 @@ ciqual_food_name:en:Hazelnut, grilled
 <en:Roasted nuts
 en:Hazelnut grilled salted
 fr:Noisette grillée salée
+agribalyse_food_code:en:15050
 ciqual_food_code:en:15050
 ciqual_food_name:en:Hazelnut, grilled, salted
 
@@ -34806,6 +35622,7 @@ la:Macadamia
 nl:Macadamia's
 sv:Macadamianötter, macadamianöt
 wikidata:en:Q310041
+agribalyse_food_code:en:15027
 ciqual_food_code:en:15027
 ciqual_food_name:en:Macadamia nut
 ciqual_food_name:fr:Noix de macadamia
@@ -34820,6 +35637,7 @@ nl:Gepelde macadamia's
 <en:Macadamia nuts
 en:Grilled and salted Macadamia nut, rilled and salted Macadamia nuts
 fr:Noix de macadamia grillée et salée, Noix de macadamia grillées et salées
+agribalyse_food_code:en:15043
 ciqual_food_code:en:15043
 ciqual_food_name:en:Macadamia nut, grilled, salted
 ciqual_food_name:fr:Noix de macadamia, grillée, salée
@@ -34841,6 +35659,7 @@ ru:Арахис
 sv:Jordnötter, jordnöt
 zh:花生
 wikidata:en:Q37383
+agribalyse_food_code:en:15001
 ciqual_food_code:en:15001
 ciqual_food_name:en:Peanut
 
@@ -34856,6 +35675,7 @@ nl:Ongepelde pinda's
 <en:Peanuts
 en:Coated peanuts
 fr:Cacahuètes enrobées d'un biscuit pour apéritif
+agribalyse_food_code:en:38406
 ciqual_food_code:en:38406
 ciqual_food_name:en:Coated peanuts
 ciqual_food_name:fr:Cacahuètes (arachide) enrobées d'un biscuit, pour apéritif
@@ -34863,6 +35683,7 @@ ciqual_food_name:fr:Cacahuètes (arachide) enrobées d'un biscuit, pour apériti
 <en:Peanuts
 en:Peanuts cooked in water with salt, Boiled peanuts with salt
 fr:Arachides bouillies salées, Arachides cuites à l'eau salée, Cacahuètes bouillies salées, Cacahuètes cuites à l'eau salée
+agribalyse_food_code:en:20581
 ciqual_food_code:en:20581
 ciqual_food_name:en:Peanut, boiled/cooked in water, w salt
 ciqual_food_name:fr:Arachide, bouillie/cuite à l'eau, salée
@@ -34882,6 +35703,7 @@ fi:paahdetut maapähkinät
 fr:Cacahuètes grillées
 hu:Pörkölt mogyoró
 nl:Gebrande pinda's
+agribalyse_food_code:en:15037
 ciqual_food_code:en:15037
 ciqual_food_name:en:Peanut, grilled
 
@@ -34889,6 +35711,7 @@ ciqual_food_name:en:Peanut, grilled
 <en:Roasted nuts
 en:Peanut grilled salted
 fr:Cacahuète grillée salée
+agribalyse_food_code:en:15002
 ciqual_food_code:en:15002
 ciqual_food_name:en:Peanut, grilled, salted
 
@@ -34899,6 +35722,7 @@ de:Geröstete Cashews, Geröstete Cashewnüsse
 fi:paahdetut cashew-pähkinät
 fr:Noix de Cajou grillées
 nl:Geroosterde cashewnoten
+agribalyse_food_code:en:15019
 ciqual_food_code:en:15019
 ciqual_food_name:en:Cashew nut, grilled, salted
 
@@ -34912,6 +35736,7 @@ la:Carya illinoinensis
 nl:Pecannoten
 sv:Pekannötter, pekannöt
 wikidata:en:Q333877
+agribalyse_food_code:en:15026
 ciqual_food_code:en:15026
 ciqual_food_name:en:Pecan nut
 ciqual_food_name:fr:Noix de pécan
@@ -34930,6 +35755,7 @@ agribalyse_proxy_food_name:fr:Noix de pécan, salées
 <en:Pecan nuts
 en:Salted pecan nut, Salted pecan nuts
 fr:Noix de pécan salées, Noix de pécan salée
+agribalyse_food_code:en:15046
 ciqual_food_code:en:15046
 ciqual_food_name:en:Pecan nut, salted
 ciqual_food_name:fr:Noix de pécan, salées
@@ -34962,6 +35788,7 @@ fr:Pistaches grillées
 hu:Pörkölt pisztácia
 it:Pistacchio tostato
 nl:Geroosterde pistachenootjes
+agribalyse_food_code:en:15044
 ciqual_food_code:en:15044
 ciqual_food_name:en:Pistachio nut, grilled
 
@@ -34969,6 +35796,7 @@ ciqual_food_name:en:Pistachio nut, grilled
 <en:Roasted pistachios
 en:Pistachio nut grilled salted
 fr:Pistache grillée salée
+agribalyse_food_code:en:15009
 ciqual_food_code:en:15009
 ciqual_food_name:en:Pistachio nut, grilled, salted
 
@@ -34983,6 +35811,7 @@ nl:Paranoten
 pt:Castanha do Pará
 sv:Paranötter, paranöt
 wikidata:en:Q81671
+agribalyse_food_code:en:15008
 ciqual_food_code:en:15008
 ciqual_food_name:en:Brazil nut
 
@@ -35002,6 +35831,7 @@ fr:Pignons de pin
 la:Pinus
 nl:Pijnboompitten
 wikidata:en:Q212933
+agribalyse_food_code:en:15025
 ciqual_food_code:en:15025
 ciqual_food_name:en:Pine nuts
 
@@ -35071,6 +35901,7 @@ zh:带壳核桃
 <en:Walnuts
 en:Dried husked walnut
 fr:Noix séchée pelée, Cerneaux
+agribalyse_food_code:en:15005
 ciqual_food_code:en:15005
 ciqual_food_name:en:Walnut, dried, husked
 ciqual_food_name:fr:Noix, séchée, cerneaux
@@ -35078,6 +35909,7 @@ ciqual_food_name:fr:Noix, séchée, cerneaux
 <en:Walnuts
 en:Fresh walnut
 fr:Noix fraîche
+agribalyse_food_code:en:15023
 ciqual_food_code:en:15023
 ciqual_food_name:en:Walnut, fresh
 ciqual_food_name:fr:Noix, fraîche
@@ -35107,6 +35939,7 @@ en:Chestnut flours
 es:Harinas de castañas
 fr:Farines de châtaignes, Farines de châtaigne
 nl:Gemalen kastanjes
+agribalyse_food_code:en:9570
 ciqual_food_code:en:9570
 ciqual_food_name:en:Chestnut flour
 
@@ -35198,6 +36031,7 @@ nl_be:Pindakazen
 ru:Арахисовая паста, Арахисовые пасты
 sv:Jordnötssmör
 wikidata:en:Q147651
+agribalyse_food_code:en:15202
 ciqual_food_code:en:15202
 ciqual_food_name:en:Peanut butter or peanut paste
 ciqual_food_name:fr:Beurre de cacahuète ou Pâte d'arachide
@@ -35224,6 +36058,7 @@ fr:Crèmes de marrons, Purées de marrons, Confitures de châtaignes, Confitures
 it:Creme di marroni, Crema di marroni
 nl:Kastanjepasta's
 wikidata:en:Q1363560
+agribalyse_food_code:en:15013
 ciqual_food_code:en:15013
 ciqual_food_name:en:Chestnut cream
 ciqual_food_name:fr:Crème de marrons
@@ -35232,6 +36067,7 @@ ciqual_food_name:fr:Crème de marrons
 <en:Plant-based spreads
 en:Canned vanilla flavoured chestnut cream
 fr:Crème de marrons vanillée appertisée, Crème de marrons à la vanille en conserve
+agribalyse_food_code:en:15016
 ciqual_food_code:en:15016
 ciqual_food_name:en:Chestnut cream, vanilla flavoured, canned
 ciqual_food_name:fr:Crème de marrons vanillée, appertisée
@@ -35240,6 +36076,7 @@ ciqual_food_name:fr:Crème de marrons vanillée, appertisée
 <en:Sweet mousses
 en:Refrigerated chestnut mousse
 fr:Mousse à la crème de marrons rayon frais
+agribalyse_food_code:en:19852
 ciqual_food_code:en:19852
 ciqual_food_name:en:Chestnut mousse, refrigerated
 ciqual_food_name:fr:Mousse à la crème de marrons, rayon frais
@@ -35261,6 +36098,7 @@ nl:Kastanjes op siroop
 <en:Canned nuts
 en:Canned chestnut
 fr:Marrons en conserve, Marron en conserve
+agribalyse_food_code:en:15039
 ciqual_food_code:en:15039
 ciqual_food_name:en:Chestnut, canned
 ciqual_food_name:fr:Châtaigne ou Marron, appertisé
@@ -35366,6 +36204,7 @@ ru:Мёд
 sv:Honung
 th:น้ำผึ้ง
 zh:蜂蜜
+agribalyse_food_code:en:31008
 ciqual_food_code:en:31008
 ciqual_food_name:en:Honey
 ciqual_food_name:fr:Miel
@@ -35374,6 +36213,7 @@ nova:en:2
 <en:Honeys
 en:Honeys from Belgium, Belgian honeys
 fr:Miels belges, Miels de Belgique
+origins:en: en:Belgium
 
 <en:Honeys from Belgium
 fr:Miel wallon
@@ -35383,6 +36223,7 @@ origins:en: en:Belgium
 
 <en:Honeys
 en:Spanish honeys
+origins:en: en:Spain
 
 <en:Spanish honeys
 es:Miel Villuercas-Ibores
@@ -35433,6 +36274,7 @@ fi:ranskalaiset hunajat
 fr:Miels français, Miels de France
 hu:Francia mézek, Mézek Franciaországból
 nl:Franse honingen
+origins:en: en:France
 
 <en:Honeys from France
 en:Honeys from Alsace
@@ -35440,54 +36282,63 @@ fr:Miels d’Alsace
 nl:Honinge nuit de de Alsace
 protected_name_file_number:en: PGI-FR-0150
 protected_name_type:en: pgi
-origins:en: en:France
+origins:en: en:France, fr:Alsace
 
 <fr:Miels d’acacia
 <fr:Miels d’Alsace
 en:Acacia honeys from Alsace
 fr:Miels d'acacia d'Alsace
 nl:Acaciahoningen ui tde Alsace
+origins:en: en:France, fr:Alsace
 
 <en:Honeys from France
 fr:Miel de Cévennes
 protected_name_file_number:en: PGI-FR-1148
 protected_name_type:en: pgi
-origins:en: en:France
+origins:en: en:France, fr:Cévennes
 
 <fr:Miels d’acacia
 <fr:Miels du Jura
 en:Acacia honeys from Jura
 fr:Miels d’acacia du Jura
 nl:Acaciahoningen uit de Jura
+origins:en: en:France, fr:Jura
 
 <en:Honeys from Alsace
 fr:Miels de châtaignier d'Alsace
 nl:Kastanjehoningen uit de Alsace
+origins:en: en:France, fr:Alsace
 
 <en:Honeys from Alsace
 <en:Flower honeys
 fr:Miels de fleurs d'Alsace
 nl:Bloemenhoningen uit de Alsace
+origins:en: en:France, fr:Alsace
 
 <en:Honeys from Alsace
 fr:Miels de forêt d'Alsace
 nl:Boshoningen uit de Alsace
+origins:en: en:France, fr:Alsace
 
 <en:Honeys from Alsace
 fr:Miels de sapin d'Alsace
 nl:Sparrenhoningen uit de Alsace
+origins:en: en:France, fr:Alsace
 
 <en:Honeys from Alsace
 fr:Miels de tilleul d'Alsace
 nl:Lindebloesemhoningen uit de Alsace
+origins:en: en:France, fr:Alsace
 
 <en:Honeys from France
 fr:Miels d'Aquitaine
 nl:Honingen uit de Aquitaine
+origins:en: en:France, fr:Aquitaine
 
 <en:Honeys from France
 fr:Miels de Bourgogne
 nl:Honingen uit de Bourgogne
+origins:en: en:France, fr:Bourgogne
 
 <en:Mediterannean honeys
 <fr:Miels de pin
@@ -35506,6 +36357,7 @@ origins:en: en:France, en:Corsica
 en:Honey of Biscay
 fr:Miels de Gascogne
 nl:Honingen uit de Gascogne
+origins:en: en:France, fr:Gascogne
 
 <en:Honeys from France
 en:Mediterannean honeys
@@ -35516,33 +36368,37 @@ nl:Honingen uit de Middellandse Zee
 <en:Honeys from France
 fr:Miels de Poitou-Charentes, Miels du Poitou-Charentes
 nl:Honingen uit de Poitou-Charantes
+origins:en: en:France, fr:Poitou-Charentes
 
 <en:Honeys from France
 fr:Miels de Provence
 nl:Honingen uit de Provence
 protected_name_file_number:en: PGI-FR-9181
 protected_name_type:en: pgi
-origins:en: en:France
+origins:en: en:France, fr:Provence
 
 <en:Honeys from France
 fr:Miels de sapin des Vosges
 nl:Sparrenhoningen uit de Vogezen
 protected_name_file_number:en: PDO-FR-0204
 protected_name_type:en: pdo
-origins:en: en:France
+origins:en: en:France, fr:Vosges
 
 <en:Honeys from France
 fr:Miels des Pays de Loire
 nl:Honingen uit de Loirestreek
+origins:en: en:France, fr:Pays de Loire
 
 <en:Honeys from France
 fr:Miels du Gâtinais, Miel du Gätinais
 nl:Honingen van de Gatinais
+origins:en: en:France, fr:Gatinais
 
 <en:Honeys from France
 en:Honeys from Jura
 fr:Miels du Jura
 nl:Honingen uit de Jura
+origins:en: en:France, fr:Jura
 
 <en:Honeys
 en:Honeys from Romania, Romanian honeys
@@ -35550,6 +36406,7 @@ de:Rumänischer Honig
 fr:Miels roumains, Miels de Roumarie, Miels de Roumanie
 hu:Mézek Romániából
 nl:Roemeense honingen
+origins:en: en:Romania
 
 <en:Honeys from Romania
 fr:Miels des rives du Danube de Roumanie
@@ -35579,6 +36436,7 @@ nl:Alpenhoningen
 <en:Honeys from the mountains
 fr:Miels des Pyrénées
 nl:Honingen uit de Pyreneeën
+origins:en: fr:Pyrénées
 
 <en:Honeys
 en:White honeys from Tigrai
@@ -35940,6 +36798,7 @@ nl:Eende-ei
 ru:Яйца уток, яйца утиные, утиные яйца
 zh:鸭蛋
 wikidata:en:Q20651335
+agribalyse_food_code:en:22060
 ciqual_food_code:en:22060
 ciqual_food_name:en:Duck egg, raw
 ciqual_food_name:fr:Oeuf de cane, cru
@@ -35950,6 +36809,7 @@ fr:Œufs d'oies, Oeuf d'oie
 it:Uova d'oca
 ru:Яйца гусей, яйца гусиные, гусиные яйца
 zh:鹅蛋
+agribalyse_food_code:en:22070
 ciqual_food_code:en:22070
 ciqual_food_name:en:Goose egg, raw
 ciqual_food_name:fr:Oeuf d'oie, cru
@@ -35994,6 +36854,7 @@ wikidata:en:Q35855322
 <en:Bird eggs
 en:Raw turkey egg, Raw turkey eggs
 fr:Oeuf de dinde cru, Oeufs de dinde crus
+agribalyse_food_code:en:22080
 ciqual_food_code:en:22080
 ciqual_food_name:en:Turkey egg, raw
 ciqual_food_name:fr:Oeuf de dinde, cru
@@ -36001,6 +36862,7 @@ ciqual_food_name:fr:Oeuf de dinde, cru
 <en:Bird eggs
 en:Hard-boiled egg
 fr:Oeuf dur
+agribalyse_food_code:en:22010
 ciqual_food_code:en:22010
 ciqual_food_name:en:Egg, hard-boiled
 ciqual_food_name:fr:Oeuf, dur
@@ -36008,6 +36870,7 @@ ciqual_food_name:fr:Oeuf, dur
 <en:Bird eggs
 en:Raw egg
 fr:Oeuf cru
+agribalyse_food_code:en:22000
 ciqual_food_code:en:22000
 ciqual_food_name:en:Egg, raw
 ciqual_food_name:fr:Oeuf, cru
@@ -36015,12 +36878,14 @@ ciqual_food_name:fr:Oeuf, cru
 <en:Bird eggs
 en:Egg white raw
 fr:Oeuf blanc (blanc d'oeuf) cru
+agribalyse_food_code:en:22001
 ciqual_food_code:en:22001
 ciqual_food_name:en:Egg white, raw
 
 <en:Bird eggs
 en:Egg yolk raw
 fr:Oeuf jaune (jaune d'oeuf) cru
+agribalyse_food_code:en:22002
 ciqual_food_code:en:22002
 ciqual_food_name:en:Egg yolk, raw
 
@@ -36041,7 +36906,7 @@ sv:Fett, Matfett
 th:ไขมัน
 zh:脂肪
 pnns_group_2:en:Fats
-who_id:10
+who_id:en:10
 
 <en:Fats
 en:Animal fats
@@ -36063,6 +36928,7 @@ nova:en:2
 <en:Margarines
 en:50-63% blended fat with vegetable and animal origins
 fr:Matière grasse mélangée végétale et laitière à 50-63% MG
+agribalyse_food_code:en:16743
 ciqual_food_code:en:16743
 ciqual_food_name:en:Blended fat (vegetable and animal origins), 50-63% fat
 ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière) à 50-63% MG
@@ -36071,6 +36937,7 @@ ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière) à 50-6
 <en:Margarines
 en:50-63% lightly salted blended fat with vegetable and animal origins
 fr:Matière grasse mélangée végétale et laitière à 50-63% MG demi-sel
+agribalyse_food_code:en:16744
 ciqual_food_code:en:16744
 ciqual_food_name:en:Blended fat (vegetable and animal origins), 50-63% fat, lightly salted
 ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière) à 50-63% MG, demi-sel
@@ -36079,6 +36946,7 @@ ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière) à 50-6
 <en:Margarines
 en:30-40% blended fat with vegetable and animal origins
 fr:Matière grasse mélangée végétale et laitière à tartiner à 30-40% MG
+agribalyse_food_code:en:16745
 ciqual_food_code:en:16745
 ciqual_food_name:en:Blended fat (vegetable and animal origins), spreadable, 30-40% fat
 ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière), à tartiner, à 30-40% MG
@@ -36087,6 +36955,7 @@ ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière), à tar
 <en:Margarines
 en:30-40% lightly salted blended fat with vegetable and animal origins
 fr:Matière grasse mélangée végétale et laitière à tartiner à 30-40% MG demi-sel
+agribalyse_food_code:en:16746
 ciqual_food_code:en:16746
 ciqual_food_name:en:Blended fat (vegetable and animal origins), spreadable, 30-40% fat, lightly salted
 ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière), à tartiner, à 30-40% MG, demi-sel
@@ -36094,12 +36963,14 @@ ciqual_food_name:fr:Matière grasse mélangée (végétale et laitière), à tar
 <en:Fats
 en:Dairy fat 25% fat light spreadable unsalted
 fr:Matière grasse laitière à 25% MG légère à tartiner doux
+agribalyse_food_code:en:16712
 ciqual_food_code:en:16712
 ciqual_food_name:en:Dairy fat 25% fat, light, spreadable, unsalted
 
 <en:Fats
 en:Dairy fat 20% fat light spreadable unsalted
 fr:Matière grasse laitière à 20% MG légère à tartiner doux
+agribalyse_food_code:en:16713
 ciqual_food_code:en:16713
 ciqual_food_name:en:Dairy fat 20% fat, light, spreadable, unsalted
 
@@ -36111,6 +36982,7 @@ nl:Rundvetten
 <en:Animal fats
 en:Chicken fat
 fr:Graisse de poulet
+agribalyse_food_code:en:16540
 ciqual_food_code:en:16540
 ciqual_food_name:en:Chicken fat
 ciqual_food_name:fr:Graisse de poulet
@@ -36122,6 +36994,7 @@ fr:Graisse de canard, gras de canard
 hu:Kacsa zsír
 it:Grasso d'anatra
 nl:Eendenvetten
+agribalyse_food_code:en:16550
 ciqual_food_code:en:16550
 ciqual_food_name:en:Duck fat
 ciqual_food_name:fr:Graisse de canard
@@ -36133,6 +37006,7 @@ fr:Saindoux
 it:Lardo
 nl:Varkensreuzels
 wikidata:en:Q72827
+agribalyse_food_code:en:16520
 ciqual_food_code:en:16520
 ciqual_food_name:en:Lard or pork fat
 ciqual_food_name:fr:Saindoux
@@ -36143,6 +37017,7 @@ de:Gänsefette
 fr:Graisse d'oie, gras d'oie, graisse d'oies, gras d'oies
 hu:Liba zsírok
 nl:Ganzenvetten
+agribalyse_food_code:en:16560
 ciqual_food_code:en:16560
 ciqual_food_name:en:Goose fat
 ciqual_food_name:fr:Graisse d'oie
@@ -36150,6 +37025,7 @@ ciqual_food_name:fr:Graisse d'oie
 <en:Animal fats
 en:Turkey fat
 fr:Graisse de dinde
+agribalyse_food_code:en:16570
 ciqual_food_code:en:16570
 ciqual_food_name:en:Turkey fat
 ciqual_food_name:fr:Graisse de dinde
@@ -36172,6 +37048,7 @@ zh:黄油脂肪
 <en:Fish oils
 en:Sardine oils
 fr:Huiles de sardine
+agribalyse_food_code:en:17640
 ciqual_food_code:en:17640
 ciqual_food_name:en:Sardine oil
 ciqual_food_name:fr:Huile de sardine
@@ -36179,6 +37056,7 @@ ciqual_food_name:fr:Huile de sardine
 <en:Fish oils
 en:Salmon oils
 fr:Huiles de saumon
+agribalyse_food_code:en:17645
 ciqual_food_code:en:17645
 ciqual_food_name:en:Salmon oil
 ciqual_food_name:fr:Huile de saumon
@@ -36186,6 +37064,7 @@ ciqual_food_name:fr:Huile de saumon
 <en:Fish oils
 en:Herring oils
 fr:Huiles de hareng
+agribalyse_food_code:en:17650
 ciqual_food_code:en:17650
 ciqual_food_name:en:Herring oil
 ciqual_food_name:fr:Huile de hareng
@@ -36195,6 +37074,7 @@ en:Codliver fats, codliver oils, Cod liver oils
 fr:Huiles de foie de cabillaud, Huiles de foie de morue
 nl:Kabeljauwleveroliën
 zh:鱼肝油脂肪
+agribalyse_food_code:en:17630
 ciqual_food_code:en:17630
 ciqual_food_name:en:Cod liver oil
 ciqual_food_name:fr:Huile de foie de morue
@@ -36225,6 +37105,7 @@ fr:Beurres de cacao
 it:Burro di cacao
 nl:Cacaoboters
 wikidata:en:Q251106
+agribalyse_food_code:en:16030
 ciqual_food_code:en:16030
 ciqual_food_name:en:Cocoa butter
 ciqual_food_name:fr:Beurre de cacao
@@ -36274,6 +37155,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine), teneur réduite
 <en:Light unsalted margarines
 en:60% unsalted vegetable fat margarine type with sunflowerseed
 fr:Matière grasse végétale allégée à 60% type margarine doux au tournesol
+agribalyse_food_code:en:16654
 ciqual_food_code:en:16654
 ciqual_food_name:en:Vegetable fat (margarine type), 60% fat, unsalted, sunflowerseed
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 60% de MG, allégée, au tournesol, doux
@@ -36281,6 +37163,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 60% de MG, al
 <en:Light unsalted margarines
 en:30-40% unsalted vegetable fat margarine type
 fr:Matière grasse végétale légère à 30-40% type margarine doux
+agribalyse_food_code:en:16733
 ciqual_food_code:en:16733
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 30-40% fat, light, unsalted
 ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, doux
@@ -36288,6 +37171,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à
 <en:Light unsalted margarines
 en:30-40% unsalted vegetable fat margarine type with plant sterols esters
 fr:Matière grasse végétale légère à 30-40% type margarine doux aux esters de stérol végétal
+agribalyse_food_code:en:16735
 ciqual_food_code:en:16735
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 30-40% fat, light, unsalted, with plant sterols esters
 ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, doux, aux esters de stérol végétal
@@ -36295,6 +37179,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à
 <en:Light unsalted margarines
 en:30-40% unsalted vegetable fat margarine type high in omega 3
 fr:Matière grasse végétale légère à 30-40% type margarine doux riche en oméga 3
+agribalyse_food_code:en:16736
 ciqual_food_code:en:16736
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 30-40% fat, light, unsalted, rich in omega 3
 ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, doux, riche en oméga 3
@@ -36303,6 +37188,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à
 <en:Light margarines
 en:30-40% lightly salted vegetable fat margarine type
 fr:Matière grasse végétale légère à 30-40% type margarine doux demi-sel
+agribalyse_food_code:en:16734
 ciqual_food_code:en:16734
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 30-40% fat, light, lightly salted
 ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à 30-40% MG, légère, demi-sel
@@ -36311,6 +37197,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine), à tartiner, à
 <en:Light margarines
 en:50-63% lightly salted vegetable fat margarine type
 fr:Matière grasse végétale allégée à 50-63% type margarine demi-sel
+agribalyse_food_code:en:16738
 ciqual_food_code:en:16738
 ciqual_food_name:en:Vegetable fat (margarine type), 50-63% fat, light, lightly salted
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, allégée, demi-sel
@@ -36319,6 +37206,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, al
 <en:Light margarines
 en:50-63% lightly salted vegetable fat margarine type high in omega 3
 fr:Matière grasse végétale allégée à 50-63% type margarine demi-sel riche en oméga 3
+agribalyse_food_code:en:16740
 ciqual_food_code:en:16740
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 50-63% fat, light, lightly salted, rich in omega 3
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, allégée, demi-sel, riche en oméga 3
@@ -36327,6 +37215,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, al
 <en:Light margarines
 en:30-40% lightly salted vegetable fat margarine type with plant sterols esters
 fr:Matière grasse végétale légère à 30-40% type margarine demi-sel aux esters de stérol végétal
+agribalyse_food_code:en:16742
 ciqual_food_code:en:16742
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 30-40% fat, light, lightly salted, with plant sterols esters
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 30-40% MG, légère, demi-sel, aux esters de stérol végétal
@@ -36334,6 +37223,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 30-40% MG, l�
 <en:Salted margarines
 en:80% salted vegetable fat margarine type
 fr:Matière grasse végétale salée à 80% type margarine
+agribalyse_food_code:en:16614
 ciqual_food_code:en:16614
 ciqual_food_name:en:Vegetable fat (like margarine), 80% fat, salted
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 80% MG, salé
@@ -36341,6 +37231,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 80% MG, salé
 <en:Unsalted margarines
 en:80% unsalted vegetable fat margarine type
 fr:Matière grasse végétale à 80% type margarine doux
+agribalyse_food_code:en:16615
 ciqual_food_code:en:16615
 ciqual_food_name:en:Vegetable fat (margarine type), 80% fat, unsalted
 ciqual_food_name:fr:Matière grasse végétale ou margarine, 80% MG, doux
@@ -36348,6 +37239,7 @@ ciqual_food_name:fr:Matière grasse végétale ou margarine, 80% MG, doux
 <en:Unsalted margarines
 en:70% unsalted vegetable fat margarine type
 fr:Matière grasse végétale à 70% type margarine doux
+agribalyse_food_code:en:16616
 ciqual_food_code:en:16616
 ciqual_food_name:en:Vegetable fat (margarine type), 70% fat, unsalted
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 70% MG, doux
@@ -36355,6 +37247,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 70% MG, doux
 <en:Light unsalted margarines
 en:50-63% unsalted vegetable fat margarine type high in omega 3
 fr:Matière grasse végétale allégée à 50-63% de matières grasses riche en oméga 3, margarine douce
+agribalyse_food_code:en:16737
 ciqual_food_code:en:16737
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3
@@ -36362,6 +37255,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, al
 <en:Light unsalted margarines
 en:50-63% unsalted vegetable fat margarine type with plant sterols esters
 fr:Matière grasse végétale allégée à 50-63% type margarine doux aux esters de stérol végétal
+agribalyse_food_code:en:16739
 ciqual_food_code:en:16739
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, with plant sterols esters
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, aux esters de stérol végétal
@@ -36369,6 +37263,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, al
 <en:Light unsalted margarines
 en:50-63% unsalted vegetable fat margarine type
 fr:Matière grasse végétale allégée à 50-63% type margarine doux
+agribalyse_food_code:en:16741
 ciqual_food_code:en:16741
 ciqual_food_name:en:Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted
 ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux
@@ -36376,6 +37271,7 @@ ciqual_food_name:fr:Matière grasse végétale (type margarine) à 50-63% MG, al
 <en:Margarines
 en:Solid vegetable fat margarine type for frying
 fr:Matière grasse ou graisse végétale solide type margarine pour friture
+agribalyse_food_code:en:16080
 ciqual_food_code:en:16080
 ciqual_food_name:en:Solid vegetable fat (margarine type), for frying
 ciqual_food_name:fr:Matière grasse ou graisse végétale solide (type margarine) pour friture
@@ -36459,6 +37355,7 @@ wikidata:en:Q4944279
 <en:Vegetable oils
 en:Frying oil
 fr:Huile pour friture
+agribalyse_food_code:en:16128
 ciqual_food_code:en:16128
 ciqual_food_name:en:Frying oil
 ciqual_food_name:fr:Huile pour friture, sans précision
@@ -36491,6 +37388,7 @@ it:Olio di mais, Olio di semi di mais
 nl:Maïs-oliën
 zh:玉米油
 wikidata:en:Q856775
+agribalyse_food_code:en:17190
 ciqual_food_code:en:17190
 ciqual_food_name:en:Maize/corn oil
 ciqual_food_name:fr:Huile de maïs
@@ -36505,6 +37403,7 @@ nl:Lijnzaadoliën
 sv:Linoljor, Linolja
 zh:亚麻籽油
 wikidata:en:Q818405
+agribalyse_food_code:en:17180
 ciqual_food_code:en:17180
 ciqual_food_name:en:Linseed oil
 
@@ -36528,6 +37427,7 @@ nl:Sesamoliën
 sv:Sesamoljor, Sesamolja
 zh:芝麻油
 wikidata:en:Q212317
+agribalyse_food_code:en:17400
 ciqual_food_code:en:17400
 ciqual_food_name:en:Sesame oil
 ciqual_food_name:fr:Huile de sésame
@@ -36546,6 +37446,7 @@ ciqual_food_name:fr:Huile de germe de blé
 <en:Vegetable oils
 en:Combined oil (blended vegetable oils)
 fr:Huile combinée (mélange d'huiles)
+agribalyse_food_code:en:17700
 ciqual_food_code:en:17700
 ciqual_food_name:en:Combined oil (blended vegetable oils)
 
@@ -36558,6 +37459,7 @@ nl:Katoenzaadoliën
 sv:Bomullsfröoljor, Bomullsfröolja
 zh:棉籽油
 wikidata:en:Q811663
+agribalyse_food_code:en:17170
 ciqual_food_code:en:17170
 ciqual_food_name:en:Cottonseed oil
 ciqual_food_name:fr:Huile de coton
@@ -36615,6 +37517,7 @@ fi:viinirypälesiemenöljyt
 fr:Huiles de pépins de raisins
 nl:Druivenpitoliën
 wikidata:en:Q898982
+agribalyse_food_code:en:17350
 ciqual_food_code:en:17350
 ciqual_food_name:en:Grapeseed oil
 ciqual_food_name:fr:Huile de pépins de raisin
@@ -36657,6 +37560,7 @@ nl:Pindaoliën, Aardnotenoliën, Arachidëneoliën
 sv:Jordnötsoljor, Jordnötsolja
 zh:花生油
 wikidata:en:Q265878
+agribalyse_food_code:en:17040
 ciqual_food_code:en:17040
 ciqual_food_name:en:Peanut oil
 
@@ -36670,6 +37574,7 @@ sv:Sojaoljor, sojaolja
 zh:大豆油
 wikidata:en:Q926892
 fr:Huile de soja
+agribalyse_food_code:en:17420
 ciqual_food_code:en:17420
 ciqual_food_name:en:Soy oil
 
@@ -36726,6 +37631,7 @@ it:Olio di nocciole
 nl:Hazelnootoliën
 zh:榛子油
 wikidata:en:Q1112606
+agribalyse_food_code:en:17210
 ciqual_food_code:en:17210
 ciqual_food_name:en:Hazelnut oil
 
@@ -36812,6 +37718,7 @@ hu:Extra szűz olívaolajok, Extra szűz olívaolaj
 it:Olio extra vergine di oliva
 nl:Extra vierge olijfoliën
 pt:Azeites virgem extra
+agribalyse_food_code:en:17270
 ciqual_food_code:en:17270
 ciqual_food_name:en:Olive oil, extra virgin
 ciqual_food_name:fr:Huile d'olive vierge extra
@@ -36919,6 +37826,7 @@ country:en:Italy
 <en:Vegetable oils
 en:Combined oil, Mix of olive oil and seeds oil
 fr:Huile combinée, Mélange d'huile d'olive et de graines
+agribalyse_food_code:en:17701
 ciqual_food_code:en:17701
 ciqual_food_name:en:Combined oil (mix of olive oil and seeds oil)
 ciqual_food_name:fr:Huile combinée, mélange d'huile d'olive et de graines
@@ -36949,6 +37857,7 @@ nl:Palmoliën
 sv:Palmoljor, Palmolja
 zh:棕榈油
 wikidata:en:Q231458
+agribalyse_food_code:en:16129
 ciqual_food_code:en:16129
 ciqual_food_name:en:Palm oil
 
@@ -36956,6 +37865,7 @@ ciqual_food_name:en:Palm oil
 <en:Palm oils
 en:Palm oil refined
 fr:Huile de palme raffinée
+agribalyse_food_code:en:16150
 ciqual_food_code:en:16150
 ciqual_food_name:en:Palm oil, refined
 
@@ -36987,6 +37897,7 @@ it:Olio di colza
 nl:Koolzaadoliën
 sv:Rovoljor, Rapsoljor, rapsolja
 wikidata:en:Q1790872
+agribalyse_food_code:en:17130
 ciqual_food_code:en:17130
 ciqual_food_name:en:Rapeseed oil
 ciqual_food_name:fr:Huile de colza
@@ -36994,6 +37905,7 @@ ciqual_food_name:fr:Huile de colza
 <en:Fats
 en:Butter oil or concentrated butter
 fr:Huile de beurre, Beurre concentré
+agribalyse_food_code:en:16401
 ciqual_food_code:en:16401
 ciqual_food_name:en:Butter oil or concentrated butter
 
@@ -37073,6 +37985,7 @@ ru:Масло подсолнечное, Подсолнечное масло
 sv:Solrosoljor, Solrosolja
 zh:葵花籽油
 wikidata:en:Q94787
+agribalyse_food_code:en:17440
 ciqual_food_code:en:17440
 ciqual_food_name:en:Sunflower oil
 
@@ -37172,6 +38085,7 @@ es:Salvados de avena
 fr:Sons d’avoine, Son d'avoine
 it:Crusche di avena
 nl:Haverzemelen
+agribalyse_food_code:en:9640
 ciqual_food_code:en:9640
 ciqual_food_name:en:Oat bran
 ciqual_food_name:fr:Son d'avoine
@@ -37182,6 +38096,7 @@ es:Salvados de arroz
 fr:Sons de riz, Son de riz
 it:Crusche di riso
 nl:Rijstzemelen
+agribalyse_food_code:en:9643
 ciqual_food_code:en:9643
 ciqual_food_name:en:Rice bran
 ciqual_food_name:fr:Son de riz
@@ -37196,6 +38111,7 @@ nl:Roggezemelen
 <en:Cereal brans
 en:Maize bran, Corn bran
 fr:Son de maïs
+agribalyse_food_code:en:9641
 ciqual_food_code:en:9641
 ciqual_food_name:en:Maize/corn bran
 ciqual_food_name:fr:Son de maïs
@@ -37206,6 +38122,7 @@ es:Salvados de trigo
 fr:Sons de blé, Son des blé, Son de blé
 it:Crusche di grano
 nl:Tarwezemelen
+agribalyse_food_code:en:9621
 ciqual_food_code:en:9621
 ciqual_food_name:en:Wheat bran
 ciqual_food_name:fr:Son de blé
@@ -37245,7 +38162,7 @@ pnns_group_2:en:Breakfast cereals
 ciqual_food_code:en:32003
 ciqual_food_name:en:Breakfast cereals, sweet (average)
 ciqual_food_name:fr:Céréales pour petit déjeuner (aliment moyen)
-who_id:6
+who_id:en:6
 
 <en:Breakfast cereals
 en:Sweet breakfast cereals fortified with vitamins and chemical elements
@@ -37272,6 +38189,7 @@ nl:Chocolade ontbijtgranen
 <en:Chocolate cereals
 en:Breakfast chocolate cereals with wheat grain flakes not fortified with vitamins and chemical elements
 fr:Pétales de blé chocolatés non enrichis en vitamines et minéraux
+agribalyse_food_code:en:32011
 ciqual_food_code:en:32011
 ciqual_food_name:en:Breakfast cereals, chocolate wheat grain flakes (not fortified with vitamins and chemical elements)
 ciqual_food_name:fr:Pétales de blé chocolatés (non enrichis en vitamines et minéraux)
@@ -37279,6 +38197,7 @@ ciqual_food_name:fr:Pétales de blé chocolatés (non enrichis en vitamines et m
 <en:Chocolate cereals
 en:Breakfast chocolate cereals not filled, not fortified with vitamins and chemical elements
 fr:Céréales chocolatées pour petit-déjeuner non fourrées, non enrichies en vitamines et minéraux
+agribalyse_food_code:en:32013
 ciqual_food_code:en:32013
 ciqual_food_name:en:Breakfast cereals, with chocolate, not filled (not fortified with vitamins and chemical elements)
 ciqual_food_name:fr:Céréales chocolatées pour petit déjeuner, non fourrées, (non enrichies en vitamines et minéraux)
@@ -37286,6 +38205,7 @@ ciqual_food_name:fr:Céréales chocolatées pour petit déjeuner, non fourrées,
 <en:Chocolate cereals
 en:Diet chocolate breakfast cereals fortified with vitamins and chemical elements
 fr:Céréales au chocolat pour petit-déjeuner équilibré enrichies en vitamines et minéraux
+agribalyse_food_code:en:32022
 ciqual_food_code:en:32022
 ciqual_food_name:en:Breakfast cereals, diet, with chocolate, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Céréales pour petit déjeuner équilibre au chocolat, enrichies en vitamines et minéraux
@@ -37293,6 +38213,7 @@ ciqual_food_name:fr:Céréales pour petit déjeuner équilibre au chocolat, enri
 <en:Chocolate cereals
 en:Diet chocolate breakfast cereals not fortified
 fr:Céréales au chocolat pour petit-déjeuner équilibré non enrichies en vitamines et minéraux
+agribalyse_food_code:en:32028
 ciqual_food_code:en:32028
 ciqual_food_name:en:Breakfast cereals, diet, with chocolate, not fortified
 ciqual_food_name:fr:Céréales pour petit déjeuner équilibre au chocolat (non enrichies en vitamines et minéraux)
@@ -37301,6 +38222,7 @@ ciqual_food_name:fr:Céréales pour petit déjeuner équilibre au chocolat (non 
 <en:Puffed cereals
 en:Chocolate breakfast cereals with puffed wheat grains fortified with vitamins and chemical elements, Chocolate breakfast cereals with popped wheat grains fortified with vitamins and chemical elements
 fr:Grains de blé soufflés chocolatés enrichis en vitamines et minéraux
+agribalyse_food_code:en:32115
 ciqual_food_code:en:32115
 ciqual_food_name:en:Breakfast cereals, chocolate puffed/popped wheat grain, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Grains de blé soufflés chocolatés, enrichis en vitamines et minéraux
@@ -37324,6 +38246,7 @@ ciqual_food_name:fr:Riz soufflé chocolaté, enrichi en vitamines et minéraux
 <en:Chocolate cereals
 en:Breakfast chocolate cereals with wheat grain flakes fortified with vitamins and chemical elements
 fr:Pétales de blé chocolatés enrichis en vitamines et minéraux
+agribalyse_food_code:en:32009
 ciqual_food_code:en:32009
 ciqual_food_name:en:Breakfast cereals, chocolate wheat grain flakes, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Pétales de blé chocolatés, enrichis en vitamines et minéraux
@@ -37331,6 +38254,7 @@ ciqual_food_name:fr:Pétales de blé chocolatés, enrichis en vitamines et miné
 <en:Chocolate cereals
 en:Breakfast chocolate high-fiber cereals fortified with vitamins and chemical elements
 fr:Céréales au chocolat riches en fibres pour petit déjeuner enrichies en vitamines et minéraux
+agribalyse_food_code:en:32008
 ciqual_food_code:en:32008
 ciqual_food_name:en:Breakfast cereals, rich in fibre, with chocolate, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Céréales pour petit déjeuner riches en fibres, au chocolat, enrichies en vitamines et minéraux
@@ -37338,6 +38262,7 @@ ciqual_food_name:fr:Céréales pour petit déjeuner riches en fibres, au chocola
 <en:Chocolate cereals
 en:Breakfast chocolate cereals not filled, fortified with vitamins and chemical elements
 fr:Céréales chocolatées pour petit déjeuner non fourrées, enrichies en vitamines et minéraux
+agribalyse_food_code:en:32001
 ciqual_food_code:en:32001
 ciqual_food_name:en:Breakfast cereals, with chocolate, not filled, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Céréales pour petit déjeuner chocolatées, non fourrées, enrichies en vitamines et minéraux
@@ -37364,6 +38289,7 @@ nl:Gevulde ontbijtgranen
 <en:Filled cereals
 en:Breakfast cereals filled with chocolate or chocolate-hazelnuts fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes enrichies en vitamines et minéraux
+agribalyse_food_code:en:32016
 ciqual_food_code:en:32016
 ciqual_food_name:en:Breakfast cereals, filled with chocolate or chocolate-hazelnuts, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes, enrichies en vitamines et minéraux
@@ -37371,6 +38297,7 @@ ciqual_food_name:fr:Céréales pour petit déjeuner fourrées au chocolat ou cho
 <en:Filled cereals
 en:Breakfast cereals filled with chocolate or chocolate-hazelnuts
 fr:Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes
+agribalyse_food_code:en:32017
 ciqual_food_code:en:32017
 ciqual_food_name:en:Breakfast cereals, filled with chocolate or chocolate-hazelnuts
 ciqual_food_name:fr:Céréales pour petit déjeuner fourrées au chocolat ou chocolat-noisettes
@@ -37378,6 +38305,7 @@ ciqual_food_name:fr:Céréales pour petit déjeuner fourrées au chocolat ou cho
 <en:Filled cereals
 en:Breakfast cereals filled with something other than chocolate fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner fourrées fourrage autre que chocolat enrichies en vitamines et minéraux
+agribalyse_food_code:en:32018
 ciqual_food_code:en:32018
 ciqual_food_name:en:Breakfast cereals, filled with a filling other than chocolate, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Céréales pour petit déjeuner fourrées avec autre chose que du chocolat (enrichies en vitamines et minéraux)
@@ -37385,102 +38313,119 @@ ciqual_food_name:fr:Céréales pour petit déjeuner fourrées avec autre chose q
 <en:Filled cereals
 en:Breakfast cereals popped wheat grain with honey or caramel fortified with vitamins and chemical elements, Breakfast cereals puffed wheat grain with honey or caramel fortified with vitamins and chemical elements
 fr:Grains de blé soufflés au miel ou caramel enrichis en vitamines et minéraux
+agribalyse_food_code:en:32000
 ciqual_food_code:en:32000
 ciqual_food_name:en:Breakfast cereals, popped or puffed wheat grain, with honey or caramel, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals rich in fibre with or without fruits fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner riches en fibres avec ou sans fruits enrichies en vitamines et minéraux
+agribalyse_food_code:en:32002
 ciqual_food_code:en:32002
 ciqual_food_name:en:Breakfast cereals, rich in fibre, with or without fruits, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals corn flakes plain fortified with vitamins and chemical elements
 fr:Pétales de maïs natures enrichis en vitamines et minéraux
+agribalyse_food_code:en:32005
 ciqual_food_code:en:32005
 ciqual_food_name:en:Breakfast cereals, corn flakes, plain, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals corn flakes plain (not fortified with vitamins and chemical elements)
 fr:Pétales de maïs natures (non enrichis en vitamines et minéraux)
+agribalyse_food_code:en:32014
 ciqual_food_code:en:32014
 ciqual_food_name:en:Breakfast cereals, corn flakes, plain (not fortified with vitamins and chemical elements)
 
 <en:Filled cereals
 en:Breakfast cereals diet plain or with honey fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner équilibre nature ou au miel enrichies en vitamines et minéraux
+agribalyse_food_code:en:32021
 ciqual_food_code:en:32021
 ciqual_food_name:en:Breakfast cereals, diet, plain or with honey, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals diet with fruits fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner équilibre aux fruits enrichies en vitamines et minéraux
+agribalyse_food_code:en:32023
 ciqual_food_code:en:32023
 ciqual_food_name:en:Breakfast cereals, diet, with fruits, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals diet with dried fruits fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner équilibre aux fruits secs (à coque) enrichis en vitamines et minéraux
+agribalyse_food_code:en:32025
 ciqual_food_code:en:32025
 ciqual_food_name:en:Breakfast cereals, diet, with dried fruits, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals diet with fruits not fortified
 fr:Céréales pour petit déjeuner équilibre aux fruits (non enrichies en vitamines et minéraux)
+agribalyse_food_code:en:32029
 ciqual_food_code:en:32029
 ciqual_food_name:en:Breakfast cereals, diet, with fruits, not fortified
 
 <en:Filled cereals
 en:Breakfast cereals diet plain not fortified
 fr:Céréales pour petit déjeuner équilibre nature (non enrichies en vitamines et minéraux)
+agribalyse_food_code:en:32030
 ciqual_food_code:en:32030
 ciqual_food_name:en:Breakfast cereals, diet, plain, not fortified
 
 <en:Filled cereals
 en:Breakfast cereals corn flakes sugar iced (not fortified with vitamins and chemical elements)
 fr:Pétales de maïs glacés au sucre (non enrichis en vitamines et minéraux)
+agribalyse_food_code:en:32107
 ciqual_food_code:en:32107
 ciqual_food_name:en:Breakfast cereals, corn flakes, sugar iced (not fortified with vitamins and chemical elements)
 
 <en:Filled cereals
 en:Breakfast cereals very rich in fibre fortified with vitamins and chemical elements
 fr:Céréales pour petit déjeuner très riches en fibres enrichies en vitamines et minéraux
+agribalyse_food_code:en:32116
 ciqual_food_code:en:32116
 ciqual_food_name:en:Breakfast cereals, very rich in fibre, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals corn flakes sugar iced fortified with vitamins and chemical elements
 fr:Pétales de maïs glacés au sucre enrichis en vitamines et minéraux
+agribalyse_food_code:en:32121
 ciqual_food_code:en:32121
 ciqual_food_name:en:Breakfast cereals, corn flakes, sugar iced, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals wheat flakes with walnuts hazelnuts or almonds fortified with vitamins and chemical elements
 fr:Pétales de blé avec noix noisettes ou amandes enrichis en vitamines et minéraux
+agribalyse_food_code:en:32123
 ciqual_food_code:en:32123
 ciqual_food_name:en:Breakfast cereals, wheat flakes with walnuts, hazelnuts or almonds, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals puffed corn with honey not fortified with vitamins and chemical elements, Breakfast cereals popped corn with honey not fortified with vitamins and chemical elements
 fr:Boules de maïs soufflées au miel (non enrichies en vitamines et minéraux)
+agribalyse_food_code:en:32129
 ciqual_food_code:en:32129
 ciqual_food_name:en:Breakfast cereals, puffed/popped corn, with honey (not fortified with vitamins and chemical elements)
 
 <en:Filled cereals
 en:Breakfast cereals puffed corn with honey fortified with vitamins and chemical elements, Breakfast cereals popped corn with honey fortified with vitamins and chemical elements
 fr:Boules de maïs soufflées au miel enrichies en vitamines et minéraux
+agribalyse_food_code:en:32133
 ciqual_food_code:en:32133
 ciqual_food_name:en:Breakfast cereals, puffed/popped corn, with honey, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals puffed cereals wholemeal fortified with vitamins and chemical elements, Breakfast cereals popped cereals wholemeal fortified with vitamins and chemical elements
 fr:Céréales complètes soufflées enrichies en vitamines et minéraux
+agribalyse_food_code:en:32134
 ciqual_food_code:en:32134
 ciqual_food_name:en:Breakfast cereals, puffed/popped cereals, wholemeal, fortified with vitamins and chemical elements
 
 <en:Filled cereals
 en:Breakfast cereals mix of puffed cereals fortified with vitamins and chemical elements, Breakfast cereals mix of extruded cereals fortified with vitamins and chemical elements
 fr:Multi-céréales soufflées ou extrudées enrichies en vitamines et minéraux
+agribalyse_food_code:en:32135
 ciqual_food_code:en:32135
 ciqual_food_name:en:Breakfast cereals, mix of puffed or extruded cereals, fortified with vitamins and chemical elements
 
@@ -37554,6 +38499,10 @@ it:Muesli con cioccolato
 nl:Muesli met chocola
 pl:Musli czekoladowe, musli z czekoladą
 ro:Müsli cu ciocolată
+
+<en:Mueslis
+en:Crunchy chocolate muesli fortified with vitamins and chemical elements
+fr:Muesli croustillant au chocolat enrichi en vitamines et minéraux
 agribalyse_food_code:en:32112
 ciqual_food_code:en:32112
 ciqual_food_name:en:Muesli, crunchy, with chocolate, with or without fruits, fortified with vitamins and chemical elements
@@ -37576,6 +38525,7 @@ it:Muesli con nocciole
 <en:Mueslis
 en:Crunchy Muesli with fruits not fortified with vitamins and chemical elements, Crunchy Muesli with fruits dried fruits grains not fortified with vitamins and chemical elements
 fr:Muesli croustillant aux fruits non enrichi en vitamines et minéraux, Muesli croustillant aux fruits secs et aux graines non enrichi en vitamines et minéraux
+agribalyse_food_code:en:32108
 ciqual_food_code:en:32108
 ciqual_food_name:en:Muesli, crunchy, with fruits and/or dried fruits, grains (not fortified with vitamins and chemical elements)
 ciqual_food_name:fr:Muesli croustillant aux fruits et/ou fruits secs, graines (non enrichi en vitamines et minéraux)
@@ -37583,6 +38533,7 @@ ciqual_food_name:fr:Muesli croustillant aux fruits et/ou fruits secs, graines (n
 <en:Mueslis
 en:Muesli flakes, Bircher-style muesli flakes
 fr:Muesli floconneux, Muesli en flocons, Flocons de muesli
+agribalyse_food_code:en:32128
 ciqual_food_code:en:32128
 ciqual_food_name:en:Muesli, flakes (Bircher-style)
 ciqual_food_name:fr:Muesli floconneux ou de type traditionnel
@@ -37604,6 +38555,7 @@ ciqual_food_name:fr:Muesli non enrichi en vitamines et minéraux (aliment moyen)
 <en:Muesli flakes
 en:Bircher-style muesli flakes with fruits fortified with vitamins and chemical elements, Bircher-style muesli flakes with dried fruits fortified with vitamins and chemical elements
 fr:Muesli floconneux aux fruits enrichi en vitamines et minéraux, Muesli floconneux aux fruits secs enrichi en vitamines et minéraux
+agribalyse_food_code:en:32110
 ciqual_food_code:en:32110
 ciqual_food_name:en:Muesli, flakes (Bircher-style), with fruits or dried fruits, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Muesli floconneux aux fruits ou fruits secs, enrichi en vitamines et minéraux
@@ -37611,6 +38563,7 @@ ciqual_food_name:fr:Muesli floconneux aux fruits ou fruits secs, enrichi en vita
 <en:Muesli flakes
 en:Bircher-style sugar free Muesli flakes with fruits, Bircher-style sugar free Muesli flakes with dried fruits
 fr:Muesli floconneux aux fruits sans sucres ajoutés, Muesli floconneux aux fruits secs sans sucres ajoutés
+agribalyse_food_code:en:32113
 ciqual_food_code:en:32113
 ciqual_food_name:en:Muesli, flakes (Bircher-style), with fruits or dried fruits, without sugar
 ciqual_food_name:fr:Muesli floconneux aux fruits ou fruits secs, sans sucres ajoutés
@@ -37618,6 +38571,7 @@ ciqual_food_name:fr:Muesli floconneux aux fruits ou fruits secs, sans sucres ajo
 <en:Mueslis
 en:Crunchy muesli with fruits fortified with vitamins and chemical elements, Crunchy muesli with dried fruits fortified with vitamins and chemical elements
 fr:Muesli croustillant aux fruits enrichi en vitamines et minéraux, Muesli croustillant aux fruits secs enrichi en vitamines et minéraux
+agribalyse_food_code:en:32111
 ciqual_food_code:en:32111
 ciqual_food_name:en:Muesli, crunchy, with fruits or dried fruits, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Muesli croustillant aux fruits ou fruits secs, enrichi en vitamines et minéraux
@@ -37625,6 +38579,7 @@ ciqual_food_name:fr:Muesli croustillant aux fruits ou fruits secs, enrichi en vi
 <en:Muesli flakes
 en:Bircher-style muesli flakes with fruits not fortified with vitamins and chemical elements, Bircher-style muesli flakes with dried fruits not fortified with vitamins and chemical elements
 fr:Muesli floconneux aux fruits non enrichi en vitamines et minéraux, Muesli floconneux aux fruits secs non enrichi en vitamines et minéraux
+agribalyse_food_code:en:32138
 ciqual_food_code:en:32138
 ciqual_food_name:en:Muesli, flakes (Bircher-style), with fruits or dried fruits (not fortified with vitamins and chemical elements)
 ciqual_food_name:fr:Muesli floconneux aux fruits ou fruits secs (non enrichi en vitamines et minéraux)
@@ -37632,6 +38587,7 @@ ciqual_food_name:fr:Muesli floconneux aux fruits ou fruits secs (non enrichi en 
 <en:Mueslis
 en:Crunchy muesli with chocolate not fortified with vitamins and chemical elements
 fr:Muesli croustillant au chocolat non enrichi en vitamines et minéraux
+agribalyse_food_code:en:32109
 ciqual_food_code:en:32109
 ciqual_food_name:en:Muesli, crunchy, with chocolate (not fortified with vitamins and chemical elements)
 ciqual_food_name:fr:Muesli croustillant au chocolat (non enrichi en vitamines et minéraux)
@@ -37689,6 +38645,7 @@ nl:Havermoutvlokken, Havermouten
 nl_be:Havervlokken
 pt:Flocos de avena
 ru:Овсяные хлопья, Хлопья овсяные
+agribalyse_food_code:en:9311
 ciqual_food_code:en:9311
 ciqual_food_name:en:Oatmeal flakes
 ciqual_food_name:fr:Flocon d'avoine
@@ -37696,6 +38653,7 @@ ciqual_food_name:fr:Flocon d'avoine
 <en:Oat flakes
 en:Raw pre-cooked oat flakes
 fr:Flocons d'avoine précuits
+agribalyse_food_code:en:32140
 ciqual_food_code:en:32140
 ciqual_food_name:en:Oat flakes, pre-cooked, raw
 ciqual_food_name:fr:Flocon d'avoine précuit
@@ -37703,6 +38661,7 @@ ciqual_food_name:fr:Flocon d'avoine précuit
 <en:Oat flakes
 en:Boiled oat flakes, Oat flakes cooked in water
 fr:Flocons d'avoine bouillis, Flocons d'avoine cuits à l'eau
+agribalyse_food_code:en:9313
 ciqual_food_code:en:9313
 ciqual_food_name:en:Oat flakes, boiled/cooked in water
 ciqual_food_name:fr:Flocons d'avoine, bouillis/cuits à l'eau
@@ -37817,6 +38776,7 @@ oqali_family:en: fr:Aperitifs a croquer - Pop corn
 <en:Popcorn
 en:Plain popcorn, Unsalted pop-corn, Unsalted air-popped maize
 fr:Popcorn nature, Pop-corn non salé, Maïs éclaté à l'air non salé
+agribalyse_food_code:en:9231
 ciqual_food_code:en:9231
 ciqual_food_name:en:Pop-corn or air-popped maize, unsalted
 ciqual_food_name:fr:Pop-corn ou Maïs éclaté, à l'air, non salé
@@ -37832,6 +38792,7 @@ hu:sós popkorn
 it:Popcorn salati
 nl:Gezouten popcorn
 pnns_group_2:en:Salty and fatty products
+agribalyse_food_code:en:9230
 ciqual_food_code:en:9230
 ciqual_food_name:en:Pop-corn or oil popped maize, salted
 ciqual_food_name:fr:Pop-corn ou Maïs éclaté, à l'huile, salé
@@ -37848,6 +38809,7 @@ nl:Zoete popcorn
 <en:Popcorn
 en:Popcorn with caramel, Popped maize with caramel, Popcorn with caramel
 fr:Popcorn au caramel, Maïs éclaté au caramel, Popcorn au caramel
+agribalyse_food_code:en:9232
 ciqual_food_code:en:9232
 ciqual_food_name:en:Pop-corn or popped maize, with caramel
 ciqual_food_name:fr:Pop-corn ou Maïs éclaté, au caramel
@@ -37947,6 +38909,7 @@ de:Gerstenmehl
 ka:ქერის ფქვილი
 nb:byggmel
 it:Farina d'orzo
+agribalyse_food_code:en:9550
 ciqual_food_code:en:9550
 ciqual_food_name:en:Barley flour
 ciqual_food_name:fr:Farine d'orge
@@ -37968,6 +38931,7 @@ fr:Farines de sarrasin, Farines de blé noir
 hu:Hajdina liszt
 it:Farine di grano saraceno
 nl:Boekweitmelen
+agribalyse_food_code:en:9540
 ciqual_food_code:en:9540
 ciqual_food_name:en:Buckwheat flour
 ciqual_food_name:fr:Farine de sarrasin
@@ -37996,6 +38960,7 @@ fr:Farines de maïs, farine de maïs
 it:Farine di mais
 nl:Maïsmeel, Maïsmelen
 wikidata:en:Q837118
+agribalyse_food_code:en:9545
 ciqual_food_code:en:9545
 ciqual_food_name:en:Maize/corn flour
 ciqual_food_name:fr:Farine de maïs
@@ -38045,6 +39010,7 @@ es:Harinas de mijo
 fr:Farines de millet
 it:Farine di miglio
 nl:Gierstmelen
+agribalyse_food_code:en:9555
 ciqual_food_code:en:9555
 ciqual_food_name:en:Millet flour
 ciqual_food_name:fr:Farine de millet
@@ -38079,6 +39045,7 @@ fr:Farines de riz, farine de riz
 it:Farine di riso
 nl:Rijstmelen
 wikidata:en:Q1269205
+agribalyse_food_code:en:9520
 ciqual_food_code:en:9520
 ciqual_food_name:en:Rice flour
 ciqual_food_name:fr:Farine de riz
@@ -38099,6 +39066,7 @@ agribalyse_proxy_food_name:fr:Farine de seigle T85
 en:Rye flours Type 130
 fr:Farines de seigle T130, farines complètes de seigle
 nl:Roggemelen T130
+agribalyse_food_code:en:9533
 ciqual_food_code:en:9533
 ciqual_food_name:en:Rye flour, type 130
 ciqual_food_name:fr:Farine de seigle T130
@@ -38108,6 +39076,7 @@ en:Rye flours Type 1740, Rye flours type 170
 de:Roggenmehle Type 1740
 fr:Farines de seigle T170, farines intégrales de seigle
 nl:Roggemelen Type 1740
+agribalyse_food_code:en:9530
 ciqual_food_code:en:9530
 ciqual_food_name:en:Rye flour, type 170
 ciqual_food_name:fr:Farine de seigle T170
@@ -38123,6 +39092,7 @@ en:Rye flours Type 997, Rye flours type 85
 de:Roggenmehle Type 997
 fr:Farines de seigle T85, farines bise de seigle, farines semi-complètes de seigle
 nl:Roggemelen Type 997
+agribalyse_food_code:en:9532
 ciqual_food_code:en:9532
 ciqual_food_name:en:Rye flour, type 85
 ciqual_food_name:fr:Farine de seigle T85
@@ -38169,6 +39139,7 @@ wikidata:en:Q2249305
 <en:Wheat flours
 en:Self-raising wheat flour
 fr:Farine de blé tendre avec levure incorporée, Farine de froment avec levure incorporée
+agribalyse_food_code:en:9437
 ciqual_food_code:en:9437
 ciqual_food_name:en:Wheat flour, self-raising
 ciqual_food_name:fr:Farine de blé tendre ou froment avec levure incorporée
@@ -38178,6 +39149,7 @@ en:Wheat flour T405, Wheat flour type 45 for pastry
 de:Weizenmehle Type 405
 fr:Farines de blé type T45, Farines de blé T45, Farines de blé type 45, farines à pâtisserie de blé, fleurs de farine de blé, Farine de blé tendre T45 pour pâtisserie, Farine de froment T45 pour pâtisserie
 nl:Tarwemeel T405
+agribalyse_food_code:en:9440
 ciqual_food_code:en:9440
 ciqual_food_name:en:Wheat flour, type 45 (for pastry)
 ciqual_food_name:fr:Farine de blé tendre ou froment T45 (pour pâtisserie)
@@ -38190,6 +39162,7 @@ es:Harinas de trigo blancas
 fi:valkoiset vehnäjauhot
 fr:Farines de blé type T55, Farines de blé T55, Farines de blé type 55, farines blanches de blé, Farine de blé tendre T55 pour pains
 nl:Witte tarwebloem
+agribalyse_food_code:en:9436
 ciqual_food_code:en:9436
 ciqual_food_name:en:Wheat flour, type 55 (for bread)
 ciqual_food_name:fr:Farine de blé tendre ou froment T55 (pour pains)
@@ -38200,6 +39173,7 @@ es:Harinas de trigo común blancas, Harinas de trigo harinero blancas
 fr:Farines de froment T55, Farines de froment T55 pour pains
 nl:Gewone witte tarwemelen
 ro:Faina albă de grâu
+agribalyse_food_code:en:9436
 ciqual_food_code:en:9436
 ciqual_food_name:en:Wheat flour, type 55 (for bread)
 ciqual_food_name:fr:Farine de blé tendre ou froment T55 (pour pains)
@@ -38212,6 +39186,7 @@ en:Semi-polished wheat flours, Wheat flour type 80, Wheat flour T80
 es:Harinas de trigo semi-integrales
 fr:Farines de blé type T80, Farines de blé T80, Farines de blé type 80, farines bises de blé, farines semi-complète de blé, Farine de blé tendre T80
 nl:Half-gepolijst tarwemeel
+agribalyse_food_code:en:9445
 ciqual_food_code:en:9445
 ciqual_food_name:en:Wheat flour, type 80
 ciqual_food_name:fr:Farine de blé tendre ou froment T80
@@ -38221,6 +39196,7 @@ ciqual_food_name:fr:Farine de blé tendre ou froment T80
 en:Semi-polished common wheat flours
 es:Harinas de trigo común semi-integrales
 fr:Farines de froment T80, Farine de froment T80
+agribalyse_food_code:en:9445
 ciqual_food_code:en:9445
 ciqual_food_name:en:Wheat flour, type 80
 ciqual_food_name:fr:Farine de blé tendre ou froment T80
@@ -38231,6 +39207,9 @@ es:Harinas de trigo blando, Harinas de trigo común, Harinas de trigo harinero
 fr:Farines de froment, Farines de blé tendre
 it:Farine di grano tenero
 nl:Gewone tarwemelen, Gewoon tarwemeel
+agribalyse_proxy_food_code:en:9410
+agribalyse_proxy_food_name:en:Wheat flour, type 110
+agribalyse_proxy_food_name:fr:Farine de blé tendre ou froment T110
 
 <en:Common wheat flours
 <en:Wheat flour T405
@@ -38239,6 +39218,7 @@ fr:Farines de froment T45
 
 <en:Common wheat flours
 fr:Farines de froment T65, Farine de froment T65
+agribalyse_food_code:en:9435
 ciqual_food_code:en:9435
 ciqual_food_name:en:Wheat flour, type 65
 ciqual_food_name:fr:Farine de blé tendre ou froment T65
@@ -38248,6 +39228,7 @@ en:Wheat flour type 65, Wheat flour T65
 fr:Farines de blé type T65, Farines de blé T65, Farines de blé type 65, farines de tradition française de blé, Farine de blé tendre T65
 de:Weizenmehle Type 812
 nl:Tarwemelen T65
+agribalyse_food_code:en:9435
 ciqual_food_code:en:9435
 ciqual_food_name:en:Wheat flour, type 65
 ciqual_food_name:fr:Farine de blé tendre ou froment T65
@@ -38255,6 +39236,7 @@ ciqual_food_name:fr:Farine de blé tendre ou froment T65
 <en:Common wheat flours
 <fr:Farines de blé type T110
 fr:Farines de froment T110
+agribalyse_food_code:en:9410
 ciqual_food_code:en:9410
 ciqual_food_name:en:Wheat flour, type 110
 ciqual_food_name:fr:Farine de blé tendre ou froment T110
@@ -38271,6 +39253,7 @@ en:Whole common wheat flours
 es:Harinas de trigo común integrales
 fr:Farines de froment T150, Farine de froment T150
 nl:Gewone volkoren tarwemelen
+agribalyse_food_code:en:9415
 ciqual_food_code:en:9415
 ciqual_food_name:en:Wheat flour, type 150
 ciqual_food_name:fr:Farine de blé tendre ou froment T150
@@ -38282,6 +39265,7 @@ de:Weizenmehle Type 1600
 es:Harinas de trigo integrales
 fr:Farines de blé type T150, Farines de blé T150, Farines de blé type 150, farines intégrales de blé, Farine de blé tendre T150
 nl:Volkoren graanmelen
+agribalyse_food_code:en:9415
 ciqual_food_code:en:9415
 ciqual_food_name:en:Wheat flour, type 150
 ciqual_food_name:fr:Farine de blé tendre ou froment T150
@@ -38337,6 +39321,7 @@ en:Wheat flour T110, Wheat flour type 110
 fr:Farines de blé type T110, Farines de blé T110, Farines de blé type 110, farines complètes de blé, Farine de blé tendre T110
 de:Weizenmehle Type 1050
 nl:Volkoren tarwemelen
+agribalyse_food_code:en:9410
 ciqual_food_code:en:9410
 ciqual_food_name:en:Wheat flour, type 110
 ciqual_food_name:fr:Farine de blé tendre ou froment T110
@@ -38399,6 +39384,7 @@ es:Harinas de espelta, Harinas de escaña mayor, Harinas de escanda mayor
 fi:spelttijauhot
 fr:Farines d'épeautre, farines de grand épeautre
 nl:Speltmelen
+agribalyse_food_code:en:9480
 ciqual_food_code:en:9480
 ciqual_food_name:en:Spelt flour
 ciqual_food_name:fr:Farine d'épeautre (grand épeautre)
@@ -38529,6 +39515,7 @@ nl:Polentamaïsgriesmelen
 <en:Corn semolinas
 en:Dried pre-cooked polenta semolina, Dried pre-cooked maize semolina, Dried pre-cooked corn semolina
 fr:Polenta précuite sèche, Semoule de maïs précuite sèche
+agribalyse_food_code:en:9614
 ciqual_food_code:en:9614
 ciqual_food_name:en:Polenta or Maize/corn semolina, pre-cooked, dried
 ciqual_food_name:fr:Polenta ou semoule de maïs, précuite, sèche
@@ -38536,6 +39523,7 @@ ciqual_food_name:fr:Polenta ou semoule de maïs, précuite, sèche
 <en:Corn semolinas
 en:Unsalted polenta, Cooked unsalted maize semolina
 fr:Polenta non salée, Semoule de maïs cuite non salée
+agribalyse_food_code:en:9615
 ciqual_food_code:en:9615
 ciqual_food_name:en:Polenta or maize semolina, cooked, unsalted
 ciqual_food_name:fr:Polenta ou semoule de maïs, cuite, non salée
@@ -38562,6 +39550,7 @@ es:Sémolas y semolinas de trigo duro, Sémolas de trigo duro, Sémola de trigo 
 fr:Semoules de blé dur, Semoules de blé dur crues
 nl:Harde tarwegriesmelen
 wikidata:en:Q381350
+agribalyse_food_code:en:9610
 ciqual_food_code:en:9610
 ciqual_food_name:en:Durum wheat semolina, raw
 ciqual_food_name:fr:Semoule de blé dur, crue
@@ -38576,6 +39565,7 @@ nl:Harde tarwe griesmelen voor couscous
 <en:Durum wheat semolinas
 en:Pre-cooked durum wheat whole grain to pan-fry
 fr:Blé dur précuit en grains entiers à poêler
+agribalyse_food_code:en:9083
 ciqual_food_code:en:9083
 ciqual_food_name:en:Durum wheat pre-cooked, whole grain, cooked, to pan-fry
 ciqual_food_name:fr:Blé dur précuit, grains entiers, cuisiné, à poêler
@@ -38583,6 +39573,7 @@ ciqual_food_name:fr:Blé dur précuit, grains entiers, cuisiné, à poêler
 <en:Durum wheat semolinas
 en:Pre-cooked durum wheat in a microwaveable bag
 fr:Blé dur précuit en sachet micro-ondable
+agribalyse_food_code:en:9082
 ciqual_food_code:en:9082
 ciqual_food_name:en:Durum wheat, pre-cooked, cooked, in a microwaveable bag
 ciqual_food_name:fr:Blé dur précuit cuisiné, en sachet micro-ondable
@@ -38590,6 +39581,7 @@ ciqual_food_name:fr:Blé dur précuit cuisiné, en sachet micro-ondable
 <en:Durum wheat semolinas
 en:Unsalted pre-cooked durum wheat with whole grain
 fr:Blé dur précuit non salé en grains entiers
+agribalyse_food_code:en:9081
 ciqual_food_code:en:9081
 ciqual_food_name:en:Durum wheat pre-cooked, whole grain, cooked, unsalted
 ciqual_food_name:fr:Blé dur précuit, grains entiers, cuit, non salé
@@ -38605,6 +39597,7 @@ wikidata:en:Q3505415
 <en:Durum wheat semolinas
 en:Raw frik, Raw crushed immature durum wheat
 fr:Frik cru, Blé dur immature concassé cru
+agribalyse_food_code:en:51510
 ciqual_food_code:en:51510
 ciqual_food_name:en:Frik (crushed immature durum wheat), raw
 ciqual_food_name:fr:Frik (blé dur immature concassé), cru
@@ -38612,6 +39605,7 @@ ciqual_food_name:fr:Frik (blé dur immature concassé), cru
 <en:Durum wheat semolinas
 en:Cooked unsalted frik, Cooked unsalted crushed immature durum wheat
 fr:Frik non salé, Blé dur immature concassé cuit non salé
+agribalyse_food_code:en:51511
 ciqual_food_code:en:51511
 ciqual_food_name:en:Frik (crushed immature durum wheat), cooked, unsalted
 ciqual_food_name:fr:Frik (blé dur immature concassé), cuit, non salé
@@ -38619,6 +39613,7 @@ ciqual_food_name:fr:Frik (blé dur immature concassé), cuit, non salé
 <en:Durum wheat semolinas
 en:Raw whole durum wheat
 fr:Blé dur entier cru
+agribalyse_food_code:en:9060
 ciqual_food_code:en:9060
 ciqual_food_name:en:Durum wheat, whole, raw
 ciqual_food_name:fr:Blé dur entier, cru
@@ -38626,6 +39621,7 @@ ciqual_food_name:fr:Blé dur entier, cru
 <en:Durum wheat semolinas
 en:Raw pre-cooked whole wheat
 fr:Blé dur précuit entier
+agribalyse_food_code:en:9080
 ciqual_food_code:en:9080
 ciqual_food_name:en:Wheat, whole, pre-cooked, raw
 ciqual_food_name:fr:Blé dur précuit, entier, cru
@@ -38652,6 +39648,7 @@ es:Almidón de maíz
 fr:Amidon de maïs, Fécule de maïs
 nl:Maïszetmelen
 wikidata:en:Q3393961
+agribalyse_food_code:en:9510
 ciqual_food_code:en:9510
 ciqual_food_name:en:Maize/corn starch
 ciqual_food_name:fr:Amidon de maïs ou fécule de maïs
@@ -38724,6 +39721,7 @@ fi:bulgur
 fr:Boulghours, Boulghour, Bulgur, Boulgours, Boulgour de blé cru
 nl:Bulgur, Burghul, Boergoel
 wikidata:en:Q250432
+agribalyse_food_code:en:9690
 ciqual_food_code:en:9690
 ciqual_food_name:en:Wheat bulgur, raw
 ciqual_food_name:fr:Boulgour de blé, cru
@@ -38731,6 +39729,7 @@ ciqual_food_name:fr:Boulgour de blé, cru
 <en:Wheat groats
 en:Unsalted cooked wheat bulgur
 fr:Boulgour de blé cuit non salé
+agribalyse_food_code:en:9691
 ciqual_food_code:en:9691
 ciqual_food_name:en:Wheat bulgur, cooked, unsalted
 ciqual_food_name:fr:Boulgour de blé, cuit, non salé
@@ -38758,6 +39757,7 @@ fr:Purées de sésame, Tahini, Tahina, Tahin, Purée de sésame
 nl:Sesampastas, Tahini, Tahina, Tahin
 nl_be:Sesampasta, Tahini, Tahina, Tahin
 wikidata:en:Q383389
+agribalyse_food_code:en:15203
 ciqual_food_code:en:15203
 ciqual_food_name:en:Tahini (sesame paste)
 ciqual_food_name:fr:Tahin ou Purée de sésame
@@ -38819,24 +39819,28 @@ fr:Levures de boulanger
 nl:Gisten
 zh:酵母
 wikidata:en:Q911712
+agribalyse_food_code:en:11045
 ciqual_food_code:en:11045
 ciqual_food_name:en:Baker's yeast, dehydrated
 
 <en:Food additives
 en:Baking powder or raising agent
 fr:levure chimique
+agribalyse_food_code:en:11046
 ciqual_food_code:en:11046
 ciqual_food_name:en:Baking powder or raising agent
 
 <en:Food additives
 en:Nutritional yeast
 fr:Levure alimentaire
+agribalyse_food_code:en:11009
 ciqual_food_code:en:11009
 ciqual_food_name:en:Nutritional yeast
 
 <en:Food additives
 en:Baker's yeast compressed
 fr:Levure de boulanger compressée
+agribalyse_food_code:en:11010
 ciqual_food_code:en:11010
 ciqual_food_name:en:Baker's yeast, compressed
 
@@ -38865,6 +39869,7 @@ fr:Bicarbonates de sodium, Bicarbonate de sodium, Bicarbonate de soude
 la:E-500ii
 nl:Natriumbicarbonaten, Natriumwaterstofcarbonaten, Dubbelkoolzure sodas
 wikidata:en:Q179731
+agribalyse_food_code:en:11507
 ciqual_food_code:en:11507
 ciqual_food_name:en:Sodium bicarbonate
 ciqual_food_name:fr:Bicarbonate de soude
@@ -38933,12 +39938,14 @@ wikidata:en:Q421991
 <en:Seaweed products
 en:Dried carragheen mosses, Chondrus crispus, dehydrated carragheen mosses
 fr:Lichen de mer séché, pioca séché, goémon rouge séché, Lichen de mer déshydraté, pioca déshydraté, goémon rouge déshydraté, Chondrus crispus
+agribalyse_food_code:en:20996
 ciqual_food_code:en:20996
 ciqual_food_name:en:Carragheen mosses (Chondrus crispus), dried or dehydrated
 
 <en:Seaweed products
 en:North Atlantic rockweed dried or dehydrated, Ascophyllum nodosum
 fr:Ascophylle noueux séché, goémon noir séché, Ascophylle noueux déshydraté, goémon noir déshydraté, Ascophyllum nodosum
+agribalyse_food_code:en:20998
 ciqual_food_code:en:20998
 ciqual_food_name:en:North Atlantic rockweed (Ascophyllum nodosum), dried or dehydrated
 ciqual_food_name:fr:Ascophylle noueux ou goémon noir (Ascophyllum nodosum), séché ou déshydraté
@@ -38955,6 +39962,7 @@ zh:明胶
 <en:Gelatin
 en:Dried gelatine
 fr:Gélatine sèche
+agribalyse_food_code:en:11007
 ciqual_food_code:en:11007
 ciqual_food_name:en:Gelatine, dried
 ciqual_food_name:fr:Gélatine, sèche
@@ -39036,6 +40044,7 @@ nl:Plantaardige gevriesdroogde producten
 <en:Frozen foods
 en:Frozen raw dauphine potato
 fr:Pomme de terre dauphine surgelée crue
+agribalyse_food_code:en:4020
 ciqual_food_code:en:4020
 ciqual_food_name:en:Dauphine potato, frozen, raw
 ciqual_food_name:fr:Pomme de terre dauphine, surgelée, crue
@@ -39043,6 +40052,7 @@ ciqual_food_name:fr:Pomme de terre dauphine, surgelée, crue
 <en:Frozen foods
 en:Frozen raw duchesse potato
 fr:Pomme de terre duchesse surgelée crue
+agribalyse_food_code:en:4042
 ciqual_food_code:en:4042
 ciqual_food_name:en:Duchesse potato, frozen, raw
 ciqual_food_name:fr:Pomme de terre duchesse, surgelée, crue
@@ -39066,11 +40076,12 @@ fr:Frites surgelées
 it:Patatine surgelate
 nl:Diepvriespatatten
 pl:Frytki mrożone
-who_id:16
+who_id:en:16
 
 <fr:Pommes de terre préfrites surgelées
 en:Frozen raw French fries intended to be microwaved, Frozen raw French chips intended to be microwaved
 fr:Frites de pommes de terre surgelées pour cuisson au micro-ondes
+agribalyse_food_code:en:4045
 ciqual_food_code:en:4045
 ciqual_food_name:en:French fries or chips, frozen, raw, intended to be microwaved
 ciqual_food_name:fr:Frites de pommes de terre, surgelées, pour cuisson micro-ondes
@@ -39078,6 +40089,7 @@ ciqual_food_name:fr:Frites de pommes de terre, surgelées, pour cuisson micro-on
 <fr:Pommes de terre préfrites surgelées
 en:Frozen deep-fried French fries, Frozen deep-fried French chips
 fr:Frites de pommes de terre surgelées cuites en friteuse
+agribalyse_food_code:en:4032
 ciqual_food_code:en:4032
 ciqual_food_name:en:French fries or chips, frozen, deep-fried
 ciqual_food_name:fr:Frites de pommes de terre, surgelées, cuites en friteuse
@@ -39085,6 +40097,7 @@ ciqual_food_name:fr:Frites de pommes de terre, surgelées, cuites en friteuse
 <fr:Pommes de terre préfrites surgelées
 en:Frozen raw French fries intended to be deep-fried, Frozen raw chips intended to be deep-fried
 fr:Frites de pommes de terre surgelées pour cuisson en friteuse
+agribalyse_food_code:en:4046
 ciqual_food_code:en:4046
 ciqual_food_name:en:French fries or chips, frozen, raw, intended to be deep-fried
 ciqual_food_name:fr:Frites de pommes de terre, surgelées, pour cuisson en friteuse
@@ -39092,6 +40105,7 @@ ciqual_food_name:fr:Frites de pommes de terre, surgelées, pour cuisson en frite
 <fr:Pommes de terre préfrites surgelées
 en:Frozen roasted French fries, Frozen baked French fries, Frozen roasted French chips, Frozen baked French fries
 fr:Frites de pommes de terre surgelées rôties, Frites de pommes de terre surgelées cuites au four
+agribalyse_food_code:en:4030
 ciqual_food_code:en:4030
 ciqual_food_name:en:French fries or chips, frozen, roasted/baked
 ciqual_food_name:fr:Frites de pommes de terre, surgelées, rôties/cuites au four
@@ -39099,6 +40113,7 @@ ciqual_food_name:fr:Frites de pommes de terre, surgelées, rôties/cuites au fou
 <fr:Pommes de terre préfrites surgelées
 en:Frozen raw French fries intended to be roasted, Frozen raw French fries intended to be baked, Frozen raw French chips intended to be roasted, Frozen raw French chips intended to be baked
 fr:Frites de pommes de terre surgelées pour cuisson rôtie, Frites de pommes de terre surgelées pour cuisson rôtie cuites au four
+agribalyse_food_code:en:4044
 ciqual_food_code:en:4044
 ciqual_food_name:en:French fries or chips, frozen, raw, intended to be roasted/baked
 ciqual_food_name:fr:Frites de pommes de terre, surgelées, pour cuisson rôtie/ au four
@@ -39106,6 +40121,7 @@ ciqual_food_name:fr:Frites de pommes de terre, surgelées, pour cuisson rôtie/ 
 <fr:Pommes de terre préfrites surgelées
 fr:Pommes rissolées surgelées, Pommes de terre rissolées surgelées
 en:Frozen cooked pre-fried potato cubes
+agribalyse_food_code:en:4027
 ciqual_food_code:en:4027
 ciqual_food_name:en:Potato, pre-fried into cubes, frozen, cooked
 ciqual_food_name:fr:Pomme de terre rissolée, surgelée, cuite
@@ -39113,6 +40129,7 @@ ciqual_food_name:fr:Pomme de terre rissolée, surgelée, cuite
 <fr:Pommes de terre préfrites surgelées
 en:Frozen raw pre-fried potato cubes
 fr:Pommes de terre rissolée crues surgelées
+agribalyse_food_code:en:4043
 ciqual_food_code:en:4043
 ciqual_food_name:en:Potato, pre-fried into cubes, frozen, raw
 ciqual_food_name:fr:Pomme de terre rissolée, surgelée, crue
@@ -39129,6 +40146,7 @@ fr:Figurines de pommes de terre surgelées
 <fr:Pommes de terre préfrites surgelées
 fr:Pommes noisettes surgelées, Pommes de terre noisette surgelées
 en:Frozen pre-fried mashed potato balls
+agribalyse_food_code:en:4013
 ciqual_food_code:en:4013
 ciqual_food_name:en:Mashed potato balls pre-fried, frozen, raw
 ciqual_food_name:fr:Pomme de terre noisette, surgelée, crue
@@ -39136,6 +40154,7 @@ ciqual_food_name:fr:Pomme de terre noisette, surgelée, crue
 <fr:Pommes de terre préfrites surgelées
 fr:Pommes dauphines surgelées, Pomme de terre dauphine cuite surgelée
 en:Frozen cooked dauphine potato
+agribalyse_food_code:en:4021
 ciqual_food_code:en:4021
 ciqual_food_name:en:Dauphine potato, frozen, cooked
 ciqual_food_name:fr:Pomme de terre dauphine, surgelée, cuite
@@ -39143,6 +40162,7 @@ ciqual_food_name:fr:Pomme de terre dauphine, surgelée, cuite
 <fr:Pommes de terre préfrites surgelées
 fr:Pommes duchesses surgelées, Pomme de terre duchesse cuite surgelée
 en:Frozen cooked duchesse potato
+agribalyse_food_code:en:4034
 ciqual_food_code:en:4034
 ciqual_food_name:en:Duchesse potato, frozen, cooked
 ciqual_food_name:fr:Pomme de terre duchesse, surgelée, cuite
@@ -39170,6 +40190,7 @@ zh:冷冻甜点
 en:Baked Alaska
 fr:Omelettes Norvégiennes glacées, Omelette norvégienne
 pnns_group_2:en:Dairy desserts
+agribalyse_food_code:en:39518
 ciqual_food_code:en:39518
 ciqual_food_name:en:baked Alaska
 ciqual_food_name:fr:Omelette norvégienne
@@ -39177,6 +40198,7 @@ ciqual_food_name:fr:Omelette norvégienne
 <en:Frozen desserts
 en:Belle Helene pear dessert, Cooked pear topped with hot chocolate sauce on a bed of vanilla ice cream
 fr:Poire belle Hélène
+agribalyse_food_code:en:39519
 ciqual_food_code:en:39519
 ciqual_food_name:en:Belle Helene pear dessert (cooked pear topped with hot chocolate sauce on a bed of vanilla ice cream)
 ciqual_food_name:fr:Poire belle Hélène
@@ -39189,6 +40211,7 @@ fr:Bûches glacées
 <en:Vacherins
 en:Vacherin ice cream
 fr:Vacherin glacé
+agribalyse_food_code:en:39502
 ciqual_food_code:en:39502
 ciqual_food_name:en:Frozen dessert, ice cream with meringue, vacherin ice cream or mystery ice cream type
 ciqual_food_name:fr:Dessert glacé type mystère ou vacherin
@@ -39196,6 +40219,7 @@ ciqual_food_name:fr:Dessert glacé type mystère ou vacherin
 <en:Frozen desserts
 en:Frozen dessert ice cream with meringue, Mystery ice cream
 fr:Mystère
+agribalyse_food_code:en:39502
 ciqual_food_code:en:39502
 ciqual_food_name:en:Frozen dessert, ice cream with meringue, vacherin ice cream or mystery ice cream type
 ciqual_food_name:fr:Dessert glacé type mystère ou vacherin
@@ -39218,11 +40242,12 @@ pnns_group_2:en:Ice cream
 ciqual_food_code:en:39500
 ciqual_food_name:en:Ice cream or sorbet or ice pop, flavoured (average)
 ciqual_food_name:fr:Glace à l'eau ou sorbet ou crème glacée, tout parfum (aliment moyen)
-who_id:5
+who_id:en:5
 
 <en:Frozen desserts
 en:Frozen dessert puff pastry to share
 fr:Dessert glacé feuilleté à partager
+agribalyse_food_code:en:39516
 ciqual_food_code:en:39516
 ciqual_food_name:en:Frozen dessert, puff pastry, to share
 ciqual_food_name:fr:Dessert glacé feuilleté, à partager
@@ -39412,6 +40437,7 @@ es:Helados de palo de chocolate, Polos de chocolate, Paletas de chocolate
 fi:Suklaajäätelötikut
 fr:Bâtonnets glacés au chocolat, Bâtonnets au chocolat, Bâtonnet chocolat, Bâtonnets chocolat, Bâtonnet enrobé de crème glacée au chocolat, Bâtonnet enrobé de glace au chocolat
 nl:Choco-ijsjes
+agribalyse_food_code:en:39503
 ciqual_food_code:en:39503
 ciqual_food_name:en:Ice cream on stick, with chocolate coating
 ciqual_food_name:fr:Glace ou crème glacée, bâtonnet, enrobé de chocolat
@@ -39426,6 +40452,7 @@ fr:Cônes glacés, Cônes à la crème glacée
 hu:Tölcséres jégkrém
 nl:IJshoorntjes
 nl-BE:Torentjes
+agribalyse_food_code:en:39509
 ciqual_food_code:en:39509
 ciqual_food_name:en:Ice cream, cone (normal size)
 ciqual_food_name:fr:Glace ou crème glacée, cône (taille standard)
@@ -39463,6 +40490,7 @@ fr:Cônes menthe chocolat, Cônes chocolat menthe
 <en:Ice cream cones
 en:Mini ice cream cone
 fr:Mini cône glacé, Mini cône de glace, Mini cône de crème glacée
+agribalyse_food_code:en:39522
 ciqual_food_code:en:39522
 ciqual_food_name:en:Ice cream, cone, mini
 ciqual_food_name:fr:Glace ou crème glacée, mini cône
@@ -39483,6 +40511,7 @@ ciqual_food_name:fr:Glace ou crème glacée, bac ou pot (aliment moyen)
 <en:Ice creams
 en:Ice cream in a box
 fr:Glace en bac, Crème glacée en bac, Bac de glace, Bac de crème glacée
+agribalyse_food_code:en:39515
 ciqual_food_code:en:39515
 ciqual_food_name:en:Ice cream, in box
 ciqual_food_name:fr:Glace ou crème glacée, en bac
@@ -39490,6 +40519,7 @@ ciqual_food_name:fr:Glace ou crème glacée, en bac
 <en:Ice creams
 en:Luxury ice cream in a box
 fr:Glace en bac, Crème glacée gourmande en bac, Bac de glace, Bac de crème glacée gourmande
+agribalyse_food_code:en:39520
 ciqual_food_code:en:39520
 ciqual_food_name:en:Ice cream, luxury, in box
 ciqual_food_name:fr:Glace ou crème glacée, gourmande, en bac
@@ -39497,6 +40527,7 @@ ciqual_food_name:fr:Glace ou crème glacée, gourmande, en bac
 <en:Ice creams
 en:Luxury ice cream in a cup, Luxury ice cream cup
 fr:Glace en pot, Crème glacée gourmande en pot, Pot de glace, Pot de crème glacée gourmande
+agribalyse_food_code:en:39521
 ciqual_food_code:en:39521
 ciqual_food_name:en:Ice cream, luxury, in cup
 ciqual_food_name:fr:Glace ou crème glacée, gourmande, en pot
@@ -39504,6 +40535,7 @@ ciqual_food_name:fr:Glace ou crème glacée, gourmande, en pot
 <en:Ice creams
 en:Ice cream in individual cup, Individual ice cream cup
 fr:Glace en pot individuel, Crème glacée en pot individuel
+agribalyse_food_code:en:39523
 ciqual_food_code:en:39523
 ciqual_food_name:en:Ice cream, in individual cup
 ciqual_food_name:fr:Glace ou crème glacée, pot individuel
@@ -39511,6 +40543,7 @@ ciqual_food_name:fr:Glace ou crème glacée, pot individuel
 <en:Ice creams
 en:Ice cream cup for children
 fr:Petit pot de glace pour enfant, Petit pot de crème glacée pour enfant
+agribalyse_food_code:en:39531
 ciqual_food_code:en:39531
 ciqual_food_name:en:Ice cream, in cup for children
 ciqual_food_name:fr:Glace ou crème glacée, petit pot enfant
@@ -39624,6 +40657,7 @@ nl:Roomijswafels
 <en:Ice creams
 en:Sundae ice cream
 fr:Sundae
+agribalyse_food_code:en:39512
 ciqual_food_code:en:39512
 ciqual_food_name:en:Frozen dessert, Sundae ice cream type
 ciqual_food_name:fr:Dessert glacé, type sundae
@@ -39631,6 +40665,7 @@ ciqual_food_name:fr:Dessert glacé, type sundae
 <en:Ice creams
 en:Ice cream log
 fr:Bûche glacée
+agribalyse_food_code:en:39533
 ciqual_food_code:en:39533
 ciqual_food_name:en:Ice cream log
 ciqual_food_name:fr:Bûche glacée
@@ -39648,6 +40683,7 @@ wikidata:en:Q13302
 <en:Sorbets
 en:Sorbet tub, Sorbet in box
 fr:Sorbet en bac
+agribalyse_food_code:en:39524
 ciqual_food_code:en:39524
 ciqual_food_name:en:Sorbet, in box
 ciqual_food_name:fr:Sorbet, en bac
@@ -39655,6 +40691,7 @@ ciqual_food_name:fr:Sorbet, en bac
 <en:Sorbets
 en:Sorbets on stick
 fr:Sorbets en bâtonnet
+agribalyse_food_code:en:31013
 ciqual_food_code:en:31013
 ciqual_food_name:en:Sorbet, on stick
 ciqual_food_name:fr:Sorbet, bâtonnet
@@ -39665,6 +40702,7 @@ es:Sorbetes de naranja
 fr:Sorbets à l’orange, Sorbets à l'orange givrée
 it:Sorbetto all'arancia
 nl:Sinaasappelsorbets
+agribalyse_food_code:en:39530
 ciqual_food_code:en:39530
 ciqual_food_name:en:Frosted lemon or orange (sorbet)
 ciqual_food_name:fr:Citron givré ou Orange givrée (sorbet)
@@ -39739,6 +40777,7 @@ fi:sitruunasorbetit
 fr:Sorbets au citron, Sorbets au citron givré
 it:Sorbetto al limone
 nl:Citroensorbets
+agribalyse_food_code:en:39530
 ciqual_food_code:en:39530
 ciqual_food_name:en:Frosted lemon or orange (sorbet)
 ciqual_food_name:fr:Citron givré ou Orange givrée (sorbet)
@@ -39847,10 +40886,11 @@ fi:mehujäät
 fr:Glaces à l'eau
 nl:Waterijsjes, IJslollies
 wikidata:en:Q855373
+agribalyse_food_code:en:39526
 ciqual_food_code:en:39526
 ciqual_food_name:en:Ice lolly
 ciqual_food_name:fr:Glace à l'eau
-who_id:5
+who_id:en:5
 
 <en:Frozen desserts
 en:Frozen yogurts, Frozen yoghurts, Frozen yogurt
@@ -39860,10 +40900,11 @@ fi:Jogurttijäätelöt
 fr:Yaourts glacés, Glaces au yaourt
 nl:Yoghurtijs
 wikidata:en:Q13319
+agribalyse_food_code:en:39517
 ciqual_food_code:en:39517
 ciqual_food_name:en:Frozen yogurt
 ciqual_food_name:fr:Glace au yaourt
-who_id:5
+who_id:en:5
 
 <en:Frozen desserts
 en:Granizados
@@ -39920,6 +40961,7 @@ wikidata:en:Q977539
 <en:Frozen desserts
 en:Iced nougat
 fr:Nougat glacé
+agribalyse_food_code:en:39529
 ciqual_food_code:en:39529
 ciqual_food_name:en:Iced nougat
 ciqual_food_name:fr:Nougat glacé
@@ -39971,7 +41013,7 @@ es:Pizzas congeladas
 fi:pakastetut pizzat
 fr:Pizzas surgelées, pizza surgelée
 it:Pizza surgelata
-nl:Diepvriespizzas
+nl:Dieprvriespizzas
 pl:Pizza mrożona
 pt:Pizzas congeladas
 sv:Frysta Pizzor, Fryst Pizza
@@ -40009,6 +41051,7 @@ pl:Ryby mrożone
 <en:Frozen fishes
 en:Frozen raw saithe
 fr:Lieu noir cru surgelé
+agribalyse_food_code:en:26047
 ciqual_food_code:en:26047
 ciqual_food_name:en:Saithe, frozen, raw
 ciqual_food_name:fr:Lieu noir, surgelé, cru
@@ -40016,24 +41059,28 @@ ciqual_food_name:fr:Lieu noir, surgelé, cru
 <en:Fish
 en:Saithe cooked
 fr:Lieu noir cuit
+agribalyse_food_code:en:26015
 ciqual_food_code:en:26015
 ciqual_food_name:en:Saithe, cooked
 
 <en:Fish
 en:Saithe raw
 fr:Lieu noir cru
+agribalyse_food_code:en:26134
 ciqual_food_code:en:26134
 ciqual_food_name:en:Saithe, raw
 
 <en:Fish
 en:Arctic char raw
 fr:Omble chevalier cru
+agribalyse_food_code:en:26171
 ciqual_food_code:en:26171
 ciqual_food_name:en:Arctic char, raw
 
 <en:Frozen fishes
 en:Frozen raw hake fillet
 fr:Filet de merlu surgelé cru
+agribalyse_food_code:en:26048
 ciqual_food_code:en:26048
 ciqual_food_name:en:Hake, fillet, frozen, raw
 ciqual_food_name:fr:Merlu, filet, surgelé, cru
@@ -40101,7 +41148,7 @@ wikidata:en:Q1364
 en:Fresh fruits
 es:Frutas frescas
 fr:Fruits frais
-who_id:15
+who_id:en:15
 
 <en:Fruits
 en:French fruits
@@ -40118,6 +41165,7 @@ origins:en: en:United Kingdom
 <en:Berries
 en:Blackcurrants, Raw black currant
 fr:Cassis, Cassis cru
+agribalyse_food_code:en:13007
 ciqual_food_code:en:13007
 ciqual_food_name:en:Black currant, raw
 ciqual_food_name:fr:Cassis, cru
@@ -40131,6 +41179,7 @@ season_in_country_fr:en: 6,7,8
 <en:Fruits
 en:Raw kumquat without pips
 fr:Kumquat sans pépins cru
+agribalyse_food_code:en:13549
 ciqual_food_code:en:13549
 ciqual_food_name:en:Kumquat, without pips, raw
 ciqual_food_name:fr:Kumquat, sans pépin, cru
@@ -40147,6 +41196,9 @@ nl:Appels
 ro:Mere
 ru:Яблоки
 wikidata:en:Q89
+agribalyse_proxy_food_code:en:13085
+agribalyse_proxy_food_name:en:Apple, Canada, pulp, raw
+agribalyse_proxy_food_name:fr:Pomme Canada, pulpe, crue
 
 <en:Apples
 <en:Fresh fruits
@@ -40203,6 +41255,7 @@ wikidata:en:Q201996
 <en:Sweet Apples
 en:Raw Golden apple pulp and skin
 fr:Pulpe et peau de pomme Golden crue
+agribalyse_food_code:en:13620
 ciqual_food_code:en:13620
 ciqual_food_name:en:Apple, var. Golden, pulp and skin, raw
 ciqual_food_name:fr:Pomme Golden, pulpe et peau, crue
@@ -40245,6 +41298,7 @@ wikidata:en:Q1723442
 <en:Acidic apples
 en:Raw Canada apple pulp
 fr:Pulpe de pomme Canada crue
+agribalyse_food_code:en:13085
 ciqual_food_code:en:13085
 ciqual_food_name:en:Apple, Canada, pulp, raw
 ciqual_food_name:fr:Pomme Canada, pulpe, crue
@@ -40252,6 +41306,7 @@ ciqual_food_name:fr:Pomme Canada, pulpe, crue
 <en:Apples
 en:Boiled raw apples without skin, Raw apples without skin cooked in water
 fr:Pulpe de pomme bouillie, Pulpe de pomme cuite à l'eau
+agribalyse_food_code:en:13176
 ciqual_food_code:en:13176
 ciqual_food_name:en:Apples, raw, without skin, cooked, boiled/cooked in water
 ciqual_food_name:fr:Pomme, pulpe, bouillie/cuite à l'eau
@@ -40259,6 +41314,7 @@ ciqual_food_name:fr:Pomme, pulpe, bouillie/cuite à l'eau
 <en:Apples
 en:Roasted apple pulp, Baked apple pulp
 fr:Pulpe de pomme rôtie, Pulpe de pomme cuite au four
+agribalyse_food_code:en:13175
 ciqual_food_code:en:13175
 ciqual_food_name:en:Apple, pulp, roasted/baked
 ciqual_food_name:fr:Pomme, pulpe, rôtie/cuite au four
@@ -40266,6 +41322,7 @@ ciqual_food_name:fr:Pomme, pulpe, rôtie/cuite au four
 <en:Apples
 en:Raw apple pulp and peel
 fr:Pulpe et peau de pomme crue
+agribalyse_food_code:en:13039
 ciqual_food_code:en:13039
 ciqual_food_name:en:Apple, pulp and peel, raw
 ciqual_food_name:fr:Pomme, pulpe et peau, crue
@@ -40273,6 +41330,7 @@ ciqual_food_name:fr:Pomme, pulpe et peau, crue
 <en:Apples
 en:Raw apple pulp
 fr:Pulpe de pomme crue
+agribalyse_food_code:en:13050
 ciqual_food_code:en:13050
 ciqual_food_name:en:Apple, pulp, raw
 ciqual_food_name:fr:Pomme, pulpe, crue
@@ -40296,6 +41354,7 @@ season_in_country_fr:en: 6,7,8
 <en:Apricots
 en:Raw pitted apricot
 fr:Abricot dénoyauté
+agribalyse_food_code:en:13000
 ciqual_food_code:en:13000
 ciqual_food_name:en:Apricot, pitted, raw
 ciqual_food_name:fr:Abricot, dénoyauté, cru
@@ -40308,6 +41367,7 @@ fi:marjat
 fr:Fruits rouges
 nl:Bosvruchten
 ro:Fructe de pădure
+agribalyse_food_code:en:13997
 ciqual_food_code:en:13997
 ciqual_food_name:en:Red berries (raspberries, strawberries, red currants, black currants) , raw
 ciqual_food_name:fr:Fruits rouges, crus (framboises, fraises, groseilles, cassis)
@@ -40337,6 +41397,7 @@ es:Moras
 fr:Mûres
 nl:Bramen
 ro:Mure
+agribalyse_food_code:en:13029
 ciqual_food_code:en:13029
 ciqual_food_name:en:Blackberry, raw
 ciqual_food_name:fr:Mûre (de ronce), crue
@@ -40351,6 +41412,7 @@ season_in_country_fr:en: 8,9
 <en:Berries
 en:Black mulberries, Raw black mulberries
 fr:Mûres noires, Mûres noires crues
+agribalyse_food_code:en:13071
 ciqual_food_code:en:13071
 ciqual_food_name:en:Black mulberry, raw
 ciqual_food_name:fr:Mûre noire (du mûrier), crue
@@ -40371,6 +41433,7 @@ fr:Myrtilles
 la:Vaccinium, Cyanococcus
 nl:Bosbessen familie
 ro:Afine
+agribalyse_food_code:en:13028
 ciqual_food_code:en:13028
 ciqual_food_name:en:Blueberry, raw
 ciqual_food_name:fr:Myrtille, crue
@@ -40387,6 +41450,7 @@ en:Elderberries, Black elders, European elders, European elderberries, European 
 es:Frutos del saúco negro, Frutos del saúco común, Saúco negro, Saúco común
 fr:Baies de sureau noir, Baies de grand sureau, Sureau noir, Grand sureau, Baies de sureau crues
 nl:Vlierbessen
+agribalyse_food_code:en:13126
 ciqual_food_code:en:13126
 ciqual_food_name:en:Elderberry, berries, raw
 ciqual_food_name:fr:Sureau, baie, crue
@@ -40407,6 +41471,7 @@ la:Vaccinium oxycoccus
 nl:Cranberries
 ro:Merișoare
 sv:Tranbär
+agribalyse_food_code:en:13113
 ciqual_food_code:en:13113
 ciqual_food_name:en:Cranberry, raw
 ciqual_food_name:fr:Canneberge ou cranberry, crue
@@ -40435,6 +41500,7 @@ nl:Frambozen
 ro:Zmeură
 sv:Hallon
 wikidata:en:Q13179
+agribalyse_food_code:en:13015
 ciqual_food_code:en:13015
 ciqual_food_name:en:Raspberry, raw
 ciqual_food_name:fr:Framboise, crue
@@ -40448,6 +41514,7 @@ season_in_country_fr:en: 6,7,8
 <en:Raspberries
 en:Frozen raw raspberries
 fr:Framboises surgelées crues
+agribalyse_food_code:en:13136
 ciqual_food_code:en:13136
 ciqual_food_name:en:Raspberry, frozen, raw
 ciqual_food_name:fr:Framboise, surgelée, crue
@@ -40460,6 +41527,7 @@ la:Ribes rubrum
 nl:Aalbessen
 ro:Coacaze roșii
 sv:Vinbär
+agribalyse_food_code:en:13019
 ciqual_food_code:en:13019
 ciqual_food_name:en:Red currant, raw
 ciqual_food_name:fr:Groseille, crue
@@ -40476,6 +41544,7 @@ de:Stachelbeeren
 fr:Groseilles à maquereaux, Groseilles à maquereaux crues
 la:Ribes uva-crispa
 sv:Krusbär
+agribalyse_food_code:en:13020
 ciqual_food_code:en:13020
 ciqual_food_name:en:Gooseberry, raw
 ciqual_food_name:fr:Groseille à maquereau, crue
@@ -40541,6 +41610,7 @@ season_in_country_fr:en: 6,7
 <en:Cherries
 en:Raw pitted cherries
 fr:Cerises dénoyautées crues
+agribalyse_food_code:en:13008
 ciqual_food_code:en:13008
 ciqual_food_name:en:Cherry, pitted, raw
 ciqual_food_name:fr:Cerise, dénoyautée, crue
@@ -40548,6 +41618,7 @@ ciqual_food_name:fr:Cerise, dénoyautée, crue
 <en:Cherries
 en:Raw morello cherries
 fr:Griottes crues
+agribalyse_food_code:en:13110
 ciqual_food_code:en:13110
 ciqual_food_name:en:Morello cherry, raw
 ciqual_food_name:fr:Griotte, crue
@@ -40596,6 +41667,7 @@ season_in_country_fr:en: 1,2,11,12
 <en:Lemons
 en:Lemon pulp
 fr:Pulpe de citron
+agribalyse_food_code:en:13009
 ciqual_food_code:en:13009
 ciqual_food_name:en:Lemon, pulp, raw
 ciqual_food_name:fr:Citron, pulpe, cru
@@ -40603,6 +41675,7 @@ ciqual_food_name:fr:Citron, pulpe, cru
 <en:Lemons
 en:Lemon zest
 fr:Zeste de citron
+agribalyse_food_code:en:13125
 ciqual_food_code:en:13125
 ciqual_food_name:en:Lemon zest, raw
 ciqual_food_name:fr:Citron, zeste, cru
@@ -40620,6 +41693,7 @@ ru:Лаймы, Лайм
 <en:Limes
 en:Lime pulp
 fr:Pulpe de citron vert
+agribalyse_food_code:en:13067
 ciqual_food_code:en:13067
 ciqual_food_name:en:Lime, pulp, raw
 ciqual_food_name:fr:Citron vert ou Lime, pulpe, cru
@@ -40645,6 +41719,7 @@ season_in_country_fr:en: 1,2,11,12
 <en:Mandarin oranges
 en:Raw Mandarin pulp
 fr:Pulpe de mandarine crue
+agribalyse_food_code:en:13090
 ciqual_food_code:en:13090
 ciqual_food_name:en:Mandarin, pulp, raw
 ciqual_food_name:fr:Mandarine, pulpe, crue
@@ -40675,6 +41750,7 @@ origins:en: en:France, en:Corsica
 <en:Clementines
 en:Raw clementine pulp
 fr:Pulpe de clémentine crue
+agribalyse_food_code:en:13082
 ciqual_food_code:en:13082
 ciqual_food_name:en:Clementine, pulp, raw
 ciqual_food_name:fr:Clémentine, pulpe, crue
@@ -40706,6 +41782,7 @@ season_in_country_fr:en: 1,2,3,12
 <en:Oranges
 en:Raw orange pulp
 fr:Pulpe d'orange crue
+agribalyse_food_code:en:13034
 ciqual_food_code:en:13034
 ciqual_food_name:en:Orange, pulp, raw
 ciqual_food_name:fr:Orange, pulpe, crue
@@ -40727,6 +41804,7 @@ season_in_country_fr:en: 2,3,4,5,6
 <en:Pomelos
 en:Raw pummelo pulp
 fr:Pulpe de pamplemousse chinois
+agribalyse_food_code:en:13614
 ciqual_food_code:en:13614
 ciqual_food_name:en:Pummelo, pulp, raw
 ciqual_food_name:fr:Pamplemousse chinois, pulpe, cru
@@ -40734,6 +41812,7 @@ ciqual_food_name:fr:Pamplemousse chinois, pulpe, cru
 <en:Pomelos
 en:Raw grapefruit pulp
 fr:Pulpe de pomelo cru, Pulpe de pamplemousse cru
+agribalyse_food_code:en:13040
 ciqual_food_code:en:13040
 ciqual_food_name:en:Grapefruit, pulp, raw
 ciqual_food_name:fr:Pomelo (dit Pamplemousse), pulpe, cru
@@ -40741,6 +41820,7 @@ ciqual_food_name:fr:Pomelo (dit Pamplemousse), pulpe, cru
 <en:Pomelos
 en:Raw yellow grapefruit pulp
 fr:Pulpe de pomelo jaune cru, Pulpe de pamplemousse jaune cru
+agribalyse_food_code:en:13179
 ciqual_food_code:en:13179
 ciqual_food_name:en:Grapefruit, yellow, pulp, raw
 ciqual_food_name:fr:Pomelo (dit Pamplemousse) jaune, pulpe, cru
@@ -40748,6 +41828,7 @@ ciqual_food_name:fr:Pomelo (dit Pamplemousse) jaune, pulpe, cru
 <en:Pomelos
 en:Raw red grapefruit pulp
 fr:Pulpe de pomelo rose cru, Pulpe de pamplemousse rose cru
+agribalyse_food_code:en:13180
 ciqual_food_code:en:13180
 ciqual_food_name:en:Grapefruit, red or pink, pulp, raw
 ciqual_food_name:fr:Pomelo (dit Pamplemousse) rose, pulpe, cru
@@ -40759,6 +41840,7 @@ es:Higos
 fr:Figues
 la:Ficus carica
 nl:Vijgen
+agribalyse_food_code:en:13012
 ciqual_food_code:en:13012
 ciqual_food_name:en:Fig, raw
 ciqual_food_name:fr:Figue, crue
@@ -40785,6 +41867,7 @@ fr:Raisins, Raisin
 nl:Druiven
 ru:Виноград
 season_in_country_fr:en: 9,10
+agribalyse_food_code:en:13112
 ciqual_food_code:en:13112
 ciqual_food_name:en:Grape, raw
 ciqual_food_name:fr:Raisin, cru
@@ -40804,6 +41887,7 @@ fr:Raisins frais, Raisin frais
 <en:Grapes
 en:Raw white grapes
 fr:Raisins blancs à gros grain type Italia, Raisins blancs à gros grain type Dattier, Raisin blanc à gros grain type Italia, Raisin blanc à gros grain type Dattier
+agribalyse_food_code:en:13044
 ciqual_food_code:en:13044
 ciqual_food_name:en:Grape, white, raw
 ciqual_food_name:fr:Raisin blanc à gros grain (type Italia ou Dattier) cru
@@ -40814,6 +41898,7 @@ de:Rote Weintrauben
 es:Uvas negras
 fr:Raisins noirs
 nl:Rode druiven
+agribalyse_food_code:en:13045
 ciqual_food_code:en:13045
 ciqual_food_name:en:Grape, red, raw
 ciqual_food_name:fr:Raisin noir, cru
@@ -40851,6 +41936,7 @@ nl:Kakis
 <en:Fruits
 en:Persimmon pulp, Raw persimmon pulp
 fr:Pulpe de kaki
+agribalyse_food_code:en:13066
 ciqual_food_code:en:13066
 ciqual_food_name:en:Persimmon, pulp, raw
 ciqual_food_name:fr:Kaki, pulpe, cru
@@ -40858,6 +41944,7 @@ ciqual_food_name:fr:Kaki, pulpe, cru
 <en:Fruits
 en:Raw immature tamarind pulp
 fr:Pulpe de tamarin vert crue
+agribalyse_food_code:en:13079
 ciqual_food_code:en:13079
 ciqual_food_name:en:Tamarind, immature fruit, pulp, raw
 ciqual_food_name:fr:Tamarin, fruit immature, pulpe, cru
@@ -40884,6 +41971,7 @@ season_in_country_fr:en: 1,2,3,11,12
 <en:Kiwifruits
 en:Kiwi fruit pulp and seeds, Raw kiwi fruit pulp and seeds
 fr:Pulpe et graines de kiwi
+agribalyse_food_code:en:13021
 ciqual_food_code:en:13021
 ciqual_food_name:en:Kiwi fruit, pulp and seeds, raw
 ciqual_food_name:fr:Kiwi, pulpe et graines, cru
@@ -40919,6 +42007,7 @@ nl:Wilde perzik
 <en:Peaches
 en:Raw peach pulp and peel
 fr:Pulpe et peau de pêche crue
+agribalyse_food_code:en:13043
 ciqual_food_code:en:13043
 ciqual_food_name:en:Peach, pulp and peel, raw
 ciqual_food_name:fr:Pêche, pulpe et peau, crue
@@ -40940,6 +42029,7 @@ season_in_country_fr:en: 7,8
 <en:Nectarines
 en:Raw nectarine pulp and peel
 fr:Pulpe et peau de nectarine crue, Pulpe et peau de brugnon cru
+agribalyse_food_code:en:13030
 ciqual_food_code:en:13030
 ciqual_food_name:en:Nectarine, pulp and peel, raw
 ciqual_food_name:fr:Nectarine ou brugnon, pulpe et peau, crue
@@ -40954,6 +42044,7 @@ wikidata:en:Q232755
 <en:Fruits
 en:Okra cooked without salt
 fr:Gombo cuit
+agribalyse_food_code:en:58103
 ciqual_food_code:en:58103
 ciqual_food_name:en:Okra, cooked, without salt
 ciqual_food_name:fr:Gombo, fruit, cuit
@@ -41039,6 +42130,7 @@ en:Raw cantaloupe melon pulp
 #eg: Cavaillon or Charentais melon
 fr:Pulpe de melon cantaloup cru
 #eg: Charentais de Cavaillon
+agribalyse_food_code:en:13026
 ciqual_food_code:en:13026
 ciqual_food_name:en:Melon, cantaloupe (ex Cavaillon or Charentais melon), pulp, raw
 ciqual_food_name:fr:Melon cantaloup (par ex.: Charentais, de Cavaillon) pulpe, cru
@@ -41060,6 +42152,7 @@ wikidata:en:Q47801
 <en:Muskmelons
 en:Raw honeydew melon pulp
 fr:Pulpe de melon miel cru, Pulpe de melon honeydew cru
+agribalyse_food_code:en:13742
 ciqual_food_code:en:13742
 ciqual_food_name:en:Melon, honeydew, pulp, raw
 ciqual_food_name:fr:Melon miel ou melon honeydew, pulpe, cru
@@ -41093,6 +42186,7 @@ wikidata:en:Q38645
 <en:Melons
 en:Raw watermelon pulp
 fr:Pulpe de pastèque crue
+agribalyse_food_code:en:13036
 ciqual_food_code:en:13036
 ciqual_food_name:en:Watermelon, pulp, raw
 ciqual_food_name:fr:Pastèque, pulpe, crue
@@ -41116,6 +42210,7 @@ season_in_country_fr:en: 1,2,3,8,9,10,11,12
 <en:Pears
 en:Raw pear pulp and peel
 fr:Pulpe et peau de poire crue
+agribalyse_food_code:en:13037
 ciqual_food_code:en:13037
 ciqual_food_name:en:Pear, pulp and peel, raw
 ciqual_food_name:fr:Poire, pulpe et peau, crue
@@ -41123,6 +42218,7 @@ ciqual_food_name:fr:Poire, pulpe et peau, crue
 <en:Pears
 en:Raw peeled pear
 fr:Pulpe de poire crue
+agribalyse_food_code:en:13107
 ciqual_food_code:en:13107
 ciqual_food_name:en:Pear, peeled, raw
 ciqual_food_name:fr:Poire, pulpe, crue
@@ -41130,6 +42226,7 @@ ciqual_food_name:fr:Poire, pulpe, crue
 <en:Pears
 en:Raw prickly pear pulp and seeds
 fr:Pulpe et graines de figue de Barbarie crue
+agribalyse_food_code:en:13063
 ciqual_food_code:en:13063
 ciqual_food_name:en:Prickly pear, pulp and seeds, raw
 ciqual_food_name:fr:Figue de Barbarie, pulpe et graines, crue
@@ -41155,6 +42252,7 @@ season_in_country_fr:en: 7,8,9
 <en:Plums
 en:Raw plums
 fr:Prunes crues
+agribalyse_food_code:en:13100
 ciqual_food_code:en:13100
 ciqual_food_name:en:Plum, raw
 ciqual_food_name:fr:Prune, crue
@@ -41163,6 +42261,7 @@ ciqual_food_name:fr:Prune, crue
 fr:Reine-Claudes fraîches, Prunes Reine-Claude
 en:Raw greengage plums
 season_in_country_fr:en: 9
+agribalyse_food_code:en:13041
 ciqual_food_code:en:13041
 ciqual_food_name:en:Greengage plum, raw
 ciqual_food_name:fr:Prune Reine-Claude, crue
@@ -41191,6 +42290,7 @@ fr:Grenades fraîches
 <en:Fruits
 en:Raw pomegranate pulp and pips
 fr:Pulpe et pépins de grenade crue
+agribalyse_food_code:en:13018
 ciqual_food_code:en:13018
 ciqual_food_name:en:Pomegranate, pulp and pips, raw
 ciqual_food_name:fr:Grenade, pulpe et pépins, crue
@@ -41202,6 +42302,7 @@ fr:Coings
 la:Cydonia oblonga
 nl:Kweeperen
 wikidata:en:Q43300
+agribalyse_food_code:en:13010
 ciqual_food_code:en:13010
 ciqual_food_name:en:Quince, raw
 ciqual_food_name:fr:Coing, cru
@@ -41233,6 +42334,7 @@ wikidata:en:Q961769
 <en:Avocados
 en:Raw avocado pulp
 fr:Pulpe d'avocat crue
+agribalyse_food_code:en:13004
 ciqual_food_code:en:13004
 ciqual_food_name:en:Avocado, pulp, raw
 ciqual_food_name:fr:Avocat, pulpe, cru
@@ -41254,6 +42356,7 @@ de:Kochbananen
 fr:Bananes plantains, banane plantain, banane farine, bananes farines, Bananes plantain cuites
 nl:Bakbananen, Kookbananen
 pnns_group_2:en:Potatoes
+agribalyse_food_code:en:53101
 ciqual_food_code:en:53101
 ciqual_food_name:en:Plantain banana, cooked
 ciqual_food_name:fr:Banane plantain, cuite
@@ -41261,6 +42364,7 @@ ciqual_food_name:fr:Banane plantain, cuite
 <en:Bananas
 en:Raw plantain bananas
 fr:Bananes plantain crues
+agribalyse_food_code:en:53100
 ciqual_food_code:en:53100
 ciqual_food_name:en:Plantain banana, raw
 ciqual_food_name:fr:Banane plantain, crue
@@ -41282,6 +42386,7 @@ wikidata:en:Q2427471
 <en:Bananas
 en:Raw banana pulp
 fr:Pulpe de banane crue
+agribalyse_food_code:en:13005
 ciqual_food_code:en:13005
 ciqual_food_name:en:Banana, pulp, raw
 ciqual_food_name:fr:Banane, pulpe, crue
@@ -41289,6 +42394,7 @@ ciqual_food_name:fr:Banane, pulpe, crue
 <en:Bananas
 en:Dried banana pulp
 fr:Pulpe de banane sèche
+agribalyse_food_code:en:13089
 ciqual_food_code:en:13089
 ciqual_food_name:en:Banana, pulp, dried
 ciqual_food_name:fr:Banane, pulpe, sèche
@@ -41317,6 +42423,7 @@ wikidata:en:Q3342808
 <en:Coconuts
 en:Fresh ripe coconut kernel
 fr:Noix de coco mûre fraîche, Amande de noix de coco mûre fraîche
+agribalyse_food_code:en:15006
 ciqual_food_code:en:15006
 ciqual_food_name:en:Coconut, ripe kernel, fresh
 ciqual_food_name:fr:Noix de coco, amande mûre, fraîche
@@ -41325,6 +42432,7 @@ ciqual_food_name:fr:Noix de coco, amande mûre, fraîche
 <en:Dried fruits
 en:Dried coconut kernel
 fr:Noix de coco sèche, Amande de noix de coco sèche
+agribalyse_food_code:en:15007
 ciqual_food_code:en:15007
 ciqual_food_name:en:Coconut, kernel, dried
 ciqual_food_name:fr:Noix de coco, amande, sèche
@@ -41332,6 +42440,7 @@ ciqual_food_name:fr:Noix de coco, amande, sèche
 <en:Coconuts
 en:Fresh immature coconut kernel
 fr:Amande fraîche de noix de coco verte
+agribalyse_food_code:en:15014
 ciqual_food_code:en:15014
 ciqual_food_name:en:Coconut, immature kernel, fresh
 ciqual_food_name:fr:Noix de coco, amande immature, fraîche
@@ -41353,6 +42462,7 @@ wikidata:en:Q3181909
 <en:Tropical fruits
 en:Raw guava pulp
 fr:Pulpe de goyave crue
+agribalyse_food_code:en:13083
 ciqual_food_code:en:13083
 ciqual_food_name:en:Guava, pulp, raw
 ciqual_food_name:fr:Goyave, pulpe, crue
@@ -41368,6 +42478,7 @@ nl:Litchis
 <en:Tropical fruits
 en:Raw lychee pulp
 fr:Pulpe de litchi cru
+agribalyse_food_code:en:13023
 ciqual_food_code:en:13023
 ciqual_food_name:en:Lychee, pulp, raw
 ciqual_food_name:fr:Litchi, pulpe, cru
@@ -41375,6 +42486,7 @@ ciqual_food_name:fr:Litchi, pulpe, cru
 <en:Tropical fruits
 en:Raw carambola pulp
 fr:Pulpe de carambole crue
+agribalyse_food_code:en:13054
 ciqual_food_code:en:13054
 ciqual_food_name:en:Carambola, pulp, raw
 ciqual_food_name:fr:Carambole, pulpe, crue
@@ -41382,6 +42494,7 @@ ciqual_food_name:fr:Carambole, pulpe, crue
 <en:Tropical fruits
 en:Raw breadfruit
 fr:Fruit à pain cru
+agribalyse_food_code:en:54500
 ciqual_food_code:en:54500
 ciqual_food_name:en:Breadfruit, raw
 ciqual_food_name:fr:Fruit à pain, cru
@@ -41423,6 +42536,7 @@ fr:Papayes fraîches
 <en:Tropical fruits
 en:Raw papaya pulp
 fr:Pulpe de papaye
+agribalyse_food_code:en:13035
 ciqual_food_code:en:13035
 ciqual_food_name:en:Papaya, pulp, raw
 ciqual_food_name:fr:Papaye, pulpe, crue
@@ -41439,6 +42553,7 @@ nl_be:Passievruchten
 <en:Tropical fruits
 en:Raw passion fruit pulp and pips
 fr:Pulpe et pépins de fruits de la passion crus, Pulpe et pépins de maracudja cru
+agribalyse_food_code:en:13016
 ciqual_food_code:en:13016
 ciqual_food_name:en:Passion fruit, pulp and pips, raw
 ciqual_food_name:fr:Fruit de la passion ou maracudja, pulpe et pépins, cru
@@ -41461,6 +42576,7 @@ fr:Ananas frais
 <en:Pineapple
 en:Pineapple pulp, Raw pineapple pulp
 fr:Pulpe d'ananas, Pulpe d'ananas cru
+agribalyse_food_code:en:13002
 ciqual_food_code:en:13002
 ciqual_food_name:en:Pineapple, pulp, raw
 ciqual_food_name:fr:Ananas, pulpe, cru
@@ -41475,10 +42591,10 @@ fr:Fruits surgelés
 nl:Bevroren fruit
 pl:Owoce mrożone
 pnns_group_2:en:fruits
-who_id:15
+who_id:en:15
 
 en:Frozen fruits with added sugar
-who_id:16
+who_id:en:16
 
 <en:Frozen fruits
 en:Frozen berries
@@ -41494,6 +42610,7 @@ en:Frozen blackberries, Frozen raw blackberries
 es:Moras congeladas
 fr:Mûres surgelées, Mûres de ronce surgelées
 nl:Bevroren bramen
+agribalyse_food_code:en:13150
 ciqual_food_code:en:13150
 ciqual_food_name:en:Blackberry, frozen, raw
 ciqual_food_name:fr:Mûre (de ronce), surgelée, crue
@@ -41505,6 +42622,7 @@ de:Tiefkühl-Heidelbeeren, Tiefkühl-Blaubeeren
 es:Arándanos congelados
 fr:Myrtilles surgelées, Myrtilles surgelées crues, Myrtille surgelée crue
 nl:Bevroren bosbessen
+agribalyse_food_code:en:13132
 ciqual_food_code:en:13132
 ciqual_food_name:en:Blueberry, frozen, raw
 ciqual_food_name:fr:Myrtille, surgelée, crue
@@ -41608,7 +42726,7 @@ pt:Frutas secas
 sv:Torkade frukter
 th:ผลไม้แห้ง
 pnns_group_2:en:Dried fruits
-who_id:16
+who_id:en:16
 
 # description:en:DATE, the fruit of the date palm (Phoenix dactylifera). Dry or soft dates are eaten out-of-hand, or may be pitted and stuffed with fillings such as almonds, walnuts, pecans, candied orange and lemon peel, tahini, marzipan or cream cheese.
 
@@ -41695,6 +42813,7 @@ wikidata:en:Q25047430
 <en:Dates
 en:Dried date pulp and peel
 fr:Datte pulpe et peau sèche
+agribalyse_food_code:en:13011
 ciqual_food_code:en:13011
 ciqual_food_name:en:Date, pulp and peel, dried
 ciqual_food_name:fr:Datte, pulpe et peau, sèche
@@ -41707,6 +42826,7 @@ fr:Pommes séchées
 it:Mele secche
 nl:Gedroogde appels
 ru:Яблоки сушёные, сушёные яблоки
+agribalyse_food_code:en:13111
 ciqual_food_code:en:13111
 ciqual_food_name:en:Apple, dried
 ciqual_food_name:fr:Pomme, sèche
@@ -41724,6 +42844,7 @@ ru:Абрикосы сушёные, курага, сушёные абрикос�
 <en:Dried fruits
 en:Pitted dried apricots
 fr:Abricots dénoyautés secs
+agribalyse_food_code:en:13001
 ciqual_food_code:en:13001
 ciqual_food_name:en:Apricot, pitted, dried
 ciqual_food_name:fr:Abricot, dénoyauté, sec
@@ -41785,6 +42906,7 @@ fr:Figues sèches, Figue sèche
 it:Fichi secchi
 nl:Gedroogde vijgen
 ru:Инжир сушёный, сушёные инжир
+agribalyse_food_code:en:13013
 ciqual_food_code:en:13013
 ciqual_food_name:en:Fig, dried
 ciqual_food_name:fr:Figue, sèche
@@ -41836,6 +42958,7 @@ fr:Pêches séchées
 nl:Gedroogde perzikken
 pt:Pêssegos secos
 ru:Персики и нектарины сушёные, сушёные персики и нектарины, персики и нектарины сушеные, сушеные персики и нектарины, сушеные персики, персики сушеные
+agribalyse_food_code:en:13118
 ciqual_food_code:en:13118
 ciqual_food_name:en:Peach, dried
 
@@ -41856,6 +42979,7 @@ fr:Pruneaux,Pruneaux secs
 it:Pesche secche
 nl:Gedroogde pruimen
 ru:Чернослив сушёный, сушёный чернослив, чернослив, сливы сушёные
+agribalyse_food_code:en:13042
 ciqual_food_code:en:13042
 ciqual_food_name:en:Prune
 ciqual_food_name:fr:Pruneau, sec
@@ -41876,6 +43000,7 @@ fr:Raisins secs
 it:Uve secche
 nl:Gedroogde rozijnen
 ru:Изюм, виноград сушёный, виноград сушеный, сушеный виноград, сушёный виноград
+agribalyse_food_code:en:13046
 ciqual_food_code:en:13046
 ciqual_food_name:en:Raisin
 
@@ -41902,7 +43027,7 @@ fi:purkitetut hedelmät
 fr:Fruits en conserve
 nl:Fruit in Blik
 pt:Frutos enlatados
-who_id:16
+who_id:en:16
 
 <en:Canned fruits
 en:Canned pineapples
@@ -41931,6 +43056,7 @@ nl:Abrikozen op siroop
 <en:Apricots in syrup
 en:Canned drained apricots in light syrup
 fr:Abricots au sirop léger appertisés égouttés
+agribalyse_food_code:en:13712
 ciqual_food_code:en:13712
 ciqual_food_name:en:Apricot, canned in light syrup, drained
 ciqual_food_name:fr:Abricot au sirop léger, appertisé, égoutté
@@ -41938,6 +43064,7 @@ ciqual_food_name:fr:Abricot au sirop léger, appertisé, égoutté
 <en:Apricots in syrup
 en:Canned drained apricot in syrup
 fr:Abricot au sirop appertisé égoutté
+agribalyse_food_code:en:13714
 ciqual_food_code:en:13714
 ciqual_food_name:en:Apricot, in syrup, canned, drained
 ciqual_food_name:fr:Abricot au sirop, appertisé, égoutté
@@ -41945,6 +43072,7 @@ ciqual_food_name:fr:Abricot au sirop, appertisé, égoutté
 <en:Apricots in syrup
 en:Canned apricots in syrup
 fr:Abricots au sirop appertisés
+agribalyse_food_code:en:13715
 ciqual_food_code:en:13715
 ciqual_food_name:en:Apricot, in syrup, canned, not drained
 ciqual_food_name:fr:Abricot au sirop, appertisé, non égoutté
@@ -41952,6 +43080,7 @@ ciqual_food_name:fr:Abricot au sirop, appertisé, non égoutté
 <en:Apricots in syrup
 en:Canned apricots in light syrup not drained
 fr:Abricots au sirop léger appertisés non égouttés
+agribalyse_food_code:en:13713
 ciqual_food_code:en:13713
 ciqual_food_name:en:Apricot, canned in light syrup, not drained
 ciqual_food_name:fr:Abricot au sirop léger, appertisé, non égoutté
@@ -41996,6 +43125,7 @@ nl:Ananas op siroop
 <en:Pineapple in syrup
 en:Canned drained pineapple in pineapple juice and syrup
 fr:Ananas au sirop et jus d'ananas appertisé égoutté
+agribalyse_food_code:en:13716
 ciqual_food_code:en:13716
 ciqual_food_name:en:Pineapple, in pineapple juice and syrup, canned, drained
 ciqual_food_name:fr:Ananas au sirop et jus d'ananas, appertisé, égoutté
@@ -42003,6 +43133,7 @@ ciqual_food_name:fr:Ananas au sirop et jus d'ananas, appertisé, égoutté
 <en:Pineapple in syrup
 en:Canned drained pineapple in light syrup
 fr:Ananas au sirop léger appertisé égoutté
+agribalyse_food_code:en:13718
 ciqual_food_code:en:13718
 ciqual_food_name:en:Pineapple, in light syrup, canned, drained
 ciqual_food_name:fr:Ananas au sirop léger, appertisé, égoutté
@@ -42010,6 +43141,7 @@ ciqual_food_name:fr:Ananas au sirop léger, appertisé, égoutté
 <en:Pineapple in syrup
 en:Canned pineapple in pineapple juice and syrup not drained
 fr:Ananas au sirop et jus d'ananas appertisé non égoutté
+agribalyse_food_code:en:13717
 ciqual_food_code:en:13717
 ciqual_food_name:en:Pineapple, in pineapple juice and syrup, canned, not drained
 ciqual_food_name:fr:Ananas au sirop et jus d'ananas, appertisé, non égoutté
@@ -42017,6 +43149,7 @@ ciqual_food_name:fr:Ananas au sirop et jus d'ananas, appertisé, non égoutté
 <en:Pineapple in syrup
 en:Canned pineapple in light syrup not drained
 fr:Ananas au sirop léger appertisé non égoutté
+agribalyse_food_code:en:13719
 ciqual_food_code:en:13719
 ciqual_food_name:en:Pineapple, in light syrup, canned, not drained
 ciqual_food_name:fr:Ananas au sirop léger, appertisé, non égoutté
@@ -42032,6 +43165,7 @@ nl:Perzikken op siroop
 <en:Peaches in syrup
 en:Canned drained peach in light syrup
 fr:Pêches au sirop léger appertisées égouttées
+agribalyse_food_code:en:13730
 ciqual_food_code:en:13730
 ciqual_food_name:en:Peach, canned in light syrup, drained
 ciqual_food_name:fr:Pêche au sirop léger, appertisée, égouttée
@@ -42039,6 +43173,7 @@ ciqual_food_name:fr:Pêche au sirop léger, appertisée, égouttée
 <en:Peaches in syrup
 en:Canned peach in light syrup
 fr:Pêches au sirop léger appertisées non égouttées
+agribalyse_food_code:en:13731
 ciqual_food_code:en:13731
 ciqual_food_name:en:Peach, canned in light syrup, not drained
 ciqual_food_name:fr:Pêche au sirop léger, appertisée, non égouttée
@@ -42054,6 +43189,7 @@ nl:Peren op siroop
 <en:Pears in syrup
 en:Canned pears in light syrup not drained
 fr:Poires au sirop léger appertisées non égouttées, Poires au sirop léger en conserve non égouttées
+agribalyse_food_code:en:13735
 ciqual_food_code:en:13735
 ciqual_food_name:en:Pear, canned in light syrup, not drained
 ciqual_food_name:fr:Poire au sirop léger, appertisée, non égouttée
@@ -42098,6 +43234,7 @@ zh:副食
 <en:Fruits in syrup
 en:Syrup for canned fruits
 fr:Sirop pour fruits appertisés
+agribalyse_food_code:en:20918
 ciqual_food_code:en:20918
 ciqual_food_name:en:Syrup for canned fruits in syrup
 ciqual_food_name:fr:Sirop pour fruits appertisés au sirop
@@ -42105,6 +43242,7 @@ ciqual_food_name:fr:Sirop pour fruits appertisés au sirop
 <en:Fruits in syrup
 en:Light syrup for canned fruits
 fr:Sirop léger pour fruits appertisés
+agribalyse_food_code:en:20919
 ciqual_food_code:en:20919
 ciqual_food_name:en:Light syrup for canned fruits in syrup
 ciqual_food_name:fr:Sirop léger pour fruits appertisés au sirop
@@ -42156,6 +43294,7 @@ nl:Geraspte rammenassen
 
 en:Fresh horseradish
 fr:Raifort cru
+agribalyse_food_code:en:11016
 ciqual_food_code:en:11016
 ciqual_food_name:en:Horseradish, fresh
 ciqual_food_name:fr:Raifort, cru
@@ -42261,6 +43400,7 @@ de:frisches Basilikum
 es:Albahaca fresca
 fr:Basilic fraîche, Basilic frais
 nl:Verse basilicums
+agribalyse_food_code:en:11033
 ciqual_food_code:en:11033
 ciqual_food_name:en:Basil, fresh
 ciqual_food_name:fr:Basilic, frais
@@ -42284,6 +43424,7 @@ nl:Gedroogde gemalen basilicums
 <en:Basil
 en:Dried basil
 fr:Basilic séché
+agribalyse_food_code:en:11032
 ciqual_food_code:en:11032
 ciqual_food_name:en:Basil, dried
 ciqual_food_name:fr:Basilic, séché
@@ -42312,6 +43453,7 @@ de:frischer Schnittlauch
 es:Cebollino fresco
 fr:Ciboulette fraîche, Ciboule fraîche
 nl:Verse biesloken
+agribalyse_food_code:en:11003
 ciqual_food_code:en:11003
 ciqual_food_name:en:Chive or spring onion, fresh
 ciqual_food_name:fr:Ciboule ou Ciboulette, fraîche
@@ -42372,6 +43514,7 @@ de:frische Korianderblätter
 es:Hojas de cilantro fresco
 fr:Feuilles de coriandre fraîche, Coriandre fraiche
 nl:Verse korianderbladeren
+agribalyse_food_code:en:11094
 ciqual_food_code:en:11094
 ciqual_food_name:en:Coriander, fresh
 ciqual_food_name:fr:Coriandre, fraiche
@@ -42400,6 +43543,7 @@ de:Koriandersamen
 es:Semillas de cilantro
 fr:Graines de coriandre
 nl:Korianderzaden
+agribalyse_food_code:en:11026
 ciqual_food_code:en:11026
 ciqual_food_name:en:Coriander, seed
 ciqual_food_name:fr:Coriandre, graine
@@ -42421,6 +43565,7 @@ de:frischer Dill
 es:Eneldo fresco
 fr:Aneth fraîche, Aneth frais
 nl:Verse dille
+agribalyse_food_code:en:11093
 ciqual_food_code:en:11093
 ciqual_food_name:en:Dill, fresh
 ciqual_food_name:fr:Aneth, frais
@@ -42449,6 +43594,7 @@ fr:Cerfeuil frais, Produits de le cerfeuil commun, Cerfeuil commun
 la:Anthriscus cerefolium
 nl:Kervelproducten
 wikidata:en:Q218462
+agribalyse_food_code:en:11002
 ciqual_food_code:en:11002
 ciqual_food_name:en:Chervil, fresh
 ciqual_food_name:fr:Cerfeuil, frais
@@ -42492,6 +43638,7 @@ wikidata:en:Q22694
 <en:Dried aromatic plants
 en:Dried marjoram
 fr:Marjolaine séchée
+agribalyse_food_code:en:11034
 ciqual_food_code:en:11034
 ciqual_food_name:en:Marjoram, dried
 ciqual_food_name:fr:Marjolaine, séchée
@@ -42523,6 +43670,7 @@ de:frische Minze
 es:Menta fresca
 fr:Menthe fraîche
 nl:Verse munt
+agribalyse_food_code:en:11027
 ciqual_food_code:en:11027
 ciqual_food_name:en:Mint, fresh
 ciqual_food_name:fr:Menthe, fraîche
@@ -42630,6 +43778,7 @@ nl:Verse oregano
 <en:Dried aromatic plants
 en:Dried oregano
 fr:Origan séché
+agribalyse_food_code:en:11035
 ciqual_food_code:en:11035
 ciqual_food_name:en:Oregano, dried
 ciqual_food_name:fr:Origan, séché
@@ -42666,6 +43815,7 @@ de:Frische Petersilie
 es:Perejil fresco
 fr:Persil frais
 nl:Verse peterselie
+agribalyse_food_code:en:11014
 ciqual_food_code:en:11014
 ciqual_food_name:en:Parsley, fresh
 ciqual_food_name:fr:Persil, frais
@@ -42682,6 +43832,7 @@ nl:Bevroren peterselie
 <en:Dried aromatic plants
 en:Dried parsley
 fr:Persil séché
+agribalyse_food_code:en:11024
 ciqual_food_code:en:11024
 ciqual_food_name:en:Parsley, dried
 ciqual_food_name:fr:Persil, séché
@@ -42724,6 +43875,7 @@ de:Frischer Rosmarin
 es:Romero fresco
 fr:Romarin frais
 nl:Verse rozemarijn
+agribalyse_food_code:en:11068
 ciqual_food_code:en:11068
 ciqual_food_name:en:Rosemary, fresh
 ciqual_food_name:fr:Romarin, frais
@@ -42732,6 +43884,7 @@ ciqual_food_name:fr:Romarin, frais
 <en:Dried aromatic plants
 en:Dried rosemary
 fr:Romarin séché
+agribalyse_food_code:en:11036
 ciqual_food_code:en:11036
 ciqual_food_name:en:Rosemary, dried
 ciqual_food_name:fr:Romarin, séché
@@ -42762,6 +43915,7 @@ wikidata:en:Q1111359
 <en:Sage
 en:Fresh sage
 fr:Sauge fraîche
+agribalyse_food_code:en:11069
 ciqual_food_code:en:11069
 ciqual_food_name:en:Sage, fresh
 ciqual_food_name:fr:Sauge, fraîche
@@ -42770,6 +43924,7 @@ ciqual_food_name:fr:Sauge, fraîche
 <en:Dried aromatic plants
 en:Dried sage
 fr:Sauge séchée
+agribalyse_food_code:en:11037
 ciqual_food_code:en:11037
 ciqual_food_name:en:Sage, dried
 ciqual_food_name:fr:Sauge, séchée
@@ -42794,6 +43949,7 @@ wikidata:en:Q22858
 <en:Dried aromatic plants
 en:Dried savory
 fr:Sarriette séchée
+agribalyse_food_code:en:11062
 ciqual_food_code:en:11062
 ciqual_food_name:en:Savory, dried
 ciqual_food_name:fr:Sarriette, séchée
@@ -42907,6 +44063,7 @@ en:Fresh tarragon
 es:Estragón fresco
 fr:Estragon frais
 nl:Verse dragon
+agribalyse_food_code:en:11092
 ciqual_food_code:en:11092
 ciqual_food_name:en:Tarragon, fresh
 ciqual_food_name:fr:Estragon, frais
@@ -42934,6 +44091,7 @@ en:Fresh thyme
 es:Tomillo fresco
 fr:Thym frais
 nl:Verse thijm
+agribalyse_food_code:en:11070
 ciqual_food_code:en:11070
 ciqual_food_name:en:Thyme, fresh
 ciqual_food_name:fr:Thym, frais
@@ -42942,6 +44100,7 @@ ciqual_food_name:fr:Thym, frais
 <en:Dried aromatic plants
 en:Dried thyme
 fr:Thym séché
+agribalyse_food_code:en:11038
 ciqual_food_code:en:11038
 ciqual_food_name:en:Thyme, dried
 ciqual_food_name:fr:Thym, séché
@@ -42975,6 +44134,7 @@ fr:Laurier, Laurier sauce, Laurier noble, Laurier vrai, Feuilles de laurier
 la:Laurus nobilis
 nl:Laurier
 wikidata:en:Q26006
+agribalyse_food_code:en:11053
 ciqual_food_code:en:11053
 ciqual_food_name:en:Bay, leaves
 ciqual_food_name:fr:Laurier, feuille
@@ -43014,6 +44174,7 @@ wikidata:en:Q33913
 <en:Dried aromatic plants
 en:Molokhia powder, Dried jute leaves
 fr:Meloukhia, Feuilles de corète séchées en poudre
+agribalyse_food_code:en:51500
 ciqual_food_code:en:51500
 ciqual_food_name:en:Molokhia powder (dried jute leaves)
 ciqual_food_name:fr:Meloukhia, feuilles de corète séchées, en poudre
@@ -43065,6 +44226,7 @@ wikidata:en:Q913548
 <en:Herbes de Provence
 en:Dried Provence herbs
 fr:Herbes de Provence séchées
+agribalyse_food_code:en:11060
 ciqual_food_code:en:11060
 ciqual_food_name:en:Provence herbs, dried
 ciqual_food_name:fr:Herbes de Provence, séchées
@@ -43144,6 +44306,7 @@ it:Sale iodato
 <en:Salts
 en:Sea igneous white salt for human consumption without enrichment, Rock white salt for human consumption without enrichment
 fr:Sel blanc alimentaire marin ignigène non iodé non fluoré, Sel blanc alimentaire marin gemme non iodé non fluoré
+agribalyse_food_code:en:11017
 ciqual_food_code:en:11017
 ciqual_food_name:en:Salt, white, for human consumption (sea, igneous or rock), no enrichment
 ciqual_food_name:fr:Sel blanc alimentaire, non iodé, non fluoré (marin, ignigène ou gemme)
@@ -43151,6 +44314,7 @@ ciqual_food_name:fr:Sel blanc alimentaire, non iodé, non fluoré (marin, ignig�
 <en:Salts
 en:Sea igneous white salt for human consumption with added iodine, Rock white salt for human consumption with added iodine
 fr:Sel blanc alimentaire marin ignigène iodé non fluoré, Sel blanc alimentaire marin gemme iodé non fluoré
+agribalyse_food_code:en:11058
 ciqual_food_code:en:11058
 ciqual_food_name:en:Salt, white, for human consumption (sea, igneous or rock), iodine added, no other enrichment
 ciqual_food_name:fr:Sel blanc alimentaire, iodé, non fluoré (marin, ignigène ou gemme)
@@ -43158,6 +44322,7 @@ ciqual_food_name:fr:Sel blanc alimentaire, iodé, non fluoré (marin, ignigène 
 <en:Salts
 en:Sea igneous white salt for human consumption with added iodine, Rock white salt for human consumption with added iodine
 fr:Sel blanc alimentaire marin ignigène iodé non fluoré, Sel blanc alimentaire marin gemme iodé non fluoré
+agribalyse_food_code:en:11058
 ciqual_food_code:en:11058
 ciqual_food_name:en:Salt, white, for human consumption (sea, igneous or rock), iodine added, no other enrichment
 ciqual_food_name:fr:Sel blanc alimentaire, iodé, non fluoré (marin, ignigène ou gemme)
@@ -43189,6 +44354,7 @@ nl:Fleurs de sel, Bloem van het zout
 <en:Sea salts
 en:Pure sea salt without enrichment
 fr:Fleur de sel non iodée non fluorée
+agribalyse_food_code:en:11082
 ciqual_food_code:en:11082
 ciqual_food_name:en:Pure sea salt, no enrichment
 ciqual_food_name:fr:Fleur de sel, non iodée, non fluorée
@@ -43197,6 +44363,7 @@ ciqual_food_name:fr:Fleur de sel, non iodée, non fluorée
 <en:Sea salts
 en:Grey sea salt without enrichment
 fr:Sel marin gris non iodé non fluoré
+agribalyse_food_code:en:11083
 ciqual_food_code:en:11083
 ciqual_food_name:en:Sea salt, grey, no enrichment
 ciqual_food_name:fr:Sel marin gris, non iodé, non fluoré
@@ -43292,6 +44459,7 @@ nl:Keukenzouten
 <en:Salts
 fr:Sels au céleri, Sel au céleri
 en:Celery salt
+agribalyse_food_code:en:11044
 ciqual_food_code:en:11044
 ciqual_food_name:en:Celery salt
 ciqual_food_name:fr:Sel au céleri
@@ -43356,6 +44524,7 @@ wikidata:en:Q33466
 <en:Cardamom
 en:Cardamom powder
 fr:Cardamome en poudre, Poudre de cardamome
+agribalyse_food_code:en:11075
 ciqual_food_code:en:11075
 ciqual_food_name:en:Cardamom, powder
 ciqual_food_name:fr:Cardamome, poudre
@@ -43381,6 +44550,7 @@ fr:Cannelle en poudre, cannelle moulue
 hu:Fahélypor
 nl:Kaneelpoeder
 nl_be:Kaneelpoeder
+agribalyse_food_code:en:11025
 ciqual_food_code:en:11025
 ciqual_food_name:en:Cinnamon, powder
 ciqual_food_name:fr:Cannelle, poudre
@@ -43401,6 +44571,7 @@ hu:Szegfűszeg
 la:Syzygium aromaticum
 nl:Kruidnagels
 wikidata:en:Q26736
+agribalyse_food_code:en:11052
 ciqual_food_code:en:11052
 ciqual_food_name:en:Cloves
 ciqual_food_name:fr:Clou de girofle
@@ -43419,6 +44590,7 @@ nl:Hele kruidnagels
 <en:Spices
 en:Curry powder
 fr:Curry en poudre, Poudre de curry
+agribalyse_food_code:en:11005
 ciqual_food_code:en:11005
 ciqual_food_name:en:Curry, powder
 ciqual_food_name:fr:Curry, poudre
@@ -43445,6 +44617,7 @@ en:Whole cumin seeds, Cumin seeds
 es:Comino en grano
 fr:Graines de cumin
 nl:Komijnzaden, Grove komijn
+agribalyse_food_code:en:11042
 ciqual_food_code:en:11042
 ciqual_food_name:en:Cumin, seed
 ciqual_food_name:fr:Cumin, graine
@@ -43452,6 +44625,7 @@ ciqual_food_name:fr:Cumin, graine
 <en:Aromatic herbs
 en:Caraway seeds
 fr:Graines de carvi
+agribalyse_food_code:en:11064
 ciqual_food_code:en:11064
 ciqual_food_name:en:Caraway, seed
 ciqual_food_name:fr:Carvi, graine
@@ -43489,6 +44663,7 @@ en:Fenugreek seeds
 es:Semillas de fenogreco
 fr:Graines de fenugrec
 nl:Fenegriekzaden
+agribalyse_food_code:en:11077
 ciqual_food_code:en:11077
 ciqual_food_name:en:Fenugreek, seed
 ciqual_food_name:fr:Fenugrec, graine
@@ -43530,6 +44705,7 @@ en:Ginger powder, Dried ginger powder
 es:Jengibre molido, Jengibre seco en polvo
 fr:Gingembre en poudre, Gingembre moulu, Gingembre sec en poudre
 nl:Gemberpoeder, Djahé
+agribalyse_food_code:en:11006
 ciqual_food_code:en:11006
 ciqual_food_name:en:Ginger, powder
 ciqual_food_name:fr:Gingembre, poudre
@@ -43539,6 +44715,7 @@ en:Fresh ginger rhizomes, Raw ginger
 es:Rizomas de jengibre frescos
 fr:Rhizomes de gingembre frais, Racines de gingembre crues
 nl:Verse gemberwortels
+agribalyse_food_code:en:11074
 ciqual_food_code:en:11074
 ciqual_food_name:en:Ginger, raw
 ciqual_food_name:fr:Gingembre, racine crue
@@ -43585,6 +44762,7 @@ es:Nuez moscada
 fr:Noix de muscade
 nl:Nootmuskaat
 wikidata:en:Q83165
+agribalyse_food_code:en:11048
 ciqual_food_code:en:11048
 ciqual_food_name:en:Nutmeg
 ciqual_food_name:fr:Noix de muscade
@@ -43630,6 +44808,7 @@ pam:Paprika
 pt-BR:Páprica
 sco:paprika
 wikidata:en:Q3127593
+agribalyse_food_code:en:11049
 ciqual_food_code:en:11049
 ciqual_food_name:en:Paprika
 ciqual_food_name:fr:Paprika
@@ -43684,6 +44863,7 @@ es:Pimienta negra en polvo
 fi:rouhitut mustapippurit
 fr:Poivre noir moulu, Poivre noir en poudre
 nl:Gemalen zwarte pepers
+agribalyse_food_code:en:11015
 ciqual_food_code:en:11015
 ciqual_food_name:en:Black pepper, powder
 ciqual_food_name:fr:Poivre noir, poudre
@@ -43691,6 +44871,7 @@ ciqual_food_name:fr:Poivre noir, poudre
 <en:Ground peppers
 en:Grouned grey peppers, Grey pepper powder
 fr:Poivre gris moulu, Poivre gris en poudre
+agribalyse_food_code:en:11020
 ciqual_food_code:en:11020
 ciqual_food_name:en:Grey pepper, powder
 ciqual_food_name:fr:Poivre gris, poudre
@@ -43770,6 +44951,7 @@ de:Weißer Pfeffer gemahlen
 es:Pimienta blanca en polvo
 fr:Poivre blanc moulu, Poivre blanc en poudre
 nl:Gemalen witte pepers
+agribalyse_food_code:en:11019
 ciqual_food_code:en:11019
 ciqual_food_name:en:White pepper, powder
 ciqual_food_name:fr:Poivre blanc, poudre
@@ -43783,6 +44965,7 @@ la:Crocus sativus
 nl:Saffraan
 nl_be:Saffraan
 wikidata:en:Q25434
+agribalyse_food_code:en:11039
 ciqual_food_code:en:11039
 ciqual_food_name:en:Saffron
 ciqual_food_name:fr:Safran
@@ -43826,6 +45009,7 @@ es:Cúrcuma molida, Cúrcuma en polvo
 fi:kurkumajauhe
 fr:Curcuma en poudre, Poudre de curcuma
 nl:Kurkumapoeders, Geelwortelpoeders, Koenjitpoeders
+agribalyse_food_code:en:11089
 ciqual_food_code:en:11089
 ciqual_food_name:en:Turmeric, powder
 ciqual_food_name:fr:Curcuma, poudre
@@ -43873,6 +45057,7 @@ fr:Extrait alcoolique de vanille
 nl:Vanille-extracten
 pt:Extracto de vainilla
 wikidata:en:Q10749869
+agribalyse_food_code:en:11065
 ciqual_food_code:en:11065
 ciqual_food_name:en:Vanilla, alcoholic extract
 ciqual_food_name:fr:Vanille, extrait alcoolique
@@ -43880,6 +45065,7 @@ ciqual_food_name:fr:Vanille, extrait alcoolique
 <en:Vanilla
 en:Aqueous vanilla extract
 fr:Extrait aqueux de vanille
+agribalyse_food_code:en:11098
 ciqual_food_code:en:11098
 ciqual_food_name:en:Vanilla, aqueous extract
 ciqual_food_name:fr:Vanille, extrait aqueux
@@ -43938,6 +45124,7 @@ en:Cayenne peppers, Cayenne pepper
 es:Cayena
 fr:Piments de Cayenne, Piment de Cayenne, Capsicum baccatum, aji, piment enragé, poivre de Cayenne
 wikidata:en:Q6598
+agribalyse_food_code:en:11088
 ciqual_food_code:en:11088
 ciqual_food_name:en:Cayenne pepper
 ciqual_food_name:fr:Poivre de Cayenne ou piment de Cayenne
@@ -44018,6 +45205,7 @@ fr:Serrano
 <en:Chili peppers
 en:Raw chili pepper
 fr:Piment cru
+agribalyse_food_code:en:20151
 ciqual_food_code:en:20151
 ciqual_food_name:en:Chili pepper, raw
 ciqual_food_name:fr:Piment, cru
@@ -44052,6 +45240,7 @@ en:Guacamole spice mix
 <en:Spice Mix
 en:Mix of 4 spices, Mix of four spices
 fr:Quatre épices
+agribalyse_food_code:en:11056
 ciqual_food_code:en:11056
 ciqual_food_name:en:Mix of 4 spices
 ciqual_food_name:fr:Quatre épices
@@ -44076,7 +45265,7 @@ th:กลุ่มผลิตภัณฑ์ไส้กรอก
 zh:酱汁
 pnns_group_2:en:Dressings and sauces
 wikidata:en:Q178359
-who_id:17
+who_id:en:17
 
 <en:Sauces
 en:Warm sauces
@@ -44101,6 +45290,7 @@ en:Light custard cream with vanilla
 de:Englische Creme
 nl:Vanillesauzen
 wikidata:en:Q1342574
+agribalyse_food_code:en:39700
 ciqual_food_code:en:39700
 ciqual_food_name:en:Light custard cream with vanilla, prepacked
 ciqual_food_name:fr:Crème anglaise, préemballée
@@ -44109,6 +45299,7 @@ ciqual_food_name:fr:Crème anglaise, préemballée
 <en:Dessert sauces
 en:Pastry cream, Custard
 fr:Crème pâtissière
+agribalyse_food_code:en:39710
 ciqual_food_code:en:39710
 ciqual_food_name:en:Pastry cream or custard
 ciqual_food_name:fr:Crème pâtissière
@@ -44137,6 +45328,7 @@ ciqual_food_name:fr:Meloukhia, sauce, artisanale
 <en:Sauces
 en:Kebab sauce
 fr:Sauce kebab
+agribalyse_food_code:en:11203
 ciqual_food_code:en:11203
 ciqual_food_name:en:Kebab sauce, prepacked
 ciqual_food_name:fr:Sauce kebab, préemballée
@@ -44144,6 +45336,7 @@ ciqual_food_name:fr:Sauce kebab, préemballée
 <en:Sauces for fishes
 fr:Sauces armoricaines, Sauce armoricaine, Sauces à l'armoricaine, Sauce à l'armoricaine, Sauce armoricaine
 en:Armorican-style sauce
+agribalyse_food_code:en:11111
 ciqual_food_code:en:11111
 ciqual_food_name:en:Armorican-style sauce, prepacked
 ciqual_food_name:fr:Sauce armoricaine, préemballée
@@ -44160,6 +45353,7 @@ fr:Sauces au vin blanc, Sauce au vin blanc
 <en:Sauces
 fr:Sauces au vin rouge, Sauces au vin rouge
 en:Red wine sauces
+agribalyse_food_code:en:11164
 ciqual_food_code:en:11164
 ciqual_food_name:en:Red wine sauce
 ciqual_food_name:fr:Sauce au vin rouge
@@ -44167,6 +45361,7 @@ ciqual_food_name:fr:Sauce au vin rouge
 <en:Sauces
 fr:Sauces au yaourt, Sauce au yaourt
 en:Yogurt sauce
+agribalyse_food_code:en:11166
 ciqual_food_code:en:11166
 ciqual_food_name:en:Yogurt sauce
 ciqual_food_name:fr:Sauce au yaourt
@@ -44177,6 +45372,7 @@ fr:Sauces aux cacahuètes, Sauce aux cacahuètes, Sauces saté, Sauce saté, Sau
 <en:Sauces
 en:Grand veneur sauce, Reduction of red wine with garlic shallots and red currant jelly
 fr:Sauce grand veneur
+agribalyse_food_code:en:11199
 ciqual_food_code:en:11199
 ciqual_food_name:en:Grand veneur sauce (a reduction of red wine with garlic, shallots and red currant jelly), prepacked
 ciqual_food_name:fr:Sauce grand veneur, préemballée
@@ -44184,6 +45380,7 @@ ciqual_food_name:fr:Sauce grand veneur, préemballée
 <en:Sauces
 en:Green pepper sauce
 fr:Sauce au poivre vert
+agribalyse_food_code:en:11115
 ciqual_food_code:en:11115
 ciqual_food_name:en:Green pepper sauce, prepacked
 ciqual_food_name:fr:Sauce au poivre vert, préemballée
@@ -44191,6 +45388,7 @@ ciqual_food_name:fr:Sauce au poivre vert, préemballée
 <en:Sauces
 en:Cream sauce with spices
 fr:Sauce à la crème aux épices
+agribalyse_food_code:en:11161
 ciqual_food_code:en:11161
 ciqual_food_name:en:Cream sauce with spices
 ciqual_food_name:fr:Sauce à la crème aux épices
@@ -44198,6 +45396,7 @@ ciqual_food_name:fr:Sauce à la crème aux épices
 <en:Sauces
 en:Cream sauce with herbs
 fr:Sauce à la crème aux herbes
+agribalyse_food_code:en:11162
 ciqual_food_code:en:11162
 ciqual_food_name:en:Cream sauce with herbs
 ciqual_food_name:fr:Sauce à la crème aux herbes
@@ -44205,6 +45404,7 @@ ciqual_food_name:fr:Sauce à la crème aux herbes
 <en:Sauces
 en:Cream sauce with mushrooms
 fr:Sauce aux champignons et à la crème
+agribalyse_food_code:en:11192
 ciqual_food_code:en:11192
 ciqual_food_name:en:Cream sauce with mushrooms, prepacked
 ciqual_food_name:fr:Sauce aux champignons et à la crème, préemballée
@@ -44212,6 +45412,7 @@ ciqual_food_name:fr:Sauce aux champignons et à la crème, préemballée
 <en:Sauces
 fr:Sauces basquaises, Sauce basquaise, Sauces aux poivrons, Sauces basquaises, Sauces aux poivrons
 en:Basque-style sauces, Tomato sauces with sweet peppers
+agribalyse_food_code:en:11170
 ciqual_food_code:en:11170
 ciqual_food_name:en:Basque-style sauce or tomato sauce with sweet peppers, prepacked
 ciqual_food_name:fr:Sauce basquaise ou Sauce aux poivrons, préemballée
@@ -44219,6 +45420,7 @@ ciqual_food_name:fr:Sauce basquaise ou Sauce aux poivrons, préemballée
 <en:Sauces
 en:Tomato sauce with vegetables
 fr:Sauce tomate aux petits légumes
+agribalyse_food_code:en:11207
 ciqual_food_code:en:11207
 ciqual_food_name:en:Tomato sauce, w vegetables, prepacked
 ciqual_food_name:fr:Sauce tomate aux petits légumes, préemballée
@@ -44226,6 +45428,7 @@ ciqual_food_name:fr:Sauce tomate aux petits légumes, préemballée
 <en:Sauces
 en:American-style sauce
 fr:Sauce américaine
+agribalyse_food_code:en:11167
 ciqual_food_code:en:11167
 ciqual_food_name:en:American-style sauce, prepacked
 ciqual_food_name:fr:Sauce américaine, préemballée
@@ -44233,6 +45436,7 @@ ciqual_food_name:fr:Sauce américaine, préemballée
 <en:Sauces for fishes
 fr:Sauces au beurre blanc, Sauces beurre blanc, Sauces au beurre blanc, Sauces beurre blanc, Sauce au beurre blanc
 en:White butter sauce
+agribalyse_food_code:en:11140
 ciqual_food_code:en:11140
 ciqual_food_name:en:White butter sauce, prepacked
 ciqual_food_name:fr:Sauce au beurre blanc, préemballée
@@ -44240,6 +45444,7 @@ ciqual_food_name:fr:Sauce au beurre blanc, préemballée
 <en:Sauces for fishes
 en:Butter sauce
 fr:Sauce au beurre
+agribalyse_food_code:en:11158
 ciqual_food_code:en:11158
 ciqual_food_name:en:Sauce, butter, prepacked
 ciqual_food_name:fr:Sauce au beurre, préemballée
@@ -44253,6 +45458,7 @@ fr:Sauces bordelaises
 <en:Sauces
 fr:Sauces bourguignonnes, Sauce bourguignonne
 en:Burgundy-style sauces
+agribalyse_food_code:en:11120
 ciqual_food_code:en:11120
 ciqual_food_name:en:Burgundy-style sauce, prepacked
 ciqual_food_name:fr:Sauce bourguignonne, préemballée
@@ -44263,6 +45469,7 @@ fr:Sauces caesar
 <en:Sauces
 fr:Sauces carbonara, Sauce carbonara
 en:Carbonara sauces, Cream sauce with lardoons
+agribalyse_food_code:en:11128
 ciqual_food_code:en:11128
 ciqual_food_name:en:Carbonara sauce (cream sauce with lardoons), prepacked
 ciqual_food_name:fr:Sauce carbonara, préemballée
@@ -44270,6 +45477,7 @@ ciqual_food_name:fr:Sauce carbonara, préemballée
 <en:Sauces
 en:Cream sauce with shallots
 fr:Sauce à l'échalote à la crème
+agribalyse_food_code:en:11122
 ciqual_food_code:en:11122
 ciqual_food_name:en:Cream sauce with shallots, prepacked
 ciqual_food_name:fr:Sauce à l'échalote à la crème, préemballée
@@ -44277,6 +45485,7 @@ ciqual_food_name:fr:Sauce à l'échalote à la crème, préemballée
 <en:Sauces
 en:Cream sauce
 fr:Sauce à la crème
+agribalyse_food_code:en:11159
 ciqual_food_code:en:11159
 ciqual_food_name:en:Cream sauce
 ciqual_food_name:fr:Sauce à la crème
@@ -44287,6 +45496,7 @@ de:Pilzsaucen
 fi:sienikastikkeet
 fr:Sauces aux champignons, Sauces champignons, Sauces champignons archiduc, Sauce aux champignons
 nl:Paddenstoelsauzen, Paddenstoelsaus
+agribalyse_food_code:en:11160
 ciqual_food_code:en:11160
 ciqual_food_name:en:Mushroom sauce, prepacked
 ciqual_food_name:fr:Sauce aux champignons, préemballée
@@ -44294,6 +45504,7 @@ ciqual_food_name:fr:Sauce aux champignons, préemballée
 <en:Sauces
 fr:Sauces chasseur, Sauce chasseur
 en:Hunter-style sauces, Garnish of mushrooms shallots and tomatoes in white wine sauce
+agribalyse_food_code:en:11129
 ciqual_food_code:en:11129
 ciqual_food_name:en:Hunter-style sauce (a garnish of mushrooms, shallots and tomatoes in white wine sauce), prepacked
 ciqual_food_name:fr:Sauce chasseur, préemballée
@@ -44310,6 +45521,7 @@ fr:Sauces dressing au yaourt
 <en:Sauces
 fr:Sauces hollandaise, Sauce hollandaise
 en:Hollandaise sauce
+agribalyse_food_code:en:11105
 ciqual_food_code:en:11105
 ciqual_food_name:en:Hollandaise sauce, prepacked
 
@@ -44327,6 +45539,7 @@ fr:Piccalillis, Sauces piccalilli, piccalilli
 
 <en:Sauces
 fr:Sauces crudités, Sauce crudités
+agribalyse_food_code:en:11187
 ciqual_food_code:en:11187
 ciqual_food_name:en:Salad dressing, prepacked
 ciqual_food_name:fr:Sauce crudités ou Sauce salade, préemballée
@@ -44339,6 +45552,7 @@ es:Aderezos
 fi:Salaattikastikkeet
 fr:Sauces salades, sauce salade, sauce pour salade
 nl:Slasauzen, sladressings
+agribalyse_food_code:en:11187
 ciqual_food_code:en:11187
 ciqual_food_name:en:Salad dressing, prepacked
 ciqual_food_name:fr:Sauce crudités ou Sauce salade, préemballée
@@ -44347,6 +45561,7 @@ ciqual_food_name:fr:Sauce crudités ou Sauce salade, préemballée
 <en:Sauces
 en:Salad dressing with reduced fat, Low fat salad dressing, Light salad dressing
 fr:Sauce crudités allégée en matière grasse, Sauce salade allégée en matière grasse
+agribalyse_food_code:en:11198
 ciqual_food_code:en:11198
 ciqual_food_name:en:Salad dressing, reduced fat, prepacked
 ciqual_food_name:fr:Sauce crudités ou Sauce salade, allégée en matière grasse, préemballée
@@ -44354,6 +45569,7 @@ ciqual_food_name:fr:Sauce crudités ou Sauce salade, allégée en matière grass
 <en:Sauces
 en:Salad dressing with 50-75% of oil
 fr:Sauce vinaigrette avec 50 à 75% d'huile
+agribalyse_food_code:en:11110
 ciqual_food_code:en:11110
 ciqual_food_name:en:Salad dressing, (50-75% of oil), prepacked
 ciqual_food_name:fr:Sauce vinaigrette (50 à 75% d'huile), préemballée
@@ -44368,6 +45584,7 @@ ciqual_food_name:fr:Sauce vinaigrette allégée en MG (25 à 50% d'huile), prée
 <en:Sauces
 en:Mustard sauce
 fr:Sauce moutarde
+agribalyse_food_code:en:11157
 ciqual_food_code:en:11157
 ciqual_food_name:en:Mustard sauce prepacked
 ciqual_food_name:fr:Sauce moutarde, préemballée
@@ -44379,6 +45596,7 @@ fi:Barbeque-kastikkeet, BBQ-kastikkeet
 fr:Sauces barbecue, Sauces BBQ
 hu:Barbecue mártások, Barbecue szószok, BBQ mártások
 nl:Barbecuesauzen
+agribalyse_food_code:en:11100
 ciqual_food_code:en:11100
 ciqual_food_name:en:Barbecue sauce, prepacked
 ciqual_food_name:fr:Sauce barbecue, préemballée
@@ -44407,6 +45625,7 @@ fi:currykastikkeet
 fr:Sauces au curry, Sauces curry
 hu:Curry mártások
 nl:Kerriesaus, Kerriesauzen
+agribalyse_food_code:en:11132
 ciqual_food_code:en:11132
 ciqual_food_name:en:Curry sauce, prepacked
 ciqual_food_name:fr:Sauce au curry, préemballée
@@ -44416,6 +45635,7 @@ en:Harissa sauces, Hot spicy sauce
 de:Harissa-Soßen
 fr:Harissas, Sauces harissa, harissa, sauce harissa, Sauce condimentaire harissa
 nl:Harissa sauzen, Harissa saus
+agribalyse_food_code:en:11112
 ciqual_food_code:en:11112
 ciqual_food_name:en:Harissa (hot spicy sauce), prepacked
 ciqual_food_name:fr:Harissa (sauce condimentaire)
@@ -44429,6 +45649,7 @@ nl:Oestersaus
 en:Madère sauces, Madeira wine sauces
 fr:Sauces Madère, Sauce madère
 nl:Medeirasauzen
+agribalyse_food_code:en:11121
 ciqual_food_code:en:11121
 ciqual_food_name:en:Madeira wine sauce, prepacked
 ciqual_food_name:fr:Sauce madère, préemballée
@@ -44454,6 +45675,7 @@ nl:Indiaase sauzen
 en:Tikka masala sauce, Indian-style garam masala sauce
 fr:Sauces tikka masala, Sauce indienne tikka masala
 nl:Tikka masala sauzen
+agribalyse_food_code:en:11202
 ciqual_food_code:en:11202
 ciqual_food_name:en:Indian-style sauce, tandoori or garam masala type, prepacked
 ciqual_food_name:fr:Sauce indienne type tandoori ou tikka masala, préemballée
@@ -44462,6 +45684,7 @@ ciqual_food_name:fr:Sauce indienne type tandoori ou tikka masala, préemballée
 en:Tandoori sauces, Indian-style tandoori sauce
 fr:Sauces tandoori, Sauce indienne tandoori
 nl:Tandoorisauzen
+agribalyse_food_code:en:11202
 ciqual_food_code:en:11202
 ciqual_food_name:en:Indian-style sauce, tandoori or garam masala type, prepacked
 ciqual_food_name:fr:Sauce indienne type tandoori ou tikka masala, préemballée
@@ -44502,6 +45725,7 @@ pt:Molho de groselha
 <en:Sauces
 fr:Sauces Nuoc-mâm, Sauces Nuoc-mâm, Sauces Nuoc Mâm, Sauces au poisson
 en:Nuoc mam sauce, Fish sauce
+agribalyse_food_code:en:11194
 ciqual_food_code:en:11194
 ciqual_food_name:en:Nuoc mam sauce or fish sauce, prepacked
 ciqual_food_name:fr:Sauce Nuoc Mâm ou Sauce au poisson, préemballée
@@ -44513,6 +45737,7 @@ es:Salsa bearnesa
 fi:bernaise-kastike
 fr:Sauces béarnaises, Sauce béarnaise
 nl:Béarnaise saus
+agribalyse_food_code:en:11102
 ciqual_food_code:en:11102
 ciqual_food_name:en:Bearnaise sauce, prepacked
 
@@ -44523,6 +45748,7 @@ nl:Patatje Joppiesaussmaaksauzen
 en:Burger sauces, Sauce burger
 fr:Sauces burger, sauces hamburger
 nl:Hamburgersauzen
+agribalyse_food_code:en:11196
 ciqual_food_code:en:11196
 ciqual_food_name:en:Burger sauce, prepacked
 ciqual_food_name:fr:Sauce burger, préemballée
@@ -44533,6 +45759,7 @@ fi:tartar-kastikkeet
 fr:Sauces tartare
 nl:Tartaarsaus
 pl:Sosy tatarskie, sos tatarski
+agribalyse_food_code:en:11051
 ciqual_food_code:en:11051
 ciqual_food_name:en:Tartare sauce, prepacked
 
@@ -44544,6 +45771,7 @@ fi:Aiolit, Aiolikastikkeet
 fr:Aïolis, Aiolis, sauces Aïoli, sauces Aïolis, sauce Aïoli
 nl:Aiolisauzen, Knoflooksauzen
 wikidata:en:Q283231
+agribalyse_food_code:en:11168
 ciqual_food_code:en:11168
 ciqual_food_name:en:Aioli sauce (garlic and olive oil mayonnaise), prepacked
 ciqual_food_name:fr:Sauce aïoli, préemballée
@@ -44556,6 +45784,7 @@ fr:Sauces béchamel, sauce béchamel
 hu:Béchamel mártások
 nl:Bechamelsauzen
 wikidata:en:Q209974
+agribalyse_food_code:en:11101
 ciqual_food_code:en:11101
 ciqual_food_name:en:Bechamel sauce, prepacked
 ciqual_food_name:fr:Sauce béchamel, préemballée
@@ -44563,6 +45792,7 @@ ciqual_food_name:fr:Sauce béchamel, préemballée
 <en:Béchamel sauces
 en:Home-made Bechamel sauce
 fr:Sauce béchamel maison
+agribalyse_food_code:en:11143
 ciqual_food_code:en:11143
 ciqual_food_name:en:Bechamel sauce, home-made
 ciqual_food_name:fr:Sauce béchamel, maison
@@ -44575,6 +45805,7 @@ fi:juustokastikkeet
 fr:Sauces au fromage, Sauce au fromage, Sauces aux fromages, Sauce aux fromages
 hu:Sajtosmártások, Sajtmártások
 nl:Kaassauzen
+agribalyse_food_code:en:11189
 ciqual_food_code:en:11189
 ciqual_food_name:en:Cheese sauce for risotto or pasta, prepacked
 
@@ -44584,6 +45815,7 @@ es:Salsas con Roquefort, Salsas con queso de Roquefort
 fr:Sauces au roquefort, Sauce au roquefort
 hu:Rokfortmártás
 nl:Roquefortsauzen
+agribalyse_food_code:en:11191
 ciqual_food_code:en:11191
 ciqual_food_name:en:Roquefort (blue cheese) sauce, prepacked
 ciqual_food_name:fr:Sauce au roquefort, préemballée
@@ -44596,6 +45828,7 @@ fi:guacamolet
 fr:Guacamoles
 nl:Guacamoles
 wikidata:en:Q207968
+agribalyse_food_code:en:25620
 ciqual_food_code:en:25620
 ciqual_food_name:en:Guacamole, prepacked
 ciqual_food_name:fr:Guacamole, préemballé
@@ -44637,12 +45870,14 @@ fr:Sauces au poivre, Sauce au poivre
 hu:Paprikaszósz, Papriaka mártás
 nl:Pepersauzen
 wikidata:en:Q3474121
+agribalyse_food_code:en:11182
 ciqual_food_code:en:11182
 ciqual_food_name:en:Sauce, pepper, prepacked
 
 <en:Sauces
 en:Sauce pepper prepacked
 fr:Sauce au poivre condimentaire froide
+agribalyse_food_code:en:11212
 ciqual_food_code:en:11212
 ciqual_food_name:en:Sauce, pepper, prepacked
 
@@ -44671,6 +45906,13 @@ pl:Majonezy, majonez
 pt:Maioneses, maionese
 ru:Майонез
 wikidata:en:Q167893
+
+<en:Sauces
+en:Chocolate sauce
+fr:Sauce au chocolat
+agribalyse_food_code:en:11300
+ciqual_food_code:en:11300
+ciqual_food_name:en:Chocolate sauce
 
 <en:Mayonnaises
 nl:Fritessauzen
@@ -44712,6 +45954,7 @@ es:Mayonesas ligeras, Mayonesas light
 fi:kevytmajoneesit
 fr:Mayonnaises allégées, Mayonnaises allégées en matières grasses, Mayonnaises allégées en matière grasse, Mayonnaise à teneur réduite en matière grasse, Mayonnaise allégée
 nl:Light mayonnaises, Halvanaises
+agribalyse_food_code:en:11079
 ciqual_food_code:en:11079
 ciqual_food_name:en:Mayonnaise, reduced fat or light mayonnaise
 ciqual_food_name:fr:Mayonnaise à teneur réduite en matière grasse ou Mayonnaise allégée
@@ -44719,6 +45962,7 @@ ciqual_food_name:fr:Mayonnaise à teneur réduite en matière grasse ou Mayonnai
 <en:Mayonnaises
 en:70% fat mayonnaise
 fr:Mayonnaise à 70% de matière grasse
+agribalyse_food_code:en:11054
 ciqual_food_code:en:11054
 ciqual_food_name:en:Mayonnaise (70% fat and more)
 ciqual_food_name:fr:Mayonnaise (70% MG min.)
@@ -44733,6 +45977,7 @@ wikidata:en:Q2227032
 <en:Mayonnaises
 en:Rouille sauces, mayonnaise flavoured with garlic chilli pepper and fish broth, Rouille flavoured with garlic chilli pepper and fish broth
 fr:Sauce rouille
+agribalyse_food_code:en:11205
 ciqual_food_code:en:11205
 ciqual_food_name:en:Mayonnaise flavoured with garlic, chilli pepper and fish broth, prepacked
 ciqual_food_name:fr:Sauce rouille, préemballée
@@ -44756,6 +46001,7 @@ ro:Muștar
 sv:Senap
 th:มัสตาร์ด
 wikidata:en:Q131748
+agribalyse_food_code:en:11013
 ciqual_food_code:en:11013
 ciqual_food_name:en:Mustard
 ciqual_food_name:fr:Moutarde
@@ -44787,6 +46033,7 @@ fr:Moutarde de Bourgogne
 protected_name_file_number:en: PGI-FR-0503
 protected_name_type:en: pgi
 origins:en: en:France
+wikidata:en:Q21427661
 
 <en:Mustards
 en:Fine mustards
@@ -44837,6 +46084,7 @@ fi:vanhanaikaiset sinapit
 fr:Moutardes à l’ancienne, moutarde à l’ancienne
 hu:Régi stílusú mustárok
 nl:Grove mosterds
+agribalyse_food_code:en:11021
 ciqual_food_code:en:11021
 ciqual_food_name:en:Mustard, with grains
 ciqual_food_name:fr:Moutarde à l'ancienne
@@ -44900,6 +46148,7 @@ fr:Sauces bolognaises, sauce bolognaise, Bolognese, Bolognaises, Bolognaise, Sau
 hu:Bolonyai szósz
 nl:Bolognaisesauzen, Bolognesesauzen
 wikidata:en:Q1162965
+agribalyse_food_code:en:11114
 ciqual_food_code:en:11114
 ciqual_food_name:en:Tomato sauce, with meat or Bolognese sauce, prepacked
 ciqual_food_name:fr:Sauce tomate à la viande ou Sauce bolognaise, préemballée
@@ -45422,6 +46671,7 @@ it:Pesto
 nl:Pestosauzen
 zh:青酱
 wikidata:en:Q9896
+agribalyse_food_code:en:11179
 ciqual_food_code:en:11179
 ciqual_food_name:en:Sauce, pesto, prepacked
 ciqual_food_name:fr:Sauce pesto, préemballée
@@ -45435,6 +46685,7 @@ fr:Sauces Pesto Rosso, Pesto rosso, Pesto rouge, pestos rouges, Sauce pesto ross
 hu:Piros pestók, Piros pestó szószok
 it:Pesto rosso
 nl:Rode pestosauzen
+agribalyse_food_code:en:11210
 ciqual_food_code:en:11210
 ciqual_food_name:en:Sauce, pesto rosso, prepacked
 ciqual_food_name:fr:Sauce pesto rosso, préemballée
@@ -45460,6 +46711,7 @@ nl:Pizzasauzen
 <en:Pizza sauces
 en:Cream sauce for pizza base
 fr:Base de pizza à la crème
+agribalyse_food_code:en:37000
 ciqual_food_code:en:37000
 ciqual_food_name:en:cream sauce for pizza base
 ciqual_food_name:fr:Base de pizza à la crème
@@ -45467,6 +46719,7 @@ ciqual_food_name:fr:Base de pizza à la crème
 <en:Pizza sauces
 en:Tomato sauce for pizza base
 fr:Base de pizza tomatée
+agribalyse_food_code:en:37002
 ciqual_food_code:en:37002
 ciqual_food_name:en:Tomato sauce for pizza base
 ciqual_food_name:fr:Base de pizza tomatée
@@ -45474,6 +46727,7 @@ ciqual_food_name:fr:Base de pizza tomatée
 <en:Pizza sauces
 en:Topping sauce for pizza
 fr:Sauce pour pizza, Garniture pour pizza
+agribalyse_food_code:en:25525
 ciqual_food_code:en:25525
 ciqual_food_name:en:Topping sauce for pizza
 ciqual_food_name:fr:Pizza, sauce garniture pour
@@ -45511,6 +46765,7 @@ nl:Sojasauzen, Ketjaps
 nl_be:Sojasaus, Ketjap
 ru:Соевые соусы, Соевый соус, Соус соевый, Соусы соевые
 wikidata:en:Q229385
+agribalyse_food_code:en:11104
 ciqual_food_code:en:11104
 ciqual_food_name:en:Soy sauce, prepacked
 ciqual_food_name:fr:Sauce soja, préemballée
@@ -45544,6 +46799,7 @@ fi:hapanimeläkastikkeet
 fr:Sauces aigre-douces, Sauces à l'aigre-douce, Sauce aigre douce
 nl:Zoetzuursauzen
 wikidata:en:Q2550606
+agribalyse_food_code:en:11163
 ciqual_food_code:en:11163
 ciqual_food_name:en:Sweet and sour sauce, prepacked
 ciqual_food_name:fr:Sauce aigre douce, préemballée
@@ -45571,6 +46827,7 @@ fr:Sauces tomates au basilic
 <en:Tomato sauces
 fr:Sauces tomates aux champignons
 en:Tomato sauces with mushrooms
+agribalyse_food_code:en:11177
 ciqual_food_code:en:11177
 ciqual_food_name:en:Tomato sauce, w mushrooms, prepacked
 ciqual_food_name:fr:Sauce tomate aux champignons, préemballée
@@ -45585,6 +46842,7 @@ fr:Sauces tomates aux légumes
 <en:Tomato sauces
 en:Tomato sauces with onions
 fr:Sauces tomate aux oignons
+agribalyse_food_code:en:11107
 ciqual_food_code:en:11107
 ciqual_food_name:en:Tomato sauce, with onions, prepacked
 ciqual_food_name:fr:Sauce tomate aux oignons, préemballée
@@ -45592,6 +46850,7 @@ ciqual_food_name:fr:Sauce tomate aux oignons, préemballée
 <en:Tomato sauces
 fr:Sauces tomates aux olives
 en:Tomato sauce with olives
+agribalyse_food_code:en:11178
 ciqual_food_code:en:11178
 ciqual_food_name:en:Tomato sauce, w olives, prepacked
 ciqual_food_name:fr:Sauce tomate aux olives, préemballée
@@ -45602,6 +46861,7 @@ fr:Sauces tomates au parmesan
 <en:Tomato sauces
 en:Tomato sauce with cheese
 fr:Sauce tomate au fromage
+agribalyse_food_code:en:11208
 ciqual_food_code:en:11208
 ciqual_food_name:en:Tomato sauce, w cheese, prepacked
 ciqual_food_name:fr:Sauce tomate au fromage, préemballée
@@ -45626,6 +46886,7 @@ pt:Ketchup
 ru:Кетчуп, Томатный кетчуп
 sv:Ketchup
 wikidata:en:Q178143
+agribalyse_food_code:en:11008
 ciqual_food_code:en:11008
 ciqual_food_name:en:Ketchup
 ciqual_food_name:fr:Ketchup
@@ -45684,6 +46945,7 @@ fi:tomaattitahnat
 fr:Concentrés de tomates, concentrés de tomate, concentré de tomates, concentré de tomate, Concentré de tomate appertisé
 nl:Tomatenpastas
 wikidata:en:Q1499073
+agribalyse_food_code:en:20068
 ciqual_food_code:en:20068
 ciqual_food_name:en:Tomato paste, concentrated, canned
 ciqual_food_name:fr:Tomate, concentré, appertisé
@@ -45691,6 +46953,7 @@ ciqual_food_name:fr:Tomate, concentré, appertisé
 <en:Tomatoes and their products
 en:Canned double concentrate tomato paste
 fr:Double concentré de tomate appertisé
+agribalyse_food_code:en:20268
 ciqual_food_code:en:20268
 ciqual_food_name:en:Tomato paste, double concentrate, canned
 ciqual_food_name:fr:Tomate, double concentré, appertisé
@@ -45703,6 +46966,7 @@ it:Polpe di pomodoro, polpa di pomodoro, polpe di pomodori, polpa di pomodori
 <en:Tomatoes and their products
 en:Boiled tomato pulp and peel, Tomato pulp and peel cooked in water
 fr:Pulpe et peau de tomate bouillie, Pulpe et peau de tomate cuite à l'eau
+agribalyse_food_code:en:20242
 ciqual_food_code:en:20242
 ciqual_food_name:en:Tomato, pulp and peel, boiled/cooked in water
 ciqual_food_name:fr:Tomate, pulpe et peau, bouillie/cuite à l'eau
@@ -45710,6 +46974,7 @@ ciqual_food_name:fr:Tomate, pulpe et peau, bouillie/cuite à l'eau
 <en:Tomatoes and their products
 en:Canned tomato pulp
 fr:Pulpe de tomate appertisée
+agribalyse_food_code:en:20169
 ciqual_food_code:en:20169
 ciqual_food_name:en:Tomato pulp, canned
 ciqual_food_name:fr:Tomate, pulpe, appertisée
@@ -45717,6 +46982,7 @@ ciqual_food_name:fr:Tomate, pulpe, appertisée
 <en:Tomatoes and their products
 en:Roasted tomato with skin, Baked tomato with skin
 fr:Pulpe et peau de tomate rôtie, Pulpe et peau de tomate cuite au four
+agribalyse_food_code:en:20289
 ciqual_food_code:en:20289
 ciqual_food_name:en:Tomato, roasted/baked, with skin
 ciqual_food_name:fr:Tomate, pulpe et peau, rôtie/cuite au four
@@ -45799,6 +47065,7 @@ origins:en: en:France, fr:Landes
 <en:Asparagus
 en:Boiled asparagus, Asparagus cooked in water
 fr:Asperge bouillie, Asperge cuite à l'eau
+agribalyse_food_code:en:20001
 ciqual_food_code:en:20001
 ciqual_food_name:en:Asparagus, boiled/cooked in water
 ciqual_food_name:fr:Asperge, bouillie/cuite à l'eau
@@ -45831,6 +47098,7 @@ nl:Maaltijdvervangers
 <en:Meal replacements
 en:Low calorie custard cream meal replacement
 fr:Substitut de repas hypocalorique crème dessert
+agribalyse_food_code:en:42000
 ciqual_food_code:en:42000
 ciqual_food_name:en:Meal replacement low calorie, Custard cream dessert-type
 ciqual_food_name:fr:Substitut de repas hypocalorique, crème dessert
@@ -45838,6 +47106,7 @@ ciqual_food_name:fr:Substitut de repas hypocalorique, crème dessert
 <en:Meal replacements
 en:Low calorie ready-to-drink meal replacement
 fr:Substitut de repas hypocalorique prêt à boire
+agribalyse_food_code:en:42003
 ciqual_food_code:en:42003
 ciqual_food_name:en:Meal replacement low calorie, ready-to-drink
 ciqual_food_name:fr:Substitut de repas hypocalorique, prêt à boire
@@ -45845,6 +47114,7 @@ ciqual_food_name:fr:Substitut de repas hypocalorique, prêt à boire
 <en:Meal replacements
 en:Low calorie meal replacement in powder reconstituted with skimmed milk
 fr:Substitut de repas hypocalorique en poudre reconstituée avec lait écrémé
+agribalyse_food_code:en:42004
 ciqual_food_code:en:42004
 ciqual_food_name:en:Meal replacement low calorie, in powder, reconstituted with skimmed milk
 ciqual_food_name:fr:Substitut de repas hypocalorique, poudre reconstituée avec lait écrémé
@@ -45852,6 +47122,7 @@ ciqual_food_name:fr:Substitut de repas hypocalorique, poudre reconstituée avec 
 <en:Meal replacements
 en:Low calorie milkshake meal replacement in powder reconstituted with skimmed milk
 fr:Substitut de repas hypocalorique milk-shake en poudre reconstitué avec lait écrémé
+agribalyse_food_code:en:42005
 ciqual_food_code:en:42005
 ciqual_food_name:en:Meal replacement low calorie, in powder, reconstituted with skimmed milk, milkshake type
 ciqual_food_name:fr:Substitut de repas hypocalorique, poudre reconstituée avec lait écrémé, type milk-shake
@@ -45859,18 +47130,21 @@ ciqual_food_name:fr:Substitut de repas hypocalorique, poudre reconstituée avec 
 <en:Meal replacements
 en:Egg powder
 fr:Oeuf en poudre
+agribalyse_food_code:en:22013
 ciqual_food_code:en:22013
 ciqual_food_name:en:Egg, powder
 
 <en:Meal replacements
 en:Egg white powder
 fr:blanc d'oeuf en poudre
+agribalyse_food_code:en:22004
 ciqual_food_code:en:22004
 ciqual_food_name:en:Egg white, powder
 
 <en:Meal replacements
 en:Egg yolk powder
 fr:jaune d'oeuf en poudre
+agribalyse_food_code:en:22003
 ciqual_food_code:en:22003
 ciqual_food_name:en:Egg yolk, powder
 
@@ -45929,6 +47203,7 @@ nl:Avocado en zalm sushi
 <en:Sushi and Maki
 en:Sushi with seafood products, Maki with seafood products
 fr:Sushi aux produits de la mer, Maki aux produits de la mer
+agribalyse_food_code:en:25456
 ciqual_food_code:en:25456
 ciqual_food_name:en:Sushi or maki with seafood products
 ciqual_food_name:fr:Sushi ou Maki aux produits de la mer
@@ -45938,6 +47213,7 @@ en:Nems, Egg roll, Nem
 fr:Nems, Nem, Pâté impérial
 nl:Loempias
 pnns_group_2:en:Appetizers
+agribalyse_food_code:en:25420
 ciqual_food_code:en:25420
 ciqual_food_name:en:Egg roll or Nem
 ciqual_food_name:fr:Nem ou Pâté impérial
@@ -45948,6 +47224,7 @@ en:Pork nems, Egg roll with cooked pork, Nem with cooked pork
 es:Nems De Cerdo
 fr:Nems au porc, Nem  au porc cuit, Pâté impérial au porc cuit
 nl:Varkensloempias
+agribalyse_food_code:en:25583
 ciqual_food_code:en:25583
 ciqual_food_name:en:Egg roll or Nem, with pork, cooked
 ciqual_food_name:fr:Nem ou Pâté impérial, au porc, cuit
@@ -45958,6 +47235,7 @@ en:Chicken nems, Egg roll with cooked chicken, Nem with cooked chicken
 es:Nems de pollo
 fr:Nems au poulet, Nem au poulet cuit, Pâté impérial au poulet cuit
 nl:Kiploempias
+agribalyse_food_code:en:25582
 ciqual_food_code:en:25582
 ciqual_food_name:en:Egg roll or Nem, with chicken, cooked
 ciqual_food_name:fr:Nem ou Pâté impérial, au poulet, cuit
@@ -45966,6 +47244,7 @@ ciqual_food_name:fr:Nem ou Pâté impérial, au poulet, cuit
 <en:Shrimps
 en:Egg roll with cooked shrimp, Nem with cooked shrimp
 fr:Nem aux crevettes, Pâté impérial aux crevettes
+agribalyse_food_code:en:25584
 ciqual_food_code:en:25584
 ciqual_food_name:en:Egg roll or Nem, with shrimp and/or crab, cooked
 ciqual_food_name:fr:Nem ou Pâté impérial aux crevettes et/ou au crabe cuit
@@ -45974,6 +47253,7 @@ ciqual_food_name:fr:Nem ou Pâté impérial aux crevettes et/ou au crabe cuit
 <en:Crab
 en:Egg roll with cooked crab, Nem with cooked crab
 fr:Nem au crabe, Pâté impérial au crabe
+agribalyse_food_code:en:25584
 ciqual_food_code:en:25584
 ciqual_food_name:en:Egg roll or Nem, with shrimp and/or crab, cooked
 ciqual_food_name:fr:Nem ou Pâté impérial aux crevettes et/ou au crabe cuit
@@ -45981,6 +47261,7 @@ ciqual_food_name:fr:Nem ou Pâté impérial aux crevettes et/ou au crabe cuit
 <en:Meals
 en:Chinese dumplings, Chinese dumpling
 fr:Bouchées à la vapeur chinoises cuites, Bouchées vapeur chinoises cuites
+agribalyse_food_code:en:25169
 ciqual_food_code:en:25169
 ciqual_food_name:en:Chinese specialty or dumplings
 ciqual_food_name:fr:Spécialité chinoise ou bouchées à la vapeur, cuite
@@ -45988,6 +47269,7 @@ ciqual_food_name:fr:Spécialité chinoise ou bouchées à la vapeur, cuite
 <en:Meals
 en:Cooked steamed shrimp dumplings, Cooked steamed shrimp dumpling
 fr:Ravioli vapeur chinois à la crevette cuit, Raviolis vapeur chinois à la crevette cuits
+agribalyse_food_code:en:25110
 ciqual_food_code:en:25110
 ciqual_food_name:en:Dumplings, steamed, with shrimps, cooked
 ciqual_food_name:fr:Ravioli chinois à la vapeur à la crevette, cuit
@@ -45997,6 +47279,7 @@ en:Spring rolls
 de:Frühlingsrollen
 fr:Rouleaux de printemps
 nl:Verse loempias, springrolls
+agribalyse_food_code:en:25419
 ciqual_food_code:en:25419
 ciqual_food_name:en:Spring roll
 ciqual_food_name:fr:Rouleau de printemps
@@ -46015,6 +47298,7 @@ ro:Musaca
 sk:Musaka
 sv:Moussaka
 wikidata:en:Q206918
+agribalyse_food_code:en:25123
 ciqual_food_code:en:25123
 ciqual_food_name:en:Moussaka
 ciqual_food_name:fr:Moussaka
@@ -46032,6 +47316,7 @@ ciqual_food_name:fr:Feuilleté salé (aliment moyen)
 en:Ham croissants, Croissant filled with ham
 fr:Croissants au jambon
 nl:Hamcroissants
+agribalyse_food_code:en:25418
 ciqual_food_code:en:25418
 ciqual_food_name:en:Croissant filled with ham
 
@@ -46046,12 +47331,14 @@ ciqual_food_name:fr:Bouchée à la reine, garnie (aliment moyen)
 <en:Vol-au-vent
 en:Vol-au-vent with fish and seafood
 fr:Bouchées à la reine au poisson et aux fruits de mer, Bouchées à la reine au poisson, Bouchées à la reine aux fruits de mer
+agribalyse_food_code:en:25503
 ciqual_food_code:en:25503
 ciqual_food_name:en:Vol-au-vent with fish and seafood
 
 <en:Vol-au-vent
 en:Vol-au-vent with meat/poultry/quenelle
 fr:Bouchées à la reine à la viande, Bouchée à la reine à la viande
+agribalyse_food_code:en:25412
 ciqual_food_code:en:25412
 ciqual_food_name:en:Vol-au-vent, with meat/poultry/quenelle
 
@@ -46065,6 +47352,7 @@ nl:Bladerdeegbakjes
 <en:Puff pastry meals
 en:Small cheese chou, Small cheese pastry puff, Gougère
 fr:Gougère
+agribalyse_food_code:en:25437
 ciqual_food_code:en:25437
 ciqual_food_name:en:Small cheese chou-pastry puff
 ciqual_food_name:fr:Gougère
@@ -46098,35 +47386,41 @@ nl:Rijstschotels
 <en:Meals
 en:Egg scrambled with added fat
 fr:Oeuf brouillé avec matière grasse
+agribalyse_food_code:en:22502
 ciqual_food_code:en:22502
 ciqual_food_name:en:Egg, scrambled, with added fat
 
 <en:Meals
 en:Egg white cooked
 fr:blanc d'oeuf cuit
+agribalyse_food_code:en:22008
 ciqual_food_code:en:22008
 ciqual_food_name:en:Egg white, cooked
 
 <en:Meals
 en:Egg poached
 fr:Oeuf poché
+agribalyse_food_code:en:22011
 ciqual_food_code:en:22011
 ciqual_food_name:en:Egg, poached
 
 <en:Meals
 en:Egg soft-boiled
 fr:Oeuf à la coque
+agribalyse_food_code:en:22014
 ciqual_food_code:en:22014
 ciqual_food_name:en:Egg, soft-boiled
 
 <en:Meals
 fr:jaune d'oeuf cuit
+agribalyse_food_code:en:22009
 ciqual_food_code:en:22009
 ciqual_food_name:en:Egg yolk, cooked
 
 <en:Meals
 en:Egg fried without added fat
 fr:Oeuf au plat sans matière grasse
+agribalyse_food_code:en:22505
 ciqual_food_code:en:22505
 ciqual_food_name:en:Egg, fried without added fat
 
@@ -46142,6 +47436,7 @@ de:Paella
 fi:paella
 fr:Paëllas, paëlla
 nl:Paellas
+agribalyse_food_code:en:25031
 ciqual_food_code:en:25031
 ciqual_food_name:en:Paëlla
 ciqual_food_name:fr:Paëlla
@@ -46168,6 +47463,7 @@ nl:Garnaalrisotto
 <en:Risottos
 en:Risotto with seafood, Seafood risotto
 fr:Risotto aux fruits de mer
+agribalyse_food_code:en:25188
 ciqual_food_code:en:25188
 ciqual_food_name:en:Risotto, w seafood
 ciqual_food_name:fr:Risotto, aux fruits de mer
@@ -46205,6 +47501,7 @@ nl:Kiprisottos, kiprisotto
 <en:Risottos
 en:Risotto with cheese, Cheese risotto
 fr:Risotto aux fromages, Risotto au fromage
+agribalyse_food_code:en:25189
 ciqual_food_code:en:25189
 ciqual_food_name:en:Risotto, w cheeses
 ciqual_food_name:fr:Risotto, aux fromages
@@ -46242,6 +47539,7 @@ ciqual_food_name:fr:Chop suey (porc ou poulet)
 <en:Meals
 en:Couscous, Durum wheat semolina pre-cooked with steam
 fr:Couscous, Semoule de blé dur roulée précuite à la vapeur
+agribalyse_food_code:en:9681
 ciqual_food_code:en:9681
 ciqual_food_name:en:Couscous (durum wheat semolina pre-cooked with steam), raw
 ciqual_food_name:fr:Couscous (semoule de blé dur roulée précuite à la vapeur), crue
@@ -46249,6 +47547,7 @@ ciqual_food_name:fr:Couscous (semoule de blé dur roulée précuite à la vapeur
 <en:Meals
 en:Cooked unsalted couscous, Unsalted durum wheat semolina pre-cooked with steam
 fr:Couscous non salé, Semoule de blé dur roulée précuite à la vapeur non salée
+agribalyse_food_code:en:9683
 ciqual_food_code:en:9683
 ciqual_food_name:en:Couscous (durum wheat semolina pre-cooked with steam), cooked, unsalted
 ciqual_food_name:fr:Couscous (semoule de blé dur roulée précuite à la vapeur), cuite, non salée
@@ -46263,6 +47562,7 @@ nl:Kant-en-klaar couscous
 <en:Prepared couscous
 en:Couscous with vegetables
 fr:Couscous de légumes
+agribalyse_food_code:en:25150
 ciqual_food_code:en:25150
 ciqual_food_name:en:Couscous with vegetables
 ciqual_food_name:fr:Couscous de légumes
@@ -46270,6 +47570,7 @@ ciqual_food_name:fr:Couscous de légumes
 <en:Prepared couscous
 en:Couscous with fish
 fr:Couscous au poisson
+agribalyse_food_code:en:25107
 ciqual_food_code:en:25107
 ciqual_food_name:en:Couscous w fish
 ciqual_food_name:fr:Couscous au poisson
@@ -46277,6 +47578,7 @@ ciqual_food_name:fr:Couscous au poisson
 <en:Prepared couscous
 en:Royal couscous with different meats
 fr:Couscous royal avec plusieurs viandes
+agribalyse_food_code:en:25127
 ciqual_food_code:en:25127
 ciqual_food_name:en:Couscous royal (with different meats)
 ciqual_food_name:fr:Couscous royal (avec plusieurs viandes)
@@ -46284,21 +47586,25 @@ ciqual_food_name:fr:Couscous royal (avec plusieurs viandes)
 <en:Prepared couscous
 en:Couscous w mutton
 fr:Couscous au mouton
+agribalyse_food_code:en:25029
 ciqual_food_code:en:25029
 ciqual_food_name:en:Couscous w mutton
 
 <en:Prepared couscous
 en:Couscous with meat
 fr:Couscous à la viande
+agribalyse_food_code:en:25152
 ciqual_food_code:en:25152
 ciqual_food_name:en:Couscous w meat
 ciqual_food_name:fr:Couscous à la viande
+agribalyse_food_code:en:25029
 ciqual_food_code:en:25029
 ciqual_food_name:en:Couscous w mutton
 
 <en:Prepared couscous
 en:Chicken couscous
 fr:Couscous au poulet
+agribalyse_food_code:en:25138
 ciqual_food_code:en:25138
 ciqual_food_name:en:Couscous w chicken
 ciqual_food_name:fr:Couscous au poulet
@@ -46306,6 +47612,7 @@ ciqual_food_name:fr:Couscous au poulet
 <en:Prepared couscous
 en:Light couscous with meat, Light couscous with chicken, Low fat couscous with meat, Low fat couscous with chicken
 fr:Couscous à la viande allégé, Couscous au poulet allégé
+agribalyse_food_code:en:25043
 ciqual_food_code:en:25043
 ciqual_food_name:en:Couscous with meat or chicken, light
 ciqual_food_name:fr:Couscous à la viande ou au poulet, allégé
@@ -46314,6 +47621,7 @@ ciqual_food_name:fr:Couscous à la viande ou au poulet, allégé
 <en:Cooked vegetables
 en:Cooked mixed vegetables for couscous
 fr:Légumes cuits pour couscous
+agribalyse_food_code:en:20497
 ciqual_food_code:en:20497
 ciqual_food_name:en:Mixed vegetables for couscous, cooked
 ciqual_food_name:fr:Légumes pour couscous, cuits
@@ -46337,6 +47645,7 @@ fr:Plats aux crevettes
 <en:Meals with shrimps
 en:Shrimp fritters
 fr:Beignet de crevette, Beignets de crevette
+agribalyse_food_code:en:10023
 ciqual_food_code:en:10023
 ciqual_food_name:en:Shrimp fritters
 ciqual_food_name:fr:Beignet de crevette
@@ -46355,6 +47664,7 @@ pt:Refeições com peixe, pratos com peixe
 
 <en:Meals with fish
 en:Frozen fish in sauce
+agribalyse_food_code:en:26054
 ciqual_food_code:en:26054
 ciqual_food_name:en:Fish, in sauce, frozen
 
@@ -46375,12 +47685,14 @@ ciqual_food_name:fr:Poisson blanc, de mer, cuit (aliment moyen)
 <en:Meals with fish
 en:White fish with Provencal-style tomato sauce
 fr:Poisson blanc à la provençale, Poisson blanc à la niçoise
+agribalyse_food_code:en:25128
 ciqual_food_code:en:25128
 ciqual_food_name:en:White fish with Provencal-style sauce (tomato sauce)
 
 <en:Meals with fish
 en:White fish with Florentine-style sauce, White fish with spinach sauce
 fr:Poisson blanc à la sauce florentine, Poisson blanc à la sauce aux épinards
+agribalyse_food_code:en:25140
 ciqual_food_code:en:25140
 ciqual_food_name:en:White fish with Florentine-style sauce (spinach sauce)
 ciqual_food_name:fr:Poisson blanc à la florentine (sauce aux épinards)
@@ -46388,12 +47700,14 @@ ciqual_food_name:fr:Poisson blanc à la florentine (sauce aux épinards)
 <en:Meals with fish
 en:White fish with mustard sauce
 fr:Poisson blanc à la sauce moutarde
+agribalyse_food_code:en:25142
 ciqual_food_code:en:25142
 ciqual_food_name:en:White fish with mustard sauce
 
 <en:Meals with fish
 en:White fish with tarragon sauce
 fr:Poisson blanc à l'estragon
+agribalyse_food_code:en:25145
 ciqual_food_code:en:25145
 ciqual_food_name:en:White fish with tarragon sauce
 ciqual_food_name:fr:Poisson blanc à l'estragon
@@ -46401,6 +47715,7 @@ ciqual_food_name:fr:Poisson blanc à l'estragon
 <en:Meals with fish
 en:White fish with sorrel sauce
 fr:Poisson blanc sauce oseille
+agribalyse_food_code:en:25146
 ciqual_food_code:en:25146
 ciqual_food_name:en:White fish with sorrel sauce
 ciqual_food_name:fr:Poisson blanc sauce oseille
@@ -46463,12 +47778,14 @@ zh:肉餐
 en:Doner kebab
 de:Döner kebab
 fr:Döner kebab
+agribalyse_food_code:en:25428
 ciqual_food_code:en:25428
 ciqual_food_name:en:Sandwich made with pita bread, kebab and raw vegetables
 
 <en:Sandwiches
 en:Sandwich made with French bread kebab and raw vegetables
 fr:Sandwich grec non pita, Kebab non pita
+agribalyse_food_code:en:25429
 ciqual_food_code:en:25429
 ciqual_food_name:en:Sandwich made with French bread, kebab and raw vegetables
 
@@ -46478,6 +47795,7 @@ de:Würstchen mit Linsen
 fi:linssimakkarat
 fr:Saucisses aux lentilles, saucisse aux lentilles, saucisses avec lentilles, saucisse avec lentilles, saucisses lentilles, saucisse lentilles
 nl:Worst met linzen
+agribalyse_food_code:en:25010
 ciqual_food_code:en:25010
 ciqual_food_name:en:Salt-cured pork belly with lentils
 ciqual_food_name:fr:Petit salé ou saucisse aux lentilles
@@ -46485,6 +47803,7 @@ ciqual_food_name:fr:Petit salé ou saucisse aux lentilles
 <en:Meals with meat
 en:Sausage in a brioche crust cooked
 fr:Saucisson brioché cuit
+agribalyse_food_code:en:30707
 ciqual_food_code:en:30707
 ciqual_food_name:en:Sausage in a brioche crust, cooked
 
@@ -46554,36 +47873,42 @@ en:Veal meat dishes
 fi:vasikka-aterioita
 fr:Plats au veau, plats à base de viande de veau, plats à base de veau, plats préparés à base de veau
 nl:Kalfsvleesmaaltijden
+agribalyse_food_code:en:8903
 ciqual_food_code:en:8903
 ciqual_food_name:en:Veal quenelle, in sauce
 
 <en:Beef dishes
 en:Veal quenelle in sauce
 fr:Quenelle de veau en sauce
+agribalyse_food_code:en:8903
 ciqual_food_code:en:8903
 ciqual_food_name:en:Veal quenelle, in sauce
 
 <en:Meals with meat
 en:Poultry quenelle in sauce
 fr:Quenelle de volaille en sauce
+agribalyse_food_code:en:8912
 ciqual_food_code:en:8912
 ciqual_food_name:en:Poultry quenelle, in sauce
 
 <en:Meals with meat
 en:Poultry quenelle raw
 fr:Quenelle de volaille crue
+agribalyse_food_code:en:8910
 ciqual_food_code:en:8910
 ciqual_food_name:en:Poultry quenelle, raw
 
 <en:Meals with meat
 en:Fish quenelle in sauce
 fr:Quenelle de poisson en sauce
+agribalyse_food_code:en:8932
 ciqual_food_code:en:8932
 ciqual_food_name:en:Fish quenelle, in sauce
 
 <en:Meals with meat
 en:Fish quenelle raw
 fr:Quenelle de poisson crue
+agribalyse_food_code:en:8933
 ciqual_food_code:en:8933
 ciqual_food_name:en:Fish quenelle, raw
 
@@ -46601,6 +47926,7 @@ en:Veal blanquette, Veal blanquettes, Veal stew in white sauce
 fr:Blanquettes de veau, blanquettes de veaux, blanquette de veau
 nl:Witte kalfsvlees
 wikidata:en:Q1191278
+agribalyse_food_code:en:25001
 ciqual_food_code:en:25001
 ciqual_food_name:en:Veal stew in white sauce
 ciqual_food_name:fr:Blanquette de veau
@@ -46616,6 +47942,7 @@ ciqual_food_name:fr:Corned-beef, appertisé
 en:Shepherd's pie, Cottage pie with meat
 fr:Hachis parmentier, parmentiers de bœuf, Hachis Parmentier au boeuf
 nl:Shepherd's pie
+agribalyse_food_code:en:25009
 ciqual_food_code:en:25009
 ciqual_food_name:en:Shepherd's pie or cottage pie with meat
 ciqual_food_name:fr:Hachis Parmentier à la viande
@@ -46625,6 +47952,7 @@ en:Bœufs bourguignons, Burgundian beef, Burgundy-style beef stew
 fi:burgundinpata
 fr:Bœufs bourguignons, Bœuf bourguignon, Boeuf bourguignon
 nl:Bœuf borguignon
+agribalyse_food_code:en:25033
 ciqual_food_code:en:25033
 ciqual_food_name:en:Burgundy-style beef stew
 ciqual_food_name:fr:Boeuf bourguignon
@@ -46632,6 +47960,7 @@ ciqual_food_name:fr:Boeuf bourguignon
 <en:Beef dishes
 en:Cooked beef stew meat
 fr:Boeuf bourguignon cuit, Pot au feu de boeuf cuit
+agribalyse_food_code:en:6230
 ciqual_food_code:en:6230
 ciqual_food_name:en:Beef, stewing meat, cooked
 ciqual_food_name:fr:Boeuf, à bourguignon ou pot-au-feu, cuit
@@ -46639,6 +47968,7 @@ ciqual_food_name:fr:Boeuf, à bourguignon ou pot-au-feu, cuit
 <en:Beef dishes
 en:Raw beef stew meat
 fr:Boeuf bourguignon cru, Pot-au-feu de boeuf cru
+agribalyse_food_code:en:6231
 ciqual_food_code:en:6231
 ciqual_food_name:en:Beef, stewing meat, raw
 ciqual_food_name:fr:Boeuf, à bourguignon ou pot-au-feu, cru
@@ -46646,6 +47976,7 @@ ciqual_food_name:fr:Boeuf, à bourguignon ou pot-au-feu, cru
 <en:Beef dishes
 en:Beef stew with carrots
 fr:Boeuf aux carottes
+agribalyse_food_code:en:25065
 ciqual_food_code:en:25065
 ciqual_food_name:en:Beef stew with carrots
 ciqual_food_name:fr:Boeuf aux carottes
@@ -46673,12 +48004,14 @@ zh:猪肉餐
 en:Caramel pork
 fr:Porc au caramel
 nl:Varkensvlees met caramel
+agribalyse_food_code:en:25207
 ciqual_food_code:en:25207
 ciqual_food_name:en:Pork with caramel sauce
 
 <en:Pork meals
 en:Pork snout in salad dressing sauce
 fr:Museau de porc vinaigrette
+agribalyse_food_code:en:8406
 ciqual_food_code:en:8406
 ciqual_food_name:en:Pork snout in salad dressing sauce
 ciqual_food_name:fr:Museau de porc vinaigrette
@@ -46693,6 +48026,7 @@ fr:Plats à la volaille, plats à base de volaille, plats préparés à base de 
 hu:Baromfihúsok
 nl:Gevogelte maaltijden
 th:ผลิตภัณฑ์จากสัตว์ปีก
+agribalyse_food_code:en:25126
 ciqual_food_code:en:25126
 ciqual_food_name:en:Poultry paupiette
 
@@ -46700,6 +48034,7 @@ ciqual_food_name:en:Poultry paupiette
 fr:Coq au vin
 wikidata:en:Q527323
 en:Cockerel in red wine sauce
+agribalyse_food_code:en:25121
 ciqual_food_code:en:25121
 ciqual_food_name:en:Cockerel in red wine sauce
 
@@ -46724,18 +48059,21 @@ fi:Ankka-ateriat
 fr:Plats au canard, plats à base de canard, plats à base de canards, plats préparés à base de canard
 nl:Eendevleesmaaltijden
 zh:鸭子菜
+agribalyse_food_code:en:25058
 ciqual_food_code:en:25058
 ciqual_food_name:en:Duck with sauce (green pepper sauce, hunter-style sauce,etc.)
 
 <en:Duck dishes
 fr:Parmentiers de canard, Parmentier de canard
 en:Shepherd's pie with duck cooked
+agribalyse_food_code:en:25587
 ciqual_food_code:en:25587
 ciqual_food_name:en:Shepherd's pie with duck, cooked
 
 <en:Duck dishes
 en:Shepherd's pie with duck uncooked
 fr:Parmentier de canard non cuit
+agribalyse_food_code:en:25195
 ciqual_food_code:en:25195
 ciqual_food_name:en:Shepherd's pie with duck
 
@@ -46748,6 +48086,7 @@ nl:Cassoulet met geconfijte eend
 <en:Cassoulets
 en:Canned white bean stew with pork
 fr:Cassoulet au porc appertisé, Cassoulet au porc en conserve
+agribalyse_food_code:en:25098
 ciqual_food_code:en:25098
 ciqual_food_name:en:White bean stew, with pork, canned
 ciqual_food_name:fr:Cassoulet au porc, appertisé
@@ -46755,6 +48094,7 @@ ciqual_food_name:fr:Cassoulet au porc, appertisé
 <en:Cassoulets
 en:Canned white bean stew with duck, Canned white bean stew with goose
 fr:Cassoulet au canard appertisé, Cassoulet au canard en conserve, Cassoulet à l'oie appertisé, Cassoulet à l'oie en conserve
+agribalyse_food_code:en:25099
 ciqual_food_code:en:25099
 ciqual_food_name:en:White bean stew, with duck or goose, canned
 ciqual_food_name:fr:Cassoulet au canard ou oie, appertisé
@@ -46780,6 +48120,7 @@ fr:Poule au pot
 <en:Poultry meals
 en:Cooked curing salted roast poultry
 fr:Rôti de volaille en salaison cuit
+agribalyse_food_code:en:28976
 ciqual_food_code:en:28976
 ciqual_food_name:en:Salt curing roast poultry, cooked
 ciqual_food_name:fr:Rôti de volaille en salaison, cuit
@@ -46804,6 +48145,7 @@ en:Chicken tajine
 fr:Tajines de poulet, Tajine de poulet
 nl:Kiptajine
 ro:Tajine de pui
+agribalyse_food_code:en:25204
 ciqual_food_code:en:25204
 ciqual_food_name:en:Chicken tagine
 
@@ -46813,12 +48155,14 @@ fi:kanacurry
 fr:Poulets au curry
 nl:Kipcurry
 zh:鸡咖喱
+agribalyse_food_code:en:25174
 ciqual_food_code:en:25174
 ciqual_food_name:en:Chicken with curry and coconut milk sauce
 
 <en:Meals with chicken
 fr:Poulets basquaise, Poulet basquaise, Poulets basquaises
 en:Chicken Basque style
+agribalyse_food_code:en:25190
 ciqual_food_code:en:25190
 ciqual_food_name:en:Chicken, Basque style
 
@@ -46836,6 +48180,7 @@ nl:Pensvleesspecialiteiten
 fr:Tripes à la mode de Caen
 en:Caen-style tripes, Tripes à la mode de Caen
 wikidata:en:Q356690
+agribalyse_food_code:en:8601
 ciqual_food_code:en:8601
 ciqual_food_name:en:Caen-style tripe
 ciqual_food_name:fr:Tripes à la mode de Caen
@@ -46843,6 +48188,7 @@ ciqual_food_name:fr:Tripes à la mode de Caen
 <en:Specialty made with tripe
 en:Prepackaged Caen-style tripes, Prepackaged tripes à la mode de Caen
 fr:Tripes à la mode de Caen préemballées
+agribalyse_food_code:en:8602
 ciqual_food_code:en:8602
 ciqual_food_name:en:Caen-style tripe, prepacked
 ciqual_food_name:fr:Tripes à la mode de Caen, préemballées
@@ -46850,6 +48196,7 @@ ciqual_food_name:fr:Tripes à la mode de Caen, préemballées
 <en:Specialty made with tripe
 en:Provencal-type tripes with tomatoes
 fr:Tripes à la tomate, Tripes à la provençale
+agribalyse_food_code:en:8612
 ciqual_food_code:en:8612
 ciqual_food_name:en:Provencal-type tripe (with tomato)
 ciqual_food_name:fr:Tripes à la tomate ou à la provençale
@@ -46857,6 +48204,7 @@ ciqual_food_name:fr:Tripes à la tomate ou à la provençale
 <en:Specialty made with tripe
 en:Raw beef tripes
 fr:Tripes de boeuf crues
+agribalyse_food_code:en:40502
 ciqual_food_code:en:40502
 ciqual_food_name:en:Tripe, beef, raw
 ciqual_food_name:fr:Tripes, boeuf, crues
@@ -46871,6 +48219,7 @@ it:Chili con carne
 nl:Chili con carne
 ro:Chili con carne
 wikidata:en:Q863794
+agribalyse_food_code:en:25111
 ciqual_food_code:en:25111
 ciqual_food_name:en:Chili con carne
 ciqual_food_name:fr:Chili con carne
@@ -46878,6 +48227,7 @@ ciqual_food_name:fr:Chili con carne
 <en:Meals with meat
 en:Osso buco
 fr:Osso buco
+agribalyse_food_code:en:25164
 ciqual_food_code:en:25164
 ciqual_food_name:en:Osso buco
 ciqual_food_name:fr:Osso buco
@@ -46909,6 +48259,7 @@ pnns_group_2:en:Pizza pies and quiches
 <en:Salted pies
 en:Pizza with onion and anchovy and black olives
 fr:Pissaladière
+agribalyse_food_code:en:25528
 ciqual_food_code:en:25528
 ciqual_food_name:en:Pizza, onion anchovy and black olives
 ciqual_food_name:fr:Pissaladière
@@ -46925,6 +48276,7 @@ wikidata:en:Q2550270
 <en:Salted pies
 en:Scallops tart
 fr:Tarte aux noix de Saint-Jacques
+agribalyse_food_code:en:25564
 ciqual_food_code:en:25564
 ciqual_food_name:en:Scallops tart
 ciqual_food_name:fr:Tarte aux noix de Saint-Jacques
@@ -46934,6 +48286,7 @@ en:Cheese pies, Cheese tarts
 de:Käsekuchen
 fr:Tartes au fromage, Tartes aux trois fromages, Tarte au fromage
 nl:Kaastaarten
+agribalyse_food_code:en:25444
 ciqual_food_code:en:25444
 ciqual_food_name:en:Cheese tart
 ciqual_food_name:fr:Tarte au fromage
@@ -46943,6 +48296,7 @@ en:Maroilles Tarts
 fr:Tartes au maroilles, Flamiche au maroilles
 nl:Maroilletaart
 wikidata:en:Q3515850
+agribalyse_food_code:en:25623
 ciqual_food_code:en:25623
 ciqual_food_name:en:Maroilles cheese tart or maroilles cheese flamiche
 
@@ -46950,6 +48304,7 @@ ciqual_food_name:en:Maroilles cheese tart or maroilles cheese flamiche
 en:Tomatoes pies, Tomato tarts
 fr:Tartes à la tomate, Tarte à la tomate
 nl:Tomatentaart
+agribalyse_food_code:en:25561
 ciqual_food_code:en:25561
 ciqual_food_name:en:Tomato tart
 ciqual_food_name:fr:Tarte à la tomate
@@ -46967,6 +48322,7 @@ nl:Tonijntaart
 <en:Salted pies
 en:Provencal-style tart
 fr:Tarte à la provençale
+agribalyse_food_code:en:25454
 ciqual_food_code:en:25454
 ciqual_food_name:en:Provencal-style tart
 ciqual_food_name:fr:Tarte à la provençale
@@ -46976,6 +48332,7 @@ en:Vegetables pies, Vegetables tarts
 de:Gemüsekuchen
 fr:Tartes aux légumes, Tarte aux légumes
 nl:Groentetaarten
+agribalyse_food_code:en:25417
 ciqual_food_code:en:25417
 ciqual_food_name:en:Vegetables tart
 ciqual_food_name:fr:Tarte aux légumes
@@ -46983,18 +48340,21 @@ ciqual_food_name:fr:Tarte aux légumes
 <en:Salted pies
 en:Pastilla filled with chicken (pie)
 fr:Pastilla au poulet
+agribalyse_food_code:en:25568
 ciqual_food_code:en:25568
 ciqual_food_name:en:Pastilla, filled with chicken (pie)
 
 <en:Salted pies
 en:Goat cheese and spinach tart
 fr:Tarte épinard chèvre
+agribalyse_food_code:en:26267
 ciqual_food_code:en:26267
 ciqual_food_name:en:Goat cheese and spinach tart
 
 <en:Salted pies
 en:Savoury cake (with cheese vegetables meat fish poultry,etc.)
 fr:Cake salé
+agribalyse_food_code:en:7814
 ciqual_food_code:en:7814
 ciqual_food_name:en:Savoury cake (with cheese, vegetables, meat, fish, poultry,etc.)
 
@@ -47075,6 +48435,7 @@ ciqual_food_name:fr:Soupe miso
 <en:Soups
 en:Dehydrated and reconstituted Moroccan soup
 fr:Soupe marocaine déshydratée reconstituée
+agribalyse_food_code:en:25924
 ciqual_food_code:en:25924
 ciqual_food_name:en:Soup, Moroccan, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe marocaine, déshydratée reconstituée
@@ -47089,6 +48450,7 @@ he:מרקי דגים
 nl:Vissoepen
 zh:鱼汤
 wikidata:en:Q5454668
+agribalyse_food_code:en:25904
 ciqual_food_code:en:25904
 ciqual_food_name:en:Soup, fish and/or crustacean, prepacked, to be reheated
 
@@ -47096,6 +48458,7 @@ ciqual_food_name:en:Soup, fish and/or crustacean, prepacked, to be reheated
 <en:Fish soups
 en:Soup fish and/or crustacean dehydrated and reconstituted
 fr:soupe de poissons
+agribalyse_food_code:en:25919
 ciqual_food_code:en:25919
 ciqual_food_name:en:Soup, fish and/or crustacean, dehydrated and reconstituted
 
@@ -47116,6 +48479,7 @@ pnns_group_2:en:Soups
 <en:Soups
 en:Mushroom soups
 fr:Soupe aux champignons
+agribalyse_food_code:en:25912
 ciqual_food_code:en:25912
 ciqual_food_name:en:Soup, mushrooms, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux champignons, préemballée à réchauffer
@@ -47123,6 +48487,7 @@ ciqual_food_name:fr:Soupe aux champignons, préemballée à réchauffer
 <en:Soups
 en: Dehydrated and reconstituted mushroom soup
 fr:Soupe aux champignons déshydratée et reconstituée
+agribalyse_food_code:en:25936
 ciqual_food_code:en:25936
 ciqual_food_name:en:Soup, mushrooms, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe aux champignons, déshydratée reconstituée
@@ -47131,6 +48496,7 @@ ciqual_food_name:fr:Soupe aux champignons, déshydratée reconstituée
 <en:Fruits and vegetables based foods
 en:Chicken and vegetables soup
 fr:Soupe à la volaille et aux légumes
+agribalyse_food_code:en:25901
 ciqual_food_code:en:25901
 ciqual_food_name:en:Soup, chicken and vegetables, prepacked, to be reheated
 ciqual_food_name:fr:Soupe à la volaille et aux légumes, préemballée à réchauffer
@@ -47138,6 +48504,7 @@ ciqual_food_name:fr:Soupe à la volaille et aux légumes, préemballée à réch
 <en:Soups
 en:Reheatable chicken and vermicelli soup
 fr:Soupe à la volaille et aux vermicelles à réchauffer
+agribalyse_food_code:en:25908
 ciqual_food_code:en:25908
 ciqual_food_name:en:Soup, chicken and vermicelli, prepacked, to be reheated
 ciqual_food_name:fr:Soupe à la volaille et aux vermicelles, préemballée à réchauffer
@@ -47146,6 +48513,7 @@ ciqual_food_name:fr:Soupe à la volaille et aux vermicelles, préemballée à r�
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted tomato and vermicelli soup
 fr:Soupe à la tomate et aux vermicelles déshydratée reconstituée
+agribalyse_food_code:en:25949
 ciqual_food_code:en:25949
 ciqual_food_name:en:Soup, tomato and vermicelli, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe à la tomate et aux vermicelles, déshydratée reconstituée
@@ -47154,6 +48522,7 @@ ciqual_food_name:fr:Soupe à la tomate et aux vermicelles, déshydratée reconst
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted cereals and vegetables soup
 fr:Soupe aux céréales et aux légumes déshydratée reconstituée
+agribalyse_food_code:en:25934
 ciqual_food_code:en:25934
 ciqual_food_name:en:Soup, cereals and vegetables, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe aux céréales et aux légumes, déshydratée reconstituée
@@ -47162,6 +48531,7 @@ ciqual_food_name:fr:Soupe aux céréales et aux légumes, déshydratée reconsti
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted soup with chicken and vegetables
 fr:Soupe à la volaille et aux légumes déshydratée et reconstituée
+agribalyse_food_code:en:25928
 ciqual_food_code:en:25928
 ciqual_food_name:en:Soup, chicken and vegetables, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe à la volaille et aux légumes, déshydratée reconstituée
@@ -47170,6 +48540,7 @@ ciqual_food_name:fr:Soupe à la volaille et aux légumes, déshydratée reconsti
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted chicken and vermicelli soup
 fr:Soupe à la volaille et aux vermicelles déshydratée reconstituée
+agribalyse_food_code:en:25950
 ciqual_food_code:en:25950
 ciqual_food_name:en:Soup, chicken and vermicelli, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe à la volaille et aux vermicelles, déshydratée reconstituée
@@ -47177,6 +48548,7 @@ ciqual_food_name:fr:Soupe à la volaille et aux vermicelles, déshydratée recon
 <en:Soups
 en:Chorba frik soup with meat and frik
 fr:Soupe chorba frik à base de viande et de frik
+agribalyse_food_code:en:25915
 ciqual_food_code:en:25915
 ciqual_food_name:en:Soup, chorba frik, w meat and frik
 ciqual_food_name:fr:Soupe chorba frik, à base de viande et de frik
@@ -47184,6 +48556,7 @@ ciqual_food_name:fr:Soupe chorba frik, à base de viande et de frik
 <en:Soups
 en:Dehydrated and reconstituted minestrone soup
 fr:Soupe minestrone déshydratée et reconstituée
+agribalyse_food_code:en:25956
 ciqual_food_code:en:25956
 ciqual_food_name:en:Soup, minestrone, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe minestrone, déshydratée reconstituée
@@ -47191,6 +48564,7 @@ ciqual_food_name:fr:Soupe minestrone, déshydratée reconstituée
 <en:Vegetable soups
 en:Reheatable tomato soup
 fr:Soupe à la tomate à réchauffer
+agribalyse_food_code:en:25914
 ciqual_food_code:en:25914
 ciqual_food_name:en:Soup, tomatoes, prepacked, to be reheated
 ciqual_food_name:fr:Soupe à la tomate, préemballée à réchauffer
@@ -47199,6 +48573,7 @@ ciqual_food_name:fr:Soupe à la tomate, préemballée à réchauffer
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted tomato soup
 fr:Soupe à la tomate déshydratée reconstituée
+agribalyse_food_code:en:25935
 ciqual_food_code:en:25935
 ciqual_food_name:en:Soup, tomatoes, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe à la tomate, déshydratée reconstituée
@@ -47207,6 +48582,7 @@ ciqual_food_name:fr:Soupe à la tomate, déshydratée reconstituée
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted leek and potato soup
 fr:Soupe aux poireaux et pommes de terre déshydratée reconstituée
+agribalyse_food_code:en:25925
 ciqual_food_code:en:25925
 ciqual_food_name:en:Soup, leek and potato, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe aux poireaux et pommes de terre, déshydratée reconstituée
@@ -47214,6 +48590,7 @@ ciqual_food_name:fr:Soupe aux poireaux et pommes de terre, déshydratée reconst
 <en:Vegetable soups
 en:Reheatable tomatoes and vermicelli soup
 fr:Soupe à la tomate et aux vermicelles à réchauffer
+agribalyse_food_code:en:25933
 ciqual_food_code:en:25933
 ciqual_food_name:en:Soup, tomatoes and vermicelli, prepacked, to be reheated
 ciqual_food_name:fr:Soupe à la tomate et aux vermicelles, préemballée à réchauffer
@@ -47221,6 +48598,7 @@ ciqual_food_name:fr:Soupe à la tomate et aux vermicelles, préemballée à réc
 <en:Vegetable soups
 en:Reheatable mixed vegetables soup
 fr:Soupe aux légumes variés à réchauffer
+agribalyse_food_code:en:25903
 ciqual_food_code:en:25903
 ciqual_food_name:en:Soup, mixed vegetables, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux légumes variés, préemballée à réchauffer
@@ -47228,6 +48606,7 @@ ciqual_food_name:fr:Soupe aux légumes variés, préemballée à réchauffer
 <en:Vegetable soups
 en:Dehydrated and reconstituted mixed vegetables soup
 fr:Soupe aux légumes déshydratée reconstituée
+agribalyse_food_code:en:25905
 ciqual_food_code:en:25905
 ciqual_food_name:en:Soup, mixed vegetables, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe aux légumes variés, déshydratée reconstituée
@@ -47235,6 +48614,7 @@ ciqual_food_name:fr:Soupe aux légumes variés, déshydratée reconstituée
 <en:Soups
 en:Reheatable minestrone soup
 fr:Soupe minestrone à réchauffer
+agribalyse_food_code:en:25916
 ciqual_food_code:en:25916
 ciqual_food_name:en:Soup, minestrone, prepacked, to be reheated
 ciqual_food_name:fr:Soupe minestrone, préemballée à réchauffer
@@ -47242,6 +48622,7 @@ ciqual_food_name:fr:Soupe minestrone, préemballée à réchauffer
 <en:Soups
 en:Reheatable lentils soup
 fr:Soupe aux lentilles à réchauffer
+agribalyse_food_code:en:25900
 ciqual_food_code:en:25900
 ciqual_food_name:en:Soup, lentils, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux lentilles, préemballée à réchauffer
@@ -47249,6 +48630,7 @@ ciqual_food_name:fr:Soupe aux lentilles, préemballée à réchauffer
 <en:Soups
 en:Reheatable split peas soup
 fr:Soupe aux pois cassés à réchauffer
+agribalyse_food_code:en:25965
 ciqual_food_code:en:25965
 ciqual_food_name:en:Soup, split peas, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux pois cassés, préemballée à réchauffer
@@ -47256,6 +48638,7 @@ ciqual_food_name:fr:Soupe aux pois cassés, préemballée à réchauffer
 <en:Soups
 en:Reheatable leek and potato soup
 fr:Soupe aux poireaux et aux pommes de terre à réchauffer
+agribalyse_food_code:en:25907
 ciqual_food_code:en:25907
 ciqual_food_name:en:Soup, leek and potato, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux poireaux et pommes de terre, préemballée à réchauffer
@@ -47283,6 +48666,7 @@ nl:Wortelsoep
 <en:Vegetable soups
 en:Reheatable carrot soup
 fr:Soupe à la carotte à réchauffer
+agribalyse_food_code:en:25913
 ciqual_food_code:en:25913
 ciqual_food_name:en:Soup, carrots, prepacked, to be reheated
 ciqual_food_name:fr:Soupe à la carotte, préemballée à réchauffer
@@ -47296,6 +48680,7 @@ nl:Pompoensoep
 <en:Pumpkin soups
 en:Reheatable pumpkin soup
 fr:Soupe au potiron à réchauffer
+agribalyse_food_code:en:25945
 ciqual_food_code:en:25945
 ciqual_food_name:en:Soup, pumpkin, prepacked, to be reheated
 ciqual_food_name:fr:Soupe au potiron, préemballée à réchauffer
@@ -47303,6 +48688,7 @@ ciqual_food_name:fr:Soupe au potiron, préemballée à réchauffer
 <en:Pumpkin soups
 en:Dehydrated and reconstituted pumpkin soup
 fr:Soupe au potiron déshydratée reconstituée
+agribalyse_food_code:en:25954
 ciqual_food_code:en:25954
 ciqual_food_name:en:Soup, pumpkin, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe au potiron, déshydratée reconstituée
@@ -47315,6 +48701,7 @@ nl:Linzensoep
 <en:Vegetable soups
 en:Reheatable green vegetables soup
 fr:Soupe aux légumes verts
+agribalyse_food_code:en:25963
 ciqual_food_code:en:25963
 ciqual_food_name:en:Soup, green vegetables, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux légumes verts, préemballée à réchauffer
@@ -47322,6 +48709,7 @@ ciqual_food_name:fr:Soupe aux légumes verts, préemballée à réchauffer
 <en:Vegetable soups
 en:Reheatable vegetables soup with cheese
 fr:Soupe aux légumes avec fromage à réchauffer
+agribalyse_food_code:en:25962
 ciqual_food_code:en:25962
 ciqual_food_name:en:Soup, vegetables with cheese, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux légumes avec fromage, préemballée à réchauffer
@@ -47329,6 +48717,7 @@ ciqual_food_name:fr:Soupe aux légumes avec fromage, préemballée à réchauffe
 <en:Vegetable soups
 en:Dehydrated and reconstituted green vegetables soup
 fr:Soupe aux légumes verts déshydratée reconstituée
+agribalyse_food_code:en:25964
 ciqual_food_code:en:25964
 ciqual_food_name:en:Soup, green vegetables, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe aux légumes verts, déshydratée reconstituée
@@ -47338,6 +48727,7 @@ en:Asparagus soups, Reheatable asparagus soup
 de:Spargelsuppen
 fr:Soupes aux asperges, Soupe aux asperges à réchauffer
 nl:Aspergesoep
+agribalyse_food_code:en:25968
 ciqual_food_code:en:25968
 ciqual_food_name:en:Soup, asparagus, prepacked, to be reheated
 ciqual_food_name:fr:Soupe aux asperges, préemballée à réchauffer
@@ -47346,6 +48736,7 @@ ciqual_food_name:fr:Soupe aux asperges, préemballée à réchauffer
 <en:Dehydrated soups
 en:Dehydrated and reconstituted asparagus soup
 fr:Soupes aux asperges déshydratées et reconstituées
+agribalyse_food_code:en:25932
 ciqual_food_code:en:25932
 ciqual_food_name:en:Soup, asparagus, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe aux asperges, déshydratée reconstituée
@@ -47354,6 +48745,7 @@ ciqual_food_name:fr:Soupe aux asperges, déshydratée reconstituée
 <en:Vegetable soups
 en:Heatable onion soup
 fr:Soupe à l'oignon à réchauffer
+agribalyse_food_code:en:25910
 ciqual_food_code:en:25910
 ciqual_food_name:en:Soup, onions, prepacked, to be reheated
 ciqual_food_name:fr:Soupe à l'oignon, préemballée à réchauffer
@@ -47362,6 +48754,7 @@ ciqual_food_name:fr:Soupe à l'oignon, préemballée à réchauffer
 <en:Vegetable soups
 en:Dehydrated and reconstituted onion soup
 fr:Soupe à l'oignon déshydratée et reconstituée
+agribalyse_food_code:en:25942
 ciqual_food_code:en:25942
 ciqual_food_name:en:Soup, onions, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe à l'oignon, déshydratée reconstituée
@@ -47401,6 +48794,7 @@ nl:Gekoelde groentesoepen
 <en:Soups
 en:Reheatable pistou soup, Reheatable basil garlic and olive oil soup
 fr:Soupe au pistou à réchauffer
+agribalyse_food_code:en:25953
 ciqual_food_code:en:25953
 ciqual_food_name:en:Soup, pistou (basil, garlic and olive oil), prepacked, to be reheated
 ciqual_food_name:fr:Soupe au pistou, préemballée à réchauffer
@@ -47408,6 +48802,7 @@ ciqual_food_name:fr:Soupe au pistou, préemballée à réchauffer
 <en:Soups
 en:Dehydrated and reconstituted pistou soup, Dehydrated and reconstituted soup with basil garlic and olive oil
 fr:Soupe au pistou déshydratée reconstituée
+agribalyse_food_code:en:25917
 ciqual_food_code:en:25917
 ciqual_food_name:en:Soup, pistou (basil, garlic and olive oil), dehydrated and reconstituted
 ciqual_food_name:fr:Soupe au pistou, déshydratée reconstituée
@@ -47437,6 +48832,7 @@ fi:gazpacho
 fr:Gaspacho, Gaspachos, gazpacho, Soupes froides type Gaspacho, Soupes froides type Gazpacho
 nl:Gazpachos
 wikidata:en:Q202677
+agribalyse_food_code:en:25967
 ciqual_food_code:en:25967
 ciqual_food_name:en:Soup, gazpacho, cold
 ciqual_food_name:fr:Soupe froide type Gaspacho ou Gazpacho
@@ -47634,6 +49030,7 @@ nl:Boullons in poeder
 <en:Dehydrated broths
 en:Dehydrated aromatic stock cube for fish
 fr:Court-bouillon pour poissons déshydraté
+agribalyse_food_code:en:11172
 ciqual_food_code:en:11172
 ciqual_food_name:en:Aromatic stock cube, for fish, dehydrated
 ciqual_food_name:fr:Court-bouillon pour poissons, déshydraté
@@ -47641,6 +49038,7 @@ ciqual_food_name:fr:Court-bouillon pour poissons, déshydraté
 <en:Dehydrated broths
 en:Broth stock, bouillon beef dehydrated
 fr:Bouillon de boeuf déshydraté
+agribalyse_food_code:en:11001
 ciqual_food_code:en:11001
 ciqual_food_name:en:Broth, stock or bouillon, beef, dehydrated
 
@@ -47696,6 +49094,7 @@ nl:Groentebouillonpoeders
 <en:Dehydrated vegetable bouillons
 en:Dehydrated and reconstituted vegetables bouillon, Dehydrated and reconstituted vegetables broth, Dehydrated and reconstituted vegetables stock
 fr:Bouillon de légumes déshydraté reconstitué
+agribalyse_food_code:en:25948
 ciqual_food_code:en:25948
 ciqual_food_name:en:Broth, stock or bouillon, vegetables, dehydrated and reconstituted
 ciqual_food_name:fr:Bouillon de légumes, déshydraté reconstitué
@@ -47718,6 +49117,7 @@ nl:Groentebouillons in pot
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted broth with meat and vegetables,Dehydrated and reconstituted stock with meat and vegetables, Dehydrated and reconstituted bouillon with meat and vegetables
 fr:Bouillon de viande et légumes type pot-au-feu prêt à consommer
+agribalyse_food_code:en:25909
 ciqual_food_code:en:25909
 ciqual_food_name:en:Broth, stock or bouillon, meat and vegetables, dehydrated and reconstituted
 ciqual_food_name:fr:Bouillon de viande et légumes type pot-au-feu, prêt à consommer
@@ -47726,6 +49126,7 @@ ciqual_food_name:fr:Bouillon de viande et légumes type pot-au-feu, prêt à con
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted broth stock, Dehydrated and reconstituted bouillon beef
 fr:Bouillon de boeuf déshydraté reconstitué
+agribalyse_food_code:en:25930
 ciqual_food_code:en:25930
 ciqual_food_name:en:Broth, stock or bouillon, beef, dehydrated and reconstituted
 ciqual_food_name:fr:Bouillon de boeuf, déshydraté reconstitué
@@ -47734,6 +49135,7 @@ ciqual_food_name:fr:Bouillon de boeuf, déshydraté reconstitué
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted broth stock with poultry, Dehydrated and reconstituted bouillon with poultry
 fr:Bouillon de volaille déshydraté reconstitué
+agribalyse_food_code:en:25947
 ciqual_food_code:en:25947
 ciqual_food_name:en:Broth, stock or bouillon, poultry, dehydrated and reconstituted
 ciqual_food_name:fr:Bouillon de volaille, déshydraté reconstitué
@@ -47742,6 +49144,7 @@ ciqual_food_name:fr:Bouillon de volaille, déshydraté reconstitué
 <en:Dried products to be rehydrated
 en:Poultry stock for sauce and cooking dehydrated
 fr:Fond de volaille pour sauces et cuisson déshydraté
+agribalyse_food_code:en:11171
 ciqual_food_code:en:11171
 ciqual_food_name:en:Poultry stock for sauce and cooking, dehydrated
 
@@ -47749,6 +49152,7 @@ ciqual_food_name:en:Poultry stock for sauce and cooking, dehydrated
 <en:Dried products to be rehydrated
 en:Broth stock or bouillon poultry dehydrated
 fr:Bouillon de volaille déshydraté
+agribalyse_food_code:en:11174
 ciqual_food_code:en:11174
 ciqual_food_name:en:Broth, stock or bouillon, poultry, dehydrated
 
@@ -47756,6 +49160,7 @@ ciqual_food_name:en:Broth, stock or bouillon, poultry, dehydrated
 <en:Dried products to be rehydrated
 en:Veal stock for sauce and cooking dehydrated
 fr:Fond de veau pour sauces et cuisson déshydraté
+agribalyse_food_code:en:11169
 ciqual_food_code:en:11169
 ciqual_food_name:en:Veal stock for sauce and cooking, dehydrated
 
@@ -47763,6 +49168,7 @@ ciqual_food_name:en:Veal stock for sauce and cooking, dehydrated
 <en:Dried products to be rehydrated
 en:Broth stock or bouillon meat and vegetables dehydrated
 fr:Bouillon de viande et légumes type pot-au-feu déshydraté
+agribalyse_food_code:en:25918
 ciqual_food_code:en:25918
 ciqual_food_name:en:Broth, stock or bouillon, meat and vegetables, dehydrated
 
@@ -47770,6 +49176,7 @@ ciqual_food_name:en:Broth, stock or bouillon, meat and vegetables, dehydrated
 <en:Dried products to be rehydrated
 en:Broth stock or bouillon meat and vegetables with fat dehydrated
 fr:Bouillon de viande et légumes type pot-au-feu non dégraissé déshydraté
+agribalyse_food_code:en:25970
 ciqual_food_code:en:25970
 ciqual_food_name:en:Broth, stock or bouillon, meat and vegetables, with fat, dehydrated
 
@@ -47796,6 +49203,7 @@ nl:Schapenbouillon
 en:Cassoulets, Canned white bean stew
 fr:Cassoulets, Cassoulet aux haricots blancs appertisé
 nl:Cassoulets, Cassoulet
+agribalyse_food_code:en:25002
 ciqual_food_code:en:25002
 ciqual_food_name:en:White bean stew, canned
 ciqual_food_name:fr:Cassoulet, appertisé
@@ -47824,6 +49232,7 @@ nl:Gebakken rijst
 ru:Жареный рис
 zh:炒饭
 wikidata:en:Q1076874
+agribalyse_food_code:en:25088
 ciqual_food_code:en:25088
 ciqual_food_name:en:Cantonese rice
 ciqual_food_name:fr:Riz cantonais
@@ -47831,6 +49240,7 @@ ciqual_food_name:fr:Riz cantonais
 <en:Meals
 en:Basque-style piperade, Fondue of sweet peppers and tomatoes flavoured with onions and garlics
 fr:Piperade basquaise
+agribalyse_food_code:en:20240
 ciqual_food_code:en:20240
 ciqual_food_name:en:Piperade, Basque-style (fondue of sweet peppers and tomatoes flavoured with onions and garlics)
 ciqual_food_name:fr:Piperade basquaise
@@ -47845,6 +49255,7 @@ nl:Zuurkolen
 <en:Sauerkrauts
 fr:Choucroutes garnies, Choucroute garnie
 en:Sauerkraut with garnish
+agribalyse_food_code:en:25003
 ciqual_food_code:en:25003
 ciqual_food_name:en:Sauerkraut, with garnish
 ciqual_food_name:fr:Choucroute garnie
@@ -47852,6 +49263,7 @@ ciqual_food_name:fr:Choucroute garnie
 <en:Sauerkrauts
 en:Drained sauerkraut without garnish
 fr:Choucroutes sans garniture égouttées
+agribalyse_food_code:en:25004
 ciqual_food_code:en:25004
 ciqual_food_name:en:Sauerkraut, without garnish, drained
 ciqual_food_name:fr:Choucroute, sans garniture, égouttée
@@ -47885,6 +49297,7 @@ fi:coleslaw
 fr:Coleslaw, Salade coleslaw, Salade de chou avec sauce, Coleslaw avec sauce
 nl:Koolsalade
 wikidata:en:Q945475
+agribalyse_food_code:en:26259
 ciqual_food_code:en:26259
 ciqual_food_name:en:Coleslaw, w sauce, prepacked
 ciqual_food_name:fr:Salade de chou ou Coleslaw, avec sauce, préemballée
@@ -47900,6 +49313,7 @@ de:Flammekueche
 fr:Flammekueches, Flammekueche, tarte flambée,  tartes flambées, flamme-küche, flamms, Flammkuchen, Flamenkuches, Tartes flambées aux lardons
 nl:Flammekueche
 wikidata:en:Q316849
+agribalyse_food_code:en:25550
 ciqual_food_code:en:25550
 ciqual_food_name:en:Flamed tart (thin-crusted onion tart with cream and lardoons)
 ciqual_food_name:fr:Flammenkueche ou Tarte flambée aux lardons
@@ -47924,6 +49338,7 @@ fr:Samoussas, samossas, samosas
 nl:Samosa
 wikidata:en: Q491517
 pnns_group_2:en:Appetizers
+agribalyse_food_code:en:25108
 ciqual_food_code:en:25108
 ciqual_food_name:en:Samosas or samoosas
 ciqual_food_name:fr:Samossas ou Samoussas
@@ -47976,6 +49391,7 @@ nl:Groentencakes
 <en:Prepared vegetables
 en:Frozen pre-fried vegetable rosti
 fr:Palets de légumes préfrits surgelés, Galettes de légumes préfrites surgelées
+agribalyse_food_code:en:25199
 ciqual_food_code:en:25199
 ciqual_food_name:en:Vegetable rosti, pre-fried, frozen
 ciqual_food_name:fr:Palet ou galette de légumes, préfrit, surgelé
@@ -47983,6 +49399,7 @@ ciqual_food_name:fr:Palet ou galette de légumes, préfrit, surgelé
 <en:Prepared vegetables
 en:Frozen pre-fried cooked vegetable rosti
 fr:Palets de légumes préfrits cuits surgelés, Galettes de légumes préfrites cuites surgelées
+agribalyse_food_code:en:25208
 ciqual_food_code:en:25208
 ciqual_food_name:en:Vegetable rosti, pre-fried, frozen, cooked
 ciqual_food_name:fr:Palet ou galette de légumes, préfrit, surgelé, cuit
@@ -47990,6 +49407,7 @@ ciqual_food_name:fr:Palet ou galette de légumes, préfrit, surgelé, cuit
 <en:Prepared vegetables
 en:Rostis, Potatoes cakes, Potato cakes
 fr:Rostis, Galette de pomme de terre, Galette de pommes de terre
+agribalyse_food_code:en:4039
 ciqual_food_code:en:4039
 ciqual_food_name:en:Rostis or Potatoes cake
 ciqual_food_name:fr:Rostis ou Galette de pomme de terre
@@ -47997,6 +49415,7 @@ ciqual_food_name:fr:Rostis ou Galette de pomme de terre
 <en:Prepared vegetables
 en:Stuffed vegetables
 fr:Légumes farcis
+agribalyse_food_code:en:25511
 ciqual_food_code:en:25511
 ciqual_food_name:en:Stuffed vegetables (excluding tomato)
 ciqual_food_name:fr:Légumes farcis (sauf tomate)
@@ -48016,6 +49435,7 @@ fi:kasvisgratiinit
 fr:Gratins de légumes, Gratin de légumes
 nl:Groente-ovenschotels
 #wikidata:en:
+agribalyse_food_code:en:25162
 ciqual_food_code:en:25162
 ciqual_food_name:en:Vegetables au gratin (oven grilled)
 ciqual_food_name:fr:Gratin de légumes
@@ -48023,6 +49443,7 @@ ciqual_food_name:fr:Gratin de légumes
 <en:Vegetable gratins
 en:Vegetables au gratin in bechamel sauce, Oven grilled vegetables in bechamel sauce
 fr:Gratin de légumes à la béchamel
+agribalyse_food_code:en:25588
 ciqual_food_code:en:25588
 ciqual_food_name:en:Vegetables au gratin (oven grilled) in bechamel sauce
 ciqual_food_name:fr:Gratin de légumes en sauce blanche type béchamel, cuit
@@ -48033,6 +49454,7 @@ de:Auberginenauflauf
 fr:Gratins d'aubergine, Gratin d'aubergine
 nl:Aubergine-ovenschotels
 #wikidata:en:
+agribalyse_food_code:en:25052
 ciqual_food_code:en:25052
 ciqual_food_name:en:Eggplant au gratin (oven grilled)
 ciqual_food_name:fr:Gratin d'aubergine
@@ -48042,6 +49464,7 @@ en:Cauliflower gratins, Cauliflower au gratin, Oven grilled cauliflower
 fr:Gratins de choux-fleurs, Gratins de chou-fleur
 nl:Bloemkool ovenschotel
 #wikidata:en:
+agribalyse_food_code:en:25101
 ciqual_food_code:en:25101
 ciqual_food_name:en:Cauliflower au gratin (oven grilled)
 ciqual_food_name:fr:Gratin de chou-fleur
@@ -48052,6 +49475,7 @@ en:Pasta gratin, Oven grilled pasta gratin
 de:Nudelaufläufe
 fr:Gratins de pâtes
 nl:Pasta ovenschotel
+agribalyse_food_code:en:25122
 ciqual_food_code:en:25122
 ciqual_food_name:en:Pasta au gratin (oven grilled)
 ciqual_food_name:fr:Gratin de pâtes
@@ -48068,6 +49492,7 @@ nl:Aardappelovenschotels
 fr:Gratins dauphinois, Gratin dauphinois, Pommes de terre au gratin
 en:Dauphiné-style creamed potatoes au gratin
 wikidata:en:Q1647122
+agribalyse_food_code:en:25056
 ciqual_food_code:en:25056
 ciqual_food_name:en:Dauphiné-style creamed potatoes au gratin
 ciqual_food_name:fr:Gratin dauphinois
@@ -48077,6 +49502,7 @@ en:Tartiflettes, Tartiflette, Cheese fondue
 fr:Tartiflettes, Tartiflette
 nl:Tartiflette
 wikidata:en:Q1759775
+agribalyse_food_code:en:25137
 ciqual_food_code:en:25137
 ciqual_food_name:en:Tartiflette (cheese fondue)
 ciqual_food_name:fr:Tartiflette
@@ -48095,6 +49521,7 @@ nl:Visovenschotels
 <en:Fish gratin
 en:Fish brandade, Fish shepherd's pie
 fr:brandade aux pommes de terre, parmentier de poisson
+agribalyse_food_code:en:25154
 ciqual_food_code:en:25154
 ciqual_food_name:en:Fish brandade or fish shepherd's pie
 
@@ -48129,12 +49556,14 @@ es:Lasaña boloñesa
 fi:Lasagne bolognese
 fr:Lasagnes à la bolognaise, Lasagnes bolognaise, Lasagne à la bolognaise
 nl:Kant-en-klaar bolognese lasagnas
+agribalyse_food_code:en:25081
 ciqual_food_code:en:25081
 ciqual_food_name:en:Lasagna or cannelloni with meat (bolognese sauce)
 
 <en:Prepared lasagne
 en:Lasagne with fish, Lasagna with fish
 fr:Lasagnes au poisson
+agribalyse_food_code:en:25139
 ciqual_food_code:en:25139
 ciqual_food_name:en:Lasagna or cannelloni with fish
 ciqual_food_name:fr:Lasagnes ou cannelloni au poisson
@@ -48156,6 +49585,7 @@ nl:Tonijnlasagna
 <en:Fish dishes
 en:Braised European hake
 fr:Merlu cuit à l'étouffée
+agribalyse_food_code:en:26120
 ciqual_food_code:en:26120
 ciqual_food_name:en:European hake, braised
 ciqual_food_name:fr:Merlu, cuit à l'étouffée
@@ -48163,6 +49593,7 @@ ciqual_food_name:fr:Merlu, cuit à l'étouffée
 <en:Fish dishes
 en:Raw European hake
 fr:Merlu cru
+agribalyse_food_code:en:26044
 ciqual_food_code:en:26044
 ciqual_food_name:en:European hake, raw
 ciqual_food_name:fr:Merlu, cru
@@ -48170,6 +49601,7 @@ ciqual_food_name:fr:Merlu, cru
 <en:Fish dishes
 en:Raw shallow-water Cape hake
 fr:Merlu blanc du Cap surgelé cru
+agribalyse_food_code:en:26233
 ciqual_food_code:en:26233
 ciqual_food_name:en:Shallow-water Cape hake, raw
 ciqual_food_name:fr:Merlu blanc du Cap, surgelé, cru
@@ -48177,6 +49609,7 @@ ciqual_food_name:fr:Merlu blanc du Cap, surgelé, cru
 <en:Fish dishes
 en:Raw blue grenadier
 fr:Grenadier bleu cru, Hoki de Nouvelle-Zélande cru
+agribalyse_food_code:en:26214
 ciqual_food_code:en:26214
 ciqual_food_name:en:Blue grenadier, raw
 ciqual_food_name:fr:Grenadier bleu ou hoki de Nouvelle-Zélande cru
@@ -48184,6 +49617,7 @@ ciqual_food_name:fr:Grenadier bleu ou hoki de Nouvelle-Zélande cru
 <en:Fish dishes
 en:Raw pond smelt
 fr:Éperlan cru
+agribalyse_food_code:en:26083
 ciqual_food_code:en:26083
 ciqual_food_name:en:Pond smelt, raw
 ciqual_food_name:fr:Éperlan, cru
@@ -48191,6 +49625,7 @@ ciqual_food_name:fr:Éperlan, cru
 <en:Fish dishes
 en:Raw garfish
 fr:Orphie commune crue
+agribalyse_food_code:en:26166
 ciqual_food_code:en:26166
 ciqual_food_name:en:Garfish, raw
 ciqual_food_name:fr:Orphie commune, crue
@@ -48198,6 +49633,7 @@ ciqual_food_name:fr:Orphie commune, crue
 <en:Fish dishes
 en:Raw European sprat
 fr:Sprat cru
+agribalyse_food_code:en:26173
 ciqual_food_code:en:26173
 ciqual_food_name:en:European sprat, raw
 ciqual_food_name:fr:Sprat, cru
@@ -48216,6 +49652,7 @@ en:Vegetable lasagne, Lasagna with vegetables
 de:Gemüselasagne
 fr:Lasagnes aux légumes
 nl:Groentelasagne
+agribalyse_food_code:en:25131
 ciqual_food_code:en:25131
 ciqual_food_name:en:Lasagna or cannelloni with vegetables
 ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes
@@ -48224,6 +49661,7 @@ ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes
 <en:Vegetarian lasagne
 en:Lasagna with cooked vegetables
 fr:Lasagnes aux légumes cuits
+agribalyse_food_code:en:25218
 ciqual_food_code:en:25218
 ciqual_food_name:en:Lasagna or cannelloni with vegetables, cooked
 ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes, cuits
@@ -48237,6 +49675,7 @@ nl:Lasagna met geitenkaas en spinazie
 <en:Vegetarian lasagne
 en:Lasagna with cooked vegetables and goat cheese
 fr:Lasagnes aux légumes cuits et au fromage de chèvre
+agribalyse_food_code:en:25219
 ciqual_food_code:en:25219
 ciqual_food_name:en:Lasagna or cannelloni with vegetables and goat cheese, cooked
 ciqual_food_name:fr:Lasagnes ou canelloni aux légumes et au fromage de chèvre, cuits
@@ -48265,6 +49704,7 @@ ciqual_food_name:fr:Légume cuit (aliment moyen)
 en:Stuffed tomatoes, Stuffed tomato
 fr:Tomates farcies, Tomate farcie
 nl:Gevulde tomaat
+agribalyse_food_code:en:25103
 ciqual_food_code:en:25103
 ciqual_food_name:en:Stuffed tomatoes
 ciqual_food_name:fr:Tomate farcie
@@ -48291,6 +49731,7 @@ fr:Carottes râpées non assaisonnées
 <en:Prepared vegetables
 fr:Céleris Rémoulade, Céleri Rémoulade, Céleris Rémoulades
 en:Celeriac in remoulade sauce
+agribalyse_food_code:en:25600
 ciqual_food_code:en:25600
 ciqual_food_name:en:Celeriac in remoulade sauce, prepacked
 ciqual_food_name:fr:Céleri rémoulade, préemballé
@@ -48311,6 +49752,7 @@ wikidata:en:Q804297
 <en:Baked beans in tomato sauce
 en:Canned haricot beans with tomato sauce
 fr:Haricots blancs à la sauce tomate appertisés
+agribalyse_food_code:en:20194
 ciqual_food_code:en:20194
 ciqual_food_name:en:Haricot beans with tomato sauce, canned
 ciqual_food_name:fr:Haricots blancs à la sauce tomate, appertisés
@@ -48331,6 +49773,7 @@ ja:ラタトゥイユ
 nl:Ratatouilles
 ru:Рататуй
 wikidata:en:Q183095
+agribalyse_food_code:en:25018
 ciqual_food_code:en:25018
 ciqual_food_name:en:Ratatouille cooked
 ciqual_food_name:fr:Ratatouille cuisinée
@@ -48348,6 +49791,7 @@ nl:Kant-en-klaar linzen
 <en:Meals with meat
 fr:Petits salés aux lentilles, petit salé aux lentilles
 en:Salt-cured pork belly with lentils
+agribalyse_food_code:en:25010
 ciqual_food_code:en:25010
 ciqual_food_name:en:Salt-cured pork belly with lentils
 ciqual_food_name:fr:Petit salé ou saucisse aux lentilles
@@ -48355,6 +49799,7 @@ ciqual_food_name:fr:Petit salé ou saucisse aux lentilles
 <en:Meals
 en:Filled Focaccia
 fr:Focaccia garnie
+agribalyse_food_code:en:7811
 ciqual_food_code:en:7811
 ciqual_food_name:en:Focaccia, filled
 ciqual_food_name:fr:Focaccia, garnie
@@ -48394,6 +49839,7 @@ en:Regina pizza, Pizza with ham and cheese and mushrooms
 de:Pizza Regina
 fr:Pizzas royales, Pizza royale, Pizza reine, Pizza Regina, Pizza jambon fromage champignons
 nl:Ham-kaas-champignon pizza
+agribalyse_food_code:en:25548
 ciqual_food_code:en:25548
 ciqual_food_name:en:Pizza, ham cheese and mushrooms
 ciqual_food_name:fr:Pizza jambon fromage champignons ou pizza royale, reine ou regina
@@ -48401,6 +49847,7 @@ ciqual_food_name:fr:Pizza jambon fromage champignons ou pizza royale, reine ou r
 <en:Pizzas
 en:Cheese and mushrooms pizza
 fr:Pizza champignons fromage
+agribalyse_food_code:en:25477
 ciqual_food_code:en:25477
 ciqual_food_name:en:Pizza, cheese and mushrooms
 ciqual_food_name:fr:Pizza champignons fromage
@@ -48413,6 +49860,7 @@ fi:margherita-pizza
 fr:Pizzas margherita, pizza margherita, pizzas marguerite, Pizza au fromage et aux tomates
 nl:Pizza Margherita
 #wikidata:en:
+agribalyse_food_code:en:25404
 ciqual_food_code:en:25404
 ciqual_food_name:en:Pizza, cheese and tomato or Margherita pizza
 ciqual_food_name:fr:Pizza au fromage ou Pizza margherita
@@ -48420,6 +49868,7 @@ ciqual_food_name:fr:Pizza au fromage ou Pizza margherita
 <en:Pizzas
 en:Pizza with ham and cheese
 fr:Pizza jambon fromage
+agribalyse_food_code:en:25435
 ciqual_food_code:en:25435
 ciqual_food_name:en:Pizza, ham and cheese
 ciqual_food_name:fr:Pizza jambon fromage
@@ -48427,6 +49876,7 @@ ciqual_food_name:fr:Pizza jambon fromage
 <en:Pizzas
 en:Chicken pizza
 fr:Pizza au poulet
+agribalyse_food_code:en:26272
 ciqual_food_code:en:26272
 ciqual_food_name:en:Pizza, chicken
 ciqual_food_name:fr:Pizza au poulet
@@ -48434,6 +49884,7 @@ ciqual_food_name:fr:Pizza au poulet
 <en:Pizzas
 en:Cured Ham Pizza
 fr:Pizza au speck, Pizza au jambon cru
+agribalyse_food_code:en:26274
 ciqual_food_code:en:26274
 ciqual_food_name:en:Pizza, cured ham
 ciqual_food_name:fr:Pizza au speck ou jambon cru
@@ -48443,6 +49894,7 @@ en:Chorizo pizzas, Chorizo pizza, Salami pizza
 fr:Pizzas au chorizo, Pizzas chorizo, Pizza au chorizo, Pizza au salami
 nl:Chorizopizzas
 #wikidata:en:
+agribalyse_food_code:en:25462
 ciqual_food_code:en:25462
 ciqual_food_name:en:Pizza, chorizo or salami
 ciqual_food_name:fr:Pizza au chorizo ou salami
@@ -48459,7 +49911,8 @@ de:Thunfischpizzen
 fr:Pizzas au thon, Pizza au thon
 nl:Tonijnpizzas
 pt:Pizzas de atum
-#wikidata:en:
+wikidata:en:Q47471957
+agribalyse_food_code:en:26270
 ciqual_food_code:en:26270
 ciqual_food_name:en:Pizza, tuna
 ciqual_food_name:fr:Pizza au thon
@@ -48467,6 +49920,7 @@ ciqual_food_name:fr:Pizza au thon
 <en:Pizzas
 en:Seafood pizza
 fr:Pizza aux fruits de mer
+agribalyse_food_code:en:25463
 ciqual_food_code:en:25463
 ciqual_food_name:en:Pizza, seafood
 ciqual_food_name:fr:Pizza aux fruits de mer
@@ -48474,6 +49928,8 @@ ciqual_food_name:fr:Pizza aux fruits de mer
 <en:Pizzas
 en:Salmon pizza
 fr:Pizza au saumon
+wikidata:en:Q54223338
+agribalyse_food_code:en:25464
 ciqual_food_code:en:25464
 ciqual_food_name:en:Pizza, salmon
 ciqual_food_name:fr:Pizza au saumon
@@ -48482,7 +49938,8 @@ ciqual_food_name:fr:Pizza au saumon
 en:Bolognese pizzas, Pizza bolognese-style with meat
 fr:Pizzas à la bolognaise, Pizzas bolognaise, Pizza à la viande type bolognaise
 nl:Bolognesepizzas
-#wikidata:en:
+wikidata:en:Q47472171
+agribalyse_food_code:en:25457
 ciqual_food_code:en:25457
 ciqual_food_name:en:Pizza, bolognese-style w meat
 ciqual_food_name:fr:Pizza à la viande, type bolognaise
@@ -48492,6 +49949,7 @@ en:Goat cheese and bacon pizzas, Goat cheese pizza with lardoons
 fr:Pizzas chèvre-lardons, Pizza au chèvre et lardons
 nl:Geitenkaas-spekpizzas
 #wikidata:en:
+agribalyse_food_code:en:25468
 ciqual_food_code:en:25468
 ciqual_food_name:en:Pizza, goat cheese and lardoons
 ciqual_food_name:fr:Pizza au chèvre et lardons
@@ -48523,6 +49981,7 @@ en:Kebab pizzas, Kebab pizza
 de:Pizza Kebab, Pizza Kebap, Dönerpizza
 fr:Pizzas au kebab, Pizza au kebab, Pizzas kebab
 nl:Pizza kebab
+agribalyse_food_code:en:26271
 ciqual_food_code:en:26271
 ciqual_food_name:en:Pizza, kebab
 ciqual_food_name:fr:Pizza kebab
@@ -48530,6 +49989,7 @@ ciqual_food_name:fr:Pizza kebab
 <en:Pizzas
 en:Vegetable pizza, Four seasons pizza, Pizza quattro stagioni
 fr:Pizza aux légumes, Pizza 4 saisons, Pizza quatre saisons
+agribalyse_food_code:en:25472
 ciqual_food_code:en:25472
 ciqual_food_name:en:Pizza, vegetables or pizza 4 seasons
 ciqual_food_name:fr:Pizza aux légumes ou Pizza 4 saisons
@@ -48556,6 +50016,7 @@ es:Pizza de cuatro quesos
 fi:Neljän juuston pizza
 fr:Pizzas aux quatre fromages, pizzas 4 fromages, Pizza aux quatre fromages, pizza 4 fromages
 nl:Vierkazenpizzas
+agribalyse_food_code:en:25478
 ciqual_food_code:en:25478
 ciqual_food_name:en:Pizza, four cheeses
 ciqual_food_name:fr:Pizza 4 fromages
@@ -48572,6 +50033,7 @@ fr:Pizzas aux six fromages, pizzas 6 fromages, Pizza aux six fromages, pizza 6 f
 <en:Cheese pizzas
 en:Cheese and onion pizza with lardoons
 fr:Pizza aux lardons oignons et fromage
+agribalyse_food_code:en:25570
 ciqual_food_code:en:25570
 ciqual_food_name:en:Pizza, lardoons onions and cheese
 ciqual_food_name:fr:Pizza aux lardons, oignons et fromage
@@ -48579,6 +50041,7 @@ ciqual_food_name:fr:Pizza aux lardons, oignons et fromage
 <en:Cheese pizzas
 en:Pizza with raclette cheese and lardoons, Pizza with tartiflette cheese and lardoons
 fr:Pizza type raclette, Pizza type tartiflette
+agribalyse_food_code:en:26273
 ciqual_food_code:en:26273
 ciqual_food_name:en:Pizza with raclette or tartiflette cheese and lardoons
 ciqual_food_name:fr:Pizza type raclette ou tartiflette
@@ -48664,6 +50127,7 @@ fr:Poêlées savoyardes
 <fr:Poêlées
 en:Frozen raw pan-fried vegetables without mushrooms
 fr:Poêlée de légumes assaisonnés surgelée crue sans champignons
+agribalyse_food_code:en:20262
 ciqual_food_code:en:20262
 ciqual_food_name:en:Vegetables pan-fried without mushrooms, frozen, raw
 ciqual_food_name:fr:Poêlée de légumes assaisonnés sans champignon, surgelée, crue
@@ -48671,6 +50135,7 @@ ciqual_food_name:fr:Poêlée de légumes assaisonnés sans champignon, surgelée
 <fr:Poêlées
 en:Frozen raw pan-fried Asian-style vegetables, Frozen raw stir-fried Asian-style vegetables
 fr:Poêlée de légumes assaisonnés à l'asiatiques, Wok de légumes surgelés
+agribalyse_food_code:en:20273
 ciqual_food_code:en:20273
 ciqual_food_name:en:Vegetables pan-fried or stir-fried, Asian-style, frozen, raw
 ciqual_food_name:fr:Poêlée de légumes assaisonnés à l'asiatiques ou wok de légumes, surgelée, crue
@@ -48678,6 +50143,7 @@ ciqual_food_name:fr:Poêlée de légumes assaisonnés à l'asiatiques ou wok de 
 <fr:Poêlées
 en:Frozen raw pan-fried Mediterranean-style grilled vegetables
 fr:Poêlée de légumes assaisonnés grillée méridionale surgelée, Poêlée de légumes assaisonnés grillée méditerranéenne surgelée
+agribalyse_food_code:en:20274
 ciqual_food_code:en:20274
 ciqual_food_name:en:Grilled vegetables pan-fried, Mediterranean-style, frozen, raw
 ciqual_food_name:fr:Poêlée de légumes assaisonnés grillée, méridionale ou méditerranéenne, surgelée, crue
@@ -48685,6 +50151,7 @@ ciqual_food_name:fr:Poêlée de légumes assaisonnés grillée, méridionale ou 
 <fr:Poêlées
 en:Frozen pan-fried vegetables  with mushrooms country-style
 fr:Poêlée de légumes assaisonnés aux champignons surgelée, Poêlée de légumes champêtre surgelée
+agribalyse_food_code:en:20498
 ciqual_food_code:en:20498
 ciqual_food_name:en:Vegetables pan-fried with mushrooms (country-style), frozen
 ciqual_food_name:fr:Poêlée de légumes assaisonnés aux champignons (champêtre), surgelée
@@ -48692,6 +50159,7 @@ ciqual_food_name:fr:Poêlée de légumes assaisonnés aux champignons (champêtr
 <fr:Poêlées
 en:Pre-fried potatoes pan-fried with lardoons, Pre-fried potatoes pan-fried with chicken
 fr:Poêlée de pommes de terre préfrites aux lardons , Poêlée de pommes de terre préfrites au poulet
+agribalyse_food_code:en:25057
 ciqual_food_code:en:25057
 ciqual_food_name:en:Pre-fried potatoes, pan-fried, lardoons or chicken, and other, without green vegetables
 ciqual_food_name:fr:Poêlée de pommes de terre préfrites, lardons ou poulet, et autres, sans légumes verts
@@ -48734,6 +50202,7 @@ nl:Natuurquenelles
 <fr:Quenelles
 en:Raw plain quenelle
 fr:Quenelle nature crue
+agribalyse_food_code:en:8937
 ciqual_food_code:en:8937
 ciqual_food_name:en:Quenelle, plain, raw
 ciqual_food_name:fr:Quenelle nature, crue
@@ -48754,6 +50223,7 @@ en:Lorraine quiche, Quiche Lorraine, Eggs and lardoons quiche
 fi:quiche lorraine
 fr:Quiches lorraines, quiche lorraine
 nl:Quiche Lorraine
+agribalyse_food_code:en:25405
 ciqual_food_code:en:25405
 ciqual_food_name:en:Quiche Lorraine (eggs and lardoons quiche)
 ciqual_food_name:fr:Quiche lorraine
@@ -48766,6 +50236,7 @@ fr:Quiches aux lardons
 <en:Quiches
 en:Onion tart
 fr:Tarte à l'oignon
+agribalyse_food_code:en:25529
 ciqual_food_code:en:25529
 ciqual_food_name:en:Onion tart
 ciqual_food_name:fr:Tarte à l'oignon
@@ -48784,6 +50255,7 @@ nl:Quiche met vis
 <en:Quiches with fish
 en:Salmon quiches, Quiches with salmon, Salmon pies, Salmon tarts
 fr:Quiches au saumon, tartes au saumon, Quiche au saumon, tarte au saumon
+agribalyse_food_code:en:25555
 ciqual_food_code:en:25555
 ciqual_food_name:en:Salmon tart
 ciqual_food_name:fr:Tarte au saumon
@@ -48793,6 +50265,7 @@ en:Leek quiche, Leek tart, Leek pie
 fr:Quiches au poireau, quiche au poireau, tartes aux poireaux, tartes au poireau, Tarte aux poireaux, Tourte aux poireaux
 nl:Preitaart
 pt:Quiche de alho-poró
+agribalyse_food_code:en:25553
 ciqual_food_code:en:25553
 ciqual_food_name:en:Leek tart or pie
 ciqual_food_name:fr:Tarte ou Tourte aux poireaux
@@ -48827,6 +50300,7 @@ ciqual_food_name:fr:Salade composée avec viande ou poisson, appertisée, égout
 
 en:Prepared and canned salad with fish
 fr:salade composée avec poisson appertisée égouttée
+agribalyse_food_code:en:25602
 ciqual_food_code:en:25602
 ciqual_food_name:en:Prepared mixed meat/ canned, drained salad
 ciqual_food_name:fr:Salade composée avec viande ou poisson, appertisée, égouttée
@@ -48835,16 +50309,19 @@ ciqual_food_name:fr:Salade composée avec viande ou poisson, appertisée, égout
 en:Piemontese salads
 fr:Salades piémontaises
 nl:Salade uit Piëmont
+wikidata:en:Q30738187
 
 <en:Potato salads
 en:Prepared potatoes salad home-made
 fr:Salade de pommes de terre maison
+agribalyse_food_code:en:25606
 ciqual_food_code:en:25606
 ciqual_food_name:en:Prepared potatoes salad, home-made
 
 <en:Piemontese salads
 en:Potato salad piémontaise-style
 fr:Salade de pomme de terre à la piémontaise
+agribalyse_food_code:en:25609
 ciqual_food_code:en:25609
 ciqual_food_name:en:Potato salad, piémontaise-style, prepacked
 ciqual_food_name:fr:Salade de pomme de terre à la piémontaise, préemballée
@@ -48862,10 +50339,12 @@ fr:Salades piémontaises au poulet, piémontaises au poulet
 
 <en:Prepared salads
 fr:Salades nicoises
+wikidata:en:Q209486
 
 <en:Prepared salads
 en:Canned prepared drained mixed tuna and vegetable salad
 fr:Salade de thon et légumes appertisée égouttée
+agribalyse_food_code:en:25601
 ciqual_food_code:en:25601
 ciqual_food_name:en:Prepared mixed tuna and vegetable salad, canned, drained
 ciqual_food_name:fr:Salade de thon et légumes, appertisée, égouttée
@@ -48900,6 +50379,7 @@ nl:Bietjessalade
 en:Caesar salads, Caesar's salad, Chicken salad with croûtons sauce
 fr:Salades caesar, Salades césar, Salade César au poulet, Salade verte au poulet avec fromage croûtons et sauce
 nl:Caesarsalade
+agribalyse_food_code:en:25628
 ciqual_food_code:en:25628
 ciqual_food_name:en:Caesar's salad (salad, chicken, croûtons, sauce)
 ciqual_food_name:fr:  Salade César au poulet (salade verte, fromage, croûtos, sauce)
@@ -48942,6 +50422,7 @@ en:Rice salads, Prepared rice salads
 de:Reissalate
 fr:Salades de riz, Salade de riz
 nl:Rijstsalade
+agribalyse_food_code:en:25614
 ciqual_food_code:en:25614
 ciqual_food_name:en:Prepared rice salad
 ciqual_food_name:fr:Salade de riz
@@ -48962,6 +50443,7 @@ nl:Vegetarische pasta salades
 <en:Pasta salads
 en:Prepared vegetable and pasta salad with meat, Prepared vegetable and pasta salad with fish
 fr:Salade de pâtes aux légumes avec poisson, Salade de pâtes aux légumes avec viande
+agribalyse_food_code:en:25619
 ciqual_food_code:en:25619
 ciqual_food_name:en:Prepared pasta salad, with vegetable, meat or fish
 ciqual_food_name:fr:Salade de pâtes aux légumes, avec poisson ou viande
@@ -48969,6 +50451,7 @@ ciqual_food_name:fr:Salade de pâtes aux légumes, avec poisson ou viande
 <en:Pasta salads
 en:Prepared vegetarian pasta salad
 fr:Salade de pâtes végétarienne
+agribalyse_food_code:en:25615
 ciqual_food_code:en:25615
 ciqual_food_name:en:Prepared pasta salad, vegetarian
 ciqual_food_name:fr:Salade de pâtes, végétarienne
@@ -48991,12 +50474,14 @@ en:Melton Mowbray Pork Pie
 protected_name_file_number:en: PGI-GB-0335
 protected_name_type:en: pgi
 origins:en: en:United Kingdom
+agribalyse_food_code:en:25560
 ciqual_food_code:en:25560
 ciqual_food_name:en:Riesling wine and pork pie
 
 <en:Pies
 en:Riesling wine and pork pie
 fr:Tourte au porc et riesling
+agribalyse_food_code:en:25560
 ciqual_food_code:en:25560
 ciqual_food_name:en:Riesling wine and pork pie
 
@@ -49011,6 +50496,7 @@ en:Squid and spicy tomato sauce pie
 fr:Tielles Sétoises, tielles, tielle, tielle sétoise, tielle à la sétoise, tielles à la sétoise
 wikidata:en:Q3528208
 pnns_group_2:en:Appetizers
+agribalyse_food_code:en:26268
 ciqual_food_code:en:26268
 ciqual_food_name:en:Squid and spicy tomato sauce pie
 ciqual_food_name:fr:Tielle sétoise
@@ -49040,6 +50526,7 @@ fi:falafelit
 fr:Falafels, falafel, Boulettes aux pois-chiche et aux fèves frites
 nl:Falafel
 wikidata:en:Q188788
+agribalyse_food_code:en:25571
 ciqual_food_code:en:25571
 ciqual_food_name:en:Falafel
 ciqual_food_name:fr:Falafel ou Boulette de pois-chiche et/ou fève, frite
@@ -49173,6 +50660,7 @@ zh:蜗牛准备材料
 <en:Snails
 en:Snail in cooked parsley butter
 fr:Escargot en sauce au beurre persillé cuit
+agribalyse_food_code:en:10042
 ciqual_food_code:en:10042
 ciqual_food_name:en:Snail in parsley butter, cooked
 ciqual_food_name:fr:Escargot en sauce au beurre persillé, cuit
@@ -49180,6 +50668,7 @@ ciqual_food_name:fr:Escargot en sauce au beurre persillé, cuit
 <en:Snails
 en:Snails in puff pastry
 fr:Feuilleté aux escargots
+agribalyse_food_code:en:25399
 ciqual_food_code:en:25399
 ciqual_food_name:en:Snails in puff pastry
 ciqual_food_name:fr:Feuilleté aux escargots
@@ -49326,6 +50815,7 @@ fr:Boulettes de viande
 <en:Meat balls
 en:Cooked beef meat balls
 fr:Boulettes au boeuf cuites
+agribalyse_food_code:en:25163
 ciqual_food_code:en:25163
 ciqual_food_name:en:Beef, meat balls, cooked
 ciqual_food_name:fr:Boeuf, boulettes cuites
@@ -49334,6 +50824,7 @@ ciqual_food_name:fr:Boeuf, boulettes cuites
 <en:Beef
 en:Beef meat balls with tomato sauce
 fr:Boulettes au bœuf à la sauce tomate
+agribalyse_food_code:en:25211
 ciqual_food_code:en:25211
 ciqual_food_name:en:Meat balls, beef, with tomato sauce
 ciqual_food_name:fr:Boulettes au bœuf, à la sauce tomate
@@ -49521,6 +51012,7 @@ nl:Rundertong
 <en:Cooked beef meat
 en:Cooked beef tongue
 fr:Langue de boeuf cuite
+agribalyse_food_code:en:40203
 ciqual_food_code:en:40203
 ciqual_food_name:en:Tongue, beef, cooked
 ciqual_food_name:fr:Langue, boeuf, cuite
@@ -49529,6 +51021,7 @@ ciqual_food_name:fr:Langue, boeuf, cuite
 <en:Raw beef meat
 en:Raw beef tongue
 fr:Langue de boeuf crue
+agribalyse_food_code:en:40202
 ciqual_food_code:en:40202
 ciqual_food_name:en:Tongue, beef, raw
 ciqual_food_name:fr:Langue, boeuf, crue
@@ -49551,6 +51044,7 @@ ciqual_food_name:fr:Langue de bœuf sauce madère
 <en:Raw beef meat
 en:Raw beef knuckle
 fr:Jarret de boeuf cru
+agribalyse_food_code:en:6150
 ciqual_food_code:en:6150
 ciqual_food_name:en:Beef, knuckle, raw
 ciqual_food_name:fr:Boeuf, jarret, cru
@@ -49558,6 +51052,7 @@ ciqual_food_name:fr:Boeuf, jarret, cru
 <en:Cooked beef meat
 en:Boiled beef knuckle, Beef knuckle cooked in water
 fr:Jarret de boeuf bouilli, Jarret de boeuf cuit à l'eau
+agribalyse_food_code:en:6151
 ciqual_food_code:en:6151
 ciqual_food_name:en:Beef, knuckle, boiled/cooked in water
 ciqual_food_name:fr:Boeuf, jarret, bouilli/cuit à l'eau
@@ -49565,6 +51060,7 @@ ciqual_food_name:fr:Boeuf, jarret, bouilli/cuit à l'eau
 <en:Cooked beef meat
 en:Boiled beef oxtail, Beef oxtail cooked in water
 fr:Queue de boeuf bouillie, Queue de boeuf cuite à l'eau
+agribalyse_food_code:en:6310
 ciqual_food_code:en:6310
 ciqual_food_name:en:Beef, oxtail, boiled/cooked in water
 ciqual_food_name:fr:Boeuf, queue, bouillie/cuite à l'eau
@@ -49572,6 +51068,7 @@ ciqual_food_name:fr:Boeuf, queue, bouillie/cuite à l'eau
 <en:Beef
 en:Grilled lean beef rib steak, Pan-fried lean beef rib steak
 fr:Entrecôte de boeuf partie maigre grillée, Entrecôte de boeuf partie maigre poêlée
+agribalyse_food_code:en:6100
 ciqual_food_code:en:6100
 ciqual_food_name:en:Beef, rib steak, lean, grilled/pan-fried
 ciqual_food_name:fr:Boeuf, entrecôte, partie maigre, grillée/poêlée
@@ -49579,6 +51076,7 @@ ciqual_food_name:fr:Boeuf, entrecôte, partie maigre, grillée/poêlée
 <en:Raw beef meat
 en:Raw beef rib steak
 fr:Entrecôte de boeuf crue
+agribalyse_food_code:en:6103
 ciqual_food_code:en:6103
 ciqual_food_name:en:Beef, rib steak, raw
 ciqual_food_name:fr:Boeuf, entrecôte, crue
@@ -49586,6 +51084,7 @@ ciqual_food_name:fr:Boeuf, entrecôte, crue
 <en:Raw beef meat
 en:Raw beef rib
 fr:Côte de boeuf crue
+agribalyse_food_code:en:6001
 ciqual_food_code:en:6001
 ciqual_food_name:en:Beef, rib, raw
 ciqual_food_name:fr:Boeuf, côte, crue
@@ -49593,6 +51092,7 @@ ciqual_food_name:fr:Boeuf, côte, crue
 <en:Cooked beef meat
 en:Braised beef short ribs
 fr:Plat de côtes de boeuf braisées
+agribalyse_food_code:en:6123
 ciqual_food_code:en:6123
 ciqual_food_name:en:Beef, short ribs, braised
 ciqual_food_name:fr:Boeuf, plat de côtes, braisé
@@ -49600,6 +51100,7 @@ ciqual_food_name:fr:Boeuf, plat de côtes, braisé
 <en:Raw beef meat
 en:Raw beef short ribs
 fr:Plats de côtes de boeuf cru
+agribalyse_food_code:en:6122
 ciqual_food_code:en:6122
 ciqual_food_name:en:Beef, short ribs, raw
 ciqual_food_name:fr:Boeuf, plat de côtes, cru
@@ -49607,6 +51108,7 @@ ciqual_food_name:fr:Boeuf, plat de côtes, cru
 <en:Cooked beef meat
 en:Cooked beef heart
 fr:Coeur de boeuf cuit
+agribalyse_food_code:en:40053
 ciqual_food_code:en:40053
 ciqual_food_name:en:Heart, beef, cooked
 ciqual_food_name:fr:Coeur, boeuf, cuit
@@ -49614,6 +51116,7 @@ ciqual_food_name:fr:Coeur, boeuf, cuit
 <en:Raw beef meat
 en:Raw beef heart
 fr:Coeur de boeuf cru
+agribalyse_food_code:en:40052
 ciqual_food_code:en:40052
 ciqual_food_name:en:Heart, beef, raw
 ciqual_food_name:fr:Coeur, boeuf, cru
@@ -49621,6 +51124,7 @@ ciqual_food_name:fr:Coeur, boeuf, cru
 <en:Cooked beef meat
 en:Cooked beef kidney
 fr:Rognon de boeuf cuit
+agribalyse_food_code:en:40403
 ciqual_food_code:en:40403
 ciqual_food_name:en:Kidney, beef, cooked
 ciqual_food_name:fr:Rognon, boeuf, cuit
@@ -49628,6 +51132,7 @@ ciqual_food_name:fr:Rognon, boeuf, cuit
 <en:Raw beef meat
 en:Raw beef kidney
 fr:Rognon de boeuf cru
+agribalyse_food_code:en:40402
 ciqual_food_code:en:40402
 ciqual_food_name:en:Kidney, beef, raw
 ciqual_food_name:fr:Rognon, boeuf, cru
@@ -49635,6 +51140,7 @@ ciqual_food_name:fr:Rognon, boeuf, cru
 <en:Cooked beef meat
 en:Braised beef chuck, Boiled beef chuck
 fr:Paleron de boeuf braisé, Paleron de boeuf bouilli
+agribalyse_food_code:en:6271
 ciqual_food_code:en:6271
 ciqual_food_name:en:Beef, chuck, braised or boiled
 ciqual_food_name:fr:Boeuf, paleron, braisé ou bouilli
@@ -49642,6 +51148,7 @@ ciqual_food_name:fr:Boeuf, paleron, braisé ou bouilli
 <en:Raw beef meat
 en:Raw beef chuck
 fr:Paleron de boeuf cru
+agribalyse_food_code:en:6270
 ciqual_food_code:en:6270
 ciqual_food_name:en:Beef, chuck, raw
 ciqual_food_name:fr:Boeuf, paleron, cru
@@ -49649,6 +51156,7 @@ ciqual_food_name:fr:Boeuf, paleron, cru
 <en:Cooked beef meat
 en:Grilled beef bolar-blade, Pan-fried beef bolar-blade
 fr:Boule de macreuse de boeuf grillée, Boule de macreuse de boeuf poêlée
+agribalyse_food_code:en:6208
 ciqual_food_code:en:6208
 ciqual_food_name:en:Beef, bolar-blade, grilled/pan-fried
 ciqual_food_name:fr:Boeuf, boule de macreuse, grillée/poêlée
@@ -49656,6 +51164,7 @@ ciqual_food_name:fr:Boeuf, boule de macreuse, grillée/poêlée
 <en:Cooked beef meat
 en:Roasted beef bolar-blade, Baked beef bolar-blade
 fr:Boule de macreuse de boeuf rôtie, Boule de macreuse de boeuf cuite au four
+agribalyse_food_code:en:6214
 ciqual_food_code:en:6214
 ciqual_food_name:en:Beef, bolar-blade, roasted/baked
 ciqual_food_name:fr:Boeuf, boule de macreuse, rôtie/cuite au four
@@ -49663,6 +51172,7 @@ ciqual_food_name:fr:Boeuf, boule de macreuse, rôtie/cuite au four
 <en:Raw beef meat
 en:Raw beef bolar-blade
 fr:Boule de macreuse de boeuf crue
+agribalyse_food_code:en:6202
 ciqual_food_code:en:6202
 ciqual_food_name:en:Beef, bolar-blade, raw
 ciqual_food_name:fr:Boeuf, boule de macreuse, crue
@@ -49670,6 +51180,7 @@ ciqual_food_name:fr:Boeuf, boule de macreuse, crue
 <en:Cooked beef meat
 en:Braised beef neck
 fr:Collier de boeuf braisé
+agribalyse_food_code:en:6241
 ciqual_food_code:en:6241
 ciqual_food_name:en:Beef, neck, braised
 ciqual_food_name:fr:Boeuf, collier, braisé
@@ -49677,6 +51188,7 @@ ciqual_food_name:fr:Boeuf, collier, braisé
 <en:Cooked beef meat
 en:Braised beef cheek, Boiled beef cheek
 fr:Joue de boeuf braisée, Joue de boeuf bouillie
+agribalyse_food_code:en:6141
 ciqual_food_code:en:6141
 ciqual_food_name:en:Beef, cheek, braised or boiled
 ciqual_food_name:fr:Boeuf, joue, braisée ou bouillie
@@ -49684,6 +51196,7 @@ ciqual_food_name:fr:Boeuf, joue, braisée ou bouillie
 <en:Raw beef meat
 en:Raw beef cheek
 fr:Joue de boeuf crue
+agribalyse_food_code:en:6140
 ciqual_food_code:en:6140
 ciqual_food_name:en:Beef, cheek, raw
 ciqual_food_name:fr:Boeuf, joue, crue
@@ -49691,6 +51204,7 @@ ciqual_food_name:fr:Boeuf, joue, crue
 <en:Beef
 en:Grilled beef sirloin steak, Pan-fried beef sirloin steak
 fr:Faux-filet de boeuf grillé, Faux-filet de boeuf poêlé
+agribalyse_food_code:en:6110
 ciqual_food_code:en:6110
 ciqual_food_name:en:Beef, sirloin steak, grilled/pan-fried
 ciqual_food_name:fr:Boeuf, faux-filet, grillé/poêlé
@@ -49698,6 +51212,7 @@ ciqual_food_name:fr:Boeuf, faux-filet, grillé/poêlé
 <en:Raw beef meat
 en:Raw beef sirloin steak red label
 fr:Faux-filet de boeuf label rouge cru
+agribalyse_food_code:en:6112
 ciqual_food_code:en:6112
 ciqual_food_name:en:Beef, sirloin steak, red label, raw
 ciqual_food_name:fr:Boeuf, faux-filet, label rouge, cru
@@ -49705,6 +51220,7 @@ ciqual_food_name:fr:Boeuf, faux-filet, label rouge, cru
 <en:Cooked beef meat
 en:Grilled beef thin flank, Pan-fried beef thin flank
 fr:Hampe de boeuf grillée, Hampe de boeuf poêlée
+agribalyse_food_code:en:6131
 ciqual_food_code:en:6131
 ciqual_food_name:en:Beef, thin flank, grilled/pan-fried
 ciqual_food_name:fr:Boeuf, hampe, grillée/poêlée
@@ -49712,6 +51228,7 @@ ciqual_food_name:fr:Boeuf, hampe, grillée/poêlée
 <en:Raw beef meat
 en:Raw beef thin flank
 fr:Hampe de boeuf crue
+agribalyse_food_code:en:6130
 ciqual_food_code:en:6130
 ciqual_food_name:en:Beef, thin flank, raw
 ciqual_food_name:fr:Boeuf, hampe, crue
@@ -49719,6 +51236,7 @@ ciqual_food_name:fr:Boeuf, hampe, crue
 <en:Cooked beef meat
 en:Grilled beef topside, Pan-fried beef topside
 fr:Tende de tranche de boeuf grillée, Tende de tranche de boeuf poêlée
+agribalyse_food_code:en:6161
 ciqual_food_code:en:6161
 ciqual_food_name:en:Beef, topside, grilled/pan-fried
 ciqual_food_name:fr:Boeuf, tende de tranche, grillée/poêlée
@@ -49726,6 +51244,7 @@ ciqual_food_name:fr:Boeuf, tende de tranche, grillée/poêlée
 <en:Cooked beef meat
 en:Grilled beef flank steak, Pan-fried beef flank steak
 fr:Bavette d'aloyau de boeuf grillée, Bavette d'aloyau de boeuf poêlée
+agribalyse_food_code:en:6211
 ciqual_food_code:en:6211
 ciqual_food_name:en:Beef, flank steak, grilled/pan-fried
 ciqual_food_name:fr:Boeuf, bavette d'aloyau, grillée/poêlée
@@ -49733,6 +51252,7 @@ ciqual_food_name:fr:Boeuf, bavette d'aloyau, grillée/poêlée
 <en:Raw beef meat
 en:Raw beef flank steak
 fr:Bavette d'aloyau de boeuf crue
+agribalyse_food_code:en:6212
 ciqual_food_code:en:6212
 ciqual_food_name:en:Beef, flank steak, raw
 ciqual_food_name:fr:Boeuf, bavette d'aloyau, crue
@@ -49740,6 +51260,7 @@ ciqual_food_name:fr:Boeuf, bavette d'aloyau, crue
 <en:Beef
 en:Braised beef
 fr:Boeuf braisé
+agribalyse_food_code:en:6101
 ciqual_food_code:en:6101
 ciqual_food_name:en:Beef, braised
 ciqual_food_name:fr:Boeuf, braisé
@@ -49747,6 +51268,7 @@ ciqual_food_name:fr:Boeuf, braisé
 <en:Cooked beef meat
 en:Cooked beef round
 fr:Gîte à la noix de boeuf cuit
+agribalyse_food_code:en:6104
 ciqual_food_code:en:6104
 ciqual_food_name:en:Beef, round, cooked
 ciqual_food_name:fr:Boeuf, gîte à la noix, cuit
@@ -49754,6 +51276,7 @@ ciqual_food_name:fr:Boeuf, gîte à la noix, cuit
 <en:Raw beef meat
 en:Raw beef round
 fr:Gîte à la noix de boeuf cru
+agribalyse_food_code:en:6102
 ciqual_food_code:en:6102
 ciqual_food_name:en:Beef, round, raw
 ciqual_food_name:fr:Boeuf, gîte à la noix, cru
@@ -49761,6 +51284,7 @@ ciqual_food_name:fr:Boeuf, gîte à la noix, cru
 <en:Cooked beef meat
 en:Roasted beef sirloin steak, Baked beef sirloin steak
 fr:Faux-filet de boeuf rôti, Faux-filet de boeuf cuit au four
+agribalyse_food_code:en:6105
 ciqual_food_code:en:6105
 ciqual_food_name:en:Beef, sirloin steak, roasted/baked
 ciqual_food_name:fr:Boeuf, faux-filet, rôti/cuit au four
@@ -49768,6 +51292,7 @@ ciqual_food_name:fr:Boeuf, faux-filet, rôti/cuit au four
 <en:Raw beef meat
 en:Raw beef sirloin steak
 fr:Faux-filet de boeuf cru
+agribalyse_food_code:en:6111
 ciqual_food_code:en:6111
 ciqual_food_name:en:Beef, sirloin steak, raw
 ciqual_food_name:fr:Boeuf, faux-filet, cru
@@ -49775,6 +51300,7 @@ ciqual_food_name:fr:Boeuf, faux-filet, cru
 <en:Cooked beef meat
 en:Roasted beef topside, Baked beef topside
 fr:Tende de tranche de boeuf rôtie, Tende de tranche de boeuf cuite au four
+agribalyse_food_code:en:6162
 ciqual_food_code:en:6162
 ciqual_food_name:en:Beef, topside, roasted/baked
 ciqual_food_name:fr:Boeuf, tende de tranche, rôtie/cuite au four
@@ -49782,6 +51308,7 @@ ciqual_food_name:fr:Boeuf, tende de tranche, rôtie/cuite au four
 <en:Raw beef meat
 en:Raw beef topside
 fr:Tende de tranche de boeuf crue
+agribalyse_food_code:en:6160
 ciqual_food_code:en:6160
 ciqual_food_name:en:Beef, topside, raw
 ciqual_food_name:fr:Boeuf, tende de tranche, crue
@@ -49789,6 +51316,7 @@ ciqual_food_name:fr:Boeuf, tende de tranche, crue
 <en:Raw beef meat
 en:Raw beef blood
 fr:Sang de boeuf cru
+agribalyse_food_code:en:40600
 ciqual_food_code:en:40600
 ciqual_food_name:en:Blood, beef, raw
 ciqual_food_name:fr:Sang, boeuf, cru
@@ -49796,6 +51324,7 @@ ciqual_food_name:fr:Sang, boeuf, cru
 <en:Cooked beef meat
 en:Grilled beef hanger steak
 fr:Onglet de boeuf grillé
+agribalyse_food_code:en:6205
 ciqual_food_code:en:6205
 ciqual_food_name:en:Beef, hanger steak, grilled
 ciqual_food_name:fr:Boeuf, onglet, grillé
@@ -49803,6 +51332,7 @@ ciqual_food_name:fr:Boeuf, onglet, grillé
 <en:Raw beef meat
 en:Raw beef hanger steak
 fr:Onglet de boeuf cru
+agribalyse_food_code:en:6204
 ciqual_food_code:en:6204
 ciqual_food_name:en:Beef, hanger steak, raw
 ciqual_food_name:fr:Boeuf, onglet, cru
@@ -49810,6 +51340,7 @@ ciqual_food_name:fr:Boeuf, onglet, cru
 <en:Cooked beef meat
 en:Grilled beef rump steak
 fr:Rumsteck de boeuf grillé
+agribalyse_food_code:en:6207
 ciqual_food_code:en:6207
 ciqual_food_name:en:Beef, rump steak, grilled
 ciqual_food_name:fr:Boeuf, rumsteck, grillé
@@ -49817,6 +51348,7 @@ ciqual_food_name:fr:Boeuf, rumsteck, grillé
 <en:Raw beef meat
 en:Raw beef rump steak
 fr:Rumsteck de boeuf cru
+agribalyse_food_code:en:6206
 ciqual_food_code:en:6206
 ciqual_food_name:en:Beef, rump steak, raw
 ciqual_food_name:fr:Boeuf, rumsteck, cru
@@ -49824,6 +51356,7 @@ ciqual_food_name:fr:Boeuf, rumsteck, cru
 <en:Beef
 en:Roast beef, Roasted beef, Baked roast beef
 fr:Rosbif rôti, Rosbif cuit au four
+agribalyse_food_code:en:6210
 ciqual_food_code:en:6210
 ciqual_food_name:en:Beef, roast beef, roasted/baked
 ciqual_food_name:fr:Boeuf, rosbif, rôti/cuit au four
@@ -49831,6 +51364,7 @@ ciqual_food_name:fr:Boeuf, rosbif, rôti/cuit au four
 <en:Raw beef meat
 en:Raw beef shoulder
 fr:Epaule de boeuf crue
+agribalyse_food_code:en:6002
 ciqual_food_code:en:6002
 ciqual_food_name:en:Beef, shoulder, raw
 ciqual_food_name:fr:Boeuf, épaule, crue
@@ -49838,6 +51372,7 @@ ciqual_food_name:fr:Boeuf, épaule, crue
 <en:Cooked beef meat
 en:Cooked young cow liver
 fr:Foie de génisse cuit
+agribalyse_food_code:en:40105
 ciqual_food_code:en:40105
 ciqual_food_name:en:Liver, young cow, cooked
 ciqual_food_name:fr:Foie, génisse, cuit
@@ -49845,6 +51380,7 @@ ciqual_food_name:fr:Foie, génisse, cuit
 <en:Raw beef meat
 en:Raw young cow liver
 fr:Foie de génisse cru
+agribalyse_food_code:en:40104
 ciqual_food_code:en:40104
 ciqual_food_name:en:Liver, young cow, raw
 ciqual_food_name:fr:Foie, génisse, cru
@@ -49857,12 +51393,14 @@ fi:kanin liha
 fr:Viande de lapin, lapin, lapins, viande de lapins, viandes de lapin, viandes de lapins
 nl:Konijn, Konijnenvlezen
 wikidata:en:Q3556748
+agribalyse_food_code:en:34001
 ciqual_food_code:en:34001
 ciqual_food_name:en:Rabbit, meat, raw
 
 <en:Rabbit meat
 en:Raw rabbit liver
 fr:Foie de lapin cru
+agribalyse_food_code:en:40110
 ciqual_food_code:en:40110
 ciqual_food_name:en:Liver, rabbit, raw
 ciqual_food_name:fr:Foie, lapin, cru
@@ -49870,6 +51408,7 @@ ciqual_food_name:fr:Foie, lapin, cru
 <en:Cooked rabbit meat
 en:Braised rabbit meat
 fr:Viande de lapin braisée
+agribalyse_food_code:en:34000
 ciqual_food_code:en:34000
 ciqual_food_name:en:Rabbit, meat, braised
 ciqual_food_name:fr:Lapin, viande braisée
@@ -49877,6 +51416,7 @@ ciqual_food_name:fr:Lapin, viande braisée
 <en:rabbit meat
 en:Cooked rabbit meat
 fr:Viande de lapin cuite
+agribalyse_food_code:en:34002
 ciqual_food_code:en:34002
 ciqual_food_name:en:Rabbit, meat, cooked
 ciqual_food_name:fr:Lapin, viande cuite
@@ -49884,6 +51424,7 @@ ciqual_food_name:fr:Lapin, viande cuite
 <en:Rabbit meat
 en:Wild Rabbit meat
 fr:viande de lapin de garenne crue
+agribalyse_food_code:en:34003
 ciqual_food_code:en:34003
 ciqual_food_name:en:Rabbit, wild, meat, raw
 ciqual_food_name:fr:Lapin de garenne, viande, crue
@@ -49891,6 +51432,7 @@ ciqual_food_name:fr:Lapin de garenne, viande, crue
 <en:Cooked rabbit meat
 en:Cooked wild rabbit meat
 fr:Viande de lapin de garenne cuite
+agribalyse_food_code:en:34004
 ciqual_food_code:en:34004
 ciqual_food_name:en:Rabbit, wild, meat, cooked
 ciqual_food_name:fr:Lapin de garenne, viande, cuite
@@ -49899,6 +51441,7 @@ ciqual_food_name:fr:Lapin de garenne, viande, cuite
 <en:Rabbit meat
 en:Rabbit with mustard sauce
 fr:Lapin à la moutarde
+agribalyse_food_code:en:25063
 ciqual_food_code:en:25063
 ciqual_food_name:en:Rabbit with mustard sauce
 
@@ -49950,6 +51493,7 @@ fr:Viande de chèvre
 <en:Goat meat
 en:Cooked young goat
 fr:Chevreau cuit
+agribalyse_food_code:en:21801
 ciqual_food_code:en:21801
 ciqual_food_name:en:Young goat, cooked
 ciqual_food_name:fr:Chevreau, cuit
@@ -49957,6 +51501,7 @@ ciqual_food_name:fr:Chevreau, cuit
 <en:Fresh meats
 en:Raw young goat
 fr:Chevreau cru
+agribalyse_food_code:en:21800
 ciqual_food_code:en:21800
 ciqual_food_name:en:Young goat, raw
 ciqual_food_name:fr:Chevreau, cru
@@ -50083,12 +51628,14 @@ fr:Brochettes de viande
 <en:Meat skewers
 en:Mixed meat on skewer
 fr:Brochette mixte de viande
+agribalyse_food_code:en:25506
 ciqual_food_code:en:25506
 ciqual_food_name:en:Mixed meat on skewer
 
 <en:Pork skewers
 en:Pork on skewer raw
 fr:Brochette de porc crue
+agribalyse_food_code:en:25566
 ciqual_food_code:en:25566
 ciqual_food_name:en:Pork on skewer, raw
 
@@ -50097,6 +51644,7 @@ ciqual_food_name:en:Pork on skewer, raw
 en:beef skewers
 fr:Brochettes de bœuf, brochette de bœuf
 nl:Rundvleesspiesjes
+agribalyse_food_code:en:25505
 ciqual_food_code:en:25505
 ciqual_food_name:en:Beef on skewer
 ciqual_food_name:fr:Brochette de boeuf
@@ -50107,6 +51655,7 @@ en:poultry skewers
 fi:siipikarjavartaat
 fr:Brochettes de volailles, brochette de volaille
 nl:Gevogeltespiesjes
+agribalyse_food_code:en:25504
 ciqual_food_code:en:25504
 ciqual_food_name:en:Poultry on skewer
 ciqual_food_name:fr:Brochette de volaille
@@ -50121,12 +51670,14 @@ nl:Kippenspiesjes
 en:Yakitori chicken skewers, yakitori chicken
 fr:Brochettes de poulet Yakitori, Yakitori de Poulet, Poulet Yakitori
 nl:Yakitori kipspiesjes
+agribalyse_food_code:en:25565
 ciqual_food_code:en:25565
 ciqual_food_name:en:Yakitori (grilled meat on skewers, Japanese-style, with sauce)
 
 <en:Beef preparations
 en:Ox muzzle in salad dressing sauce
 fr:Museau de boeuf en vinaigrette
+agribalyse_food_code:en:25610
 ciqual_food_code:en:25610
 ciqual_food_name:en:Ox muzzle in salad dressing sauce
 ciqual_food_name:fr:Museau de boeuf en vinaigrette
@@ -50184,6 +51735,7 @@ fr:Bresaola
 it:Bresaola
 nl:Bresaola
 wikidata:en:Q910095
+agribalyse_food_code:en:28503
 ciqual_food_code:en:28503
 ciqual_food_name:en:Bresaola
 ciqual_food_name:fr:Bresaola
@@ -50207,6 +51759,7 @@ ciqual_food_name:fr:Bœuf, steak haché, cuit (aliment moyen)
 <en:Cooked ground beef steaks
 en:Cooked minced beef steak with 5% fat
 fr:Steak haché de bœuf cuit à 5% de matières grasses
+agribalyse_food_code:en:6251
 ciqual_food_code:en:6251
 ciqual_food_name:en:Beef, minced steak, 5% fat, cooked
 ciqual_food_name:fr:Bœuf, steak haché 5% MG, cuit
@@ -50214,6 +51767,7 @@ ciqual_food_name:fr:Bœuf, steak haché 5% MG, cuit
 <en:Ground beef steaks
 en:Raw minced beef steak with 5% fat
 fr:Steak haché de bœuf cru à 5% de matières grasses
+agribalyse_food_code:en:6250
 ciqual_food_code:en:6250
 ciqual_food_name:en:Beef, minced steak, 5% fat, raw
 ciqual_food_name:fr:Bœuf, steak haché 5% MG, cru
@@ -50221,6 +51775,7 @@ ciqual_food_name:fr:Bœuf, steak haché 5% MG, cru
 <en:Cooked ground beef steaks
 en:Cooked minced beef steak with 10% fat
 fr:Steak haché de bœuf cuit à 10% de matières grasses
+agribalyse_food_code:en:6253
 ciqual_food_code:en:6253
 ciqual_food_name:en:Beef, minced steak, 10% fat, cooked
 ciqual_food_name:fr:Bœuf, steak haché 10% MG, cuit
@@ -50228,6 +51783,7 @@ ciqual_food_name:fr:Bœuf, steak haché 10% MG, cuit
 <en:Ground beef steaks
 en:Raw minced beef steak with 10% fat
 fr:Steak haché de bœuf cru à 10% de matières grasses
+agribalyse_food_code:en:6252
 ciqual_food_code:en:6252
 ciqual_food_name:en:Beef, minced steak, 10% fat, raw
 ciqual_food_name:fr:Bœuf, steak haché 10% MG, cru
@@ -50235,6 +51791,7 @@ ciqual_food_name:fr:Bœuf, steak haché 10% MG, cru
 <en:Cooked ground beef steaks
 en:Cooked minced beef steak with 15% fat
 fr:Steak haché de bœuf cuit à 15% de matières grasses
+agribalyse_food_code:en:6255
 ciqual_food_code:en:6255
 ciqual_food_name:en:Beef, minced steak, 15% fat, cooked
 ciqual_food_name:fr:Bœuf, steak haché 15% MG, cuit
@@ -50242,6 +51799,7 @@ ciqual_food_name:fr:Bœuf, steak haché 15% MG, cuit
 <en:Ground beef steaks
 en:Raw minced beef steak with 15% fat
 fr:Steak haché de bœuf cru à 15% de matières grasses
+agribalyse_food_code:en:6254
 ciqual_food_code:en:6254
 ciqual_food_name:en:Beef, minced steak, 15% fat, raw
 ciqual_food_name:fr:Bœuf, steak haché 15% MG, cru
@@ -50249,6 +51807,7 @@ ciqual_food_name:fr:Bœuf, steak haché 15% MG, cru
 <en:Cooked ground beef steaks
 en:Cooked minced beef steak with 20% fat
 fr:Steak haché de bœuf cuit à 20% de matières grasses
+agribalyse_food_code:en:6257
 ciqual_food_code:en:6257
 ciqual_food_name:en:Beef, minced steak, 20% fat, cooked
 ciqual_food_name:fr:Bœuf, steak haché 20% MG, cuit
@@ -50256,6 +51815,7 @@ ciqual_food_name:fr:Bœuf, steak haché 20% MG, cuit
 <en:Ground beef steaks
 en:Raw minced beef steak with 20% fat
 fr:Steak haché de bœuf cru à 20% de matières grasses
+agribalyse_food_code:en:6256
 ciqual_food_code:en:6256
 ciqual_food_name:en:Beef, minced steak, 20% fat, raw
 ciqual_food_name:fr:Bœuf, steak haché 20% MG, cru
@@ -50263,6 +51823,7 @@ ciqual_food_name:fr:Bœuf, steak haché 20% MG, cru
 <en:Cooked ground beef steaks
 en:Beef steak, Grilled beef steak
 fr:Steak de boeuf grillé, Bifteck de boeuf grillé
+agribalyse_food_code:en:6200
 ciqual_food_code:en:6200
 ciqual_food_name:en:Beef, steak or beef steak, grilled
 ciqual_food_name:fr:Boeuf, steak ou bifteck, grillé
@@ -50270,6 +51831,7 @@ ciqual_food_name:fr:Boeuf, steak ou bifteck, grillé
 <en:Ground beef steaks
 en:Beef steak, Raw beef steak
 fr:Steak de boeuf cru, Bifteck cru
+agribalyse_food_code:en:6201
 ciqual_food_code:en:6201
 ciqual_food_name:en:Beef, steak or beef steak, raw
 ciqual_food_name:fr:Boeuf, steak ou bifteck, cru
@@ -50289,6 +51851,7 @@ fr:Rôtis de veau, Rôti de veau
 <en:Beef preparations
 en:Cooked veal roast
 fr:Rôti de veau cuit
+agribalyse_food_code:en:6551
 ciqual_food_code:en:6551
 ciqual_food_name:en:Veal, roast, cooked
 ciqual_food_name:fr:Veau, rôti, cuit
@@ -50296,6 +51859,7 @@ ciqual_food_name:fr:Veau, rôti, cuit
 <en:Beef preparations
 en:Raw veal roast
 fr:Rôti de veau cru
+agribalyse_food_code:en:6550
 ciqual_food_code:en:6550
 ciqual_food_name:en:Veal, roast, raw
 ciqual_food_name:fr:Veau, rôti, cru
@@ -50303,6 +51867,7 @@ ciqual_food_name:fr:Veau, rôti, cru
 <en:Beef preparations
 en:Veal stock
 fr:Fond de veau
+agribalyse_food_code:en:11304
 ciqual_food_code:en:11304
 ciqual_food_name:en:Veal stock, prepacked
 ciqual_food_name:fr:Fond de veau, préemballé
@@ -50365,6 +51930,7 @@ wikidata:en:Q429518
 <en:Turkey preparations
 fr:Cordons bleus de dinde
 nl:Kalkoen cordon bleus
+agribalyse_food_code:en:25089
 ciqual_food_code:en:25089
 ciqual_food_name:en:Veal escalope cordon bleu (topped with a ham slice and Gruyere sauce)
 
@@ -50372,6 +51938,7 @@ ciqual_food_name:en:Veal escalope cordon bleu (topped with a ham slice and Gruye
 <en:Chicken preparations
 fr:Cordons bleus de poulet
 nl:Kip cordon bleus
+agribalyse_food_code:en:25089
 ciqual_food_code:en:25089
 ciqual_food_name:en:Veal escalope cordon bleu (topped with a ham slice and Gruyere sauce)
 
@@ -50444,6 +52011,7 @@ zh:猪肉
 <en:Pork
 en:Raw pork meat
 fr:Viande de porc crue
+agribalyse_food_code:en:28472
 ciqual_food_code:en:28472
 ciqual_food_name:en:Pork, shoulder lower half, without rind, fat and bone, raw
 
@@ -50457,6 +52025,7 @@ ciqual_food_name:fr:Porc, viande, cuite (aliment moyen)
 
 <en:Cooked pork meat
 fr:échine de porc rôtie, échine de porc au four
+agribalyse_food_code:en:28451
 ciqual_food_code:en:28451
 ciqual_food_name:en:Pork, loin, roasted/baked
 ciqual_food_name:fr:Porc, échine, rôtie/cuite au four
@@ -50465,12 +52034,14 @@ ciqual_food_name:fr:Porc, échine, rôtie/cuite au four
 <en:Meat preparations
 en:Rolled escalope of pork with pistachios
 fr:Roulade de porc pistachée
+agribalyse_food_code:en:8373
 ciqual_food_code:en:8373
 ciqual_food_name:en:Rolled escalope of pork with pistachios
 
 <en:Raw pork meat
 en:Pork ham escalope raw
 fr:escalope de porc crue
+agribalyse_food_code:en:28460
 ciqual_food_code:en:28460
 ciqual_food_name:en:Pork, ham escalope, raw
 
@@ -50483,6 +52054,7 @@ nl:Varkensspiesjes
 <en:Cooked pork meat
 en:Cooked pork racks
 fr:Carrés de porc cuits
+agribalyse_food_code:en:28105
 ciqual_food_code:en:28105
 ciqual_food_name:en:Pork, rack, cooked
 ciqual_food_name:fr:Porc, carré, cuit
@@ -50490,6 +52062,7 @@ ciqual_food_name:fr:Porc, carré, cuit
 <en:Cooked pork meat
 en:Braised pork spare-ribs
 fr:Travers de porc braisés
+agribalyse_food_code:en:28401
 ciqual_food_code:en:28401
 ciqual_food_name:en:Pork, spare-ribs, braised
 ciqual_food_name:fr:Porc, travers, braisé
@@ -50497,6 +52070,7 @@ ciqual_food_name:fr:Porc, travers, braisé
 <en:Raw pork meat
 en:Raw pork spare-ribs
 fr:Travers de porc crus
+agribalyse_food_code:en:28400
 ciqual_food_code:en:28400
 ciqual_food_name:en:Pork, spare-ribs, raw
 ciqual_food_name:fr:Porc, travers, cru
@@ -50504,6 +52078,7 @@ ciqual_food_name:fr:Porc, travers, cru
 <en:Raw pork meat
 en:Raw pork knuckle, Raw pork shank
 fr:Jarret de porc cru
+agribalyse_food_code:en:28004
 ciqual_food_code:en:28004
 ciqual_food_name:en:Pork, knuckle or shank, raw
 ciqual_food_name:fr:Porc, jarret, cru
@@ -50511,6 +52086,7 @@ ciqual_food_name:fr:Porc, jarret, cru
 <en:Cooked pork meat
 en:Cooked pork loin
 fr:Longe de porc cuite
+agribalyse_food_code:en:28007
 ciqual_food_code:en:28007
 ciqual_food_name:en:Pork loin, cooked
 ciqual_food_name:fr:Porc, longe, cuite
@@ -50518,6 +52094,7 @@ ciqual_food_name:fr:Porc, longe, cuite
 <en:Cooked pork meat
 en:Cooked pork tenderloin roast
 fr:Filet maigre de porc en rôti cuit
+agribalyse_food_code:en:28202
 ciqual_food_code:en:28202
 ciqual_food_name:en:Pork tenderloin roast, cooked
 ciqual_food_name:fr:Porc, filet, maigre, en rôti, cuit
@@ -50525,6 +52102,7 @@ ciqual_food_name:fr:Porc, filet, maigre, en rôti, cuit
 <en:Cooked pork meat
 en:Cooked pork round steak
 fr:Rouelle de jambon cuite, Rouelle de jambon de porc cuite
+agribalyse_food_code:en:28103
 ciqual_food_code:en:28103
 ciqual_food_name:en:Pork, round steak, cooked
 ciqual_food_name:fr:Porc, rouelle de jambon, cuite
@@ -50532,6 +52110,7 @@ ciqual_food_name:fr:Porc, rouelle de jambon, cuite
 <en:Cooked pork meat
 en:Cooked pork filet mignon
 fr:Filet mignon de porc cuit
+agribalyse_food_code:en:28203
 ciqual_food_code:en:28203
 ciqual_food_name:en:Pork filet mignon, cooked
 ciqual_food_name:fr:Porc, filet mignon, cuit
@@ -50581,6 +52160,7 @@ fr:Escalopes de porc
 <en:Pork
 en:Salt-cured pork trotters
 fr:Pied de porc demi-sel
+agribalyse_food_code:en:28540
 ciqual_food_code:en:28540
 ciqual_food_name:en:Pork trotters salt-cured
 ciqual_food_name:fr:Pied de porc demi-sel
@@ -50588,6 +52168,7 @@ ciqual_food_name:fr:Pied de porc demi-sel
 <en:Raw pork meat
 en:Raw rindless pork jowl
 fr:Gorge de porc découennée crue
+agribalyse_food_code:en:28471
 ciqual_food_code:en:28471
 ciqual_food_name:en:Pork, jowl, rindless, raw
 ciqual_food_name:fr:Porc, gorge, découennée, crue
@@ -50595,6 +52176,7 @@ ciqual_food_name:fr:Porc, gorge, découennée, crue
 <en:Cooked pork meat
 en:Cooked pork liver
 fr:Foie de porc cuit
+agribalyse_food_code:en:40113
 ciqual_food_code:en:40113
 ciqual_food_name:en:Liver, pork, cooked
 ciqual_food_name:fr:Foie, porc, cuit
@@ -50602,18 +52184,21 @@ ciqual_food_name:fr:Foie, porc, cuit
 <en:Pork
 en:Pork liver mousse superior quality
 fr:Mousse de foie de porc supérieure
+agribalyse_food_code:en:8312
 ciqual_food_code:en:8312
 ciqual_food_name:en:Pork liver mousse, superior quality
 
 <en:Pork
 en:Pork liver mousse
 fr:Mousse de foie de porc
+agribalyse_food_code:en:8313
 ciqual_food_code:en:8313
 ciqual_food_name:en:Pork liver mousse
 
 <en:Cooked pork meat
 en:Cooked pork kidney
 fr:Rognon de porc cuit
+agribalyse_food_code:en:40405
 ciqual_food_code:en:40405
 ciqual_food_name:en:Kidney, pork, cooked
 ciqual_food_name:fr:Rognon, porc, cuit
@@ -50621,6 +52206,7 @@ ciqual_food_name:fr:Rognon, porc, cuit
 <en:Pork
 en:Salt-cured pork ear
 fr:Oreille de porc demi-sel
+agribalyse_food_code:en:28530
 ciqual_food_code:en:28530
 ciqual_food_name:en:Pork ear sat-cured
 ciqual_food_name:fr:Oreille de porc demi-sel
@@ -50628,6 +52214,7 @@ ciqual_food_name:fr:Oreille de porc demi-sel
 <en:Raw pork meat
 en:Raw pork rind
 fr:Couenne de porc crue
+agribalyse_food_code:en:28478
 ciqual_food_code:en:28478
 ciqual_food_name:en:Pork, rind, raw
 ciqual_food_name:fr:Porc, couenne, crue
@@ -50635,6 +52222,7 @@ ciqual_food_name:fr:Porc, couenne, crue
 <en:Raw pork meat
 en:Raw pork belly with flank removed, Raw pork belly flank off
 fr:Poitrine de porc crue sans mouille, Poitrine de porc crue cutter
+agribalyse_food_code:en:28479
 ciqual_food_code:en:28479
 ciqual_food_name:en:Pork, belly, flank removed, raw
 ciqual_food_name:fr:Porc, poitrine cutter, sans mouille, crue
@@ -50642,6 +52230,7 @@ ciqual_food_name:fr:Porc, poitrine cutter, sans mouille, crue
 <en:Raw pork meat
 en:Raw pork rind
 fr:Couenne de porc crue
+agribalyse_food_code:en:28478
 ciqual_food_code:en:28478
 ciqual_food_name:en:Pork, rind, raw
 ciqual_food_name:fr:Porc, couenne, crue
@@ -50649,6 +52238,7 @@ ciqual_food_name:fr:Porc, couenne, crue
 <en:Raw pork meat
 en:Raw pork belly with flank removed, Raw pork belly flank off
 fr:Poitrine de porc crue sans mouille, Poitrine de porc crue cutter
+agribalyse_food_code:en:28479
 ciqual_food_code:en:28479
 ciqual_food_name:en:Pork, belly, flank removed, raw
 ciqual_food_name:fr:Porc, poitrine cutter, sans mouille, crue
@@ -50656,12 +52246,14 @@ ciqual_food_name:fr:Porc, poitrine cutter, sans mouille, crue
 <en:Raw pork meat
 en:Raw pork shoulders, Raw pork shoulder
 fr:Epaule de porc crue, épaules de porc crues
+agribalyse_food_code:en:28001
 ciqual_food_code:en:28001
 ciqual_food_name:en:Pork, shoulder, raw
 
 <en:Cooked pork meat
 en:Cooked pork shoulder
 fr:Epaule de porc cuite
+agribalyse_food_code:en:28010
 ciqual_food_code:en:28010
 ciqual_food_name:en:Pork, shoulder, cooked
 ciqual_food_name:fr:Porc, épaule, cuite
@@ -50669,6 +52261,7 @@ ciqual_food_name:fr:Porc, épaule, cuite
 <en:Raw pork meat
 en:Raw smoked pork belly
 fr:Poitrine de porc fumée crue
+agribalyse_food_code:en:28502
 ciqual_food_code:en:28502
 ciqual_food_name:en:Pork belly, smoked, raw
 ciqual_food_name:fr:Poitrine de porc, fumée, crue
@@ -50676,18 +52269,21 @@ ciqual_food_name:fr:Poitrine de porc, fumée, crue
 <en:Cooked pork meat
 en:Cooked pork shoulder standard rind less and fatless
 fr:Épaule de porc cuite standard découennée dégraissée
+agribalyse_food_code:en:28924
 ciqual_food_code:en:28924
 ciqual_food_name:en:Cooked pork shoulder, standard, rind less and fatless
 
 <en:Pork
 fr:Rôtis de porc, rôti de porc
 en:Pork roast raw
+agribalyse_food_code:en:28300
 ciqual_food_code:en:28300
 ciqual_food_name:en:Pork, roast, raw
 
 <en:Cooked pork meat
 en:Cooked pork roast
 fr:Rôti de porc cuit
+agribalyse_food_code:en:28301
 ciqual_food_code:en:28301
 ciqual_food_name:en:Pork, roast, cooked
 ciqual_food_name:fr:Porc, rôti, cuit
@@ -50703,6 +52299,7 @@ zh:排骨, 猪排骨
 <en:Cooked pork meat
 en:Grilled pork chops, Grilled pork ribs
 fr:Côtes de porc grillées
+agribalyse_food_code:en:28101
 ciqual_food_code:en:28101
 ciqual_food_name:en:Pork, chop, grilled
 ciqual_food_name:fr:Porc, côte, grillée
@@ -50711,6 +52308,7 @@ ciqual_food_name:fr:Porc, côte, grillée
 <en:Raw pork meat
 en:Raw pork chops, Raw pork ribs
 fr:Côtes de porc crues
+agribalyse_food_code:en:28100
 ciqual_food_code:en:28100
 ciqual_food_name:en:Pork, chop, raw
 ciqual_food_name:fr:Porc, côte, crue
@@ -50718,6 +52316,7 @@ ciqual_food_name:fr:Porc, côte, crue
 <en:Raw pork meat
 en:Raw pork racks
 fr:Carrés de porc crus
+agribalyse_food_code:en:28104
 ciqual_food_code:en:28104
 ciqual_food_name:en:Pork, rack, raw
 ciqual_food_name:fr:Porc, carré, cru
@@ -50729,6 +52328,7 @@ fi:possun maha
 fr:Poitrine de porc, Poitrine de porc demi-sel
 nl:Varkensbuik
 zh:猪肚, 猪肚肉
+agribalyse_food_code:en:28550
 ciqual_food_code:en:28550
 ciqual_food_name:en:Pork belly salt-cured
 ciqual_food_name:fr:Poitrine de porc demi-sel
@@ -50736,6 +52336,7 @@ ciqual_food_name:fr:Poitrine de porc demi-sel
 <en:Pork
 en:Dried pancetta
 fr:Pancetta, Poitrine roulée sèche
+agribalyse_food_code:en:28858
 ciqual_food_code:en:28858
 ciqual_food_name:en:Pancetta, dried
 ciqual_food_name:fr:Pancetta ou Poitrine roulée sèche
@@ -50744,54 +52345,63 @@ ciqual_food_name:fr:Pancetta ou Poitrine roulée sèche
 <en:Raw pork meat
 en:Pork belly raw
 fr:poitrine de porc crue
+agribalyse_food_code:en:28002
 ciqual_food_code:en:28002
 ciqual_food_name:en:Pork, belly, raw
 
 <en:Raw pork meat
 en:Pork loin raw
 fr:longue de porc crue
+agribalyse_food_code:en:28003
 ciqual_food_code:en:28003
 ciqual_food_name:en:Pork loin, raw
 
 <en:Pork
 en:Pork round steak raw
 fr:rouelle de porc crue
+agribalyse_food_code:en:28102
 ciqual_food_code:en:28102
 ciqual_food_name:en:Pork, round steak, raw
 
 <en:Raw pork meat
 en:Pork tenderloin lean raw
 fr:filet de porc cru
+agribalyse_food_code:en:28201
 ciqual_food_code:en:28201
 ciqual_food_name:en:Pork tenderloin, lean, raw
 
 <en:Cooked pork meat
 en:Pork eye of shortloin raw
 fr:filet de porc rôti avec chaînette
+agribalyse_food_code:en:28480
 ciqual_food_code:en:28480
 ciqual_food_name:en:Prok, eye of shortloin, raw
 
 <en:Pork
 en:Pork filet mignon raw
 fr:filet mingon de porc
+agribalyse_food_code:en:28204
 ciqual_food_code:en:28204
 ciqual_food_name:en:Pork filet mignon, raw
 
 <en:Raw pork meat
 en:Pork 90/10 trimming raw
 fr:Porc maigre 90/10 cru
+agribalyse_food_code:en:28475
 ciqual_food_code:en:28475
 ciqual_food_name:en:Pork, 90/10 trimming, raw
 
 <en:Raw pork meat
 en:Pork 80/20 trimming raw
 fr:Porc maigre 80/20 cru
+agribalyse_food_code:en:28476
 ciqual_food_code:en:28476
 ciqual_food_name:en:Pork, 80/20 trimming, raw
 
 <en:Pork
 en:Pork shoulder upper half without rind fat and bone raw
 fr:palette de porc
+agribalyse_food_code:en:28477
 ciqual_food_code:en:28477
 ciqual_food_name:en:Pork, shoulder upper half, without rind, fat and bone, raw
 
@@ -50811,6 +52421,7 @@ zh:猪舌, 口条
 <en:Raw pork meat
 en:Raw pork tongue
 fr:Langue de porc crue
+agribalyse_food_code:en:40205
 ciqual_food_code:en:40205
 ciqual_food_name:en:Tongue, pork, raw
 ciqual_food_name:fr:Langue, porc, crue
@@ -50825,6 +52436,7 @@ zh:猪心
 <en:Pork
 en:Preserved pork liver
 fr:Confit de foie de porc
+agribalyse_food_code:en:8120
 ciqual_food_code:en:8120
 ciqual_food_name:en:Preserved pork liver
 ciqual_food_name:fr:Confit de foie de porc
@@ -50832,6 +52444,7 @@ ciqual_food_name:fr:Confit de foie de porc
 <en:Raw pork meat
 en:Raw pork liver
 fr:Foie de porc cru
+agribalyse_food_code:en:40119
 ciqual_food_code:en:40119
 ciqual_food_name:en:Liver, pork, raw
 ciqual_food_name:fr:Foie, porc, cru
@@ -50839,6 +52452,7 @@ ciqual_food_name:fr:Foie, porc, cru
 <en:Cooked pork meat
 en:Cooked pork liver
 fr:Foie de porc cuit
+agribalyse_food_code:en:40113
 ciqual_food_code:en:40113
 ciqual_food_name:en:Liver, pork, cooked
 ciqual_food_name:fr:Foie, porc, cuit
@@ -50846,6 +52460,7 @@ ciqual_food_name:fr:Foie, porc, cuit
 <en:Raw pork meat
 en:Raw pork heart
 fr:Coeur de porc cru
+agribalyse_food_code:en:40060
 ciqual_food_code:en:40060
 ciqual_food_name:en:Heart, pork, raw
 ciqual_food_name:fr:Coeur, porc, cru
@@ -50854,6 +52469,7 @@ ciqual_food_name:fr:Coeur, porc, cru
 <en:Cooked kidneys
 en:Cooked pork kidneys
 fr:Rognons de porc cuits
+agribalyse_food_code:en:40405
 ciqual_food_code:en:40405
 ciqual_food_name:en:Kidney, pork, cooked
 ciqual_food_name:fr:Rognon, porc, cuit
@@ -50861,6 +52477,7 @@ ciqual_food_name:fr:Rognon, porc, cuit
 <en:Raw pork meat
 en:Raw pork kidney
 fr:Rognons de porc crus
+agribalyse_food_code:en:40404
 ciqual_food_code:en:40404
 ciqual_food_name:en:Kidney, pork, raw
 ciqual_food_name:fr:Rognon, porc, cru
@@ -50868,6 +52485,7 @@ ciqual_food_name:fr:Rognon, porc, cru
 <en:Pork
 en:Salt-cured pork ear
 fr:Oreille de porc demi-sel
+agribalyse_food_code:en:28530
 ciqual_food_code:en:28530
 ciqual_food_name:en:Pork ear sat-cured
 ciqual_food_name:fr:Oreille de porc demi-sel
@@ -50948,6 +52566,7 @@ country:en:France
 <en:Poultries
 fr:Volaille de Gascogne
 country:en:France
+origins:en: en:France, fr:Gascogne
 
 <en:Poultries
 fr:Volaille de Houdan
@@ -50957,23 +52576,28 @@ country:en:France
 en:Poultries from Janzé
 fr:Volaille de Janzé
 country:en:France
+origins:en: en:France, fr:Janzé
 
 <en:Poultries
 fr:Volaille de la Champagne
 country:en:France
+origins:en: en:France, fr:Champagne
 
 <en:Poultries
 fr:Volaille du Berry
 country:en:France
+origins:en: en:France, fr:Berry
 
 <en:Poultries
 fr:Volaille du Gatinais
 country:en:France
+origins:en: en:France, fr:Gatinais
 
 <en:Poultries
 en:Poultry from Languedoc
 fr:Volaille du Languedoc
 country:en:France
+origins:en: en:France, fr:Languedoc
 
 <en:Poultries
 en:Poultry from Lauragais
@@ -51036,22 +52660,27 @@ country:en:France
 <en:Poultries
 fr:Volailles de Normandie
 country:en:France
+origins:en: en:France, fr:Normandie
 
 <en:Poultries
 fr:Volailles de Vendée
 country:en:France
+origins:en: en:France, fr:Vendée
 
 <en:Poultries
 fr:Volailles des Landes
 country:en:France
+origins:en: en:France, fr:Landes
 
 <en:Poultries
 fr:Volailles du Béarn
 country:en:France
+origins:en: en:France, fr:Béarn
 
 <en:Poultries
 fr:Volailles du Charolais
 country:en:France
+origins:en: en:France, fr:Charolais
 
 <en:Poultries
 fr:Volailles du Forez
@@ -51079,6 +52708,7 @@ country:en:France
 <en:Poultries
 fr:Volailles du Val de Sèvres
 country:en:France
+origins:en: en:France, fr:Val de Sèvres
 
 <en:Poultries
 fr:Volailles du Velay
@@ -51087,6 +52717,7 @@ country:en:France
 <en:Chickens
 en:Hen meat and skin raw
 fr:viande de poulet avec peau crue
+agribalyse_food_code:en:36000
 ciqual_food_code:en:36000
 ciqual_food_name:en:Hen, meat and skin, raw
 ciqual_food_name:fr:Poule, viande et peau, crue
@@ -51094,6 +52725,7 @@ ciqual_food_name:fr:Poule, viande et peau, crue
 <en:Chickens
 en:Hen meat only raw
 fr:viande de poulet crue
+agribalyse_food_code:en:36001
 ciqual_food_code:en:36001
 ciqual_food_name:en:Hen, meat only, raw
 ciqual_food_name:fr:Poule, viande ,crue
@@ -51102,6 +52734,7 @@ ciqual_food_name:fr:Poule, viande ,crue
 <en:Chickens
 en:Cooked chicken heart
 fr:Coeur de poulet cuit
+agribalyse_food_code:en:40056
 ciqual_food_code:en:40056
 ciqual_food_name:en:Heart, chicken, cooked
 ciqual_food_name:fr:Coeur, poulet, cuit
@@ -51109,6 +52742,7 @@ ciqual_food_name:fr:Coeur, poulet, cuit
 <en:Chickens
 en:Raw chicken heart
 fr:Coeur de poulet cru
+agribalyse_food_code:en:40054
 ciqual_food_code:en:40054
 ciqual_food_name:en:Heart, chicken, raw
 ciqual_food_name:fr:Coeur, poulet, cru
@@ -51117,6 +52751,7 @@ ciqual_food_name:fr:Coeur, poulet, cru
 <en:Chickens
 en:Cooked chicken liver
 fr:Foie de poulet cuit
+agribalyse_food_code:en:40116
 ciqual_food_code:en:40116
 ciqual_food_name:en:Liver, chicken, cooked
 ciqual_food_name:fr:Foie, poulet, cuit
@@ -51124,6 +52759,7 @@ ciqual_food_name:fr:Foie, poulet, cuit
 <en:Chickens
 en:Raw chicken liver
 fr:Foie de poulet cru
+agribalyse_food_code:en:40111
 ciqual_food_code:en:40111
 ciqual_food_name:en:Liver, chicken, raw
 ciqual_food_name:fr:Foie, poulet, cru
@@ -51131,6 +52767,7 @@ ciqual_food_name:fr:Foie, poulet, cru
 <en:Poultries
 en:Preserved poultry liver
 fr:Confit de foie de volaille
+agribalyse_food_code:en:8125
 ciqual_food_code:en:8125
 ciqual_food_name:en:Preserved poultry liver
 ciqual_food_name:fr:Confit de foie de volaille
@@ -51138,6 +52775,7 @@ ciqual_food_name:fr:Confit de foie de volaille
 <en:Poultries
 en:Raw liver poultry
 fr:Foie de volaille cru
+agribalyse_food_code:en:40108
 ciqual_food_code:en:40108
 ciqual_food_name:en:Liver, poultry, raw
 ciqual_food_name:fr:Foie, volaille, cru
@@ -51146,6 +52784,7 @@ ciqual_food_name:fr:Foie, volaille, cru
 <en:Chickens
 en:Cooked chicken heart
 fr:Coeur de poulet cuit
+agribalyse_food_code:en:40056
 ciqual_food_code:en:40056
 ciqual_food_name:en:Heart, chicken, cooked
 ciqual_food_name:fr:Coeur, poulet, cuit
@@ -51153,6 +52792,7 @@ ciqual_food_name:fr:Coeur, poulet, cuit
 <en:Chickens
 en:Raw chicken heart
 fr:Coeur de poulet cru
+agribalyse_food_code:en:40054
 ciqual_food_code:en:40054
 ciqual_food_name:en:Heart, chicken, raw
 ciqual_food_name:fr:Coeur, poulet, cru
@@ -51161,6 +52801,7 @@ ciqual_food_name:fr:Coeur, poulet, cru
 <en:Chickens
 en:Cooked chicken liver
 fr:Foie de poulet cuit
+agribalyse_food_code:en:40116
 ciqual_food_code:en:40116
 ciqual_food_name:en:Liver, chicken, cooked
 ciqual_food_name:fr:Foie, poulet, cuit
@@ -51168,6 +52809,7 @@ ciqual_food_name:fr:Foie, poulet, cuit
 <en:Poultries
 en:Raw chicken liver
 fr:Foie de poulet cru
+agribalyse_food_code:en:40111
 ciqual_food_code:en:40111
 ciqual_food_name:en:Liver, chicken, raw
 ciqual_food_name:fr:Foie, poulet, cru
@@ -51175,6 +52817,7 @@ ciqual_food_name:fr:Foie, poulet, cru
 <en:Poultries
 en:Preserved poultry liver
 fr:Confit de foie de volaille
+agribalyse_food_code:en:8125
 ciqual_food_code:en:8125
 ciqual_food_name:en:Preserved poultry liver
 ciqual_food_name:fr:Confit de foie de volaille
@@ -51182,6 +52825,7 @@ ciqual_food_name:fr:Confit de foie de volaille
 <en:Poultries
 en:Raw liver poultry
 fr:Foie de volaille cru
+agribalyse_food_code:en:40108
 ciqual_food_code:en:40108
 ciqual_food_name:en:Liver, poultry, raw
 ciqual_food_name:fr:Foie, volaille, cru
@@ -51189,6 +52833,7 @@ ciqual_food_name:fr:Foie, volaille, cru
 <en:Poultries
 en:Poultry minced meat
 fr:Haché de volaille
+agribalyse_food_code:en:28927
 ciqual_food_code:en:28927
 ciqual_food_name:en:Poultry, minced meat
 ciqual_food_name:fr:Haché de volaille
@@ -51206,6 +52851,7 @@ fr:Poulets panés, Poulet pané
 <en:Meat preparations
 en:Poultry nuggets
 fr:Nuggets de volaille
+agribalyse_food_code:en:25512
 ciqual_food_code:en:25512
 ciqual_food_name:en:Poultry nuggets
 
@@ -51222,6 +52868,7 @@ nl_be:Kipnuggets
 ru:куриные наггетсы
 zh:鸡块
 wikidata:en:Q1072190
+agribalyse_food_code:en:36027
 ciqual_food_code:en:36027
 ciqual_food_name:en:Chicken, nugget, breaded croquette
 
@@ -51239,6 +52886,7 @@ nl:Kalkoennuggets
 <en:Cooked poultries
 en:Cooked quail with meat and skin
 fr:Caille cuite avec viande et peau
+agribalyse_food_code:en:36102
 ciqual_food_code:en:36102
 ciqual_food_name:en:Quail, meat and skin, cooked
 ciqual_food_name:fr:Caille, viande et peau, cuite
@@ -51281,6 +52929,7 @@ ciqual_food_name:fr:Faisan, viande et peau, cru
 <en:Pheasant
 en:Roasted pheasant meat, Baked pheasant meat
 fr:Viande de faisan rôtie, Viande de faisan cuite au four
+agribalyse_food_code:en:36402
 ciqual_food_code:en:36402
 ciqual_food_name:en:Pheasant, meat, roasted/baked
 ciqual_food_name:fr:Faisan, viande, rôtie/cuite au four
@@ -51298,6 +52947,7 @@ wikidata:en:Q3736439
 <en:Raw meats
 en:Raw duck meat
 fr:Viande de canard crue
+agribalyse_food_code:en:36201
 ciqual_food_code:en:36201
 ciqual_food_name:en:Duck, meat, raw
 ciqual_food_name:fr:Canard, viande, crue
@@ -51305,6 +52955,7 @@ ciqual_food_name:fr:Canard, viande, crue
 <en:Raw duck meat
 en:Raw duck liver
 fr:Foie de canard cru
+agribalyse_food_code:en:40121
 ciqual_food_code:en:40121
 ciqual_food_name:en:Liver, duck, raw
 ciqual_food_name:fr:Foie, canard, cru
@@ -51320,6 +52971,7 @@ en:Duck confit, Preserved duck
 fr:Confits de canard, confit de canard
 nl:Gekonfijte eend
 zh:油封鸭
+agribalyse_food_code:en:8110
 ciqual_food_code:en:8110
 ciqual_food_name:en:Preserved duck
 ciqual_food_name:fr:Confit de canard
@@ -51327,6 +52979,7 @@ ciqual_food_name:fr:Confit de canard
 <en:Ducks
 en:Reheated duck confit conserved in rendered fat without skin
 fr:Confit de canard sans peau réchauffé
+agribalyse_food_code:en:8109
 ciqual_food_code:en:8109
 ciqual_food_name:en:Duck confit (conserved in rendered fat), meat (leg) without skin, reheated
 ciqual_food_name:fr:Confit de canard, viande (cuisse), sans peau, réchauffé
@@ -51342,6 +52995,7 @@ zh:鸭胸
 <en:Duck breasts
 en:Smoked duck brests, Smoked duck breast fillet
 fr:Magrets de canard fumés, Magret de canard fumé
+agribalyse_food_code:en:8111
 ciqual_food_code:en:8111
 ciqual_food_name:en:Duck breast fillet, smoked
 ciqual_food_name:fr:Canard, magret fumé
@@ -51349,6 +53003,7 @@ ciqual_food_name:fr:Canard, magret fumé
 <en:Duck breasts
 en:Duck brests cooked in pan, Duck magret cooked in pan
 fr:Magrets de canard grillés, Magret de canard grillé, Magret de canard poêlé
+agribalyse_food_code:en:36205
 ciqual_food_code:en:36205
 ciqual_food_name:en:Duck, magret, cooked in pan
 ciqual_food_name:fr:Canard, magret, grillé/poêlé
@@ -51357,6 +53012,7 @@ ciqual_food_name:fr:Canard, magret, grillé/poêlé
 <en:Duck breasts
 en:Raw duck breasts
 fr:Magrets de canard crus, Magret de canard cru
+agribalyse_food_code:en:36206
 ciqual_food_code:en:36206
 ciqual_food_name:en:Duck, breast fillet
 ciqual_food_name:fr:Canard, magret, cru
@@ -51370,6 +53026,7 @@ fr:Cuisses de canard confites
 <en:Ducks
 en:Duck leg meat with skin
 fr:cuisse de canard avec peau desossée
+agribalyse_food_code:en:36203
 ciqual_food_code:en:36203
 ciqual_food_name:en:Duck, leg, meat and skin, raw
 ciqual_food_name:fr:Canard, cuisse avec peau, sans os, crue
@@ -51377,6 +53034,7 @@ ciqual_food_name:fr:Canard, cuisse avec peau, sans os, crue
 <en:Ducks
 en:Duck meat and skin raw
 fr:Viande de canard avec peau
+agribalyse_food_code:en:36204
 ciqual_food_code:en:36204
 ciqual_food_name:en:Duck, meat and skin, raw
 ciqual_food_name:fr:Canard, viande et peau, cru
@@ -51385,6 +53043,7 @@ ciqual_food_name:fr:Canard, viande et peau, cru
 <en:Ducks
 en:Roasted duck with meat and skin, Baked duck with meat and skin
 fr:Canard rôti avec viande et peau, Canard cuit au four avec viande et peau
+agribalyse_food_code:en:36200
 ciqual_food_code:en:36200
 ciqual_food_name:en:Duck, meat and skin, roasted/baked
 ciqual_food_name:fr:Canard, viande et peau, rôti/cuit au four
@@ -51393,6 +53052,7 @@ ciqual_food_name:fr:Canard, viande et peau, rôti/cuit au four
 <en:Ducks
 en:Roasted duck meat, Baked duck meat
 fr:Viande de canard rôtie, Viande de canard cuite au four
+agribalyse_food_code:en:36202
 ciqual_food_code:en:36202
 ciqual_food_name:en:Duck, meat, roasted/baked
 ciqual_food_name:fr:Canard, viande, rôtie/cuite au four
@@ -51425,6 +53085,7 @@ zh:火鸡, 鲜火鸡肉, 鲜火鸡
 <en:Turkeys
 en:Raw turkey meat
 fr:Viande de dinde crue
+agribalyse_food_code:en:36300
 ciqual_food_code:en:36300
 ciqual_food_name:en:Turkey, meat and skin, raw
 
@@ -51432,6 +53093,7 @@ ciqual_food_name:en:Turkey, meat and skin, raw
 <en:Turkeys
 en:Cooked turkey heart
 fr:Coeur de dinde cuit
+agribalyse_food_code:en:40057
 ciqual_food_code:en:40057
 ciqual_food_name:en:Heart, turkey, cooked
 ciqual_food_name:fr:Coeur, dinde, cuit
@@ -51439,6 +53101,7 @@ ciqual_food_name:fr:Coeur, dinde, cuit
 <en:Raw turkey meat
 en:Raw turkey heart
 fr:Coeur de dinde cru
+agribalyse_food_code:en:40055
 ciqual_food_code:en:40055
 ciqual_food_name:en:Heart, turkey, raw
 ciqual_food_name:fr:Coeur, dinde, cru
@@ -51447,6 +53110,7 @@ ciqual_food_name:fr:Coeur, dinde, cru
 <en:Turkey dishes
 en:Cooked turkey liver
 fr:Foie de dinde cuit
+agribalyse_food_code:en:40118
 ciqual_food_code:en:40118
 ciqual_food_name:en:Liver, turkey, cooked
 ciqual_food_name:fr:Foie, dinde, cuit
@@ -51454,6 +53118,7 @@ ciqual_food_name:fr:Foie, dinde, cuit
 <en:Raw turkey meat
 en:Raw turkey liver
 fr:Foie de dinde cru
+agribalyse_food_code:en:40115
 ciqual_food_code:en:40115
 ciqual_food_name:en:Liver, turkey, raw
 ciqual_food_name:fr:Foie, dinde, cru
@@ -51461,12 +53126,14 @@ ciqual_food_name:fr:Foie, dinde, cru
 <en:Raw turkey meat
 en:Turkey meat raw
 fr:viande de dinde sans peau crue
+agribalyse_food_code:en:36301
 ciqual_food_code:en:36301
 ciqual_food_name:en:Turkey, meat, raw
 
 <en:Raw turkey meat
 en:Turkey leg meat only raw
 fr:cuisse de dinde sans peau crue
+agribalyse_food_code:en:36307
 ciqual_food_code:en:36307
 ciqual_food_name:en:Turkey, leg, meat only, raw
 
@@ -51488,6 +53155,7 @@ ciqual_food_name:fr:Pigeon, cru
 <en:Pigeon
 en:Roasted pigeon meat, Baked pigeon meat
 fr:Viande de pigeon rôtie, Viande de pigeon cuite au four
+agribalyse_food_code:en:36602
 ciqual_food_code:en:36602
 ciqual_food_name:en:Pigeon, meat, roasted/baked
 ciqual_food_name:fr:Pigeon, viande, rôtie/cuite au four
@@ -51509,6 +53177,7 @@ nl_be:Kapoen
 pl:Kapłon
 zh:阉鸡
 wikidata:en:Q594676
+agribalyse_food_code:en:36050
 ciqual_food_code:en:36050
 ciqual_food_name:en:Capon, meat and skin, raw
 
@@ -51522,6 +53191,7 @@ origins:en: en:France, fr:Périgord
 <en:Capon
 en:Baked capon meat and skin, Roasted capon meat and skin
 fr:Chapon rôti avec viande et peau, Chapon cuit au four avec viande et peau
+agribalyse_food_code:en:36051
 ciqual_food_code:en:36051
 ciqual_food_name:en:Capon, meat and skin, roasted/baked
 ciqual_food_name:fr:Chapon, viande et peau, rôti/cuit au four
@@ -51535,6 +53205,7 @@ zh:鹅, 鹅肉
 <en:Geese
 en:Raw goose meat
 fr:viande d'oie crue
+agribalyse_food_code:en:36500
 ciqual_food_code:en:36500
 ciqual_food_name:en:Goose, meat, raw
 ciqual_food_name:fr:Oie, viande crue
@@ -51542,6 +53213,7 @@ ciqual_food_name:fr:Oie, viande crue
 <en:Geese
 en:Raw goose meat with skin
 fr:viande et peau d'oie crue
+agribalyse_food_code:en:36501
 ciqual_food_code:en:36501
 ciqual_food_name:en:Goose, meat and skin, raw
 ciqual_food_name:fr:Oie, viande et peau, crue
@@ -51550,6 +53222,7 @@ ciqual_food_name:fr:Oie, viande et peau, crue
 <en:Geese
 en:Roasted goose meat, Baked goose meat
 fr:Viande d'oie rôtie, Viande d'oie cuite au four
+agribalyse_food_code:en:36502
 ciqual_food_code:en:36502
 ciqual_food_name:en:Goose, meat, roasted/baked
 ciqual_food_name:fr:Oie, viande, rôtie/cuite au four
@@ -51558,6 +53231,7 @@ ciqual_food_name:fr:Oie, viande, rôtie/cuite au four
 <en:Geese
 en:Roasted goose with meat and skin, Baked goose with meat and skin
 fr:Oie rôtie avec viande et peau, Oie cuite au four avec viande et peau
+agribalyse_food_code:en:36503
 ciqual_food_code:en:36503
 ciqual_food_name:en:Goose, meat and skin, roasted/baked
 ciqual_food_name:fr:Oie, viande et peau, rôtie/cuite au four
@@ -51569,6 +53243,7 @@ fr:Confits d’oie, Confit d’oie
 <en:Raw goose meat
 en:Raw goose liver
 fr:Foie d'oie cru
+agribalyse_food_code:en:40120
 ciqual_food_code:en:40120
 ciqual_food_name:en:Liver, goose, raw
 ciqual_food_name:fr:Foie, oie, cru
@@ -51577,18 +53252,21 @@ ciqual_food_name:fr:Foie, oie, cru
 fr:Pintades, Pintade
 nl:Parelhoenders
 en:Guinea fowl
+agribalyse_food_code:en:36700
 ciqual_food_code:en:36700
 ciqual_food_name:en:Guinea fowl, raw
 
 <en:Guinea fowl
 en:Guinea fowl leg
 fr:cuisse de pintade
+agribalyse_food_code:en:36703
 ciqual_food_code:en:36703
 ciqual_food_name:en:Guinea fowl, leg, raw
 
 <en:Guinea fowl
 en:Guinea fowl breast
 fr:poitrine de pintade
+agribalyse_food_code:en:36702
 ciqual_food_code:en:36702
 ciqual_food_name:en:Guinea fowl, breast, raw
 ciqual_food_name:fr:Pintade, poitrine, crue
@@ -51786,12 +53464,14 @@ wikipedia:en:https://en.wikipedia.org/wiki/Chicken_as_food
 <en:Raw meats
 en:Raw chicken meat
 fr:Viande de poulet crue
+agribalyse_food_code:en:36016
 ciqual_food_code:en:36016
 ciqual_food_name:en:Chicken, meat and skin, raw
 
 <en:Chickens
 en:Raw chicken meat without skin, Chicken meat raw
 fr:Viande de poulet crue sans peau, viande de poulet sans peau crue
+agribalyse_food_code:en:36003
 ciqual_food_code:en:36003
 ciqual_food_name:en:Chicken, meat, raw
 
@@ -51877,6 +53557,7 @@ nl:Kipschnitzel
 en:Breaded chicken cutlets, Breaded turkey escalope
 fr:Escalopes de poulet panées, Escalopes de poulet panée, Escalope de poulet panée
 nl:Kippenschnitzel
+agribalyse_food_code:en:36036
 ciqual_food_code:en:36036
 ciqual_food_name:en:Turkey, breaded escalope
 ciqual_food_name:fr:Poulet, escalope panée
@@ -51896,6 +53577,7 @@ zh:鸡胸
 <en:Chicken breasts
 en:Cooked chicken breast without skin
 fr:Filet de poulet sans peau cuit
+agribalyse_food_code:en:36018
 ciqual_food_code:en:36018
 ciqual_food_name:en:Chicken, breast, without skin, cooked
 ciqual_food_name:fr:Poulet, filet, sans peau, cuit
@@ -51904,6 +53586,7 @@ ciqual_food_name:fr:Poulet, filet, sans peau, cuit
 <en:Chicken breasts
 en:Roasted chicken breast with meat and skin, Baked chicken breast with meat and skin
 fr:Poitrine de poulet rôtie avec viande et peau, Poitrine de poulet cuite au four avec viande et peau
+agribalyse_food_code:en:36032
 ciqual_food_code:en:36032
 ciqual_food_name:en:Chicken, breast, meat and skin, roasted/baked
 ciqual_food_name:fr:Poulet, poitrine, viande et peau, rôti/cuit au four
@@ -51912,6 +53595,7 @@ ciqual_food_name:fr:Poulet, poitrine, viande et peau, rôti/cuit au four
 <en:Chicken wings
 en:Roasted chicken wing meat and skin, Baked chicken wing meat and skin
 fr:Aile de poulet avec viande et peau rôtie, Aile de poulet avec viande et peau cuite au four
+agribalyse_food_code:en:36033
 ciqual_food_code:en:36033
 ciqual_food_name:en:Chicken, wing, meat and skin, roasted/baked
 ciqual_food_name:fr:Poulet, aile, viande et peau, rôti/cuit au four
@@ -51920,6 +53604,7 @@ ciqual_food_name:fr:Poulet, aile, viande et peau, rôti/cuit au four
 <en:Chicken thighs
 en:Roasted chicken leg meat and skin, Baked chicken leg meat and skin
 fr:Cuisse de poulet rôtie avec viande et peau, Cuisse de poulet cuite au four avec viande et peau
+agribalyse_food_code:en:36004
 ciqual_food_code:en:36004
 ciqual_food_name:en:Chicken, leg, meat and skin, roasted/baked
 ciqual_food_name:fr:Poulet, cuisse, viande et peau, rôtie/cuite au four
@@ -51928,6 +53613,7 @@ ciqual_food_name:fr:Poulet, cuisse, viande et peau, rôtie/cuite au four
 <en:Chicken thighs
 en:Roasted chicken leg meat, Baked chicken leg meat
 fr:Cuisse de poulet rôtie sans peau, Cuisse de poulet cuite au four sans peau
+agribalyse_food_code:en:36006
 ciqual_food_code:en:36006
 ciqual_food_name:en:Chicken leg, meat, roasted/baked
 ciqual_food_name:fr:Poulet, cuisse, viande, rôti/cuit au four
@@ -51936,6 +53622,7 @@ ciqual_food_name:fr:Poulet, cuisse, viande, rôti/cuit au four
 <en:Chicken thighs
 en:Boiled chicken leg meat, Chicken leg meat cooked in water
 fr:Cuisse de poulet bouillie, Cuisse de poulet cuite à l'eau
+agribalyse_food_code:en:36030
 ciqual_food_code:en:36030
 ciqual_food_name:en:Chicken leg, meat, boiled/cooked in water
 ciqual_food_name:fr:Poulet, cuisse, viande, bouilli/cuit à l'eau
@@ -51944,6 +53631,7 @@ ciqual_food_name:fr:Poulet, cuisse, viande, bouilli/cuit à l'eau
 <en:Chicken thighs
 en:Boiled chicken leg with meat and skin, Chicken leg with meat and skin cooked in water
 fr:Cuisse de poulet avec viande et peau bouillie, Cuisse de poulet avec viande et peau cuite à l'eau
+agribalyse_food_code:en:36031
 ciqual_food_code:en:36031
 ciqual_food_name:en:Chicken, leg, meat and skin, boiled/cooked in water
 ciqual_food_name:fr:Poulet, cuisse, viande et peau, bouilli/cuit à l'eau
@@ -51991,6 +53679,7 @@ nl:Kalkoenfilets
 <en:Turkey breasts
 en:Turkey ham, cooked turkey breast
 fr:blanc de dinde en tranche, jambon de dinde
+agribalyse_food_code:en:28964
 ciqual_food_code:en:28964
 ciqual_food_name:en:Turkey cooked ham, in slices
 ciqual_food_name:fr:Jambon de dinde ou Blanc de dinde en tranche
@@ -51998,6 +53687,7 @@ ciqual_food_name:fr:Jambon de dinde ou Blanc de dinde en tranche
 <en:Turkeys
 en:Turkey wings
 fr:ailes de dinde
+agribalyse_food_code:en:36310
 ciqual_food_code:en:36310
 ciqual_food_name:en:Turkey, wing, raw
 ciqual_food_name:fr:Dinde, aile, crue
@@ -52012,6 +53702,7 @@ de:Putenschnitzel
 fi:kalkkunaleikkeleet
 fr:Escalopes de dinde, escalopes de dindes, escalope de dinde, escalope de dindes
 nl:Kalkoenkoteletten, Kalkoenkotelet
+agribalyse_food_code:en:36304
 ciqual_food_code:en:36304
 ciqual_food_name:en:Turkey, escalope, raw
 
@@ -52019,6 +53710,7 @@ ciqual_food_name:en:Turkey, escalope, raw
 <en:Turkey cutlets
 en:Sautéed turkey escalope with salt, Pan-fried turkey escalope with salt
 fr:Escalope de dinde sautée, Escalope de dinde poêlée
+agribalyse_food_code:en:36306
 ciqual_food_code:en:36306
 ciqual_food_name:en:Turkey, escalope, sautéed/pan-fried, with salt
 ciqual_food_name:fr:Dinde, escalope, sautée/poêlée
@@ -52027,6 +53719,7 @@ ciqual_food_name:fr:Dinde, escalope, sautée/poêlée
 <en:Turkey cutlets
 en:Roasted turkey escalope, Baked turkey escalope
 fr:Escalope de dinde rôtie, Escalope de dinde cuite au four
+agribalyse_food_code:en:36308
 ciqual_food_code:en:36308
 ciqual_food_name:en:Turkey, escalope, roasted/baked
 ciqual_food_name:fr:Dinde, escalope, rôtie/cuite au four
@@ -52038,6 +53731,7 @@ ciqual_food_name:fr:Dinde, escalope, rôtie/cuite au four
 <en:Turkeys
 fr:Rôtis de dinde, rôtis de dindes, rôti de dinde, rôti de dindes
 en:Roasted turkey meat, baked turkey meat
+agribalyse_food_code:en:36302
 ciqual_food_code:en:36302
 ciqual_food_name:en:Turkey, meat, roasted/baked
 
@@ -52045,6 +53739,7 @@ ciqual_food_name:en:Turkey, meat, roasted/baked
 en:Turkey thighs, Turkey leg meat
 fr:Cuisses de dinde, cuisses de dindes, cuisse de dinde, cuisse de dindes
 nl:Kalkoendijen
+agribalyse_food_code:en:36305
 ciqual_food_code:en:36305
 ciqual_food_name:en:Turkey, leg, meat and skin, raw
 
@@ -52052,6 +53747,7 @@ ciqual_food_name:en:Turkey, leg, meat and skin, raw
 <fr:Allumettes de volaille
 fr:Allumettes de dinde, alumettes de dinde, allumette de dinde, alumette de dinde
 en:Minced turkey ham, grated turkey ham, diced turkey ham
+agribalyse_food_code:en:28929
 ciqual_food_code:en:28929
 ciqual_food_name:en:Poultry ham in cube, grated or minced
 
@@ -52099,6 +53795,7 @@ wikidata:en:Q1464898
 fr:Andouilles
 en:Chitterling sausage
 wikidata:en:Q492769
+agribalyse_food_code:en:8500
 ciqual_food_code:en:8500
 ciqual_food_name:en:Chitterling sausage
 ciqual_food_name:fr:Andouille
@@ -52106,6 +53803,7 @@ ciqual_food_name:fr:Andouille
 <fr:Andouilles
 fr:Andouilles de Vire, Andouille de Vire
 en:Chitterling sausage from Vire
+agribalyse_food_code:en:8512
 ciqual_food_code:en:8512
 ciqual_food_name:en:Chitterling sausage from Vire
 ciqual_food_name:fr:Andouille de Vire
@@ -52113,6 +53811,7 @@ ciqual_food_name:fr:Andouille de Vire
 <fr:Andouilles
 fr:Andouilles de Guémené, Andouille de Guémené
 en:Chitterling sausage from Guéméné
+agribalyse_food_code:en:8501
 ciqual_food_code:en:8501
 ciqual_food_name:en:Chitterling sausage from Guéméné
 ciqual_food_name:fr:Andouille de Guéméné
@@ -52120,6 +53819,7 @@ ciqual_food_name:fr:Andouille de Guéméné
 <fr:Andouilles
 en:Pan-reheated chitterling sausage
 fr:Andouille réchauffée à la poêle
+agribalyse_food_code:en:8504
 ciqual_food_code:en:8504
 ciqual_food_name:en:Chitterling sausage, pan-reheated
 ciqual_food_name:fr:Andouille, réchauffée à la poêle
@@ -52127,6 +53827,7 @@ ciqual_food_name:fr:Andouille, réchauffée à la poêle
 <fr:Andouilles
 en:Sautéed chitterling sausage, Pan-fried chitterling sausage
 fr:Andouillette sautée, Andouillette poêlée
+agribalyse_food_code:en:8551
 ciqual_food_code:en:8551
 ciqual_food_name:en:Chitterling sausage, sautéed/pan-fried
 ciqual_food_name:fr:Andouillette, sautée/poêlée
@@ -52134,6 +53835,7 @@ ciqual_food_name:fr:Andouillette, sautée/poêlée
 <fr:Andouilles
 en:Raw chitterling sausage
 fr:Andouillette crue
+agribalyse_food_code:en:8550
 ciqual_food_code:en:8550
 ciqual_food_name:en:Chitterling sausage, raw
 ciqual_food_name:fr:Andouillette, crue
@@ -52149,6 +53851,7 @@ wikidata:en:Q1106345
 en:Capicola, coppa
 fr:Coppa
 nl:Capocollo
+agribalyse_food_code:en:28850
 ciqual_food_code:en:28850
 ciqual_food_name:en:Coppa
 ciqual_food_name:fr:Coppa
@@ -52185,6 +53888,7 @@ wikidata:en:Q170486
 <en:Pork
 en:Pork ham escalope
 fr:escalope de jambon de porc
+agribalyse_food_code:en:28461
 ciqual_food_code:en:28461
 ciqual_food_name:en:Pork, ham escalope, cooked
 ciqual_food_name:fr:Porc, escalope de jambon, cuite
@@ -52192,12 +53896,14 @@ ciqual_food_name:fr:Porc, escalope de jambon, cuite
 <en:Pork
 en:Pork way leg without rind fat and bone raw
 fr:Porc jambon sans jarret sans bateau découenné dégraisssé désossé cru
+agribalyse_food_code:en:28473
 ciqual_food_code:en:28473
 ciqual_food_name:en:Pork, way leg, without rind, fat and bone, raw
 
 <en:Pork
 en:Dry-cured ham with fat and rind removed
 fr:Jambon sec découenné dégraissé
+agribalyse_food_code:en:28802
 ciqual_food_code:en:28802
 ciqual_food_name:en:Dry-cured ham, fat and rind removed
 ciqual_food_name:fr:Jambon sec, découenné, dégraissé
@@ -52213,6 +53919,7 @@ nl:Gesmoorde ham
 <en:Braised hams
 en:Braised ham on the bone
 fr:Jambon à l'os braisé
+agribalyse_food_code:en:28905
 ciqual_food_code:en:28905
 ciqual_food_name:en:Braised ham on the bone
 ciqual_food_name:fr:Jambon à l'os braisé
@@ -52220,6 +53927,7 @@ ciqual_food_name:fr:Jambon à l'os braisé
 <en:Braised hams
 en:Round of ham cooked
 fr:Rond de jambon cuit
+agribalyse_food_code:en:28917
 ciqual_food_code:en:28917
 ciqual_food_name:en:Round of ham, cooked
 ciqual_food_name:fr:Rond de jambon cuit
@@ -52227,6 +53935,7 @@ ciqual_food_name:fr:Rond de jambon cuit
 <en:Braised hams
 en:Knuckle of ham cooked
 fr:Jambonneau cuit
+agribalyse_food_code:en:28960
 ciqual_food_code:en:28960
 ciqual_food_name:en:Knuckle of ham, cooked
 ciqual_food_name:fr:Jambonneau, cuit
@@ -52234,6 +53943,7 @@ ciqual_food_name:fr:Jambonneau, cuit
 <en:Braised hams
 en:Raw pork knuckle of ham without rind without fat without bone
 fr:Jambonneau arrière de porc découenné dégraisssé désossé cru
+agribalyse_food_code:en:28474
 ciqual_food_code:en:28474
 ciqual_food_name:en:Pork, knuckle oh ham, without rind, fat and bone, raw
 ciqual_food_name:fr:Porc, jambonneau arrière, découenné, dégraisssé, désossé, cru
@@ -52252,6 +53962,7 @@ fi:kypsät savustetut kinkut
 fr:Jambons blancs fumés, jambons cuits fumés, Jambon blanc fumé, jambon cuit fumé
 hu:Fehér füstölt sonka
 nl:gerookte gekookte ham
+agribalyse_food_code:en:28803
 ciqual_food_code:en:28803
 ciqual_food_name:en:Cooked ham, smoked
 
@@ -52266,12 +53977,14 @@ hu:Fehér sonka
 it:Prosciutti cotti
 nl:Gekookte ham
 wikidata:en:Q3820622
+agribalyse_food_code:en:28925
 ciqual_food_code:en:28925
 ciqual_food_name:en:Cooked ham, Parisian-style, rind less and fatless
 
 <en:Hams
 en:Pork ham intended to be cooked, Pork ham intended to be roasted, Pork ham intended to be baked
 fr:Jambon de porc à cuire
+agribalyse_food_code:en:28700
 ciqual_food_code:en:28700
 ciqual_food_name:en:Pork ham, intended to be cooked or pork ham, intended to be roast/bake
 
@@ -52285,42 +53998,49 @@ ciqual_food_name:fr:Jambon persillé en gelée
 <en:Hams
 en:Cooked ham superior quality
 fr:Jambon cuit supérieur
+agribalyse_food_code:en:28900
 ciqual_food_code:en:28900
 ciqual_food_name:en:Cooked ham, superior quality
 
 <en:Hams
 en:Cooked ham superior quality with rind
 fr:Jambon cuit supérieur avec couenne
+agribalyse_food_code:en:28901
 ciqual_food_code:en:28901
 ciqual_food_name:en:Cooked ham, superior quality, with rind
 
 <en:Hams
 en:Cooked ham superior quality rind less
 fr:Jambon cuit supérieur découenné
+agribalyse_food_code:en:28902
 ciqual_food_code:en:28902
 ciqual_food_name:en:Cooked ham, superior quality, rind less
 
 <en:Hams
 en:Cooked ham superior quality rind less and fatless
 fr:Jambon cuit supérieur découenné dégraissé
+agribalyse_food_code:en:28906
 ciqual_food_code:en:28906
 ciqual_food_name:en:Cooked ham, superior quality, rind less and fatless
 
 <en:Hams
 en:Cooked ham superior quality reduced salt
 fr:Jambon cuit supérieur à teneur réduite en sel
+agribalyse_food_code:en:28907
 ciqual_food_code:en:28907
 ciqual_food_name:en:Cooked ham, superior quality, reduced salt
 
 <en:Hams
 en:Cooked ham choice
 fr:Jambon de choix cuit
+agribalyse_food_code:en:28910
 ciqual_food_code:en:28910
 ciqual_food_name:en:Cooked ham, choice
 
 <en:Hams
 en:Cooked ham choice w rind
 fr:Jambon cuit choix avec couenne
+agribalyse_food_code:en:28912
 ciqual_food_code:en:28912
 ciqual_food_name:en:Cooked ham, choice, w rind
 
@@ -52349,6 +54069,7 @@ en:Diced ham, Dices of ham, Ham in cube
 fi:kinkkukuutiot
 fr:Dés de jambon, dés de jambons
 nl:Hamblokjes
+agribalyse_food_code:en:28922
 ciqual_food_code:en:28922
 ciqual_food_name:en:Ham in cube, grated or minced
 
@@ -52361,6 +54082,7 @@ fr:Jambons crus, jambon cru
 es: jamón de país, jamón salado
 it:Prosciutti crudi
 nl:Rauwe ham
+agribalyse_food_code:en:28800
 ciqual_food_code:en:28800
 ciqual_food_name:en:Cured ham, raw
 ciqual_food_name:fr:Jambon cru
@@ -52375,6 +54097,7 @@ fr:Jambons secs, jambon sec
 hu:Szárított sonkák
 nl:Gedroogde hammen, Gedroogde ham
 pt:Presuntos secos
+agribalyse_food_code:en:28812
 ciqual_food_code:en:28812
 ciqual_food_name:en:Dry-cured ham
 ciqual_food_name:fr:Jambon sec
@@ -52392,6 +54115,7 @@ wikidata:en:Q1230067
 
 <en:Bayonne ham
 en:Raw smoked cured Bayonne ham
+agribalyse_food_code:en:28811
 ciqual_food_code:en:28811
 ciqual_food_name:en:Bayonne Cured ham, raw, smoked
 ciqual_food_name:fr:Jambon de Bayonne
@@ -52455,6 +54179,7 @@ fr:Jambons de Parme, jambon de parme, Jambon sec de Parme
 it:Prosciutto di Parma
 nl:Parmahammen
 wikidata:en:Q13360207
+agribalyse_food_code:en:28844
 ciqual_food_code:en:28844
 ciqual_food_name:en:Parma dry-cured ham
 ciqual_food_name:fr:Jambon sec de Parme
@@ -52481,6 +54206,7 @@ en:Dry-cured Serrano ham
 fr:Jambons Serrano, jambon serrano, Jambon sec Serrano
 es:Jamón serrano
 wikidata:en:Q584324
+agribalyse_food_code:en:28845
 ciqual_food_code:en:28845
 ciqual_food_name:en:Serrano dry-cured ham
 ciqual_food_name:fr:Jambon sec Serrano
@@ -52488,6 +54214,7 @@ ciqual_food_name:fr:Jambon sec Serrano
 <fr:Jambons crus
 fr:Jambons crus fumés, jambon cru fumé, jambons secs fumés, jambon sec fumé
 en:Raw smoked cured ham
+agribalyse_food_code:en:28801
 ciqual_food_code:en:28801
 ciqual_food_name:en:Cured ham, raw, smoked
 ciqual_food_name:fr:Jambon cru, fumé
@@ -52495,6 +54222,7 @@ ciqual_food_name:fr:Jambon cru, fumé
 <fr:Jambons crus
 en:Raw cured smoked ham with reduced fat
 fr:Jambon cru fumé allégé en matières grasses
+agribalyse_food_code:en:28804
 ciqual_food_code:en:28804
 ciqual_food_name:en:Cured ham, raw, smoked, reduced fat
 ciqual_food_name:fr:Jambon cru, fumé, allégé en matière grasse
@@ -52582,12 +54310,14 @@ fr:Rillettes de volaille
 fr:Rillettes d'oie, rillettes à l'oie
 en:Rillettes goose
 fr:Rillettes d'oie
+agribalyse_food_code:en:8030
 ciqual_food_code:en:8030
 ciqual_food_name:en:Rillettes, goose
 
 <fr:Rillettes de volaille
 en:Rillettes pure goose
 fr:Rillettes pur oie
+agribalyse_food_code:en:8025
 ciqual_food_code:en:8025
 ciqual_food_name:en:Rillettes, pure goose
 
@@ -52596,6 +54326,7 @@ ciqual_food_name:en:Rillettes, pure goose
 en:duck rillettes
 fr:Rillettes de canard, rillettes au canard
 nl:Eendenrillettes
+agribalyse_food_code:en:8026
 ciqual_food_code:en:8026
 ciqual_food_name:en:Rillettes, duck
 
@@ -52607,6 +54338,7 @@ fr:Rillettes de dinde
 en:chicken rillettes
 fr:Rillettes de poulet, rillettes au poulet
 nl:Kiprillettes
+agribalyse_food_code:en:8040
 ciqual_food_code:en:8040
 ciqual_food_name:en:Rillettes, poultry
 
@@ -52638,6 +54370,7 @@ fr:Rillettes de mouton
 <fr:Rillettes de viande rouge
 en:Pork rillettes
 fr:Rillettes de porc, Rillettes de cochon
+agribalyse_food_code:en:8000
 ciqual_food_code:en:8000
 ciqual_food_name:en:Rillettes, pork
 
@@ -52645,6 +54378,7 @@ ciqual_food_name:en:Rillettes, pork
 <en:Prepared meats
 en:Rillettes pure pork
 fr:Rillettes pur porc
+agribalyse_food_code:en:8001
 ciqual_food_code:en:8001
 ciqual_food_name:en:Rillettes, pure pork
 
@@ -52652,6 +54386,7 @@ ciqual_food_name:en:Rillettes, pure pork
 <en:Pork rillettes
 fr:Rillettes du Mans
 en:Rillettes from Mans
+agribalyse_food_code:en:8015
 ciqual_food_code:en:8015
 ciqual_food_name:en:Rillettes from Mans
 
@@ -52661,6 +54396,7 @@ fr:Rillettes de Tours
 protected_name_file_number:en: PGI-FR-0845
 protected_name_type:en: pgi
 origins:en: en:France, fr:Tours
+agribalyse_food_code:en:8010
 ciqual_food_code:en:8010
 ciqual_food_name:en:Rillettes from Tours
 
@@ -52693,6 +54429,7 @@ en:Fish rillettes
 de:Fisch-Rillettes
 fr:Rillettes de poissons, rillettes de poisson
 nl:Visrillettes
+agribalyse_food_code:en:8080
 ciqual_food_code:en:8080
 ciqual_food_name:en:Rillette, fish
 ciqual_food_name:fr:Rillettes de poisson
@@ -52723,6 +54460,7 @@ fr:Rillettes de cabillaud, Rillettes de morue
 <en:Fish rillettes
 en:Mackerel rillettes
 fr:Rillettes de maquereau
+agribalyse_food_code:en:8083
 ciqual_food_code:en:8083
 ciqual_food_name:en:Rillettes, mackerel
 
@@ -52737,6 +54475,7 @@ fr:Rillettes de sardine
 en:Salmon Rillettes
 fr:Rillettes de saumon
 nl:Zalmrillettes
+agribalyse_food_code:en:8081
 ciqual_food_code:en:8081
 ciqual_food_name:en:Rillettes, salmon
 
@@ -52784,6 +54523,7 @@ ciqual_food_name:fr:Saucisse (aliment moyen)
 <en:Sausages
 en:Raw sausage meat with pure pork
 fr:Chair à saucisse pur porc crue
+agribalyse_food_code:en:30051
 ciqual_food_code:en:30051
 ciqual_food_name:en:Sausage meat, pure pork, raw
 ciqual_food_name:fr:Chair à saucisse, pur porc, crue
@@ -52791,6 +54531,7 @@ ciqual_food_name:fr:Chair à saucisse, pur porc, crue
 <en:Sausages
 en:Ham sausages, Ham sausage
 fr:Saucisses de jambon pur porc, Saucisse de jambon pur porc
+agribalyse_food_code:en:30764
 ciqual_food_code:en:30764
 ciqual_food_name:en:Ham sausage
 ciqual_food_name:fr:Saucisse de jambon pur porc
@@ -52798,6 +54539,7 @@ ciqual_food_name:fr:Saucisse de jambon pur porc
 <en:Sausages
 en:Raw sausage meat with pork and beef
 fr:Chair à saucisse porc et bœuf crue
+agribalyse_food_code:en:30052
 ciqual_food_code:en:30052
 ciqual_food_name:en:Sausage meat, pork and beef, raw
 ciqual_food_name:fr:Chair à saucisse, porc et bœuf, crue
@@ -52805,6 +54547,7 @@ ciqual_food_name:fr:Chair à saucisse, porc et bœuf, crue
 <en:Sausages
 en:Beer sausages, Beer sausage
 fr:Saucisses de bière, Saucisse de bière
+agribalyse_food_code:en:30766
 ciqual_food_code:en:30766
 ciqual_food_name:en:Beer sausage
 ciqual_food_name:fr:Saucisse de bière
@@ -52812,6 +54555,7 @@ ciqual_food_name:fr:Saucisse de bière
 <en:Sausages
 en:Sausage meat raw
 fr:Chair à saucisse crue
+agribalyse_food_code:en:30050
 ciqual_food_code:en:30050
 ciqual_food_name:en:Sausage meat, raw
 
@@ -52835,12 +54579,14 @@ fi:siipikarjamakkarat
 fr:Saucisses de volaille
 hu:Baromfi kolbász
 nl:Gevogelteworst, Gevogelteworsten
+agribalyse_food_code:en:30131
 ciqual_food_code:en:30131
 ciqual_food_name:en:Poultry sausage
 
 <en:Sausages
 en:Poultry sausage delicatessen style
 fr:Saucisse de volaille façon charcutière
+agribalyse_food_code:en:30130
 ciqual_food_code:en:30130
 ciqual_food_name:en:Poultry sausage, delicatessen style
 ciqual_food_name:fr:Saucisse de volaille, façon charcutière
@@ -52850,6 +54596,7 @@ fr:Saucisses cocktail
 nl:Cocktailworstjes
 en:Cocktail sausage
 es:Salchichas cocktail
+agribalyse_food_code:en:30746
 ciqual_food_code:en:30746
 ciqual_food_name:en:Cocktail sausage
 
@@ -52911,6 +54658,7 @@ fr:Saucisses de veau, Saucisse de veau
 
 <en:Sausages
 fr:Merguez, Merguez crue
+agribalyse_food_code:en:30150
 ciqual_food_code:en:30150
 ciqual_food_name:en:Merguez sausage, raw
 ciqual_food_name:fr:Merguez, crue
@@ -52933,6 +54681,7 @@ nl:Rundvlees-merguez
 <fr:Merguez
 en:Raw pure beef merguez sausage
 fr:Merguez pur bœuf crue
+agribalyse_food_code:en:30152
 ciqual_food_code:en:30152
 ciqual_food_name:en:Merguez sausage, pure beef, raw
 ciqual_food_name:fr:Merguez, pur bœuf, crue
@@ -52940,6 +54689,7 @@ ciqual_food_name:fr:Merguez, pur bœuf, crue
 <fr:Merguez
 en:Cooked beef and mutton merguez sausages
 fr:Merguez de boeuf et mouton cuites
+agribalyse_food_code:en:30155
 ciqual_food_code:en:30155
 ciqual_food_name:en:Merguez sausage, beef and mutton, cooked
 ciqual_food_name:fr:Merguez, boeuf et mouton, cuite
@@ -52947,6 +54697,7 @@ ciqual_food_name:fr:Merguez, boeuf et mouton, cuite
 <fr:Merguez
 en:Raw beef and mutton merguez sausages
 fr:Merguez de boeuf et mouton crues
+agribalyse_food_code:en:30156
 ciqual_food_code:en:30156
 ciqual_food_name:en:Merguez sausage, beef and mutton, raw
 ciqual_food_name:fr:Merguez, boeuf et mouton, crue
@@ -52954,6 +54705,7 @@ ciqual_food_name:fr:Merguez, boeuf et mouton, crue
 <fr:Merguez
 en:Raw beef mutton and pork merguez sausage
 fr:Merguez bœuf mouton et porc crue
+agribalyse_food_code:en:30154
 ciqual_food_code:en:30154
 ciqual_food_name:en:Merguez sausage, beef, mutton and pork, raw
 ciqual_food_name:fr:Merguez, bœuf, mouton et porc, crue
@@ -52961,6 +54713,7 @@ ciqual_food_name:fr:Merguez, bœuf, mouton et porc, crue
 <fr:Merguez
 en:Raw pork and beef merguez sausage
 fr:Merguez de porc et bœuf crue
+agribalyse_food_code:en:30153
 ciqual_food_code:en:30153
 ciqual_food_name:en:Merguez sausage, pork and beef, raw
 ciqual_food_name:fr:Merguez, porc et bœuf, crue
@@ -52970,6 +54723,7 @@ en:Saveloy, Cervelat
 fr:Cervelas
 de:Zervelatwurst
 wikidata:en:Q673154
+agribalyse_food_code:en:30730
 ciqual_food_code:en:30730
 ciqual_food_name:en:Saveloy or cervelat
 ciqual_food_name:fr:Cervelas
@@ -52977,6 +54731,7 @@ ciqual_food_name:fr:Cervelas
 <en:Sausages
 en:Saveloy from Obernai Alsace, Cervelas from Obernai Alsace
 fr:Cervelas d'Alsace, cervelas obernois, Cervelas à l'alsacienne
+agribalyse_food_code:en:30731
 ciqual_food_code:en:30731
 ciqual_food_name:en:Saveloy or cervelat (from Obernai Alsace)
 ciqual_food_name:fr:Cervelas obernois
@@ -52984,6 +54739,7 @@ ciqual_food_name:fr:Cervelas obernois
 <en:Sausages
 en:Pure pork saveloy with garlic, Pure pork cervelat with garlic
 fr:Cervelas à l'ail pur porc
+agribalyse_food_code:en:30732
 ciqual_food_code:en:30732
 ciqual_food_name:en:Saveloy or cervelat, pure pork with garlic
 ciqual_food_name:fr:Cervelas à l'ail, pur porc
@@ -52992,6 +54748,7 @@ ciqual_food_name:fr:Cervelas à l'ail, pur porc
 <fr:Cervelas
 en:Braised pork brain
 fr:Cervelle de porc braisée
+agribalyse_food_code:en:40004
 ciqual_food_code:en:40004
 ciqual_food_name:en:Brain, pork, braised
 ciqual_food_name:fr:Cervelle, porc, braisée
@@ -52999,6 +54756,7 @@ ciqual_food_name:fr:Cervelle, porc, braisée
 <fr:Cervelas
 en:Raw pork brain
 fr:Cervelle de porc crue
+agribalyse_food_code:en:40005
 ciqual_food_code:en:40005
 ciqual_food_name:en:Brain, pork, raw
 ciqual_food_name:fr:Cervelle, porc, crue
@@ -53018,6 +54776,7 @@ en:Frankfurter sausages, Frankfurter sausage
 fr:Saucisses de Francfort, Saucisse de Francfort
 es:salchichas Frankfurt, frankfurt
 nl:Frankfurter worsten
+agribalyse_food_code:en:30134
 ciqual_food_code:en:30134
 ciqual_food_name:en:Frankfurter sausage
 ciqual_food_name:fr:Saucisse de Francfort
@@ -53035,6 +54794,7 @@ fr:Saucisses de foie
 hu:Májkolbászok
 nl:Leverworst
 wikidata:en:Q1570466
+agribalyse_food_code:en:30176
 ciqual_food_code:en:30176
 ciqual_food_name:en:Liver sausage
 ciqual_food_name:fr:Saucisse de foie
@@ -53089,6 +54849,7 @@ fr:Chipolatas aux herbes, Chipolats herbes
 <fr:Chipolatas
 en:Raw chipolata slim sausage
 fr:Chipolata crue
+agribalyse_food_code:en:30115
 ciqual_food_code:en:30115
 ciqual_food_name:en:Chipolata slim sausage, raw
 ciqual_food_name:fr:Chipolata, crue
@@ -53096,6 +54857,7 @@ ciqual_food_name:fr:Chipolata, crue
 <fr:Chipolatas
 en:Cooked chipolata sausages
 fr:Chipolatas cuites
+agribalyse_food_code:en:30005
 ciqual_food_code:en:30005
 ciqual_food_name:en:Chipolata sausage, cooked
 ciqual_food_name:fr:Chipolata, cuite
@@ -53111,6 +54873,7 @@ fr:Diot de Savoie
 <fr:Diot de Savoie
 en:Raw Diot, Raw sausage from Savoy
 fr:Diot cru
+agribalyse_food_code:en:30177
 ciqual_food_code:en:30177
 ciqual_food_name:en:Diot (sausage from Savoy), raw
 ciqual_food_name:fr:Diot, cru
@@ -53132,6 +54895,7 @@ fr:Saucisses de foie alsacienne
 <en:French sausages
 en:Smoked Alsatian sausage or Landjäger
 fr:Saucisse alsacienne fumée, Gendarme fumé
+agribalyse_food_code:en:30125
 ciqual_food_code:en:30125
 ciqual_food_name:en:Smoked Alsatian sausage or Landjäger
 
@@ -53167,6 +54931,7 @@ nl:Worst uit Montbéliard
 protected_name_file_number:en: PGI-FR-0869
 protected_name_type:en: pgi
 origins:en: en:France, fr:Montbéliard
+agribalyse_food_code:en:30105
 ciqual_food_code:en:30105
 ciqual_food_name:en:Montbeliard sausage
 
@@ -53177,6 +54942,7 @@ nl:Worst uit Morteau, Worsten uit Morteau
 protected_name_file_number:en: PGI-FR-0556
 protected_name_type:en: pgi
 origins:en: en:France
+agribalyse_food_code:en:30104
 ciqual_food_code:en:30104
 ciqual_food_name:en:Morteaux sausage
 
@@ -53186,6 +54952,7 @@ de:Straßburger Würstchen
 es:Salchichas de estrasburgo
 fr:Saucisses de Strasbourg, Knacks
 nl:Worst uit Straatsburg
+agribalyse_food_code:en:30742
 ciqual_food_code:en:30742
 ciqual_food_name:en:Strasbourg sausage
 
@@ -53204,6 +54971,7 @@ nl:Worsten uit Toulouse, Toulouseworsten
 <en:French sausages
 en:Raw Toulouse sausages
 fr:Saucisse de Toulouse crue
+agribalyse_food_code:en:30110
 ciqual_food_code:en:30110
 ciqual_food_name:en:Toulouse sausage, raw
 ciqual_food_name:fr:Saucisse de Toulouse, crue
@@ -53211,6 +54979,7 @@ ciqual_food_name:fr:Saucisse de Toulouse, crue
 <en:French sausages
 en:Cooked Toulouse sausage
 fr:Saucisses de Toulouse cuites
+agribalyse_food_code:en:30011
 ciqual_food_code:en:30011
 ciqual_food_name:en:Toulouse sausage, cooked
 ciqual_food_name:fr:Saucisse de Toulouse, cuite
@@ -53226,6 +54995,7 @@ fr:Diots, Diot
 <en:French sausages
 en:Raw Viennese pork and veal sausages
 fr:Saucisses viennoises crues
+agribalyse_food_code:en:30750
 ciqual_food_code:en:30750
 ciqual_food_name:en:Viennese sausage, pork and veal, raw
 ciqual_food_name:fr:Saucisse viennoise, crue
@@ -53261,6 +55031,7 @@ origins:en: en:France
 <fr:Boudins blancs
 en:Raw truffled white pudding
 fr:Boudin blanc truffé cru
+agribalyse_food_code:en:8803
 ciqual_food_code:en:8803
 ciqual_food_name:en:White pudding, truffled, raw
 ciqual_food_name:fr:Boudin blanc truffé, cru
@@ -53277,6 +55048,7 @@ wikidata:en:Q154482
 <en:Black pudding
 en:Refrigerated black pudding, Refrigerated blood sausage
 fr:Boudin noir rayon frais
+agribalyse_food_code:en:8703
 ciqual_food_code:en:8703
 ciqual_food_name:en:Black pudding (blood sausage), refrigerated
 ciqual_food_name:fr:Boudin noir, rayon frais
@@ -53307,18 +55079,21 @@ fr:Charcuteries cuites, Charcuterie cuite
 <fr:Charcuteries cuites
 en:Pâté in crust
 fr:Pâté en croûte
+agribalyse_food_code:en:8391
 ciqual_food_code:en:8391
 ciqual_food_name:en:Pâté in crust
 
 <fr:Charcuteries cuites
 en:Morteaux sausage boiled/cooked in water
 fr:Saucisse de Morteau bouillie
+agribalyse_food_code:en:30108
 ciqual_food_code:en:30108
 ciqual_food_name:en:Morteaux sausage, boiled/cooked in water
 
 <fr:Charcuteries cuites
 en:Swiss sausage intended to be cook
 fr:Saucisse suisse à cuire
+agribalyse_food_code:en:30118
 ciqual_food_code:en:30118
 ciqual_food_name:en:Swiss sausage, intended to be cook
 
@@ -53329,24 +55104,28 @@ fi:mortadella
 fr:Mortadelle
 nl:Mortadella
 wikidata:en:Q169757
+agribalyse_food_code:en:30789
 ciqual_food_code:en:30789
 ciqual_food_name:en:Mortadella
 
 <fr:Charcuteries cuites
 en:Mortadella pure pork
 fr:Mortadelle pur porc
+agribalyse_food_code:en:30790
 ciqual_food_code:en:30790
 ciqual_food_name:en:Mortadella, pure pork
 
 <fr:Charcuteries cuites
 en:Pork and beef mortadella
 fr:Mortadelle porc et boeuf
+agribalyse_food_code:en:30791
 ciqual_food_code:en:30791
 ciqual_food_name:en:Pork and beef mortadella
 
 <fr:Charcuteries cuites
 en:Mortadella with pistachios pure pork
 fr:Mortadelle pistachée pur porc
+agribalyse_food_code:en:30797
 ciqual_food_code:en:30797
 ciqual_food_name:en:Mortadella with pistachios, pure pork
 
@@ -53360,6 +55139,7 @@ fr:Andouillettes de Troyes
 <fr:Andouillettes
 en:Raw chitterling sausage from Troyes
 fr:Andouillette de Troyes crue
+agribalyse_food_code:en:8552
 ciqual_food_code:en:8552
 ciqual_food_name:en:Chitterling sausage from Troyes, raw
 ciqual_food_name:fr:Andouillette de Troyes, crue
@@ -53405,6 +55185,7 @@ wikidata:en:Q3217888
 <en:Lardons
 en:Raw lardoons
 fr:Lardons nature crus
+agribalyse_food_code:en:28501
 ciqual_food_code:en:28501
 ciqual_food_name:en:Lardoons, raw
 ciqual_food_name:fr:Lardon nature, cru
@@ -53412,6 +55193,7 @@ ciqual_food_name:fr:Lardon nature, cru
 <en:Lardons
 en:Lardoons cooked
 fr:Lardons nature cuits
+agribalyse_food_code:en:28504
 ciqual_food_code:en:28504
 ciqual_food_name:en:Cooked lardoons
 ciqual_food_name:fr:Lardon nature, cuit
@@ -53422,6 +55204,7 @@ de:Räucherspeck
 es:Lardones ahumados
 fr:Lardons de porc fumés, Lardons fumés cuits
 nl:Gerookte spekjes
+agribalyse_food_code:en:28725
 ciqual_food_code:en:28725
 ciqual_food_name:en:Smoked lardoons, cooked
 ciqual_food_name:fr:Lardon fumé, cuit
@@ -53429,6 +55212,7 @@ ciqual_food_name:fr:Lardon fumé, cuit
 <en:Lardons
 en:Raw smoked lardoons
 fr:Lardons fumés crus
+agribalyse_food_code:en:28720
 ciqual_food_code:en:28720
 ciqual_food_name:en:Smoked lardoons, raw
 ciqual_food_name:fr:Lardon fumé, cru
@@ -53446,6 +55230,7 @@ en:Head cheese, Head-cheese pâté, Brawn pâté
 fr:Pâtés de tête, Pâté de tête, Fromage de tête
 nl:Hoofdkazen
 wikidata:en:Q4675762
+agribalyse_food_code:en:8400
 ciqual_food_code:en:8400
 ciqual_food_name:en:Head-cheese pâté or brawn
 ciqual_food_name:fr:Fromage de tête
@@ -53453,6 +55238,7 @@ ciqual_food_name:fr:Fromage de tête
 <fr:Pâté
 en:Country-style pâté with mushrooms
 fr:Pâté forestier, Terrine forestière, Pâté aux champignons, Terrine aux champignons
+agribalyse_food_code:en:8250
 ciqual_food_code:en:8250
 ciqual_food_name:en:Country-style pâté with mushrooms
 ciqual_food_name:fr:Pâté ou terrine aux champignons (forestier)
@@ -53460,6 +55246,7 @@ ciqual_food_name:fr:Pâté ou terrine aux champignons (forestier)
 <fr:Pâté
 en:Pâté w green pepper
 fr:Pâté au poivre vert
+agribalyse_food_code:en:8201
 ciqual_food_code:en:8201
 ciqual_food_name:en:Pâté w green pepper
 
@@ -53476,6 +55263,7 @@ es:Patés de hígado de cerdo
 fr:Pâtés de foie de porc
 pt:Patês de figado de porco
 ro:Pate de ficat de porc, Pate din ficat de porc
+agribalyse_food_code:en:8305
 ciqual_food_code:en:8305
 ciqual_food_name:en:Pork liver pâté
 
@@ -53486,36 +55274,42 @@ de:Bauernpasteten
 fi:maaseutupateet
 fr:Pâtés de campagne
 nl:Landelijke pasteien
+agribalyse_food_code:en:8211
 ciqual_food_code:en:8211
 ciqual_food_name:en:Country-style pâté or terrine
 
 <fr:Pâté
 en:Pork liver pâté superior quality
 fr:Pâté de foie de porc supérieur
+agribalyse_food_code:en:8300
 ciqual_food_code:en:8300
 ciqual_food_name:en:Pork liver pâté, superior quality
 
 <fr:Pâté
 en:Breton pâté
 fr:Pâté breton
+agribalyse_food_code:en:8214
 ciqual_food_code:en:8214
 ciqual_food_name:en:Breton pâté
 
 <fr:Pâté
 en:Game pâté
 fr:Pâté de gibier
+agribalyse_food_code:en:8245
 ciqual_food_code:en:8245
 ciqual_food_name:en:Game pâté
 
 <fr:Pâté
 en:Poultry liver pâté
 fr:Pâté de foie de volaille
+agribalyse_food_code:en:8316
 ciqual_food_code:en:8316
 ciqual_food_name:en:Poultry liver pâté
 
 <fr:Pâté
 en:Goose liver pâté
 fr:Pâté de foie d'oie
+agribalyse_food_code:en:8326
 ciqual_food_code:en:8326
 ciqual_food_name:en:Goose liver pâté
 
@@ -53525,6 +55319,7 @@ de:Kaninchenpasteten
 fr:Pâtés de lapin
 nl:Konijnpaté
 ro:Pateu de iepure
+agribalyse_food_code:en:8240
 ciqual_food_code:en:8240
 ciqual_food_name:en:Rabbit pâté
 
@@ -53553,6 +55348,7 @@ fr:Mousse de raifort
 fr:Mousses de canard, mousses de canards, mousse de canards, mousse de canard
 nl:Eendemoussen
 en:Duck mousse
+agribalyse_food_code:en:8315
 ciqual_food_code:en:8315
 ciqual_food_name:en:Duck mousse
 
@@ -53640,24 +55436,28 @@ wikipedia:en:https://en.wikipedia.org/wiki/Chorizo
 # ingredient/fr:chorizo has 210 products in 6 languages @2019-04-24
 # category/fr:chorizos has 267 products @2019-05-19
 # usage:fr:chorizo (maigre et gras de porc, sel, épices et extraits d'épices, dextrose de blé, ferments lactiques, conservateurs :E301, E250)
+agribalyse_food_code:en:30315
 ciqual_food_code:en:30315
 ciqual_food_name:en:Spicy pork sausage with red pepper, no precision
 
 <en:chorizo
 en:Spicy pork sausage with red pepper in large slices
 fr:Chorizo supérieur doux ou fort type charcuterie en tranches
+agribalyse_food_code:en:30317
 ciqual_food_code:en:30317
 ciqual_food_name:en:Spicy pork sausage with red pepper, in large slices
 
 <en:chorizo
 en:Dry spicy pork sausage with red pepper
 fr:Chorizo supérieur doux ou fort
+agribalyse_food_code:en:30316
 ciqual_food_code:en:30316
 ciqual_food_name:en:Dry spicy pork sausage with red pepper
 
 <fr:Saucissons
 fr:Rosettes, rosette, rosette de Lyon
 en:Rosette dry sausage
+agribalyse_food_code:en:30304
 ciqual_food_code:en:30304
 ciqual_food_name:en:Rosette dry sausage
 
@@ -53668,12 +55468,14 @@ fi:salami
 fr:Salamis, Salami
 hu:Szalámi
 nl:Salamis
+agribalyse_food_code:en:30350
 ciqual_food_code:en:30350
 ciqual_food_name:en:Salami
 
 <fr:Saucissons
 en:Salami pork and beef
 fr:Salami porc et boeuf
+agribalyse_food_code:en:30352
 ciqual_food_code:en:30352
 ciqual_food_name:en:Salami, pork and beef
 
@@ -53681,12 +55483,14 @@ ciqual_food_name:en:Salami, pork and beef
 en:Pork salami
 fi:Sianlihasalami
 fr:Salami de porc
+agribalyse_food_code:en:30351
 ciqual_food_code:en:30351
 ciqual_food_name:en:Salami, pure pork
 
 <en:Salami
 en:Salami Danish-style
 fr:Salami type danois
+agribalyse_food_code:en:30366
 ciqual_food_code:en:30366
 ciqual_food_name:en:Salami, Danish-style
 
@@ -53715,18 +55519,21 @@ origins:en: en:France, fr:Ardèche
 <fr:Saucissons
 fr:Saucisses sèches, Saucisse sèche
 nl:Gedroogde worsten
+agribalyse_food_code:en:30309
 ciqual_food_code:en:30309
 ciqual_food_name:en:Sausage, dried
 
 <fr:Saucissons
 en:Sausage from Paris
 fr:Saucisson de Paris
+agribalyse_food_code:en:30705
 ciqual_food_code:en:30705
 ciqual_food_name:en:Sausage from Paris
 
 <fr:Saucissons
 en:Sausage from Paris smoked
 fr:Saucisson de Paris fumé
+agribalyse_food_code:en:30706
 ciqual_food_code:en:30706
 ciqual_food_name:en:Sausage from Paris, smoked
 
@@ -53734,6 +55541,7 @@ ciqual_food_name:en:Sausage from Paris, smoked
 fr:Saucissons à l’ail, saucisson à l’ail
 en:Garlic sausage
 nl:Knoflookworstjes
+agribalyse_food_code:en:30700
 ciqual_food_code:en:30700
 ciqual_food_name:en:Garlic sausage
 ciqual_food_name:fr:Saucisson à l'ail
@@ -53746,6 +55554,7 @@ nl:Gebakken worstjes
 fr:Saucissons secs, Saucisson sec
 nl:Droge worstjes
 en:Dry sausage
+agribalyse_food_code:en:30300
 ciqual_food_code:en:30300
 ciqual_food_name:en:Dry sausage
 
@@ -53753,12 +55562,14 @@ ciqual_food_name:en:Dry sausage
 fr:Saucissons secs pur porc, saucisson sec pur porc
 nl:Droge varkensworstjes
 en:Dry sausage pure pork
+agribalyse_food_code:en:30301
 ciqual_food_code:en:30301
 ciqual_food_name:en:Dry sausage, pure pork
 
 <fr:Saucissons secs
 en:Dry sausage pure pork superior quality
 fr:Saucisson sec pur porc qualité supérieure
+agribalyse_food_code:en:30302
 ciqual_food_code:en:30302
 ciqual_food_name:en:Dry sausage, pure pork, superior quality
 
@@ -53776,6 +55587,7 @@ origins:en: en:France, fr:Corse
 
 <fr:Saucissons secs
 fr:Saucissons secs aux noisettes
+agribalyse_food_code:en:30311
 ciqual_food_code:en:30311
 ciqual_food_name:en:Dry sausage w walnuts and/or hazelnuts
 
@@ -53827,6 +55639,7 @@ en:Tuna rillettes
 es:Rillettes De atún
 fr:Rillettes de thon
 nl:Tonijnrillettes, tonijnrillette
+agribalyse_food_code:en:8082
 ciqual_food_code:en:8082
 ciqual_food_name:en:Rillettes, tuna
 ciqual_food_name:fr:Rillettes de thon
@@ -53835,6 +55648,7 @@ ciqual_food_name:fr:Rillettes de thon
 <en:Fish rillettes
 en:Tuna in Catalan-style or in tomato sauce canned
 fr:Thon à la catalane
+agribalyse_food_code:en:26243
 ciqual_food_code:en:26243
 ciqual_food_name:en:Tuna, in Catalan-style or in tomato sauce, canned
 
@@ -53845,6 +55659,7 @@ fr:Viandes de mouton
 <en:sheep meat
 en:Raw mutton leg
 fr:Gigot de mouton cru
+agribalyse_food_code:en:21006
 ciqual_food_code:en:21006
 ciqual_food_name:en:Mutton, leg, raw
 ciqual_food_name:fr:Mouton, gigot, cru
@@ -53852,6 +55667,7 @@ ciqual_food_name:fr:Mouton, gigot, cru
 <en:sheep meat
 en:Raw sheep foot
 fr:Pied de mouton cru
+agribalyse_food_code:en:21004
 ciqual_food_code:en:21004
 ciqual_food_name:en:Sheep, foot, raw
 ciqual_food_name:fr:Mouton, pied, cru
@@ -53859,6 +55675,7 @@ ciqual_food_name:fr:Mouton, pied, cru
 <en:sheep meat
 en:Raw sheep head
 fr:Tête de mouton crue
+agribalyse_food_code:en:21005
 ciqual_food_code:en:21005
 ciqual_food_name:en:Sheep, head, raw
 ciqual_food_name:fr:Mouton, tête, crue
@@ -53866,6 +55683,7 @@ ciqual_food_name:fr:Mouton, tête, crue
 <en:sheep meat
 en:Raw mutton meat
 fr:Viande de mouton crue
+agribalyse_food_code:en:21001
 ciqual_food_code:en:21001
 ciqual_food_name:en:Mutton, meat, raw
 ciqual_food_name:fr:Mouton, viande, crue
@@ -53873,6 +55691,7 @@ ciqual_food_name:fr:Mouton, viande, crue
 <en:sheep meat
 en:Raw mutton shoulder
 fr:Epaule de mouton crue
+agribalyse_food_code:en:21003
 ciqual_food_code:en:21003
 ciqual_food_name:en:Mutton, shoulder, raw
 ciqual_food_name:fr:Mouton, épaule, crue
@@ -53909,6 +55728,7 @@ ciqual_food_name:fr:Agneau, côte ou côtelette, grillée/poêlée (aliment moye
 <en:Grilled lamb chops
 en:Grilled lamb cutlet
 fr:Côtelette d'agneau grillée
+agribalyse_food_code:en:21501
 ciqual_food_code:en:21501
 ciqual_food_name:en:Lamb cutlet, grilled
 ciqual_food_name:fr:Agneau, côtelette, grillée
@@ -53923,6 +55743,7 @@ ciqual_food_name:fr:Agneau, côte ou côtelette, crue (aliment moyen)
 <en:Lamb meat
 en:Raw lamb cutlet
 fr:Côtelette d'agneau crue
+agribalyse_food_code:en:21500
 ciqual_food_code:en:21500
 ciqual_food_name:en:Lamb, cutlet, raw
 ciqual_food_name:fr:Agneau, côtelette, crue
@@ -54006,6 +55827,7 @@ fr:Ris d'agneau
 <fr:Ris d'agneau
 en:Cooked lamb sweetbread
 fr:Ris d'agneau cuit
+agribalyse_food_code:en:40303
 ciqual_food_code:en:40303
 ciqual_food_name:en:Sweetbread, lamb, cooked
 ciqual_food_name:fr:Ris, agneau, cuit
@@ -54013,6 +55835,7 @@ ciqual_food_name:fr:Ris, agneau, cuit
 <fr:Ris d'agneau
 en:Raw lamb sweetbread
 fr:Ris d'agneau cru
+agribalyse_food_code:en:40302
 ciqual_food_code:en:40302
 ciqual_food_name:en:Sweetbread, lamb, raw
 ciqual_food_name:fr:Ris, agneau, cru
@@ -54020,6 +55843,7 @@ ciqual_food_name:fr:Ris, agneau, cru
 <en:Lamb meat
 en:Raw lamb chop fillet
 fr:Filet de côte d'agneau crue
+agribalyse_food_code:en:21516
 ciqual_food_code:en:21516
 ciqual_food_name:en:Lamb, chop fillet, raw
 ciqual_food_name:fr:Agneau, côte filet, crue
@@ -54027,6 +55851,7 @@ ciqual_food_name:fr:Agneau, côte filet, crue
 <en:Grilled lamb chops
 en:Grilled lamb chop fillet, Pan-fried lamb chop fillet
 fr:Côte de filet d'agneau grillée, Côte de filet d'agneau poêlée
+agribalyse_food_code:en:21509
 ciqual_food_code:en:21509
 ciqual_food_name:en:Lamb, chop fillet, grilled/pan-fried
 ciqual_food_name:fr:Agneau, côte filet, grillée/poêlée
@@ -54034,6 +55859,7 @@ ciqual_food_name:fr:Agneau, côte filet, grillée/poêlée
 <en:Grilled lamb chops
 en:Chop grilled lamb rib, Pan-fried lamb rib
 fr:Côte première d'agneau grillée, Côte première d'agneau poêlée
+agribalyse_food_code:en:21512
 ciqual_food_code:en:21512
 ciqual_food_name:en:Lamb, rib chop, grilled/pan-fried
 ciqual_food_name:fr:Agneau, côte première, grillée/poêlée
@@ -54041,6 +55867,7 @@ ciqual_food_name:fr:Agneau, côte première, grillée/poêlée
 <en:Lamb meat
 en:Raw lamb rib chop
 fr:Côte d'agneau première crue
+agribalyse_food_code:en:21517
 ciqual_food_code:en:21517
 ciqual_food_name:en:Lamb, rib chop, raw
 ciqual_food_name:fr:Agneau, côte première, crue
@@ -54048,6 +55875,7 @@ ciqual_food_name:fr:Agneau, côte première, crue
 <en:Cooked lamb meat
 en:Grilled lamb leg, Pan-fried lamb leg
 fr:Gigot d'agneau grillé, Gigot d'agneau poêlé
+agribalyse_food_code:en:21518
 ciqual_food_code:en:21518
 ciqual_food_name:en:Lamb, leg, grilled/pan-fried
 ciqual_food_name:fr:Agneau, gigot, grillé/poêlé
@@ -54055,6 +55883,7 @@ ciqual_food_name:fr:Agneau, gigot, grillé/poêlé
 <en:Lamb meat
 en:Raw lamb leg
 fr:Gigot d'agneau cru
+agribalyse_food_code:en:21502
 ciqual_food_code:en:21502
 ciqual_food_name:en:Lamb, leg, raw
 ciqual_food_name:fr:Agneau, gigot, cru
@@ -54062,6 +55891,7 @@ ciqual_food_name:fr:Agneau, gigot, cru
 <en:Lamb meat
 en:Raw lamb saddle
 fr:Selle d'agneau crue
+agribalyse_food_code:en:21515
 ciqual_food_code:en:21515
 ciqual_food_name:en:Lamb, saddle, raw
 ciqual_food_name:fr:Agneau, selle, crue
@@ -54069,6 +55899,7 @@ ciqual_food_name:fr:Agneau, selle, crue
 <en:Cooked lamb meat
 en:Grilled lamb saddle, Pan-fried lamb saddle
 fr:Selle d'agneau partie maigre grillée, Selle d'agneau partie maigre poêlée
+agribalyse_food_code:en:21520
 ciqual_food_code:en:21520
 ciqual_food_name:en:Lamb, saddle, grilled/pan-fried
 ciqual_food_name:fr:Agneau, selle, partie maigre, grillée/poêlée
@@ -54076,6 +55907,7 @@ ciqual_food_name:fr:Agneau, selle, partie maigre, grillée/poêlée
 <en:Cooked lamb meat
 en:Roasted lean lamb saddle, Baked lean lamb saddle
 fr:Selle d'agneau partie maigre rôtie, Selle d'agneau partie maigre cuite au four
+agribalyse_food_code:en:21513
 ciqual_food_code:en:21513
 ciqual_food_name:en:Lamb, saddle, lean, roasted/baked
 ciqual_food_name:fr:Agneau, selle, partie maigre, rôtie/cuite au four
@@ -54083,6 +55915,7 @@ ciqual_food_name:fr:Agneau, selle, partie maigre, rôtie/cuite au four
 <en:Cooked lamb meat
 en:Roasted lamb leg, Baked lamb leg
 fr:Gigot d'agneau rôti au four, Gigot d'agneau cuit au four
+agribalyse_food_code:en:21503
 ciqual_food_code:en:21503
 ciqual_food_name:en:Lamb, leg, roasted/baked
 ciqual_food_name:fr:Agneau, gigot, rôti/cuit au four
@@ -54090,6 +55923,7 @@ ciqual_food_name:fr:Agneau, gigot, rôti/cuit au four
 <en:Cooked lamb meat
 en:Braised lamb leg
 fr:Gigot d'agneau braisé
+agribalyse_food_code:en:21519
 ciqual_food_code:en:21519
 ciqual_food_name:en:Lamb, leg, braised
 ciqual_food_name:fr:Agneau, gigot, braisé
@@ -54097,6 +55931,7 @@ ciqual_food_name:fr:Agneau, gigot, braisé
 <en:Cooked lamb meat
 en:Braised lamb neck, Boiled lamb neck
 fr:Collier d'agneau braisé, Collier d'agneau bouilli
+agribalyse_food_code:en:21508
 ciqual_food_code:en:21508
 ciqual_food_name:en:Lamb, neck, braised or boiled
 ciqual_food_name:fr:Agneau, collier, braisé ou bouilli
@@ -54104,6 +55939,7 @@ ciqual_food_name:fr:Agneau, collier, braisé ou bouilli
 <en:Cooked lamb meat
 en:Raw lamb neck
 fr:Collier d'agneau cru
+agribalyse_food_code:en:21514
 ciqual_food_code:en:21514
 ciqual_food_name:en:Lamb, neck, raw
 ciqual_food_name:fr:Agneau, collier, cru
@@ -54112,6 +55948,7 @@ ciqual_food_name:fr:Agneau, collier, cru
 <en:Meat skewers
 en:Lamb on skewer
 fr:Brochette d'agneau
+agribalyse_food_code:en:25541
 ciqual_food_code:en:25541
 ciqual_food_name:en:Lamb on skewer
 ciqual_food_name:fr:Brochette d'agneau
@@ -54202,6 +56039,7 @@ origins:en: en:France
 <en:Lamb meat
 en:Cooked lamb brains
 fr:Cervelles d'agneau cuites
+agribalyse_food_code:en:40003
 ciqual_food_code:en:40003
 ciqual_food_name:en:Brain, lamb, cooked
 ciqual_food_name:fr:Cervelle, agneau, cuite
@@ -54209,6 +56047,7 @@ ciqual_food_name:fr:Cervelle, agneau, cuite
 <en:Lamb meat
 en:Raw lamb brain
 fr:Cervelle d'agneau crue
+agribalyse_food_code:en:40002
 ciqual_food_code:en:40002
 ciqual_food_name:en:Brain, lamb, raw
 ciqual_food_name:fr:Cervelle, agneau, crue
@@ -54216,6 +56055,7 @@ ciqual_food_name:fr:Cervelle, agneau, crue
 <en:Cooked lamb meat
 en:Cooked lamb hearts
 fr:Coeurs d'agneau cuits
+agribalyse_food_code:en:40059
 ciqual_food_code:en:40059
 ciqual_food_name:en:Heart, lamb, cooked
 ciqual_food_name:fr:Coeur, agneau, cuit
@@ -54223,6 +56063,7 @@ ciqual_food_name:fr:Coeur, agneau, cuit
 <en:Lamb meat
 en:Raw lamb heart
 fr:Coeur d'agneau cru
+agribalyse_food_code:en:40058
 ciqual_food_code:en:40058
 ciqual_food_name:en:Heart, lamb, raw
 ciqual_food_name:fr:Coeur, agneau, cru
@@ -54230,6 +56071,7 @@ ciqual_food_name:fr:Coeur, agneau, cru
 <en:Cooked lamb meat
 en:Cooked lamb liver
 fr:Foie d'agneau cuit
+agribalyse_food_code:en:40103
 ciqual_food_code:en:40103
 ciqual_food_name:en:Liver, lamb, cooked
 ciqual_food_name:fr:Foie, agneau, cuit
@@ -54237,6 +56079,7 @@ ciqual_food_name:fr:Foie, agneau, cuit
 <en:Lamb meat
 en:Raw lamb liver
 fr:Foie d'agneau cru
+agribalyse_food_code:en:40102
 ciqual_food_code:en:40102
 ciqual_food_name:en:Liver, lamb, raw
 ciqual_food_name:fr:Foie, agneau, cru
@@ -54245,6 +56088,7 @@ ciqual_food_name:fr:Foie, agneau, cru
 <en:Cooked kidneys
 en:Braised lamb kidneys
 fr:Rognons d'agneau braisés
+agribalyse_food_code:en:40406
 ciqual_food_code:en:40406
 ciqual_food_name:en:Kidney, lamb, braised
 ciqual_food_name:fr:Rognon, agneau, braisé
@@ -54252,6 +56096,7 @@ ciqual_food_name:fr:Rognon, agneau, braisé
 <en:Lamb meat
 en:Raw lamb kidneys
 fr:Rognons d'agneau crus
+agribalyse_food_code:en:40407
 ciqual_food_code:en:40407
 ciqual_food_name:en:Kidney, lamb, raw
 ciqual_food_name:fr:Rognon, agneau, cru
@@ -54259,6 +56104,7 @@ ciqual_food_name:fr:Rognon, agneau, cru
 <en:Cooked lamb meat
 en:Roasted lamb shoulders, baked lamb shoulders
 fr:Epaules rôties d'agneau, Epaules d'agneau cuites au four
+agribalyse_food_code:en:21506
 ciqual_food_code:en:21506
 ciqual_food_name:en:Lamb, shoulder, roasted/baked
 ciqual_food_name:fr:Agneau, épaule, rôtie/cuite au four
@@ -54266,6 +56112,7 @@ ciqual_food_name:fr:Agneau, épaule, rôtie/cuite au four
 <en:Cooked lamb meat
 en:Roasted lean lamb shoulders, Baked lean lamb shoulders
 fr:Epaules d'agneau maigres rôties, Epaules d'agneau maigres cuites au four
+agribalyse_food_code:en:21507
 ciqual_food_code:en:21507
 ciqual_food_name:en:Lamb, shoulder, lean, roasted/baked
 ciqual_food_name:fr:Agneau, épaule, maigre, rôtie/cuite au four
@@ -54273,6 +56120,7 @@ ciqual_food_name:fr:Agneau, épaule, maigre, rôtie/cuite au four
 <en:Lamb meat
 en:Raw lamb shoulder
 fr:Epaule d'agneau crue
+agribalyse_food_code:en:21504
 ciqual_food_code:en:21504
 ciqual_food_name:en:Lamb, shoulder, raw
 ciqual_food_name:fr:Agneau, épaule, crue
@@ -54280,6 +56128,7 @@ ciqual_food_name:fr:Agneau, épaule, crue
 <en:Lamb meat
 en:Raw lean lamb shoulder
 fr:Epaule d'agneau maigre crue
+agribalyse_food_code:en:21505
 ciqual_food_code:en:21505
 ciqual_food_name:en:Lamb, shoulder, lean, raw
 ciqual_food_name:fr:Agneau, épaule, maigre, crue
@@ -54287,6 +56136,7 @@ ciqual_food_name:fr:Agneau, épaule, maigre, crue
 <en:Lamb meat
 en:Stewed lamb garnished with potatoes and other vegetables
 fr:Navarin d'agneau aux légumes
+agribalyse_food_code:en:25124
 ciqual_food_code:en:25124
 ciqual_food_name:en:Stewed lamb garnished with potatoes and other vegetables
 ciqual_food_name:fr:Navarin d'agneau aux légumes
@@ -54304,6 +56154,7 @@ zh:培根, 猪培根, 猪肉培根
 <en:Bacon
 en:Raw rindless pork back fat
 fr:Bardière de porc découennée crue
+agribalyse_food_code:en:28470
 ciqual_food_code:en:28470
 ciqual_food_name:en:Pork, back fat, rindless, raw
 ciqual_food_name:fr:Porc, bardière découennée, crue
@@ -54311,6 +56162,7 @@ ciqual_food_name:fr:Porc, bardière découennée, crue
 <en:Bacon
 en:Raw pork fat
 fr:Lard gras cru
+agribalyse_food_code:en:16530
 ciqual_food_code:en:16530
 ciqual_food_name:en:Pork fat, raw
 ciqual_food_name:fr:Lard gras, cru
@@ -54393,6 +56245,7 @@ ciqual_food_name:fr:Veau, viande, cuite (aliment moyen)
 <en:Cooked veal meat
 en:Pan-fried calf sweetbread, Sautéed calf sweetbread
 fr:Ris de veau braisé, Ris de veau sauté, Ris de veau poêlé
+agribalyse_food_code:en:40305
 ciqual_food_code:en:40305
 ciqual_food_name:en:Sweetbread, calf, sautéed/pan-fried
 ciqual_food_name:fr:Ris, veau, braisé ou sauté/poêlé
@@ -54400,6 +56253,7 @@ ciqual_food_name:fr:Ris, veau, braisé ou sauté/poêlé
 <en:Veal meat
 en:Raw calf sweetbread
 fr:Ris de veau cru
+agribalyse_food_code:en:40304
 ciqual_food_code:en:40304
 ciqual_food_name:en:Sweetbread, calf, raw
 ciqual_food_name:fr:Ris, veau, cru
@@ -54407,6 +56261,7 @@ ciqual_food_name:fr:Ris, veau, cru
 <en:Cooked veal meat
 en:Braised veal knuckle, Braised veal shank, Boiled veal knuckle, Boiled veal shank
 fr:Jarret de veau braisé, Jarret de veau bouilli
+agribalyse_food_code:en:6581
 ciqual_food_code:en:6581
 ciqual_food_name:en:Veal, knuckle or shank, braised or boiled
 ciqual_food_name:fr:Veau, jarret, braisé ou bouilli
@@ -54414,6 +56269,7 @@ ciqual_food_name:fr:Veau, jarret, braisé ou bouilli
 <en:Veal meat
 en:Raw veal knuckle, Raw veal shank
 fr:Jarret de veau cru
+agribalyse_food_code:en:6583
 ciqual_food_code:en:6583
 ciqual_food_name:en:Veal, knuckle or shank, raw
 ciqual_food_name:fr:Veau, jarret, cru
@@ -54421,6 +56277,7 @@ ciqual_food_name:fr:Veau, jarret, cru
 <en:Cooked veal meat
 en:Boiled calf head, Calf head cooked in water
 fr:Tête de veau bouillie, Tête de veau cuite à l'eau
+agribalyse_food_code:en:6582
 ciqual_food_code:en:6582
 ciqual_food_name:en:Calf, head, boiled/cooked in water
 ciqual_food_name:fr:Veau, tête, bouillie/cuite à l'eau
@@ -54428,6 +56285,7 @@ ciqual_food_name:fr:Veau, tête, bouillie/cuite à l'eau
 <en:Cooked veal meat
 en:Braised veal neck, Boiled veal neck
 fr:Collier de veau braisé, Collier de veau bouilli
+agribalyse_food_code:en:6591
 ciqual_food_code:en:6591
 ciqual_food_name:en:Veal, neck, braised or boiled
 ciqual_food_name:fr:Veau, collier, braisé ou bouilli
@@ -54435,6 +56293,7 @@ ciqual_food_name:fr:Veau, collier, braisé ou bouilli
 <en:Veal meat
 en:Raw veal neck
 fr:Collier de veau cru
+agribalyse_food_code:en:6590
 ciqual_food_code:en:6590
 ciqual_food_name:en:Veal, neck, raw
 ciqual_food_name:fr:Veau, collier, cru
@@ -54442,6 +56301,7 @@ ciqual_food_name:fr:Veau, collier, cru
 <en:Cooked veal meat
 en:Grilled veal chop, Pan-fried veal chop
 fr:Côte de veau grillée, Côte de veau poêlée
+agribalyse_food_code:en:6511
 ciqual_food_code:en:6511
 ciqual_food_name:en:Veal, chop, grilled/pan-fried
 ciqual_food_name:fr:Veau, côte, grillée/poêlée
@@ -54449,6 +56309,7 @@ ciqual_food_name:fr:Veau, côte, grillée/poêlée
 <en:Veal meat
 en:Raw veal chop
 fr:Côte de veau crue
+agribalyse_food_code:en:6510
 ciqual_food_code:en:6510
 ciqual_food_name:en:Veal, chop, raw
 ciqual_food_name:fr:Veau, côte, crue
@@ -54457,6 +56318,7 @@ ciqual_food_name:fr:Veau, côte, crue
 <en:Cooked kidneys
 en:Sautéed veal kidney, Pan-fried veal kidney
 fr:Rognons de veau braisés, Rognons de veau sautés, Rognons de veau poêlés
+agribalyse_food_code:en:40408
 ciqual_food_code:en:40408
 ciqual_food_name:en:Kidney, veal, sautéed/pan-fried
 ciqual_food_name:fr:Rognon, veau, braisé ou sauté/poêlé
@@ -54464,6 +56326,7 @@ ciqual_food_name:fr:Rognon, veau, braisé ou sauté/poêlé
 <en:Veal meat
 en:Raw calf kidney
 fr:Rognons de veau crus
+agribalyse_food_code:en:40409
 ciqual_food_code:en:40409
 ciqual_food_name:en:Kidney, calf, raw
 ciqual_food_name:fr:Rognon, veau, cru
@@ -54471,6 +56334,7 @@ ciqual_food_name:fr:Rognon, veau, cru
 <en:Cooked veal meat
 en:Cooked calf brain
 fr:Cervelle de veau cuite
+agribalyse_food_code:en:40007
 ciqual_food_code:en:40007
 ciqual_food_name:en:Brain, calf, cooked
 ciqual_food_name:fr:Cervelle, veau, cuite
@@ -54478,6 +56342,7 @@ ciqual_food_name:fr:Cervelle, veau, cuite
 <en:Veal meat
 en:Raw calf brain
 fr:Cervelle de veau crue
+agribalyse_food_code:en:40006
 ciqual_food_code:en:40006
 ciqual_food_name:en:Brain, calf, raw
 ciqual_food_name:fr:Cervelle, veau, crue
@@ -54485,6 +56350,7 @@ ciqual_food_name:fr:Cervelle, veau, crue
 <en:Cooked veal meat
 en:Cooked calf liver
 fr:Foie de veau cuit
+agribalyse_food_code:en:40107
 ciqual_food_code:en:40107
 ciqual_food_name:en:Liver, calf, cooked
 ciqual_food_name:fr:Foie, veau, cuit
@@ -54492,6 +56358,7 @@ ciqual_food_name:fr:Foie, veau, cuit
 <en:Veal meat
 en:Raw calf liver
 fr:Foie de veau cru
+agribalyse_food_code:en:40106
 ciqual_food_code:en:40106
 ciqual_food_name:en:Liver, calf, raw
 ciqual_food_name:fr:Foie, veau, cru
@@ -54499,6 +56366,7 @@ ciqual_food_name:fr:Foie, veau, cru
 <en:Cooked veal meat
 en:Cooked calf tongue
 fr:Langue de veau cuite
+agribalyse_food_code:en:40201
 ciqual_food_code:en:40201
 ciqual_food_name:en:Tongue, calf, cooked
 ciqual_food_name:fr:Langue, veau, cuite
@@ -54506,6 +56374,7 @@ ciqual_food_name:fr:Langue, veau, cuite
 <en:Veal meat
 en:Raw calf tongue
 fr:Langue de veau crue
+agribalyse_food_code:en:40204
 ciqual_food_code:en:40204
 ciqual_food_name:en:Tongue, calf, raw
 ciqual_food_name:fr:Langue, veau, crue
@@ -54513,6 +56382,7 @@ ciqual_food_name:fr:Langue, veau, crue
 <en:Cooked veal meat
 en:Sautéed veal loin, Pan-fried veal loin
 fr:Carré de veau sauté, Carré de veau poêlé
+agribalyse_food_code:en:6512
 ciqual_food_code:en:6512
 ciqual_food_name:en:Veal, loin, sautéed/pan-fried
 ciqual_food_name:fr:Veau, carré, sauté/poêlé
@@ -54520,6 +56390,7 @@ ciqual_food_name:fr:Veau, carré, sauté/poêlé
 <en:Veal meat
 en:Raw veal loin
 fr:Carré de veau cru
+agribalyse_food_code:en:6513
 ciqual_food_code:en:6513
 ciqual_food_name:en:Veal, loin, raw
 ciqual_food_name:fr:Veau, carré, cru
@@ -54527,6 +56398,7 @@ ciqual_food_name:fr:Veau, carré, cru
 <en:Cooked veal meat
 en:Grilled veal shoulder, Pan-fried veal shoulder
 fr:Epaule de veau grillée, Epaule de veau poêlée
+agribalyse_food_code:en:6562
 ciqual_food_code:en:6562
 ciqual_food_name:en:Veal, shoulder, grilled/pan-fried
 ciqual_food_name:fr:Veau, épaule, grillée/poêlée
@@ -54534,6 +56406,7 @@ ciqual_food_name:fr:Veau, épaule, grillée/poêlée
 <en:Veal meat
 en:Raw veal shoulder
 fr:Epaule de veau crue
+agribalyse_food_code:en:6560
 ciqual_food_code:en:6560
 ciqual_food_name:en:Veal, shoulder, raw
 ciqual_food_name:fr:Veau, épaule, crue
@@ -54541,6 +56414,7 @@ ciqual_food_name:fr:Veau, épaule, crue
 <en:Veal meat
 en:Raw calf foot
 fr:Pied de veau cru
+agribalyse_food_code:en:6580
 ciqual_food_code:en:6580
 ciqual_food_name:en:Calf, foot, raw
 ciqual_food_name:fr:Veau, pied, cru
@@ -54548,6 +56422,7 @@ ciqual_food_name:fr:Veau, pied, cru
 <en:Cooked veal meat
 en:Grilled veal tenderloin, Pan-fried veal tenderloin
 fr:Noix de veau grillée, Noix de veau poêlée
+agribalyse_food_code:en:6523
 ciqual_food_code:en:6523
 ciqual_food_name:en:Veal, tenderloin, grilled/pan-fried
 ciqual_food_name:fr:Veau, noix, grillée/poêlée
@@ -54555,6 +56430,7 @@ ciqual_food_name:fr:Veau, noix, grillée/poêlée
 <en:Cooked veal meat
 en:Roasted veal tenderloin
 fr:Noix de veau rôtie
+agribalyse_food_code:en:6524
 ciqual_food_code:en:6524
 ciqual_food_name:en:Veal, tenderloin, roasted
 ciqual_food_name:fr:Veau, noix, rôtie
@@ -54562,6 +56438,7 @@ ciqual_food_name:fr:Veau, noix, rôtie
 <en:Veal meat
 en:Raw veal tenderloins
 fr:Noix de veau crues
+agribalyse_food_code:en:6522
 ciqual_food_code:en:6522
 ciqual_food_name:en:Veal, tenderloin, raw
 ciqual_food_name:fr:Veau, noix, crue
@@ -54569,6 +56446,7 @@ ciqual_food_name:fr:Veau, noix, crue
 <en:Cooked veal meat
 en:Cooked veal escalopes
 fr:Escalopes de veau cuites
+agribalyse_food_code:en:6520
 ciqual_food_code:en:6520
 ciqual_food_name:en:Veal, escalope, cooked
 ciqual_food_name:fr:Veau, escalope, cuite
@@ -54576,6 +56454,7 @@ ciqual_food_name:fr:Veau, escalope, cuite
 <en:Veal meat
 en:Raw veal escalopes
 fr:Escalopes de veau crues
+agribalyse_food_code:en:6521
 ciqual_food_code:en:6521
 ciqual_food_name:en:Veal, escalope, raw
 ciqual_food_name:fr:Veau, escalope, crue
@@ -54583,6 +56462,7 @@ ciqual_food_name:fr:Veau, escalope, crue
 <en:Cooked veal meat
 en:Cooked veal bread escalopes
 fr:Escalopes panées de veau cuites
+agribalyse_food_code:en:25173
 ciqual_food_code:en:25173
 ciqual_food_name:en:Veal, bread escalope, cooked
 ciqual_food_name:fr:Veau, escalope panée, cuite
@@ -54590,6 +56470,7 @@ ciqual_food_name:fr:Veau, escalope panée, cuite
 <en:Cooked veal meat
 en:Roasted veal fillet, Baked veal fillet
 fr:Filets de veau rôtis, Filets de veau cuits au four
+agribalyse_food_code:en:6531
 ciqual_food_code:en:6531
 ciqual_food_name:en:Veal fillet, roasted/baked
 ciqual_food_name:fr:Veau, filet, rôti/cuit au four
@@ -54597,6 +56478,7 @@ ciqual_food_name:fr:Veau, filet, rôti/cuit au four
 <en:Veal meat
 en:Raw veal fillets
 fr:Filets de veau crus
+agribalyse_food_code:en:6530
 ciqual_food_code:en:6530
 ciqual_food_name:en:Veal fillet, raw
 ciqual_food_name:fr:Veau, filet, cru
@@ -54604,6 +56486,7 @@ ciqual_food_name:fr:Veau, filet, cru
 <en:Veal meat
 en:Raw veal breast
 fr:Poitrine de veau crue
+agribalyse_food_code:en:6540
 ciqual_food_code:en:6540
 ciqual_food_name:en:Veal, breast, raw
 ciqual_food_name:fr:Veau, poitrine, crue
@@ -54611,6 +56494,7 @@ ciqual_food_name:fr:Veau, poitrine, crue
 <en:Veal meat
 en:Raw veal heart
 fr:Coeur de veau cru
+agribalyse_food_code:en:40062
 ciqual_food_code:en:40062
 ciqual_food_name:en:Heart, veal, raw
 ciqual_food_name:fr:Coeur, veau, cru
@@ -54618,6 +56502,7 @@ ciqual_food_name:fr:Coeur, veau, cru
 <en:Veal meat
 en:Olive veal, Veal paupiette
 fr:Paupiette de veau
+agribalyse_food_code:en:25125
 ciqual_food_code:en:25125
 ciqual_food_name:en:Veal olive or veal paupiette
 ciqual_food_name:fr:Paupiette de veau
@@ -54625,6 +56510,7 @@ ciqual_food_name:fr:Paupiette de veau
 <en:Cooked veal meat
 en:Veal paupiette cooked in oven
 fr:Paupiette de veau cuite au four
+agribalyse_food_code:en:25213
 ciqual_food_code:en:25213
 ciqual_food_name:en:Veal paupiette, cooked in oven
 ciqual_food_name:fr:Paupiette de veau, cuite au four
@@ -54633,6 +56519,7 @@ ciqual_food_name:fr:Paupiette de veau, cuite au four
 <en:Ground steaks
 en:Raw veal minced steak with 20% fat
 fr:Steak haché de veau cru à 20% de matières grasses
+agribalyse_food_code:en:6535
 ciqual_food_code:en:6535
 ciqual_food_name:en:Veal, minced steak, 20% fat, raw
 ciqual_food_name:fr:Veau, steak haché 20% MG, cru
@@ -54641,6 +56528,7 @@ ciqual_food_name:fr:Veau, steak haché 20% MG, cru
 <en:Ground steaks
 en:Raw veal minced steak with 15% fat
 fr:Steak haché de veau cru à 15% de matières grasses
+agribalyse_food_code:en:6536
 ciqual_food_code:en:6536
 ciqual_food_name:en:Veal, minced steak, 15% fat, raw
 ciqual_food_name:fr:Veau, steak haché 15% MG, cru
@@ -54805,12 +56693,14 @@ en:Tomme cheese from cow's milk
 de:Tomme
 en:Tomme
 wikidata:en:Q2164539
+agribalyse_food_code:en:12758
 ciqual_food_code:en:12758
 ciqual_food_name:en:Tomme cheese, from cow's milk
 
 <en:Mountain cheeses
 en:Tomme cheese reduced fat around 13% fat
 fr:Tomme allégée en matière grasse environ 13% MG
+agribalyse_food_code:en:12760
 ciqual_food_code:en:12760
 ciqual_food_name:en:Tomme cheese, reduced fat, around 13% fat
 
@@ -54822,6 +56712,7 @@ fr:Tomme d’Italie, Tommes d'Italie
 fr:Tomme de Savoie, Tommes de Savoie
 en:Tomme cheese from mountain or Savoy
 country:en:France
+agribalyse_food_code:en:12759
 ciqual_food_code:en:12759
 ciqual_food_name:en:Tomme cheese, from mountain or Savoy
 
@@ -54956,6 +56847,7 @@ fr:Morilles, Morille, Morchellas
 it:Morchella
 nl:Morielje, Morille, Morchella
 wikidata:en:Q371101
+agribalyse_food_code:en:20105
 ciqual_food_code:en:20105
 ciqual_food_name:en:Morel, raw
 ciqual_food_name:fr:Champignon, morille, crue
@@ -55095,6 +56987,7 @@ nl:Paddestoelenmelanges
 <en:Mushrooms
 en:Greek-style marinated mushrooms
 fr:Champignons à la grecque
+agribalyse_food_code:en:25605
 ciqual_food_code:en:25605
 ciqual_food_name:en:Greek-style marinated mushrooms
 ciqual_food_name:fr:Champignon à la grecque
@@ -55627,6 +57520,7 @@ wikidata:en:Q20065
 <en:Dry pastas
 en:Dried raw wholemeal pasta
 fr:Pâtes sèches au blé complet crues
+agribalyse_food_code:en:9870
 ciqual_food_code:en:9870
 ciqual_food_name:en:Dried pasta, wholemeal, raw
 ciqual_food_name:fr:Pâtes sèches, au blé complet, crues
@@ -55634,6 +57528,7 @@ ciqual_food_name:fr:Pâtes sèches, au blé complet, crues
 <en:Pastas
 en:Cooked unsalted wholemeal dried pasta
 fr:Pâtes sèches au blé complet cuites non salées
+agribalyse_food_code:en:9871
 ciqual_food_code:en:9871
 ciqual_food_name:en:Dried pasta, wholemeal, cooked, unsalted
 ciqual_food_name:fr:Pâtes sèches, au blé complet, cuites, non salées
@@ -55649,6 +57544,7 @@ nl:Eierpastas, eierpasta
 <en:Pastas
 en:Dried raw pasta
 fr:Pâtes sèches crues
+agribalyse_food_code:en:9810
 ciqual_food_code:en:9810
 ciqual_food_name:en:Dried pasta, raw
 ciqual_food_name:fr:Pâtes sèches standard, crues
@@ -55656,6 +57552,7 @@ ciqual_food_name:fr:Pâtes sèches standard, crues
 <en:Pastas
 en:Cooked unsalted dried pasta
 fr:Pâtes sèches cuites non salées
+agribalyse_food_code:en:9811
 ciqual_food_code:en:9811
 ciqual_food_name:en:Dried pasta, cooked, unsalted
 ciqual_food_name:fr:Pâtes sèches standard, cuites, non salées
@@ -55663,6 +57560,7 @@ ciqual_food_name:fr:Pâtes sèches standard, cuites, non salées
 <en:Egg pastas
 en:Raw fresh egg pasta
 fr:Pâtes fraîches aux œufs crues
+agribalyse_food_code:en:9815
 ciqual_food_code:en:9815
 ciqual_food_name:en:Fresh egg pasta, raw
 ciqual_food_name:fr:Pâtes fraîches, aux œufs, crues
@@ -55678,6 +57576,7 @@ nl:Gedroogde eipasta
 <en:Dry pastas
 en:Dried raw egg pasta
 fr:Pâtes sèches aux œufs crues
+agribalyse_food_code:en:9821
 ciqual_food_code:en:9821
 ciqual_food_name:en:Dried egg pasta, raw
 ciqual_food_name:fr:Pâtes sèches, aux œufs, crues
@@ -55691,6 +57590,7 @@ nl:Gearomatiseerde en gekleurde pasta
 <en:Dry pastas
 en:Cooked unsalted dried egg pasta
 fr:Pâtes sèches aux œufs cuites non salées
+agribalyse_food_code:en:9822
 ciqual_food_code:en:9822
 ciqual_food_name:en:Dried egg pasta, cooked, unsalted
 ciqual_food_name:fr:Pâtes sèches, aux œufs, cuites, non salées
@@ -55708,6 +57608,7 @@ pl:Makaron bezglutenowy
 <en:Gluten-free pasta
 en:Dried raw gluten-free pasta
 fr:Pâtes sèches sans gluten crues
+agribalyse_food_code:en:9874
 ciqual_food_code:en:9874
 ciqual_food_name:en:Dried pasta, gluten-free, raw
 ciqual_food_name:fr:Pâtes sèches, sans gluten, crues
@@ -55715,6 +57616,7 @@ ciqual_food_name:fr:Pâtes sèches, sans gluten, crues
 <en:Gluten-free pasta
 en:Cooked unsalted gluten-free dried pasta
 fr:Pâtes sèches sans gluten cuites non salées
+agribalyse_food_code:en:9824
 ciqual_food_code:en:9824
 ciqual_food_name:en:Dried pasta, gluten-free, cooked, unsalted
 ciqual_food_name:fr:Pâtes sèches, sans gluten, cuites, non salées
@@ -55949,6 +57851,7 @@ wikidata:en:Q20010
 <en:Cannelloni
 en:Cannelloni with vegetables
 fr:Cannelloni aux légumes
+agribalyse_food_code:en:25131
 ciqual_food_code:en:25131
 ciqual_food_name:en:Lasagna or cannelloni with vegetables
 ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes
@@ -55956,6 +57859,7 @@ ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes
 <en:Cannelloni
 en:Cannelloni with cooked vegetables
 fr:Cannelloni aux légumes cuits
+agribalyse_food_code:en:25218
 ciqual_food_code:en:25218
 ciqual_food_name:en:Lasagna or cannelloni with vegetables, cooked
 ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes, cuits
@@ -55963,6 +57867,7 @@ ciqual_food_name:fr:Lasagnes ou cannelloni aux légumes, cuits
 <en:Cannelloni
 en:Cannelloni with fish
 fr:Cannelloni au poisson
+agribalyse_food_code:en:25139
 ciqual_food_code:en:25139
 ciqual_food_name:en:Lasagna or cannelloni with fish
 ciqual_food_name:fr:Lasagnes ou cannelloni au poisson
@@ -55970,6 +57875,7 @@ ciqual_food_name:fr:Lasagnes ou cannelloni au poisson
 <en:Cannelloni
 en:Lasagna with goat cheese and spinach, Cannelloni with goat cheese and spinach
 fr:Lasagnes au fromage et aux épinards, Cannelloni au fromage et aux épinards
+agribalyse_food_code:en:25635
 ciqual_food_code:en:25635
 ciqual_food_name:en:Lasagna or cannelloni with goat cheese and spinach
 ciqual_food_name:fr:Lasagnes ou cannelloni au fromage et aux épinards
@@ -55977,6 +57883,7 @@ ciqual_food_name:fr:Lasagnes ou cannelloni au fromage et aux épinards
 <en:Cannelloni
 en:Cannelloni with cooked vegetables and goat cheese
 fr:Canelloni aux légumes cuits et au fromage de chèvre
+agribalyse_food_code:en:25219
 ciqual_food_code:en:25219
 ciqual_food_name:en:Lasagna or cannelloni with vegetables and goat cheese, cooked
 ciqual_food_name:fr:Lasagnes ou canelloni aux légumes et au fromage de chèvre, cuits
@@ -56045,6 +57952,7 @@ origins:en: en:France
 <en:Fresh pasta
 en:Fresh cooked unsalted egg pasta
 fr:Pâtes fraîches aux œufs cuites non salées
+agribalyse_food_code:en:9816
 ciqual_food_code:en:9816
 ciqual_food_name:en:Fresh egg pasta, cooked, unsalted
 ciqual_food_name:fr:Pâtes fraîches, aux œufs, cuites, non salées
@@ -56128,6 +58036,7 @@ origins:en: en:France
 <en:Stuffed Pastas
 en:Cooked fresh pasta stuffed with cheese, Cooked raviolis
 fr:Pâtes fraîches au fromage farcies et cuites, Raviolis du Dauphiné cuits, Ravioles du Dauphiné cuites
+agribalyse_food_code:en:25149
 ciqual_food_code:en:25149
 ciqual_food_name:en:Fresh pasta, stuffed with cheese (e.g. ravioli), cooked
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis, ravioles du Dauphiné), au fromage, cuites
@@ -56135,6 +58044,7 @@ ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis, ravioles du Dauphin
 <en:Stuffed Pastas
 en:Raw fresh pasta stuffed with cheese, Raw raviolis
 fr:Pâtes fraîches au fromage farcies et crues, Raviolis du Dauphiné crus, Ravioles du Dauphiné crues
+agribalyse_food_code:en:25181
 ciqual_food_code:en:25181
 ciqual_food_name:en:Fresh pasta, stuffed with cheese (e.g. ravioli), raw
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis, ravioles du Dauphiné), au fromage, crues
@@ -56142,6 +58052,7 @@ ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis, ravioles du Dauphin
 <en:Stuffed Pastas
 en:Cooked fresh pasta stuffed with cheese and vegetables
 fr:Pâtes fraîches cuites farcies au fromage et aux légumes
+agribalyse_food_code:en:25155
 ciqual_food_code:en:25155
 ciqual_food_name:en:Fresh pasta, stuffed with cheese and vegetables (e.g. ravioli), cooked
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), au fromage et aux légumes, cuites
@@ -56152,6 +58063,7 @@ en:Meat ravioli
 <en:Stuffed Pastas
 en:Raw fresh pasta stuffed with meat
 fr:Pâtes fraîches crues farcies à la viande
+agribalyse_food_code:en:25157
 ciqual_food_code:en:25157
 ciqual_food_name:en:Fresh pasta, stuffed with meat (e.g. bolognese-style ravioli), raw
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), à la viande (ex : bolognaise), crues
@@ -56159,6 +58071,7 @@ ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), à la viande (ex :
 <en:Stuffed Pastas
 en:Cooked fresh pasta stuffed with meat
 fr:Pâtes fraîches cuites farcies à la viande
+agribalyse_food_code:en:25158
 ciqual_food_code:en:25158
 ciqual_food_name:en:Fresh pasta, stuffed with meat (e.g. bolognese-style ravioli), cooked
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), à la viande (ex : bolognaise), cuites
@@ -56166,6 +58079,7 @@ ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), à la viande (ex :
 <en:Stuffed Pastas
 en:Raw fresh pasta stuffed with cheese and vegetables
 fr:Pâtes fraîches crues farcies au fromage et aux légumes
+agribalyse_food_code:en:25182
 ciqual_food_code:en:25182
 ciqual_food_name:en:Fresh pasta, stuffed with cheese and vegetables (e.g. ravioli), raw
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), au fromage et aux légumes, crues
@@ -56173,6 +58087,7 @@ ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), au fromage et aux 
 <en:Stuffed Pastas
 en:Cooked fresh pasta stuffed with vegetables
 fr:Pâtes fraîches cuites farcies aux légumes
+agribalyse_food_code:en:25193
 ciqual_food_code:en:25193
 ciqual_food_name:en:Fresh pasta, stuffed with vegetables (e.g. ravioli), cooked
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), aux légumes, cuites
@@ -56180,6 +58095,7 @@ ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), aux légumes, cuit
 <en:Stuffed Pastas
 en:Raw fresh pasta stuffed with vegetables
 fr:Pâtes fraîches crues farcies aux légumes
+agribalyse_food_code:en:25203
 ciqual_food_code:en:25203
 ciqual_food_name:en:Fresh pasta, stuffed with vegetables (e.g. ravioli), raw
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : ravioli), aux légumes, crues
@@ -56330,18 +58246,21 @@ nl:Tagliatella carbonara
 <en:Pasta dishes
 en:Bolognese-style pasta (spaghetti tagliatelle…)
 fr:Pâtes à la bolognaise
+agribalyse_food_code:en:25085
 ciqual_food_code:en:25085
 ciqual_food_name:en:Bolognese-style pasta (spaghetti, tagliatelle…)
 
 <en:Pasta dishes
 en:Carbonara-style pasta (spaghetti tagliatelle…)
 fr:Pâtes à la carbonara
+agribalyse_food_code:en:25135
 ciqual_food_code:en:25135
 ciqual_food_name:en:Carbonara-style pasta (spaghetti, tagliatelle…)
 
 <en:Pasta dishes
 en:Pasta with cheese sauce (spaghetti tagliatelle…)
 fr:Pâtes en sauce aux fromages
+agribalyse_food_code:en:25198
 ciqual_food_code:en:25198
 ciqual_food_name:en:Pasta with cheese sauce (spaghetti, tagliatelle…)
 
@@ -56417,6 +58336,7 @@ wikidata:en:Q716004
 <en:Noodles
 en:Cooked unsalted rice noodles
 fr:Vermicelles de riz cuits non salés
+agribalyse_food_code:en:9901
 ciqual_food_code:en:9901
 ciqual_food_name:en:Rice noodle, cooked, unsalted
 ciqual_food_name:fr:Vermicelle de riz, cuite, non salée
@@ -56424,6 +58344,7 @@ ciqual_food_name:fr:Vermicelle de riz, cuite, non salée
 <en:Noodles
 en:Dried rice noodles
 fr:Vermicelles de riz secs
+agribalyse_food_code:en:9900
 ciqual_food_code:en:9900
 ciqual_food_name:en:Rice noodle, dried
 ciqual_food_name:fr:Vermicelle de riz, sèche
@@ -56431,6 +58352,7 @@ ciqual_food_name:fr:Vermicelle de riz, sèche
 <en:Noodles
 en:Sautéed noodles with shrimps, Pan-fried noodles with shrimps
 fr:Nouilles sautées aux crevettes, Nouilles poêlées aux crevettes
+agribalyse_food_code:en:25183
 ciqual_food_code:en:25183
 ciqual_food_name:en:Noodles with shrimps sautéed/pan-fried
 ciqual_food_name:fr:Nouilles sautées/poêlées aux crevettes
@@ -56455,6 +58377,7 @@ zh:中式鸡蛋面
 <en:Chinese noodles
 en:Flavoured cooked Asian noodles
 fr:Nouilles asiatiques cuites aromatisées
+agribalyse_food_code:en:9085
 ciqual_food_code:en:9085
 ciqual_food_name:en:Asian noodles, flavoured, cooked
 ciqual_food_name:fr:Nouilles asiatiques cuites, aromatisées
@@ -56462,6 +58385,7 @@ ciqual_food_name:fr:Nouilles asiatiques cuites, aromatisées
 <en:Chinese noodles
 en:Cooked unsalted plain Asian noodles
 fr:Nouilles asiatiques cuites nature non salées
+agribalyse_food_code:en:9086
 ciqual_food_code:en:9086
 ciqual_food_name:en:Asian noodles, plain, cooked, unsalted
 ciqual_food_name:fr:Nouilles asiatiques cuites, nature, non salées
@@ -56469,6 +58393,7 @@ ciqual_food_name:fr:Nouilles asiatiques cuites, nature, non salées
 <en:Chinese noodles
 en:Flavoured dehydrated Asian noodles
 fr:Nouilles asiatiques aromatisées déshydratées
+agribalyse_food_code:en:9863
 ciqual_food_code:en:9863
 ciqual_food_name:en:Asian noodles, flavoured, dehydrated
 ciqual_food_name:fr:Nouilles asiatiques aromatisées, déshydratées
@@ -56494,6 +58419,7 @@ fr:Soupes de nouilles instantanées, Soupe de nouilles instantanée, Soupe de no
 nl:Instantnoedelsoepen
 ru:Супы быстрого приготовления
 zh:方便面汤, 速食面汤
+agribalyse_food_code:en:25955
 ciqual_food_code:en:25955
 ciqual_food_name:en:Soup, Asian-style with noodles, prepacked, to be reheated
 
@@ -56501,6 +58427,7 @@ ciqual_food_name:en:Soup, Asian-style with noodles, prepacked, to be reheated
 <en:Dried products to be rehydrated
 en:Dehydrated and reconstituted Asian-style soup with noodles
 fr:Soupe de pâtes asiatique déshydratée et reconstituée
+agribalyse_food_code:en:25923
 ciqual_food_code:en:25923
 ciqual_food_name:en:Soup, Asian-style with noodles, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe asiatique, avec pâtes, déshydratée reconstituée
@@ -56582,6 +58509,7 @@ wikidata:en:Q727605
 <en:Biscuits
 en:Biscuit with milk
 fr:Biscuit sec au lait
+agribalyse_food_code:en:24030
 ciqual_food_code:en:24030
 ciqual_food_name:en:Biscuit (cookie), with milk
 ciqual_food_name:fr:Biscuit sec au lait
@@ -56589,42 +58517,49 @@ ciqual_food_name:fr:Biscuit sec au lait
 <en:Biscuits
 en:Crispy biscuit (cookie) with chocolate reduced fat
 fr:Biscuit sec croquant au chocolat allégé en matière grasse
+agribalyse_food_code:en:24007
 ciqual_food_code:en:24007
 ciqual_food_name:en:Crispy biscuit (cookie), with chocolate, reduced fat
 
 <en:Biscuits and cakes
 en:Butter biscuit (cookie) with chocolate
 fr:Biscuit sec petit beurre au chocolat
+agribalyse_food_code:en:24017
 ciqual_food_code:en:24017
 ciqual_food_name:en:Butter biscuit (cookie), with chocolate
 
 <en:Biscuits and cakes
 en:Biscuit (cookie) with chocolate prepacked
 fr:Biscuit sec au chocolat
+agribalyse_food_code:en:24036
 ciqual_food_code:en:24036
 ciqual_food_name:en:Biscuit (cookie), with chocolate, prepacked
 
 <en:Biscuits and cakes
 en:Breakfast biscuit (cookie) with chocolate
 fr:Biscuit sec pour petit déjeuner au chocolat
+agribalyse_food_code:en:24040
 ciqual_food_code:en:24040
 ciqual_food_name:en:Breakfast biscuit (cookie), with chocolate
 
 <en:Biscuits and cakes
 en:Biscuit (cookie) snack w chocolate filling
 fr:biscuit chocolat
+agribalyse_food_code:en:24231
 ciqual_food_code:en:24231
 ciqual_food_name:en:Biscuit (cookie), snack w chocolate filling
 
 <en:Biscuits and cakes
 en:Coated chocolate bar without biscuit
 fr:barre au chocolat
+agribalyse_food_code:en:31001
 ciqual_food_code:en:31001
 ciqual_food_name:en:Coated chocolate bar without biscuit
 
 <en:Biscuits and cakes
 en:Diet crispy biscuit without chocolate
 fr:Biscuit sec croquant sans chocolat allégé en matière grasse
+agribalyse_food_code:en:24031
 ciqual_food_code:en:24031
 ciqual_food_name:en:Crispy biscuit (cookie), without chocolate, reduced fat
 ciqual_food_name:fr:Biscuit sec croquant (ex : tuile) sans chocolat, allégé en matière grasse
@@ -56632,6 +58567,7 @@ ciqual_food_name:fr:Biscuit sec croquant (ex : tuile) sans chocolat, allégé en
 <en:Biscuits
 en:Biscuit with nuts, Lightly chocolate-flavoured biscuit with nuts
 fr:Biscuit sec fourré aux noix, Biscuit sec légèrement chocolaté fourré aux noix
+agribalyse_food_code:en:24055
 ciqual_food_code:en:24055
 ciqual_food_name:en:Biscuit (cookie) with nuts (no chocolate or lightly chocolate-flavoured)
 ciqual_food_name:fr:Biscuit sec fourré fruits à coque (non ou légèrement chocolaté)
@@ -56639,6 +58575,7 @@ ciqual_food_name:fr:Biscuit sec fourré fruits à coque (non ou légèrement cho
 <en:Biscuits and cakes
 en:Biscuit filled with fruit paste, Biscuit filled with fruit puree
 fr:Biscuit sec fourré à la pâte de fruits, Biscuit sec fourré à la purée de fruits
+agribalyse_food_code:en:24037
 ciqual_food_code:en:24037
 ciqual_food_name:en:Biscuit (cookie) filled with fruit paste or fruit puree
 ciqual_food_name:fr:Biscuit sec fourré à la pâte ou purée de fruits
@@ -56646,6 +58583,7 @@ ciqual_food_name:fr:Biscuit sec fourré à la pâte ou purée de fruits
 <en:Biscuits and cakes
 en:Snack biscuit with fruits filling
 fr:Goûter sec fourré parfum fruits, Goûter sec sandwiché parfum fruits
+agribalyse_food_code:en:24240
 ciqual_food_code:en:24240
 ciqual_food_name:en:Biscuit (cookie), snack with fruits filling
 ciqual_food_name:fr:Goûter sec fourré (sandwiché) parfum fruits
@@ -56653,12 +58591,14 @@ ciqual_food_name:fr:Goûter sec fourré (sandwiché) parfum fruits
 <en:Biscuits and cakes
 en:Biscuit (cookie) covering with a chocolate bar
 fr:Biscuit sec avec tablette de chocolat
+agribalyse_food_code:en:24016
 ciqual_food_code:en:24016
 ciqual_food_name:en:Biscuit (cookie), covering with a chocolate bar
 
 <en:Biscuits and cakes
 en:Biscuit (cookie) chocolate covering
 fr:Biscuit sec avec nappage au chocolat
+agribalyse_food_code:en:24038
 ciqual_food_code:en:24038
 ciqual_food_name:en:Biscuit (cookie), chocolate covering
 
@@ -56680,6 +58620,7 @@ ciqual_food_name:en:Biscuit (cookie), chocolate covering
 <en:wafer biscuit
 en:Vanilla flavoured wafer biscuit
 fr:Gaufrette fourrée vanille
+agribalyse_food_code:en:24313
 ciqual_food_code:en:24313
 ciqual_food_name:en:Wafer biscuit, plain or vanilla flavoured, prepacked
 ciqual_food_name:fr:Gaufrette, fourrée vanille, préemballée
@@ -56687,6 +58628,7 @@ ciqual_food_name:fr:Gaufrette, fourrée vanille, préemballée
 <en:Biscuits and cakes
 en:Cone wafer for ice cream
 fr:Cône pour glace, Cornet pour glace
+agribalyse_food_code:en:24685
 ciqual_food_code:en:24685
 ciqual_food_name:en:Cone, wafer for ice cream
 ciqual_food_name:fr:Cône ou cornet classique, pour glace
@@ -56694,6 +58636,7 @@ ciqual_food_name:fr:Cône ou cornet classique, pour glace
 <en:Biscuits and cakes
 en:Thin biscuit with almonds
 fr:Biscuit sec aux amandes, tuile aux amandes
+agribalyse_food_code:en:24615
 ciqual_food_code:en:24615
 ciqual_food_name:en:Biscuit (cookie), thin, w almonds
 ciqual_food_name:fr:Biscuit sec ou tuile, aux amandes
@@ -56701,6 +58644,7 @@ ciqual_food_name:fr:Biscuit sec ou tuile, aux amandes
 <en:Biscuits and cakes
 en:Thin biscuit with fruits
 fr:Biscuit sec aux fruits, tuile aux fruits
+agribalyse_food_code:en:24616
 ciqual_food_code:en:24616
 ciqual_food_name:en:Biscuit (cookie), thin, w fruits
 ciqual_food_name:fr:Biscuit sec type tuile, aux fruits
@@ -56708,6 +58652,7 @@ ciqual_food_name:fr:Biscuit sec type tuile, aux fruits
 <en:Biscuits and cakes
 en:Fruit biscuit with reduced salt
 fr:Biscuit sec aux fruits hyposodé
+agribalyse_food_code:en:24004
 ciqual_food_code:en:24004
 ciqual_food_name:en:Biscuit (cookie) with fruits, reduced salt
 ciqual_food_name:fr:Biscuit sec aux fruits, hyposodé
@@ -56715,6 +58660,7 @@ ciqual_food_name:fr:Biscuit sec aux fruits, hyposodé
 <en:Biscuits and cakes
 en:Fruit biscuit with reduced fat
 fr:Biscuit sec fourré aux fruits allégé en matière grasse
+agribalyse_food_code:en:24008
 ciqual_food_code:en:24008
 ciqual_food_name:en:Biscuit (cookie) filled with fruits, reduced fat
 ciqual_food_name:fr:Biscuit sec fourré aux fruits, allégé en matière grasse
@@ -56722,6 +58668,7 @@ ciqual_food_name:fr:Biscuit sec fourré aux fruits, allégé en matière grasse
 <en:Biscuits and cakes
 en:Reduced fat biscuit bar filled with fruits
 fr:Barre biscuitée fourrée aux fruits allégée en matière grasse
+agribalyse_food_code:en:24039
 ciqual_food_code:en:24039
 ciqual_food_name:en:Biscuit bar filled with fruits, reduced fat
 ciqual_food_name:fr:Barre biscuitée fourrée aux fruits, allégée en matière grasse
@@ -56750,6 +58697,7 @@ origins:en: en:Portugal
 <en:Desserts
 en:French toast
 fr:Pain perdu
+agribalyse_food_code:en:39236
 ciqual_food_code:en:39236
 ciqual_food_name:en:French toast
 ciqual_food_name:fr:Pain perdu
@@ -56758,6 +58706,7 @@ ciqual_food_name:fr:Pain perdu
 <en:Desserts
 en:Refrigerated floating island, Refrigerated meringue poached in milk and served in a light custard cream
 fr:Ile flottante rayon frais
+agribalyse_food_code:en:39215
 ciqual_food_code:en:39215
 ciqual_food_name:en:Floating island (meringue poached in milk and served in a light custard cream), refrigerated
 ciqual_food_name:fr:Ile flottante, rayon frais
@@ -56766,6 +58715,7 @@ ciqual_food_name:fr:Ile flottante, rayon frais
 <en:Desserts
 en:Refrigerated caramelized custard cream, Refrigerated crème brûlée
 fr:Crème brûlée rayon frais
+agribalyse_food_code:en:39213
 ciqual_food_code:en:39213
 ciqual_food_name:en:Caramelized custard cream (crème brûlée), refrigerated
 ciqual_food_name:fr:Crème brûlée, rayon frais
@@ -56774,6 +58724,7 @@ ciqual_food_name:fr:Crème brûlée, rayon frais
 <en:Desserts
 en:Refrigerated custard cream with caramel sauce
 fr:Crème caramel rayon frais
+agribalyse_food_code:en:39209
 ciqual_food_code:en:39209
 ciqual_food_name:en:Custard cream with caramel sauce, refrigerated
 ciqual_food_name:fr:Crème caramel, rayon frais
@@ -56797,6 +58748,7 @@ fi:Makronit, Macaronit
 fr:Macarons, Macaron, Macaron sec
 nl:Macarons
 pl:Makarony
+agribalyse_food_code:en:23027
 ciqual_food_code:en:23027
 ciqual_food_name:en:Macaroon
 
@@ -56804,6 +58756,7 @@ ciqual_food_name:en:Macaroon
 <en:Desserts
 en:Macaron filled with jam or cream
 fr:Macaron moelleux fourré à la confiture ou à la crème
+agribalyse_food_code:en:23024
 ciqual_food_code:en:23024
 ciqual_food_name:en:Macaron filled with jam or cream
 
@@ -56818,6 +58771,7 @@ fr:Babas au rhum, Baba au rhum, Baba au rhum
 nl:Baba au rhum
 wikidata:en:Q265457
 oqali_family:en: fr:Biscuits et gateaux industriels - Babas au rhum
+agribalyse_food_code:en:23020
 ciqual_food_code:en:23020
 ciqual_food_name:en:Rum baba, prepacked
 ciqual_food_name:fr:Baba au rhum, préemballé
@@ -56829,6 +58783,7 @@ es:Roscón de Reyes
 fr:Galettes des rois, Galette des rois, Gâteaux des rois, Galette des rois feuilletée, Galettes à la frangipane, Galette à la frangipane, Galettes des rois à la frangipane
 nl:Koningentaarten, Koningentaart
 wikidata:en:Q177166
+agribalyse_food_code:en:23680
 ciqual_food_code:en:23680
 ciqual_food_name:en:Twelfth Night cake
 ciqual_food_name:fr:Galette des rois feuilletée
@@ -56836,6 +58791,7 @@ ciqual_food_name:fr:Galette des rois feuilletée
 <en:Pastries
 en:Twelfth Night cake with almond paste, Twelfth Night cake puff pastry filled with almond paste
 fr:Galette des rois feuilletée fourrée à la frangipane, Pithiviers
+agribalyse_food_code:en:23684
 ciqual_food_code:en:23684
 ciqual_food_name:en:Twelfth Night cake (puff pastry filled with almond paste)
 ciqual_food_name:fr:Galette des rois feuilletée, fourrée frangipane, et Pithiviers
@@ -56843,6 +58799,7 @@ ciqual_food_name:fr:Galette des rois feuilletée, fourrée frangipane, et Pithiv
 <en:Pastries
 en:Basque cake with custard, Basque shortbread with custard
 fr:Gâteau basque à la crème pâtissière
+agribalyse_food_code:en:23802
 ciqual_food_code:en:23802
 ciqual_food_name:en:Basque cake (shortbread), with custard
 ciqual_food_name:fr:Gâteau basque, crème pâtissière
@@ -56850,6 +58807,7 @@ ciqual_food_name:fr:Gâteau basque, crème pâtissière
 <en:Pastries
 en:Basque cake with cherries, Shortbread with cherries
 fr:Gâteau basque aux cerises
+agribalyse_food_code:en:23803
 ciqual_food_code:en:23803
 ciqual_food_name:en:Basque cake (shortbread), with cherries
 ciqual_food_name:fr:Gâteau basque, cerises
@@ -56860,6 +58818,7 @@ en:Canelés, cannelés, Canelé cake
 fr:Canelés, cannelés, canelés de Bordeaux, cannelés de Bordeaux, Canelé, cannelé
 nl:Canelé
 wikidata:en:Q2746070
+agribalyse_food_code:en:23022
 ciqual_food_code:en:23022
 ciqual_food_name:en:Canelé cake
 ciqual_food_name:fr:Canelé
@@ -56872,6 +58831,7 @@ fr:Profiteroles, Profiterole, Profiterolles, Choux à la crème, Chou à la crè
 it:Profiterole, Profiteroles
 nl:Soesje, Profiterole
 wikidata:en:Q2513811
+agribalyse_food_code:en:23455
 ciqual_food_code:en:23455
 ciqual_food_name:en:Pastry cream puff
 ciqual_food_name:fr:Chou à la crème (chantilly ou pâtissière)
@@ -56879,18 +58839,21 @@ ciqual_food_name:fr:Chou à la crème (chantilly ou pâtissière)
 <en:Pastries
 en:Profiteroles (chou pastry) with vanilla ice cream and chocolate sauce
 fr:Profiterole avec glace vanille et sauce chocolat
+agribalyse_food_code:en:23472
 ciqual_food_code:en:23472
 ciqual_food_name:en:Profiteroles (chou pastry), with vanilla ice cream and chocolate sauce
 
 <en:Pastries
 en:Profiteroles (chou pastry) with custard and chocolate sauce refrigerated
 fr:Profiteroles (crème pâtissière et sauce chocolat) rayon frais
+agribalyse_food_code:en:23474
 ciqual_food_code:en:23474
 ciqual_food_name:en:Profiteroles (chou pastry), with custard and chocolate sauce, refrigerated
 
 <en:Cream puff
 en:Chou pastry filled with whipped cream
 fr:Choux à la crème chantilly, Chou à la crème chantilly
+agribalyse_food_code:en:23456
 ciqual_food_code:en:23456
 ciqual_food_name:en:Chou pastry filled with whipped cream
 ciqual_food_name:fr:Chou à la crème chantilly
@@ -56898,6 +58861,7 @@ ciqual_food_name:fr:Chou à la crème chantilly
 <en:Cream puff
 en:Chou pastry filled with custard
 fr:Chou à la crème pâtissière
+agribalyse_food_code:en:23457
 ciqual_food_code:en:23457
 ciqual_food_name:en:Chou pastry filled with custard
 ciqual_food_name:fr:Chou à la crème pâtissière
@@ -56908,6 +58872,7 @@ fi:Kookosmakronit, Kookosmacaronit
 fr:Rochers à la noix de coco, Congolais, Rochers coco, rocher à la noix de coco, rocher coco, Petit gâteau à la noix de coco
 nl:Kokosmacaron
 wikidata:en:Q2993000
+agribalyse_food_code:en:23033
 ciqual_food_code:en:23033
 ciqual_food_name:en:Rock-shaped coconut cake
 ciqual_food_name:fr:Rocher coco, Congolais, Petit gâteau à la noix de coco
@@ -56917,6 +58882,7 @@ ciqual_food_name:fr:Rocher coco, Congolais, Petit gâteau à la noix de coco
 fr:Paris-Brest
 en:Chou pastry with praline flavoured creme
 wikidata:en:Q1137495
+agribalyse_food_code:en:23005
 ciqual_food_code:en:23005
 ciqual_food_name:en:Chou pastry with praline flavoured creme
 
@@ -56924,6 +58890,7 @@ ciqual_food_name:en:Chou pastry with praline flavoured creme
 fr:Éclairs
 nl:Eclairs
 wikidata:en:Q273426
+agribalyse_food_code:en:23477
 ciqual_food_code:en:23477
 ciqual_food_name:en:Eclair
 ciqual_food_name:fr:Éclair
@@ -56945,6 +58912,7 @@ en:Open pies, Open pie, Flan tart with eggs
 fr:Flans pâtissiers, flan pâtissier, Flan pâtissier aux oeufs, Flan à la parisienne
 nl:Puddingtaarten
 wikidata:en: Q14747193
+agribalyse_food_code:en:23525
 ciqual_food_code:en:23525
 ciqual_food_name:en:Flan tart with eggs
 ciqual_food_name:fr:Flan pâtissier aux oeufs ou à la parisienne
@@ -56955,6 +58923,7 @@ fi:marengit
 fr:Meringues, meringue
 nl:Schuimpjes
 wikidata:en: Q276276
+agribalyse_food_code:en:24520
 ciqual_food_code:en:24520
 ciqual_food_name:en:Meringue
 ciqual_food_name:fr:Meringue
@@ -56962,6 +58931,7 @@ ciqual_food_name:fr:Meringue
 <en:Pastries
 en:Pastry biscuit with meringue
 fr:Biscuit pâtissier meringué
+agribalyse_food_code:en:24060
 ciqual_food_code:en:24060
 ciqual_food_name:en:Pastry biscuit with meringue
 ciqual_food_name:fr:Biscuit pâtissier meringué
@@ -56970,6 +58940,7 @@ ciqual_food_name:fr:Biscuit pâtissier meringué
 fr:Millefeuilles, millefeuille, fr:Mille-feuille
 en:Mille-feuille pastry
 wikidata:en: Q12491
+agribalyse_food_code:en:24666
 ciqual_food_code:en:24666
 ciqual_food_name:en:Mille-feuille pastry
 ciqual_food_name:fr:Mille-feuille
@@ -56986,6 +58957,7 @@ wikidata:en:Q3442427
 <en:Desserts
 en:Baklava
 fr:Baklava
+agribalyse_food_code:en:23300
 ciqual_food_code:en:23300
 ciqual_food_name:en:Baklava (oriental pastry with almonds and syrup)
 ciqual_food_name:fr:Baklava, Baklawa, pâtisserie orientale aux amandes et sirop
@@ -56994,6 +58966,7 @@ ciqual_food_name:fr:Baklava, Baklawa, pâtisserie orientale aux amandes et sirop
 <en:Desserts
 en:Gazelle horn
 fr:Corne de gazelle
+agribalyse_food_code:en:23301
 ciqual_food_code:en:23301
 ciqual_food_name:en:Gazelle horn (oriental pastry with almonds and syrup)
 ciqual_food_name:fr:Corne de gazelle (pâtisserie orientale aux amandes et sirop)
@@ -57107,6 +59080,7 @@ nl:Chocoladetaarten
 <en:Sweet pies
 en:Fruit pies with confectioner's custard
 fr:Tartes aux fruits et crème pâtissière
+agribalyse_food_code:en:23479
 ciqual_food_code:en:23479
 ciqual_food_name:en:Fruit pie with confectioner's custard
 ciqual_food_name:fr:Tarte aux fruits et crème pâtissière
@@ -57114,6 +59088,7 @@ ciqual_food_name:fr:Tarte aux fruits et crème pâtissière
 <en:Sweet pies
 en:Fruit tarts, Fruit pies
 fr:Tartes aux fruits, Tartelettes aux fruits
+agribalyse_food_code:en:23499
 ciqual_food_code:en:23499
 ciqual_food_name:en:Fruit tart
 ciqual_food_name:fr:Tarte ou tartelette aux fruits
@@ -57124,6 +59099,7 @@ de:Zitronentörtchen
 fi:sitruunaleivokset
 fr:Tartes au citron, Tarte au citron
 nl:Citroentaarten
+agribalyse_food_code:en:23485
 ciqual_food_code:en:23485
 ciqual_food_name:en:Lemon tart
 ciqual_food_name:fr:Tarte au citron
@@ -57137,6 +59113,7 @@ nl:Citroen meringue taart
 <en:Lemon tarts
 en:Red berries tart
 fr:Tarte aux fruits rouges
+agribalyse_food_code:en:23495
 ciqual_food_code:en:23495
 ciqual_food_name:en:Red berries tart
 ciqual_food_name:fr:Tarte aux fruits rouges
@@ -57163,6 +59140,7 @@ en:Apricot pies, Apricots tart
 de:Aprikosenkuchen, Marillenkuchen
 fr:Tartes aux abricots, Tartes à l'abricot, Tarte aux abricots, Tarte à l'abricot
 nl:Abrikozentaart
+agribalyse_food_code:en:23494
 ciqual_food_code:en:23494
 ciqual_food_name:en:Apricots tart
 ciqual_food_name:fr:Tarte aux abricots
@@ -57176,6 +59154,7 @@ nl:Frambozentaarten
 <en:Sweet pies
 en:Sponge sandwich cake filled and topped with raspberries
 fr:Framboisier
+agribalyse_food_code:en:23009
 ciqual_food_code:en:23009
 ciqual_food_name:en:Sponge sandwich cake filled and topped with strawberries or raspberries
 ciqual_food_name:fr:Fraisier ou framboisier
@@ -57195,6 +59174,7 @@ nl:Aardbeientaart
 <en:Sweet pies
 en:Sponge sandwich cake filled and topped with strawberries
 fr:Fraisier
+agribalyse_food_code:en:23009
 ciqual_food_code:en:23009
 ciqual_food_name:en:Sponge sandwich cake filled and topped with strawberries or raspberries
 ciqual_food_name:fr:Fraisier ou framboisier
@@ -57206,6 +59186,7 @@ es:Pasteles de manzana
 fi:omenapiiraat
 fr:Tartes aux pommes, Tarte aux pommes, Tartes à la pomme, Tarte à la pomme, Tartelettes aux pommes, Tartelette aux pommes
 nl:Appeltaarten
+agribalyse_food_code:en:23490
 ciqual_food_code:en:23490
 ciqual_food_name:en:Apple tart
 ciqual_food_name:fr:Tarte ou tartelette aux pommes
@@ -57221,6 +59202,7 @@ fr:Tartes Tatin, Tarte Tatin, Tarte Tatin aux pommes
 nl:Tarte Tatin
 ru:Тарт Татен
 wikidata:en:Q1147946
+agribalyse_food_code:en:23496
 ciqual_food_code:en:23496
 ciqual_food_name:en:Tatin tart (caramelized upside-down apple tart)
 ciqual_food_name:fr:Tarte Tatin aux pommes
@@ -57228,6 +59210,7 @@ ciqual_food_name:fr:Tarte Tatin aux pommes
 <en:Sweet pies
 en:Strawberry tart, Strawberries tart
 fr:Tartes aux fraises
+agribalyse_food_code:en:23491
 ciqual_food_code:en:23491
 ciqual_food_name:en:Strawberries tart
 ciqual_food_name:fr:Tarte aux fraises
@@ -57241,6 +59224,7 @@ nl:Peertaarten
 <en:Sweet pies
 en:Peer tart with almonds
 fr:Tarte aux poires amandine
+agribalyse_food_code:en:24663
 ciqual_food_code:en:24663
 ciqual_food_name:en:Peer tart with almonds
 ciqual_food_name:fr:Tarte aux poires amandine
@@ -57251,6 +59235,7 @@ en:Pies from Normandy, Apple pie with custard and flour and eggs and cream and s
 fi:normandialaisia piiraita
 fr:Tartes normandes, Tarte normande, Tarte normande aux pommes avec garniture farine œufs crème sucre calvados
 nl:Normandische taarten
+agribalyse_food_code:en:23481
 ciqual_food_code:en:23481
 ciqual_food_name:en:Apple pie with custard (flour, eggs, cream, sugar, apple alcohol)
 ciqual_food_name:fr:Tarte normande aux pommes (garniture farine, œufs, crème, sucre, calvados)
@@ -57271,6 +59256,7 @@ en:Chocolate tartlets
 fr:Tartelettes au chocolat
 nl:Chocolade taartjes
 en:Chocolate tart from bakery
+agribalyse_food_code:en:23497
 ciqual_food_code:en:23497
 ciqual_food_name:en:Chocolate tart from bakery
 
@@ -57311,12 +59297,14 @@ nl:Peertaartjes
 <en:Tartlets
 en:Biscuit (small tart) with chocolate pre-packed
 fr:tartelette au chocolat
+agribalyse_food_code:en:24052
 ciqual_food_code:en:24052
 ciqual_food_name:en:Biscuit (small tart), with chocolate, pre-packed
 
 <en:Tartlets
 en:Biscuit with fruit covering, Small tart with fruit covering
 fr:Biscuit sec nappé aux fruits, Tartelette aux fruits
+agribalyse_food_code:en:24679
 ciqual_food_code:en:24679
 ciqual_food_name:en:Biscuit (small tart), with fruit covering
 ciqual_food_name:fr:Biscuit sec nappé aux fruits, tartelette
@@ -57389,6 +59377,7 @@ de:Burritos
 fr:Burritos
 nl:Burritos
 wikidata:en:Q390823
+agribalyse_food_code:en:25459
 ciqual_food_code:en:25459
 ciqual_food_name:en:Burritos
 
@@ -57399,6 +59388,7 @@ wikidata:en:Q1032806
 <fr:Canapés
 en:Canapés with various toppings, Toasts with various toppings
 fr:Toasts avec garnitures diverses, Canapés salés avec garnitures diverses
+agribalyse_food_code:en:25523
 ciqual_food_code:en:25523
 ciqual_food_name:en:Canapés (toasts w various toppings)
 ciqual_food_name:fr:Toasts ou Canapés salés, garnitures diverses
@@ -57415,6 +59405,7 @@ wikidata:en:Q667478
 <en:Cheeseburgers
 en:Cheeseburgers from fast food restaurants
 fr:Cheeseburgers de fast food
+agribalyse_food_code:en:25414
 ciqual_food_code:en:25414
 ciqual_food_name:en:Cheeseburger, from fast foods restaurant
 ciqual_food_name:fr:Cheeseburger, provenant de fast food
@@ -57422,6 +59413,7 @@ ciqual_food_name:fr:Cheeseburger, provenant de fast food
 <en:Cheeseburgers
 en:Double cheeseburgers from fast food restaurants
 fr:Double cheeseburgers de fast food
+agribalyse_food_code:en:25415
 ciqual_food_code:en:25415
 ciqual_food_name:en:Cheeseburger, double, from fast foods restaurant
 ciqual_food_name:fr:Double cheeseburger, provenant de fast food
@@ -57429,6 +59421,7 @@ ciqual_food_name:fr:Double cheeseburger, provenant de fast food
 <en:Sandwiches
 en:Fish burgers
 fr:Burgers au poisson
+agribalyse_food_code:en:25416
 ciqual_food_code:en:25416
 ciqual_food_name:en:Fish burger, fast foods restaurant
 ciqual_food_name:fr:Burger au poisson
@@ -57436,6 +59429,7 @@ ciqual_food_name:fr:Burger au poisson
 <en:Sandwiches
 en:Large round sandwich with lettuce tuna anchovy and black olives
 fr:Pan bagnat
+agribalyse_food_code:en:25513
 ciqual_food_code:en:25513
 ciqual_food_name:en:Large round sandwich with lettuce, tuna, anchovy and black olives
 ciqual_food_name:fr:Pan bagnat
@@ -57444,6 +59438,7 @@ ciqual_food_name:fr:Pan bagnat
 fr:Croque-madame, croquemadame
 en:Toasted ham sandwich topped with grated cheese and a fried egg
 wikidata:en:Q746
+agribalyse_food_code:en:25542
 ciqual_food_code:en:25542
 ciqual_food_name:en:Toasted ham sandwich topped with grated cheese and a fried egg
 
@@ -57452,12 +59447,14 @@ fr:Croque-monsieur, Croque-messieurs, croquemonsieur
 en:Toasted ham sandwich topped with grated cheese
 el:Κροκ-μεσιέ
 wikidata:en:Q738
+agribalyse_food_code:en:25400
 ciqual_food_code:en:25400
 ciqual_food_name:en:Toasted ham sandwich topped with grated cheese
 
 <en:Sandwiches
 en:Grilled cheese & ham sandwich prepacked
 fr:Croque-monsieur frais
+agribalyse_food_code:en:25547
 ciqual_food_code:en:25547
 ciqual_food_name:en:Grilled cheese & ham sandwich, prepacked
 
@@ -57477,6 +59474,7 @@ wikidata:en:Q6663
 <en:Hamburgers
 en:Hamburger from fast food
 fr:Hamburger de fast food
+agribalyse_food_code:en:25413
 ciqual_food_code:en:25413
 ciqual_food_name:en:Hamburger, from fast foods restaurant
 ciqual_food_name:fr:Hamburger, provenant de fast food
@@ -57484,6 +59482,7 @@ ciqual_food_name:fr:Hamburger, provenant de fast food
 <en:Hamburgers
 en:Raw beef based burger with 15% fat
 fr:Haché à base de bœuf cru à 15% de matières grasses, Préparation de viande hachée de boeuf crue à 15% de matières grasses
+agribalyse_food_code:en:6260
 ciqual_food_code:en:6260
 ciqual_food_name:en:Burger, beef based, 15% fat, raw
 ciqual_food_name:fr:Haché à base de bœuf ou Préparation de viande hachée de boeuf, 15% MG, cru
@@ -57491,6 +59490,7 @@ ciqual_food_name:fr:Haché à base de bœuf ou Préparation de viande hachée de
 <en:Sandwiches
 en:Chicken burger
 fr:Burger au poulet
+agribalyse_food_code:en:25502
 ciqual_food_code:en:25502
 ciqual_food_name:en:Chicken burger , fast foods restaurant
 
@@ -57510,6 +59510,7 @@ fr:Hot-dogs, Hot-dog
 ja:ホットドッグ
 nl:Hotdogs
 wikidata:en:Q181055
+agribalyse_food_code:en:25403
 ciqual_food_code:en:25403
 ciqual_food_name:en:Hot-dog
 
@@ -57532,36 +59533,42 @@ ciqual_food_name:fr:Sandwich baguette (aliment moyen)
 <en:French bread sandwiches
 en:Sandwich made with French bread salami and butter
 fr:Sandwich baguette salami beurre
+agribalyse_food_code:en:25536
 ciqual_food_code:en:25536
 ciqual_food_name:en:Sandwich made with French bread, salami and butter
 
 <en:French bread sandwiches
 en:Sandwich made with French bread ham and butter
 fr:Sandwich baguette jambon beurre
+agribalyse_food_code:en:25517
 ciqual_food_code:en:25517
 ciqual_food_name:en:Sandwich made with French bread, ham and butter
 
 <en:French bread sandwiches
 en:Sandwich made with French bread ham and emmental cheese
 fr:Sandwich baguette jambon emmental
+agribalyse_food_code:en:25485
 ciqual_food_code:en:25485
 ciqual_food_name:en:Sandwich made with French bread, ham and emmental cheese
 
 <en:French bread sandwiches
 en:Sandwich made with French bread ham emmental cheese and butter
 fr:Sandwich baguette jambon emmental beurre
+agribalyse_food_code:en:25521
 ciqual_food_code:en:25521
 ciqual_food_name:en:Sandwich made with French bread, ham, emmental cheese and butter
 
 <en:Sandwiches
 en:Sandwich made with wholemeal loaf bread ham and cheese
 fr:Sandwich pain de mie complet jambon fromage
+agribalyse_food_code:en:25576
 ciqual_food_code:en:25576
 ciqual_food_name:en:Sandwich made with wholemeal loaf bread, ham and cheese
 
 <en:French bread sandwiches
 en:Sandwich made with French bread camembert cheese and butter
 fr:Sandwich baguette camembert beurre
+agribalyse_food_code:en:25518
 ciqual_food_code:en:25518
 ciqual_food_name:en:Sandwich made with French bread, camembert cheese and butter
 ciqual_food_name:fr:Sandwich baguette, camembert, beurre
@@ -57569,6 +59576,7 @@ ciqual_food_name:fr:Sandwich baguette, camembert, beurre
 <en:French bread sandwiches
 en:Sandwich made with French bread and hard-boiled egg and raw vegetables and butter
 fr:Sandwich baguette jambon oeuf dur crudités beurre
+agribalyse_food_code:en:25475
 ciqual_food_code:en:25475
 ciqual_food_name:en:Sandwich made with French bread, hard-boiled egg, raw vegetables (tomato and lettuce) and butter
 ciqual_food_name:fr:Sandwich baguette, jambon, oeuf dur, crudités (tomate, salade), beurre
@@ -57576,6 +59584,7 @@ ciqual_food_name:fr:Sandwich baguette, jambon, oeuf dur, crudités (tomate, sala
 <en:French bread sandwiches
 en:Sandwich made with French bread and tuna and raw vegetables and mayonnaise
 fr:Sandwich baguette thon crudités mayonnaise
+agribalyse_food_code:en:25431
 ciqual_food_code:en:25431
 ciqual_food_name:en:Sandwich made with French bread, tuna, raw vegetables (tomato and lettuce) and mayonnaise
 ciqual_food_name:fr:Sandwich baguette, thon, crudités (tomate, salade), mayonnaise
@@ -57583,6 +59592,7 @@ ciqual_food_name:fr:Sandwich baguette, thon, crudités (tomate, salade), mayonna
 <en:French bread sandwiches
 en:Sandwich made with French bread and tuna and sweet corn and raw vegetables
 fr:Sandwich baguette thon maïs crudités
+agribalyse_food_code:en:25490
 ciqual_food_code:en:25490
 ciqual_food_name:en:Sandwich made with French bread, tuna, sweet corn and raw vegetables
 ciqual_food_name:fr:Sandwich baguette, thon, maïs, crudités
@@ -57590,6 +59600,7 @@ ciqual_food_name:fr:Sandwich baguette, thon, maïs, crudités
 <en:Sandwiches
 en:Sandwich made with wholemeal loaf bread and tuna and raw vegetables and mayonnaise
 fr:Sandwich pain de mie complet thon crudités mayonnaise
+agribalyse_food_code:en:25575
 ciqual_food_code:en:25575
 ciqual_food_name:en:Sandwich made with wholemeal loaf bread, tuna, raw vegetables and mayonnaise
 ciqual_food_name:fr:Sandwich pain de mie complet, thon, crudités, mayonnaise
@@ -57597,6 +59608,7 @@ ciqual_food_name:fr:Sandwich pain de mie complet, thon, crudités, mayonnaise
 <en:French bread sandwiches
 en:Sandwich made with French bread and egg and raw vegetables and mayonnaise
 fr:Sandwich baguette oeuf crudités mayonnaise
+agribalyse_food_code:en:25532
 ciqual_food_code:en:25532
 ciqual_food_name:en:Sandwich made with French bread, egg, raw vegetables (tomato and lettuce) and mayonnaise
 ciqual_food_name:fr:Sandwich baguette, oeuf, crudités (tomate, salade), mayonnaise
@@ -57604,6 +59616,7 @@ ciqual_food_name:fr:Sandwich baguette, oeuf, crudités (tomate, salade), mayonna
 <en:French bread sandwiches
 en:Sandwich made with French bread and smoked salmon and butter
 fr:Sandwich baguette saumon fumé beurre
+agribalyse_food_code:en:25488
 ciqual_food_code:en:25488
 ciqual_food_name:en:Sandwich made with French bread, smoked salmon and butter
 ciqual_food_name:fr:Sandwich baguette, saumon fumé, beurre
@@ -57612,6 +59625,7 @@ ciqual_food_name:fr:Sandwich baguette, saumon fumé, beurre
 <en:Sandwiches filled with cold cuts
 en:Sandwich made with French bread pork and raw vegetables and mayonnaise
 fr:Sandwich baguette porc crudités mayonnaise
+agribalyse_food_code:en:25533
 ciqual_food_code:en:25533
 ciqual_food_name:en:Sandwich made with French bread, pork, raw vegetables (lettuce & tomato) and mayonnaise
 ciqual_food_name:fr:Sandwich baguette, porc, crudités (tomate, salade), mayonnaise
@@ -57620,6 +59634,7 @@ ciqual_food_name:fr:Sandwich baguette, porc, crudités (tomate, salade), mayonna
 <en:Sandwiches filled with cold cuts
 en:Sandwich made with French bread and turkey and raw vegetables and mayonnaise
 fr:Sandwich baguette dinde crudités mayonnaise
+agribalyse_food_code:en:25531
 ciqual_food_code:en:25531
 ciqual_food_name:en:Sandwich made with French bread, turkey, raw vegetables (lettuce & tomato) and mayonnaise
 ciqual_food_name:fr:Sandwich baguette, dinde, crudités (tomate, salade), mayonnaise
@@ -57628,6 +59643,7 @@ ciqual_food_name:fr:Sandwich baguette, dinde, crudités (tomate, salade), mayonn
 <en:Sandwiches
 en:Sandwich made with French bread with raw vegetables and mayonnaise
 fr:Sandwich baguette crudités mayonnaise
+agribalyse_food_code:en:25530
 ciqual_food_code:en:25530
 ciqual_food_name:en:Sandwich made with French bread, raw vegetables and mayonnaise
 ciqual_food_name:fr:Sandwich baguette, crudités diverses, mayonnaise
@@ -57678,6 +59694,7 @@ nl:Speksandwiches
 <en:French bread sandwiches
 en:Sandwich made with French bread and dry sausage and butter
 fr:Sandwich baguette saucisson beurre
+agribalyse_food_code:en:25520
 ciqual_food_code:en:25520
 ciqual_food_name:en:Sandwich made with French bread, dry sausage and butter
 ciqual_food_name:fr:Sandwich baguette, saucisson, beurre
@@ -57686,6 +59703,7 @@ ciqual_food_name:fr:Sandwich baguette, saucisson, beurre
 <en:French bread sandwiches
 en:Sandwich made with French bread and merguez sausage and ketchup and mustard
 fr:Sandwich baguette merguez au ketchup et à la moutarde
+agribalyse_food_code:en:25535
 ciqual_food_code:en:25535
 ciqual_food_name:en:Sandwich made with French bread, merguez sausage, ketchup and mustard
 ciqual_food_name:fr:Sandwich baguette, merguez, ketchup moutarde
@@ -57694,6 +59712,7 @@ ciqual_food_name:fr:Sandwich baguette, merguez, ketchup moutarde
 <en:French bread sandwiches
 en:Sandwich made with French bread pâté and pickles
 fr:Sandwich baguette pâté cornichons
+agribalyse_food_code:en:25519
 ciqual_food_code:en:25519
 ciqual_food_name:en:Sandwich made with French bread, pâté and pickles
 ciqual_food_name:fr:Sandwich baguette, pâté, cornichons
@@ -57710,6 +59729,7 @@ nl:Hamsandwiches
 <en:French bread sandwiches
 en:Sandwich made with French bread and chicken and raw vegetables and mayonnaise
 fr:Sandwich baguette poulet crudités mayonnaise
+agribalyse_food_code:en:25476
 ciqual_food_code:en:25476
 ciqual_food_name:en:Sandwich made with French bread, chicken, raw vegetables (lettuce & tomato) and mayonnaise
 ciqual_food_name:fr:Sandwich baguette, poulet, crudités (tomate, salade), mayonnaise
@@ -57717,6 +59737,7 @@ ciqual_food_name:fr:Sandwich baguette, poulet, crudités (tomate, salade), mayon
 <en:Sandwiches filled with cold cuts
 en:Sandwich made with wholemeal loaf bread and chicken and raw vegetables and mayonnaise
 fr:Sandwich pain de mie complet poulet crudités mayonnaise
+agribalyse_food_code:en:25577
 ciqual_food_code:en:25577
 ciqual_food_name:en:Sandwich made with wholemeal loaf bread, chicken, raw vegetables and mayonnaise
 ciqual_food_name:fr:Sandwich pain de mie complet, poulet, crudités, mayonnaise
@@ -57724,6 +59745,7 @@ ciqual_food_name:fr:Sandwich pain de mie complet, poulet, crudités, mayonnaise
 <en:Sandwiches filled with cold cuts
 en:Sandwich made with loaf bread and various fillings
 fr:Sandwich pain de mie avec garnitures diverses
+agribalyse_food_code:en:25544
 ciqual_food_code:en:25544
 ciqual_food_name:en:Sandwich made with loaf bread, various filling
 ciqual_food_name:fr:Sandwich pain de mie, garnitures diverses
@@ -57731,6 +59753,7 @@ ciqual_food_name:fr:Sandwich pain de mie, garnitures diverses
 <en:Sandwiches filled with cold cuts
 en:Sandwich made with wholemeal loaf bread and ham and raw vegetables and cheese
 fr:Sandwich pain de mie complet jambon crudités fromage
+agribalyse_food_code:en:25574
 ciqual_food_code:en:25574
 ciqual_food_name:en:Sandwich made with wholemeal loaf bread, ham, raw vegetables, cheese (optional)
 ciqual_food_name:fr:Sandwich pain de mie complet, jambon, crudités, fromage optionnel
@@ -57875,6 +59898,7 @@ origins:en: en:Armenia
 <en:Seafood
 en:Belgian sea products
 fr:Produits de la mer belges
+origins:en: en:Belgium
 
 <en:Belgian sea products
 fr:Escavèche de Chimay
@@ -57933,6 +59957,7 @@ ciqual_food_name:fr:Corégone lavaret, cru
 <en:Fishes
 en:Steamed spiny scorpionfish
 fr:Rascasse cuite à la vapeur
+agribalyse_food_code:en:26148
 ciqual_food_code:en:26148
 ciqual_food_name:en:Spiny scorpionfish, steamed
 ciqual_food_name:fr:Rascasse, cuite à la vapeur
@@ -57940,6 +59965,7 @@ ciqual_food_name:fr:Rascasse, cuite à la vapeur
 <en:Fishes
 en:Raw spiny scorpionfish
 fr:Rascasse crue
+agribalyse_food_code:en:26063
 ciqual_food_code:en:26063
 ciqual_food_name:en:Spiny scorpionfish, raw
 ciqual_food_name:fr:Rascasse, crue
@@ -57947,6 +59973,7 @@ ciqual_food_name:fr:Rascasse, crue
 <en:Fishes
 en:Cooked ling
 fr:Julienne cuite, Lingue cuite
+agribalyse_food_code:en:26234
 ciqual_food_code:en:26234
 ciqual_food_name:en:Ling, cooked
 ciqual_food_name:fr:Julienne ou Lingue, cuite
@@ -57954,6 +59981,7 @@ ciqual_food_name:fr:Julienne ou Lingue, cuite
 <en:Fishes
 en:Raw ling
 fr:Julienne crue, Lingue crue
+agribalyse_food_code:en:26130
 ciqual_food_code:en:26130
 ciqual_food_name:en:Ling, raw
 ciqual_food_name:fr:Julienne ou Lingue, crue
@@ -57961,6 +59989,7 @@ ciqual_food_name:fr:Julienne ou Lingue, crue
 <en:Fishes
 en:Raw blue ling
 fr:Lingue bleue crue
+agribalyse_food_code:en:26194
 ciqual_food_code:en:26194
 ciqual_food_name:en:Blue ling, raw
 ciqual_food_name:fr:Lingue bleue ou Lingue, crue
@@ -57968,6 +59997,7 @@ ciqual_food_name:fr:Lingue bleue ou Lingue, crue
 <en:Fishes
 en:Raw common dentex
 fr:Denté cru
+agribalyse_food_code:en:26103
 ciqual_food_code:en:26103
 ciqual_food_name:en:Common dentex, raw
 ciqual_food_name:fr:Denté, cru
@@ -57975,6 +60005,7 @@ ciqual_food_name:fr:Denté, cru
 <en:Fishes
 en:Raw John Dory
 fr:Saint-Pierre cru
+agribalyse_food_code:en:26104
 ciqual_food_code:en:26104
 ciqual_food_name:en:John dory, raw
 ciqual_food_name:fr:Saint-Pierre, cru
@@ -57989,6 +60020,7 @@ ciqual_food_name:fr:Grand sébaste, ou dorade sébaste, ou daurade sébaste, cru
 <en:Fishes
 en:Raw golden redfish
 fr:Sébaste du nord crue, Dorade sébaste crue, Daurade sébaste crue
+agribalyse_food_code:en:26210
 ciqual_food_code:en:26210
 ciqual_food_name:en:Golden redfish, raw
 ciqual_food_name:fr:Sébaste du nord, ou dorade sébaste, ou daurade sébaste, crue
@@ -57996,6 +60028,7 @@ ciqual_food_name:fr:Sébaste du nord, ou dorade sébaste, ou daurade sébaste, c
 <en:Fishes
 en:Raw pouting
 fr:Tacaud cru
+agribalyse_food_code:en:26133
 ciqual_food_code:en:26133
 ciqual_food_name:en:Pouting, raw
 ciqual_food_name:fr:Tacaud, cru
@@ -58006,6 +60039,7 @@ en:Pollan, Irish pollan
 <en:Fishes
 en:Breaded fried European plaice
 fr:Carrelet pané frit, Plie pané frit
+agribalyse_food_code:en:26002
 ciqual_food_code:en:26002
 ciqual_food_name:en:European plaice, breaded, fried
 ciqual_food_name:fr:Carrelet ou plie, pané, frit
@@ -58013,6 +60047,7 @@ ciqual_food_name:fr:Carrelet ou plie, pané, frit
 <en:Fishes
 en:Steamed European plaice
 fr:Carrelet cuit à la vapeur, Plie cuit à la vapeur
+agribalyse_food_code:en:26003
 ciqual_food_code:en:26003
 ciqual_food_name:en:European plaice, steamed
 ciqual_food_name:fr:Carrelet ou plie, cuit à la vapeur
@@ -58027,12 +60062,14 @@ ciqual_food_name:fr:Carrelet ou plie, cru
 <en:Fishes
 en:Raw European plaice
 fr:Plie commun cru
+agribalyse_food_code:en:26204
 ciqual_food_code:en:26204
 ciqual_food_name:en:European plaice, raw
 ciqual_food_name:fr:Plie commune, crue
 
 <en:Fishes
 fr:Carpe rôtie, carpe cuite au four
+agribalyse_food_code:en:27004
 ciqual_food_code:en:27004
 ciqual_food_name:en:Carp roasted, carp baked
 ciqual_food_name:fr:Carpe rôtie, carpe cuite au four
@@ -58040,6 +60077,7 @@ ciqual_food_name:fr:Carpe rôtie, carpe cuite au four
 <en:Fishes
 en:Breaded fried lemon sole
 fr:Limande-sole panée frite
+agribalyse_food_code:en:26016
 ciqual_food_code:en:26016
 ciqual_food_name:en:Lemon sole, breaded, fried
 ciqual_food_name:fr:Limande-sole, panée, frite
@@ -58047,6 +60085,7 @@ ciqual_food_name:fr:Limande-sole, panée, frite
 <en:Fishes
 en:Steamed lemon sole
 fr:Limande-sole cuite à la vapeur
+agribalyse_food_code:en:26017
 ciqual_food_code:en:26017
 ciqual_food_name:en:Lemon sole, steamed
 ciqual_food_name:fr:Limande-sole, cuite à la vapeur
@@ -58054,6 +60093,7 @@ ciqual_food_name:fr:Limande-sole, cuite à la vapeur
 <en:Fishes
 en:Raw lemon sole
 fr:Limande-sole crue
+agribalyse_food_code:en:26135
 ciqual_food_code:en:26135
 ciqual_food_name:en:Lemon sole, raw
 ciqual_food_name:fr:Limande-sole, crue
@@ -58061,6 +60101,7 @@ ciqual_food_name:fr:Limande-sole, crue
 <en:Fishes
 en:Common raw dab
 fr:Limande crue
+agribalyse_food_code:en:26057
 ciqual_food_code:en:26057
 ciqual_food_name:en:Common dab, raw
 ciqual_food_name:fr:Limande, crue
@@ -58068,6 +60109,7 @@ ciqual_food_name:fr:Limande, crue
 <en:Fishes
 en:Raw largehead hairtail
 fr:Sabre cru
+agribalyse_food_code:en:26153
 ciqual_food_code:en:26153
 ciqual_food_name:en:Largehead hairtail, raw
 ciqual_food_name:fr:Sabre, cru
@@ -58075,6 +60117,7 @@ ciqual_food_name:fr:Sabre, cru
 <en:Fishes
 en:Raw shark
 fr:Requin cru
+agribalyse_food_code:en:26162
 ciqual_food_code:en:26162
 ciqual_food_name:en:Shark, raw
 ciqual_food_name:fr:Requin, cru
@@ -58082,6 +60125,7 @@ ciqual_food_name:fr:Requin, cru
 <en:Fishes
 en:Roasted ray, Baked ray
 fr:Raie rôtie, Raie cuite au four
+agribalyse_food_code:en:26031
 ciqual_food_code:en:26031
 ciqual_food_name:en:Ray, roasted/baked
 ciqual_food_name:fr:Raie, rôtie/cuite au four
@@ -58089,6 +60133,7 @@ ciqual_food_name:fr:Raie, rôtie/cuite au four
 <en:Fishes
 en:Ray cooked in an aromatic stock
 fr:Raie cuite au court-bouillon
+agribalyse_food_code:en:26073
 ciqual_food_code:en:26073
 ciqual_food_name:en:Ray, cooked in an aromatic stock
 ciqual_food_name:fr:Raie, cuite au court-bouillon
@@ -58096,6 +60141,7 @@ ciqual_food_name:fr:Raie, cuite au court-bouillon
 <en:Fishes
 en:Raw ray
 fr:Raie crue
+agribalyse_food_code:en:26052
 ciqual_food_code:en:26052
 ciqual_food_name:en:Ray, raw
 ciqual_food_name:fr:Raie, crue
@@ -58103,6 +60149,7 @@ ciqual_food_name:fr:Raie, crue
 <en:Fishes
 en:Cooked nursehound, Cooked lesser spotted dogfish
 fr:Roussette cuite, Petite roussette cuite, Saumonette cuite
+agribalyse_food_code:en:26033
 ciqual_food_code:en:26033
 ciqual_food_name:en:Nursehound or lesser spotted dogfish, cooked
 ciqual_food_name:fr:Roussette ou petite roussette ou saumonette, cuite
@@ -58110,6 +60157,7 @@ ciqual_food_name:fr:Roussette ou petite roussette ou saumonette, cuite
 <en:Fishes
 en:Raw nursehound, Raw lesser spotted dogfish
 fr:Roussette crue, Petite roussette crue, Saumonette crue
+agribalyse_food_code:en:26074
 ciqual_food_code:en:26074
 ciqual_food_name:en:Nursehound or lesser spotted dogfish, raw
 ciqual_food_name:fr:Roussette ou petite roussette ou saumonette, crue
@@ -58117,6 +60165,7 @@ ciqual_food_name:fr:Roussette ou petite roussette ou saumonette, crue
 <en:Fishes
 en:Raw megrim
 fr:Cardine franche crue
+agribalyse_food_code:en:26084
 ciqual_food_code:en:26084
 ciqual_food_name:en:Megrim, raw
 ciqual_food_name:fr:Cardine franche, crue
@@ -58152,6 +60201,7 @@ origins:en: en:United Kingdom
 <en:Scallop
 en:Cooked scallop with coral
 fr:Coquille Saint-Jacques cuite avec noix et corail
+agribalyse_food_code:en:10004
 ciqual_food_code:en:10004
 ciqual_food_name:en:Scallop, with coral, cooked
 ciqual_food_name:fr:Coquille Saint-Jacques, noix et corail, cuite
@@ -58159,6 +60209,7 @@ ciqual_food_name:fr:Coquille Saint-Jacques, noix et corail, cuite
 <en:Scallop
 en:Raw scallop with coral
 fr:Coquilles Saint-Jacques crues avec noix et corail
+agribalyse_food_code:en:10003
 ciqual_food_code:en:10003
 ciqual_food_name:en:Scallop, with coral, raw
 ciqual_food_name:fr:Coquille Saint-Jacques, noix et corail, crue
@@ -58166,6 +60217,7 @@ ciqual_food_name:fr:Coquille Saint-Jacques, noix et corail, crue
 <en:Scallop
 en:Raw American sea scallop without coral, Raw Canadian sea scallop without coral
 fr:Pecten d'Amérique avec noix cru, Peigne du Canada avec noix cru
+agribalyse_food_code:en:10048
 ciqual_food_code:en:10048
 ciqual_food_name:en:American or Canadian sea scallop, without coral, raw
 ciqual_food_name:fr:Pecten d'Amérique ou Peigne du canada, noix, crue
@@ -58173,6 +60225,7 @@ ciqual_food_name:fr:Pecten d'Amérique ou Peigne du canada, noix, crue
 <en:Scallop
 en:Raw Peru sea scallop without coral
 fr:Pétoncle avec noix crue, Peigne du Pérou avec noix cru
+agribalyse_food_code:en:10049
 ciqual_food_code:en:10049
 ciqual_food_name:en:Peru sea scallop, without coral, raw
 ciqual_food_name:fr:Pétoncle ou Peigne du Pérou, noix, crue
@@ -58180,6 +60233,7 @@ ciqual_food_name:fr:Pétoncle ou Peigne du Pérou, noix, crue
 <en:Scallop
 en:Raw scallop without coral
 fr:Coquilles Saint-Jacques crues avec noix
+agribalyse_food_code:en:10045
 ciqual_food_code:en:10045
 ciqual_food_name:en:Scallop, without coral, raw
 ciqual_food_name:fr:Coquille Saint-Jacques, noix, crue
@@ -58406,6 +60460,7 @@ fr:Filets de sardines à l’huile d’olive
 nl:Sardientjesfilets op olijfolie
 en:sardine fillets in olive oil
 fr:filets de sardine à l'huile d'olive
+agribalyse_food_code:en:26231
 ciqual_food_code:en:26231
 ciqual_food_name:en:European pilchard or sardine, fillets without fishbone, in olive oil, canned, drained
 
@@ -58413,6 +60468,7 @@ ciqual_food_name:en:European pilchard or sardine, fillets without fishbone, in o
 <en:Sardine fillets
 en:European pilchard or sardine in oil canned drained
 fr:Sardine à l'huile appertisée égouttée
+agribalyse_food_code:en:26034
 ciqual_food_code:en:26034
 ciqual_food_name:en:European pilchard or sardine, in oil, canned, drained
 
@@ -58420,6 +60476,7 @@ ciqual_food_name:en:European pilchard or sardine, in oil, canned, drained
 <en:Sardine fillets
 en:European pilchard or sardine in olive oil canned drained
 fr:Sardine à l'huile d'olive appertisée égouttée
+agribalyse_food_code:en:26040
 ciqual_food_code:en:26040
 ciqual_food_name:en:European pilchard or sardine, in olive oil, canned, drained
 
@@ -58427,6 +60484,7 @@ ciqual_food_name:en:European pilchard or sardine, in olive oil, canned, drained
 <en:Sardine fillets
 en:Pilchard in tomato sauce canned drained
 fr:Pilchard sauce tomate appertisé égoutté
+agribalyse_food_code:en:26027
 ciqual_food_code:en:26027
 ciqual_food_name:en:Pilchard, in tomato sauce, canned, drained
 
@@ -58434,6 +60492,7 @@ ciqual_food_name:en:Pilchard, in tomato sauce, canned, drained
 <en:Sardine fillets
 en:European pilchard or sardine in tomato sauce canned drained
 fr:Sardine sauce tomate appertisée égouttée
+agribalyse_food_code:en:26035
 ciqual_food_code:en:26035
 ciqual_food_name:en:European pilchard or sardine, in tomato sauce, canned, drained
 
@@ -58531,6 +60590,7 @@ agribalyse_proxy_food_name:fr:Crevette, cuite
 <en:Shrimps
 en:Cooked shrimps
 fr:Crevettes cuites
+agribalyse_food_code:en:10007
 ciqual_food_code:en:10007
 ciqual_food_name:en:Shrimp or prawn, cooked
 ciqual_food_name:fr:Crevette, cuite
@@ -58538,6 +60598,7 @@ ciqual_food_name:fr:Crevette, cuite
 <en:Shrimps
 en:Raw shrimps
 fr:Crevettes crues
+agribalyse_food_code:en:10021
 ciqual_food_code:en:10021
 ciqual_food_name:en:Shrimp or prawn, raw
 ciqual_food_name:fr:Crevette, crue
@@ -58546,6 +60607,7 @@ ciqual_food_name:fr:Crevette, crue
 <en:Frozen seafood
 en:Raw frozen shrimps
 fr:Crevettes crues surgelées
+agribalyse_food_code:en:10038
 ciqual_food_code:en:10038
 ciqual_food_name:en:Shrimp, frozen, raw
 ciqual_food_name:fr:Crevette, surgelée, crue
@@ -58589,6 +60651,7 @@ wikidata:en:Q1058410
 <en:Prawns
 en:Prawn cooked
 fr:Crevettes roses cuites
+agribalyse_food_code:en:10007
 ciqual_food_code:en:10007
 ciqual_food_name:en:Shrimp or prawn, cooked
 ciqual_food_name:fr:Crevette, cuite
@@ -58596,6 +60659,7 @@ ciqual_food_name:fr:Crevette, cuite
 <en:Prawns
 en:Raw deep water pink shrimps
 fr:Crevettes roses crues
+agribalyse_food_code:en:10059
 ciqual_food_code:en:10059
 ciqual_food_name:en:deep water pink shrimp, raw
 ciqual_food_name:fr:Crevette rose, crue
@@ -58625,6 +60689,7 @@ nl:Rivierkreeftjes
 en:Jumbo shrimps
 fr:Langoustines, Langoustine crue
 nl:Langoustines
+agribalyse_food_code:en:10024
 ciqual_food_code:en:10024
 ciqual_food_name:en:Norway lobster, raw
 ciqual_food_name:fr:Langoustine, crue
@@ -58683,6 +60748,7 @@ ciqual_food_name:fr:Brochet, cru
 <en:skewers
 en:Fish on skewer
 fr:Brochettes de poisson
+agribalyse_food_code:en:25539
 ciqual_food_code:en:25539
 ciqual_food_name:en:Fish on skewer
 ciqual_food_name:fr:Brochette de poisson
@@ -58712,6 +60778,7 @@ wikidata:en:Q815740
 <en:Surimi
 en:Surimi on sticks in slices with crab flavour, Grated surimi on sticks with crab flavour
 fr:Bâtonnets de surimi en tranche saveur crabe, Bâtonnets de surimi râpés saveur crabe
+agribalyse_food_code:en:26046
 ciqual_food_code:en:26046
 ciqual_food_name:en:Surimi, on sticks, in slices or grated, crab flavour
 ciqual_food_name:fr:Surimi, bâtonnets, tranche ou râpé saveur crabe
@@ -58719,6 +60786,7 @@ ciqual_food_name:fr:Surimi, bâtonnets, tranche ou râpé saveur crabe
 <en:Surimi
 en:Surimi filled with cheese
 fr:Surimi fourré au fromage
+agribalyse_food_code:en:26239
 ciqual_food_code:en:26239
 ciqual_food_name:en:Surimi, filled w cheese
 ciqual_food_name:fr:Surimi, fourré au fromage
@@ -58733,12 +60801,14 @@ wikidata:en:Q12860188
 <en:Fish preparations
 fr:Croquettes de poisson, beignet de poisson frit, nuggets de poisson frit
 en:Fish croquette fritter, nuggets fried
+agribalyse_food_code:en:26028
 ciqual_food_code:en:26028
 ciqual_food_name:en:Fish, croquette, fritter or nuggets, fried
 
 <en:Fish preparations
 en:Meat poultry or fish fritters home-made
 fr:nuggets fait maisons
+agribalyse_food_code:en:25551
 ciqual_food_code:en:25551
 ciqual_food_name:en:Meat, poultry or fish fritters, home-made
 
@@ -58752,12 +60822,14 @@ fi:leivitetty kala
 fr:Poissons panés, Poisson pané
 nl:Gepaneerde vis
 sv:Panerad fisk
+agribalyse_food_code:en:26030
 ciqual_food_code:en:26030
 ciqual_food_name:en:Fish, breaded, fried
 
 <en:Breaded fish
 en:Fish breaded frozen raw
 fr:Poisson pané surgelé cru
+agribalyse_food_code:en:26029
 ciqual_food_code:en:26029
 ciqual_food_name:en:Fish, breaded, frozen, raw
 ciqual_food_name:fr:Poisson pané, surgelé, cru
@@ -58776,6 +60848,7 @@ nl:Gepaneerde heek
 en:Breaded whiting
 fr:Poissons panés de merlan, Poisson pané de merlan, Merlans panés, Merlan pané
 nl:Gepaneerde wijting
+agribalyse_food_code:en:26124
 ciqual_food_code:en:26124
 ciqual_food_name:en:Whiting, breaded
 ciqual_food_name:fr:Merlan, pané
@@ -58783,6 +60856,7 @@ ciqual_food_name:fr:Merlan, pané
 <en:Fishes
 en:Fried whiting
 fr:Merlans frits, Merlan frit
+agribalyse_food_code:en:26021
 ciqual_food_code:en:26021
 ciqual_food_name:en:Whiting, fried
 ciqual_food_name:fr:Merlan, frit
@@ -58790,6 +60864,7 @@ ciqual_food_name:fr:Merlan, frit
 <en:Fishes
 en:Steamed whiting
 fr:Merlan cuit à la vapeur
+agribalyse_food_code:en:26022
 ciqual_food_code:en:26022
 ciqual_food_name:en:Whiting, steamed
 ciqual_food_name:fr:Merlan, cuit à la vapeur
@@ -58797,6 +60872,7 @@ ciqual_food_name:fr:Merlan, cuit à la vapeur
 <en:Fishes
 en:Raw whiting
 fr:Merlan cru
+agribalyse_food_code:en:26095
 ciqual_food_code:en:26095
 ciqual_food_name:en:Whiting, raw
 ciqual_food_name:fr:Merlan, cru
@@ -58823,6 +60899,7 @@ zh:罐头鱼
 <en:Sardines
 en:Raw European pilchard, Raw European sardine
 fr:Sardine crue
+agribalyse_food_code:en:26065
 ciqual_food_code:en:26065
 ciqual_food_name:en:European pilchard or sardine, raw
 ciqual_food_name:fr:Sardine, crue
@@ -58830,6 +60907,7 @@ ciqual_food_name:fr:Sardine, crue
 <en:Sardines
 en:Grilled European pilchard, Grilled sardine
 fr:Sardine grillée
+agribalyse_food_code:en:26136
 ciqual_food_code:en:26136
 ciqual_food_name:en:European pilchard or sardine, grilled
 ciqual_food_name:fr:Sardine, grillée
@@ -58917,6 +60995,7 @@ nl:Zalm in blik
 <en:Canned salmons
 en:Canned drained salmons
 fr:Saumons appertisés égouttés, Saumons égouttés en conserve
+agribalyse_food_code:en:26119
 ciqual_food_code:en:26119
 ciqual_food_name:en:Salmon, canned, drained
 ciqual_food_name:fr:Saumon, appertisé, égoutté
@@ -58958,6 +61037,7 @@ wikidata:en:Q1420441
 <en:Pollocks
 en:Raw Alaska pollock
 fr:Lieu d'Alaska cru, Colin d'Alaska cru
+agribalyse_food_code:en:26006
 ciqual_food_code:en:26006
 ciqual_food_name:en:Alaska pollock, raw
 ciqual_food_name:fr:Lieu ou colin d'Alaska, cru
@@ -58965,6 +61045,7 @@ ciqual_food_name:fr:Lieu ou colin d'Alaska, cru
 <en:Pollocks
 en:Smoked Alaska pollock
 fr:Lieu d'Alaska fumé, Colin d'Alaska fumé
+agribalyse_food_code:en:26152
 ciqual_food_code:en:26152
 ciqual_food_name:en:Alaska pollock, smoked
 ciqual_food_name:fr:Lieu ou colin d'Alaska, fumé
@@ -58972,6 +61053,7 @@ ciqual_food_name:fr:Lieu ou colin d'Alaska, fumé
 <en:Pollocks
 en:Raw pollack
 fr:Lieu jaune cru, Colin cru
+agribalyse_food_code:en:26129
 ciqual_food_code:en:26129
 ciqual_food_name:en:Pollack, raw
 ciqual_food_name:fr:Lieu jaune ou colin, cru
@@ -58995,6 +61077,7 @@ nl:Ansjovisfilets
 <en:Semi-preserved foods
 en:Semi-preserved drained anchovy fillets rolled with capers
 fr:Filets d'anchois roulés aux câpres égouttés en semi-conserve
+agribalyse_food_code:en:25999
 ciqual_food_code:en:25999
 ciqual_food_name:en:Anchovy, fillets, rolled with capers, semi-preserved, drained
 ciqual_food_name:fr:Anchois, filets roulés aux câpres, semi-conserve, égoutté
@@ -59003,6 +61086,7 @@ ciqual_food_name:fr:Anchois, filets roulés aux câpres, semi-conserve, égoutt�
 <en:Semi-preserved foods
 en:Semi-preserved drained anchovy fillets in oil
 fr:Filets d'anchois égouttés à l'huile en semi-conserve
+agribalyse_food_code:en:26000
 ciqual_food_code:en:26000
 ciqual_food_name:en:Anchovy, fillets, in oil, semi-preserved, drained
 ciqual_food_name:fr:Anchois, filets à l'huile, semi-conserve, égoutté
@@ -59028,6 +61112,7 @@ fr:Filets d'anchois marinés à la catalane
 <en:Fish fillets
 en:Capelin raw
 fr:Capelan cru
+agribalyse_food_code:en:26108
 ciqual_food_code:en:26108
 ciqual_food_name:en:Capelin, raw
 ciqual_food_name:fr:Capelan, cru
@@ -59072,6 +61157,7 @@ nl:Tonijnfilets
 <en:Fishes
 en:Steamed Greenland halibut
 fr:Flétan du Groënland cuit à la vapeur, Flétan noir cuit à la vapeur, Flétan commun cuit à la vapeur
+agribalyse_food_code:en:26247
 ciqual_food_code:en:26247
 ciqual_food_name:en:Greenland halibut, steamed
 ciqual_food_name:fr:Flétan du Groënland ou flétan noir ou flétan commun, cuit à la vapeur
@@ -59085,6 +61171,7 @@ nl:Rauwe vis
 <en:Raw fishes
 en:Raw Atlantic halibut
 fr:Flétan de l'Atlantique cru, flétan blanc cru
+agribalyse_food_code:en:26009
 ciqual_food_code:en:26009
 ciqual_food_name:en:Atlantic halibut, raw
 ciqual_food_name:fr:Flétan de l'Atlantique ou flétan blanc, cru
@@ -59099,6 +61186,7 @@ ciqual_food_name:fr:Thon rouge, cru
 <en:Raw fishes
 en:Raw swordfish
 fr:Espadon cru
+agribalyse_food_code:en:26082
 ciqual_food_code:en:26082
 ciqual_food_name:en:Swordfish, raw
 ciqual_food_name:fr:Espadon, cru
@@ -59106,6 +61194,7 @@ ciqual_food_name:fr:Espadon, cru
 <en:Raw fishes
 en:Raw brown meagre
 fr:Corb cru
+agribalyse_food_code:en:26107
 ciqual_food_code:en:26107
 ciqual_food_name:en:Brown meagre, raw
 ciqual_food_name:fr:Corb, cru
@@ -59113,6 +61202,7 @@ ciqual_food_name:fr:Corb, cru
 <en:Raw fishes
 en:Raw snapper
 fr:Vivaneau cru
+agribalyse_food_code:en:26146
 ciqual_food_code:en:26146
 ciqual_food_name:en:Snapper, raw
 ciqual_food_name:fr:Vivaneau, cru
@@ -59120,12 +61210,14 @@ ciqual_food_name:fr:Vivaneau, cru
 <en:Fishes
 en:Snapper cooked
 fr:Vivaneau cuit
+agribalyse_food_code:en:26147
 ciqual_food_code:en:26147
 ciqual_food_name:en:Snapper, cooked
 
 <en:Raw fishes
 en:Raw crevalle jack
 fr:Carangue cru
+agribalyse_food_code:en:26157
 ciqual_food_code:en:26157
 ciqual_food_name:en:Crevalle jack, raw
 ciqual_food_name:fr:Carangue, cru
@@ -59133,6 +61225,7 @@ ciqual_food_name:fr:Carangue, cru
 <en:Raw fishes
 en:Raw grouper
 fr:Mérou cru
+agribalyse_food_code:en:26178
 ciqual_food_code:en:26178
 ciqual_food_name:en:Grouper, raw
 ciqual_food_name:fr:Mérou, cru
@@ -59140,6 +61233,7 @@ ciqual_food_name:fr:Mérou, cru
 <en:Fishes
 en:Raw bigeye scad
 fr:Coulirou cru
+agribalyse_food_code:en:26159
 ciqual_food_code:en:26159
 ciqual_food_name:en:Bigeye scad, raw
 ciqual_food_name:fr:Coulirou, cru
@@ -59147,6 +61241,7 @@ ciqual_food_name:fr:Coulirou, cru
 <en:Fishes
 en:Raw bogue, Raw boops boops
 fr:Bogue crue
+agribalyse_food_code:en:26100
 ciqual_food_code:en:26100
 ciqual_food_name:en:Bogue, raw
 ciqual_food_name:fr:Bogue, crue
@@ -59154,6 +61249,7 @@ ciqual_food_name:fr:Bogue, crue
 <en:Fishes
 en:Raw big-scale sand smelt to fry, Raw whole small fish to fry
 fr:Joëls pour friture crus, Petits poissons entiers pour friture crus
+agribalyse_food_code:en:26240
 ciqual_food_code:en:26240
 ciqual_food_name:en:Big-scale sand smelt (whole small fish), to fry, raw
 ciqual_food_name:fr:Joëls (petits poissons entiers) pour friture, crus
@@ -59181,6 +61277,7 @@ ciqual_food_name:fr:Saumon, cuit, sans précision (aliment moyen)
 <en:Cooked salmons
 en:grilled salmon, pan-fried salmon
 fr:saumon grillé, saumé poêlé
+agribalyse_food_code:en:26229
 ciqual_food_code:en:26229
 ciqual_food_name:en:Salmon, grilled/pan-fried
 ciqual_food_name:fr:Saumon, grillé/poêlé
@@ -59188,6 +61285,7 @@ ciqual_food_name:fr:Saumon, grillé/poêlé
 <en:Cooked salmons
 en:Steamed salmon
 fr:Saumon cuit à la vapeur
+agribalyse_food_code:en:26038
 ciqual_food_code:en:26038
 ciqual_food_name:en:Salmon, steamed
 ciqual_food_name:fr:Saumon, cuit à la vapeur
@@ -59199,6 +61297,7 @@ fi:viljellyt lohet
 fr:Saumons d'élevage
 it:Salmoni d'allevamenti
 nl:Gekweekte zalm
+agribalyse_food_code:en:26036
 ciqual_food_code:en:26036
 ciqual_food_name:en:Salmon, raw, farmed
 
@@ -59206,6 +61305,7 @@ ciqual_food_name:en:Salmon, raw, farmed
 <en:Cooked salmons
 en:Salmons from farming microwaved
 fr:Saumon d'élevage cuit au micro-ondes
+agribalyse_food_code:en:26211
 ciqual_food_code:en:26211
 ciqual_food_name:en:Salmon, microwaved, farmed
 ciqual_food_name:fr:Saumon, cuit au micro-ondes, élevage
@@ -59214,6 +61314,7 @@ ciqual_food_name:fr:Saumon, cuit au micro-ondes, élevage
 <en:Cooked salmons
 en:Salmons from farming boiled, Salmons from farming cooked in water
 fr:Saumon d'élevage bouilli, Saumon d'élevage cuit à l'eau chaude
+agribalyse_food_code:en:26217
 ciqual_food_code:en:26217
 ciqual_food_name:en:Salmon, boiled/cooked in water, farmed
 ciqual_food_name:fr:Saumon, bouilli/cuit à l'eau, élevage
@@ -59222,6 +61323,7 @@ ciqual_food_name:fr:Saumon, bouilli/cuit à l'eau, élevage
 <en:Cooked salmons
 en:Farmed salmon farmed roasted/baked
 fr:saumon d'élevage cuit au four
+agribalyse_food_code:en:26230
 ciqual_food_code:en:26230
 ciqual_food_name:en:Salmon, farmed, roasted/baked
 ciqual_food_name:fr:Saumon, élevage, rôti/cuit au four
@@ -59240,6 +61342,7 @@ nl:Zalmfilet
 <en:Salmons
 en:Salmon with sorrel
 fr:Saumon à l'oseille
+agribalyse_food_code:en:25077
 ciqual_food_code:en:25077
 ciqual_food_name:en:Salmon with sorrel
 
@@ -59249,12 +61352,14 @@ en:Scottish Wild Salmon
 protected_name_file_number:en: PGI-GB-0863
 protected_name_type:en: pgi
 origins:en: en:United Kingdom
+agribalyse_food_code:en:26161
 ciqual_food_code:en:26161
 ciqual_food_name:en:Salmon, raw, wild
 
 <en:Salmons
 en:Salmon raw wild
 fr:Saumon cru sauvage
+agribalyse_food_code:en:26161
 ciqual_food_code:en:26161
 ciqual_food_name:en:Salmon, raw, wild
 
@@ -59276,6 +61381,7 @@ nl:Ansjovis
 <en:Anchovy
 en:Raw common anchovy
 fr:Anchois commun cru
+agribalyse_food_code:en:26079
 ciqual_food_code:en:26079
 ciqual_food_name:en:Common anchovy, raw
 ciqual_food_name:fr:Anchois commun, cru
@@ -59284,6 +61390,7 @@ ciqual_food_name:fr:Anchois commun, cru
 <en:Semi-preserved foods
 en:Semi-preserved anchovy in salt
 fr:Anchois au sel, Anchoité semi-conserve
+agribalyse_food_code:en:26177
 ciqual_food_code:en:26177
 ciqual_food_name:en:Anchovy, in salt (semi-preserved)
 ciqual_food_name:fr:Anchois au sel (anchoité, semi-conserve)
@@ -59291,6 +61398,7 @@ ciqual_food_name:fr:Anchois au sel (anchoité, semi-conserve)
 <en:Anchovy
 en:Marinated common anchovy
 fr:Anchois commun mariné
+agribalyse_food_code:en:26187
 ciqual_food_code:en:26187
 ciqual_food_name:en:Common anchovy, marinated
 ciqual_food_name:fr:Anchois commun, mariné
@@ -59316,6 +61424,7 @@ fr:Églefin, Haddock
 <en:Haddock
 en:Grilled haddock, Pan-fried haddock
 fr:Églefin grillé, Églefin poêlé
+agribalyse_food_code:en:26126
 ciqual_food_code:en:26126
 ciqual_food_name:en:Haddock, grilled/pan-fried
 ciqual_food_name:fr:Églefin, grillé/poêlé
@@ -59324,6 +61433,7 @@ cooking_method:en en:pan-fried, en:grilled
 <en:Haddock
 en:Steamed haddock
 fr:Églefin cuit à la vapeur
+agribalyse_food_code:en:26008
 ciqual_food_code:en:26008
 ciqual_food_name:en:Haddock, steamed
 ciqual_food_name:fr:Églefin, cuit à la vapeur
@@ -59332,6 +61442,7 @@ cooking_method:en en:steamed
 <en:Haddock
 en:Raw haddock
 fr:Églefin cru
+agribalyse_food_code:en:26122
 ciqual_food_code:en:26122
 ciqual_food_name:en:Haddock, raw
 ciqual_food_name:fr:Églefin, cru
@@ -59340,6 +61451,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Raw conger
 fr:Congre cru
+agribalyse_food_code:en:26127
 ciqual_food_code:en:26127
 ciqual_food_name:en:Conger, raw
 ciqual_food_name:fr:Congre, cru
@@ -59348,6 +61460,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Raw roundnose grenadier
 fr:Grenadier cru, Grenadier de roche cru
+agribalyse_food_code:en:26128
 ciqual_food_code:en:26128
 ciqual_food_name:en:Roundnose grenadier, raw
 ciqual_food_name:fr:Grenadier (de roche), cru
@@ -59356,6 +61469,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Raw grenadier
 fr:Hoki cru
+agribalyse_food_code:en:26213
 ciqual_food_code:en:26213
 ciqual_food_name:en:Grenadier, from any fishing spot, raw
 ciqual_food_name:fr:Hoki, tout lieu de pêche, cru
@@ -59364,6 +61478,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Raw tub gurnard
 fr:Grondin perlon cru
+agribalyse_food_code:en:26219
 ciqual_food_code:en:26219
 ciqual_food_name:en:Tub gurnard, raw
 ciqual_food_name:fr:Grondin perlon, cru
@@ -59372,6 +61487,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Raw blue shark fillet without skin
 fr:Filet d'empereur sans peau cru
+agribalyse_food_code:en:26241
 ciqual_food_code:en:26241
 ciqual_food_name:en:Blue shark, fillet, without skin, raw
 ciqual_food_name:fr:Empereur, filet, sans peau, cru
@@ -59393,24 +61509,28 @@ cooking_method:en en:smoked
 <en:Fishes
 en:Surmullet or red mullet raw
 fr:Rouget-barbet de roche cru
+agribalyse_food_code:en:26085
 ciqual_food_code:en:26085
 ciqual_food_name:en:Surmullet or red mullet, raw
 
 <en:Fishes
 en:Surmullet or red mullet steamed
 fr:Rouget-barbet de roche vapeur
+agribalyse_food_code:en:26110
 ciqual_food_code:en:26110
 ciqual_food_name:en:Surmullet or red mullet, steamed
 
 <en:Fishes
 en:Surmullet or red mullet fillet with skin frozen raw (from Thailand or Senegal)
 fr:Rouget-barbet filet avec peau surgelé cru (Thaïlande Sénégal…)
+agribalyse_food_code:en:26244
 ciqual_food_code:en:26244
 ciqual_food_name:en:Surmullet or red mullet, fillet with skin, frozen, raw (from Thailand or Senegal)
 
 <en:Fishes
 en:Common sole raw
 fr:Sole crue
+agribalyse_food_code:en:26058
 ciqual_food_code:en:26058
 ciqual_food_name:en:Common sole, raw
 cooking_method:en en:raw
@@ -59418,6 +61538,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Common sole fried
 fr:Sole frite
+agribalyse_food_code:en:26062
 ciqual_food_code:en:26062
 ciqual_food_name:en:Common sole, fried
 cooking_method:en en:fried
@@ -59425,6 +61546,7 @@ cooking_method:en en:fried
 <en:Fishes
 en:Common sole steamed
 fr:Sole cuite à la vapeur
+agribalyse_food_code:en:26059
 ciqual_food_code:en:26059
 ciqual_food_name:en:Common sole, steamed
 cooking_method:en en:steamed
@@ -59432,12 +61554,14 @@ cooking_method:en en:steamed
 <en:Fishes
 en:Common sole boiled/cooked in water
 fr:Sole cuite à l'eau
+agribalyse_food_code:en:26061
 ciqual_food_code:en:26061
 ciqual_food_name:en:Common sole, boiled/cooked in water
 
 <en:Fishes
 en:Common sole grilled
 fr:Sole poêlée
+agribalyse_food_code:en:26248
 ciqual_food_code:en:26248
 ciqual_food_name:en:Common sole, grilled
 cooking_method:en en:grilled
@@ -59445,12 +61569,14 @@ cooking_method:en en:grilled
 <en:Fishes
 en:Common sole roasted/baked
 fr:sole rôtie ou cuite au four
+agribalyse_food_code:en:26060
 ciqual_food_code:en:26060
 ciqual_food_name:en:Common sole, roasted/baked
 
 <en:Fishes
 en:Tonguesole raw
 fr:sole tropicale crue, sole langue crue
+agribalyse_food_code:en:26200
 ciqual_food_code:en:26200
 ciqual_food_name:en:Tonguesole, raw
 
@@ -59468,6 +61594,7 @@ nl:Gerookte zalm
 pt:Salmões fumados
 ro:Somon afumat
 zh:烟熏三文鱼
+agribalyse_food_code:en:26037
 ciqual_food_code:en:26037
 ciqual_food_name:en:Salmon, smoked
 
@@ -59510,6 +61637,7 @@ nl:Gerookte brasem
 <en:Breams
 en:Black seabream roasted/baked
 fr:Dorade grise rôtie ou cuite au four, daurade grise rôtie ou cuite au four
+agribalyse_food_code:en:26222
 ciqual_food_code:en:26222
 ciqual_food_name:en:Black seabream, roasted/baked
 
@@ -59521,6 +61649,7 @@ nl:Gerookte zwaardvis
 <en:Smoked fishes
 en:Swordfish roasted/baked
 fr:Espadon rôti, espadon cuit au four
+agribalyse_food_code:en:26093
 ciqual_food_code:en:26093
 ciqual_food_name:en:Swordfish, roasted/baked
 
@@ -59530,6 +61659,7 @@ en:Smoked haddock
 fr:Haddocks fumés, haddock fumé, eglefins fumés, eglefin fumé, aiglefins fumés, aigrefin fumés, églefins fumés, églefin fumé
 nl:Gerookte schelvis
 en:Smoked haddock
+agribalyse_food_code:en:26090
 ciqual_food_code:en:26090
 ciqual_food_name:en:Haddock, smoked
 ciqual_food_name:fr:Haddock (fumé) ou églefin fumé
@@ -59546,6 +61676,7 @@ nl:Gerookte haring
 <en:Herring
 en:Smoked Atlantic herring fillet
 fr:Filet de hareng fumé doux
+agribalyse_food_code:en:25998
 ciqual_food_code:en:25998
 ciqual_food_name:en:Atlantic herring, smoked, fillet
 ciqual_food_name:fr:Hareng fumé, filet, doux
@@ -59553,6 +61684,7 @@ ciqual_food_name:fr:Hareng fumé, filet, doux
 <en:Herring
 en:Smoked Atlantic herring in oil
 fr:Hareng fumé à l'huile
+agribalyse_food_code:en:26232
 ciqual_food_code:en:26232
 ciqual_food_name:en:Atlantic herring, smoked, in oil
 ciqual_food_name:fr:Hareng fumé, à l'huile
@@ -59560,6 +61692,7 @@ ciqual_food_name:fr:Hareng fumé, à l'huile
 <en:Herring
 en:Plain smoked Atlantic herring
 fr:Hareng fumé au naturel
+agribalyse_food_code:en:26013
 ciqual_food_code:en:26013
 ciqual_food_name:en:Atlantic herring, smoked, plain
 ciqual_food_name:fr:Hareng fumé, au naturel
@@ -59569,6 +61702,7 @@ en:Smoked mackerels
 de:geräucherte Makrelen
 fr:Maquereaux fumés
 nl:Gerookte makreel
+agribalyse_food_code:en:26087
 ciqual_food_code:en:26087
 ciqual_food_name:en:Mackerel, smoked
 ciqual_food_name:fr:Maquereau, fumé
@@ -59599,6 +61733,7 @@ fi:taimenet
 fr:Truites
 it:Trote, trota
 nl:Forel
+agribalyse_food_code:en:26092
 ciqual_food_code:en:26092
 ciqual_food_name:en:Sea trout, raw
 
@@ -59606,6 +61741,7 @@ ciqual_food_name:en:Sea trout, raw
 <en:Trouts
 en:Trout farmed raw
 fr:Truite d'élevage crue
+agribalyse_food_code:en:27008
 ciqual_food_code:en:27008
 ciqual_food_name:en:Trout, farmed, raw
 cooking_method:en en:raw
@@ -59614,6 +61750,7 @@ cooking_method:en en:raw
 <en:Trouts
 en:Trout farmed raw
 fr:Truite d'élevage crue
+agribalyse_food_code:en:27008
 ciqual_food_code:en:27008
 ciqual_food_name:en:Trout, farmed, raw
 cooking_method:en en:raw
@@ -59622,6 +61759,7 @@ cooking_method:en en:raw
 <en:Trouts
 en:Trout farmed smoked
 fr:Truite d'élevage fumée
+agribalyse_food_code:en:27029
 ciqual_food_code:en:27029
 ciqual_food_name:en:Trout, farmed, smoked
 cooking_method:en en:smoked
@@ -59638,6 +61776,7 @@ ciqual_food_name:en:Rainbow trout, raw, farmed
 <en:Trouts
 en:Salmon trout raw
 fr:Truite saumonée crue
+agribalyse_food_code:en:27021
 ciqual_food_code:en:27021
 ciqual_food_name:en:Salmon trout, raw
 cooking_method:en en:raw
@@ -59645,12 +61784,14 @@ cooking_method:en en:raw
 <en:Fishes
 en:Carp raw farmed
 fr:Carpe crue élevage
+agribalyse_food_code:en:27003
 ciqual_food_code:en:27003
 ciqual_food_name:en:Carp, raw, farmed
 
 <en:Fishes
 en:European perch raw
 fr:Perche crue
+agribalyse_food_code:en:27010
 ciqual_food_code:en:27010
 ciqual_food_name:en:European perch, raw
 cooking_method:en en:raw
@@ -59658,6 +61799,7 @@ cooking_method:en en:raw
 <en:Fishes
 en:Nile perch raw
 fr:Perche du Nil crue
+agribalyse_food_code:en:27025
 ciqual_food_code:en:27025
 ciqual_food_name:en:Nile perch, raw
 cooking_method:en en:raw
@@ -59668,24 +61810,28 @@ en:Cooked trouts
 <en:Cooked trouts
 en:Rainbow trout farmed roasted, Rainbow trout farmed baked
 fr:Truite arc en ciel élevage rôtie, truite arc en ciel élevage cuite au four
+agribalyse_food_code:en:27014
 ciqual_food_code:en:27014
 ciqual_food_name:en:Rainbow trout, farmed, roasted/baked
 
 <en:Cooked trouts
 en:Steamed Rainbow trout from farming
 fr:Truite arc en ciel d'élevage cuite à la vapeur
+agribalyse_food_code:en:27015
 ciqual_food_code:en:27015
 ciqual_food_name:en:Rainbow trout, farmed, steamed
 
 <en:Cooked trouts
 en:Roasted trout, baked trout
 fr:Truite rôtie, truite cuite au four
+agribalyse_food_code:en:27006
 ciqual_food_code:en:27006
 ciqual_food_name:en:Trout, roasted/baked
 
 <en:Trouts
 en:Trout steamed
 fr:Truite cuite à la vapeur
+agribalyse_food_code:en:27007
 ciqual_food_code:en:27007
 ciqual_food_name:en:Trout, steamed
 cooking_method:en en:steamed
@@ -59693,12 +61839,14 @@ cooking_method:en en:steamed
 <en:Fishes
 en:European perch roasted/baked
 fr:Perche rôtie ou cuite au four
+agribalyse_food_code:en:27005
 ciqual_food_code:en:27005
 ciqual_food_name:en:European perch, roasted/baked
 
 <en:Fishes
 en:Red gurnard raw
 fr:Grondin cru
+agribalyse_food_code:en:26106
 ciqual_food_code:en:26106
 ciqual_food_name:en:Red gurnard, raw
 
@@ -59717,6 +61865,7 @@ pt:Atum
 th:ทูน่า
 zh:吞拿鱼
 wikidata:en:Q2346039
+agribalyse_food_code:en:26053
 ciqual_food_code:en:26053
 ciqual_food_name:en:Tuna, raw
 
@@ -59751,6 +61900,7 @@ nl:Tonijnstukjes
 <en:Canned tunas
 en:Canned drained tuna in oil
 fr:Thon à l'huile appertisé égoutté, Thon à l'huile égoutté en conserve
+agribalyse_food_code:en:26071
 ciqual_food_code:en:26071
 ciqual_food_name:en:Tuna, in oil, canned, drained
 ciqual_food_name:fr:Thon à l'huile, appertisé, égoutté
@@ -59758,6 +61908,7 @@ ciqual_food_name:fr:Thon à l'huile, appertisé, égoutté
 <en:Canned tunas
 en:Canned drained tuna flaked in tomato sauce
 fr:Miettes de thon à la tomate appertisées, Miettes de thon à la tomate en conserve
+agribalyse_food_code:en:26242
 ciqual_food_code:en:26242
 ciqual_food_name:en:Tuna, flaked, in tomato sauce, canned, drained
 ciqual_food_name:fr:Miettes de thon à la tomate, appertisées
@@ -59765,6 +61916,7 @@ ciqual_food_name:fr:Miettes de thon à la tomate, appertisées
 <en:Canned tunas
 en:Canned drained tuna flaked in oil
 fr:Miettes de thon à l'huile appertisées, Miettes de thon à l'huile en conserve
+agribalyse_food_code:en:26245
 ciqual_food_code:en:26245
 ciqual_food_name:en:Tuna, flaked, in oil, canned, drained
 ciqual_food_name:fr:Miettes de thon à l'huile, appertisées
@@ -59789,6 +61941,7 @@ ru:Тунец копчёный, Копчёный тунец
 <en:Tunas
 en:Tuna roasted/baked
 fr:Thon rôti, thon cuit au four
+agribalyse_food_code:en:26041
 ciqual_food_code:en:26041
 ciqual_food_name:en:Tuna, roasted/baked
 
@@ -59850,6 +62003,7 @@ nl:Witte tonijn natuur
 <en:Albacore
 en:Canned drained albacore in olive oil
 fr:Thon germon à l'huile d'olive appertisé égoutté, Thon blanc à l'huile d'olive appertisé égoutté
+agribalyse_food_code:en:26179
 ciqual_food_code:en:26179
 ciqual_food_name:en:Albacore, in olive oil, canned, drained
 ciqual_food_name:fr:Thon germon ou thon blanc, à l'huile d'olive, appertisé, égoutté
@@ -59857,6 +62011,7 @@ ciqual_food_name:fr:Thon germon ou thon blanc, à l'huile d'olive, appertisé, �
 <en:Albacore
 en:Albacore steamed under pressure
 fr:Thon germon cuit à la vapeur sous pression, Thon blanc cuit à la vapeur sous pression
+agribalyse_food_code:en:26077
 ciqual_food_code:en:26077
 ciqual_food_name:en:Albacore, steamed under pressure
 ciqual_food_name:fr:Thon germon ou thon blanc, cuit à la vapeur sous pression
@@ -59870,6 +62025,7 @@ fr:Thons blancs, Thons germon, thons blanc germon, germon, thon blanc germon
 la:Thunnus alalunga
 nl:Witte tonijn
 wikidata:en:Q239977
+agribalyse_food_code:en:26076
 ciqual_food_code:en:26076
 ciqual_food_name:en:Albacore, raw
 
@@ -59895,12 +62051,14 @@ wikidata:en:Q269781
 
 <en:Yellowfin tunas
 fr:Thons albacore au naturel, Thon albacore naturel appertisé égoutté, thon jaune naturel appertisé égoutté
+agribalyse_food_code:en:26181
 ciqual_food_code:en:26181
 ciqual_food_name:en:Yellowfin tuna, canned in brine, drained
 
 <en:Yellowfin tunas
 fr:Thons albacore au naturel, thon jaune cru
 en:Yellowfin tuna raw
+agribalyse_food_code:en:26064
 ciqual_food_code:en:26064
 ciqual_food_name:en:Yellowfin tuna, raw
 
@@ -59911,6 +62069,7 @@ fr:thons listao, bonite à ventre rayé, listao
 la:Katsuwonus pelamis
 nl:Echte bonito, Bonito, Skipjack, Skipjacktonijn
 wikidata:en:Q633957
+agribalyse_food_code:en:26101
 ciqual_food_code:en:26101
 ciqual_food_name:en:Bonito, raw
 
@@ -59939,6 +62098,7 @@ wikidata:en:Q1224135
 <en:Bass
 en:Raw American bass
 fr:Bar rayé cru, Bar d'Amérique cru
+agribalyse_food_code:en:26001
 ciqual_food_code:en:26001
 ciqual_food_name:en:American bass, raw
 ciqual_food_name:fr:Bar rayé ou bar d'Amérique cru
@@ -59946,6 +62106,7 @@ ciqual_food_name:fr:Bar rayé ou bar d'Amérique cru
 <en:Bass
 en:Raw Atlantic bass
 fr:Bar cru, Loup de l'Atlantique
+agribalyse_food_code:en:26075
 ciqual_food_code:en:26075
 ciqual_food_name:en:Atlantic bass, raw
 ciqual_food_name:fr:Bar ou loup de l'Atlantique, cru
@@ -59953,6 +62114,7 @@ ciqual_food_name:fr:Bar ou loup de l'Atlantique, cru
 <en:Bass
 en:Raw European bass
 fr:Bar commun cru, Loup cru
+agribalyse_food_code:en:26072
 ciqual_food_code:en:26072
 ciqual_food_name:en:European bass, raw
 ciqual_food_name:fr:Bar commun ou loup, cru, sans précision
@@ -59960,6 +62122,7 @@ ciqual_food_name:fr:Bar commun ou loup, cru, sans précision
 <en:Bass
 en:Raw wild mediterranean bass
 fr:Bar commun cru sauvage, Loup de Méditerranée cru sauvage
+agribalyse_food_code:en:26205
 ciqual_food_code:en:26205
 ciqual_food_name:en:Mediterranean bass, raw, wild
 ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, sauvage
@@ -59967,6 +62130,7 @@ ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, sauvage
 <en:Bass
 en:Raw farmed Mediterranean bass
 fr:Bar commun cru d'élevage, Loup de Méditerranée cru d'élevage
+agribalyse_food_code:en:26206
 ciqual_food_code:en:26206
 ciqual_food_name:en:Mediterranean bass, raw, farmed
 ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, élevage
@@ -59974,6 +62138,7 @@ ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, élevage
 <en:Fishes
 en:Spotted wolffish
 fr:Loup tacheté cru
+agribalyse_food_code:en:26172
 ciqual_food_code:en:26172
 ciqual_food_name:en:Spotted wolffish
 ciqual_food_name:fr:Loup tacheté, cru
@@ -59994,6 +62159,7 @@ nl:Brasem
 <en:Breams
 en:Raw wild gilthead seabream
 fr:Daurade sauvage crue, Dorade royale sauvage crue, Vraie daurade sauvage crue
+agribalyse_food_code:en:26080
 ciqual_food_code:en:26080
 ciqual_food_name:en:Gilthead seabream, raw, wild
 ciqual_food_name:fr:Dorade royale, ou daurade ou vraie daurade, crue, sauvage
@@ -60001,6 +62167,7 @@ ciqual_food_name:fr:Dorade royale, ou daurade ou vraie daurade, crue, sauvage
 <en:Breams
 en:Farmed wild gilthead seabream
 fr:Dorade royale d'élevage crue, Daurade d'élevage crue, Vraie daurade d'élevage crue
+agribalyse_food_code:en:26088
 ciqual_food_code:en:26088
 ciqual_food_name:en:Gilthead seabream, raw, farmed
 ciqual_food_name:fr:Dorade royale ou daurade ou vraie daurade, crue, élevage
@@ -60008,6 +62175,7 @@ ciqual_food_name:fr:Dorade royale ou daurade ou vraie daurade, crue, élevage
 <en:Breams
 en:Raw freshwater bream
 fr:Brème cru
+agribalyse_food_code:en:26170
 ciqual_food_code:en:26170
 ciqual_food_name:en:Freshwater bream, raw
 ciqual_food_name:fr:Brème, cru
@@ -60028,6 +62196,7 @@ fi:suolasilli
 fr:Harengs marinés, hareng mariné, Hareng Bismarck, Harengs Bismarck
 nl:Zure haring
 wikidata:en:Q695101
+agribalyse_food_code:en:26010
 ciqual_food_code:en:26010
 ciqual_food_name:en:Atlantic herring, marinated, or rollmops
 ciqual_food_name:fr:Hareng mariné ou rollmops
@@ -60038,6 +62207,7 @@ de:Rollmops, Rollmöpse
 fr:Rollmops, Rollmop
 nl:Rolmops
 wikidata:en:Q1424531
+agribalyse_food_code:en:26010
 ciqual_food_code:en:26010
 ciqual_food_name:en:Atlantic herring, marinated, or rollmops
 ciqual_food_name:fr:Hareng mariné ou rollmops
@@ -60050,6 +62220,7 @@ wikidata:en:Q1510347
 <en:Herring
 en:Fried Atlantic herring
 fr:Hareng frit
+agribalyse_food_code:en:26012
 ciqual_food_code:en:26012
 ciqual_food_name:en:Atlantic herring, fried
 ciqual_food_name:fr:Hareng, frit
@@ -60057,6 +62228,7 @@ ciqual_food_name:fr:Hareng, frit
 <en:Herring
 en:Grilled Atlantic herring, Pan-fried Atlantic herring
 fr:Hareng grillé, Hareng poêlé
+agribalyse_food_code:en:26014
 ciqual_food_code:en:26014
 ciqual_food_name:en:Atlantic herring, grilled/pan-fried
 ciqual_food_name:fr:Hareng, grillé/poêlé
@@ -60064,6 +62236,7 @@ ciqual_food_name:fr:Hareng, grillé/poêlé
 <en:Herring
 en:Raw Atlantic herring
 fr:Hareng cru
+agribalyse_food_code:en:26011
 ciqual_food_code:en:26011
 ciqual_food_name:en:Atlantic herring, raw
 ciqual_food_name:fr:Hareng, cru
@@ -60071,6 +62244,7 @@ ciqual_food_name:fr:Hareng, cru
 <en:Herring
 en:Raw lean Atlantic herring
 fr:Hareng maigre cru
+agribalyse_food_code:en:26237
 ciqual_food_code:en:26237
 ciqual_food_name:en:Atlantic herring, lean, raw
 ciqual_food_name:fr:Hareng maigre, cru
@@ -60078,6 +62252,7 @@ ciqual_food_name:fr:Hareng maigre, cru
 <en:Herring
 en:Raw oily Atlantic herring
 fr:Hareng gras cru
+agribalyse_food_code:en:26238
 ciqual_food_code:en:26238
 ciqual_food_name:en:Atlantic herring, oily, raw
 ciqual_food_name:fr:Hareng gras, cru
@@ -60085,6 +62260,7 @@ ciqual_food_name:fr:Hareng gras, cru
 <en:Rollmops
 en:Marinated Atlantic rollmops
 fr:Rollmops
+agribalyse_food_code:en:26010
 ciqual_food_code:en:26010
 ciqual_food_name:en:Atlantic herring, marinated, or rollmops
 ciqual_food_name:fr:Hareng mariné ou rollmops
@@ -60105,6 +62281,7 @@ nl:Kwabaal
 <en:Anglers
 en:Grilled anglerfish
 fr:Lotte grillée, Lotte poêlée, Baudroie grillée, Baudroie poêlée
+agribalyse_food_code:en:26081
 ciqual_food_code:en:26081
 ciqual_food_name:en:Anglerfish, grilled
 ciqual_food_name:fr:Lotte ou baudroie, grillée/poêlée
@@ -60112,6 +62289,7 @@ ciqual_food_name:fr:Lotte ou baudroie, grillée/poêlée
 <en:Anglers
 en:Raw anglerfish
 fr:Lotte crue, Baudroie crue
+agribalyse_food_code:en:26018
 ciqual_food_code:en:26018
 ciqual_food_name:en:Anglerfish, raw
 ciqual_food_name:fr:Lotte ou baudroie, crue
@@ -60142,6 +62320,7 @@ fi:Makrillifileet
 fr:Filets de maquereaux
 nl:Makreelfilets
 pl:Filety z makreli
+agribalyse_food_code:en:26123
 ciqual_food_code:en:26123
 ciqual_food_name:en:Mackerel, canned in brine, drained
 
@@ -60149,6 +62328,7 @@ ciqual_food_name:en:Mackerel, canned in brine, drained
 <en:Fish fillets
 en:Mackerel fillet in tomato sauce canned drained
 fr:Maquereau filet sauce tomate appertisé égoutté
+agribalyse_food_code:en:26086
 ciqual_food_code:en:26086
 ciqual_food_name:en:Mackerel, fillet, in tomato sauce, canned, drained
 
@@ -60156,6 +62336,7 @@ ciqual_food_name:en:Mackerel, fillet, in tomato sauce, canned, drained
 <en:Fish fillets
 en:Mackerel fillet in mustard sauce canned drained
 fr:Maquereau filet sauce moutarde appertisé égoutté
+agribalyse_food_code:en:26096
 ciqual_food_code:en:26096
 ciqual_food_name:en:Mackerel, fillet, in mustard sauce, canned, drained
 
@@ -60163,12 +62344,14 @@ ciqual_food_name:en:Mackerel, fillet, in mustard sauce, canned, drained
 <en:Fish fillets
 en:Mackerel fillet in white wine canned drained
 fr:Maquereau filet au vin blanc appertisé égoutté
+agribalyse_food_code:en:26097
 ciqual_food_code:en:26097
 ciqual_food_name:en:Mackerel, fillet, in white wine, canned, drained
 
 <en:Mackerels
 en:Raw mackerel
 fr:Maquereau cru
+agribalyse_food_code:en:26051
 ciqual_food_code:en:26051
 ciqual_food_name:en:Mackerel, raw
 ciqual_food_name:fr:Maquereau, cru
@@ -60176,6 +62359,7 @@ ciqual_food_name:fr:Maquereau, cru
 <en:Mackerels
 en:Fried mackerel
 fr:Maquereau frit
+agribalyse_food_code:en:26020
 ciqual_food_code:en:26020
 ciqual_food_name:en:Mackerel, fried
 ciqual_food_name:fr:Maquereau, frit
@@ -60183,6 +62367,7 @@ ciqual_food_name:fr:Maquereau, frit
 <en:Mackerels
 en:Roasted mackerel, baked mackerel
 fr:Maquereau rôti, maquereau cuit au four
+agribalyse_food_code:en:26019
 ciqual_food_code:en:26019
 ciqual_food_name:en:Mackerel, roasted/baked
 ciqual_food_name:fr:Maquereau, rôti/cuit au four
@@ -60190,6 +62375,7 @@ ciqual_food_name:fr:Maquereau, rôti/cuit au four
 <en:Mackerels
 en:Marinated mackerel
 fr:Maquereau mariné
+agribalyse_food_code:en:26186
 ciqual_food_code:en:26186
 ciqual_food_name:en:Mackerel, marinated
 ciqual_food_name:fr:Maquereau, mariné
@@ -60197,6 +62383,7 @@ ciqual_food_name:fr:Maquereau, mariné
 <en:Mackerels
 en:Raw Atlantic chub mackerel
 fr:Maquereau espagnol cru, Maquereau blanc cru, Maquereau billard cru
+agribalyse_food_code:en:26102
 ciqual_food_code:en:26102
 ciqual_food_name:en:Atlantic chub mackerel, raw
 ciqual_food_name:fr:Maquereau espagnol ou maquereau blanc ou billard cru
@@ -60204,6 +62391,7 @@ ciqual_food_name:fr:Maquereau espagnol ou maquereau blanc ou billard cru
 <en:Mackerels
 en:Raw horse mackerel
 fr:Chinchard cru
+agribalyse_food_code:en:26113
 ciqual_food_code:en:26113
 ciqual_food_name:en:Horse mackerel, raw
 ciqual_food_name:fr:Chinchard, cru
@@ -60211,6 +62399,7 @@ ciqual_food_name:fr:Chinchard, cru
 <en:Mackerels
 en:Raw oily horse mackerel
 fr:Chinchard gras cru
+agribalyse_food_code:en:26236
 ciqual_food_code:en:26236
 ciqual_food_name:en:Horse mackerel, oily (autumn, winter), raw
 ciqual_food_name:fr:Chinchard gras, cru
@@ -60218,6 +62407,7 @@ ciqual_food_name:fr:Chinchard gras, cru
 <en:Mackerels
 en:Raw lean horse mackerel
 fr:Chinchard maigre cru
+agribalyse_food_code:en:26235
 ciqual_food_code:en:26235
 ciqual_food_name:en:Horse mackerel, lean (spring, summer), raw
 ciqual_food_name:fr:Chinchard maigre, cru
@@ -60262,6 +62452,7 @@ nl:Makreelfilets natuur
 <en:Fishes
 en:Roasted turbot, Baked turbot
 fr:Turbot rôti, Turbot cuit au four
+agribalyse_food_code:en:26094
 ciqual_food_code:en:26094
 ciqual_food_name:en:Turbot, roasted/baked
 ciqual_food_name:fr:Turbot, rôti/cuit au four
@@ -60269,6 +62460,7 @@ ciqual_food_name:fr:Turbot, rôti/cuit au four
 <en:Fishes
 en:Raw wild turbot
 fr:Turbot sauvage cru
+agribalyse_food_code:en:26042
 ciqual_food_code:en:26042
 ciqual_food_name:en:Turbot, raw, wild
 ciqual_food_name:fr:Turbot sauvage, cru
@@ -60276,6 +62468,7 @@ ciqual_food_name:fr:Turbot sauvage, cru
 <en:Fishes
 en:Raw turbot
 fr:Turbot cru
+agribalyse_food_code:en:26174
 ciqual_food_code:en:26174
 ciqual_food_name:en:Turbot, raw
 ciqual_food_name:fr:Turbot, cru
@@ -60283,6 +62476,7 @@ ciqual_food_name:fr:Turbot, cru
 <en:Fishes
 en:Farmed raw turbot
 fr:Turbot d'élevage cru
+agribalyse_food_code:en:26201
 ciqual_food_code:en:26201
 ciqual_food_name:en:Turbot, raw, farmed
 ciqual_food_name:fr:Turbot d'élevage, cru
@@ -60290,6 +62484,7 @@ ciqual_food_name:fr:Turbot d'élevage, cru
 <en:Fishes
 en:Cooked Pangasius filets
 fr:Filet de Panga cuit, Filet de Pangasius cuit, Filet de poisson-chat du Mékong cuit
+agribalyse_food_code:en:27018
 ciqual_food_code:en:27018
 ciqual_food_name:en:Pangasius, filets, cooked
 ciqual_food_name:fr:Panga, Pangasius, ou poisson-chat du Mékong, filet, cuit
@@ -60297,6 +62492,7 @@ ciqual_food_name:fr:Panga, Pangasius, ou poisson-chat du Mékong, filet, cuit
 <en:Fishes
 en:Raw brown bullhead
 fr:Pangasius cru, Poisson-chat cru
+agribalyse_food_code:en:27017
 ciqual_food_code:en:27017
 ciqual_food_name:en:Brown bullhead, raw
 ciqual_food_name:fr:Pangasius ou Poisson-chat, cru
@@ -60304,6 +62500,7 @@ ciqual_food_name:fr:Pangasius ou Poisson-chat, cru
 <en:Bass
 en:Roasted European bass, Baked European bass
 fr:Bar commun rôti, Bar commun cuit au four, Loup rôti, Loup cuit au four
+agribalyse_food_code:en:27030
 ciqual_food_code:en:27030
 ciqual_food_name:en:European bass, roasted/baked
 ciqual_food_name:fr:Bar commun ou loup, rôti/cuit au four
@@ -60311,6 +62508,7 @@ ciqual_food_name:fr:Bar commun ou loup, rôti/cuit au four
 <en:Fishes
 en:Roasted mullet, Baked mullet
 fr:Mulet rôti, Mulet cuit au four
+agribalyse_food_code:en:26026
 ciqual_food_code:en:26026
 ciqual_food_name:en:Mullet, roasted/baked
 ciqual_food_name:fr:Mulet, rôti/cuit au four
@@ -60318,6 +62516,7 @@ ciqual_food_name:fr:Mulet, rôti/cuit au four
 <en:Fishes
 en:Raw mullet
 fr:Mulet cru
+agribalyse_food_code:en:26091
 ciqual_food_code:en:26091
 ciqual_food_name:en:Mullet, raw
 ciqual_food_name:fr:Mulet, cru
@@ -60341,24 +62540,28 @@ ciqual_food_name:fr:Cabillaud, cuit, sans précision (aliment moyen)
 <en:Fishes
 en:Black seabream raw
 fr:dorade grise crue, daurade grise crue, griset crue
+agribalyse_food_code:en:26099
 ciqual_food_code:en:26099
 ciqual_food_name:en:Black seabream, raw
 
 <en:Fishes
 en:Blackspot seabream raw
 fr:dorade rose crue, daurade rose crue
+agribalyse_food_code:en:26109
 ciqual_food_code:en:26109
 ciqual_food_name:en:Blackspot seabream, raw
 
 <en:Fishes
 en:Salema raw
 fr:Saupe crue
+agribalyse_food_code:en:26111
 ciqual_food_code:en:26111
 ciqual_food_name:en:Salema, raw
 
 <en:Cooked cods
 en:Roasted cods, Baked cods
 fr:Cabillauds rôtis, Cabillauds cuits au four
+agribalyse_food_code:en:26023
 ciqual_food_code:en:26023
 ciqual_food_name:en:Cod, roasted/baked
 ciqual_food_name:fr:Cabillaud, rôti/cuit au four
@@ -60366,6 +62569,7 @@ ciqual_food_name:fr:Cabillaud, rôti/cuit au four
 <en:Cooked cods
 en:Steamed cods
 fr:Cabillauds cuits à la vapeur
+agribalyse_food_code:en:26025
 ciqual_food_code:en:26025
 ciqual_food_name:en:Cod, steamed
 ciqual_food_name:fr:Cabillaud, cuit à la vapeur
@@ -60373,6 +62577,7 @@ ciqual_food_name:fr:Cabillaud, cuit à la vapeur
 <en:Cods
 en:Raw cod
 fr:Cabillaud cru
+agribalyse_food_code:en:26043
 ciqual_food_code:en:26043
 ciqual_food_name:en:Cod, raw
 ciqual_food_name:fr:Cabillaud, cru
@@ -60380,6 +62585,7 @@ ciqual_food_name:fr:Cabillaud, cru
 <en:Cods
 en:Salted boiled cod, Salted cod cooked in water
 fr:Morue salée bouillie, Morue salée cuite à l'eau
+agribalyse_food_code:en:26024
 ciqual_food_code:en:26024
 ciqual_food_name:en:Cod, salted, boiled/cooked in water
 ciqual_food_name:fr:Morue, salée, bouillie/cuite à l'eau
@@ -60387,6 +62593,7 @@ ciqual_food_name:fr:Morue, salée, bouillie/cuite à l'eau
 <en:Cods
 en:Salted dried cod
 fr:Morue salée sèche
+agribalyse_food_code:en:26098
 ciqual_food_code:en:26098
 ciqual_food_name:en:Cod, salted, dried
 ciqual_food_name:fr:Morue, salée, sèche
@@ -60493,6 +62700,7 @@ wikidata:en:Q15735642
 <en:Mussels
 en:Raw common mussels
 fr:Moules communes crues
+agribalyse_food_code:en:10014
 ciqual_food_code:en:10014
 ciqual_food_name:en:Mussel, common, raw
 ciqual_food_name:fr:Moule commune, crue
@@ -60500,6 +62708,7 @@ ciqual_food_name:fr:Moule commune, crue
 <en:Mussels
 en:Raw Mediterranean mussels
 fr:Moules de Méditerranée crues
+agribalyse_food_code:en:10026
 ciqual_food_code:en:10026
 ciqual_food_name:en:Mediterranean mussel, raw
 ciqual_food_name:fr:Moule de Méditerranée, crue
@@ -60507,6 +62716,7 @@ ciqual_food_name:fr:Moule de Méditerranée, crue
 <en:Mussels
 en:Mussels in a shallot and white wine broth
 fr:Moules marinières, Moules aux oignons et au vin blanc
+agribalyse_food_code:en:10082
 ciqual_food_code:en:10082
 ciqual_food_name:en:Mussels, in a shallot and white wine broth
 ciqual_food_name:fr:Moules marinières (oignons et vin blanc)
@@ -60514,6 +62724,7 @@ ciqual_food_name:fr:Moules marinières (oignons et vin blanc)
 <en:Mussels
 en:Filled mussels, Mussels filled with fat parsley and garlic
 fr:Moules farcies crues, Moules farcies en persillade crues
+agribalyse_food_code:en:10083
 ciqual_food_code:en:10083
 ciqual_food_name:en:Mussels, filled (fat, parsley and garlic…)
 ciqual_food_name:fr:Moules farcies (matière grasse persillade…) crues
@@ -60535,6 +62746,7 @@ origins:en: en:United Kingdom
 <en:Mussels
 en:Boiled mussels, Mussels cooked in water
 fr:Moules bouillies, Moules cuites à l'eau
+agribalyse_food_code:en:10013
 ciqual_food_code:en:10013
 ciqual_food_name:en:Mussel, boiled/cooked in water
 ciqual_food_name:fr:Moule, bouillie/cuite à l'eau
@@ -60556,6 +62768,7 @@ fr:Moules à l'escabèche
 <en:Canned mussels
 en:Canned drained mussels
 fr:Moules appertisées égouttées
+agribalyse_food_code:en:10028
 ciqual_food_code:en:10028
 ciqual_food_name:en:Mussel, canned, drained
 ciqual_food_name:fr:Moule, appertisée, égouttée
@@ -60563,6 +62776,7 @@ ciqual_food_name:fr:Moule, appertisée, égouttée
 <en:Canned mussels
 en:Canned drained mussels in Catalan-style sauce, Canned drained mussels in Catalan-style marinade, Canned drained mussels in tomato sauce
 fr:Moules appertisées égouttées à la sauce catalane, Moules appertisées égouttées à la sauce escabèche, Moules appertisées égouttées à la sauce tomate
+agribalyse_food_code:en:10081
 ciqual_food_code:en:10081
 ciqual_food_name:en:Mussels, in Catalan-style sauce or marinade (tomatoes), canned, drained
 ciqual_food_name:fr:Moules à la sauce catalane ou escabèche (tomate), appertisée, égouttée
@@ -60587,6 +62801,7 @@ origins:en: en:United Kingdom
 <en:Oysters
 en:Raw oysters
 fr:Huîtres crues
+agribalyse_food_code:en:10011
 ciqual_food_code:en:10011
 ciqual_food_name:en:Oyster, raw
 ciqual_food_name:fr:Huître, sans précision, crue
@@ -60594,6 +62809,7 @@ ciqual_food_name:fr:Huître, sans précision, crue
 <en:Oysters
 en:Raw Pacific oysters
 fr:Huîtres creuses crues
+agribalyse_food_code:en:10035
 ciqual_food_code:en:10035
 ciqual_food_name:en:Pacific oyster, raw
 ciqual_food_name:fr:Huître creuse, crue
@@ -60601,6 +62817,7 @@ ciqual_food_name:fr:Huître creuse, crue
 <en:Oysters
 en:Raw European oysters
 fr:Huîtres plates crues
+agribalyse_food_code:en:10036
 ciqual_food_code:en:10036
 ciqual_food_name:en:European oyster, raw
 ciqual_food_name:fr:Huître plate, crue
@@ -60641,6 +62858,7 @@ wikidata:en:Q550774
 <en:Calamari
 en:Raw squid
 fr:Calmar cru, Calamar cru, Encornet cru
+agribalyse_food_code:en:10001
 ciqual_food_code:en:10001
 ciqual_food_name:en:Squid, raw
 ciqual_food_name:fr:Calmar ou calamar ou encornet, cru
@@ -60648,18 +62866,21 @@ ciqual_food_name:fr:Calmar ou calamar ou encornet, cru
 <en:Mollusc
 en:Squid boiled/cooked in water
 fr:calamar cuit à l'eau, encornet cuit à l'eau, calmar cuit à l'eau
+agribalyse_food_code:en:10037
 ciqual_food_code:en:10037
 ciqual_food_name:en:Squid, boiled/cooked in water
 
 <en:Mollusc
 en:Squid fried or pan-fried with fat
 fr:calamar frit ou poêlé
+agribalyse_food_code:en:10084
 ciqual_food_code:en:10084
 ciqual_food_name:en:Squid, fried or pan-fried with fat
 
 <en:Mollusc
 en:Squid fritter Roman-style
 fr:beignet de calamar à la romaine, encornet à la romaine
+agribalyse_food_code:en:10002
 ciqual_food_code:en:10002
 ciqual_food_name:en:Squid fritter, Roman-style
 
@@ -60669,6 +62890,7 @@ en:Taramasalata
 fr:Taramas, tarama
 nl:Taramasalata
 wikidata:en:Q1246721
+agribalyse_food_code:en:8293
 ciqual_food_code:en:8293
 ciqual_food_name:en:Taramasalata, prepacked
 ciqual_food_name:fr:Tarama, préemballé
@@ -60688,12 +62910,14 @@ nl:Taramasalata met zalm
 en:Salmon carpaccio
 fr:Carpaccio de saumon
 nl:Zalmcarpaccio
+agribalyse_food_code:en:25537
 ciqual_food_code:en:25537
 ciqual_food_name:en:Salmon carpaccio, w marinade
 
 <en:Seafood
 en:Fish au gratin intended to be cooked, Seafood au gratin intended to be cooked
 fr:Gratin de poissons à cuire, Gratin de fruits de mer à cuire, Cassolette de poissons à cuire, Cassolette de fruits de mer à cuire
+agribalyse_food_code:en:25037
 ciqual_food_code:en:25037
 ciqual_food_name:en:Fish or seafood au gratin, intended to be cook
 ciqual_food_name:fr:Gratin ou cassolette de poisson et / ou fruits de mer, à cuire
@@ -60701,6 +62925,7 @@ ciqual_food_name:fr:Gratin ou cassolette de poisson et / ou fruits de mer, à cu
 <en:Seafood
 en:Fish and shrimp au gratin previously frozen
 fr:Gratin de poissons cuit, Gratin de fruits de mer à cuit, Cassolette de poissons cuit, Cassolette de fruits de mer cuit
+agribalyse_food_code:en:25038
 ciqual_food_code:en:25038
 ciqual_food_name:en:Fish and shrimp 'au gratin', previously frozen
 ciqual_food_name:fr:Gratin ou cassolette de poisson et / ou fruits de mer, cuit
@@ -60815,6 +63040,7 @@ fr:Confitures de lait, Confiture de lait
 nl:Dulce de leche
 ru:варёная сгущёнка
 wikidata:en:Q917761
+agribalyse_food_code:en:31040
 ciqual_food_code:en:31040
 ciqual_food_name:en:Dulce de leche or confiture de lait
 ciqual_food_name:fr:Confiture de lait
@@ -60997,6 +63223,7 @@ hu:Málna lekvár
 it:Confetture di lamponi
 nl:Frambozenjams
 sv:Hallonsylter, hallonsylt
+agribalyse_food_code:en:31062
 ciqual_food_code:en:31062
 ciqual_food_name:en:Jam, raspberry
 ciqual_food_name:fr:Confiture de framboise (extra ou classique)
@@ -61012,6 +63239,7 @@ hu:Eper lekvár
 it:Confetture di fragole
 nl:Aardbeienjam, Aardbeienjams
 sv:Jordgubbssylter, jordgubbssylt
+agribalyse_food_code:en:31024
 ciqual_food_code:en:31024
 ciqual_food_name:en:Jam, strawberry
 ciqual_food_name:fr:Confiture de fraise (extra ou classique)
@@ -61140,6 +63368,7 @@ hu:Sárgabarack
 it:Confetture di albicocca
 nl:Abrikozenjams
 sv:Aprikossylter
+agribalyse_food_code:en:31037
 ciqual_food_code:en:31037
 ciqual_food_name:en:Jam, apricot
 ciqual_food_name:fr:Confiture d'abricot (extra ou classique)
@@ -61154,6 +63383,7 @@ hu:Cseresznye lekvár
 it:Confetture di ciliegie
 nl:Kersenjams
 sv:Körsbärsylter
+agribalyse_food_code:en:31038
 ciqual_food_code:en:31038
 ciqual_food_name:en:Jam, cherry
 ciqual_food_name:fr:Confiture de cerise (extra ou classique)
@@ -61306,6 +63536,7 @@ es:Mermeladas y confituras ligeras, Mermeladas y confituras light
 fi:kevythillot
 fr:Confiture de fruits allégée en sucres, Confitures allégées
 nl:Suikervrije jams
+agribalyse_food_code:en:31110
 ciqual_food_code:en:31110
 ciqual_food_name:en:Jam, reduced sugar
 ciqual_food_name:fr:Confiture, tout type de fruits, allégée en sucres (extra ou classique)
@@ -61343,6 +63574,7 @@ fr:Marmelades d’oranges, Marmelade d’oranges
 hu:Narancs marmelád
 nl:Sinaasappelmarmelades
 wikidata:en:Q19842607
+agribalyse_food_code:en:31039
 ciqual_food_code:en:31039
 ciqual_food_name:en:Marmalade, orange
 ciqual_food_name:fr:Marmelade d'orange
@@ -61362,6 +63594,7 @@ wikidata:en:Q40867220
 <en:Vegetables based foods
 en:Vegetable flans, Vegetable flan
 fr:Flans de légumes, Flans aux légumes, Flan de légumes, Flan aux légumes
+agribalyse_food_code:en:8297
 ciqual_food_code:en:8297
 ciqual_food_name:en:Vegetable flan
 ciqual_food_name:fr:Flan de légumes
@@ -61514,6 +63747,7 @@ fr:Pâtes à tartiner aux noisettes et au cacao, pâtes à tartiner aux noisette
 hu:Kenhető csokoládé és mogyoró
 it:Crema con nocciole e cacao
 nl:Choco-hazelnootpastas
+agribalyse_food_code:en:31032
 ciqual_food_code:en:31032
 ciqual_food_name:en:Chocolate spread with hazelnuts
 
@@ -61571,6 +63805,7 @@ ru:Тапенада
 sv:Tapenade
 pms:Tapenades, tapenade
 wikidata:en:Q129031
+agribalyse_food_code:en:11043
 ciqual_food_code:en:11043
 ciqual_food_name:en:Tapenade (a puree of capers, pitted black olives, anchovy and herbs, with olive oil and lemon juice
 ciqual_food_name:fr:Tapenade
@@ -61629,6 +63864,7 @@ fi:hummus
 fr:Houmous, hommos, hoummous, houmos, oumos, humus, hummus
 nl:Hoemoes, Houmous, Hummus
 wikidata:en:Q241987
+agribalyse_food_code:en:25621
 ciqual_food_code:en:25621
 ciqual_food_name:en:Hummus
 ciqual_food_name:fr:Houmous
@@ -61682,6 +63918,7 @@ wikidata:en:Q5339301
 <en:Plant-based foods
 en:Raw pumpkin pulp
 fr:Pulpe de citrouille crue
+agribalyse_food_code:en:20166
 ciqual_food_code:en:20166
 ciqual_food_name:en:Pumpkin, pulp, raw
 ciqual_food_name:fr:Citrouille, pulpe, crue
@@ -61689,6 +63926,7 @@ ciqual_food_name:fr:Citrouille, pulpe, crue
 <en:Plant-based foods
 en:Raw pumpkin pulp, Raw cucurbita moschata pulp
 fr:Pulpe de courge musquée
+agribalyse_food_code:en:20128
 ciqual_food_code:en:20128
 ciqual_food_name:en:Pumpkin (cucurbita moschata), pulp, raw
 ciqual_food_name:fr:Courge musquée, pulpe, crue
@@ -61696,6 +63934,7 @@ ciqual_food_name:fr:Courge musquée, pulpe, crue
 <en:Plant-based foods
 en:Raw red kuri squash, Raw red kuri pulp
 fr:Pulpe de potimarron
+agribalyse_food_code:en:20132
 ciqual_food_code:en:20132
 ciqual_food_name:en:Red kuri squash, pulp, raw
 ciqual_food_name:fr:Potimarron, pulpe, cru
@@ -61703,6 +63942,7 @@ ciqual_food_name:fr:Potimarron, pulpe, cru
 <en:Plant-based foods
 en:Raw sweet green hokkaido squash, Raw sweet green hokkaido pulp
 fr:Pulpe de courge hokkaïdo
+agribalyse_food_code:en:20134
 ciqual_food_code:en:20134
 ciqual_food_name:en:Sweet green hokkaido squash, pulp, raw
 ciqual_food_name:fr:Courge hokkaïdo, pulpe, crue
@@ -61717,6 +63957,7 @@ nl:Pompoenzaden en afgeleiden
 <en:Squash plant products
 en:Raw squash
 fr:Courge crue
+agribalyse_food_code:en:20139
 ciqual_food_code:en:20139
 ciqual_food_name:en:Squash, all types, raw
 ciqual_food_name:fr:Courge, crue
@@ -61728,6 +63969,7 @@ fr:Courges fraîches, Courge fraîche
 <en:Squash plant products
 en:Cooked spaghetti squash pulp
 fr:Pulpe de courge spaghetti cuite
+agribalyse_food_code:en:20143
 ciqual_food_code:en:20143
 ciqual_food_name:en:Squash, spaghetti, pulp, cooked
 ciqual_food_name:fr:Courge spaghetti, pulpe, cuite
@@ -61735,6 +63977,7 @@ ciqual_food_name:fr:Courge spaghetti, pulpe, cuite
 <en:Squash plant products
 en:Raw spaghetti squash pulp
 fr:Pulpe de courge spaghetti crue
+agribalyse_food_code:en:20145
 ciqual_food_code:en:20145
 ciqual_food_name:en:Squash, spaghetti, pulp, raw
 ciqual_food_name:fr:Courge spaghetti, pulpe, crue
@@ -61807,6 +64050,7 @@ nl:Geroosterde gepelde pompoenpitten
 <en:Seeds
 en:Cucurbitacea seeds
 fr:Graines de cucurbitacées
+agribalyse_food_code:en:15028
 ciqual_food_code:en:15028
 ciqual_food_name:en:Cucurbitacea, seed
 ciqual_food_name:fr:Cucurbitacées, graine
@@ -61834,6 +64078,7 @@ hu:Naprafogómagok
 nl:Zonnebloempitten
 ru:Семена подсолнечника, Подсолнечные семечки, Семечки подсолнечника
 wikidata:en:Q1076906
+agribalyse_food_code:en:15011
 ciqual_food_code:en:15011
 ciqual_food_name:en:Sunflower seed
 ciqual_food_name:fr:Tournesol, graine
@@ -61903,6 +64148,7 @@ nl:Geroosterde gepelde zonnebloempitten
 <en:Roasted sunflower seeds
 en:Sunflower seed grilled and salted
 fr:Graines de tournesol grillées et salées
+agribalyse_food_code:en:15045
 ciqual_food_code:en:15045
 ciqual_food_name:en:Sunflower seed, grilled, salted
 ciqual_food_name:fr:Tournesol, graine, grillé, salé
@@ -61912,6 +64158,7 @@ en:Papaver seeds, Papaver, Poppy seeds
 fr:Graines de pavot, Pavot
 nl:Maanzaad
 wikidata:en:Q146391
+agribalyse_food_code:en:11061
 ciqual_food_code:en:11061
 ciqual_food_name:en:Poppy, seed
 ciqual_food_name:fr:Pavot, graine
@@ -61960,6 +64207,7 @@ fi:fariinisokerit
 fr:Sucres roux, sucre roux, Sucres blonds
 nl:Bruine suikers
 wikidata:en:Q11190742
+agribalyse_food_code:en:31017
 ciqual_food_code:en:31017
 ciqual_food_name:en:Sugar, brown
 ciqual_food_name:fr:Sucre roux
@@ -62043,6 +64291,7 @@ it:Zucchero bianco
 nl:Kristalsuikers
 pl:Cukier biały
 wikidata:en:Q15631442
+agribalyse_food_code:en:31016
 ciqual_food_code:en:31016
 ciqual_food_name:en:Sugar, white
 ciqual_food_name:fr:Sucre blanc
@@ -62094,6 +64343,7 @@ es:Azúcar vainillado, Azúcar vainillada
 fr:Sucres vanillés
 nl:Vanillesuikers
 wikidata:en:Q3492989
+agribalyse_food_code:en:31044
 ciqual_food_code:en:31044
 ciqual_food_name:en:Sugar, vanilla flavoured
 ciqual_food_name:fr:Sucre vanillé
@@ -62190,6 +64440,7 @@ fr:Saccharine, Saccarine, Édulcorant à la saccharine
 la:E-954
 nl:Saccharine
 wikidata:en:Q191381
+agribalyse_food_code:en:31064
 ciqual_food_code:en:31064
 ciqual_food_name:en:Saccharin sweetener
 ciqual_food_name:fr:Édulcorant à la saccharine
@@ -62227,6 +64478,7 @@ nl:Fructose, Vruchtensuiker
 nl_be:Fructose, Vruchtensuiker
 ru:Фруктоза
 wikidata:en:Q122043
+agribalyse_food_code:en:31077
 ciqual_food_code:en:31077
 ciqual_food_name:en:Fructose
 ciqual_food_name:fr:Fructose
@@ -62325,6 +64577,7 @@ ciqual_food_name:fr:Boisson concentrée à diluer, sans sucres ajoutés, avec é
 <en:Syrups
 en:Syrup with sugar to be diluted
 fr:Sirop à diluer sucré
+agribalyse_food_code:en:18017
 ciqual_food_code:en:18017
 ciqual_food_name:en:Syrup, with sugar (to be diluted)
 ciqual_food_name:fr:Sirop à diluer, sucré
@@ -62332,6 +64585,7 @@ ciqual_food_name:fr:Sirop à diluer, sucré
 <en:Syrups
 en:Mint-flavoured syrup with sugar diluted in water, Strawberry-flavoured syrup with sugar diluted in water
 fr:Boisson préparée sucrée à partir de sirop à la menthe à diluer dans l'eau, Boisson préparée sucrée à partir de sirop aux fraises à diluer dans l'eau
+agribalyse_food_code:en:18058
 ciqual_food_code:en:18058
 ciqual_food_name:en:Syrup (mint, strawberries flavouredetc.), with sugar diluted in water
 ciqual_food_name:fr:Boisson préparée à partir de sirop à diluer type menthe, fraise, etc, sucré, dilué dans l'eau
@@ -62497,6 +64751,7 @@ fr:Mélasses, Mélasse de canne
 nl:Melasses
 nl_be:Melasses
 wikidata:en:Q154389
+agribalyse_food_code:en:31067
 ciqual_food_code:en:31067
 ciqual_food_name:en:Cane molasses
 ciqual_food_name:fr:Mélasse de canne
@@ -62557,6 +64812,7 @@ nl:Gebakken ui
 <en:Onions and their products
 en:Dried onions
 fr:Oignons séchés
+agribalyse_food_code:en:20180
 ciqual_food_code:en:20180
 ciqual_food_name:en:Onion, dried
 ciqual_food_name:fr:Oignon, séché
@@ -62617,7 +64873,7 @@ pt:Vegetais enlatados
 ru:Консервированные овощи, Овощи консервированные, Консервы из овощей
 th:ผักกระป๋อง
 zh:罐头蔬菜
-who_id:16
+who_id:en:16
 
 <en:Canned vegetables
 <en:Belgian endives
@@ -62636,6 +64892,7 @@ nl:Artisjokken en blik
 <en:Canned artichokes
 en:Canned drained artichoke, Canned drained artichokes
 fr:Artichaut appertisé et égoutté, Artichauts appertisés et égouttés
+agribalyse_food_code:en:20067
 ciqual_food_code:en:20067
 ciqual_food_name:en:Artichoke, canned, drained
 ciqual_food_name:fr:Artichaut, appertisé, égoutté
@@ -62643,6 +64900,7 @@ ciqual_food_name:fr:Artichaut, appertisé, égoutté
 <en:Canned artichokes
 en:Canned drained artichoke hearts
 fr:Coeurs d'artichaut appertisés et égouttés
+agribalyse_food_code:en:20155
 ciqual_food_code:en:20155
 ciqual_food_name:en:Artichoke, heart, canned, drained
 ciqual_food_name:fr:Artichaut, coeur, appertisé, égoutté
@@ -62650,6 +64908,7 @@ ciqual_food_name:fr:Artichaut, coeur, appertisé, égoutté
 <en:Canned artichokes
 en:Canned drained artichoke base
 fr:Fonds d'artichaut appertisés égouttés
+agribalyse_food_code:en:20156
 ciqual_food_code:en:20156
 ciqual_food_name:en:Artichoke base, canned, drained
 ciqual_food_name:fr:Artichaut, fond, appertisé, égoutté
@@ -62680,6 +64939,7 @@ nl:Witte asperges in blik
 <en:Canned asparagus
 en:Canned drained asparagus
 fr:Asperges appertisées égouttées
+agribalyse_food_code:en:20076
 ciqual_food_code:en:20076
 ciqual_food_name:en:Asparagus, canned, drained
 ciqual_food_name:fr:Asperge, appertisée, égouttée
@@ -62704,6 +64964,7 @@ nl:Spruiten in blik
 <en:Brussels sprouts
 en:Canned drained Brussels sprouts
 fr:Choux de Bruxelles appertisés égouttés
+agribalyse_food_code:en:20077
 ciqual_food_code:en:20077
 ciqual_food_name:en:Brussels sprout, canned, drained
 ciqual_food_name:fr:Chou de Bruxelles, appertisé, égoutté
@@ -62721,6 +64982,7 @@ nl:Wortels in blik
 <en:Carrots
 en:Canned drained carrots
 fr:Carottes en conserve égouttées, Carottes appertisées égouttées
+agribalyse_food_code:en:20007
 ciqual_food_code:en:20007
 ciqual_food_name:en:Carrot, canned, drained
 ciqual_food_name:fr:Carotte, appertisée, égouttée
@@ -62759,6 +65021,7 @@ fr:Macédoines de légumes en conserve, macédoines de légume en conserve, mac�
 <en:Canned vegetables
 en:Canned drained diced mixed vegetables
 fr:Macédoines de légumes appertisées égouttées
+agribalyse_food_code:en:20051
 ciqual_food_code:en:20051
 ciqual_food_name:en:Diced mixed vegetables, canned, drained
 ciqual_food_name:fr:Macédoine de légumes, appertisée, égouttée
@@ -62809,6 +65072,7 @@ nl:Schorseneer in blik
 <en:Canned vegetables
 en:Canned drained salsify
 fr:Salsifis appertisés égouttés, Salsifis en conserve égouttés
+agribalyse_food_code:en:20081
 ciqual_food_code:en:20081
 ciqual_food_name:en:Salsify, canned, drained
 ciqual_food_name:fr:Salsifis, appertisé, égoutté
@@ -62826,6 +65090,7 @@ nl:Spinazie in blik
 <en:Spinachs
 en:Canned drained spinachs
 fr:Épinards appertisés égouttés
+agribalyse_food_code:en:20060
 ciqual_food_code:en:20060
 ciqual_food_name:en:Spinach, canned, drained
 ciqual_food_name:fr:Épinard, appertisé, égoutté
@@ -62842,6 +65107,7 @@ nl:Tomaten in blik
 <en:Tomatoes
 en:Raw green tomatoes
 fr:Tomates vertes crues
+agribalyse_food_code:en:20119
 ciqual_food_code:en:20119
 ciqual_food_name:en:Tomato, green, raw
 ciqual_food_name:fr:Tomate verte, crue
@@ -62986,11 +65252,12 @@ hu:Friss zöldségek
 nl:Verse groenten
 ru:Свежие овощи
 zh:新鲜蔬菜
-who_id:15
+who_id:en:15
 
 <en:Vegetables
 en:Raw sorrel
 fr:Oseille crue
+agribalyse_food_code:en:20111
 ciqual_food_code:en:20111
 ciqual_food_name:en:Sorrel, raw
 ciqual_food_name:fr:Oseille, crue
@@ -62998,6 +65265,7 @@ ciqual_food_name:fr:Oseille, crue
 <en:Vegetables
 en:Frozen raw Chinese artichokes, Frozen raw Japanese artichokes
 fr:Crosnes surgelés crus
+agribalyse_food_code:en:20231
 ciqual_food_code:en:20231
 ciqual_food_name:en:Chinese or Japanese artichokes, frozen, raw
 ciqual_food_name:fr:Crosne, surgelé, cru
@@ -63005,6 +65273,7 @@ ciqual_food_name:fr:Crosne, surgelé, cru
 <en:Vegetables
 en:Cooked Jerusalem artichoke
 fr:Topinambour cuit
+agribalyse_food_code:en:20050
 ciqual_food_code:en:20050
 ciqual_food_name:en:Jerusalem artichoke, cooked
 ciqual_food_name:fr:Topinambour, cuit
@@ -63012,6 +65281,7 @@ ciqual_food_name:fr:Topinambour, cuit
 <en:Vegetables
 en:Raw Jerusalem artichoke
 fr:Topinambour cru
+agribalyse_food_code:en:20196
 ciqual_food_code:en:20196
 ciqual_food_name:en:Jerusalem artichoke, raw
 ciqual_food_name:fr:Topinambour, cru
@@ -63027,6 +65297,7 @@ season_in_country_fr:en: 1,2,3,10,11,12
 <en:Vegetables
 en:Raw parsnip
 fr:Panais cru
+agribalyse_food_code:en:20181
 ciqual_food_code:en:20181
 ciqual_food_name:en:Parsnip, raw
 ciqual_food_name:fr:Panais, cru
@@ -63034,6 +65305,7 @@ ciqual_food_name:fr:Panais, cru
 <en:Cooked vegetables
 en:Cooked parsnip
 fr:Panais cuits
+agribalyse_food_code:en:20133
 ciqual_food_code:en:20133
 ciqual_food_name:en:Parsnip, cooked
 ciqual_food_name:fr:Panais, cuit
@@ -63041,6 +65313,7 @@ ciqual_food_name:fr:Panais, cuit
 <en:Cooked vegetables
 en:Cooked red kidney beans
 fr:Haricots rouges cuits
+agribalyse_food_code:en:20503
 ciqual_food_code:en:20503
 ciqual_food_name:en:Red kidney bean, cooked
 ciqual_food_name:fr:Haricot rouge, cuit
@@ -63048,6 +65321,7 @@ ciqual_food_name:fr:Haricot rouge, cuit
 <en:Cooked vegetables
 en:Cooked broad beans
 fr:Fèves cuites
+agribalyse_food_code:en:20500
 ciqual_food_code:en:20500
 ciqual_food_name:en:Broad bean, cooked
 ciqual_food_name:fr:Fève, cuite
@@ -63084,6 +65358,7 @@ season_in_country_fr:en: 1,2,11,12
 <en:Cooked vegetables
 en:Cooked salsify
 fr:Salsifis cuits
+agribalyse_food_code:en:20046
 ciqual_food_code:en:20046
 ciqual_food_name:en:Salsify, cooked
 ciqual_food_name:fr:Salsifis, cuit
@@ -63091,6 +65366,7 @@ ciqual_food_name:fr:Salsifis, cuit
 <en:Salsifis
 en:Raw black salsify
 fr:Salsifis noirs crus
+agribalyse_food_code:en:20197
 ciqual_food_code:en:20197
 ciqual_food_name:en:Salsify, black, raw
 ciqual_food_name:fr:Salsifis noir, cru
@@ -63116,6 +65392,7 @@ nl:Artisjokharten
 <en:Cooked vegetables
 en:Cooked globe artichoke
 fr:Artichaut cuit
+agribalyse_food_code:en:20000
 ciqual_food_code:en:20000
 ciqual_food_name:en:Artichoke, globe, cooked
 ciqual_food_name:fr:Artichaut, cuit
@@ -63125,6 +65402,7 @@ ciqual_food_name:fr:Artichaut, cuit
 en:Fresh artichokes, Artichoke globe raw
 fr:Artichauts frais
 season_in_country_fr:en: 5,6,7,8,9
+agribalyse_food_code:en:20052
 ciqual_food_code:en:20052
 ciqual_food_name:en:Artichoke, globe, raw
 
@@ -63132,6 +65410,7 @@ ciqual_food_name:en:Artichoke, globe, raw
 <en:Frozen foods
 en:Frozen raw artichoke bottom
 fr:Fond d'artichaut cru surgelé
+agribalyse_food_code:en:20232
 ciqual_food_code:en:20232
 ciqual_food_name:en:Artichoke base, frozen, raw
 ciqual_food_name:fr:Artichaut, fond, surgelé, cru
@@ -63168,6 +65447,7 @@ nl:Witte asperges
 <en:White asparagus
 en:Raw peeled white asparagus, Raw peeled purple asparagus
 fr:Asperges blanches pelées crues, Asperges violettes pelées crues
+agribalyse_food_code:en:20282
 ciqual_food_code:en:20282
 ciqual_food_name:en:Asparagus, white or purple, peeled, raw
 ciqual_food_name:fr:Asperge, blanche ou violette, pelée, crue
@@ -63186,6 +65466,7 @@ nl:Mini asperges
 <en:Asparagus
 en:Asparagus green raw
 fr:Asperges vertes crues
+agribalyse_food_code:en:20279
 ciqual_food_code:en:20279
 ciqual_food_name:en:Asparagus, green, raw
 ciqual_food_name:fr:Asperge, verte, crue
@@ -63197,6 +65478,7 @@ nl:Handgeschilde asperges
 <en:Asparagus
 en:Peeled raw asparagus
 fr:Asperges pelées crues
+agribalyse_food_code:en:20073
 ciqual_food_code:en:20073
 ciqual_food_name:en:Asparagus, peeled, raw
 ciqual_food_name:fr:Asperge, pelée, crue
@@ -63226,6 +65508,7 @@ es:Berenjenas
 fr:Aubergines
 la:Solanum melongena
 nl:Aubergines
+agribalyse_food_code:en:20053
 ciqual_food_code:en:20053
 ciqual_food_name:en:Eggplant, raw
 
@@ -63238,6 +65521,7 @@ season_in_country_fr:en: 6,7,8,9
 <en:Aubergines
 en:Eggplant cooked
 fr:Aubergine cuite
+agribalyse_food_code:en:20002
 ciqual_food_code:en:20002
 ciqual_food_name:en:Eggplant, cooked
 
@@ -63246,6 +65530,7 @@ fr:Ristes d’aubergines
 en:Riste with eggplant and tomatoes and onions
 fr:Riste d'aubergines avec aubergines et tomates et oignons
 wikidata:en:Q53560342
+agribalyse_food_code:en:25196
 ciqual_food_code:en:25196
 ciqual_food_name:en:Riste (Eggplant, tomatoes, onions)
 ciqual_food_name:fr:Riste d'aubergines (aubergines, tomates, oignons)
@@ -63268,6 +65553,7 @@ season_in_country_fr:en: 1,2,3,10,11,12
 <en:Vegetables
 en:Raw beetroot
 fr:Betterave rouge crue
+agribalyse_food_code:en:20091
 ciqual_food_code:en:20091
 ciqual_food_name:en:Beetroot, raw
 ciqual_food_name:fr:Betterave rouge, crue
@@ -63275,6 +65561,7 @@ ciqual_food_name:fr:Betterave rouge, crue
 <en:Cooked vegetables
 en:Cooked beetroots
 fr:Betteraves rouges cuites
+agribalyse_food_code:en:20003
 ciqual_food_code:en:20003
 ciqual_food_name:en:Beetroot, cooked
 ciqual_food_name:fr:Betterave rouge, cuite
@@ -63292,6 +65579,7 @@ nl:Witlof
 <en:Leaf vegetables
 en:Raw curly endives
 fr:Chicorée frisée crue
+agribalyse_food_code:en:20012
 ciqual_food_code:en:20012
 ciqual_food_name:en:Curly endive, raw
 ciqual_food_name:fr:Salade ou chicorée frisée, crue
@@ -63299,6 +65587,7 @@ ciqual_food_name:fr:Salade ou chicorée frisée, crue
 <en:Leaf vegetables
 en:Raw red endives
 fr:Chicorée rouge crue
+agribalyse_food_code:en:20162
 ciqual_food_code:en:20162
 ciqual_food_name:en:Red endive, raw
 ciqual_food_name:fr:Chicorée rouge, crue
@@ -63306,6 +65595,7 @@ ciqual_food_name:fr:Chicorée rouge, crue
 <en:Leaf vegetables
 en:Raw green endive
 fr:Chicorée verte crue
+agribalyse_food_code:en:20163
 ciqual_food_code:en:20163
 ciqual_food_name:en:Green endive, raw
 ciqual_food_name:fr:Chicorée verte, crue
@@ -63319,6 +65609,7 @@ season_in_country_fr:en: 1,2,3,4,10
 <en:Leaf vegetables
 en:Raw chicory
 fr:Endives crues
+agribalyse_food_code:en:20026
 ciqual_food_code:en:20026
 ciqual_food_name:en:Chicory, raw
 ciqual_food_name:fr:Endive, crue
@@ -63424,6 +65715,7 @@ season_in_country_fr:en: 9,10,11
 <en:Broccoli
 en:Raw broccoli
 fr:Brocolis crus
+agribalyse_food_code:en:20057
 ciqual_food_code:en:20057
 ciqual_food_name:en:Broccoli, raw
 ciqual_food_name:fr:Brocoli, cru
@@ -63432,6 +65724,7 @@ ciqual_food_name:fr:Brocoli, cru
 <en:Cooked vegetables
 en:Cooked broccoli
 fr:Brocolis cuits
+agribalyse_food_code:en:20006
 ciqual_food_code:en:20006
 ciqual_food_name:en:Broccoli, cooked
 ciqual_food_name:fr:Brocoli, cuit
@@ -63448,6 +65741,7 @@ nl:Spruiten
 <en:Brussels sprouts
 en:Raw Brussels sprouts
 fr:Choux de Bruxelles crus
+agribalyse_food_code:en:20058
 ciqual_food_code:en:20058
 ciqual_food_name:en:Brussels sprout, raw
 ciqual_food_name:fr:Chou de Bruxelles, cru
@@ -63469,6 +65763,7 @@ nl:Kolen
 <en:Cabbages
 en:Raw white cabbage
 fr:Chou blanc cru
+agribalyse_food_code:en:20116
 ciqual_food_code:en:20116
 ciqual_food_name:en:White cabbage, raw
 ciqual_food_name:fr:Chou blanc, cru
@@ -63476,6 +65771,7 @@ ciqual_food_name:fr:Chou blanc, cru
 <en:Cabbages
 en:Boiled green cabbage boiled, Green cabbage cooked in water
 fr:Chou vert boulli, Chou vert cuit à l'eau
+agribalyse_food_code:en:20015
 ciqual_food_code:en:20015
 ciqual_food_name:en:Green cabbage, boiled/cooked in water
 ciqual_food_name:fr:Chou vert, cuit
@@ -63483,6 +65779,7 @@ ciqual_food_name:fr:Chou vert, cuit
 <en:Cabbages
 en:Raw green cabbage
 fr:Chou vert cru
+agribalyse_food_code:en:20069
 ciqual_food_code:en:20069
 ciqual_food_name:en:Green cabbage, raw
 ciqual_food_name:fr:Chou vert, cru
@@ -63490,6 +65787,7 @@ ciqual_food_name:fr:Chou vert, cru
 <en:Cabbages
 en:Boiled red cabbage, Red cabbage cooked in water
 fr:Chou rouge boulli, Chou rouge cuit à l'eau
+agribalyse_food_code:en:20095
 ciqual_food_code:en:20095
 ciqual_food_name:en:Red cabbage, boiled/cooked in water
 ciqual_food_name:fr:Chou rouge, bouilli/cuit à l'eau
@@ -63497,6 +65795,7 @@ ciqual_food_name:fr:Chou rouge, bouilli/cuit à l'eau
 <en:Cabbages
 en:Raw red cabbage
 fr:Chou rouge cru
+agribalyse_food_code:en:20014
 ciqual_food_code:en:20014
 ciqual_food_name:en:Red cabbage, raw
 ciqual_food_name:fr:Chou rouge, cru
@@ -63504,6 +65803,7 @@ ciqual_food_name:fr:Chou rouge, cru
 <en:Cabbages
 en:Boiled kohlrabi, Kohlrabi cooked in water
 fr:Chou-rave bouilli, Chou-rave cuit à l'eau
+agribalyse_food_code:en:20094
 ciqual_food_code:en:20094
 ciqual_food_name:en:Kohlrabi, boiled/cooked in water
 ciqual_food_name:fr:Chou-rave, bouilli/cuit à l'eau
@@ -63511,6 +65811,7 @@ ciqual_food_name:fr:Chou-rave, bouilli/cuit à l'eau
 <en:Cabbages
 en:Raw cabbage turnips
 fr:Choux-raves crus, Chou-rave cru
+agribalyse_food_code:en:20065
 ciqual_food_code:en:20065
 ciqual_food_name:en:Turnip cabbage, raw
 ciqual_food_name:fr:Chou-rave, cru
@@ -63518,6 +65819,7 @@ ciqual_food_name:fr:Chou-rave, cru
 <en:Cabbages
 en:Raw Chinese cabbage, Raw nappa cabbage, Raw bok choy
 fr:Chou chinois, Pak-choi, Pé-tsai cru
+agribalyse_food_code:en:20167
 ciqual_food_code:en:20167
 ciqual_food_name:en:Chinese cabbage (nappa cabbage or bok choy), raw
 ciqual_food_name:fr:Chou chinois ou pak-choi ou pé-tsai, cru
@@ -63526,6 +65828,7 @@ ciqual_food_name:fr:Chou chinois ou pak-choi ou pé-tsai, cru
 <en:Cooked vegetables
 en:Cooked Chinese cabbage, Cooked nappa cabbage, Bok choy
 fr:Chou chinois (pak-choi ou pé-tsai) cuit
+agribalyse_food_code:en:20221
 ciqual_food_code:en:20221
 ciqual_food_name:en:Chinese cabbage (nappa cabbage or bok choy), cooked
 ciqual_food_name:fr:Chou chinois cuit, Pak-choi, Pé-tsai
@@ -63534,6 +65837,7 @@ ciqual_food_name:fr:Chou chinois cuit, Pak-choi, Pé-tsai
 <en:Cooked vegetables
 en:Cooked curly kale
 fr:Chou frisé cuit
+agribalyse_food_code:en:20219
 ciqual_food_code:en:20219
 ciqual_food_name:en:Curly kale, cooked
 ciqual_food_name:fr:Chou frisé, cuit
@@ -63541,6 +65845,7 @@ ciqual_food_name:fr:Chou frisé, cuit
 <en:Cabbages
 en:Raw curly kale
 fr:Chou frisé cru
+agribalyse_food_code:en:20218
 ciqual_food_code:en:20218
 ciqual_food_name:en:Curly kale, raw
 ciqual_food_name:fr:Chou frisé, cru
@@ -63561,6 +65866,7 @@ nl:Kardoen
 <en:Cardoons
 en:Raw cardoons
 fr:Cardon crus
+agribalyse_food_code:en:20054
 ciqual_food_code:en:20054
 ciqual_food_name:en:Cardoon, raw
 ciqual_food_name:fr:Cardon, cru
@@ -63569,6 +65875,7 @@ ciqual_food_name:fr:Cardon, cru
 <en:Cooked vegetables
 en:Cooked cardoons
 fr:Cardons cuits
+agribalyse_food_code:en:20241
 ciqual_food_code:en:20241
 ciqual_food_name:en:Cardoon, cooked
 ciqual_food_name:fr:Cardon, cuit
@@ -63590,6 +65897,7 @@ sv:Morötter, morot
 <en:Cooked vegetables
 en:Cooked carrots
 fr:Carottes cuites
+agribalyse_food_code:en:20008
 ciqual_food_code:en:20008
 ciqual_food_name:en:Carrot, cooked
 ciqual_food_name:fr:Carotte, cuite
@@ -63597,6 +65905,7 @@ ciqual_food_name:fr:Carotte, cuite
 <en:Carrots
 en:Raw carrots
 fr:Carottes crues
+agribalyse_food_code:en:20009
 ciqual_food_code:en:20009
 ciqual_food_name:en:Carrot, raw
 ciqual_food_name:fr:Carotte, crue
@@ -63633,6 +65942,7 @@ season_in_country_fr:en: 1,2,3,9,10,11,12
 <en:Culinary plants
 en:Fresh glasswort, Fresh salicornia
 fr:Salicorne fraîche, Salicornia fraîche
+agribalyse_food_code:en:20283
 ciqual_food_code:en:20283
 ciqual_food_name:en:Glasswort (Salicornia sp.), fresh
 ciqual_food_name:fr:Salicorne (Salicornia sp.), fraîche
@@ -63640,6 +65950,7 @@ ciqual_food_name:fr:Salicorne (Salicornia sp.), fraîche
 <en:Cauliflowers
 en:Raw cauliflowers
 fr:Choux-fleurs crus
+agribalyse_food_code:en:20016
 ciqual_food_code:en:20016
 ciqual_food_name:en:Cauliflower, raw
 ciqual_food_name:fr:Chou-fleur, cru
@@ -63648,6 +65959,7 @@ ciqual_food_name:fr:Chou-fleur, cru
 <en:Cooked vegetables
 en:Cooked cauliflowers
 fr:Choux-fleurs cuits, Chou-fleur cuit
+agribalyse_food_code:en:20017
 ciqual_food_code:en:20017
 ciqual_food_name:en:Cauliflower, cooked
 ciqual_food_name:fr:Chou-fleur, cuit
@@ -63675,6 +65987,7 @@ origins:en: en:United Kingdom
 <en:Celery
 en:Canned drained celery stalks
 fr:Céleri-branche appertisé égoutté, Céleri branche appertisé égoutté
+agribalyse_food_code:en:20078
 ciqual_food_code:en:20078
 ciqual_food_name:en:Celery stalk, canned, drained
 ciqual_food_name:fr:Céleri branche, appertisé, égoutté
@@ -63683,6 +65996,7 @@ ciqual_food_name:fr:Céleri branche, appertisé, égoutté
 <en:Cooked vegetables
 en:Cooked celery stalks
 fr:Céleri-branche cuit
+agribalyse_food_code:en:20024
 ciqual_food_code:en:20024
 ciqual_food_name:en:Celery stalk, cooked
 ciqual_food_name:fr:Céleri branche, cuit
@@ -63690,6 +66004,7 @@ ciqual_food_name:fr:Céleri branche, cuit
 <en:Celery
 en:Celery stalk, Raw celery stalk
 fr:Céleris branche
+agribalyse_food_code:en:20023
 ciqual_food_code:en:20023
 ciqual_food_name:en:Celery stalk, raw
 ciqual_food_name:fr:Céleri branche, cru
@@ -63697,6 +66012,7 @@ ciqual_food_name:fr:Céleri branche, cru
 <en:Celery
 en:Raw celeriac
 fr:Céleri-rave cru
+agribalyse_food_code:en:20055
 ciqual_food_code:en:20055
 ciqual_food_name:en:Celeriac, raw
 ciqual_food_name:fr:Céleri-rave, cru
@@ -63705,6 +66021,7 @@ ciqual_food_name:fr:Céleri-rave, cru
 <en:Cooked vegetables
 en:Cooked celeriac
 fr:Céleri-rave cuit
+agribalyse_food_code:en:20025
 ciqual_food_code:en:20025
 ciqual_food_name:en:Celeriac, cooked
 ciqual_food_name:fr:Céleri-rave, cuit
@@ -63787,6 +66104,7 @@ season_in_country_fr:en: 6,7,8,9,10,11
 <en:Cooked vegetables
 en:Cooked Swiss chard
 fr:Bette cuite, Blette cuite
+agribalyse_food_code:en:20005
 ciqual_food_code:en:20005
 ciqual_food_name:en:Swiss chard, cooked
 ciqual_food_name:fr:Bette ou blette, cuite
@@ -63794,6 +66112,7 @@ ciqual_food_name:fr:Bette ou blette, cuite
 <en:Chards
 en:Raw Swiss chard
 fr:Bette crue, Blette crue
+agribalyse_food_code:en:20004
 ciqual_food_code:en:20004
 ciqual_food_name:en:Swiss chard, raw
 ciqual_food_name:fr:Bette ou blette, crue
@@ -63809,6 +66128,7 @@ la:Cucumis sativus
 nl:Komkommers
 ru:Огурцы, Огурец
 wikidata:en:Q23425
+agribalyse_food_code:en:20019
 ciqual_food_code:en:20019
 ciqual_food_name:en:Cucumber, pulp and peel, raw
 
@@ -63864,6 +66184,7 @@ wikidata:en:Q178547
 # wikidata:en:Q28604477 what is this?
 # category/endives has 8 products @2019-05-22
 # ingredient/endive has 125 products @2019-05-22
+agribalyse_food_code:en:20090
 ciqual_food_code:en:20090
 ciqual_food_name:en:Escaroles
 ciqual_food_name:fr:Scarole, crue
@@ -63964,6 +66285,7 @@ zh:小茴香
 wikipedia:en:https://en.wikipedia.org/wiki/Fennel
 wikidata:en:Q43511
 # fr:fenouil has 634 products in 6 languages @2018-10-21
+agribalyse_food_code:en:20028
 ciqual_food_code:en:20028
 ciqual_food_name:en:Fennel, raw
 ciqual_food_name:fr:Fenouil, cru
@@ -63975,6 +66297,7 @@ season_in_country_fr:en: 4,6,7,8,9,10,11
 <en:fennel
 en:Boiled fennel, Fennel cooked in water
 fr:Fenouil bouilli, Fenouil cuit à l'eau
+agribalyse_food_code:en:20118
 ciqual_food_code:en:20118
 ciqual_food_name:en:Fennel, boiled/cooked in water
 ciqual_food_name:fr:Fenouil, bouilli/cuit à l'eau
@@ -64004,6 +66327,7 @@ de:Fenchelsamen
 es:Semillas de hinojo
 fr:Graines de fenouil
 nl:Venkelzaden
+agribalyse_food_code:en:11066
 ciqual_food_code:en:11066
 ciqual_food_name:en:Fennel, seed
 ciqual_food_name:fr:Fenouil, graine
@@ -64022,6 +66346,7 @@ nl:Knoflook
 en:Fresh garlic
 fr:Ail frais, Ail cru
 season_in_country_fr:en: 7,8,9,10,11,12
+agribalyse_food_code:en:11000
 ciqual_food_code:en:11000
 ciqual_food_name:en:Garlic, fresh
 ciqual_food_name:fr:Ail, cru
@@ -64161,6 +66486,7 @@ carbon_footprint_fr_foodges_ingredient:fr:Poireau
 <en:Cooked vegetables
 en:Cooked leeks
 fr:Poireaux cuits
+agribalyse_food_code:en:20040
 ciqual_food_code:en:20040
 ciqual_food_name:en:Leek, cooked
 ciqual_food_name:fr:Poireau, cuit
@@ -64168,6 +66494,7 @@ ciqual_food_name:fr:Poireau, cuit
 <en:Leeks
 en:Raw leek
 fr:Poireaux crus
+agribalyse_food_code:en:20039
 ciqual_food_code:en:20039
 ciqual_food_name:en:Leek, raw
 ciqual_food_name:fr:Poireau, cru
@@ -64184,6 +66511,7 @@ season_in_country_fr:en: 1,2,3,4,9,10,11,12
 <en:Leeks
 en:Leeks fondue, Slow-simmered leeks
 fr:Fondue de poireau
+agribalyse_food_code:en:20135
 ciqual_food_code:en:20135
 ciqual_food_name:en:Leeks fondue or slow-simmered leeks
 ciqual_food_name:fr:Fondue de poireau
@@ -64296,6 +66624,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lettuce
 wikipedia:en:https://en.wikipedia.org/wiki/Lactuca
 # ingredient/fr:laitue has 157 products in 5 languages @2019-04-04
 # category/lettuces has 84 products @2019-5-22
+agribalyse_food_code:en:20031
 ciqual_food_code:en:20031
 ciqual_food_name:en:Lettuce, raw
 ciqual_food_name:fr:Laitue, crue
@@ -64307,6 +66636,7 @@ season_in_country_fr:en: 5,6,7,8,9
 <en:Lettuces
 en:Romaine lettuce, Raw cos, Raw romaine lettuce
 fr:Laitue romaine, Laitue romaine crue
+agribalyse_food_code:en:20171
 ciqual_food_code:en:20171
 ciqual_food_name:en:Cos or romaine lettuce, raw
 ciqual_food_name:fr:Laitue romaine, crue
@@ -64314,6 +66644,7 @@ ciqual_food_name:fr:Laitue romaine, crue
 <en:Lettuces
 en:Iceberg lettuce
 fr:Laitue iceberg
+agribalyse_food_code:en:20200
 ciqual_food_code:en:20200
 ciqual_food_name:en:Iceberg lettuce, raw
 ciqual_food_name:fr:Laitue iceberg, crue
@@ -64398,6 +66729,7 @@ fr:Oignons rouges frais
 <en:Onions
 en:Raw onions
 fr:Oignons crus
+agribalyse_food_code:en:20034
 ciqual_food_code:en:20034
 ciqual_food_name:en:Onion, raw
 ciqual_food_name:fr:Oignon, cru
@@ -64406,6 +66738,7 @@ ciqual_food_name:fr:Oignon, cru
 <en:Cooked vegetables
 en:Cooked onions
 fr:Oignons cuits
+agribalyse_food_code:en:20035
 ciqual_food_code:en:20035
 ciqual_food_name:en:Onion, cooked
 ciqual_food_name:fr:Oignon, cuit
@@ -64429,6 +66762,7 @@ season_in_country_fr:en: 10,11,12
 <en:Shallots
 en:Raw shallots
 fr:Échalotes crues
+agribalyse_food_code:en:20097
 ciqual_food_code:en:20097
 ciqual_food_name:en:Shallot, raw
 ciqual_food_name:fr:Échalote, crue
@@ -64437,6 +66771,7 @@ ciqual_food_name:fr:Échalote, crue
 <en:Cooked vegetables
 en:Cooked shallots
 fr:Échalotes cuites
+agribalyse_food_code:en:20255
 ciqual_food_code:en:20255
 ciqual_food_name:en:Shallot, cooked
 ciqual_food_name:fr:Échalote, cuite
@@ -64473,6 +66808,7 @@ agribalyse_proxy_food_name:fr:Poivron vert, cuit
 <en:Cooked peppers
 en:Cooked sweet green peppers
 fr:Poivrons verts cuits
+agribalyse_food_code:en:20086
 ciqual_food_code:en:20086
 ciqual_food_name:en:Sweet pepper, green, cooked
 ciqual_food_name:fr:Poivron vert, cuit
@@ -64480,6 +66816,7 @@ ciqual_food_name:fr:Poivron vert, cuit
 <en:Sweet Peppers
 en:Raw sweet peppers
 fr:Poivrons crus
+agribalyse_food_code:en:20041
 ciqual_food_code:en:20041
 ciqual_food_name:en:Sweet pepper, green, yellow or red, raw
 ciqual_food_name:fr:Poivron, vert, jaune ou rouge, cru
@@ -64487,6 +66824,7 @@ ciqual_food_name:fr:Poivron, vert, jaune ou rouge, cru
 <en:Raw sweet peppers
 en:Raw yellow sweet peppers
 fr:Poivrons jaunes crus
+agribalyse_food_code:en:20168
 ciqual_food_code:en:20168
 ciqual_food_name:en:Sweet pepper, yellow, raw
 ciqual_food_name:fr:Poivron jaune, cru
@@ -64494,6 +66832,7 @@ ciqual_food_name:fr:Poivron jaune, cru
 <en:Raw sweet peppers
 en:Raw red sweet peppers
 fr:Poivrons rouges crus
+agribalyse_food_code:en:20087
 ciqual_food_code:en:20087
 ciqual_food_name:en:Sweet pepper, red, raw
 ciqual_food_name:fr:Poivron rouge, cru
@@ -64501,6 +66840,7 @@ ciqual_food_name:fr:Poivron rouge, cru
 <en:Raw sweet peppers
 en:Raw green sweet peppers
 fr:Poivrons verts crus
+agribalyse_food_code:en:20085
 ciqual_food_code:en:20085
 ciqual_food_name:en:Sweet pepper, green, raw
 ciqual_food_name:fr:Poivron vert, cru
@@ -64523,6 +66863,7 @@ nl:Rode paprikas
 <en:Cooked peppers
 en:Cooked sweet red peppers
 fr:Poivrons rouges cuits
+agribalyse_food_code:en:20088
 ciqual_food_code:en:20088
 ciqual_food_name:en:Sweet pepper, red, cooked
 ciqual_food_name:fr:Poivron rouge, cuit
@@ -64530,6 +66871,7 @@ ciqual_food_name:fr:Poivron rouge, cuit
 <en:Sweet Peppers
 en:Canned drained sweet red peppers
 fr:Poivrons rouges appertisés égouttés
+agribalyse_food_code:en:20275
 ciqual_food_code:en:20275
 ciqual_food_name:en:Sweet pepper, red, canned, drained
 ciqual_food_name:fr:Poivron rouge, appertisé, égoutté
@@ -64670,6 +67012,7 @@ origins:en: en:France, fr:Noirmoutier
 <en:Potatoes
 en:Boiled potatoes, Potatoes cooked in water
 fr:Pommes de terre bouillies, Pommes de terre cuites à l'eau
+agribalyse_food_code:en:4003
 ciqual_food_code:en:4003
 ciqual_food_name:en:Potato, boiled/cooked in water
 ciqual_food_name:fr:Pomme de terre, bouillie/cuite à l'eau
@@ -64677,6 +67020,7 @@ ciqual_food_name:fr:Pomme de terre, bouillie/cuite à l'eau
 <en:Potatoes
 en:Boiled peeled ware potatoes, Peeled ware potatoes cooked in water
 fr:Pommes de terre de conservation sans peau bouillies, Pommes de terre de conservation sans peau cuites à l'eau
+agribalyse_food_code:en:4028
 ciqual_food_code:en:4028
 ciqual_food_name:en:Ware potato, boiled/cooked in water, peeled
 ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à l'eau
@@ -64684,6 +67028,7 @@ ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à
 <en:Potatoes
 en:Peeled boiled early potato boiled, Peeled early potato cooked in water
 fr:Pommes de terre primeur sans peau bouillies, Pommes de terre primeur sans peau cuites à l'eau
+agribalyse_food_code:en:4029
 ciqual_food_code:en:4029
 ciqual_food_name:en:Early potato, boiled/cooked in water, peeled
 ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
@@ -64691,6 +67036,7 @@ ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
 <en:Potatoes
 en:Baked peeled potatoes
 fr:Pommes de terre sans peau cuites au four
+agribalyse_food_code:en:4002
 ciqual_food_code:en:4002
 ciqual_food_name:en:Potato, peeled, baked
 ciqual_food_name:fr:Pomme de terre, sans peau, cuite au four
@@ -64698,6 +67044,7 @@ ciqual_food_name:fr:Pomme de terre, sans peau, cuite au four
 <en:Potatoes
 en:Raw peeled potatoes
 fr:Pommes de terre sans peau crues
+agribalyse_food_code:en:4008
 ciqual_food_code:en:4008
 ciqual_food_name:en:Potato, peeled, raw
 ciqual_food_name:fr:Pomme de terre, sans peau, crue
@@ -64705,6 +67052,7 @@ ciqual_food_name:fr:Pomme de terre, sans peau, crue
 <en:Potatoes
 en:Roasted potatoes, Bakes potatoes
 fr:Pommes de terre rôties, Pommes de terre cuites au four
+agribalyse_food_code:en:4026
 ciqual_food_code:en:4026
 ciqual_food_name:en:Potato, roasted/baked
 ciqual_food_name:fr:Pomme de terre, rôtie/cuite au four
@@ -64712,6 +67060,7 @@ ciqual_food_name:fr:Pomme de terre, rôtie/cuite au four
 <en:Potatoes
 en:Plain dehydrated potato flakes
 fr:Flocons de pommes de terre déshydratés nature
+agribalyse_food_code:en:4022
 ciqual_food_code:en:4022
 ciqual_food_name:en:Potato flakes, dehydrated, plain
 ciqual_food_name:fr:Pomme de terre, flocons déshydratés, nature
@@ -64719,6 +67068,7 @@ ciqual_food_name:fr:Pomme de terre, flocons déshydratés, nature
 <en:Potatoes
 en:Sautéed Potatoes, Pan-fried potatoes
 fr:Pommes de terre sautées, Pommes de terre poêlées
+agribalyse_food_code:en:4015
 ciqual_food_code:en:4015
 ciqual_food_name:en:Potato, sautéed/pan-fried
 ciqual_food_name:fr:Pomme de terre, sautée/poêlée
@@ -64726,6 +67076,7 @@ ciqual_food_name:fr:Pomme de terre, sautée/poêlée
 <en:Potatoes
 en:Sautéed potato with goose fat, Pan-fried potato with goose fat
 fr:Pommes de terre sautées à la graisse de canard, Pommes de terre poêlées à la graisse de canard
+agribalyse_food_code:en:4036
 ciqual_food_code:en:4036
 ciqual_food_name:en:Potato, sautéed/pan-fried, with goose fat
 ciqual_food_name:fr:Pomme de terre sautée/poêlée à la graisse de canard
@@ -64733,6 +67084,7 @@ ciqual_food_name:fr:Pomme de terre sautée/poêlée à la graisse de canard
 <en:Potatoes
 en:Vacuum-packed steamed potatoes
 fr:Pommes de terre vapeur sous vide
+agribalyse_food_code:en:4014
 ciqual_food_code:en:4014
 ciqual_food_name:en:Potato, steamed, vacuum-packed
 ciqual_food_name:fr:Pomme de terre vapeur, sous vide
@@ -64740,6 +67092,7 @@ ciqual_food_name:fr:Pomme de terre vapeur, sous vide
 <en:Potatoes
 en:Raw new potatoes
 fr:Pommes de terre nouvelles crues
+agribalyse_food_code:en:4023
 ciqual_food_code:en:4023
 ciqual_food_name:en:New potato, raw
 ciqual_food_name:fr:Pomme de terre nouvelle, crue
@@ -64765,6 +67118,7 @@ season_in_country_fr:en: 1,9,10,11,12
 <en:Pumpkins
 en:Raw pumpkin
 fr:Potiron cru
+agribalyse_food_code:en:20044
 ciqual_food_code:en:20044
 ciqual_food_name:en:Pumpkin, raw
 ciqual_food_name:fr:Potiron, cru
@@ -64772,6 +67126,7 @@ ciqual_food_name:fr:Potiron, cru
 <en:Pumpkins
 en:Raw pulp of melonnette jaspée from Vendée, Squash of melonnette jaspée from Vendée
 fr:Pulpe de courge melonnette crue
+agribalyse_food_code:en:20136
 ciqual_food_code:en:20136
 ciqual_food_name:en:Squash, melonnette jaspée from Vendée, pulp, raw
 ciqual_food_name:fr:Courge melonnette, pulpe, crue
@@ -64780,6 +67135,7 @@ ciqual_food_name:fr:Courge melonnette, pulpe, crue
 <en:Cooked vegetables
 en:Cooked pumpkins
 fr:Potirons cuits
+agribalyse_food_code:en:20096
 ciqual_food_code:en:20096
 ciqual_food_name:en:Pumpkin, cooked
 ciqual_food_name:fr:Potiron, cuit
@@ -64787,6 +67143,7 @@ ciqual_food_name:fr:Potiron, cuit
 <en:Pumpkins
 en:Canned drained pumpkin
 fr:Potiron appertisé égoutté
+agribalyse_food_code:en:20043
 ciqual_food_code:en:20043
 ciqual_food_name:en:Pumpkin, canned, drained
 ciqual_food_name:fr:Potiron, appertisé, égoutté
@@ -64803,6 +67160,7 @@ es:Calabazas Butternut
 fr:Courges Butternut, Doubeurre, Courge doubeurre, Pulpe de courge doubeurre crue, Pulpe de courge butternut crue
 nl:Muskaatpompoen
 wikidata:en:Q4169287
+agribalyse_food_code:en:20138
 ciqual_food_code:en:20138
 ciqual_food_name:en:Squash, butternut, pulp, raw
 ciqual_food_name:fr:Courge doubeurre (butternut), pulpe, crue
@@ -64955,6 +67313,7 @@ fr:Radis rouges, Radis rouge, Radis roses, Radis rose
 la:Raphanus sativus var. sativus
 nl:Radijs
 wikidata:en:Q1057750
+agribalyse_food_code:en:20045
 ciqual_food_code:en:20045
 ciqual_food_name:en:Radish, raw
 ciqual_food_name:fr:Radis rouge, cru
@@ -64968,6 +67327,7 @@ en:Black radishes, Black radish
 fr:Radis noirs
 la:Raphanus sativus subsp. niger
 wikidata:en:Q159587
+agribalyse_food_code:en:20089
 ciqual_food_code:en:20089
 ciqual_food_name:en:Radish, black, raw
 ciqual_food_name:fr:Radis noir, cru
@@ -64999,6 +67359,7 @@ fr:Choux rouges frais
 <en:Vegetables
 en:Raw taro tubers
 fr:Tubercules de taro crus
+agribalyse_food_code:en:53200
 ciqual_food_code:en:53200
 ciqual_food_name:en:Taro, tuber, raw
 ciqual_food_name:fr:Taro, tubercule, cru
@@ -65006,6 +67367,7 @@ ciqual_food_name:fr:Taro, tubercule, cru
 <en:Cooked vegetables
 en:Cooked taro tubes
 fr:Tubercules de taro cuits
+agribalyse_food_code:en:53201
 ciqual_food_code:en:53201
 ciqual_food_name:en:Taro, tuber, cooked
 ciqual_food_name:fr:Taro, tubercule, cuit
@@ -65013,6 +67375,7 @@ ciqual_food_name:fr:Taro, tubercule, cuit
 <en:Cooked vegetables
 en:Cooked cassava, Cooked manioc roots
 fr:Manioc, Racine cuite
+agribalyse_food_code:en:54034
 ciqual_food_code:en:54034
 ciqual_food_name:en:Cassava or manioc, roots, cooked
 ciqual_food_name:fr:Manioc, racine cuite
@@ -65020,6 +67383,7 @@ ciqual_food_name:fr:Manioc, racine cuite
 <en:Vegetables
 en:Raw cassava roots, Raw manioc roots
 fr:Racines de manioc crues
+agribalyse_food_code:en:54031
 ciqual_food_code:en:54031
 ciqual_food_name:en:Cassava or manioc, roots, raw
 ciqual_food_name:fr:Manioc, racine crue
@@ -65027,6 +67391,7 @@ ciqual_food_name:fr:Manioc, racine crue
 <en:Vegetables
 en:Raw tapioca
 fr:Tapioca cru, Tapioca, Perles du Japon crues, Perles du Japon
+agribalyse_food_code:en:4000
 ciqual_food_code:en:4000
 ciqual_food_name:en:Tapioca, raw
 ciqual_food_name:fr:Tapioca ou Perles du Japon, cru
@@ -65073,6 +67438,7 @@ nl:Verse rabarber
 <en:Vegetable rods
 en:Rhubarb stalk cooked with sugar
 fr:Tiges de rhubarbe cuites sucrées
+agribalyse_food_code:en:13048
 ciqual_food_code:en:13048
 ciqual_food_name:en:Rhubarb, stalk, cooked, with sugar
 ciqual_food_name:fr:Rhubarbe, tige, cuite, sucrée
@@ -65080,6 +67446,7 @@ ciqual_food_name:fr:Rhubarbe, tige, cuite, sucrée
 <en:Vegetable rods
 en:Raw rhubarb stalk
 fr:Tiges de rhubarbe crues
+agribalyse_food_code:en:13047
 ciqual_food_code:en:13047
 ciqual_food_name:en:Rhubarb, stalk, raw
 ciqual_food_name:fr:Rhubarbe, tige, crue
@@ -65095,6 +67462,7 @@ wikidata:en:Q1775431
 <en:Leaf vegetables
 en:Raw romanesco cauliflower, Raw romanesco broccoli
 fr:Chou romanesco cru, Brocoli à pomme cru
+agribalyse_food_code:en:20280
 ciqual_food_code:en:20280
 ciqual_food_name:en:Romanesco cauliflower or romanesco broccoli, raw
 ciqual_food_name:fr:Chou romanesco ou brocoli à pomme, cru
@@ -65142,6 +67510,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Scallion
 <en:Cooked vegetables
 en:Cooked New Zealand spinach
 fr:Tétragone cornue cuite
+agribalyse_food_code:en:20158
 ciqual_food_code:en:20158
 ciqual_food_name:en:New Zealand spinach, cooked
 ciqual_food_name:fr:Tétragone cornue, cuite
@@ -65160,6 +67529,7 @@ wikidata:en:Q81464
 <en:Spinachs
 en:Spinach with cream sauce
 fr:Épinards à la crème
+agribalyse_food_code:en:25026
 ciqual_food_code:en:25026
 ciqual_food_name:en:Spinach w cream sauce
 ciqual_food_name:fr:Épinards à la crème
@@ -65168,6 +67538,7 @@ ciqual_food_name:fr:Épinards à la crème
 <en:Cooked vegetables
 en:Cooked spinach
 fr:Épinards cuits
+agribalyse_food_code:en:20027
 ciqual_food_code:en:20027
 ciqual_food_name:en:Spinach, cooked
 ciqual_food_name:fr:Épinard, cuit
@@ -65176,6 +67547,7 @@ ciqual_food_name:fr:Épinard, cuit
 <en:Fresh vegetables
 en:Raw spinach
 fr:Épinards crus
+agribalyse_food_code:en:20059
 ciqual_food_code:en:20059
 ciqual_food_name:en:Spinach, raw
 ciqual_food_name:fr:Épinard, cru
@@ -65190,6 +67562,7 @@ season_in_country_fr:en: 1,2,3,4,5,9,10,11,12
 <en:Spinachs
 en:Raw spinach young leaves
 fr:Jeunes pousses d'épinards pour salades
+agribalyse_food_code:en:20270
 ciqual_food_code:en:20270
 ciqual_food_name:en:Spinach, young leaves, raw
 ciqual_food_name:fr:Épinard, jeunes pousses pour salades, cru
@@ -65297,6 +67670,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Turnip
 <en:Turnip
 en:Raw rutabaga, Raw swede
 fr:Rutabaga cru
+agribalyse_food_code:en:20201
 ciqual_food_code:en:20201
 ciqual_food_name:en:Rutabaga or Swede, raw
 ciqual_food_name:fr:Rutabaga, cru
@@ -65305,6 +67679,7 @@ ciqual_food_name:fr:Rutabaga, cru
 <en:Cooked vegetables
 en:Cooked rutabaga, Cooked swede
 fr:Rutabaga cuit
+agribalyse_food_code:en:20165
 ciqual_food_code:en:20165
 ciqual_food_name:en:Rutabaga or Swede, cooked
 ciqual_food_name:fr:Rutabaga, cuit
@@ -65313,6 +67688,7 @@ ciqual_food_name:fr:Rutabaga, cuit
 <en:Cooked vegetables
 en:Cooked turnips
 fr:Navets cuits
+agribalyse_food_code:en:20033
 ciqual_food_code:en:20033
 ciqual_food_name:en:Turnip, cooked
 ciqual_food_name:fr:Navet, cuit
@@ -65320,6 +67696,7 @@ ciqual_food_name:fr:Navet, cuit
 <en:Turnip
 en:Raw peeled turnips
 fr:Navets pelés crus
+agribalyse_food_code:en:20064
 ciqual_food_code:en:20064
 ciqual_food_name:en:Turnip, peeled, raw
 ciqual_food_name:fr:Navet, pelé, cru
@@ -65367,6 +67744,7 @@ fr:Tomates cerise, Tomates cerises
 la:Solanum lycopersicum var. cerasiforme, Lycopersicon lycopersicum var. cerasiforme, Lycopersicon esculentum var. cerasiforme
 nl:Kerstomaten
 wikidata:en:Q6540634
+agribalyse_food_code:en:20172
 ciqual_food_code:en:20172
 ciqual_food_name:en:Tomato, cherry, raw
 ciqual_food_name:fr:Tomate cerise, crue
@@ -65374,6 +67752,7 @@ ciqual_food_name:fr:Tomate cerise, crue
 <en:Tomatoes
 en:Provencal-style tomatoes, Breaded tomatoes stuffed with garlic and parsley
 fr:Tomates à la provençale
+agribalyse_food_code:en:25524
 ciqual_food_code:en:25524
 ciqual_food_name:en:Provencal-style tomato (breaded tomatoes stuffed with garlic and parsley)
 ciqual_food_name:fr:Tomate à la provençale
@@ -65397,6 +67776,7 @@ fr:Chair de tomates
 <en:Peeled tomatoes
 en:Canned drained peeled tomatoes
 fr:Tomates pelées appertisées égouttées
+agribalyse_food_code:en:20048
 ciqual_food_code:en:20048
 ciqual_food_name:en:Tomato, peeled, canned, drained
 ciqual_food_name:fr:Tomate, pelée, appertisée, égouttée
@@ -65421,6 +67801,7 @@ season_in_country_fr:en: 5,6,7,8,9,10
 <en:Zucchini
 en:Raw courgette pulp and peel, Raw zucchini pulp and peel
 fr:Pulpe et peau de courgette crue
+agribalyse_food_code:en:20020
 ciqual_food_code:en:20020
 ciqual_food_name:en:Courgette or zucchini, pulp and peel, raw
 ciqual_food_name:fr:Courgette, pulpe et peau, crue
@@ -65429,6 +67810,7 @@ ciqual_food_name:fr:Courgette, pulpe et peau, crue
 <en:Cooked vegetables
 en:Cooked pulp and peel courgette, Cooked pulp and peel zucchini
 fr:Pulpe et peau de courgette cuite
+agribalyse_food_code:en:20021
 ciqual_food_code:en:20021
 ciqual_food_name:en:Courgette or zucchini, pulp and peel, cooked
 ciqual_food_name:fr:Courgette, pulpe et peau, cuite
@@ -65437,6 +67819,7 @@ ciqual_food_name:fr:Courgette, pulpe et peau, cuite
 <en:Frozen vegetables
 en:Frozen raw courgette pulp and peel, Frozen raw zucchini pulp and peel
 fr:Pulpe et peau de courgette surgelée crue
+agribalyse_food_code:en:20230
 ciqual_food_code:en:20230
 ciqual_food_name:en:Courgette or zucchini, pulp and peel, frozen, raw
 ciqual_food_name:fr:Courgette, pulpe et peau, surgelée, crue
@@ -65467,6 +67850,7 @@ fr:Mélanges de légumes pour soupes
 <en:Frozen foods
 en:Frozen raw mixed vegetables for soups
 fr:Légumes surgelés crus pour potage
+agribalyse_food_code:en:20263
 ciqual_food_code:en:20263
 ciqual_food_name:en:Mixed vegetables for soups, frozen, raw
 ciqual_food_name:fr:Légumes pour potages, surgelés, crus
@@ -65499,6 +67883,7 @@ es:Ensaladas vegetales
 fi:lehtisalaatit
 fr:Salades vertes, salades feuilles
 nl:Bladsla
+agribalyse_food_code:en:25604
 ciqual_food_code:en:25604
 ciqual_food_name:en:Green salad, raw, without seasoning
 ciqual_food_name:fr:Salade verte, crue, sans assaisonnement
@@ -65542,6 +67927,7 @@ wikidata:en:Q158954
 wikipedia:en:https://en.wikipedia.org/wiki/Valerianella_locusta
 # ingredient/fr:mâche has 133 products in french @2019-05-08
 # category/corn-salad has 73 products @2019-05-22
+agribalyse_food_code:en:20099
 ciqual_food_code:en:20099
 ciqual_food_name:en:Lamb's lettuce, raw
 ciqual_food_name:fr:Mâche, crue
@@ -65560,6 +67946,7 @@ nl:Rucola, raketsla
 nl_be:Rucola, raketsla
 pl:Rokietta siewna, rukolą
 wikidata:en:Q156884
+agribalyse_food_code:en:20217
 ciqual_food_code:en:20217
 ciqual_food_name:en:Roman rocket, raw
 ciqual_food_name:fr:Roquette, crue
@@ -65571,6 +67958,7 @@ fr:Cresson alénois
 la:Lepidium sativum
 nl:Tuinkers
 wikidata:en:Q27033
+agribalyse_food_code:en:20199
 ciqual_food_code:en:20199
 ciqual_food_name:en:Garden cress, raw
 ciqual_food_name:fr:Cresson alénois, cru
@@ -65578,6 +67966,7 @@ ciqual_food_name:fr:Cresson alénois, cru
 <en:Leaf vegetables
 en:Mesclun, Mix of baby salad leaves
 fr:Mesclun, Mélange de jeunes pousses de salade
+agribalyse_food_code:en:20272
 ciqual_food_code:en:20272
 ciqual_food_name:en:Mesclun or salads, mix of baby leaves
 ciqual_food_name:fr:Mesclun ou salade, mélange de jeunes pousses
@@ -65590,6 +67979,7 @@ fr:Cresson, Cresson de fontaine, Cresson d’eau
 la:Nasturtium officinale
 nl:Witte waterkers
 wikidata:en:Q150452
+agribalyse_food_code:en:20022
 ciqual_food_code:en:20022
 ciqual_food_name:en:Watercress, raw
 ciqual_food_name:fr:Cresson de fontaine, cru
@@ -65601,6 +67991,7 @@ season_in_country_fr:en: 1,2,3,4,5,9,10,11,12
 <en:Leaf vegetables
 en:Raw curly endive
 fr:Salade frisée crue
+agribalyse_food_code:en:20012
 ciqual_food_code:en:20012
 ciqual_food_name:en:Curly endive, raw
 ciqual_food_name:fr:Salade ou chicorée frisée, crue
@@ -65627,7 +68018,7 @@ es:Verduras y hortalizas deshidratadas, Verduras y hortalizas desecadas, Verdura
 fi:kuivatut vihannekset
 fr:Légumes séchés
 nl:Gedroogde groenten
-who_id:16
+who_id:en:16
 
 <en:Dried vegetables
 <en:Tomatoes and their products
@@ -65637,6 +68028,7 @@ es:Tomates secos, Tomates deshidratados, Tomates desecados
 fi:kuivatut tomaatit
 fr:Tomate séchée, Tomates séchées
 nl:Gedrooge tomaten
+agribalyse_food_code:en:20189
 ciqual_food_code:en:20189
 ciqual_food_name:en:Tomato, dried
 ciqual_food_name:fr:Tomate, séchée
@@ -65644,6 +68036,7 @@ ciqual_food_name:fr:Tomate, séchée
 <en:Dried vegetables
 en:Dried broad beans
 fr:Fèves sèches
+agribalyse_food_code:en:20518
 ciqual_food_code:en:20518
 ciqual_food_name:en:Broad bean, dried
 ciqual_food_name:fr:Fève, sèche
@@ -65661,6 +68054,7 @@ es:Tomates secos en aceite, Tomates secos rehidratados en aceite
 fi:kuivattuja tomaatteja öljyssä
 fr:Tomate séchée à l'huile, Tomates séchées à l'huile, Tomates séchées réhydratées à l'huile
 nl:Gedroogde tomaten op olie
+agribalyse_food_code:en:20256
 ciqual_food_code:en:20256
 ciqual_food_name:en:Tomato, dried, in oil
 ciqual_food_name:fr:Tomate, séchée, à l'huile
@@ -65691,6 +68085,7 @@ es:Ajo seco molido, Ajos secos en polvo
 fr:Ail sec broyé, Ail séché en poudre
 hu:Fokhagyma por, Foghagyma granulátum
 nl:Knoflookpoeders
+agribalyse_food_code:en:11023
 ciqual_food_code:en:11023
 ciqual_food_name:en:Garlic, powder, dried
 ciqual_food_name:fr:Ail séché, poudre
@@ -65766,12 +68161,13 @@ es:Leguminosas frescas, Legumbres frescas
 fi:tuoreet palkokasvit
 fr:Légumineuses frais
 nl:Verse bonen
-who_id:15
+who_id:en:15
 
 <en:Legumes
 <en:Fresh plant-based foods
 en:Raw mix of cereals and legumes
 fr:Mélange de céréales et légumineuses crues
+agribalyse_food_code:en:9612
 ciqual_food_code:en:9612
 ciqual_food_name:en:Mix of cereals and legumes, raw
 ciqual_food_name:fr:Mélange de céréales et légumineuses, cru
@@ -65788,6 +68184,7 @@ nl:Tuinbonen
 <en:Fresh vegetables
 en:Fresh broad beans to shell
 fr:Fèves fraîches à écosser
+agribalyse_food_code:en:20517
 ciqual_food_code:en:20517
 ciqual_food_name:en:Broad bean, to shell, fresh
 ciqual_food_name:fr:Fève à écosser, fraîche
@@ -65796,6 +68193,7 @@ ciqual_food_name:fr:Fève à écosser, fraîche
 <en:Vegetables
 en:Raw butter beans, Raw yellow beans
 fr:Haricots beurre crus
+agribalyse_food_code:en:20195
 ciqual_food_code:en:20195
 ciqual_food_name:en:Butter bean or yellow bean, raw
 ciqual_food_name:fr:Haricot beurre, cru
@@ -65804,6 +68202,7 @@ ciqual_food_name:fr:Haricot beurre, cru
 <en:Vegetables
 en:Raw flat beans
 fr:Haricots plats crus
+agribalyse_food_code:en:20269
 ciqual_food_code:en:20269
 ciqual_food_name:en:Flat bean, raw
 ciqual_food_name:fr:Haricot plat, cru
@@ -65830,6 +68229,7 @@ ciqual_food_name:fr:Haricot vert, cru
 <en:Cooked vegetables
 en:Cooked French beans
 fr:Haricots verts cuits
+agribalyse_food_code:en:20030
 ciqual_food_code:en:20030
 ciqual_food_name:en:French bean, cooked
 ciqual_food_name:fr:Haricot vert, cuit
@@ -65877,6 +68277,7 @@ season_in_country_fr:en: 5,6,7
 <en:Green peas
 en:Raw garden peas
 fr:Petits pois crus
+agribalyse_food_code:en:20072
 ciqual_food_code:en:20072
 ciqual_food_name:en:Garden peas, raw
 ciqual_food_name:fr:Petits pois, crus
@@ -65885,6 +68286,7 @@ ciqual_food_name:fr:Petits pois, crus
 <en:Cooked vegetables
 en:Cooked garden peas
 fr:Petits pois cuits
+agribalyse_food_code:en:20037
 ciqual_food_code:en:20037
 ciqual_food_name:en:Garden peas, cooked
 ciqual_food_name:fr:Petits pois, cuits
@@ -65893,6 +68295,7 @@ ciqual_food_name:fr:Petits pois, cuits
 <en:Frozen foods
 en:Frozen cooked garden peas
 fr:Petits pois surgelés cuits
+agribalyse_food_code:en:20124
 ciqual_food_code:en:20124
 ciqual_food_name:en:Garden peas, frozen, cooked
 ciqual_food_name:fr:Petits pois, surgelés, cuits
@@ -65901,6 +68304,7 @@ ciqual_food_name:fr:Petits pois, surgelés, cuits
 <en:Frozen foods
 en:Frozen raw garden peas
 fr:Petits pois surgelés crus
+agribalyse_food_code:en:20084
 ciqual_food_code:en:20084
 ciqual_food_name:en:Garden peas, frozen, raw
 ciqual_food_name:fr:Petits pois, surgelés, crus
@@ -65908,6 +68312,7 @@ ciqual_food_name:fr:Petits pois, surgelés, crus
 <en:Green peas
 en:Canned drained garden peas
 fr:Petits pois appertisés égouttés
+agribalyse_food_code:en:20036
 ciqual_food_code:en:20036
 ciqual_food_name:en:Garden peas, canned, drained
 ciqual_food_name:fr:Petits pois, appertisés, égouttés
@@ -65931,6 +68336,7 @@ fr:Graines de alfalfa
 la:Medicago sativa
 nl:Alfalfazaden
 wikidata:en:Q156106
+agribalyse_food_code:en:15032
 ciqual_food_code:en:15032
 ciqual_food_name:en:Alphalfa seeds, raw
 ciqual_food_name:fr:Luzerne, graine
@@ -65938,6 +68344,7 @@ ciqual_food_name:fr:Luzerne, graine
 <en:Alfalfa seeds
 en:Raw sprouted alfalfa seeds
 fr:Graines de Luzerne germées, Graines de luzerne cultivée
+agribalyse_food_code:en:15029
 ciqual_food_code:en:15029
 ciqual_food_name:en:Alfalfa seeds, sprouted, raw
 ciqual_food_name:fr:Luzerne, graine germée
@@ -65962,6 +68369,7 @@ ciqual_food_name:fr:Légume sec, cuit (aliment moyen)
 <en:Pulses
 en:Dried flageolet green beans
 fr:Flageolets verts secs, Haricots flageolets verts secs
+agribalyse_food_code:en:20539
 ciqual_food_code:en:20539
 ciqual_food_name:en:Flageolet bean, green, dried
 ciqual_food_name:fr:Haricot flageolet, vert, sec
@@ -65969,6 +68377,7 @@ ciqual_food_name:fr:Haricot flageolet, vert, sec
 <en:Cooked pulses
 en:Cooked flageolet beans
 fr:Flageolets cuits, Haricots flageolets cuits
+agribalyse_food_code:en:20513
 ciqual_food_code:en:20513
 ciqual_food_name:en:Flageolet bean, cooked
 ciqual_food_name:fr:Haricot flageolet, cuit
@@ -65976,6 +68385,7 @@ ciqual_food_name:fr:Haricot flageolet, cuit
 <en:Cooked pulses
 en:Cooked flageolet green beans
 fr:Flageolets verts cuits, Haricots flageolets verts cuits
+agribalyse_food_code:en:20540
 ciqual_food_code:en:20540
 ciqual_food_name:en:Flageolet bean, green, cooked
 ciqual_food_name:fr:Haricot flageolet, vert, cuit
@@ -65992,6 +68402,7 @@ wikidata:en:Q380279
 <en:Pulses
 en:Dried split peas
 fr:Pois cassés secs
+agribalyse_food_code:en:20515
 ciqual_food_code:en:20515
 ciqual_food_name:en:Split pea, dried
 ciqual_food_name:fr:Pois cassé, sec
@@ -65999,6 +68410,7 @@ ciqual_food_name:fr:Pois cassé, sec
 <en:Cooked pulses
 en:Cooked split peas
 fr:Pois cassés cuits
+agribalyse_food_code:en:20506
 ciqual_food_code:en:20506
 ciqual_food_name:en:Split pea, cooked
 ciqual_food_name:fr:Pois cassé, cuit
@@ -66026,6 +68438,7 @@ it:Fagioli di Lima
 la:Phaseolus lunatus
 nl:Limabonen
 wikidata:en:Q1166136
+agribalyse_food_code:en:20126
 ciqual_food_code:en:20126
 ciqual_food_name:en:Lima bean, raw
 ciqual_food_name:fr:Haricot de Lima, cru
@@ -66033,6 +68446,7 @@ ciqual_food_name:fr:Haricot de Lima, cru
 <en:Pulses
 en:Whole soybean grain
 fr:Soja graine entière
+agribalyse_food_code:en:20901
 ciqual_food_code:en:20901
 ciqual_food_name:en:Soybean, whole grain
 ciqual_food_name:fr:Soja, graine entière
@@ -66051,6 +68465,7 @@ wikidata:en:Q81375
 <en:Chickpeas
 en:Dried chickpeas, Dried chick peas
 fr:Pois chiches secs
+agribalyse_food_code:en:20516
 ciqual_food_code:en:20516
 ciqual_food_name:en:Chick pea, dried
 ciqual_food_name:fr:Pois chiche, sec
@@ -66059,6 +68474,7 @@ ciqual_food_name:fr:Pois chiche, sec
 <en:Cooked vegetables
 en:Cooked chick peas
 fr:Pois chiche cuits
+agribalyse_food_code:en:20507
 ciqual_food_code:en:20507
 ciqual_food_name:en:Chick pea, cooked
 ciqual_food_name:fr:Pois chiche, cuit
@@ -66144,6 +68560,7 @@ wikidata:en:Q18175531
 <en:Red beans
 en:Dried red kidney beans
 fr:Haricots rouges secs
+agribalyse_food_code:en:20525
 ciqual_food_code:en:20525
 ciqual_food_name:en:Red kidney bean, dried
 ciqual_food_name:fr:Haricot rouge, sec
@@ -66161,6 +68578,7 @@ nl:Witte bonen
 <en:Cooked vegetables
 en:Cooked haricot beans
 fr:Haricots blancs cuits
+agribalyse_food_code:en:20502
 ciqual_food_code:en:20502
 ciqual_food_name:en:Haricot bean, cooked
 ciqual_food_name:fr:Haricot blanc, cuit
@@ -66168,6 +68586,7 @@ ciqual_food_name:fr:Haricot blanc, cuit
 <en:White beans
 en:Dry haricot beans
 fr:Haricots blancs secs
+agribalyse_food_code:en:20501
 ciqual_food_code:en:20501
 ciqual_food_name:en:Haricot bean, dry
 ciqual_food_name:fr:Haricot blanc, sec
@@ -66235,6 +68654,7 @@ wikidata:en:Q131226
 <en:Lentils
 en:Sprouted lentils
 fr:Lentilles germées
+agribalyse_food_code:en:20521
 ciqual_food_code:en:20521
 ciqual_food_name:en:Lentils, sprouted
 ciqual_food_name:fr:Lentille, germée
@@ -66242,6 +68662,7 @@ ciqual_food_name:fr:Lentille, germée
 <en:Lentils
 en:Dried lentils
 fr:Lentilles sèches
+agribalyse_food_code:en:20504
 ciqual_food_code:en:20504
 ciqual_food_name:en:Lentil, dried
 ciqual_food_name:fr:Lentille, sèche
@@ -66250,6 +68671,7 @@ ciqual_food_name:fr:Lentille, sèche
 <en:Cooked vegetables
 en:Cooked lentils
 fr:Lentilles cuites
+agribalyse_food_code:en:20505
 ciqual_food_code:en:20505
 ciqual_food_name:en:Lentil, cooked
 ciqual_food_name:fr:Lentille, cuite
@@ -66282,6 +68704,7 @@ nl:Gepelde linzen
 <en:Blonde lentils
 en:Dried blond lentils
 fr:Lentilles blondes sèches
+agribalyse_food_code:en:20586
 ciqual_food_code:en:20586
 ciqual_food_name:en:Lentil, blond, dried
 ciqual_food_name:fr:Lentille blonde, sèche
@@ -66290,6 +68713,7 @@ ciqual_food_name:fr:Lentille blonde, sèche
 <en:Cooked vegetables
 en:Cooked blond lentils
 fr:Lentilles blondes cuites
+agribalyse_food_code:en:20588
 ciqual_food_code:en:20588
 ciqual_food_name:en:Lentil, blond, cooked
 ciqual_food_name:fr:Lentille blonde, cuite
@@ -66310,6 +68734,7 @@ nl:Gepelde rode linzen
 <en:Red lentils
 en:Dried pink lentils, Dried red lentils
 fr:Lentilles corail sèches
+agribalyse_food_code:en:20535
 ciqual_food_code:en:20535
 ciqual_food_name:en:Lentil, pink or red, dried
 ciqual_food_name:fr:Lentille corail, sèche
@@ -66318,6 +68743,7 @@ ciqual_food_name:fr:Lentille corail, sèche
 <en:Cooked vegetables
 en:Cooked pink lentils, Cooked red lentils
 fr:Lentille corail cuites
+agribalyse_food_code:en:20589
 ciqual_food_code:en:20589
 ciqual_food_name:en:Lentil, pink or red, cooked
 ciqual_food_name:fr:Lentille corail, cuite
@@ -66344,6 +68770,7 @@ pt:Lentilhas verde
 <en:Cooked vegetables
 en:Cooked green lentils
 fr:Lentilles vertes cuites
+agribalyse_food_code:en:20587
 ciqual_food_code:en:20587
 ciqual_food_name:en:-
 ciqual_food_name:fr:Lentille verte, cuite
@@ -66351,6 +68778,7 @@ ciqual_food_name:fr:Lentille verte, cuite
 <en:Lentils
 en:Dried green lentils
 fr:Lentilles vertes sèches
+agribalyse_food_code:en:20585
 ciqual_food_code:en:20585
 ciqual_food_name:en:Lentil, green, dried
 ciqual_food_name:fr:Lentille verte, sèche
@@ -66365,6 +68793,8 @@ nl:Rode linzen
 
 <en:Lentils
 fr:lentilles rosées de Champagne, lentillon de Champagne
+origins:en: en:France, fr:Champagne
+
 
 <en:Pulses
 en:Lupin beans, Lupins, Lupini beans
@@ -66378,6 +68808,7 @@ wikidata:en:Q156811
 <en:Pulses
 en:Raw lupin grains
 fr:Graines de lupin crues
+agribalyse_food_code:en:20534
 ciqual_food_code:en:20534
 ciqual_food_name:en:lupin grain, raw
 ciqual_food_name:fr:Lupin, graine crue
@@ -66406,6 +68837,7 @@ wikidata:en:Q484447
 <en:Cooked pulses
 en:Cooked Mung beans
 fr:Haricots mungo cuits
+agribalyse_food_code:en:20531
 ciqual_food_code:en:20531
 ciqual_food_name:en:Mung bean, cooked
 ciqual_food_name:fr:Haricot mungo, cuit
@@ -66413,6 +68845,7 @@ ciqual_food_name:fr:Haricot mungo, cuit
 <en:Pulses
 en:Dry mung beans, Dry mature mung beans
 fr:Haricots mungo secs
+agribalyse_food_code:en:20530
 ciqual_food_code:en:20530
 ciqual_food_name:en:Beans, mung, mature, seeds, dry
 ciqual_food_name:fr:Haricot mungo, sec
@@ -66422,12 +68855,14 @@ ciqual_food_name:fr:Haricot mungo, sec
 en:Sprouted mung beans, Mung bean sprouts
 fr:Haricots mungos germés, Pousses de haricot mungo, jeunes pousses de haricot mungo, Pousses de soja vert, Pousse de ambérique vert
 es:Germinados de judía mungo
+agribalyse_food_code:en:20183
 ciqual_food_code:en:20183
 ciqual_food_name:en:Mung bean, sprouted or soy spouts, raw
 ciqual_food_name:fr:Haricot mungo germé ou pousse de ""soja"", cru
 
 en:Soy sprouts
 fr:Pousses de soja
+agribalyse_food_code:en:20183
 ciqual_food_code:en:20183
 ciqual_food_name:en:Mung bean, sprouted or soy spouts, raw
 ciqual_food_name:fr:Haricot mungo germé ou pousse de ""soja"", cru
@@ -66498,6 +68933,7 @@ wikidata:en:Q1468260
 <en:Pulses
 en:Raw snow peas
 fr:Pois mange-tout crus, Pois gourmand crus
+agribalyse_food_code:en:20173
 ciqual_food_code:en:20173
 ciqual_food_name:en:Snow pea, raw
 ciqual_food_name:fr:Pois mange-tout ou pois gourmand, cru
@@ -66505,6 +68941,7 @@ ciqual_food_name:fr:Pois mange-tout ou pois gourmand, cru
 <en:Pulses
 en:Snow peas boiled in water, Snow peas cooked in water
 fr:Pois mange-tout bouillis, Pois mange-tout cuits à l'eau, Pois gourmands bouillis, Pois gourmandscuits à l'eau
+agribalyse_food_code:en:20216
 ciqual_food_code:en:20216
 ciqual_food_name:en:Snow pea, boiled/cooked in water
 ciqual_food_name:fr:Pois mange-tout ou pois gourmand, bouilli/cuit à l'eau
@@ -66512,6 +68949,7 @@ ciqual_food_name:fr:Pois mange-tout ou pois gourmand, bouilli/cuit à l'eau
 <en:Cooked pulses
 en:Cooked snow peas
 fr:Pois mange-tout cuits, Pois gourmands cuits
+agribalyse_food_code:en:20243
 ciqual_food_code:en:20243
 ciqual_food_name:en:Snow pea, cooked
 ciqual_food_name:fr:Pois mange-tout ou pois gourmands, cuits
@@ -66538,7 +68976,7 @@ fi:purkitetut palkokasvit
 fr:Légumineuses en conserve
 hu:Hüvelyes konzervek
 nl:Bonen in blik
-who_id:16
+who_id:en:16
 
 <en:Canned legumes
 <en:Chickpeas
@@ -66553,6 +68991,7 @@ nl:Kikkererwten in blik
 <en:Chickpeas
 en:Canned drained chick peas
 fr:Pois chiche appertisés égouttés
+agribalyse_food_code:en:20532
 ciqual_food_code:en:20532
 ciqual_food_name:en:Chick pea, canned, drained
 ciqual_food_name:fr:Pois chiche, appertisé, égoutté
@@ -66574,6 +69013,7 @@ nl:Flageoletbonen in blik
 <en:Canned common beans
 en:Canned drained flageolet beans
 fr:Flageolets appertisés égouttés, Flageolets en conserve égouttés, Haricots flageolets appertisés égouttés, Haricots flageolets en conserve égouttés
+agribalyse_food_code:en:20508
 ciqual_food_code:en:20508
 ciqual_food_name:en:Flageolet bean, canned, drained
 ciqual_food_name:fr:Haricot flageolet, appertisé, égouttés
@@ -66589,6 +69029,7 @@ nl:Rode bonen in blik
 <en:Canned common beans
 en:Canned drained red kidney beans
 fr:Haricots rouges appertisés égouttés
+agribalyse_food_code:en:20524
 ciqual_food_code:en:20524
 ciqual_food_name:en:Red kidney bean, canned, drained
 ciqual_food_name:fr:Haricot rouge, appertisé, égoutté
@@ -66615,6 +69056,7 @@ nl:Linzen in blik
 <en:Canned legumes
 en:Canned drained seasoned lentils
 fr:Lentilles cuisinées appertisées égouttées, Lentilles cuisinées égouttées en conserve
+agribalyse_food_code:en:20510
 ciqual_food_code:en:20510
 ciqual_food_name:en:Lentil, seasoned, canned, drained
 ciqual_food_name:fr:Lentille, cuisinée, appertisée, égouttée
@@ -66650,6 +69092,11 @@ ciqual_food_name:fr:Haricot vert, appertisé, égoutté
 <en:Canned vegetables
 en:Canned butter beans, canned drained butter beans, Canned drained yellow beans
 fr:Haricots beurre en conserve, Haricots beurre appertisés égouttés
+
+<en:Canned legumes
+<en:Canned vegetables
+en:Canned drained butter beans, Canned drained yellow beans
+fr:Haricots beurre appertisés égouttés
 agribalyse_food_code:en:20063
 ciqual_food_code:en:20063
 ciqual_food_name:en:Butter bean or yellow bean, canned, drained
@@ -66688,6 +69135,7 @@ nl:Doperwten met worteltjes in blik
 <en:Canned vegetables
 en:Canned drained garden peas and carrots
 fr:Petits pois et carottes appertisés égouttés
+agribalyse_food_code:en:20093
 ciqual_food_code:en:20093
 ciqual_food_name:en:Garden peas and carrots, canned, drained
 ciqual_food_name:fr:Petits pois et carottes, appertisés, égouttés
@@ -66753,6 +69201,7 @@ nl:Mungoboonkiemen in blik
 <en:Canned legume sprouts
 en:Canned drained sprouted mung beans, Canned drained soy sprouts
 fr:Haricots mungo germés appertisés égouttés, Pousses de soja appertisées égouttées
+agribalyse_food_code:en:20029
 ciqual_food_code:en:20029
 ciqual_food_name:en:Mung bean, sprouted or soy spouts, canned, drained
 ciqual_food_name:fr:Haricot mungo germé ou pousse de soja, appertisé, égoutté
@@ -66793,6 +69242,7 @@ de:Kichererbsenmehle
 es:Harinas de garbanzos
 fr:Farines de pois chiche, Farine de pois chiche
 nl:Kikkererwtenmelen
+agribalyse_food_code:en:9580
 ciqual_food_code:en:9580
 ciqual_food_name:en:Chick pea flour
 ciqual_food_name:fr:Farine de pois chiche
@@ -66826,6 +69276,7 @@ en:Soybean flours, Soya flour
 es:Harinas de soja
 fr:Farines de soja
 nl:Sojaboonmelen
+agribalyse_food_code:en:20900
 ciqual_food_code:en:20900
 ciqual_food_name:en:Soya flour
 
@@ -66953,6 +69404,7 @@ zh:豆腐
 # zh-tw:豆腐
 wikidata:en:Q177378
 wikipedia:en:https://en.wikipedia.org/wiki/Tofu
+agribalyse_food_code:en:20904
 ciqual_food_code:en:20904
 ciqual_food_name:en:Tofu, plain
 ciqual_food_name:fr:Tofu, nature
@@ -66967,6 +69419,7 @@ fr:Tempeh
 ja:テンペ
 nl:Tempeh
 wikidata:en:Q120096
+agribalyse_food_code:en:20917
 ciqual_food_code:en:20917
 ciqual_food_name:en:Tempeh
 ciqual_food_name:fr:Tempeh
@@ -66986,6 +69439,7 @@ fr:Miso
 ja:味噌, みそ
 nl:Misos
 wikidata:en:Q235169
+agribalyse_food_code:en:20916
 ciqual_food_code:en:20916
 ciqual_food_name:en:Miso
 ciqual_food_name:fr:Miso
@@ -67005,12 +69459,14 @@ pt:Vinagres
 zh:醋
 pnns_group_2:en:Dressings and sauces
 wikidata:en:Q41354
+agribalyse_food_code:en:11018
 ciqual_food_code:en:11018
 ciqual_food_name:en:Vinegar
 ciqual_food_name:fr:Vinaigre
 
 <en:Vinegars
 en:Spanish vinegars
+origins:en: en:Spain
 
 <en:Spanish vinegars
 es:Vinagre de Montilla-Moriles
@@ -67041,6 +69497,7 @@ it:Aceto balsamico
 ja:バルサミコ酢, バルサミコす
 nl:Balsamicoazijnen
 wikidata:en:Q170037
+agribalyse_food_code:en:11091
 ciqual_food_code:en:11091
 ciqual_food_name:en:Vinegar, balsamic
 ciqual_food_name:fr:Vinaigre balsamique
@@ -67091,6 +69548,7 @@ fr:Vinaigres de cidre, vinaigre de cidre, vinaigres de cidre de pomme, Vinaigre 
 hu:Almaecet
 nl:Ciderazijnen
 wikidata:en:Q618322
+agribalyse_food_code:en:11090
 ciqual_food_code:en:11090
 ciqual_food_name:en:Vinegar, cider
 ciqual_food_name:fr:Vinaigre de cidre
@@ -67238,6 +69696,7 @@ fr:Gaufres liégeoises, gaufres liegeoises, gaufres de Liège, gaufre liégeoise
 nl:Luikse wavels
 ro:Vafe din Liège
 en:Plain Brussels-style soft waffle, Brussels-style soft waffle with sugar
+agribalyse_food_code:en:23851
 ciqual_food_code:en:23851
 ciqual_food_name:en:Soft waffle (Brussels-style), plain or with sugar, prepacked
 ciqual_food_name:fr:Gaufre moelleuse (type bruxelloise ou liégeoise), nature ou sucrée, préemballée
@@ -67249,12 +69708,14 @@ fi:suklaapäällysteiset vohvelit
 fr:Gaufres nappées de chocolat, Gaufres au chocolat, Gaufres au cacao, Gaufre croustillante fine chocolatée, Gaufre croustillante sèche chocolatée
 nl:Wafels met chocola
 ro:Vafe cu ciocolată
+agribalyse_food_code:en:23854
 ciqual_food_code:en:23854
 ciqual_food_name:en:Wafer biscuit, crunchy (thin or dry), with chocolate, prepacked
 
 <en:Waffles
 en:Soft waffle (Brussels-style) with chocolate prepacked
 fr:Gaufre chocolatée
+agribalyse_food_code:en:23852
 ciqual_food_code:en:23852
 ciqual_food_name:en:Soft waffle (Brussels-style), with chocolate, prepacked
 
@@ -67287,6 +69748,7 @@ wikidata:en:Q1226651
 <en:Biscuits and cakes
 en:Plain wafers, Wafer biscuit without filling
 fr:Gaufrettes natures, Gaufrette sans fourrage, Eventail sans fourrage
+agribalyse_food_code:en:24300
 ciqual_food_code:en:24300
 ciqual_food_name:en:Wafer biscuit without filling
 ciqual_food_name:fr:Gaufrette ou éventail sans fourrage
@@ -67319,6 +69781,7 @@ fr:Gaufrettes fourrées au chocolat, Gaufrette fourrée au chocolat
 hu:Csokoládéval töltött ostya
 nl:Wafeltjes gevuld met chocola
 ro:Napolitane umplute cu ciocolată, Napolitane cu ciocolată
+agribalyse_food_code:en:24311
 ciqual_food_code:en:24311
 ciqual_food_name:en:Wafer biscuit, filled with chocolate, prepacked
 
@@ -67334,6 +69797,7 @@ ro:Napolitane umplute cu vanilie, Napolitane cu vanilie
 <en:Biscuits and cakes
 en:Nut stuffed wafers
 fr:Gaufrettes fourrées aux fruits à coques
+agribalyse_food_code:en:24312
 ciqual_food_code:en:24312
 ciqual_food_name:en:Wafer biscuit, filled with nuts (hazelnut, almond, praline, etc.), with chocolate or not, prepacked
 ciqual_food_name:fr:Gaufrette fourrée fruits à coque (noisette, amande, praline, etc.), chocolatée ou non, préemballée
@@ -67341,6 +69805,7 @@ ciqual_food_name:fr:Gaufrette fourrée fruits à coque (noisette, amande, pralin
 <en:Biscuits and cakes
 en:Fruits stuffed wafers
 fr:Gaufrette fourrée aux fruits
+agribalyse_food_code:en:24320
 ciqual_food_code:en:24320
 ciqual_food_name:en:Wafer biscuit, with fruits
 ciqual_food_name:fr:Gaufrette fourrée, aux fruits
@@ -67578,6 +70043,7 @@ es:Aceitunas verdes rellenas de anchoa
 fi:vihreät anjovistäytteiset oliivit
 fr:Olives vertes farcies à l'anchois, Olives vertes farcies aux anchois, Olives vertes fourrées aux anchois
 nl:Ansjovisolijven
+agribalyse_food_code:en:13147
 ciqual_food_code:en:13147
 ciqual_food_name:en:Olive, green, stuffed (anchovy, sweet peppers, etc…)
 ciqual_food_name:fr:Olives vertes, fourrées ou farcies (anchois, poivrons, etc.)
@@ -67588,6 +70054,7 @@ es:Aceitunas verdes rellenas de pimiento
 fi:vihreät paprikatäytteiset oliivit
 fr:Olives vertes farcies au poivron, Olives vertes fourrées aux poivrons, Olives vertes farcies aux poivrons
 nl:Peperolijven
+agribalyse_food_code:en:13147
 ciqual_food_code:en:13147
 ciqual_food_name:en:Olive, green, stuffed (anchovy, sweet peppers, etc…)
 ciqual_food_name:fr:Olives vertes, fourrées ou farcies (anchois, poivrons, etc.)
@@ -67711,6 +70178,9 @@ fi:Merilevät ja merilevätuotteet
 fr:Algues et dérivés, Algues
 nl:Algen
 wikidata:en:Q37868
+agribalyse_proxy_food_code:en:20986
+agribalyse_proxy_food_name:en:Sea belt (Saccharina latissima), dried or dehydrated
+agribalyse_proxy_food_name:fr:Kombu royal (Saccharina latissima), séchée ou déshydratée
 
 <en:Seaweeds and their products
 <en:Canned plant-based foods
@@ -67854,12 +70324,14 @@ jp:昆布
 ko:다시마
 nl:Kombu, Konbu
 wikidata:en:Q11261547
+agribalyse_food_code:en:20990
 ciqual_food_code:en:20990
 ciqual_food_name:en:Kombu or Japanese kelp (Laminaria japonica), dried or dehydrated
 
 <en:Kombu seaweeds
 en:Sea belt (Saccharina latissima) dried or dehydrated
 fr:Kombu royal (Saccharina latissima) séchée, Kombu royal (Saccharina latissima) déshydratée
+agribalyse_food_code:en:20986
 ciqual_food_code:en:20986
 ciqual_food_name:en:Sea belt (Saccharina latissima), dried or dehydrated
 ciqual_food_name:fr:Kombu royal (Saccharina latissima), séchée ou déshydratée
@@ -67867,6 +70339,7 @@ ciqual_food_name:fr:Kombu royal (Saccharina latissima), séchée ou déshydraté
 <en:Kombu seaweeds
 en:Tangle (Laminaria digitata) dried or dehydrated
 fr:Kombu breton (Laminaria digitata) séchée, Kombu breton (Laminaria digitata) déshydratée
+agribalyse_food_code:en:20991
 ciqual_food_code:en:20991
 ciqual_food_name:en:Tangle (Laminaria digitata), dried or dehydrated
 ciqual_food_name:fr:Kombu breton (Laminaria digitata), séchée ou déshydratée
@@ -68008,10 +70481,12 @@ fr:Algues wakame, Wakame
 la:Undaria pinnatifida
 nl:Wakame
 wikidata:en:Q864682
+agribalyse_food_code:en:20984
 ciqual_food_code:en:20984
 ciqual_food_name:en:Wakame (Undaria pinnatifida), dried or dehydrate
 
 fr:Algues wakame de l'Atlantique
+agribalyse_food_code:en:20999
 ciqual_food_code:en:20999
 ciqual_food_name:en:Atlantic wakame (Alaria esculenta), dried or dehydrated
 
@@ -68095,6 +70570,7 @@ es:Salteados de vegetales asados congelados
 <en:Frozen vegetable mixes
 en:Frozen raw spring vegetables
 fr:Printanière de légumes surgelée crue
+agribalyse_food_code:en:20267
 ciqual_food_code:en:20267
 ciqual_food_name:en:Spring vegetables, frozen, raw (French beans, carrots, potatoes, green peas, onions)
 ciqual_food_name:fr:Printanière de légumes, surgelée, crue (haricots verts, carottes, pomme de terre, petits pois, oignons)
@@ -68102,6 +70578,7 @@ ciqual_food_name:fr:Printanière de légumes, surgelée, crue (haricots verts, c
 <en:Frozen vegetable mixes
 en:Frozen raw mixed vegetables
 fr:Mélange de légumes surgelés crus
+agribalyse_food_code:en:20101
 ciqual_food_code:en:20101
 ciqual_food_name:en:Mixed vegetables, frozen, raw
 ciqual_food_name:fr:Légumes, mélange surgelé, crus
@@ -68109,6 +70586,7 @@ ciqual_food_name:fr:Légumes, mélange surgelé, crus
 <en:Frozen vegetable mixes
 en:Frozen mixed diced vegetables
 fr:Macédoine de légumes surgelée
+agribalyse_food_code:en:20271
 ciqual_food_code:en:20271
 ciqual_food_name:en:Mixed diced vegetables, frozen
 ciqual_food_name:fr:Macédoine de légumes, surgelée
@@ -68116,6 +70594,7 @@ ciqual_food_name:fr:Macédoine de légumes, surgelée
 <en:Frozen vegetable mixes
 en:Frozen raw thinly-shredded vegetables, Frozen raw diced vegetables
 fr:Julienne de légumes surgelée, Brunoise de légumes surgelée
+agribalyse_food_code:en:20265
 ciqual_food_code:en:20265
 ciqual_food_name:en:Thinly-shredded or diced vegetables, frozen, raw
 ciqual_food_name:fr:Julienne ou brunoise de légumes, surgelée, crue
@@ -68142,6 +70621,7 @@ en:Frozen baked potatoes
 es:Patatas panadera congeladas
 fr:Pommes de terre cuites surgelées, pommes de terre cuites congelées
 nl:Diepvries gebakken aardappelen
+agribalyse_food_code:en:4035
 ciqual_food_code:en:4035
 ciqual_food_name:en:Mashed potato balls pre-fried, frozen, cooked
 
@@ -68210,7 +70690,7 @@ pl:Mrożone warzywa
 pt:Legumes congelados
 zh:冷藏蔬菜
 pnns_group_2:en:vegetables
-who_id:15
+who_id:en:15
 
 <en:Frozen vegetables
 <en:Leeks
@@ -68223,6 +70703,7 @@ nl:Diepvries prei
 <en:Leeks
 en:Frozen raw leeks
 fr:Poireaux surgelés crus
+agribalyse_food_code:en:20236
 ciqual_food_code:en:20236
 ciqual_food_name:en:Leek, frozen, raw
 ciqual_food_name:fr:Poireau, surgelé, cru
@@ -68314,6 +70795,7 @@ pl:Brokuł (różyczki) głęboko mrożony
 <en:Frozen vegetables
 en:Frozen raw broccoli
 fr:Brocoli surgelé cru
+agribalyse_food_code:en:20204
 ciqual_food_code:en:20204
 ciqual_food_name:en:Broccoli, frozen, raw
 ciqual_food_name:fr:Brocoli, surgelé, cru
@@ -68322,6 +70804,7 @@ ciqual_food_name:fr:Brocoli, surgelé, cru
 <en:Frozen vegetables
 en:Frozen cooked broccoli
 fr:Brocoli surgelé cuit
+agribalyse_food_code:en:20205
 ciqual_food_code:en:20205
 ciqual_food_name:en:Broccoli, frozen, cooked
 ciqual_food_name:fr:Brocoli, surgelé, cuit
@@ -68338,6 +70821,7 @@ nl:Diepvriesspruitjes
 <en:Brussels sprouts
 en:Frozen cooked Brussels sprouts
 fr:Choux de Bruxelles surgelés cuits
+agribalyse_food_code:en:20207
 ciqual_food_code:en:20207
 ciqual_food_name:en:Brussels sprout, frozen, cooked
 ciqual_food_name:fr:Chou de Bruxelles, surgelé, cuit
@@ -68346,6 +70830,7 @@ ciqual_food_name:fr:Chou de Bruxelles, surgelé, cuit
 <en:Brussels sprouts
 en:Frozen raw Brussels sprouts
 fr:Choux de Bruxelles surgelés crus
+agribalyse_food_code:en:20206
 ciqual_food_code:en:20206
 ciqual_food_name:en:Brussels sprout, frozen, raw
 ciqual_food_name:fr:Chou de Bruxelles, surgelé, cru
@@ -68354,6 +70839,7 @@ ciqual_food_name:fr:Chou de Bruxelles, surgelé, cru
 <en:Cooked vegetables
 en:Cooked Brussels sprouts
 fr:Choux de Bruxelles cuits
+agribalyse_food_code:en:20013
 ciqual_food_code:en:20013
 ciqual_food_name:en:Brussels sprout, cooked
 ciqual_food_name:fr:Chou de Bruxelles, cuit
@@ -68385,6 +70871,7 @@ nl:Diepvries gehakte wortels
 <en:Frozen carrots
 en:Frozen cooked carrots
 fr:Carottes surgelées cuites
+agribalyse_food_code:en:20209
 ciqual_food_code:en:20209
 ciqual_food_name:en:Carrot, frozen, cooked
 ciqual_food_name:fr:Carotte, surgelée, cuite
@@ -68392,6 +70879,7 @@ ciqual_food_name:fr:Carotte, surgelée, cuite
 <en:Frozen carrots
 en:Frozen raw carrots
 fr:Carottes surgelées crues
+agribalyse_food_code:en:20208
 ciqual_food_code:en:20208
 ciqual_food_name:en:Carrot, frozen, raw
 ciqual_food_name:fr:Carotte, surgelée, crue
@@ -68409,6 +70897,7 @@ nl:Diepvries bloemkool
 <en:Frozen vegetables
 en:Frozen cooked cauliflowers
 fr:Choux-fleurs surgelés cuits, Chou-fleur surgelé cuit
+agribalyse_food_code:en:20122
 ciqual_food_code:en:20122
 ciqual_food_name:en:Cauliflower, frozen, cooked
 ciqual_food_name:fr:Chou-fleur, surgelé, cuit
@@ -68417,6 +70906,7 @@ ciqual_food_name:fr:Chou-fleur, surgelé, cuit
 <en:Frozen vegetables
 en:Raw frozen cauliflowers
 fr:Choux-fleurs surgelés crus, Chou-fleur surgelé cru
+agribalyse_food_code:en:20082
 ciqual_food_code:en:20082
 ciqual_food_name:en:Cauliflower, frozen, raw
 ciqual_food_name:fr:Chou-fleur, surgelé, cru
@@ -68464,6 +70954,7 @@ nl:Diepvries knolrapen
 <en:Turnip
 en:Frozen raw turnips
 fr:Navets surgelés crus
+agribalyse_food_code:en:20234
 ciqual_food_code:en:20234
 ciqual_food_name:en:Turnip, frozen, raw
 ciqual_food_name:fr:Navet, surgelé, cru
@@ -68490,6 +70981,7 @@ en:Frozen fresh broad beans, Frozen fresh fava beans, Frozen immature broad bean
 es:Habas frescas congeladas, Habitas frescas congeladas, Habas inmaduras congeladas, Habitas inmaduras congeladas, Habas congeladas
 fr:Fèves fraîches surgelées, Féverolles frais surgelés
 nl:Diepvries tuinbonen
+agribalyse_food_code:en:20536
 ciqual_food_code:en:20536
 ciqual_food_name:en:Broad bean, fresh, frozen
 ciqual_food_name:fr:Fève, fraîche, surgelée
@@ -68498,6 +70990,7 @@ ciqual_food_name:fr:Fève, fraîche, surgelée
 <en:Frozen legumes
 en:Frozen raw peeled broad beans
 fr:Fèves pelées surgelées crues
+agribalyse_food_code:en:20541
 ciqual_food_code:en:20541
 ciqual_food_name:en:Broad bean, peeled, frozen, raw
 ciqual_food_name:fr:Fève, pelée, surgelée, crue
@@ -68506,6 +70999,7 @@ ciqual_food_name:fr:Fève, pelée, surgelée, crue
 <en:Frozen legumes
 en:Frozen water boiled broad beans without peal
 fr:Fèves pelées surgelées cuites à l'eau
+agribalyse_food_code:en:20542
 ciqual_food_code:en:20542
 ciqual_food_name:en:Broad bean, without peal, frozen, water boiled
 ciqual_food_name:fr:Fève, pelée, surgelée, cuite à l'eau
@@ -68514,6 +71008,7 @@ ciqual_food_name:fr:Fève, pelée, surgelée, cuite à l'eau
 <en:Frozen legumes
 en:Frozen water boiled broad beans
 fr:Fèves surgelées cuites à l'eau
+agribalyse_food_code:en:20543
 ciqual_food_code:en:20543
 ciqual_food_name:en:Broad bean, frozen, water boiled
 ciqual_food_name:fr:Fève, surgelée, cuite à l'eau
@@ -68522,6 +71017,7 @@ ciqual_food_name:fr:Fève, surgelée, cuite à l'eau
 <en:Frozen legumes
 en:Frozen flageolet beans
 fr:Haricots flageolets surgelés
+agribalyse_food_code:en:20537
 ciqual_food_code:en:20537
 ciqual_food_name:en:flageolet bean, frozen
 ciqual_food_name:fr:Haricot flageolet, surgelé
@@ -68539,6 +71035,7 @@ nl:Diepvries sperziebonen
 <en:Frozen green beans
 fr:Haricots verts surgelés précuits, Haricots verts cuits surgelés
 en:Frozen cooked French bean
+agribalyse_food_code:en:20071
 ciqual_food_code:en:20071
 ciqual_food_name:en:French bean, frozen, cooked
 ciqual_food_name:fr:Haricot vert, surgelé, cuit
@@ -68546,6 +71043,7 @@ ciqual_food_name:fr:Haricot vert, surgelé, cuit
 <en:Frozen green beans
 en:Frozen raw French beans
 fr:Haricots verts surgelés crus
+agribalyse_food_code:en:20070
 ciqual_food_code:en:20070
 ciqual_food_name:en:French bean, frozen, raw
 ciqual_food_name:fr:Haricot vert, surgelé, cru
@@ -68706,6 +71204,7 @@ nl:Diepvries bladspinazies
 <en:Frozen spinachs
 en:Frozen cooked spinach
 fr:Épinards surgelés cuits
+agribalyse_food_code:en:20121
 ciqual_food_code:en:20121
 ciqual_food_name:en:Spinach, frozen, cooked
 ciqual_food_name:fr:Épinard, surgelé, cuit
@@ -68713,6 +71212,7 @@ ciqual_food_name:fr:Épinard, surgelé, cuit
 <en:Frozen spinachs
 en:Frozen raw spinach
 fr:Épinards surgelés crus
+agribalyse_food_code:en:20083
 ciqual_food_code:en:20083
 ciqual_food_name:en:Spinach, frozen, raw
 ciqual_food_name:fr:Épinard, surgelé, cru
@@ -68759,7 +71259,7 @@ fr:Légumineuses surgelées, légumineuses surgelés
 nl:Diepvriespeulvruchten
 pl:Rośliny strączkowe głęboko mrożone
 pnns_group_2:en:legumes
-who_id:15
+who_id:en:15
 
 <en:Frozen legumes
 en:Frozen lima beans
@@ -68879,6 +71379,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Heart_of_palm
 <en:Hearts of palm
 en:Canned drained palm heart
 fr:Coeur de palmier appertisé égoutté
+agribalyse_food_code:en:20018
 ciqual_food_code:en:20018
 ciqual_food_name:en:Palm heart, canned, drained
 ciqual_food_name:fr:Coeur de palmier, appertisé, égoutté
@@ -68903,6 +71404,7 @@ pnns_group_2:en:Appetizers
 fr:Blinis
 nl:Blinis
 wikidata:en:Q815898
+agribalyse_food_code:en:23805
 ciqual_food_code:en:23805
 ciqual_food_name:en:Blinis
 ciqual_food_name:fr:Blini
@@ -68959,6 +71461,7 @@ fr:Barres de céréales aux fruits, Barre de céréales aux fruits, Barre céré
 it:Barrette di cereali con frutti
 nl:Ontbijtrepen met fruit
 ro:Batoane de cereale cu fructe
+agribalyse_food_code:en:31113
 ciqual_food_code:en:31113
 ciqual_food_name:en:Cereal bar w fruit
 ciqual_food_name:fr:Barre céréalière aux fruits
@@ -68966,6 +71469,7 @@ ciqual_food_name:fr:Barre céréalière aux fruits
 <en:Fruits cereal bars
 en:Cereal bar with fruits fortified with vitamins and minerals
 fr:Barre céréalière équilibre aux fruits enrichie en vitamines et minéraux
+agribalyse_food_code:en:31101
 ciqual_food_code:en:31101
 ciqual_food_name:en:Cereal bar with fruit, fortified with vitamins and minerals
 ciqual_food_name:fr:Barre céréalière équilibre aux fruits, enrichie en vitamines et minéraux
@@ -69005,36 +71509,42 @@ fr:Barres de céréales au chocolat, Barre de céréales au chocolat
 it:Barrette di cereali con cioccolato
 nl:Chocolade graanrepen
 ro:Batoane de cereale cu ciocolată
+agribalyse_food_code:en:31106
 ciqual_food_code:en:31106
 ciqual_food_name:en:Chocolate cereal bar
 
 <en:Cereal bars
 en:Milky cereal breakfast bar with chocolate fortified with vitamins and minerals, Milky cereal breakfast bar fortified with vitamins and minerals
 fr:barre de céréales au lait et au chocholat
+agribalyse_food_code:en:31100
 ciqual_food_code:en:31100
 ciqual_food_name:en:Milky cereal breakfast bar, with chocolate or not, fortified with vitamins and minerals
 
 <en:Chocolate cereal bars
 en:Cereal bar with chocolate fortified with vitamins and minerals
 fr:barre de céréales au chocolat renforcée en vitamines et minéraux
+agribalyse_food_code:en:31102
 ciqual_food_code:en:31102
 ciqual_food_name:en:Cereal bar with chocolate, fortified with vitamins and minerals
 
 <en:Chocolate cereal bars
 en:Chocolate confectionery or bar with dairy filling
 fr:Barres ou confiserie chocolatées au lait
+agribalyse_food_code:en:31012
 ciqual_food_code:en:31012
 ciqual_food_name:en:Chocolate confectionery or bar, with dairy filling
 
 <en:Chocolate cereal bars
 en:Chocolate snack bar dairy filling
 fr:barre de chocolat au lait frais
+agribalyse_food_code:en:31073
 ciqual_food_code:en:31073
 ciqual_food_name:en:Chocolate snack bar, dairy filling
 
 <en:Chocolate cereal bars
 en:Chocolate snack bar dairy filling with sponge cake
 fr:barre de chocolat au lait frais avec génoise
+agribalyse_food_code:en:31099
 ciqual_food_code:en:31099
 ciqual_food_name:en:Chocolate snack bar, dairy filling with sponge cake
 
@@ -69054,6 +71564,7 @@ ciqual_food_name:fr:Barre céréalière diététique hypocalorique
 <en:Nuts cereal bars
 en:Cereal bar with almonds or hazelnuts
 fr:Barre céréalière aux amandes ou aux noisettes
+agribalyse_food_code:en:31114
 ciqual_food_code:en:31114
 ciqual_food_name:en:Cereal bar with almonds or hazelnuts
 ciqual_food_name:fr:Barre céréalière aux amandes ou noisettes
@@ -69112,6 +71623,7 @@ nl:IJsrepen
 <en:Ice creams
 en:Chocolate coated ice cream
 fr:Barre glacée chocolatée
+agribalyse_food_code:en:31035
 ciqual_food_code:en:31035
 ciqual_food_name:en:Ice cream, chocolate coated
 ciqual_food_name:fr:Barre glacée chocolatée
@@ -69143,6 +71655,7 @@ fr:Croissants
 it:Croissants
 nl:Croissants
 wikidata:en:Q207832
+agribalyse_food_code:en:7602
 ciqual_food_code:en:7602
 ciqual_food_name:en:Croissant
 ciqual_food_name:fr:Croissant, sans précision
@@ -69150,6 +71663,7 @@ ciqual_food_name:fr:Croissant, sans précision
 <en:Croissants
 en:Croissant from bakery
 fr:Croissant artisanal
+agribalyse_food_code:en:7615
 ciqual_food_code:en:7615
 ciqual_food_name:en:Croissant, ordinary, from bakery
 ciqual_food_name:fr:Croissant ordinaire, artisanal
@@ -69161,6 +71675,7 @@ es:Croissants de mantequilla
 fi:Voisarvet, Voikroisantit, Voicroissantit
 fr:Croissants au beurre, Croissant au beurre artisanal
 nl:Roombotercroissants
+agribalyse_food_code:en:7620
 ciqual_food_code:en:7620
 ciqual_food_name:en:Croissant, butter, from bakery
 ciqual_food_name:fr:Croissant au beurre, artisanal
@@ -69198,6 +71713,7 @@ nl:Croissants met jam
 <en:Croissants
 en:Croissant with almonds from bakery, Almond croissant
 fr:Croissant aux amandes artisanal
+agribalyse_food_code:en:7650
 ciqual_food_code:en:7650
 ciqual_food_name:en:Croissant w almonds, from bakery
 ciqual_food_name:fr:Croissant aux amandes, artisanal
@@ -69208,6 +71724,7 @@ fr:Chouquettes, Chouquette
 ja:シューケット
 nl:Chouquette-soesjes
 wikidata:en:Q9167992
+agribalyse_food_code:en:23467
 ciqual_food_code:en:23467
 ciqual_food_name:en:Chou pastry, sugar coated
 ciqual_food_name:fr:Chouquette
@@ -69224,6 +71741,7 @@ nl:Appelflappen
 nl_be:Appelflappen
 pl:Appelflap
 wikidata:en:Q2461000
+agribalyse_food_code:en:23480
 ciqual_food_code:en:23480
 ciqual_food_name:en:Apple turnover
 ciqual_food_name:fr:Chausson aux pommes
@@ -69236,12 +71754,14 @@ fi:Suklaavoisarvi, Suklaakroisantti, Suklaacroissantit
 fr:Pains au chocolat, Chocolatines
 nl:Chocolade croissants, Chocolade croissant
 wikidata:en:Q1190838
+agribalyse_food_code:en:7730
 ciqual_food_code:en:7730
 ciqual_food_name:en:Chocolate croissant, puff pastry, from bakery
 
 <en:Viennoiseries
 en:Chocolate croissant prepacked
 fr:Pain au chocolat préemballé
+agribalyse_food_code:en:7733
 ciqual_food_code:en:7733
 ciqual_food_name:en:Chocolate croissant, prepacked
 
@@ -69253,6 +71773,7 @@ fr:Pains au lait, pain au lait
 nl:Melkbroodjes
 pt:Pães de leite
 wikidata:en:Q3360557
+agribalyse_food_code:en:7711
 ciqual_food_code:en:7711
 ciqual_food_name:en:Milk roll, prepacked
 ciqual_food_name:fr:Pain au lait, préemballé
@@ -69265,6 +71786,7 @@ fr:Pains au lait natures
 <en:Milk bread rolls
 en:Milk roll from bakery
 fr:Pain au lait artisanal
+agribalyse_food_code:en:7710
 ciqual_food_code:en:7710
 ciqual_food_name:en:Milk roll, from bakery
 ciqual_food_name:fr:Pain au lait, artisanal
@@ -69275,6 +71797,7 @@ ciqual_food_name:fr:Pain au lait, artisanal
 en:Milk bread rolls with chocolate, Milk roll filled with chocolate drops
 fr:Pains au lait au chocolat, pains au lait aux pépites de chocolat, Pain au lait aux pépites de chocolat
 nl:Melkbroodjes met chocola
+agribalyse_food_code:en:7712
 ciqual_food_code:en:7712
 ciqual_food_name:en:Milk roll filled with chocolate drops, prepacked
 ciqual_food_name:fr:Pain au lait aux pépites de chocolat préemballé
@@ -69284,6 +71807,7 @@ en:Brioche bread, Vienna bread
 fr:Pains briochés, Pains viennois
 nl:Viennoiserie brood
 wikidata:en:Q3031313
+agribalyse_food_code:en:7225
 ciqual_food_code:en:7225
 ciqual_food_name:en:Brioche or Vienna bread
 ciqual_food_name:fr:Pain brioché ou viennois
@@ -69328,6 +71852,7 @@ zh:布里歐
 wikidata:en:Q917574
 wikipedia:en:https://en.wikipedia.org/wiki/Brioche
 carbon_footprint_fr_foodges_ingredient:fr:Viennoiseries Brioche industrielle préemballée
+agribalyse_food_code:en:7741
 ciqual_food_code:en:7741
 ciqual_food_name:en:Brioche
 ciqual_food_name:fr:Brioche, sans précision
@@ -69343,6 +71868,7 @@ fr:Brioches tranchées
 <en:Brioches
 en:Brioche from bakery
 fr:Brioche de boulangerie traditionnelle
+agribalyse_food_code:en:7742
 ciqual_food_code:en:7742
 ciqual_food_name:en:Brioche, from bakery
 ciqual_food_name:fr:Brioche, de boulangerie traditionnelle
@@ -69350,6 +71876,7 @@ ciqual_food_name:fr:Brioche, de boulangerie traditionnelle
 <en:Brioches
 en:Brioche prepacked
 fr:Brioche préemballée
+agribalyse_food_code:en:7740
 ciqual_food_code:en:7740
 ciqual_food_name:en:Brioche, prepacked
 ciqual_food_name:fr:Brioche, préemballée
@@ -69361,6 +71888,7 @@ wikidata:en:Q168263
 <en:Brioches
 en:Christmas brioche with candied fruits
 fr:Couronne de Noël aux fruits confits,  Brioche de Noël aux fruits confits
+agribalyse_food_code:en:7744
 ciqual_food_code:en:7744
 ciqual_food_name:en:Christmas brioche with candied fruits, prepacked
 ciqual_food_name:fr:Couronne de Noël (Brioche) aux fruits confits, préemballée
@@ -69368,6 +71896,7 @@ ciqual_food_name:fr:Couronne de Noël (Brioche) aux fruits confits, préemballé
 <en:Brioches
 en:Brioche filled with fruits
 fr:Brioche fourrée aux fruits
+agribalyse_food_code:en:7738
 ciqual_food_code:en:7738
 ciqual_food_name:en:Brioche, filled with fruits
 
@@ -69381,6 +71910,7 @@ wikidata:en:Q1317802
 <en:Brioches
 fr:Brioches au chocolat, Brioches aux pépites de chocolat, Brioche au chocolat, Brioche aux pépites de chocolat
 en:Brioche filled with chocolate drops, Chocolate brioche bun
+agribalyse_food_code:en:7735
 ciqual_food_code:en:7735
 ciqual_food_name:en:Brioche, filled with chocolate drops
 ciqual_food_name:fr:Brioche aux pépites de chocolat
@@ -69388,6 +71918,7 @@ ciqual_food_name:fr:Brioche aux pépites de chocolat
 <en:Brioches
 en:Brioche filled with chocolate
 fr:Brioche fourrée au chocolat
+agribalyse_food_code:en:7737
 ciqual_food_code:en:7737
 ciqual_food_name:en:Brioche, filled with chocolate
 
@@ -69397,6 +71928,7 @@ fr:Brioches aux fruits, Brioche au fruit
 <en:Brioches
 fr:Brioches pur beurre, Brioche pur beurre
 en:Pure butter brioche
+agribalyse_food_code:en:7745
 ciqual_food_code:en:7745
 ciqual_food_name:en:Brioche, pure butter
 ciqual_food_name:fr:Brioche pur beurre
@@ -69415,6 +71947,7 @@ fr:Brioches Vendéennes, Brioche vendéenne
 <en:Brioches
 en:Brioche filled with custard, Chinese brioche
 fr:Brioche fourrée crème pâtissière, Brioche chinois, Chinois brioché, Chinois
+agribalyse_food_code:en:7739
 ciqual_food_code:en:7739
 ciqual_food_name:en:Brioche, filled with custard (Chinese brioche type), prepacked
 ciqual_food_name:fr:Brioche fourrée crème pâtissière (type chinois), préemballée
@@ -69556,6 +72089,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Crêpe
 <en:Crêpes
 en:Refrigerated plain crepe
 fr:Crêpe nature rayon frais
+agribalyse_food_code:en:23799
 ciqual_food_code:en:23799
 ciqual_food_name:en:Crepe, plain, prepacked, refrigerated
 ciqual_food_name:fr:Crêpe, nature, préemballée, rayon frais
@@ -69563,6 +72097,7 @@ ciqual_food_name:fr:Crêpe, nature, préemballée, rayon frais
 <en:Crêpes
 en:Plain crepe at room temperature
 fr:Crêpe nature
+agribalyse_food_code:en:23800
 ciqual_food_code:en:23800
 ciqual_food_name:en:Crepe, plain, prepacked, room temperature
 ciqual_food_name:fr:Crêpe, nature, préemballée, rayon température ambiante
@@ -69570,6 +72105,7 @@ ciqual_food_name:fr:Crêpe, nature, préemballée, rayon température ambiante
 <en:Crêpes
 en:Crepe filled with sugar
 fr:Crêpe fourrée au sucre
+agribalyse_food_code:en:23815
 ciqual_food_code:en:23815
 ciqual_food_name:en:Crepe filled with sugar, prepacked
 ciqual_food_name:fr:Crêpe préemballée, fourrée au sucre
@@ -69598,6 +72134,7 @@ de:Crêpes gefüllt mit Schokolade
 fr:Crêpes fourrées au chocolat, Crêpes au chocolat, Crêpes maison fourrées au chocolat
 nl:Pannenkoeken gevuld met chocola
 oqali_family:en: fr:Biscuits et gateaux industriels - Crepes au chocolat
+agribalyse_food_code:en:23821
 ciqual_food_code:en:23821
 ciqual_food_name:en:Crepe, filled with chocolate or chocolate and hazelnut spread, home-made
 ciqual_food_name:fr:Crêpe maison, fourrée au chocolat ou à la pâte à tartiner chocolat et noisettes
@@ -69605,6 +72142,7 @@ ciqual_food_name:fr:Crêpe maison, fourrée au chocolat ou à la pâte à tartin
 <en:Filled crêpes
 en:Home-made crepes filled with chocolate and hazelnut spread
 fr:Crêpes maison fourrées à la pâte à tartiner chocolat et noisettes
+agribalyse_food_code:en:23821
 ciqual_food_code:en:23821
 ciqual_food_name:en:Crepe, filled with chocolate or chocolate and hazelnut spread, home-made
 ciqual_food_name:fr:Crêpe maison, fourrée au chocolat ou à la pâte à tartiner chocolat et noisettes
@@ -69615,6 +72153,7 @@ ciqual_food_name:fr:Crêpe maison, fourrée au chocolat ou à la pâte à tartin
 <en:Filled crêpes
 en:Home-made crepes filled with chocolate and hazelnut spread
 fr:Crêpes maison fourrées à la pâte à tartiner chocolat et noisettes
+agribalyse_food_code:en:23821
 ciqual_food_code:en:23821
 ciqual_food_name:en:Crepe, filled with chocolate or chocolate and hazelnut spread, home-made
 ciqual_food_name:fr:Crêpe maison, fourrée au chocolat ou à la pâte à tartiner chocolat et noisettes
@@ -69623,6 +72162,7 @@ ciqual_food_name:fr:Crêpe maison, fourrée au chocolat ou à la pâte à tartin
 en:Filled crêpes with jam, Home-made crepes filled with jam
 fr:Crêpes fourrées à la confiture, Crêpes maison fourrées à la confiture, Crêpes à la confiture
 nl:Pannenkoeken gevuld met jam
+agribalyse_food_code:en:23820
 ciqual_food_code:en:23820
 ciqual_food_name:en:Crepe, filled with jam, home-made
 ciqual_food_name:fr:Crêpe maison, fourrée à la confiture
@@ -69630,6 +72170,7 @@ ciqual_food_name:fr:Crêpe maison, fourrée à la confiture
 <en:Filled crêpes
 en:Crepe filled with strawberries
 fr:Crêpes fourrées aux fraises
+agribalyse_food_code:en:23830
 ciqual_food_code:en:23830
 ciqual_food_name:en:Crepe filled with strawberries, prepacked
 ciqual_food_name:fr:Crêpe préemballée, fourrée fraise
@@ -69643,30 +72184,35 @@ nl:Galettes
 <en:Crêpes and galettes
 en:Ham and mushroom pancake in cheese sauce
 fr:Ficelle picarde
+agribalyse_food_code:en:26256
 ciqual_food_code:en:26256
 ciqual_food_name:en:Ham and mushroom pancake in cheese sauce
 
 <en:Crêpes and galettes
 en:Crepe filled with ham
 fr:Galette fourrée béchamel jambon
+agribalyse_food_code:en:25409
 ciqual_food_code:en:25409
 ciqual_food_name:en:Crepe, filled with ham
 
 <en:Crêpes and galettes
 en:Crepe or buckwheat crepe filled with cheese ham and bechamel sauce
 fr:Galette fourrée béchamel jambon fromage
+agribalyse_food_code:en:25410
 ciqual_food_code:en:25410
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with cheese, ham and bechamel sauce
 
 <en:Crêpes and galettes
 en:Crepe or buckwheat crepe filled with mushrooms and bechamel sauce cooked
 fr:Galette fourrée béchamel champignon cuite
+agribalyse_food_code:en:25581
 ciqual_food_code:en:25581
 ciqual_food_name:en:Crepe or buckwheat crepe, filled with mushrooms and bechamel sauce, cooked
 
 <en:Galettes
 fr:Galettes de blé noir, galette de blé noir, galette de sarazin, galettes de sarrasin, galette de sarrasin, galettes de sarazin, crêpe au sarrasin
 en:Plain buckwheat crepes
+agribalyse_food_code:en:23801
 ciqual_food_code:en:23801
 ciqual_food_name:en:Buckwheat crepe, plain, prepacked
 ciqual_food_name:fr:Galette de sarrasin, nature, préemballée
@@ -69732,6 +72278,7 @@ ciqual_food_name:fr:Gésier, canard, confit, appertisé
 en:Chicken gizzards, Raw chicken gizzards
 fr:Gésiers de poulet, Gésiers de poulet crus
 nl:Kippenspiermaag
+agribalyse_food_code:en:40700
 ciqual_food_code:en:40700
 ciqual_food_name:en:Gizzard, chicken, raw
 ciqual_food_name:fr:Gésier, poulet, cru
@@ -69984,6 +72531,7 @@ fi:Täysjyväriisikakut
 fr:Galettes de riz complet soufflé, galettes de riz complet, Galettes de riz soufflé complet
 it:Gallette di riso integrale
 nl:Volkoren rijstwafels
+agribalyse_food_code:en:7352
 ciqual_food_code:en:7352
 ciqual_food_name:en:Puffed rice textured bread, wholemeal
 ciqual_food_name:fr:Galette de riz soufflé complet
@@ -70047,6 +72595,7 @@ de:Gepuffte Vollkornkuchen
 es:Tortitas multicereales, Tortitas de varios cereales
 fr:Galettes multicéréales soufflées, Galettes muticéréales, Galettes multicéréales soufflées
 nl:Meergranen wafels
+agribalyse_food_code:en:7353
 ciqual_food_code:en:7353
 ciqual_food_name:en:Puffed cereals textured bread
 ciqual_food_name:fr:Galettes multicéréales soufflées
@@ -70076,6 +72625,7 @@ ciqual_food_name:fr:Crackers de table au froment
 <en:Crackers
 en:Plain salty snacks, Plain salty crackers
 fr:Biscuits apéritifs nature, Crackers nature
+agribalyse_food_code:en:38402
 ciqual_food_code:en:38402
 ciqual_food_name:en:Salty snacks, crackers, plain
 ciqual_food_name:fr:Biscuit apéritif, crackers, nature
@@ -70090,6 +72640,7 @@ fr:Crêpes dentelle salées, Crêpes dentelles salées
 <fr:Crêpes dentelles salées
 fr:Crêpes dentelle au fromage, Crêpe dentelle pour apéritif au fromage
 en:Salted crispy crepe with cheese
+agribalyse_food_code:en:38408
 ciqual_food_code:en:38408
 ciqual_food_name:en:Salted crispy crepe with cheese, prepacked
 ciqual_food_name:fr:Crêpe dentelle (pour apéritif) au fromage, préemballée
@@ -70104,6 +72655,7 @@ fi:Brezel, Pretzel
 fr:Bretzels, Mini bretzels
 nl:Pretzels
 oqali_family:en: fr:Aperitifs a croquer - Sticks et bretzels
+agribalyse_food_code:en:38107
 ciqual_food_code:en:38107
 ciqual_food_name:en:Salty snacks, mini pretzels or sticks
 ciqual_food_name:fr:Biscuit apéritif, mini bretzel ou sticks
@@ -70111,6 +72663,7 @@ ciqual_food_name:fr:Biscuit apéritif, mini bretzel ou sticks
 <en:Crackers
 en:Salty snacks puff pastry
 fr:Biscuit apéritif feuilleté
+agribalyse_food_code:en:38407
 ciqual_food_code:en:38407
 ciqual_food_name:en:Salty snacks, puff pastry
 ciqual_food_name:fr:Biscuit apéritif feuilleté
@@ -70122,6 +72675,7 @@ nl:Gepofte zoutjes
 <en:Crackers
 fr:Biscuits apéritifs allégés, Biscuits apéritifs nature allégés en matière grasse, Crackers nature allégés en matière grasse
 en:Salty snacks with reduced fat, Crackers with reduced fat
+agribalyse_food_code:en:38403
 ciqual_food_code:en:38403
 ciqual_food_name:en:Salty snacks, crackers, reduced fat
 ciqual_food_name:fr:Biscuit apéritif, crackers, nature, allégé en matière grasse
@@ -70132,6 +72686,7 @@ fr:Biscuits apéritifs au sésame
 <en:Crackers
 fr:Biscuits apéritifs fourrés au fromage, fr:Biscuits apéritifs crackers garnis au fromage, Biscuits apéritifs crackers fourrés au fromage
 en:Salty snacks crackers garnished with cheese, Salty snacks crackers filled with cheese
+agribalyse_food_code:en:38401
 ciqual_food_code:en:38401
 ciqual_food_name:en:Salty snacks, crackers, garnished or filled with cheese
 ciqual_food_name:fr:Biscuit apéritif, crackers, garni ou fourré, au fromage
@@ -70139,6 +72694,7 @@ ciqual_food_name:fr:Biscuit apéritif, crackers, garni ou fourré, au fromage
 <fr:Biscuits apéritifs soufflés
 fr:Biscuits apéritifs soufflés à base de maïs
 en:Puffed salty snacks made from maize, Puffed salty snacks made from corn
+agribalyse_food_code:en:38400
 ciqual_food_code:en:38400
 ciqual_food_name:en:Puffed salty snacks, made from maize/corn, without peanuts
 ciqual_food_name:fr:Biscuit apéritif soufflé, à base de maïs, sans cacahuète
@@ -70146,6 +72702,7 @@ ciqual_food_name:fr:Biscuit apéritif soufflé, à base de maïs, sans cacahuèt
 <fr:Biscuits apéritifs soufflés
 fr:Biscuit apéritif soufflé à base de maïs à la cacahuète
 en:Puffed salty snacks made from maize with peanuts, Puffed salty snacks made from corn with peanuts
+agribalyse_food_code:en:38404
 ciqual_food_code:en:38404
 ciqual_food_name:en:Puffed salty snacks, made from maize/corn, with peanuts
 ciqual_food_name:fr:Biscuit apéritif soufflé, à base de maïs, à la cacahuète
@@ -70153,6 +72710,7 @@ ciqual_food_name:fr:Biscuit apéritif soufflé, à base de maïs, à la cacahuè
 <fr:Biscuits apéritifs soufflés
 fr:Biscuits apéritifs soufflés à base de pomme de terre, Biscuits apéritifs soufflés à base de pomme de terre type Monster Munch, Monster Munch
 en:Puffed salty snacks made from potato
+agribalyse_food_code:en:38106
 ciqual_food_code:en:38106
 ciqual_food_name:en:Puffed salty snacks, made from potato
 ciqual_food_name:fr:Biscuit apéritif soufflé, à base de pomme de terre
@@ -70160,6 +72718,7 @@ ciqual_food_name:fr:Biscuit apéritif soufflé, à base de pomme de terre
 <fr:Biscuits apéritifs soufflés
 en:Puffed salty snacks made from potato and soy
 fr:Biscuit apéritif soufflé à base de pomme de terre et de soja
+agribalyse_food_code:en:38108
 ciqual_food_code:en:38108
 ciqual_food_name:en:Puffed salty snacks, made from potato and soy
 ciqual_food_name:fr:Biscuit apéritif soufflé, à base de pomme de terre et de soja
@@ -70330,6 +72889,7 @@ fr:Pâtes brisées, Pâte brisée, Pâtes à tarte brisées, Pâte brisée cuite
 en:Baked shortcrust pastry
 nl:Zanddegen
 nl_be:Zanddeeg
+agribalyse_food_code:en:23412
 ciqual_food_code:en:23412
 ciqual_food_name:en:Pastry, short crust, baked
 ciqual_food_name:fr:Pâte brisée, matière grasse végétale, cuite
@@ -70337,6 +72897,7 @@ ciqual_food_name:fr:Pâte brisée, matière grasse végétale, cuite
 <en:Pie dough
 en:Raw shortcrust pastry
 fr:Pâte brisée crue
+agribalyse_food_code:en:23410
 ciqual_food_code:en:23410
 ciqual_food_name:en:Short crust pastry, raw
 ciqual_food_name:fr:Pâte brisée, crue
@@ -70344,6 +72905,7 @@ ciqual_food_name:fr:Pâte brisée, crue
 <en:Pie dough
 en:Raw shortcrust pastry with pure butter
 fr:Pâte brisée pur beurre crue
+agribalyse_food_code:en:23414
 ciqual_food_code:en:23414
 ciqual_food_name:en:Short crust pastry, pure butter, raw
 ciqual_food_name:fr:Pâte brisée, pur beurre, crue
@@ -70354,6 +72916,7 @@ de:Blätterteig Platten
 fr:Pâtes feuilletées, Pâte feuilletée, Pâtes à tarte feuilletées, Pâte feuilletée cuite
 nl:Bladerdegen
 nl_be:Bladerdeeg
+agribalyse_food_code:en:23422
 ciqual_food_code:en:23422
 ciqual_food_name:en:Puff pastry, cooked
 ciqual_food_name:fr:Pâte feuilletée, cuite
@@ -70362,6 +72925,7 @@ ciqual_food_name:fr:Pâte feuilletée, cuite
 <en:Frozen foods
 en:Frozen raw shortcrust pastry with pure butter
 fr:Pâte brisée pur beurre surgelée crue
+agribalyse_food_code:en:23415
 ciqual_food_code:en:23415
 ciqual_food_name:en:Short crust pastry, pure butter, frozen, raw
 ciqual_food_name:fr:Pâte brisée, pur beurre, surgelée, crue
@@ -70369,6 +72933,7 @@ ciqual_food_name:fr:Pâte brisée, pur beurre, surgelée, crue
 <en:Pie dough
 en:Cooked pure butter puff pastry
 fr:Pâte feuilletée pur beurre cuite
+agribalyse_food_code:en:23426
 ciqual_food_code:en:23426
 ciqual_food_name:en:Puff pastry, pure butter, cooked
 ciqual_food_name:fr:Pâte feuilletée pur beurre, cuite
@@ -70376,6 +72941,7 @@ ciqual_food_name:fr:Pâte feuilletée pur beurre, cuite
 <en:Pie dough
 en:Raw puff pastry with pure butter
 fr:Pâte feuilletée pur beurre crue
+agribalyse_food_code:en:23424
 ciqual_food_code:en:23424
 ciqual_food_name:en:Puff pastry, pure butter, raw
 ciqual_food_name:fr:Pâte feuilletée pur beurre, crue
@@ -70383,6 +72949,7 @@ ciqual_food_name:fr:Pâte feuilletée pur beurre, crue
 <en:Pie dough
 en:Raw Puff pastry
 fr:Pâte feuilletée crue à la matière grasse végétale
+agribalyse_food_code:en:23420
 ciqual_food_code:en:23420
 ciqual_food_name:en:Puff pastry, raw
 ciqual_food_name:fr:Pâte feuilletée, matière grasse végétale, crue
@@ -70391,6 +72958,7 @@ ciqual_food_name:fr:Pâte feuilletée, matière grasse végétale, crue
 <en:Frozen foods
 en:Frozen raw puff pastry
 fr:Pâte feuilletée surgelée crue
+agribalyse_food_code:en:23421
 ciqual_food_code:en:23421
 ciqual_food_name:en:Puff pastry, frozen, raw
 ciqual_food_name:fr:Pâte feuilletée, surgelée, crue
@@ -70399,6 +72967,7 @@ ciqual_food_name:fr:Pâte feuilletée, surgelée, crue
 <en:Frozen foods
 en:Frozen raw puff pastry with pure butter
 fr:Pâte feuilletée pur beurre surgelée crue
+agribalyse_food_code:en:23425
 ciqual_food_code:en:23425
 ciqual_food_name:en:Puff pastry, pure butter, frozen, raw
 ciqual_food_name:fr:Pâte feuilletée pur beurre, surgelée crue
@@ -70406,6 +72975,7 @@ ciqual_food_name:fr:Pâte feuilletée pur beurre, surgelée crue
 <en:Pie dough
 en:Phyllo dough raw, Filo dough raw
 fr:Pâte phyllo crue, Pâte filo crue
+agribalyse_food_code:en:23445
 ciqual_food_code:en:23445
 ciqual_food_name:en:Phyllo or filo dough, raw
 ciqual_food_name:fr:Pâte phyllo ou Pâte filo, crue
@@ -70418,6 +72988,7 @@ nl_be:Korstdeeg
 <fr:Pâtes sablées
 en:Raw shortbread dough
 fr:Pâte sablée crue
+agribalyse_food_code:en:23440
 ciqual_food_code:en:23440
 ciqual_food_name:en:Shortbread dough, raw
 ciqual_food_name:fr:Pâte sablée, crue
@@ -70425,6 +72996,7 @@ ciqual_food_name:fr:Pâte sablée, crue
 <fr:Pâtes sablées
 en:Raw shortbread dough with pure butter
 fr:Pâte sablée pur beurre crue
+agribalyse_food_code:en:23444
 ciqual_food_code:en:23444
 ciqual_food_name:en:Shortbread dough, pure butter, raw
 ciqual_food_name:fr:Pâte sablée pur beurre, crue
@@ -70433,6 +73005,7 @@ ciqual_food_name:fr:Pâte sablée pur beurre, crue
 <en:Frozen foods
 en:Frozen raw shortbread dough with pure butter
 fr:Pâte sablée pur beurre surgelée crue
+agribalyse_food_code:en:23446
 ciqual_food_code:en:23446
 ciqual_food_name:en:Shortbread dough, pure butter, frozen, raw
 ciqual_food_name:fr:Pâte sablée pur beurre, surgelée, crue
@@ -70440,6 +73013,7 @@ ciqual_food_name:fr:Pâte sablée pur beurre, surgelée, crue
 <fr:Pâtes sablées
 en:Cooked shortbread dough with pure butter
 fr:Pâte sablée pur beurre cuite
+agribalyse_food_code:en:23448
 ciqual_food_code:en:23448
 ciqual_food_name:en:Shortbread dough, pure butter, cooked
 ciqual_food_name:fr:Pâte sablée pur beurre, cuite
@@ -70447,6 +73021,7 @@ ciqual_food_name:fr:Pâte sablée pur beurre, cuite
 <fr:Pâtes sablées
 en:Cooked shortbread dough
 fr:Pâte sablée cuite
+agribalyse_food_code:en:23442
 ciqual_food_code:en:23442
 ciqual_food_name:en:Shortbread dough, cooked
 ciqual_food_name:fr:Pâte sablée, cuite
@@ -70467,6 +73042,7 @@ nl:Gerechten die paardenvlees kunnen bevatten
 <en:Pizza dough
 en:Cooked pizza base
 fr:Pâte à pizza cuite
+agribalyse_food_code:en:96778
 ciqual_food_code:en:96778
 ciqual_food_name:en:Pizza base, cooked
 ciqual_food_name:fr:Pâte à pizza cuite
@@ -70474,6 +73050,7 @@ ciqual_food_name:fr:Pâte à pizza cuite
 <en:Pizza dough
 en:Pizza pastry base
 fr:Préparation pour pâte à pizza
+agribalyse_food_code:en:23403
 ciqual_food_code:en:23403
 ciqual_food_name:en:Pizza pastry base
 ciqual_food_name:fr:Préparation pour pâte à pizza
@@ -70481,6 +73058,7 @@ ciqual_food_name:fr:Préparation pour pâte à pizza
 <en:Pizza dough
 en:Raw thin-crust pizza shell, Raw thin-crust pizza dough
 fr:Pâte à pizza fine crue
+agribalyse_food_code:en:23402
 ciqual_food_code:en:23402
 ciqual_food_name:en:Thin-crust pizza shell, raw
 ciqual_food_name:fr:Pâte à pizza fine, crue
@@ -70488,6 +73066,7 @@ ciqual_food_name:fr:Pâte à pizza fine, crue
 <en:Pizza dough
 en:Raw pizza base
 fr:Pâte à pizza crue
+agribalyse_food_code:en:37001
 ciqual_food_code:en:37001
 ciqual_food_name:en:Pizza base, raw
 ciqual_food_name:fr:Pâte à pizza crue
@@ -70554,6 +73133,7 @@ wikidata:en:Q2157176
 <en:Bamboo shoots
 en:Canned drained bamboo shoots
 fr:Pousses de bambou appertisées égouttées
+agribalyse_food_code:en:20188
 ciqual_food_code:en:20188
 ciqual_food_name:en:Bamboo shoots, canned, drained
 ciqual_food_name:fr:Bambou, pousses, appertisées, égouttées
@@ -70561,6 +73141,7 @@ ciqual_food_name:fr:Bambou, pousses, appertisées, égouttées
 <en:Bamboo shoots
 en:Raw bamboo shoots
 fr:Pousses de bambou crues
+agribalyse_food_code:en:20198
 ciqual_food_code:en:20198
 ciqual_food_name:en:Bamboo shoots, raw
 ciqual_food_name:fr:Bambou, pousse, crue
@@ -70601,6 +73182,7 @@ en:Mashed carrots, Carrots puree
 de:Karottenbreie
 fr:Purées de carottes
 nl:Wortelpureeën
+agribalyse_food_code:en:20261
 ciqual_food_code:en:20261
 ciqual_food_name:en:Carrots, puree
 ciqual_food_name:fr:Carotte, purée
@@ -70610,6 +73192,7 @@ en:Mashed zucchini, Courgettes puree
 de:Zucchinibreie
 fr:Purées de courgettes, Purée de courgettes
 nl:Courgettepureeën
+agribalyse_food_code:en:20264
 ciqual_food_code:en:20264
 ciqual_food_name:en:Courgettes, puree
 ciqual_food_name:fr:Courgette, purée
@@ -70619,6 +73202,7 @@ en:Mashed broccoli, Broccoli puree
 de:Brokkolibreie, Broccolibreie
 fr:Purées de brocolis, Purée de brocolis
 nl:Brocollipureeën
+agribalyse_food_code:en:20259
 ciqual_food_code:en:20259
 ciqual_food_name:en:Broccoli, puree
 ciqual_food_name:fr:Brocoli, purée
@@ -70628,6 +73212,7 @@ en:Mashed spinachs, Spinach puree
 de:Spinatbreie
 fr:Purées d'épinards
 nl:Spinaziepureeën
+agribalyse_food_code:en:20285
 ciqual_food_code:en:20285
 ciqual_food_name:en:Spinach, puree
 ciqual_food_name:fr:Épinard, purée
@@ -70643,6 +73228,7 @@ en:Mashed celeriac, Celeriac puree
 de:Selleriebreie
 fr:Purées de céleri-rave, Purée de céleri-rave
 nl:Koolraappureeën
+agribalyse_food_code:en:20278
 ciqual_food_code:en:20278
 ciqual_food_name:en:Celeriac, puree
 ciqual_food_name:fr:Céleri-rave, purée
@@ -70658,6 +73244,7 @@ nl:Pompoenpureeën
 fr:Purées de haricots verts, Purées d'haricots verts
 nl:Sperziebonenpureeën
 en:French bean puree
+agribalyse_food_code:en:20257
 ciqual_food_code:en:20257
 ciqual_food_name:en:French bean, puree
 ciqual_food_name:fr:Haricots verts, purée
@@ -70665,6 +73252,7 @@ ciqual_food_name:fr:Haricots verts, purée
 <en:Mashed vegetables
 en:Green peas puree
 fr:Purée de petits pois
+agribalyse_food_code:en:20284
 ciqual_food_code:en:20284
 ciqual_food_name:en:Green peas, puree
 ciqual_food_name:fr:Petits pois, purée
@@ -70672,6 +73260,7 @@ ciqual_food_name:fr:Petits pois, purée
 <en:Mashed vegetables
 en:Canned tomato puree
 fr:Purée de tomates appertisée, Purée de tomates en conserve
+agribalyse_food_code:en:20170
 ciqual_food_code:en:20170
 ciqual_food_name:en:Tomato puree, canned
 ciqual_food_name:fr:Tomate, purée, appertisée
@@ -70679,6 +73268,7 @@ ciqual_food_name:fr:Tomate, purée, appertisée
 <en:Mashed vegetables
 en:Mashed vegetables mix
 fr:Purée de légumes mélangés
+agribalyse_food_code:en:20258
 ciqual_food_code:en:20258
 ciqual_food_name:en:Vegetables (3-4 types), mashed
 ciqual_food_name:fr:Légumes (3-4 sortes en mélange), purée
@@ -70690,6 +73280,7 @@ fr:Taboulés, Taboulé, Salade de couscous, Salades de couscous
 nl:Tabouleh
 nl_be:Tabouleh
 wikidata:en:Q607690
+agribalyse_food_code:en:25608
 ciqual_food_code:en:25608
 ciqual_food_name:en:Tabbouleh, prepacked
 ciqual_food_name:fr:Taboulé ou Salade de couscous, préemballé
@@ -70697,6 +73288,7 @@ ciqual_food_name:fr:Taboulé ou Salade de couscous, préemballé
 <en:Meals
 en:Vegetable fritters
 fr:Beignets de légumes
+agribalyse_food_code:en:25556
 ciqual_food_code:en:25556
 ciqual_food_name:en:Vegetable fritters
 ciqual_food_name:fr:Beignet de légumes
@@ -70704,6 +73296,7 @@ ciqual_food_name:fr:Beignet de légumes
 <en:Meals
 en:Filled fritter garnished with shrimps and vegetables and poultry and meat, Filo pastry garnished with shrimps and vegetables and poultry and meat
 fr:Brick garni aux crevettes et légumes et volaille et viande et poisson
+agribalyse_food_code:en:25438
 ciqual_food_code:en:25438
 ciqual_food_name:en:Fritter, filled (filo pastry) (garnish : shrimps, vegetables, poultry, meat, etc.)
 ciqual_food_name:fr:Brick garni (garniture : crevettes, légumes, volaille, viande, poisson, etc.)
@@ -70711,6 +73304,7 @@ ciqual_food_name:fr:Brick garni (garniture : crevettes, légumes, volaille, vian
 <en:Meals
 en:Fritter filled with eggs, Filo pastry filled with eggs
 fr:Brick à l'oeuf
+agribalyse_food_code:en:25557
 ciqual_food_code:en:25557
 ciqual_food_name:en:Fritter, filled with eggs (filo pastry)
 ciqual_food_name:fr:Brick à l'oeuf
@@ -70718,6 +73312,7 @@ ciqual_food_name:fr:Brick à l'oeuf
 <en:Meals
 en:Fritter filled with beef, Filo pastry filled with beef
 fr:Brick au boeuf
+agribalyse_food_code:en:25558
 ciqual_food_code:en:25558
 ciqual_food_name:en:Fritter, filled with beef (filo pastry)
 ciqual_food_name:fr:Brick au boeuf
@@ -70725,6 +73320,7 @@ ciqual_food_name:fr:Brick au boeuf
 <en:Meals
 en:Fritter filled with potatoes, Filo pastry filled with potatoes
 fr:Brick à la pomme de terre
+agribalyse_food_code:en:25559
 ciqual_food_code:en:25559
 ciqual_food_name:en:Fritter, filled with potatoes (filo pastry)
 ciqual_food_name:fr:Brick à la pomme de terre
@@ -70742,6 +73338,7 @@ de:Hünchen-Taboulé
 fr:Taboulés au poulet, Taboulé au poulet, Salade de couscous au poulet
 nl:Kiptaboulehs
 nl_be:Tabouleh met Kip
+agribalyse_food_code:en:26269
 ciqual_food_code:en:26269
 ciqual_food_name:en:Tabbouleh with chicken, prepacked
 ciqual_food_name:fr:Taboulé ou Salade de couscous au poulet, préemballé
@@ -70788,6 +73385,7 @@ en:Vegetables terrines, Vegetable mousses
 fr:Terrines de légumes, Mousses de légumes
 nl:Groenteschotels
 pnns_group_2:en:Salty and fatty products
+agribalyse_food_code:en:8296
 ciqual_food_code:en:8296
 ciqual_food_name:en:Vegetable terrine or mousse
 ciqual_food_name:fr:Terrine ou mousse de légumes
@@ -70815,12 +73413,14 @@ nl:Bloedworstterinnes, Bloedworstterrine
 <en:Terrines
 en:Fish terrine
 fr:Terrine de poisson
+agribalyse_food_code:en:8291
 ciqual_food_code:en:8291
 ciqual_food_name:en:Fish terrine
 
 <en:Terrines
 en:Seafood terrine with or without fish
 fr:Terrine de fruits de mer avec ou sans poisson
+agribalyse_food_code:en:8292
 ciqual_food_code:en:8292
 ciqual_food_name:en:Seafood terrine, with or without fish
 
@@ -70875,6 +73475,7 @@ en:Rabbit terrines
 fi:kaniterriinit
 fr:Terrines de lapin
 nl:Konijnterrines, Konijnterrine, Konijnevleespotten
+agribalyse_food_code:en:8242
 ciqual_food_code:en:8242
 ciqual_food_name:en:Rabbit terrine
 
@@ -70924,6 +73525,7 @@ en:Duck terrines
 fi:ankkaterriinit
 fr:Terrines de canard
 nl:Eendterrines, Eendterrine, Eendevleespotten
+agribalyse_food_code:en:8232
 ciqual_food_code:en:8232
 ciqual_food_name:en:Duck terrine
 
@@ -70951,6 +73553,7 @@ nl:Spirulina
 ro:Spirulina
 zh:螺旋藻
 wikidata:en:Q285335
+agribalyse_food_code:en:11086
 ciqual_food_code:en:11086
 ciqual_food_name:en:Spirulina, (spirulina sp.), dried
 
@@ -71144,6 +73747,7 @@ ro:Tajine
 <en:Tajine
 en:Mutton tagine
 fr:Tajine de mouton
+agribalyse_food_code:en:25159
 ciqual_food_code:en:25159
 ciqual_food_name:en:Mutton tagine
 ciqual_food_name:fr:Tajine de mouton
@@ -71153,6 +73757,7 @@ en:Endives with ham, Endive with ham, Chicory with ham
 fr:Endives au jambon, Endive au jambon
 nl:Witloof met hesp, Witloof met ham
 ro:Andive cu șuncă
+agribalyse_food_code:en:25073
 ciqual_food_code:en:25073
 ciqual_food_name:en:Chicory w ham
 ciqual_food_name:fr:Endive au jambon
@@ -71161,12 +73766,14 @@ ciqual_food_name:fr:Endive au jambon
 en:Puff pastries with ham and cheese, puff pastry with ham and cheese
 fr:Feuilletés jambon fromage
 nl:Ham-kaas-soesjes
+agribalyse_food_code:en:8395
 ciqual_food_code:en:8395
 ciqual_food_name:en:Ham, in a pastry crusty
 
 <en:Puff pastry meals
 en:Cheese soufflé
 fr:Soufflé au fromage
+agribalyse_food_code:en:25020
 ciqual_food_code:en:25020
 ciqual_food_name:en:Cheese soufflé
 ciqual_food_name:fr:Soufflé au fromage
@@ -71191,6 +73798,7 @@ nl:Worst friands
 <en:Friands
 en:Meat in puff pastry
 fr:Feuilleté à la viande, Friand à la viande
+agribalyse_food_code:en:25402
 ciqual_food_code:en:25402
 ciqual_food_name:en:Meat in puff pastry
 ciqual_food_name:fr:Feuilleté ou Friand à la viande
@@ -71199,6 +73807,7 @@ ciqual_food_name:fr:Feuilleté ou Friand à la viande
 <en:Friands
 en:Cheese in puff pastry, Puff pastry cheese pocket
 fr:Feuilleté au fromage, Friand au fromage
+agribalyse_food_code:en:25401
 ciqual_food_code:en:25401
 ciqual_food_name:en:Cheese in puff pastry
 ciqual_food_name:fr:Feuilleté ou Friand au fromage
@@ -71207,6 +73816,7 @@ ciqual_food_name:fr:Feuilleté ou Friand au fromage
 <en:Friands
 en:Ham and cheese in puffed pastry
 fr:Feuilleté jambon fromage
+agribalyse_food_code:en:25508
 ciqual_food_code:en:25508
 ciqual_food_name:en:Ham and cheese in puffed pastry
 
@@ -71214,6 +73824,7 @@ ciqual_food_name:en:Ham and cheese in puffed pastry
 <en:Friands
 en:Fish or seafood in puff pastry
 fr:Feuilleté au poisson et/ou fruits de mer
+agribalyse_food_code:en:25151
 ciqual_food_code:en:25151
 ciqual_food_name:en:Fish or seafood in puff pastry
 
@@ -71246,6 +73857,7 @@ ciqual_food_name:fr:Feuille de brick, cuite à sec sans matière grasse
 <en:Meals
 en:Khatfa, Phyllo pastry, Filo pastry
 fr:Khatfa
+agribalyse_food_code:en:51550
 ciqual_food_code:en:51550
 ciqual_food_name:en:Khatfa (phyllo or filo pastry), prepacked
 ciqual_food_name:fr:Khatfa feuille de brick, préemballée
@@ -71289,6 +73901,7 @@ nl:Diepvriesschorseneren
 <en:Salsifis
 en:Frozen raw salsify
 fr:Salsifis surgelés crus
+agribalyse_food_code:en:20237
 ciqual_food_code:en:20237
 ciqual_food_name:en:Salsify, frozen, raw
 ciqual_food_name:fr:Salsifis, surgelé, cru
@@ -71307,6 +73920,7 @@ nl:Waterkerssoep
 <en:Soups
 en:Reheatable watercress soup
 fr:Soupe au cresson à réchauffer
+agribalyse_food_code:en:25958
 ciqual_food_code:en:25958
 ciqual_food_name:en:Soup, watercress, prepacked, to be reheated
 ciqual_food_name:fr:Soupe au cresson, préemballée à réchauffer
@@ -71314,6 +73928,7 @@ ciqual_food_name:fr:Soupe au cresson, préemballée à réchauffer
 <en:Soups
 en:Dehydrated and reconstituted watercress soup
 fr:Soupe au cresson déshydratée reconstituée
+agribalyse_food_code:en:25957
 ciqual_food_code:en:25957
 ciqual_food_name:en:Soup, watercress, dehydrated and reconstituted
 ciqual_food_name:fr:Soupe au cresson, déshydratée reconstituée
@@ -71346,6 +73961,7 @@ nl:Garnering
 <en:Cooking helpers
 en:Dehydrated Madeira wine aspic
 fr:Gelée au madère déshydratée
+agribalyse_food_code:en:11175
 ciqual_food_code:en:11175
 ciqual_food_name:en:Madeira wine aspic, dehydrated
 ciqual_food_name:fr:Gelée au madère, déshydratée
@@ -71353,6 +73969,7 @@ ciqual_food_name:fr:Gelée au madère, déshydratée
 <en:Cooking helpers
 en:Madeira wine aspic
 fr:Gelée au madère
+agribalyse_food_code:en:11176
 ciqual_food_code:en:11176
 ciqual_food_name:en:Madeira wine aspic
 ciqual_food_name:fr:Gelée au madère
@@ -71413,6 +74030,7 @@ en:Vegetable risottos, Risotto with vegetables
 de:Gemüserisotto
 fr:Risottos aux légumes, Risotto aux légumes
 nl:Groenterisotto
+agribalyse_food_code:en:25187
 ciqual_food_code:en:25187
 ciqual_food_name:en:Risotto, w vegetables
 ciqual_food_name:fr:Risotto, aux légumes
@@ -71438,6 +74056,7 @@ nl:Groentetortellini
 en:Acras, Accras
 fr:Acras, Accras
 nl:Acra
+agribalyse_food_code:en:25433
 ciqual_food_code:en:25433
 ciqual_food_name:en:Caribbean-style fish fritters, fish acras
 
@@ -71450,6 +74069,7 @@ nl:Truffade
 en:Aligots, Aligot, Mashed potatoes with fresh tome cheese
 fr:Aligots, Aligot, Purée de pomme de terre à la tomme fraîche
 nl:Aligot
+agribalyse_food_code:en:4041
 ciqual_food_code:en:4041
 ciqual_food_name:en:Mashed potatoes w fresh tome cheese
 ciqual_food_name:fr:Aligot (purée de pomme de terre à la tomme fraîche)
@@ -71481,6 +74101,7 @@ nl:Diepvries limabonen
 <en:Frozen vegetables
 en:Frozen raw butter beans, Frozen raw yellow beans
 fr:Haricots beurre surgelés crus
+agribalyse_food_code:en:20203
 ciqual_food_code:en:20203
 ciqual_food_name:en:Butter bean or yellow bean, frozen, raw
 ciqual_food_name:fr:Haricot beurre, surgelé, cru
@@ -71489,6 +74110,7 @@ ciqual_food_name:fr:Haricot beurre, surgelé, cru
 <en:Onions
 en:Frozen raw onions
 fr:Oignons surgelés crus
+agribalyse_food_code:en:20235
 ciqual_food_code:en:20235
 ciqual_food_name:en:Onion, frozen, raw
 ciqual_food_name:fr:Oignon, surgelé, cru
@@ -71509,6 +74131,7 @@ wikidata:en:Q1366456
 <en:Sandwiches
 en:Sandwich made with panini bread raw cured ham mozzarella cheese and tomato
 fr:Sandwich panini jambon cru mozzarella tomates
+agribalyse_food_code:en:25434
 ciqual_food_code:en:25434
 ciqual_food_name:en:Sandwich made with panini bread, raw cured ham, mozzarella cheese and tomato
 
@@ -71549,6 +74172,7 @@ ro:Iaurturi cu cereale
 <en:Yogurts with cereals
 en:Fat free fermented yogurt with cereals, Fat free fermented milk dairy specialty with cereals
 fr:Yaourt au lait fermenté aux céréales à 0% de matières grasses, Spécialité laitière aux céréales à 0% de matières grasses
+agribalyse_food_code:en:19558
 ciqual_food_code:en:19558
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, with cereals, fat free
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux céréales, 0% MG
@@ -71556,6 +74180,7 @@ ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux céré
 <en:Yogurts with cereals
 en:Fermented milk yogurt with cereals, Dairy specialty with cereals
 fr:Yaourt au lait fermenté aux céréales, Spécialité laitière aux céréales
+agribalyse_food_code:en:19579
 ciqual_food_code:en:19579
 ciqual_food_name:en:Yogurt, fermented milk or dairy specialty, w cereals
 ciqual_food_name:fr:Yaourt, lait fermenté ou spécialité laitière, aux céréales
@@ -71575,6 +74200,7 @@ nl:Bananenmuffins
 <en:Fruit muffins
 en:Blueberry Muffins
 fr:Muffins aux myrtilles
+agribalyse_food_code:en:23950
 ciqual_food_code:en:23950
 ciqual_food_name:en:Muffin, with blueberry or chocolate
 
@@ -71584,6 +74210,7 @@ fr:Bonbons dragéifiés
 <en:White chocolates
 en:White chocolate bar with dried fruits
 fr:Chocolat blanc en tablette aux fruits secs
+agribalyse_food_code:en:31026
 ciqual_food_code:en:31026
 ciqual_food_name:en:White chocolate bar, with dried fruits (nuts, almonds, raisins, praline)
 ciqual_food_name:fr:Chocolat blanc aux fruits secs (noisettes, amandes, raisins, praliné) , tablette
@@ -71613,6 +74240,7 @@ ciqual_food_name:en:Almond cake
 <en:Cakes
 en:Soft cake with nuts
 fr:Gâteau moelleux aux fruits à coque
+agribalyse_food_code:en:23938
 ciqual_food_code:en:23938
 ciqual_food_name:en:Soft cake with nuts
 ciqual_food_name:fr:Gâteau moelleux aux fruits à coque
@@ -71620,6 +74248,7 @@ ciqual_food_name:fr:Gâteau moelleux aux fruits à coque
 <en:Cakes
 en:Soft cake filled with fruits, Mini sponge roll filled with fruits
 fr:Gâteau moelleux fourré aux fruits, Mini-roulé fourré aux fruits, Mini-cake fourré aux fruits
+agribalyse_food_code:en:23941
 ciqual_food_code:en:23941
 ciqual_food_name:en:Soft cake filled with fruits, mini sponge roll type
 ciqual_food_name:fr:Gâteau moelleux fourré aux fruits type mini-roulé ou mini-cake fourré
@@ -71628,6 +74257,7 @@ ciqual_food_name:fr:Gâteau moelleux fourré aux fruits type mini-roulé ou mini
 en:Fruit mousses, Refrigerated fruit mousse
 fr:Mousses aux fruits, Mousse aux fruits rayon frais
 nl:Vruchtenmousse
+agribalyse_food_code:en:39228
 ciqual_food_code:en:39228
 ciqual_food_name:en:Fruit mousse, refrigerated
 ciqual_food_name:fr:Mousse aux fruits, rayon frais
@@ -71658,6 +74288,7 @@ nl:Chocola Charlottes
 en:Fruit Charlottes
 fr:Charlottes aux fruits
 nl:Vruchtencharlotte
+agribalyse_food_code:en:23531
 ciqual_food_code:en:23531
 ciqual_food_name:en:Fruit charlotte
 ciqual_food_name:fr:Charlotte aux fruits
@@ -71672,6 +74303,7 @@ wikidata:en:Q2006073
 <en:Crumbles
 en:Apple crumbles
 fr:Crumbles aux pommes
+agribalyse_food_code:en:23493
 ciqual_food_code:en:23493
 ciqual_food_name:en:Apple crumble
 ciqual_food_name:fr:Crumble aux pommes

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -1559,7 +1559,7 @@ fi:hedelmäpektiini, hedelmäpektiinit
 fr:pectine de fruit, pectines de fruits
 hu:gyümölcspektin
 it:pectina di frutta
-nl:vruchtenpectine, fruitpectine
+nl:vruchtenpectine
 # fr:pectine-de-fruit has 1579 products in 6 languages @2018-11-03
 
 <en:fruit pectin
@@ -9852,7 +9852,6 @@ fi:kova juusto
 fr:fromage à pâte dure
 hu:keménysajt
 it:formaggio a pasta dura
-nl:harde kaas
 pt:queijo de pasta dura, queijo duro
 sv:Hårdost
 # fr:fromage-à-pâte-dure has 133 products in 5 languages @2018-10-28
@@ -16109,6 +16108,11 @@ fr:amidon de pois
 de:Erbsenstärke
 nl:erwtenzetmeel
 
+# Wikipedia: Arrowroot is a starch obtained from the rhizomes (rootstock) of several tropical plants, traditionally Maranta arundinacea, but also Florida arrowroot from Zamia integrifolia, and tapioca from cassava (Manihot esculenta), which is often labelled as arrowroot.
+
+<en:starch
+en:arrowroot, arrowroot power, arrowroot starch, arrowroot flour
+
 # description:en:TAPIOCA is a starch extracted from cassava root (tapioca seems to be the same as tapioca starch, but not used as such on ingredient lists)
 
 <en:starch
@@ -21704,7 +21708,7 @@ fr:arôme naturel de vanille, arôme naturel vanille, arômes naturels de vanill
 hu:természetes vanília aroma
 it:aroma naturale di vaniglia, aroma naturale vaniglia
 nb:naturlig vanilijarom
-nl:natuurlijk vanillearoma, natuurlijk vanille aroma, natuurlijke vanille aroma
+nl:natuurlijk vanillearoma, natuurlijk vanille aroma
 pl:naturalny aromat wanilii, naturalny aromat waniliowy
 pt:aroma de baunilha natural, aromatizante de baunilha natural
 sv:naturlig vaniljarom, naturlig vanilijarom
@@ -25450,7 +25454,7 @@ fr:farine de seigle
 hu:rozsliszt
 it:farina di segala
 nb:rugmel
-nl:roggemeel, roggebloem, rogge-bloem
+nl:roggebloem
 pl:mąka żytnia
 pt:farinha de centeio
 ro:făină de secară, faina de secara
@@ -28115,6 +28119,10 @@ fi:ruokosokerimelassi, ruokomelassi
 nl:rietsuikermelasse
 sv:rörsockermelass
 
+<en:sugar
+fr:mélasse de canne
+fi:ruokomelassi
+
 
 # description:en: TREHALOSE is a sugar consisting of two molecules of glucose. It is also known as mycose or tremalose. Trehalose has about 45% the sweetness of sucrose at concentrations above 22%, but when the concentration is reduced, its sweetness decreases more quickly than that of sucrose, so that a 2.3% solution tastes 6.5 times less sweet as the equivalent sugar solution. It is commonly used in prepared frozen foods, like ice cream, because it lowers the freezing point of foods.
 
@@ -28171,11 +28179,6 @@ wikipedia:en:https://en.wikipedia.org/wiki/Trehalose
 # ingredient/fr:tréhalose has 66 products in 4 languages @2019-04-02
 # usage:en:trehalose (source of glucose)
 
-#en:description:Melado is a mixture of sugar and molasses; crude sugar as it comes from the pans without being drained.
-<en:sugar
-<en:molasses
-en:melado
-nl:melado
 
 # SYRUP is a condiment that is a thick, viscous liquid consisting primarily of a solution of sugar in water, containing a large amount of dissolved sugars but showing little tendency to deposit crystals.
 # Warning:the wikipedia translations mixes syrup and glucose syrup
@@ -28616,12 +28619,12 @@ openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-and-fructose-sy
 
 <en:wheat
 <en:fructose syrup
+<en:fructose syrup
 <en:glucose syrup
-en:wheat glucose-fructose syrup
+ru:глюкозно-фруктозный сироп
 de:Glukose-und Fruktosesirup (Weizen)
 fr:sirop de glucose-fructose de blé
 nl:glucose-fructosestroop van tarwe
-ru:глюкозно-фруктозный сироп
 sk:glukózový-fruktózový sirup
 sr:glukozno-fruktozni sirup
 sv:glukos-fruktossirap
@@ -29322,7 +29325,6 @@ en:potato protein
 de:kartoffelprotein
 fi:perunaproteiini
 fr:protéine de pomme de terre, protéines de pomme de terre
-nl:aardappeleiwit
 # ingredient/fr:proteine-de-pomme-de-terre has 44 products in 4 languages @2020-05-25
 
 # description:en:HYDROLYZED VEGETABLE PROTEIN -  products are foodstuffs obtained by protein hydrolysis
@@ -38703,12 +38705,20 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lychee
 <en:lychee
 es:Lichis deshuesados
 
+<en:fruit
+en:Rambutan
+fr:Ramboutan, Litchi chevelu
+
+<en:fruit
+en:longan
+fr:longane, longani, oeil du dragon
+
+
 ###################################################################################################
 #
 #                                Melon
 #
 ###################################################################################################
-
 
 # MELON is any of various plants of the family Cucurbitaceae with sweet edible, fleshy fruit.
 
@@ -39357,6 +39367,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Custard_apple
 <en:fruit
 en:persimmon,sharon fruit
 es:caqui
+fr:kaki
 wikipedia:en:https://en.wikipedia.org/wiki/Diospyros_kaki
 
 <en:persimmon
@@ -42065,14 +42076,18 @@ fi:sikuri
 fr:Chicorée
 it:Cicoria
 
+<en:chicory
+en:chicory root
+fr:racine de chicorée
+
 <en:vegetable fiber
 <en:chicory
-en:chicory fibre
+en:chicory fibre, chicory root fiber
 da:cikoriefibre
 de:Zichorienfäser
 es:fibra de la raíz de achicoria,fibra de achicoria
 fi:sikurikuitu, sikurijuurikuitu
-fr:fibre de chicorée, fibres de chicorée
+fr:fibre de chicorée, fibres de chicorée, fibre de racine de chicorée, fibres de racine de chicorée, fibres de racines de chicorée
 nl:chicoreivezel
 sv:fiber från cikoriarot
 # ingredient/fr:fibre-de-chicoree has 254 products in 5 languages @2018-12-10
@@ -45328,6 +45343,33 @@ carbon_footprint_fr_foodges_value:fr:8.4
 # fr:Radis de saison
 # ingredient/fr:Radis-de-saison has no products @2019-05-16
 
+<en:radish
+en:daikon, white radish, winter radish, Oriental radish, long white radish
+ca:rave blanc
+de:Winterrettich
+fr:radis blanc, radis d'hiver, radis chinois, daikon
+ja:ダイコン
+nl:witte rammenas
+
+<en:radish
+en:black radish
+de:Schwarzer Winter-Rettich
+fr:radis noir, radis d'Espagne
+nl:Rammenas
+
+<en:root vegetable
+en:lotus root
+fr:racine de lotus
+
+<en:vegetable
+en:okra
+de:Okra, Gemüse-Eibisch
+es:quimbombó, quingombó, gombo, molondrón, ocra, okra, bamia, candia, abelmosco,ñajú
+fr:gombo
+it:gombo, ocra, okra
+nl:okra
+pt:Quiabo
+
 
 # description:en:RHUBARB is a cultivated plant in the genus Rheum in the family Polygonaceae. Rhubarb is stewed with sugar or used in pies and desserts, but it can also be put into savoury dishes or pickled. Rhubarb can be dehydrated and infused with fruit juice.
 
@@ -46208,9 +46250,9 @@ wikipedia:en:https://en.wikipedia.org/wiki/Sweet_potato
 nutriscore_fruits_vegetables_nuts:en:no
 
 <en:root vegetable
-en:manioc
+en:manioc, cassava, yuka, manioc root
 de:Maniok
-fr:manioc
+fr:manioc, racine de manioc
 nutriscore_fruits_vegetables_nuts:en:no
 
 <en:root vegetable
@@ -54971,7 +55013,7 @@ mk:Мајоран
 ms:Marjoram
 mt:merqtux
 nb:merian
-nl:marjolein, marjoraan
+nl:marjolein
 nn:merian
 oc:Majorana
 pa:ਮਰੂਆ
@@ -69004,7 +69046,7 @@ es:huevos de granero
 fi:lattiakanojen munat, vapaan kanan munat, onnellisen kanan munat, pesämunat
 fr:œufs d'élevage au sol, œufs de poules élevées au sol, œufs de ponte au sol, oeufs d'élevage au sol, oeufs de poules élevées au sol, oeufs de ponte au sol, sol
 it:uova di allevamento al suolo
-nl:scharreleieren, scharrelei, scharrel-ei
+nl:scharreleieren, scharrelei
 # ingredient/fr:œufs-d’élevage-au-sol has 168 products in 4 languages @2018-12-18
 # ingredient/fr:œufs-de-poules-élevées-au-sol has 111 products in 4 languages @2018-12-18
 
@@ -69898,7 +69940,7 @@ es:fibra de guisante
 fi:hernekuitu
 fr:fibre de pois, fibres de pois
 it:fibra di pisello
-nl:erwtenvezel, erwtvezel
+nl:erwtenvezel
 ro:fibre de mazare
 # ingredient/fr:fibre-de-pois has 173 products in 7 languages @2019-04-21
 


### PR DESCRIPTION
Not sure what happened, but a commit seems to have removed all the agribalyse_food_codes 
https://github.com/openfoodfacts/openfoodfacts-server/commit/aeeca450e68267986fe6927e6e3442bac2c9f22b#diff-f10308cb67581847fc8c5b78473832bf

reverting commit aeeca45