### PR TITLE
P1 bug fix -- Fix broken cropper, do not require cross origin check, fixes #4070

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -363,13 +363,13 @@ function change_image(imagefield, imgid) {
   });
 
 	$('img#crop_' + imagefield).cropper({
-		"viewMode" : 2, "guides": false, "autoCrop": false, "zoomable": true, "zoomOnWheel": false, "zoomOnTouch": false, "toggleDragModeOnDblclick": true
+		"viewMode" : 2, "guides": false, "autoCrop": false, "zoomable": true, "zoomOnWheel": false, "zoomOnTouch": false, "toggleDragModeOnDblclick": true, "checkCrossOrigin" : false
 	});
 
 	$("#zoom_on_wheel_" + imagefield).change(function() {
     var zoomOnWheel = $("#zoom_on_wheel_" + imagefield).is(':checked');
     $('img#crop_' + imagefield).cropper('destroy').cropper({
-      "viewMode" : 2, "guides": false, "autoCrop": false, "zoomable": true, "zoomOnWheel": zoomOnWheel, "zoomOnTouch": false, "toggleDragModeOnDblclick": true
+      "viewMode" : 2, "guides": false, "autoCrop": false, "zoomable": true, "zoomOnWheel": zoomOnWheel, "zoomOnTouch": false, "toggleDragModeOnDblclick": true, "checkCrossOrigin": false
 	});	} );
 
 	$(document).foundation('equalizer', 'reflow');


### PR DESCRIPTION
it looks like we updated the version of cropper.js and my guess is that it started to make cross origin checks. disabling them for now, until we find a way to fix the nginx config to send the right headers for the right requests.

Better solution will be to fix the CORS headers: https://github.com/openfoodfacts/openfoodfacts-server/issues/4073