### PR TITLE
Changing "Modern Greek" to "Greek", fixes #4070

### DIFF
--- a/taxonomies/languages.txt
+++ b/taxonomies/languages.txt
@@ -11335,7 +11335,7 @@ el:Ελληνικά, Ελληνική γλώσσα, Νέα ελληνική γλ
 es:griego moderno, Idioma griego moderno
 fi:Kreikka, Kreikan kieli, Nykykreikka
 fo:Grikskt mál, Nýgrikskt mál
-fr:grec moderne, Romaïque, el
+fr:Grec, grec moderne, Romaïque, el
 frr:Griichisk spriak, Neigriichisk
 gl:Grego moderno
 got:𐌽𐌹𐌿𐌾𐌰𐌺𐍂𐌴𐌺𐌹𐍃𐌺𐌰𐍂𐌰𐌶𐌳𐌰

--- a/taxonomies/languages.txt
+++ b/taxonomies/languages.txt
@@ -11344,7 +11344,7 @@ hi:यूनानी, आधुनिक यूनानी भाषा
 hr:Grčki jezik, Novogrčki jezik, Novogrčki
 hy:Հունարեն, նոր հունարեն
 ilo:Griego, Moderno a Griego
-it:greco moderno, Neoellenico, Lingua neogreca, Grammatica greca moderna, lingua greca moderna
+it:Greco, Lingua greca, Greco moderno, Lingua greca moderna, Neoellenico, Lingua neogreca
 kab:Tayunanit
 ko:그리스어, 현대 그리스어
 la:Lingua Graeca, Lingua Neograeca, Neograeca, Lingua Graeca moderna, Neograece, Lingua Graeca hodierna

--- a/taxonomies/languages.txt
+++ b/taxonomies/languages.txt
@@ -11324,50 +11324,51 @@ language_code_2:en:mh
 language_code_3:en:mah
 wikidata:en:Q36280
 
-en:Modern Greek, Modern Greek language, el, el, gre
-be:Новагрэчаская мова
+en:Greek, Greek language, Modern Greek, Modern Greek language, el, el, gre
+be:Грэчаская мова, Новагрэчаская мова
 ca:Grec demòtic
 chr:ᎠᏂᎪᎢ ᎧᏬᏂᎯᏍᏗ
-cs:Novořečtina, Moderní řečtina
-da:Nygræsk
-de:Neugriechisch, Modernes Griechisch, Neugriechische Sprache
-el:Νέα ελληνική γλώσσα, Νέα ελληνική, Νεοελληνική, Νεοελληνική Γλώσσα, Νέα ελληνικά
+cs:Řečtina, Novořečtina, Moderní řečtina
+da:Græsk, Nygræsk
+de:Griechisch, Griechische Sprache, Neugriechisch, Modernes Griechisch, Neugriechische Sprache
+el:Ελληνικά, Ελληνική γλώσσα, Νέα ελληνική γλώσσα, Νέα ελληνική, Νεοελληνική, Νεοελληνική Γλώσσα, Νέα ελληνικά
 es:griego moderno, Idioma griego moderno
-fi:Nykykreikka
-fo:Nýgrikskt mál
+fi:Kreikan kieli, Nykykreikka
+fo:Grikskt mál, Nýgrikskt mál
 fr:grec moderne, Romaïque, el
-frr:Neigriichisk
+frr:Griichisk spriak, Neigriichisk
 gl:Grego moderno
 got:𐌽𐌹𐌿𐌾𐌰𐌺𐍂𐌴𐌺𐌹𐍃𐌺𐌰𐍂𐌰𐌶𐌳𐌰
 he:יוונית מודרנית
-hi:आधुनिक यूनानी भाषा
-hr:Novogrčki jezik, Novogrčki
-hy:նոր հունարեն
-ilo:Moderno a Griego
+hi:यूनानी, आधुनिक यूनानी भाषा
+hr:Grčki jezik, Novogrčki jezik, Novogrčki
+hy:Հունարեն, նոր հունարեն
+ilo:Griego, Moderno a Griego
 it:greco moderno, Neoellenico, Lingua neogreca, Grammatica greca moderna, lingua greca moderna
 kab:Tayunanit
-ko:현대 그리스어
-la:Lingua Neograeca, Neograeca, Lingua Graeca moderna, Neograece, Lingua Graeca hodierna
+ko:그리스어, 현대 그리스어
+la:Lingua Graeca, Lingua Neograeca, Neograeca, Lingua Graeca moderna, Neograece, Lingua Graeca hodierna
 ln:Ligreki lya lɛlɔ́
-lv:Jaungrieķu valoda
-mk:новогрчки јазик, современ грчки јазик
-nb:Nygresk, Nygresk språk
+lv:Grieķu valoda, Jaungrieķu valoda
+mk:Грчки јазик, новогрчки јазик, современ грчки јазик
+nb:Gresk, Nygresk, Nygresk språk
 nds:Neegreeksche Spraak, Neegreeksche Sprake, Neegreeksch, Niegreeksche Spraak
-nl:Nieuwgrieks, Gemeenschappelijke Nieuw-Griekse taal, Nieuw-Grieks, Kini neo-elliniki glossa, Modern Grieks
+nl:Grieks, Nieuwgrieks, Gemeenschappelijke Nieuw-Griekse taal, Nieuw-Grieks, Kini neo-elliniki glossa, Modern Grieks
 om:Afaan Giriik
-pl:język nowogrecki, Demotyk, Dimotiki, Nowogr., Nowożytna greka, Nwgr., Język grecki współczesny, Język grecki nowożytny, Greka nowożytna, Greka współczesna
-pt:grego moderno, Demótico, Língua grega moderna
+pl:Język grecki, język nowogrecki, Demotyk, Dimotiki, Nowogr., Nowożytna greka, Nwgr., Język grecki współczesny, Język grecki nowożytny, Greka nowożytna, Greka współczesna
+pt:Grego, Língua grega, grego moderno, Demótico, Língua grega moderna
 ro:Limba greacă modernă, Limba neogreacă
-ru:новогреческий язык
+ru:Греческий язык, новогреческий язык
 scn:Lingua greca muderna, Grecu mudernu
-sk:Novogréčtina, Nová gréčtina
-sv:Nygrekiska, Modern grekiska
+sk:Grécke jazyky, Novogréčtina, Nová gréčtina
+sv:Grekiska, Nygrekiska, Modern grekiska
 tl:Modernong Griyego
-uk:Новогрецька мова
-zh:现代希腊语
+uk:Грецька мова, Новогрецька мова
+zh:希腊语, 现代希腊语
 language_code_2:en:el
 language_code_3:en:gre
 wikidata:en:Q36510
+wikidata:en:Q9129
 
 en:Moldovan, Moldovan language, mo
 af:Moldawies

--- a/taxonomies/languages.txt
+++ b/taxonomies/languages.txt
@@ -11333,7 +11333,7 @@ da:Græsk, Nygræsk
 de:Griechisch, Griechische Sprache, Neugriechisch, Modernes Griechisch, Neugriechische Sprache
 el:Ελληνικά, Ελληνική γλώσσα, Νέα ελληνική γλώσσα, Νέα ελληνική, Νεοελληνική, Νεοελληνική Γλώσσα, Νέα ελληνικά
 es:griego moderno, Idioma griego moderno
-fi:Kreikan kieli, Nykykreikka
+fi:Kreikka, Kreikan kieli, Nykykreikka
 fo:Grikskt mál, Nýgrikskt mál
 fr:grec moderne, Romaïque, el
 frr:Griichisk spriak, Neigriichisk


### PR DESCRIPTION
...at least in languages where it changes the sort order.
Translations from https://www.wikidata.org/wiki/Q9129, and any short forms from the infobox on languages' own wikipedia entries for "greek language".

For https://github.com/openfoodfacts/openfoodfacts-server/issues/4070
