### PR TITLE
Taxonomy edits 6 - ingredients & additives

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -275,7 +275,7 @@ e_number:en:101a
 
 # description:en:TARTRAZINE is a synthetic lemon yellow azo dye primarily used as a food coloring.
 
-en:E102, Tartrazine, Yellow 5, Yellow number 5, Yellow no 5, Yellow no5, FD&C Yellow 5, FD&C Yellow no 5, FD&C Yellow no5, FD and C Yellow no. 5, FD and C Yellow 5
+en:E102, Tartrazine, Yellow 5, Yellow number 5, Yellow no 5, Yellow no5, FD&C Yellow 5, FD&C Yellow no 5, FD&C Yellow no5, FD and C Yellow no. 5, FD and C Yellow 5, Yellow 5 lake
 bg:E102, Тартразин
 ca:E102, Tartrazina
 cs:E102, Tartrazin, FD&C žluť 5, E 102, Tartazin
@@ -459,7 +459,7 @@ colour_index:en:CI 18965
 vegan:en:yes
 vegetarian:en:yes
 
-en:E110, Sunset yellow FCF, CI Food Yellow 3, Orange Yellow S, FD&C Yellow 6, FD & C Yellow No.6, FD and C Yellow No. 6, Yellow No.6, Yellow 6, FD and C Yellow 6, C.I. 15985
+en:E110, Sunset yellow FCF, CI Food Yellow 3, Orange Yellow S, FD&C Yellow 6, FD & C Yellow No.6, FD and C Yellow No. 6, Yellow No.6, Yellow 6, FD and C Yellow 6, C.I. 15985, Yellow 6 lake
 bg:E110, Сънсет жълто FCF, CI хранително жълто 3, Yellow 6
 ca:E110, Groc ataronjat S
 cs:E110, Sunset yellow FCF, Yellow 6, Žluť SY, E 110
@@ -791,7 +791,7 @@ vegetarian:en:yes
 
 # description:en:ERYTHROSINE, is an organoiodine compound, specifically a derivative of fluorone. It is cherry or melon-pink synthetic, primarily used for food coloring.
 
-en:E127, Erythrosine, FD&C Red 3, FD & C Red No.3, Red No. 3, FD&C Red no3, FD and C Red 3
+en:E127, Erythrosine, FD&C Red 3, FD & C Red No.3, Red No. 3, FD&C Red no3, FD and C Red 3, Red 3, Red 3 lake
 bg:E127, Еритрозин
 ca:E127, Eritrosina
 cs:E127, Erythrosin, Erytrosin, E 127
@@ -878,7 +878,7 @@ additives_classes:en: en:colour
 vegan:en:yes
 vegetarian:en:yes
 
-en:E129, Allura red ac, Allura Red AC, FD&C Red 40, FD and C Red 40, Red 40, Red no40, Red no. 40, FD and C Red no. 40, Food Red 17, C.I. 16035
+en:E129, Allura red ac, Allura Red AC, FD&C Red 40, FD and C Red 40, Red 40, Red no40, Red no. 40, FD and C Red no. 40, Food Red 17, C.I. 16035, Red 40 lake
 bg:E129, Алура червено ac
 ca:E129, Vermell Allure 2C
 cs:E129, Allura red ac, červeň ac, Červeň Allura AC
@@ -992,7 +992,7 @@ efsa_evaluation_adi:en: 5
 vegan:en:yes
 vegetarian:en:yes
 
-en:E132, Indigotine, indigo carmine, FD&C Blue 2, FD and C Blue 2
+en:E132, Indigotine, indigo carmine, FD&C Blue 2, FD and C Blue 2, C.I. Food Blue 2, Blue 2 lake, Blue 2
 bg:E132, Индиготин, индиго кармин
 ca:E132, Indigotina, carmí indi, carmi indi
 cs:E132, Indigotin, indigocarmine, Indigo karmín
@@ -1018,6 +1018,7 @@ sv:E132, Indigotin, indigokarmin
 # nl_be:E132, Indigotine, indigokarmijn
 e_number:en:132
 wikidata:en:Q410120
+wikipedia:en:https://en.wikipedia.org/wiki/Indigo_carmine
 efsa:en:http://www.efsa.europa.eu/fr/efsajournal/doc/2818.pdf
 efsa_evaluation_url:en: https://efsa.onlinelibrary.wiley.com/doi/10.2903/j.efsa.2014.3768
 efsa_evaluation_date:en: 2014/07/25
@@ -1030,7 +1031,7 @@ vegetarian:en:yes
 
 # description:en: BRILLIANT BLUE FCF (Blue 1) is an organic compound classified as a blue triarylmethane dye, reflecting its chemical structure. Known under various commercial names, it is a colorant for foods and other substances.
 
-en:E133, Brilliant blue FCF, FD&C Blue 1, FD and C Blue 1, Blue 1, fd&c blue no. 1.
+en:E133, Brilliant blue FCF, FD&C Blue 1, FD and C Blue 1, Blue 1, fd&c blue no. 1, Blue 1 lake
 bg:E133, Брилянтно синьо FCF
 ca:E133, Blau brillant FCF
 cs:E133, Brilantní modř FCF
@@ -1040,7 +1041,7 @@ el:E133, Λαμπρο κυανο FCF
 es:E133, Azul brillante FCF, Azul brillante FCP, E 133, Brilliant Blue FCF, azul FD&C 1
 et:E133, Briljantsinine FCF
 fi:E133, Briljanttisininen FCF
-fr:E133, Bleu brillant FCF, C.I. Acid Blue 9, C.I. Food Blue 2, Blue 2 lake, Blue 2, CI 42090, C-Blau 21, Erioglaucin A, Blue 1, Brilliant Blue FCF, bleu brillant, FD&C Blue No.1, FD&C Blue #1, BB FCF, Acid Blue 9, D&C Blue No. 4, Alzen Food Blue No. 1, Atracid Blue FG, Erioglaucine, Eriosky blue, Patent Blue AR, Xylene Blue VSG, CAS 25305-78-6, CAS 2650-18-2, CAS 3844-45-9, CAS 71701-18-3, CAS 15792-67-3, 2650-18-2, 15792-67-3
+fr:E133, Bleu brillant FCF, C.I. Acid Blue 9, CI 42090, C-Blau 21, Erioglaucin A, Blue 1, Brilliant Blue FCF, bleu brillant, FD&C Blue No.1, FD&C Blue #1, BB FCF, Acid Blue 9, D&C Blue No. 4, Alzen Food Blue No. 1, Atracid Blue FG, Erioglaucine, Eriosky blue, Patent Blue AR, Xylene Blue VSG, CAS 25305-78-6, CAS 2650-18-2, CAS 3844-45-9, CAS 71701-18-3, CAS 15792-67-3, 2650-18-2, 15792-67-3
 ga:E133, gorm lonrach FCF
 he:E133, כחול בוהק FCF
 hu:E133, Brilliánskék FCF
@@ -1409,7 +1410,7 @@ efsa_evaluation_exposure_95th_greater_than_adi:en: en:children, en:toddlers
 vegan:en:yes
 vegetarian:en:yes
 
-en:E143, Fast Green FCF, Food green 3, C.I. 42053, Solid Green FCF, Green 1724, FD&C Green No. 3
+en:E143, Fast Green FCF, Food green 3, C.I. 42053, Solid Green FCF, Green 1724, FD&C Green No. 3, Green 3
 bg:E143, E143 food additive
 cs:E143, E143 food additive
 da:E143, E143 food additive

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -459,7 +459,7 @@ colour_index:en:CI 18965
 vegan:en:yes
 vegetarian:en:yes
 
-en:E110, Sunset yellow FCF, CI Food Yellow 3, Orange Yellow S, FD&C Yellow 6, FD & C Yellow No.6, FD and C Yellow No. 6, Yellow No.6, Yellow 6, FD and C Yellow 6, C.I. 15985, Yellow 6 lake
+en:E110, Sunset yellow FCF, CI Food Yellow 3, Orange Yellow S, FD&C Yellow 6, FD & C Yellow No.6, FD and C Yellow No. 6, Yellow No.6, Yellow 6, FD and C Yellow 6, C.I. 15985, Yellow 6 lake, Sunset Yellow
 bg:E110, Сънсет жълто FCF, CI хранително жълто 3, Yellow 6
 ca:E110, Groc ataronjat S
 cs:E110, Sunset yellow FCF, Yellow 6, Žluť SY, E 110

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -73079,7 +73079,7 @@ ciqual_food_name:fr:Blé germé, cru
 <en:Sprouts
 en:Alfalfa sprouts
 fr:Pousses d'alfalfa
-en:Germinados de alfalfa
+es:Germinados de alfalfa
 
 <en:Sprouts
 en:lentil sprouts

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -23881,11 +23881,6 @@ de:getrockneter Gerstenmalzextrakt
 <en:barley malt extract
 fr:extrait de malte d'orge houblonné
 
-<en:malted barley
-en:malted barley flour
-es:harina de malta
-nl:gerstemoutmeel
-
 <en:barley malt extract
 <en:syrup
 en:barley malt syrup
@@ -25064,6 +25059,7 @@ sv:spannmålsmjöl
 <en:cereal flour
 en:malt flour
 de:Malzmehl
+es:harina de malta
 fi:mallasjauho
 fr:farine de malt
 sv:maltmjöl
@@ -25320,6 +25316,7 @@ fi:ohramallasjauho
 fr:farine de malt d'orge, farine d'orge malté
 hu:árpamalátaliszt
 it:farina di orzo maltato, farina d'orzo maltato, farina di malto d'orzo
+nl:gerstemoutmeel
 sv:kornmaltmjöl, maltmjöl av korn
 
 <en:barley flour

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -32846,10 +32846,10 @@ sv:Trinatriumdifosfat, Trinatriumpyrofosfat, trinatriumvätedifosfat
 <en:diphosphates
 en:Tetrasodium diphosphate, Tetrasodium pyrophosphate, sodium pyrophosphate, e450iii
 ar:بيروفوسفات صوديوم
-bg:Тетранатриев дифосфат, Тетранатриев пирофосфат, тетранатриев дифосфат
+bg:Тетранатриев дифосфат, Тетранатриев пирофосфат
 cs:Difosforečnan sodný, Pyrofosforečnan tetrasodný
-da:Tetranatriumdiphosphat, Tetranatriumpyrophosphat, tetranatriumdiphosphat
-de:Tetranatriumdiphosphat, Tetranatriumpyrophosphat, Tetranatriumdiphosphat
+da:Tetranatriumdiphosphat, Tetranatriumpyrophosphat
+de:Tetranatriumdiphosphat, Tetranatriumpyrophosphat
 el:Πυροφωσφορικο νατριο, Πυροφωσφορικό άλας νατρίου, διφωσφορικό νάτριο
 eo:Natria pirofosfato
 es:Difosfato tetrasódico, Pirofosfato tetrasódico, difosfato de tetrasodio
@@ -32859,17 +32859,17 @@ fi:Tetranatriumdifosfaatti, Natriumpyrofosfaatti
 fr:diphosphate tétrasodique, Pyrophosphate de sodium, pyrophosphate de soude, pyrophosphate acide de sodium
 hu:Tetranátrium-difoszfát, Tetranátrium-pirofoszfát, Tetranátrium-difoszfát
 it:Difosfato tetrasodico, Pirofosfato tetrasodico, disfosfato tetrasodico, Pirofosfato di sodio
-lt:Tetranatrio difosfatas, Tetranatrio pirofosfatas, tetranatrio difosfatas
-lv:Tetranātrija difosfāts, Tetranātrija pirofosfāts, Tetranātrija difosfāts
+lt:Tetranatrio difosfatas, Tetranatrio pirofosfatas
+lv:Tetranātrija difosfāts, Tetranātrija pirofosfāts
 mt:Difosfat tetrasodiku, Pirofosfat tetrasodiku, Disfosfat tetrasodiku
 nl:Tetranatriumdifosfaat, Tetranatriumpyrofosfaat
 pl:Difosforan tetrasodowy, Pirofosforan czterosodowy, difosforan czterosodowy
 pt:Difosfato tetrassódico, Pirofosfato tetrassódico, difosfato de tetrassódio
-ro:Difosfat tetrasodic, Pirofosfat tetrasodic, Difosfat tetrasodic
+ro:Difosfat tetrasodic, Pirofosfat tetrasodic
 ru:Пирофосфат натрия
 sh:etranatrijum pirofosfat
-sk:Difosforečnan tetrasodný, Pyrofosforečnan tetrasodný, difosforečnan tetrasodný
-sl:Tetranatrijev difosfat, tetranatrijev pirofosfat, tetranatrijev difosfat
+sk:Difosforečnan tetrasodný, Pyrofosforečnan tetrasodný
+sl:Tetranatrijev difosfat, tetranatrijev pirofosfat
 sr:Tetranatrijum pirofosfat
 sv:Tetranatriumdifosfat, Tetranatriumpyrofosfat
 vi:Natri pyrophotphat

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -52794,31 +52794,6 @@ fr:moutarde forte
 <en:mustard
 fr:moutarde à l'ancienne
 
-# description:en:A spice commonly called star anise, staranise, star anise seed, Chinese star anise, or badiane that closely resembles anise in flavor is obtained from the star-shaped pericarps of the fruit of I. verum which are harvested just before ripening.  Star anise contains anethole, the same compound that gives the unrelated anise its flavor. Star anise is an ingredient of the traditional five-spice powder of Chinese cooking.
-
-<en:spice
-en:star anise
-ar:انيسون نجمي
-cs:Badyán
-da:Stjerneanis
-de:Sternanis
-es:Anis estrellado
-et:Tähtaniis
-eu:Txinatar anis
-fi:tähtianis, rusotähtianis
-fr:badiane, anise étoilé
-it:Anice stellato
-nl:steranijs
-ru:анис звёздчатый
-sv:Stjärnanis
-wikidata:en:Q1760637
-# ingredient/fr:badiane has 121 products in 3 languages @2019-04-26
-carbon_footprint_fr_foodges_ingredient:fr:Anis - Badiane
-carbon_footprint_fr_foodges_value:fr:2.7
-
-<en:star anise
-fr:anéthol de badiane
-
 # description:en:A PINK PEPPERCORN is a dried berry of the shrub Schinus molle, commonly known as the Peruvian peppertree. Although a peppercorn is the dried fruit of a plant from the genus Piper, pink peppercorns came to be called such because they resemble peppercorns, and because they, too, have a peppery flavour. As they are members of the cashew family, they may cause allergic reactions including anaphylaxis for persons with a tree nut allergy.
 
 <en:spice
@@ -52841,26 +52816,26 @@ wikipedia:en:https://en.wikipedia.org/wiki/Pink_peppercorn
 # ingredient/fr:baies-roses has 141 products in 5 languages @2019-04-16
 # usage:fr:épice (baies roses)
 
-# A spice commonly called star anise, staranise, star anise seed, Chinese star anise, or badian that closely resembles anise in flavor is obtained from the star-shaped pericarps of the fruit of I. verum which are harvested just before ripening.
+# description:en:A spice commonly called star anise, staranise, star anise seed, Chinese star anise, or badian that closely resembles anise in flavor is obtained from the star-shaped pericarps of the fruit of I. verum which are harvested just before ripening. Star anise contains anethole, the same compound that gives the unrelated anise its flavor. Star anise is an ingredient of the traditional five-spice powder of Chinese cooking.
 
 <en:spice
 en:star anise
 af:Steranys
-ar:ليسوم حقيقي
+ar:ليسوم حقيقي, انيسون نجمي
 az:Əsl badyan
 be:Бадзян сапраўдны
 bg:звездовиден анасон
 bo:གོ་སྙོད་ཟུར་བརྒྱད།
 ca:Anís estrellat
-cs:Badyáník pravý
+cs:Badyán, Badyáník pravý
 da:Stjerneanis
 de:Sternanis
 es:Anis estrellado
-et:harilik tähtaniisipuu
+et:Tähtaniis, harilik tähtaniisipuu
 eu:Txinatar anis
 fa:بادیان ختایی
 fi:tähtianis, rusotähtianis
-fr:anis étoilé
+fr:anis étoilé, badiane, badiane chinoise
 gl:Anís estrelado
 gu:બાદિયાન
 hi:चक्रफूल
@@ -52897,6 +52872,13 @@ zh:八角
 # yue:八角
 wikidata:en:Q1760637
 # fr:anis-étoilé has 72 products in 4 languages @2018-10-24
+# ingredient/fr:badiane has 121 products in 3 languages @2019-04-26
+carbon_footprint_fr_foodges_ingredient:fr:Anis - Badiane
+carbon_footprint_fr_foodges_value:fr:2.7
+
+<en:star anise
+fr:anéthol de badiane
+
 
 <en:spice
 nl:speculaaskruiden

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -31977,7 +31977,7 @@ eo:Acidpasto
 es:Masa madre
 fa:نان خمیر ترش
 fi:taikinajuuri, taikinanjuuri, hapantaikina
-fr:levain, levain naturel
+fr:levain, levain naturel, levain panaire
 he:מחמצת שאור
 hu:Kovász
 id:Adonan asam
@@ -31997,6 +31997,7 @@ sr:Кисело тесто
 sv:Surdeg
 zh:老麵
 # nap:Criscito
+wikidata:en:Q904889
 wikipedia:en:https://en.wikipedia.org/wiki/Sourdough
 
 <en:sourdough
@@ -32017,7 +32018,7 @@ fr:levain déshydraté et dévitalisé
 
 <en:sourdough
 en:wheat sourdough
-fr:levain de blé
+fr:levain de blé, levain panaire de blé
 de:Weizensauerteig
 es:masa madre de trigo, masa madre natural de trigo
 fi:vehnätaikinanjuuri, vehnähapantaikina
@@ -48578,6 +48579,8 @@ es:harina de garbanzo
 fi:kikhernejauho
 fr:farine de pois chiche, farine de pois chiches
 sv:kikärtsmjöl
+wikidata:en:Q651829
+wikipedia:en:https://en.wikipedia.org/wiki/Gram_flour
 
 <en:pea
 en:garden peas
@@ -52409,7 +52412,7 @@ nl:gemalen galangawortel, laos
 
 # <en:root vegetable
 <en:spice
-en:ginger, stem ginger
+en:ginger, stem ginger, ginger root
 af:Gemmer
 ak:kakadro, Kakaduro
 am:ዝንጅብል
@@ -60777,8 +60780,9 @@ wikidata:en:Q783575
 
 
 # <en:cod
-
-fr:œufs de cabillaud, oeufs de cabillaud
+<en:roe
+en:cod roe
+fr:œufs de cabillaud, oeufs de cabillaud, œufs de morue
 vegetarian:en:no
 vegan:en:no
 # ingredient/fr:œufs-de-cabillaud has 69 products in french @2018-12-29

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -6335,7 +6335,6 @@ cy:Cynnyrch llaeth
 da:Mejeriprodukter
 de:Milcherzeugnisse, Milchprodukte, Molkereiprodukte, Milcherzeugnis, Milchprodukt, Molkereiprodukt
 el:Γαλακτοκομικά προϊόντα
-en:Dairy product
 eo:Laktoprodukto
 es:productos lácteos, leche y sus derivados, leche y derivados, derivados lácteos, lácteos, lácteo
 et:Piimatoode
@@ -31593,7 +31592,7 @@ fr:maltodextrine fumée
 
 <en:maltodextrin
 en:tapioca maltodextrin
-de:Tapiokastärke, Tapioka Maltodextrin,Tapioka-Maltodextrin
+de:Tapioka Maltodextrin,Tapioka-Maltodextrin
 es:Maltodextrina de tapioca
 fi:tapiokamaltodekstriini
 fr:maltodextrine de tapioca, malto-dextrine de tapioca
@@ -59209,7 +59208,7 @@ ca:pinetell de calceta, Suillus luteus
 co:Pinaghjolu, Suillus luteus
 cs:klouzek obecný
 cy:Boled llithrig, Suillus luteus
-de:Butterpilze, Butterpilze, Suillus luteus
+de:Butterpilze, Suillus luteus
 et:Võitatik, Suillus luteus
 fi:Voitatti, Suillus luteus
 fr:bolet jaune, bolets jaunes, Suillus luteus, Boletus luteus
@@ -59333,7 +59332,7 @@ sv:rekonstituerad svart champinjon
 # description:en:PLEUROTUS OSTREATUS, the oyster mushroom, is a common edible mushroom.
 
 <en:mushroom
-en:oyster mushroom, straw mushroom
+en:oyster mushroom
 ba:Ҡарама бәшмәге
 be:Вешанка звычайная
 bg:кладница

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -4543,7 +4543,7 @@ fi:neohesperidiinidihydrokalkoni, neohesperidiini DC
 fr:Néohespéridine dihydrochalcone, néohespéridine dc
 gl:Neohesperidina dihidrocalcona
 hu:Neoheszperidin-dihidro-kalkon
-it:neoesperidina diidrocalcone, Neoesperidina diidrocalcone
+it:neoesperidina diidrocalcone
 lt:Neohesperidinas dc
 lv:Neohesperidīns dc
 mt:Neoesperidina diidroċalkon
@@ -5543,7 +5543,7 @@ en:bifidus actiregularis, b. actiregularis
 bg:Bifidus ActiRegularis
 de:Bifidus ActiRegularis, Bifidus Kultur ActiRegularis
 fi:bifidus actiregularis
-fr:Bifidus actiregularis, bifidus actiregularis
+fr:bifidus actiregularis
 hu:bifidus actiregularis
 la:bifidus actiregularis
 nl:Bifidus Actiregularis
@@ -12392,7 +12392,7 @@ fi:B8-vitamiini, B8
 fr:vitamine b8, b8
 hu:B8-vitamin, B8
 it:vitamina b8, B8
-pl:Witamina B8, witamina B8, B8
+pl:witamina B8, B8
 # ingredient/vitamin-b8 has 35 products in 3 languages @2018-11-24
 
 
@@ -12591,7 +12591,7 @@ et:C-vitamiin, Askorbiinhape
 eu:C bitamina
 fa:ویتامین ث
 fi:C-vitamiini, askorbiinihappo, ascorbiinihappo
-fr:vitamine C, acide ascorbique, acide L-ascorbique, acide l-ascorbique, antioxydant e300
+fr:vitamine C, acide ascorbique, acide L-ascorbique, antioxydant e300
 gl:Vitamina C, Ácido ascórbico
 he:ויטמין C
 hi:विटामिन सी
@@ -13426,7 +13426,7 @@ en:Salt from Guérande
 ca:Sal de Guérande
 de:Salz aus Guérande
 es:Sal de Guérande
-fr:Sel de Guérande, sel de guérande, sel marin de guérande, sel de Guérande IGP
+fr:Sel de Guérande, sel marin de guérande, sel de Guérande IGP
 nl:Zout uit Guérande
 
 <en:sea salt
@@ -16049,7 +16049,7 @@ fr:amidon de pommes de terre, amidon de pomme de terre, fécule de pommes de ter
 hu:burgonyakeményítő
 id:Tepung kentang
 is:kartöflusterkja
-it:Fecola di patate, amido di patata, amido di patate, fecola di patate
+it:fecola di patate, amido di patata, amido di patate
 ja:片栗粉
 ko:감자 녹말
 ms:Kanji kentang
@@ -17814,7 +17814,7 @@ fi:avokadoöljy
 fr:huile d'avocat
 hu:avokádóolaj
 it:olio di avocado
-pl:Olej z awokado, olej z awokado
+pl:olej z awokado
 from_palm_oil:en:no
 
 # description:en:CORN OIL (maize oil) is oil extracted from the germ of corn (maize).
@@ -18303,7 +18303,7 @@ ca:oli de gira-sol, oli vegetal de gira-sol,oli de girasol, oli vegetal de giras
 cs:Slunečnicový olej
 da:solsikkeolie
 de:Sonnenblumenöl
-el:ηλιέλαιο, Ηλιέλαιο
+el:ηλιέλαιο
 es:aceite de girasol,aceite vegetal de girasol,aceite de semillas de girasol,aceite de maravilla
 et:Päevalilleõli
 eu:ekilore-olio
@@ -18759,7 +18759,7 @@ vegetarian:en:no
 
 <en:poultry fat
 en:duck fat
-da:Andefedt, andefedt
+da:andefedt
 de:Entenfett
 es:grasa de pato
 fi:ankanrasva
@@ -19032,7 +19032,7 @@ ar:خل بلسميك
 bs:Balzamovo sirće
 ca:Vinagre balsàmic
 cs:Balzámový ocet
-da:Balsamicoeddike, balsamicoeddike
+da:balsamicoeddike
 de:Aceto balsamico, Balsamessig
 eo:Balzamvinagro
 es:Aceto balsámico,vinagre balsamico,vinagre balsamico de modena
@@ -20846,7 +20846,7 @@ nl:calvados
 
 <en:alcohol
 en:rum
-da:Rom, rom
+da:rom
 de:Rum
 es:Ron
 fi:rommi
@@ -20854,7 +20854,7 @@ fr:rhum
 hu:rum
 it:rum
 nl:Rum
-pl:Rum, rum
+pl:rum
 ru:Ром
 sv:rom
 
@@ -23450,7 +23450,7 @@ ay:Siwara
 az:Adi arpa
 ba:Арпа
 be:Ячмень звычайны
-bg:ечемик, Ечемик, ечемичен
+bg:ечемик, ечемичен
 bn:যব
 bo:ནས།
 br:Heiz
@@ -25676,7 +25676,7 @@ ay:Tunqu
 az:Qarğıdalı
 ba:Шәкәр кукурузы
 be:Кукуруза
-bg:царевица, Царевица
+bg:царевица
 bi:Corn
 bm:Kaba
 bn:ভুট্টা
@@ -25734,7 +25734,7 @@ lb:Mais
 li:Meis
 ln:Lisángú
 lt:kukurūzai, Paprastasis kukurūzas
-lv:kukurūza, Kukurūza
+lv:kukurūza
 mg:Katsaka
 mk:Пченка
 ml:ചോളം
@@ -27718,7 +27718,7 @@ es:Azúcar de palma
 fi:Palmusokeri
 fr:sucre de palme
 it:Zucchero di palma
-pl:Cukier palmowy, cukier palmowy
+pl:cukier palmowy
 
 <en:unrefined sugar
 <en:palm sugar
@@ -28652,7 +28652,7 @@ fr:sirop de candi, sirop de sucre candi
 
 # nova:en:maple-syrup
 en:maple syrup
-da:Ahornsirup, ahornsirup
+da:ahornsirup
 de:Ahornsirup
 fi:vaahterasiirappi
 fr:sirop d’érable
@@ -30933,11 +30933,11 @@ ar:ماء مكربن
 az:Qazlı su
 bs:Soda voda
 ca:Aigua carbonatada
-cs:Sodovka, Sodová voda, sodovka, sifon, sycená, perlivá voda
+cs:sodovka, Sodová voda, sifon, sycená, perlivá voda
 da:Danskvand
 de:Tafelwasser
 ee:Gaseeritud vesi, karboniseeritud vesi, mulliga vesi
-el:Σόδα, σόδα
+el:σόδα
 eo:Karbonata akvo
 es:Agua carbonatada
 fi:soodavesi, hiilihapotettu vesi
@@ -31576,7 +31576,7 @@ es:Gasificante, Agente leudante, agentes gasificantes,gasificantes,leavenings,le
 et:Kergitusaine
 fa:عامل ورآورنده
 fi:nostatusaine, nostatusaineet
-fr:Agent levant, agent de levuration, agent levant, agents levants,agents de levage
+fr:agent levant, agent de levuration, agents levants, agents de levage
 ga:Oibreán éiritheach
 he:התפחה
 hu:Térfogatnövelő szer
@@ -31638,12 +31638,12 @@ gl:Lévedo
 he:שמרים
 hi:खमीर
 hr:Kvasac
-hu:élesztő, Élesztő
+hu:élesztő
 hy:Խմորասնկեր
 id:Khamir
 io:Hefo
 is:Ger
-it:lievito, Lievito
+it:lievito
 ja:酵母
 jv:Khamir
 ka:საფუარები
@@ -31656,7 +31656,7 @@ mk:Квасец
 ml:യീസ്റ്റ്
 ms:Yis
 nb:Gjær
-nl:gist, Gist
+nl:gist
 nn:Gjær
 pa:ਖ਼ਮੀਰ
 pl:Drożdże
@@ -31784,7 +31784,7 @@ bg:Мая
 ca:Llevat de forner
 de:Backhefe
 el:Μαγιά αρτοποιίας
-es:levadura de panadería, Levadura de panadería
+es:levadura de panadería
 et:Pärm, Pinnakääritamine
 fa:مخمر نان, ساکارومایسس سرویزیه
 fi:leivinhiiva, oluthiiva, viinihiiva
@@ -32145,7 +32145,7 @@ da:Dikaliumphosphat, Dikaliummonophosphat, sekundært kaliumphosphat, dikaliumor
 de:Dikaliumphosphat
 el:Οξινο φωσφορικο καλιο, Όξινο ορθοφωσφορικό κάλιο
 eo:Kalia fosfato dubaza
-es:Fosfato dipotásico, fosfato dipotásico
+es:fosfato dipotásico
 et:Dikaaliumvesinikfosfaat
 fa:دی‌پتاسیم فسفات
 fi:dikaliumfosfaatti
@@ -35303,7 +35303,7 @@ fr:jus de pomme à base de concentré, jus de pomme à base de jus concentré, J
 hu:sűrített almalé, almalé sűrítmény, almalé koncentrátum, almalé koncentrátumból
 it:succo di mele a base di concentrato
 nl:appelsap uit concentraat
-pl:Sok jabłkowy z koncentratu, sok jabłkowy z koncentratu
+pl:sok jabłkowy z koncentratu
 sv:äppeljuice från koncentrat
 # ingredient/fr:jus-de-pomme-à-base-de-concentré has 240 products @2018-10-04
 
@@ -35897,7 +35897,7 @@ fr:jus de citron à base de concentré, jus de citron reconstitué, jus de citro
 hu:citromlé koncentrátum
 it:succo di limone da concentrato
 nl:citroensap uit concentraat
-pl:Sok cytrynowy z koncentratu, sok cytrynowy z koncentratu
+pl:sok cytrynowy z koncentratu
 sv:citronjuice från koncentrat, citronsaft från koncentrat
 
 
@@ -36714,7 +36714,7 @@ fi:akerola, acerola
 fr:acérola
 it:acerola
 nl:acerola
-pl:Acerola, acerola
+pl:acerola
 ru:Ацерола
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/acerola
 # 133 products in 4 languages @2018-10-03
@@ -36728,7 +36728,7 @@ fi:akerola-uute, acerola-uute
 fr:extrait d'acérola, jus concentré d'acérola, extrait sec d'acérola
 it:estratto d'acerola
 nl:acerola-extract
-pl:Sok z aceroli, sok z aceroli
+pl:sok z aceroli
 ru:Сок ацеролы
 # ingredient/acerola-juice has 18 products in 2 languages @2018-10-03
 # en:process:en:powdered
@@ -38886,7 +38886,7 @@ fi:ananasmehu
 fr:jus d'ananas
 it:succo di ananas
 nl:Ananassap
-pl:Sok ananasowy, sok ananasowy, Sok z ananasa, sok z ananasa
+pl:sok ananasowy, sok z ananasa
 ru:Ананасовый сок
 sv:ananasjuice
 zh:菠萝汁
@@ -38917,7 +38917,7 @@ fi:ananasmehu tiivisteestä
 fr:jus d'ananas à base de concentré, Jus d'ananas à base de jus d'ananas concentré, Jus d'ananas à base de jus concentré
 it:succo d'ananas a base di concentrato
 nl:Ananassap van concentraat
-pl:Sok ananasowy z koncentratu, sok ananasowy z koncentratu
+pl:sok ananasowy z koncentratu
 # ingredient/fr:jus-d'ananas-à-base-de-concentré has 96 products in 3 languages @2018-09-30
 
 <en:pineapple
@@ -44583,7 +44583,7 @@ nl:rode ui, rode uien
 nn:raudlauk
 or:ନାଲି ପିଆଜ
 pa:ਲਾਲ ਪਿਆਜ਼
-pl:Czerwona cebula, czerwona cebula
+pl:czerwona cebula
 ro:ceapă roșie
 ru:красный лук
 sq:qepë e kuqe
@@ -46849,7 +46849,7 @@ nl:tomatenblokjes in tomatensap van biologische oorsprong
 
 <en:chopped tomatoes
 en:crushed tomato
-da:Flåede tomater, flåede tomater
+da:flåede tomater
 de:stückige Tomaten, Tomaten stückig
 el:πουρές τομάτας
 es:Puré de tomate
@@ -49728,7 +49728,7 @@ en:peanut paste
 
 <en:peanut
 en:roasted peanuts
-da:Ristede peanuts, ristede peanuts
+da:ristede peanuts
 de:geröstete Erdnüsse
 es:cacahuetes tostados
 fi:paahdettu maapähkinä, paahdetut maapähkinät
@@ -50247,7 +50247,7 @@ vegetarian:en:yes
 <en:seed
 <en:chia
 en:chia seed, chia seeds
-da:Chiafrø, chiafrø
+da:chiafrø
 de:Chiasamen
 es:semillas de chia
 fi:chia-siemen, chia-siemenet, chiansiemen
@@ -50402,7 +50402,7 @@ fi:kurpitsansiemen, kurpitsansiemenet
 fr:graine de courge, graines de courge, graines de potiron, graines de citrouille
 it:semi di zucca
 nl:pompoenpitten
-pl:Nasiona dyni, nasiona dyni
+pl:nasiona dyni
 sv:pumpafrön, pumpakärnor
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:graine-de-courge
 # 234 products in 5 languages @2018-10-07
@@ -53150,7 +53150,7 @@ ne:कागते घाँस
 nl:citroengras, Sereh
 or:ଲେମନ ଗ୍ରାସ୍
 pa:ਲੈਮਨ ਗਰਾਸ
-pl:Trawa cytrynowa, trawa cytrynowa
+pl:trawa cytrynowa
 pt:erva-principe
 sq:barishte
 sr:Лимун-трава
@@ -54433,7 +54433,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Marjoram
 ###################################################################################################
 <en:herb
 en:herbes de Provence
-da:Herbes de Provence, herbes de Provence
+da:herbes de Provence
 de:Provence-Kräuter, Kräuter der Provence
 es:Hierbas de Provenza
 fi:herbes de provence
@@ -57242,7 +57242,7 @@ fr:extrait de thé vert, extraits de thé vert, infusion concentrée de thé ver
 it:estratto di te verde
 kk:кек шай сығындысы
 nl:groene thee-extract
-pl:Ekstrakt z zielonej herbaty, ekstrakt z zielonej herbaty
+pl:ekstrakt z zielonej herbaty
 pt:extrato de ché verde
 ru:экстракт зеленого чая
 sv:grönt te-extrakt
@@ -67634,7 +67634,7 @@ sv:kycklingfond
 
 <en:chicken meat
 en:chicken fillet
-da:Kyllingefilet, kyllingefilet
+da:kyllingefilet
 de:Hühnerfilet
 es:Filete de pechuga de pollo
 fi:kanafilee
@@ -68942,7 +68942,7 @@ fr:extraits végétaux à pouvoir colorant
 # <en:ingredients_processing:en:concentrated
 en:concentrate, concentrated, from concentrate
 ar:مركز
-da:Koncentrat, koncentrat, fra koncentrat
+da:koncentrat, fra koncentrat
 de:Konzentrat, aus Konzentrat
 es:concentrado
 fa:کنسانتره

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -59443,9 +59443,10 @@ wikipedia:en:https://en.wikipedia.org/wiki/Pleurotus_ostreatus
 
 
 # description:en:MARASMIUS OREADES, the Scotch bonnet, is also known as the fairy ring mushroom or fairy ring champignon.
+# comment:en:In English, "Scotch bonnet" usually means the pepper rather than the mushroom: https://en.wikipedia.org/wiki/Scotch_bonnet
 
 <en:Mushroom
-en:Scotch bonnet
+en:fairy ring mushroom, Scotch bonnet mushroom
 bg:обикновена челядинка
 ca:cama-sec
 cs:špička obecná

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -21311,10 +21311,15 @@ hu:természetes bodza aroma
 
 <en:natural flavouring
 en:natural tarragon flavouring
+es:aroma natural de estragón
 de:natürliches Estragonaroma, natürliches Estragon-Aroma
 fi:luontainen rakuuna-aromi
-fr:arôme naturel d'estragon
+fr:arôme naturel d'estragon, arome naturel d'estragon
 hu:természetes tárkony aroma
+
+<en:natural tarragon flavouring
+fr:arôme naturel d'estragon avec autres arômes naturels
+fi:luontainen rakuuna-aromi ja muut luontaiset aromit
 
 <en:natural flavouring
 fr:arôme naturel de sucre roux
@@ -21488,18 +21493,6 @@ de:natürliches Lorbeeraroma, natürliches Lorbeer-Aroma
 fi:luontainen laakerinlehtiaromi
 fr:arôme naturel de laurier, arome naturel de laurier
 hu:természetes babér aroma
-
-<en:natural flavouring
-en:natural estragon flavouring
-de:natürliches Estragonaroma, natürliches Estragon-Aroma
-es:aroma natural de estragón
-fi:luontainen rakuuna-aromi
-fr:arôme naturel d'estragon, arome naturel d'estragon
-hu:természetes tárkony aroma
-
-<en:natural estragon flavouring
-fr:arôme naturel d'estragon avec autres arômes naturels
-fi:luontainen rakuuna-aromi ja muut luontaiset aromit
 
 <en:natural flavouring
 en:natural paprika flavor, natural flavor of paprika

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -18815,7 +18815,7 @@ it:grasso d'oca
 
 # VINAIGRE is a liquid consisting of about 5–20% acetic acid (CH3COOH)[citation needed], water (H2O), and trace chemicals that may include flavorings.
 
-en:vinegar, white vinegar
+en:vinegar
 af:Asyn
 an:Vinagre
 ar:خل
@@ -18836,7 +18836,7 @@ et:Äädikas
 eu:Ozpin
 fa:سرکه
 fi:Etikka
-fr:vinaigre, vinaigres, vinaigre blanc
+fr:vinaigre, vinaigres
 fy:Jittik
 ga:Fínéagar
 gl:Vinagre
@@ -18905,6 +18905,7 @@ zh:醋
 # vec:Axedo
 # vls:Azyn
 # war:Suoy
+wikidata:en:Q41354
 wikipedia:en:https://en.wikipedia.org/wiki/Vinegar
 vegan:en:yes
 vegetarian:en:yes
@@ -18913,6 +18914,7 @@ carbon_footprint_fr_foodges_value:fr:4.2
 
 <en:vinegar
 en:white vinegar
+fr:vinaigre blanc
 
 <en:vinegar
 en:distilled vinegar
@@ -19059,13 +19061,15 @@ ru:Бальзамический уксус
 sv:Balsamvinäger
 uk:Бальзамічний оцет
 zh:意大利香醋
-wikidata:en:Q618322
+wikidata:en:Q170037
 wikipedia:en:https://en.wikipedia.org/wiki/Balsamic_vinegar
 
 <en:balsamic vinegar
 en:balsamic vinegar of modena, modena balsamic vinegar
 fr:vinaigre balsamique de modène
 it:aceto balsamico di modena
+wikidata:en:Q3604285
+wikipedia:en:https://en.wikipedia.org/wiki/Balsamic_vinegar_of_Modena
 
 <en:balsamic vinegar
 en:white balsamic vinegar

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -28371,7 +28371,7 @@ wikidata:en:Q14770547
 en:dehydrated glucose syrup, powdered glucose syrup, dried glucose syrup
 da:tørret glukosesirup
 de:getrockneter Glukosesirup, dehydrierter Glukosesirup
-es:Sirope deshidratado de glucosa
+es:Sirope deshidratado de glucosa, jarabe de glucosa deshidratado
 fi:kuivattu glukoosisiirappi
 fr:sirop de glucose déshydraté, sirop de glucose en poudre
 hu:dehidratált glükózszirup, szárított glükózszirup, dehidratált glükóz szirup, szárított glükóz szirup
@@ -28389,10 +28389,6 @@ nl:tarweglucosestrooppoeder
 sv:glukossirap från vetemjöl
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-de-glucose-de-blé-en-poudre
 # 49 products in 3 languages @2018-09-24
-
-<en:glucose syrup
-en:dried glucose syrup
-es:jarabe de glucosa deshidritado
 
 <en:corn syrup
 <en:glucose

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -29243,15 +29243,6 @@ nl:gehydrolyseerde plantaardige eiwitten
 # ingredient/fr:protéines-végétales-réhydratées has 32 products in french @2019-03-11
 
 <en:vegetable protein
-fr:protéines de blé
-
-<fr:protéines de blé
-fr:protéines de blé déshydratées
-
-<fr:protéines de blé
-fr:protéines de blé partiellement hydrolysées
-
-<en:vegetable protein
 en:pea protein
 da:Ærteprotein
 de:Erbsenprotein
@@ -29404,6 +29395,12 @@ it:proteine del grano
 nl:graneneiwit
 pt:proteína de trigo
 sv:veteprotein
+
+<en:wheat protein
+fr:protéines de blé déshydratées
+
+<en:wheat protein
+fr:protéines de blé partiellement hydrolysées
 
 <en:wheat protein
 en:rehydrated wheat protein

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -6756,7 +6756,7 @@ eu:Esne
 fa:شیر
 fi:maito, maidosta
 fo:Mjólk
-fr:Lait, lait
+fr:Lait
 fy:Molke
 ga:Bainne
 gd:Bainne
@@ -6765,7 +6765,7 @@ gn:Kamby
 gu:દૂધ
 gv:Bainney
 he:חלב
-hr:Mlijeko, mlijeko
+hr:Mlijeko
 ht:Lèt
 hu:Tej, Tejet
 hy:Կաթ
@@ -6775,7 +6775,7 @@ ik:Immuk
 is:Mjólk
 it:Latte
 iu:ᐃᒻᒧᒃ
-ja:乳, 乳
+ja:乳
 jv:Susu
 ka:რძე
 kk:Сүт
@@ -6802,7 +6802,7 @@ ne:दूध
 nl:melk
 nn:Mjølk
 nv:Abeʼ
-oc:Lach, lach, lait, lèit
+oc:Lach, lait, lèit
 or:କ୍ଷୀର
 pa:ਦੁੱਧ
 pl:Mleko
@@ -6824,7 +6824,7 @@ sr:Млеко
 su:Susu
 sv:Mjölk
 sw:Maziwa
-ta:பால், பால்
+ta:பால்
 te:పాలు
 tg:Шир
 th:นม
@@ -7206,12 +7206,14 @@ carbon_footprint_fr_foodges_value:fr:1.2
 en:organic UHT pasteurised semi-skimmed milk
 ca:llet semidesnatada ecològica esterilitzada UHT, llet parcialment desnatada ecològica esterilitzada UHT
 es:leche semidesnatada ecológica esterilizada UHT, leche parcialmente desnatada ecológica esterilizada UHT
-fr:lait demi-écrémé issu de l'agriculture biologique stérilisé u h t
+fr:lait demi-écrémé issu de l'agriculture biologique stérilisé u h t, lait demi-écrémé biologique stérilisé uht
 
 <en:pasteurized skimmed milk
 en:organic pasteurized skimmed milk
 de:pasteurisierte entrahmte Bio-Milch
 fr:lait biologique écrémé et pasteurisé
+
+# comment:en:Is there a difference between pasteurized milk and sterilised milk?
 
 <en:semi-skimmed milk
 <en:sterilised milk
@@ -7220,10 +7222,6 @@ ca:llet parcialment desnatada esterilitzada, llet esterilitzada parcialment desn
 de:sterilisierte teilentrahmte Milch, teilentrahmte Milch sterilisiert
 es:leche parcialmente desnatada esterelizada, leche semidesnatada esterilizada, leche esterilizada parcialmente desnatada, leche esterilizada semidesnatada
 fr:lait demi-écrémé stérilisé
-
-<en:sterilised semi-skimmed milk
-en:organic UHT pasteurised semi-skimmed milk
-fr:lait demi-écrémé biologique stérilisé uht
 
 <en:semi-skimmed milk
 fr:lait de montagne partiellement écrémé
@@ -7338,7 +7336,7 @@ fr:lait entier stérilisé uht issu de l'agriculture biologique
 
 <en:whole milk
 <en:pasteurised milk
-en:pasteurised whole milk, pasteurised whole milk
+en:pasteurised whole milk, pasteurized whole milk
 ca:llet sencera pasteuritzada, llet pasteuritzada senceea
 de:pasteurisierte Vollmilch
 es:leche entera pasteurizada, leche pasteurizada entera
@@ -8764,9 +8762,9 @@ hu:tejszín
 io:Kremo
 is:Rjómi
 it:panna, crema di latte
-ja:クリーム, クリーム
+ja:クリーム
 kk:Кілегей
-ko:크림, 크림
+ko:크림
 ky:Каймак
 la:Cramum
 lb:Rahm, Ram, Schmant
@@ -8790,14 +8788,14 @@ so:Labeen
 sq:Pana
 sv:Grädde
 sw:Samli
-ta:பாலாடை, பாலாடை
+ta:பாலாடை
 te:మీగడ
 th:ครีม
 tr:Krema
 uk:Вершки
 ur:ملائی
 uz:Qaymoq
-vi:Kem, Kem
+vi:Kem
 zh:鮮奶油, 奶油
 # ast:Crema de lleche
 # bar:Rahm
@@ -8840,7 +8838,7 @@ de:Cremepulver, Sahnepulver
 es:nata en polvo, crema de llet en polvo
 et:koorepulber
 fi:kermajauhe
-fr:crème en poudre, crème en poudre, poudre de crème
+fr:crème en poudre, poudre de crème
 hu:tejszínpor
 it:panna in polvere
 nl:roompoeder, poederroom
@@ -11103,7 +11101,7 @@ de:Raclette
 eo:Rakledo
 es:raclette
 fi:Raclette
-fr:raclette, Raclette
+fr:Raclette
 he:רקלט
 hu:Raclette, Raclette sajt
 hy:Ռակլետ

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -7410,7 +7410,6 @@ fi:lehmän raakamaito, raaka lehmänmaito
 fr:lait de vache cru, lait cru de vache
 hu:nyers tehéntej
 nl:rauwe koemelk
-ru:коровье молоко
 sv:opastöriserad komjölk
 
 <en:cow's milk
@@ -16060,7 +16059,7 @@ pl:Mąka ziemniaczana
 pt:fecula de batata
 ro:amidon din cartofi, amidon de cartofi
 ru:Картофельный крахмал
-sv:potatismjöl, potatisstärkelse
+sv:potatisstärkelse
 uk:Картопляний крохмаль
 zh:太白粉
 wikipedia:en:https://en.wikipedia.org/wiki/Potato_starch
@@ -16686,7 +16685,6 @@ nl:gefractioneerd melkvet
 en:butterfat, pastry butter, anhydrous milk fat, concentrated butter, butter oil, anhydrous butter
 bg:безводно масло
 bs:mliječna mast
-cs:mléčný tuk
 cy:braster menyn
 da:smørfedt, smørolie
 de:Butterreinfett, wasserfreies Milchfett
@@ -16994,7 +16992,7 @@ he:שמן ושומן דקלים
 hu:pálmaolaj és -zsír, pálmaolaj és pálmazsír, pálmaolaj és zsír
 it:olio e grasso di palma
 nl:palm olie en vet
-pl:Tłuszcz palmowy
+pl:Olej i tłuszcz palmowy
 ru:Пальмовое масло и жирр
 sv:Palmolja och fett
 uk:Пальмова олія і жири
@@ -20485,7 +20483,6 @@ de:Marsala
 es:Marsala
 fi:marsala, marsala-viini
 fo:Marsalavín
-fi:Marsala
 fr:vin marsala, vin Marsala AOC, marsala
 hr:Marsala
 hu:Marsala
@@ -21010,7 +21007,6 @@ vegetarian:en:maybe
 
 <en:flavouring
 en:artificial flavouring, artificial flavour, artificial flavor, artificial flavoring
-ca:Oli i greix de palma
 da:kunstig smag
 de:künstliches Aroma
 es:aroma artificial, saborizante artificial,sabor artificial
@@ -27122,7 +27118,7 @@ de:Xanthan und Guarkernmehl
 es:goma xantana y goma guar,goma guar, goma xantica
 fi:ksantaanikumi ja johanneksenleipäpuujauhe
 fr:gomme xanthane et gomme guar, gomme xanthane et gomme de guar
-hu:xantángumi
+hu:xantángumi és guargumi
 
 <en:gum arabic
 de:Verdickungsmittel Gummi arabicum
@@ -28533,16 +28529,11 @@ openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-and-fructose-sy
 # 5775 products in 21 languages @2018-09-24
 
 <en:wheat
-<en:fructose syrup
-<en:glucose syrup
+<en:glucose-fructose syrup
 en:wheat glucose-fructose syrup
 de:Glukose-und Fruktosesirup (Weizen)
 fr:sirop de glucose-fructose de blé
 nl:glucose-fructosestroop van tarwe
-ru:глюкозно-фруктозный сироп
-sk:glukózový-fruktózový sirup
-sr:glukozno-fruktozni sirup
-sv:glukos-fruktossirap
 openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-and-fructose-syrup
 openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-de-glucose-fructose-de-blé
 # 271 products in 4 languages @2018-09-24
@@ -28696,8 +28687,6 @@ vegetarian:en:yes
 fr:sirop de sucres issus de fruits
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:sirop-de-sucres-issus-de-fruits
 # 22 products @2019-05-30
-
-fr:sirop de sucre candi
 
 
 <en:sugar
@@ -46892,7 +46881,6 @@ carbon_footprint_fr_foodges_value:fr:2.9
 
 <en:tomato
 en:tomato purée, tomato paste, tomato concentrate
-ca:Llet en pols
 da:tomatpuré, tomatpure, tomatkoncentrat
 de:Tomatenmark, Tomatenkonzentrat, Tomatenpüree, Tomatenmark einfach konzentriert
 es:concentrado de tomate, pasta de tomate, tomate-concentrado
@@ -49044,7 +49032,6 @@ fi:luomumanteli, luomumantelit, luomu manteli, luomu mantelit
 
 <en:almond
 en:almond with skin
-da:mandel
 de:Mandeln mit Haut
 es:almendra con piel
 fi:kuorellinen manteli
@@ -56998,7 +56985,6 @@ fr:the de ceylan
 
 <en:tea
 en:tea extract
-af:swart tee
 da:te-ekstrakt
 de:Tee-Extrakt
 es:Extracto de té
@@ -68602,9 +68588,6 @@ fr:blanc d'oeuf en poudre pasteurisé
 
 <en:powdered egg white
 nl:scharrelei-eiwitpoeder
-
-<en:powdered egg white
-nl:vrije uitloopeiwitpoeder
 
 <en:powdered egg white
 fr:blanc d'oeuf en poudre de poules élevées au sol

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -23405,74 +23405,6 @@ fi:kypsennetty bulgur, kypsennetty bulgurvehnä
 fr:boulgour cuit
 hu:főtt bulgur
 
-# Bread crumbs or breadcrumbs (regional variants:breading, crispies) are sliced residue of dry bread, used for breading or crumbing foods.
-
-# This is a compound ingredient, e.g.:chapelure (farine de blé, levure, sel)
-
-en:bread crumbs
-ar:بقسماط
-be:Паніровачныя сухары
-bg:Галета
-ca:farina de galeta
-cs:strouhanka
-da:Rasp
-de:Paniermehl
-el:ψίχουλα ψωμιού
-eo:raspaĵo
-es:pan rallado, migaja de pan rallado
-eu:Ogi birrindu
-fa:آرد سوخاری
-fi:Korppujauho
-fr:chapelure
-gl:Pan relado
-he:פירורי לחם
-hu:kenyérmorzsa
-id:Tepung roti
-io:Raspo-pano
-it:pane grattugiato
-ja:パン粉
-ko:빵가루
-lt:Malti džiūvėsiai
-nb:Strøkavring
-nl:paneermeel
-pl:Bułka tarta
-pt:pão ralado
-ru:Панировочные сухари
-sk:Strúhanka
-sv:Ströbröd, brödsmulor
-uk:Паніровка
-vi:Vụn bánh mì
-zh:麵包屑
-# eml:Pan radû
-# pt-br:farinha de rosca
-# yue:麪包糠
-wikidata:en:Q658413
-wikipedia:en:https://en.wikipedia.org/wiki/Bread_crumbs
-vegan:en:maybe
-vegetarian:en:maybe
-# fr:chapelure has 2441 products in 7 languages @2018-11-12
-
-<en:bread crumbs
-fr:chapelure de blé
-de:Weizenpaniermehl
-# fr:chapelure-de-blé has 185 products in 2 languages @2018-11-12
-
-<en:bread crumbs
-en:panko
-da:panko
-de:panko
-es:panko
-fr:panko
-it:panko
-nl:panko
-ru:Панко
-wikidata:en:Q1820454
-# en:panko has 20 products in english @2018-11-12
-
-<en:bread crumbs
-de:Panade
-# de:comment:Panade (Weizenmehl, Sonnenblumenöl, Salz, Hefe, Gewürz Paprika)
-
 ##################################################################################
 #
 #                        Emmer
@@ -71085,29 +71017,30 @@ fr:chocolat noir de couverture
 fr:intérieur cône
 
 # description:en:BREAD CRUMBS are sliced residue of dry bread, used for breading or crumbing foods, topping casseroles, stuffing poultry, thickening stews, adding inexpensive bulk to soups, meatloaves and similar foods, and making a crisp and crunchy covering for fried foods, especially breaded cutlets like tonkatsu and schnitzel.
+# This is a compound ingredient, e.g.:chapelure (farine de blé, levure, sel)
 
 <en:coating
 en:bread crumbs, breadcrumbs
 ar:بقسماط
 be:Паніровачныя сухары
 bg:Галета
-ca:pa ratllat
+ca:pa ratllat, farina de galeta
 cs:strouhanka
 da:Rasp
 de:Paniermehl, Panur, Semmelbrösel
 el:ψίχουλα ψωμιού
 eo:raspaĵo
-es:pan rallado,migas de pan
+es:pan rallado, migas de pan, migaja de pan rallado
 eu:Ogi birrindu
 fa:آرد سوخاری
 fi:korppujauho, paneerausjauho, leivite
 fr:Chapelure, panure, Chapelures
 gl:Pan relado
 he:פירורי לחם
-hu:zsemlemorzsa
+hu:zsemlemorzsa, kenyérmorzsa
 id:Tepung roti
 io:Raspo-pano
-it:pangrattato
+it:pangrattato, pane grattugiato
 ja:パン粉
 ko:빵가루
 lt:Malti džiūvėsiai
@@ -71117,7 +71050,7 @@ pl:panierka, Bułka tarta
 pt:pão ralado
 ru:Панировочные сухари
 sk:Strúhanka
-sv:panering, ströbröd, paneringsmjöl
+sv:panering, ströbröd, paneringsmjöl, brödsmulor
 uk:Паніровка
 vi:Vụn bánh mì
 zh:麵包屑
@@ -71127,10 +71060,34 @@ zh:麵包屑
 wikidata:en:Q658413
 wikipedia:en:https://en.wikipedia.org/wiki/Bread_crumbs
 # ingredient/fr:panure has 462 products in 6 languages @2019-05-17
+vegan:en:maybe
+vegetarian:en:maybe
+# fr:chapelure has 2441 products in 7 languages @2018-11-12
 
 <en:breadcrumbs
 en:wholemeal breadcrumbs
 es:pan rallado integral
+
+<en:bread crumbs
+fr:chapelure de blé
+de:Weizenpaniermehl
+# fr:chapelure-de-blé has 185 products in 2 languages @2018-11-12
+
+<en:bread crumbs
+en:panko
+da:panko
+de:panko
+es:panko
+fr:panko
+it:panko
+nl:panko
+ru:Панко
+wikidata:en:Q1820454
+# en:panko has 20 products in english @2018-11-12
+
+<en:bread crumbs
+de:Panade
+# de:comment:Panade (Weizenmehl, Sonnenblumenöl, Salz, Hefe, Gewürz Paprika)
 
 # <en:compound
 fr:pain de mie au blé malté

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -7407,7 +7407,7 @@ wikipedia:fr:https://fr.wikipedia.org/wiki/Lait_de_vache
 en:raw cow's milk
 ca:llet crua de vaca, llet de vaca crua
 de:Kuhrohmilch
-es:leche de vaca cruda, leche cruda de vaca, leche de vaca cruda
+es:leche de vaca cruda, leche cruda de vaca
 fi:lehmän raakamaito, raaka lehmänmaito
 fr:lait de vache cru, lait cru de vache
 hu:nyers tehéntej
@@ -13885,13 +13885,14 @@ ca:cor de vedella
 de:Rinderherz
 es:corazón de res, corazón de ternera
 fi:naudan sydän
-fr:Cœur de bœuf
+fr:Cœur de bœuf, coeur de boeuf
 hu:marhaszív
 vegan:en:no
 vegetarian:en:no
 wikidata:en:Q63327617
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:naudan-syd%C3%A4n
 # 1 entry @ 2019-11-02
+# ingredient/fr:cœur-de-bœuf has 17 products in french @2019–02-12
 
 <en:beef meat
 en:beef meat extract
@@ -13913,9 +13914,6 @@ es:preparación de carne molida de res
 # <en:compound
 fr:préparation de viande de boeuf cuite
 
-<en:beef meat
-fr:cœur de bœuf, coeur de boeuf
-# ingredient/fr:cœur-de-bœuf has 17 products in french @2019–02-12
 
 
 <en:beef meat
@@ -15974,7 +15972,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Modified_starch
 # Corn starch or maize starch is the starch derived from the corn (maize) grain.
 
 <en:starch
-en:corn starch, corn starch, maize starch, cornstarch
+en:corn starch, maize starch, cornstarch
 ar:نشا الذرة
 ca:Midó de blat de moro
 cs:Kukuřičný škrob
@@ -36980,7 +36978,7 @@ cs:Borůvka
 da:blåbær
 de:Heidelbeer, Heidelbeeren, Heidelbeere
 eo:mirtelo
-es:arándano azul, arándanos azules, arándano azul, mora azul
+es:arándano azul, arándanos azules, mora azul
 fa:بیل‌بری
 fi:mustikka, pensasmustikka
 fr:myrtille
@@ -42169,9 +42167,6 @@ tr:sanmsak tozu
 en:black garlic
 es:ajo negro
 
-<en:garlic
-es:ajo tierno
-
 # description:en:Allium ursinum, known as WILD GARLIC, ramsons, buckrams, broad-leaved garlic, wood garlic, bear leek or bear's garlic, is a bulbous perennial flowering plant in the amaryllis family Amaryllidaceae.
 
 <en:garlic
@@ -44907,7 +44902,7 @@ fr:oignon grillé en poudre
 <en:onion
 en:fried onion
 es:cebollas fritas
-fr:oignon frit, oignons frits, oignon frit
+fr:oignon frit, oignons frits
 de:frittierte Zwiebeln
 hu:Sült hagyma
 nl:gefrituurde ui, gefrituurde uien
@@ -46039,7 +46034,7 @@ da:kartoffelflager
 de:Kartoffelflocken
 es:copos de patata
 fi:perunahiutale, perunahiutaleita
-fr:flocon de pomme de terre, flocons de pommes de terre, flocons de pomme de terre, flocon de pomme de terre
+fr:flocon de pomme de terre, flocons de pommes de terre, flocons de pomme de terre
 it:fiocchi di patate
 nl:aardappelvlokken
 ru:картофельние хлопья
@@ -46555,7 +46550,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bird%27s_eye_chili
 
 <en:chili pepper
 en:allspice, jamaica pepper, myrtle pepper
-fr:piment de la jamaïque, piment de Jamaïque, piment de jamaïque
+fr:piment de la jamaïque, piment de jamaïque
 fi:maustepippuri
 de:Jamaikapfeffer
 nl:Jamaicaanse peper
@@ -60183,7 +60178,7 @@ en:alaska pollock, Alaskan pollock, Theragra chalcogramma
 az:Mintay
 bg:treska pestrá
 ca:peix carboner d'Alaska
-de:Alaska Seelachs, Alaska-Pollack, Alaska-Seelachs, Alaska-Seelachsfilet, Alaska-Seelachs-Filet
+de:Alaska Seelachs, Alaska-Pollack, Alaska-Seelachs
 es:Abadejo de Alaska, colín de Alaska
 fa:زغال‌ماهی آلاسکا
 fi:Alaskanseiti
@@ -68372,7 +68367,7 @@ fr:œufs de poules élevées en cage, oeufs de poules élevées en cage, 20 oeuf
 fr:oeufs de poules élevées en cage de categorie a
 
 <fr:œufs de poules élevées en cage
-fr:oeufs frais de poules élevées en cage, oeufs de poules élevées en cage
+fr:oeufs frais de poules élevées en cage
 # 4@2019-05-31
 
 <fr:oeufs de poules élevées en cage
@@ -68448,7 +68443,7 @@ de:Eipulver
 el:αλεύρι σίτου αυγό σκόνη
 es:huevo en polvo
 fi:munajauhe, kananmunajauhe
-fr:œuf en poudre, œuf en poudre, œufs en poudre, poudre d'œuf, poudre d'œuf, oeuf en poudre, oeuf en poudre, oeufs en poudre, poudre d'oeuf, poudre d'oeuf
+fr:œuf en poudre, œufs en poudre, poudre d'œuf, oeuf en poudre, oeufs en poudre, poudre d'oeuf
 it:uova in polvere
 lv:kiausšinių milteliai
 nl:eipoeder, ei-poeder

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -27737,6 +27737,11 @@ ta:தென்னை சர்க்கரை
 wikidata:en:Q5139861
 wikipedia:en:https://en.wikipedia.org/wiki/Coconut_sugar
 # 50in3@2019-06-09
+# ingredient/fr:sucre-de-fleur-de-coco has 49 products @2019-05-27
+
+<en:coconut sugar
+nl:biologische kokosbloesem siroop
+# ingredient/nl:biologische-kokosbloesem-siroop has 1 product @2019-05-24
 
 <en:sugar
 en:grape sugar, raisin sugar
@@ -28686,12 +28691,6 @@ ru:Сахарный сироп
 sv:sockersirap
 vegan:en:yes
 vegetarian:en:yes
-
-fr:sucre de fleur de coco
-it:zucchero di fiori di cocco
-nl:biologische kokosbloesem siroop
-# ingredient/nl:biologische-kokosbloesem-siroop has 1 product @2019-05-24
-# ingredient/fr:sucre-de-fleur-de-coco has 49 products @2019-05-27
 
 <en:sugar syrup
 fr:sirop de sucres issus de fruits

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -70729,6 +70729,27 @@ wikidata:en:Q211340
 wikipedia:en:https://en.wikipedia.org/wiki/Pita
 # ingredient/fr:pain-pita has 3 products in 1 language @2020-06-13
 
+# description:en:A tortilla is a type of thin flatbread, typically made from nixtamalized corn or wheat flour.
+
+<en:bread
+en:tortilla
+fr:tortilla
+wikidata:en:Q55642411
+wikipedia:en:https://en.wikipedia.org/wiki/Tortilla
+
+# mainIngredient:en:wheat
+<en:tortilla
+en:wheat tortilla, flour tortilla
+fr:Tortillas de blé
+wikidata:en:Q204251
+wikipedia:en:https://en.wikipedia.org/wiki/Flour_tortilla
+
+<en:tortilla
+en:corn tortilla
+fr:tortilla de maïs
+wikidata:en:Q15660894
+wikipedia:en:https://en.wikipedia.org/wiki/Corn_tortilla
+
 # description:en:A waffle is a dish made from leavened batter or dough that is cooked between two plates that are patterned to give a characteristic size, shape, and surface impression.
 
 # <en:compound
@@ -71328,9 +71349,6 @@ fr:galette de blé
 it:torte di grano
 # ingredient/fr:galette-de-blé has 60 products in 4 languages @2019-02-09
 # Weizenfladen [ Weizenmehl, Wasser, Kokosnussöl, Kochsalz ]
-
-# mainIngredient:en:wheat
-fr:Tortillas de blé
 
 # description:en:The "PETIT BEURRE", or "Véritable Petit Beurre", also known under the initials "VPB", is a kind of shortbread from Nantes, that is best known in France. It is the Petit Beurre of the LU society, which has become a success worldwide.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -22478,10 +22478,6 @@ hu:korpa
 en:bran flour
 es:harina de salvado
 
-<en:bran
-en:soy bran
-es:salvado de soja
-
 en:cereal
 ca:Cereal,cereals
 cs:Cereálie
@@ -31401,10 +31397,13 @@ de:Sojaschrot, Sojagrieß
 fi:soijarouhe
 sv:sojafärs
 
+<en:bran
 <en:soya
-de:Sojamehl
-fi:soijajauho
+en:soy bran, soya bran
+de:Sojakleie
+fi:soijaleseet
 fr:son de soja
+es:salvado de soja
 
 <en:soya
 fr:pousses de soja
@@ -31413,9 +31412,6 @@ fr:pousses de soja
 
 <en:soya
 de:Sojaerzeugnis
-
-<en:soya
-de:Sojakleie
 
 <en:soya
 es:concentrado de soja

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -1156,7 +1156,7 @@ hu:feldolgozott Eucheuma-moszat, feldolgozott eucheuma alga
 # fr:e407a has 325 products in 4 languages @2018-11-03
 
 <en:carrageenan
-fr:épaississant carraghénane, épaississant carraghénane, gélifiant e407
+fr:épaississant carraghénane, gélifiant e407
 
 <en:carrageenan
 en:e407 stabilizer
@@ -1870,7 +1870,7 @@ el:μόνο- και διγλυκερίδια λιπαρών οξέων
 es:monoglicéridos y diglicéridos de ácidos grasos, monoglicéridos de acidos grasos, diglicéridos de ácidos grasos
 et:Rasvhapete mono- ja diglütseriidid
 fi:rasvahappojen mono- ja diglyseridit
-fr:mono- et diglycérides d'acides gras, mono et diglycérides d'acide gras, diglycérides d'acide gras, diglycérides d'acides gras, mono et di glycérides d'acides gras, diglycérides d'acides gras
+fr:mono- et diglycérides d'acides gras, mono et diglycérides d'acide gras, diglycérides d'acide gras, diglycérides d'acides gras, mono et di glycérides d'acides gras
 hu:zsírsavak mono- és digliceridjei
 it:mono-e digliceridi degli acidi grassi, mono e digliceridi degli acidi grassi
 lt:Riebalų rūgščių mono- ir digliceridai
@@ -1905,7 +1905,7 @@ en:mono and diglycerides of fatty acids of vegetable origin
 ca:monoglicèrids i diglicèrids d'àcids grassos d'origen vegetal, monoglicèrids d'àcids grassos d'origen vegetal, diglicèrids d'àcids grassos d'origen vegetal
 de:Mono- und Diglyzeride von Speisefettsäuren
 es:monoglicéridos y diglicéridos de ácidos grasos de origen vegetal, monoglicéridos de acidos grasos de origen vegetal, diglicéridos de ácidos grasos de origen vegetal
-fr:mono- et diglycérides d'acides gras d'origine végétale, mono et diglycérides d'acides gras d'origine végétale, mono et diglycérides d'acides gras d'origine végétale
+fr:mono- et diglycérides d'acides gras d'origine végétale, mono et diglycérides d'acides gras d'origine végétale
 nl:mono- en diglyceriden van plantaardige vetzuren
 pt:mono e diglicéridos de ácidos gordos de origem vegetal
 # fr:mono- et diglycérides d'acides gras d'origine végétale has 53 products @2018-11-12
@@ -5377,7 +5377,7 @@ pl:żywe kultury bakterii jogurtowych
 pt:fermentos lácteos, culturas lácteas, leveduras lacteas, fermentos láticos, fermentos lácticos
 ro:culturi lactice, culturi lactice selecționate, culturi lactice selectionate, fermenți de iaurt, fermenti de iaurt
 ru:Молочные ферменты, пробиотические микроорганизм
-sv:syrningskultur, syrakultur, syrakulturer, mjölksyrakultur, yoghurtkultur, startkultur, filkultur, filmjölkskultur, starterkultur, levande mjölksyrakultur, startkultur, mjölksyrakulturer
+sv:syrningskultur, syrakultur, syrakulturer, mjölksyrakultur, yoghurtkultur, startkultur, filkultur, filmjölkskultur, starterkultur, levande mjölksyrakultur, mjölksyrakulturer
 # fr:ferments-lactique has 10437 products in 23 languages @2019-07-09
 vegan:en:yes
 vegetarian:en:yes
@@ -12316,7 +12316,7 @@ ar:بيوتين
 be:біятын
 bg:биотин
 bs:Biotin
-ca:biotina, vitamina B7, biotina, Vitamina H, B7
+ca:biotina, vitamina B7, Vitamina H, B7
 cy:Biotin cs:Biotin, vitamin B7, vitamin H
 da:Biotin
 de:Biotin, Vitamin B7, Vitamin H
@@ -12914,7 +12914,7 @@ et:Tokoferoolid, E-vitamiin, Vitamiin E
 eu:E bitamina
 fa:ویتامین ای
 fi:Tokoferoli, E-vitamiini
-fr:tocophérol, tocophérol, vitamine e, vitamines e
+fr:tocophérol, vitamine e, vitamines e
 gl:Vitamina E
 he:E ויטמין
 hi:विटामिन ई
@@ -16017,7 +16017,7 @@ da:modificeret majsstivelse
 de:modifizierte Maisstärke
 es:Almidón modificado de maiz, almidon de maiz modificado
 fi:muunnettu maissitärkkelys, modifioitu maissitärkkelys, muunneltu maissitärkkelys, muunnettua maissitärkkelystä
-fr:amidon transformé de maïs, amidon de maïs transformé, amidon modifié de maïs, amidon de maïs modifié, amidons modifié de maïs, amidon de maïs modifié, amidons modifiés de maïs
+fr:amidon transformé de maïs, amidon de maïs transformé, amidon modifié de maïs, amidon de maïs modifié, amidons modifié de maïs, amidons modifiés de maïs
 hu:módosított kukoricakeményítő
 it:amido modificato di mais, amido di mais modificato
 nb:modifisert maisstivelse
@@ -16670,7 +16670,7 @@ nb:melkefett
 nl:melkvet
 pl:tłuszcz mlecny, tłuszcz mleczny
 pt:gorda do leite
-ro:grasimi din lapte, grăsimi din lapte, grasime din lapte, grasimi din lapte, grăsime din lapte
+ro:grasimi din lapte, grăsimi din lapte, grasime din lapte, grăsime din lapte
 ru:молочный жнр
 sv:mjölkfett
 vegan:en:no
@@ -27109,7 +27109,7 @@ de:Guarkernmehl
 el:κομμι χαρουτιων
 es:goma guar
 fi:guarkumi
-fr:gomme guar, gomme de guar, gomme guar, guar
+fr:gomme guar, gomme de guar, guar
 hu:guargumi, guarmézga
 it:gomma di guar
 nl:guargom
@@ -29240,7 +29240,7 @@ da:hydrolyseret vegetabllsk protein. hydrolysert vegetabilsk protein
 de:hydrolysiertes Pflanzenprotein, aufgeschlossenes Pflanzeneiweiß
 es:Proteina vegetal hidrolizada, hidrolizado de proteína vegetal
 fi:hydrolysoitu kasviproteiini, kasviproteiinihydrosylaatti
-fr:protéine végétale hydrolysée, protéines végétales hydrolysées, protéine végétale hydrolysée
+fr:protéine végétale hydrolysée, protéines végétales hydrolysées
 hu:hidrolizált növényi fehérjék, hidolizált növényi fehérje
 nb:hydrolysert vegetabilsk protein
 nl:gehydroliseerde plantaardige eiwit, gehydroliseerd plantaardig eiwit, gehydroliseerde plantaardige eiwitten
@@ -29455,7 +29455,7 @@ da:mælkeprotein
 de:Milcheiweiß, Milchprotein, Milcheiweißerzeugnis, Milcheiweisserzeugnis, Magermilchpulverzusatz, Milcheiweiss, Milchproteine
 es:proteína de leche,proteinas lacteas
 fi:maitoproteiini, maitoproteiinit
-fr:protéine de lait, protéines de lait, protéines du lait, protéines du lait, protéines laitières, protéines lactiques, protéine lactique, lactoprotéine, lactoprotéines
+fr:protéine de lait, protéines de lait, protéines du lait, protéines laitières, protéines lactiques, protéine lactique, lactoprotéine, lactoprotéines
 hu:tejfehérjék, tejfehérje
 it:proteine del latte
 nl:melkeiwit, melkeiwitten, melk eiwit
@@ -30032,7 +30032,7 @@ en:cocoa bean chips
 de:kakaobohnenchips
 es:pepitas de cacao, trozos de habas de cacao, trocitos de pepitas de cacao
 fi:Kaakaopapusipsit
-fr:éclats de fèves de cacao, éclats de fèves de cacao
+fr:éclats de fèves de cacao
 it:granella di semi di cacao, scaglie di cacao, granella di fave di cacao, granella di cacao
 # ingredient/fr:éclats-de-fèves-de-cacao has 122 products in 6 languages @2019-05-26
 
@@ -31304,7 +31304,7 @@ ar:فول الصويا
 ca:soia, soja,faves de soja
 cs:Sója luštinatá, sójové boby
 da:Sojabønne
-de:Sojabohne, Sojabohnen, Sojakerne, Sojakerne
+de:Sojabohne, Sojabohnen, Sojakerne
 eo:Sojfabo
 es:granos de soja, habas de soja, habas de soya, semillas de soja
 et:Sojauba, sojaoad
@@ -32114,7 +32114,7 @@ da:Monokaliumphosphat, Monobasisk kaliumphosphat, monokaliummonophosphat
 de:Monokaliumphosphat
 el:Δισοξινο φωσφορικο καλιο
 es:Fosfato monopotásico, Fosfato monobásico potásico, monofosfato monopotásico
-et:Kaaliumdivesinikfosfaat, Kaaliumdivesinikfosfaat
+et:Kaaliumdivesinikfosfaat
 fi:Monokaliumfosfaatti, Yhdenarvoinen kaliumfosfaatti, Monokaliummonofosfaatti
 fr:Phosphate monopotassique
 hu:Monokálium-foszfát, Egybázisú kálium-foszfát, Monokálium-monofoszfát
@@ -32146,7 +32146,7 @@ de:Dikaliumphosphat
 el:Οξινο φωσφορικο καλιο, Όξινο ορθοφωσφορικό κάλιο
 eo:Kalia fosfato dubaza
 es:Fosfato dipotásico, fosfato dipotásico
-et:Dikaaliumvesinikfosfaat, Dikaaliumvesinikfosfaat
+et:Dikaaliumvesinikfosfaat
 fa:دی‌پتاسیم فسفات
 fi:dikaliumfosfaatti
 fr:phosphate dipotassique
@@ -32253,7 +32253,7 @@ da:Monocalciumphosphat, Monobasisk calciumphosphat
 de:Monocalciumphosphat
 el:Δισοξινο φωσφορικο ασβεστιο, Μονοβασικό φωσφορικό ασβέστιο
 es:fosfato monocalcico
-et:Kaltsiumdivesinikfosfaat, Kaltsiumdivesinikfosfaat
+et:Kaltsiumdivesinikfosfaat
 fa:مونوکلسیم فسفات
 fi:Monokalsiumfosfaatti, Yhdenarvoinen kalsiumfosfaatti
 fr:phosphate monocalcique, orthophosphate monocalcique
@@ -32428,7 +32428,7 @@ hu:Dimagnézium-foszfát, Magnézium-hidrogén-foszfát, Magnézium-foszfát ké
 it:Fosfato di dimagnesio, Idrogeno fosfato di magnesio, fosfato di magnesio dibasico, ortofosfato bimagnesico
 lt:Dimagnio fosfatas, Magnio divandenilio fosfatas, magnio fosfatas dvibazis, dimagnio ortofosfatas
 lv:Dimagnija fosfāts, Magnija hidrogēnfosfāts, Divbāziskais magnija fosfāts, Dimagnija ortofosfāts
-mt:Fosfat dimanjeżiku, Fosfat idroġenat tal-manjeżju, Fosfat idroġenat tal-manjeżju, Ortofosfat dimanjeżiku
+mt:Fosfat dimanjeżiku, Fosfat idroġenat tal-manjeżju, Ortofosfat dimanjeżiku
 nl:Dimagnesiumfosfaat, Magnesiumwaterstoffosfaat, tweebasisch magnesiumfosfaat, dimagnesiumorthofosfaat
 pl:Fosforan dimagnezu, Wodorofosforan magnezu, fosforan magnezu dizasadowy, ortofosforan dimagnezu
 pt:Fosfato de dimagnésio, Hidrogenofosfato de magnésio, fosfato dibásico de magnésio, ortofosfato de dimagnésio
@@ -32733,7 +32733,7 @@ es:difosfato disódico
 et:Dinaatriumdifosfaat, Dinaatriumdivesinikdifosfaat
 fa:دی‌سدیم پیروفسفات
 fi:Dinatriumdifosfaatti, Dinatriumdivetydifosfaatti, Dinatriumdivetypyrofosfaatti, Hapan natriumpyrofosfaatti
-fr:diphosphate disodique, diphosphates de sodium, diphosphate de sodium, Pyrophosphate acide de soude, pyrophosphate de sodium, diphosphates de sodium, pyrophosphate de soude
+fr:diphosphate disodique, diphosphates de sodium, diphosphate de sodium, Pyrophosphate acide de soude, pyrophosphate de sodium, pyrophosphate de soude
 hu:Dinátrium-difoszfát
 it:difosfato disodico
 ja:二リン酸二水素二ナトリウム
@@ -32798,7 +32798,7 @@ et:Tetranaatriumdifosfaat
 fa:تتراسدیوم پیروفسفات
 fi:Tetranatriumdifosfaatti, Natriumpyrofosfaatti
 fr:diphosphate tétrasodique, Pyrophosphate de sodium, pyrophosphate de soude, pyrophosphate acide de sodium
-hu:Tetranátrium-difoszfát, Tetranátrium-pirofoszfát, Tetranátrium-difoszfát
+hu:Tetranátrium-difoszfát, Tetranátrium-pirofoszfát
 it:Difosfato tetrasodico, Pirofosfato tetrasodico, disfosfato tetrasodico, Pirofosfato di sodio
 lt:Tetranatrio difosfatas, Tetranatrio pirofosfatas
 lv:Tetranātrija difosfāts, Tetranātrija pirofosfāts
@@ -43755,7 +43755,7 @@ sv:svartmorotjuice
 
 <fr:jus de carotte noire
 fr:jus de carotte noire concentré, jus concentré de carotte noire, jus de carotte pourpre concentré, jus concentré de carotte pourpre
-de:Schwarzmöhrensaftkonzentrat, konzentrierter Saft aus schwarzer Karotte, konzentrierter Saft aus schwarzer Karotte
+de:Schwarzmöhrensaftkonzentrat, konzentrierter Saft aus schwarzer Karotte
 nl:zwarte wortelsapconcentraat
 # fr:jus-de-carotte-noire-concentré has 26 products in 2 languages @2018-10-20
 # fr:jus-de-carotte-pourpre-concentré has 22 products @2018-10-20
@@ -44147,7 +44147,7 @@ en:Heart of palm, Hearts of palm
 ar:جمار
 de:Palmherzen, Palmherz
 eo:Palmomedolo
-es:Palmito, Palmito
+es:Palmito
 fa:پنیر نخل
 fi:Palmun sydän
 fr:Cœur de palmier, cœurs de palmiers, cœurs de palmier, coeur de palmier, coeurs de palmiers, coeurs de palmier, choux palmistes, chou palmiste
@@ -46816,7 +46816,7 @@ de:gehackte Tomaten, Tomatenhack, Tomatenfruchtfleisch, zerkleinerte Tomaten
 el:ψιλοκαμμένη ντομάτα
 es:Tomates en trozos, tomate troceado
 fi:pilkottu tomaatti, pilkotut tomaatit
-fr:tomate concassée, tomates concassées, tomates concassées, concassé de tomates
+fr:tomate concassée, tomates concassées, concassé de tomates
 hu:szeletelt paradicsom
 it:pomodori tritati
 nb:hakkede tomater
@@ -47497,7 +47497,7 @@ en:grilled courgette
 de:grillierte Zucchetti, gegrillte Zucchini, Zucchini geröstet
 es:calabacín asado
 fi:grillattu kesäkurpitsa
-fr:courgette grillée, courgettes grillées, courgette grillée
+fr:courgette grillée, courgettes grillées
 it:zucchine grigliate
 nl:gegrilde courgette
 # en:grilled-courgette has 238 products in 5 languages @2018-10-26
@@ -49651,7 +49651,7 @@ ro:nuci de macadamia, nuci de Queensland
 ru:макадамия, орехи Куинсленд
 sk:makadamové orechy, queenslandské orechy
 sl:makadamija, orehi Queensland
-sv:makadamianöt, Queenslandsnöt, macadamianöt, macadamianöt
+sv:makadamianöt, Queenslandsnöt, macadamianöt
 zh:夏威夷果
 wikidata:en:Q11027461
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noix-de-macadamia
@@ -51185,7 +51185,7 @@ da:urt
 de:Gewürz, Kräuter
 es:hierba,hierbas,plantas aromáticas, planta aromática,hierbas aromaticas, finas hierbas, mezcla de finas hierbas
 fi:yrtti, yrtit, mausteyrtit
-fr:herbe, herbes, plantes aromatiques, plante aromatique, fines herbes, fine herbe, mélange de plantes aromatiques, plantes aromatiques, herbes aromatiques
+fr:herbe, herbes, plantes aromatiques, plante aromatique, fines herbes, fine herbe, mélange de plantes aromatiques, herbes aromatiques
 he:עשב
 hu:gyógynövény, gyógynövények
 it:erba, piante aromatiche
@@ -51215,7 +51215,7 @@ da:Krydderurter og krydderier
 de:Kräuter und Gewürze
 es:hierbas y especias
 fi:yrtit ja mausteet
-fr:épices et plantes aromatique, épice et plante aromatique, épice et plantes aromatiques, épices et plantes aromatiques, épices et plante aromatique, plantes aromatiques et épices, extraits d'épices et d'herbes, herbe et épice, herbes et épices, épices et herbes, épices et herbes aromatiques, épice et aromate, épices et aromates, épices et aromate, épice et aromates, épices et arômes, aromates et épices, plantes aromatiques et épices, herbe et épice, herbes et épices, épices et herbes, épices et herbes aromatiques
+fr:épices et plantes aromatique, épice et plante aromatique, épice et plantes aromatiques, épices et plantes aromatiques, épices et plante aromatique, plantes aromatiques et épices, extraits d'épices et d'herbes, herbe et épice, herbes et épices, épices et herbes, épices et herbes aromatiques, épice et aromate, épices et aromates, épices et aromate, épice et aromates, épices et arômes, aromates et épices
 it:Erbe e spezie
 nl:kruiden en specerijen
 pl:Zioła i przyprawy
@@ -55511,7 +55511,7 @@ he:חסה, חסה תרבותית
 hr:Salata, Zelena salata
 ht:Leti
 hu:saláta, kerti saláta
-hy:հազար, հազար
+hy:հազար
 id:Selada
 io:Latugo
 is:Salat
@@ -63292,7 +63292,7 @@ ar:سپیداج سست‌کمر, Sepiella inermis
 de:Wirbelloser Tintenfisch, Sepiella inermis
 fr:Seiche sans épines, Sepiella inermis
 it:Sepiella inermis
-la:Sepiella inermis, Sepiella inermis
+la:Sepiella inermis
 zh:曼氏无针乌贼, Sepiella inermis
 wikipedia:en:https://en.wikipedia.org/wiki/Sepiella_inermis
 # ingredient/fr:Sepiella-inermis has 2 products in french @2019-01-05
@@ -64230,7 +64230,7 @@ wikidata:en:Q920979
 
 <en:squid
 en:swordtip squid, Uroteuthis edulis
-fr:Uroteuthis edulis, Calmar épée, Calmar, Encornet, Uroteuthis edulis
+fr:Uroteuthis edulis, Calmar épée, Calmar, Encornet
 ja:ケンサキイカ, Uroteuthis edulis
 la:Uroteuthis edulis, Loligo edulis
 zh:剑尖枪乌贼, Uroteuthis edulis
@@ -64668,7 +64668,7 @@ hu:Kaliforniai vörösrák, Procambarus clarkii
 it:Gambero killer, Procambarus clarkii
 ja:アメリカザリガニ, Procambarus clarkii
 ko:미국가재, Procambarus clarkii
-la:Procambarus clarkii, Procambarus clarkii
+la:Procambarus clarkii
 nl:Rode rivierkreeft, Procambarus clarkii
 pt:Lagostim vermelho da Luisiana, Procambarus clarkii
 sk:Rak americký, Procambarus clarkii
@@ -68442,7 +68442,7 @@ nl:extra-verse hele eieren
 # fr:oeufs-entiers-extra-frais has 73 products in french @2018-12-18
 
 <en:whole egg
-fr:Oeufs entiers pasteurisés, Oeufs entiers pasteurisés
+fr:Oeufs entiers pasteurisés
 de:pasteurisiertes Vollei
 
 <en:whole egg

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -28587,10 +28587,6 @@ sv:invertsockersirap
 fr:sirop de sucre inverti cristallisé
 
 <en:invert sugar syrup
-fr:sirop de sucre partiellement inverti
-it:sciroppo di zucchero parzialmente invertito
-
-<en:invert sugar syrup
 en:cane invert syrup, invert cane syrup
 de:brauner Invertzuckersirup, Invertzuckersirup aus Rohrzucker
 fi:Ruokoinverttisiirappi
@@ -28718,10 +28714,12 @@ de:rohrzuckersirup
 fi:ruokosokerisiirappi
 
 <en:sugar
+<en:invert sugar syrup
 en:partially inverted sugar syrup
 es:jarabe de azucar parcialmente invertido
 fi:osittain invertoitu sokerisiirappi
 fr:sirop de sucre partiellement inverti
+it:sciroppo di zucchero parzialmente invertito
 sv:delvis inverterad sockersirap
 # ingredient/en:partially-inverted-sugar-syrup has 101 products in 2 languages @2020-06-08
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -4757,7 +4757,10 @@ wikipedia:en:https://en.wikipedia.org/wiki/Erythritol
 # additive/e968-erythritol has 662 products in 7 languages @2019-04-05
 
 
+# description:en:AMYLASE are enzymes that catalyse the hydrolysis of starch into sugars.
+# comment:en:when indicated, probably alpha-amylase is meant
 # alpha-amylase, (α-amylase) is a protein enzyme EC 3.2.1.1 that hydrolyses alpha bonds of large, alpha-linked polysaccharides, such as starch and glycogen, yielding glucose and maltose.
+# comment:en:"en:amylase" is defined in additives.txt
 
 <en:amylase
 en:alpha-amylase, E1100, E-1100, E 1100
@@ -6128,12 +6131,6 @@ vegetarian:en:yes
 <en:coagulating enzyme
 en:sheep rennet
 es:cuajo ovino	
-
-# description:en:AMYLASE are enzymes that catalyse the hydrolysis of starch into sugars.
-# coment:en:when indicated, probably alpha-amylase is meant
-
-<en:enzyme
-en:E1100
 
 # description:en:CELLULASE is any of several enzymes produced chiefly by fungi, bacteria, and protozoans that catalyze cellulolysis, the decomposition of cellulose and of some related polysaccharides. Cellulase is used for commercial food processing in coffee.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -46964,8 +46964,8 @@ carbon_footprint_fr_foodges_value:fr:2.9
 en:tomato purée, tomato paste, tomato concentrate
 ca:Llet en pols
 da:tomatpuré, tomatpure, tomatkoncentrat
-de:Tomatenmark, konzentriertes Tomatenpüree, Tomatenkonzentrat, Tomatenmarkkonzentrat, Tomatenpüree, Tomatenmark einfach konzentriert
-es:concentrado de tomate, pasta de tomate
+de:Tomatenmark, Tomatenkonzentrat, Tomatenpüree, Tomatenmark einfach konzentriert
+es:concentrado de tomate, pasta de tomate, tomate-concentrado
 et:tomatipüree
 fi:tomaattipyree, tomaattipyre, tomaattitahna, tomaattitiiviste, tomaattisose
 fr:purée de tomate, concentré de tomate, concentré de tomates, pâte de tomate, purée de tomates, puree de tomate, concentre de tomate
@@ -46980,6 +46980,9 @@ ru:Томатная паста, томатный концентрат
 sv:tomatpuré, tomatpyré, tomatpure, tomatkoncentrat, mosade tomater
 carbon_footprint_fr_foodges_ingredient:fr:Sauce tomate
 carbon_footprint_fr_foodges_value:fr:2.9
+wikidata:en:Q1114674
+wikipedia:en:https://en.wikipedia.org/wiki/Tomato_pur%C3%A9e
+wikipedia:en:https://en.wikipedia.org/wiki/Tomato_paste
 # ingredient/fr:purée-de-tomate has 2637 products @2018-12-26
 
 <en:tomato purée
@@ -47002,10 +47005,10 @@ nl:half ingedikte tomatenpuree
 <fr:purée de tomate mi-réduite
 fr:purée de tomates mi-réduite reconstituée
 
+# comment:en:This is where the tomato has been puréed *and* concentrated further.
 <en:tomato purée
 en:concentrated tomato purée
-de:Tomatenkonzentrat, konzentriertes Tomatenmark, Tomatenpüreekonzentrat, Tomatenmarkkonzentrat, konzentriertes Tomatenpüree
-es:tomate-concentrado
+de:konzentriertes Tomatenmark, Tomatenpüreekonzentrat, Tomatenmarkkonzentrat, konzentriertes Tomatenpüree
 fi:tiivistetty tomaattipyree, tiivistettyä tomaattipyreetä
 fr:purée de tomate concentrée, purée de tomates concentrée, purée de tomates concentrées
 hu:sűrített paradicsompüré, sűrített paradicsom, paradicsom (sűrítmény), paradicsom (sűrítményből)

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -23851,16 +23851,18 @@ fi:luomu tattari
 fr:sarrasin biologique
 hu:bio hajdina
 
+#<en:compound
 <en:buckwheat
 en:buckwheat flakes
 da:boghvedeflager
 de:Buchweizenflocken
 es:copos de sarraceno
 fi:tattarihiutale
-fr:flocons de sarrasin
+fr:flocons de sarrasin, pétales de sarrasin
 hu:hajdinapehely
-nl:boekweitvlokken
+nl:boekweitvlokken, boekweitflakes
 sv:boveteflingor
+# pétales de sarrasin (sarrasin, sel)
 
 <en:buckwheat
 en:puffed buckwheat
@@ -23906,13 +23908,6 @@ zh:卡莎
 wikidata:en:Q10379618
 wikipedia:en:https://en.wikipedia.org/wiki/Kasha
 # ingredient/fr:kasha has 13 products @2019-02-17
-
-#<en:compound
-<en:buckwheat
-fr:pétales de sarrasin
-fi:tattarihiutale
-nl:boekweitflakes
-# pétales de sarrasin (sarrasin, sel)
 
 <en:buckwheat
 fr:sarrasin réhydraté

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -27475,7 +27475,7 @@ es:azucar caramelizado en polvo
 
 <en:sugar
 en:white sugar
-de:weißer Zucker, Zucker
+de:weißer Zucker
 es:Azúcar blanco,Azúcar blanco comun,azúcar blanquilla
 fi:valkoinen sokeri
 fr:sucre blanc
@@ -27523,8 +27523,9 @@ sv:florsocker
 <en:sugar
 fr:sucre caramélisé en poudre
 
+# comment:en:powdered sugar and icing sugar may be the same thing.
 <en:sugar
-en:granulated sugar, powdered sugar
+en:powdered sugar
 de:Puderzucker
 es:Azucar en polvo
 fi:jauhettu sokeri
@@ -27532,6 +27533,8 @@ fr:sucre en poudre, sucre en grains
 hu:porcukor
 it:zucchero semolato
 nl:poedersuiker
+wikidata:en:Q151070
+wikipedia:en:https://en.wikipedia.org/wiki/Powdered_sugar
 
 <en:sugar
 fr:sucre candi
@@ -27562,7 +27565,11 @@ wikipedia:en:https://en.wikipedia.org/wiki/Vanilla_sugar
 # ingredient/fr:sucre-vanille has 77 products in 2 languages @2020-06-08
 
 <en:sugar
+en:nib sugar, pearl sugar
 fr:sucre perlé
+it:granella di zucchero
+wikidata:en:Q914538
+wikipedia:en:https://en.wikipedia.org/wiki/Nib_sugar
 
 <en:sugar
 fr:sucre blond
@@ -27570,6 +27577,8 @@ fr:sucre blond
 <en:sugar
 fr:sucre du lait
 
+# description:en:Granulated, familiar as table sugar, with a grain size about 0.5-0.6 mm across.
+# comment:en:"granulated sugar" is generally white sugar, but other sugars can be in granulated form too.
 <en:sugar
 en:granulated sugar
 de:Zucker mittelgross
@@ -27580,11 +27589,18 @@ hu:kristálycukor
 nl:Kristalsuiker
 # ingredient/fr:sucre-cristal has 77 products @2019-06-08
 
+# description:en:Caster sugar is finer than granulated sugar, but coarser than powdered/icing sugar, with a grain size of about 0.35 mm.
 <en:sugar
+en:caster sugar
 fr:sucre semoule
+wikidata:en:Q3502834
+wikipedia:fr:https://fr.wikipedia.org/wiki/Sucre_semoule
 
 <en:sugar
+en:sugar cube
 fr:Sucre en morceaux
+wikidata:en:Q1042920
+wikipedia:fr:https://fr.wikipedia.org/wiki/Sucre_en_morceaux
 # 4@2019-06-05
 
 #################### Sugars from specific sources ##############
@@ -27712,9 +27728,9 @@ cs:nerafinovaný třtinový cukr
 da:rå rørsukker
 de:Rohrohrzucker, Roh-Rohrzucker, roher Rohrzucker
 el:ακατέργαστη ζάχαρη ζαχαροκάλαμου
-es:Azucar de caña sin refinar, azucar de caña no refinada,azucar de caña en bruto,azúcar integral de caña sin refinar,panela
+es:Azucar de caña sin refinar, azucar de caña no refinada,azucar de caña en bruto
 fi:raakaruokosokeri
-fr:sucre de canne non raffiné, sucre de canne brut, sucre de canne roux, sucre roux de canne, sucre de canne roux non raffiné, sucre de canne complet, suc de canne intégral, sucre brut de canne, sucre complet de canne
+fr:sucre de canne non raffiné, sucre de canne brut, sucre de canne roux, sucre roux de canne, sucre de canne roux non raffiné, sucre brut de canne
 hu:finomítatlan nádcukor
 it:zucchero di canna grezzo
 nl:Ongeraffineerde rietsuiker, ruwe rietsuiker
@@ -27723,6 +27739,7 @@ sv:rårörsocker
 
 <en:cane sugar
 en:whole cane sugar
+fr:sucre de canne complet, suc de canne intégral, sucre de canne intégral, sucre complet de canne
 es:azucar de caña integral,azucar integral de caña 
 
 <en:whole cane sugar
@@ -27753,7 +27770,9 @@ wikidata:en:Q837194
 <en:unrefined cane sugar
 <en:whole cane sugar
 en:unrefined whole cane sugar
-es:azúcar de caña integral no refinada,panela
+es:azúcar de caña integral no refinada, azúcar integral de caña sin refinar, panela
+wikidata:en:Q10357458
+wikipedia:en:https://en.wikipedia.org/wiki/Panela
 
 <en:sugar
 en:beet sugar

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -20866,8 +20866,8 @@ pl:Rum, rum
 ru:Ром
 sv:rom
 
-<en:rhum
-en:white rhum
+<en:rum
+en:white rum
 da:hvid rom
 de:weißer Rum
 fi:vaalea rommi
@@ -20877,7 +20877,7 @@ nl:witte rum
 wikidata:en:Q26869768
 # 20@2019-06-04
 
-<en:white rhum
+<en:white rum
 fr:Rhum blanc agricole
 
 <en:alcohol
@@ -27193,7 +27193,7 @@ pt:goma de guar
 ro:gumă guar, guma guar, gumă de guar, guma de guar
 
 <en:guar flour
-<en:carob flour
+<en:carob seed flour
 fr:farine de graines de caroube et farine de graines de guar
 
 
@@ -68377,7 +68377,7 @@ nl:ei van hennen met vrije uitloop
 fr:œufs de poules élevées en plein air calibre moyen
 
 <en:free range chicken eggs
-<en:organic egg
+<en:organic chicken egg
 en:organic free range chicken eggs
 fr:oeufs frais de poules élevées en plein air issus de l'agriculture biologique
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -16682,7 +16682,7 @@ nl:gefractioneerd melkvet
 # comment:en:BUTTERFAT seems to be more than just butter, water has been removed
 
 <en:milkfat
-en:butterfat, pastry butter, anhydrous milk fat, concentrated butter, butter oil, anhydrous butter
+en:butterfat, butter fat, pastry butter, anhydrous milk fat, concentrated butter, butter oil, anhydrous butter
 bg:безводно масло
 bs:mliječna mast
 cy:braster menyn
@@ -34660,6 +34660,7 @@ en:plum sugar
 #
 ###################################################################################################
 # The QUINCE (Cydonia oblonga) is the sole member of the genus Cydonia in the family Rosaceae (which also contains apples and pears, among other fruits).
+# comment:en:Greek uses the same word for cockles and quinces.
 
 <en:fruit
 en:quince, quinces
@@ -42774,6 +42775,7 @@ en:beetroot syrup
 es:sirope de remolacha
 
 <en:beetroot
+en:beetroot juice
 fr:jus de betterave
 de:Randensaft
 fi:punajuurimehu
@@ -63108,6 +63110,7 @@ ja:アワビ
 wikipedia:en:https://en.wikipedia.org/wiki/Abalone
 
 # A cockle is an edible, marine bivalve mollusc. Although many small edible bivalves are loosely called cockles, true cockles are species in the family Cardiidae.
+# comment:en:Greek uses the same word for cockles and quinces.
 
 <en:mollusc
 en:cockles


### PR DESCRIPTION
More of the same, although 66f6e90 assumes that the ingredients list is _always_ used case insensitively, and doesn't need both upper and lower case versions of names.