### PR TITLE
fix: use HTML::Entities instead of require

### DIFF
--- a/scripts/import_fleurymichon.pl
+++ b/scripts/import_fleurymichon.pl
@@ -51,6 +51,7 @@ use Encode;
 use JSON::PP;
 use Time::Local;
 use XML::Rules;
+use HTML::Entities qw/decode_entities/;
 
 $lc = "fr";
 $country = "en:france";
@@ -591,9 +592,7 @@ BOO_JOE_ROB => "Joël Robuchon"
 					$debug and print STDERR "ingredients 2 : $params{$ingredients_fields{$field}} \n";
 
 
-					require HTML::Entities;
-					$params{ $ingredients_fields{$field} }
-						= HTML::Entities->decode_entities(
+					$params{ $ingredients_fields{$field} } = decode_entities(
 						$params{ $ingredients_fields{$field} } );
 
 					$debug and print STDERR "ingredients 3 : $params{$ingredients_fields{$field}} \n";


### PR DESCRIPTION
**Description:**

Fixes #4108

calling `HTML::Entities->decode_entities` will return a list where
the first value is the class name and second is the actual return value.

**Related issues and discussion:** #4108 
