### PR TITLE
Don't use method invocation where it isn't needed

### DIFF
--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -250,7 +250,7 @@ sub retrieve {
 	if ($@ ne '')
 	{
 		require Carp;
-		Carp->carp("cannot retrieve $file : $@");
+		Carp::carp("cannot retrieve $file : $@");
  	}
 
 	return $return;

--- a/scripts/delete_old_cropped_images.pl
+++ b/scripts/delete_old_cropped_images.pl
@@ -149,7 +149,7 @@ my %codes = ();
 						}
 
 						require File::Copy;
-						File::Copy->move( "$dir/$file",
+						File::Copy::move( "$dir/$file",
 							"$www_root/old-images/products/$path/" )
 							or die("could not move: $!\n");
 

--- a/scripts/extract_images.pl
+++ b/scripts/extract_images.pl
@@ -113,7 +113,7 @@ while (my $product_ref = $cursor->next) {
 				print STDERR "$file - id: $imageid\n";
 
 				require File::Copy;
-				File::Copy->copy( "$dir/$file",
+				File::Copy::copy( "$dir/$file",
 					"$target_dir/$code" . '_' . $imageid . ".jpg" )
 					or die("could not copy: $!\n");
 

--- a/scripts/extract_nutrition_images_and_crop_data.pl
+++ b/scripts/extract_nutrition_images_and_crop_data.pl
@@ -143,7 +143,7 @@ while (my $product_ref = $cursor->next) {
 				print STDERR "copying imgid: $imgid\n";
 
 				require File::Copy;
-				File::Copy->copy( "$dir/$imgid.jpg",
+				File::Copy::copy( "$dir/$imgid.jpg",
 					"$target_dir/$code" . '_' . $imgid . ".jpg" )
 					or print STDERR ("could not copy: $!\n");
 

--- a/scripts/import_fleurymichon.pl
+++ b/scripts/import_fleurymichon.pl
@@ -264,7 +264,7 @@ print STDERR "importing products\n";
 			if ($code eq '') {
 				print STDERR "empty code\n";
 				require Data::Dumper;
-				print STDERR Data::Dumper->Dumper($fleurymichon_product_ref);
+				print STDERR Data::Dumper::Dumper($fleurymichon_product_ref);
 				exit;
 			}
 

--- a/scripts/import_systemeu.pl
+++ b/scripts/import_systemeu.pl
@@ -427,7 +427,7 @@ while (my $imported_product_ref = $csv->getline_hr ($io)) {
 			if ($code eq '') {
 				print STDERR "empty code\n";
 				require Data::Dumper;
-				print STDERR Data::Dumper->Dumper($imported_product_ref);
+				print STDERR Data::Dumper::Dumper($imported_product_ref);
 				print "EMPTY CODE\n";
 				next;
 			}

--- a/scripts/obsolete/import_sodebo.pl
+++ b/scripts/obsolete/import_sodebo.pl
@@ -213,7 +213,7 @@ while (my $imported_product_ref = $csv->getline_hr ($io)) {
 			if ($code eq '') {
 				print STDERR "empty code\n";
 				require Data::Dumper;
-				print STDERR Data::Dumper->Dumper($imported_product_ref);
+				print STDERR Data::Dumper::Dumper($imported_product_ref);
 				print "EMPTY CODE\n";
 				next;
 			}

--- a/scripts/obsolete/remove_deleted_products_from_db.pl
+++ b/scripts/obsolete/remove_deleted_products_from_db.pl
@@ -70,7 +70,7 @@ my $cursor = get_products_collection()->query({})->fields({ code => 1 });;
 				get_products_collection()->delete_one({"code" => $code});
 						my $err = $database->last_error();
 		require Data::Dumper;
-		print STDERR Data::Dumper->Dumper($err);
+		print STDERR Data::Dumper::Dumper($err);
 				# store_product($product_ref, "desindex deleted product");
 			}
 		}

--- a/scripts/tag_stores_magasins_u.pl
+++ b/scripts/tag_stores_magasins_u.pl
@@ -140,7 +140,7 @@ while (my $imported_product_ref = $csv->getline_hr ($io)) {
 			if ($code eq '') {
 				print STDERR "empty code\n";
 				require Data::Dumper;
-				print STDERR Data::Dumper->Dumper($imported_product_ref);
+				print STDERR Data::Dumper::Dumper($imported_product_ref);
 				print "EMPTY CODE\n";
 				next;
 			}

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -493,7 +493,7 @@ while (my $product_ref = $cursor->next) {
 									my $source = "$www_root/images/products/$path/${imgid}_zu.$rev.$size.jpg";
 									my $target = "$www_root/images/products/$path/${imgid}_" . $product_ref->{lc} . ".$rev.$size.jpg";
 									print STDERR "move $source to $target\n";
-									File::Copy->move($source, $target);
+									File::Copy::move($source, $target);
 								}
 							}
 							$product_values_changed = 1;


### PR DESCRIPTION
**Description:**

Applying the lessons from #4109.
Change `->` to `::` to avoid passing the left hand side to the subroutine.