### PR TITLE
ingredient parsing: don't truncate purée after percentage

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1142,7 +1142,18 @@ sub parse_ingredients_text($) {
 				}
 
 				# 90% boeuf, 100% pur jus de fruit, 45% de matière grasses
-				if ($ingredient =~ /^\s*(\d+((\,|\.)\d+)?)\s*(\%|g)\s*(pur|de|d')?\s*/i) {
+				if ($ingredient =~ m{^
+									 \s*
+									 ( \d+ ([,.] \d+)? )
+									 \s*
+									 (\%|g)
+									 \s*
+
+									 ( (?: pur | de ) \s | d' )?
+									 \s*
+									}sxmi
+					)
+				{
 					$percent = $1;
 					$debug_ingredients and $log->debug("percent found before", { ingredient => $ingredient, percent => $percent, new_ingredient => $'}) if $log->is_debug();
 					$ingredient = $';

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -1609,6 +1609,53 @@ is_deeply ($product_ref->{ingredients},
 
 ) or diag explain $product_ref;
 
+# Bugs #3827, #3706, #3826 - truncated purée
+$product_ref = {
+	lc => "fr",
+	ingredients_text =>
+		"19% purée de tomate, 90% boeuf, 100% pur jus de fruit, 45% de matière grasses",
+};
+
+extract_ingredients_from_text($product_ref);
+
+delete_ingredients_percent_values( $product_ref->{ingredients} );
+delete $product_ref->{ingredients_percent_analysis};
+
+is_deeply(
+	$product_ref->{ingredients},
+	[   {   'id'         => 'en:crushed-tomato',
+			'percent'    => 19,
+			'rank'       => 1,
+			'text'       => "pur\x{e9}e de tomate",
+			'vegan'      => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{   'id'         => 'en:beef',
+			'percent'    => '90',
+			'rank'       => 2,
+			'text'       => 'boeuf',
+			'vegan'      => 'no',
+			'vegetarian' => 'no'
+		},
+		{   'id'         => 'en:fruit-juice',
+			'percent'    => 100,
+			'rank'       => 3,
+			'text'       => 'jus de fruit',
+			'vegan'      => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{   'from_palm_oil' => 'maybe',
+			'id'            => 'en:oil-and-fat',
+			'percent'       => '45',
+			'rank'          => 4,
+			'text'          => "mati\x{e8}re grasses",
+			'vegan'         => 'maybe',
+			'vegetarian'    => 'maybe'
+		}
+	],
+) or diag explain $product_ref;
+
+
 # Finnish
 $product_ref = {
 	lc => "fi",


### PR DESCRIPTION
**Description:**

Require a space after 'pur' or 'de' in the regex. Fixes #3827, #3706, #3826

**Related issues and discussion:** #3827 #3706 #3826
