### PR TITLE
support rev for product read API, #4134

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9206,7 +9206,6 @@ sub display_product_api($)
 	if (defined $rev) {
 		$log->info("displaying product revision") if $log->is_info();
 		$product_ref = retrieve_product_rev($product_id, $rev);
-		$header .= '<meta name="robots" content="noindex,follow">';
 	}
 	else {
 		$product_ref = retrieve_product($product_id);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9198,7 +9198,19 @@ sub display_product_api($)
 	my %response = ();
 
 	$response{code} = $code;
-	my $product_ref = retrieve_product($product_id);
+	
+	my $product_ref;
+
+	my $rev = param("rev");
+	local $log->context->{rev} = $rev;
+	if (defined $rev) {
+		$log->info("displaying product revision") if $log->is_info();
+		$product_ref = retrieve_product_rev($product_id, $rev);
+		$header .= '<meta name="robots" content="noindex,follow">';
+	}
+	else {
+		$product_ref = retrieve_product($product_id);
+	}	
 
 	if ($code !~ /^\d{4,24}$/) {
 


### PR DESCRIPTION
fixes #4134 

add support for queries like https://world.openfoodfacts.org/api/v0/product/8410422407028/salsa-picante-louisiana-chovi?rev=28