### PR TITLE
Remove dangling symlink lang/pt/texts/dados.html

### DIFF
--- a/lang/pt/texts/dados.html
+++ b/lang/pt/texts/dados.html
@@ -1,1 +1,0 @@
-data.en.html


### PR DESCRIPTION
Dangling symlink pointing to data.en.html, which was deleted in https://github.com/openfoodfacts/openfoodfacts-server/commit/53ca24735b29a787af59e529028b40974bde83a4