### PR TITLE
ingredients parsing - ignore "allergy advice" in ingredients lists

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1186,6 +1186,7 @@ sub parse_ingredients_text($) {
 					}
 				}
 
+				# Check ingredient against labels taxonomy. If it exists there, don't parse it as an ingredient, and add it to labels. See also further down.
 				if (defined $labels_regexps{$product_lc}) {
 					# start with uncomposed labels first, so that we decompose "fair-trade organic" into "fair-trade, organic"
 					foreach my $labelid (reverse @labels) {
@@ -1300,6 +1301,17 @@ sub parse_ingredients_text($) {
 
 						# Remove some sentences
 						my %ignore_regexps = (
+
+							'en' => [
+								# breaking this regexp into the comma separated combinations (because each comma makes a new ingredient):
+								# (allerg(en|y) advice[:!]? )?(for allergens[,]? )?(including cereals containing gluten, )?see ingredients (highlighted )?in bold
+								# We can't just trim it from the end of the ingredients, because trace allergens can come after it.
+								'^allerg(en|y) advice([:!]? for allergens)?( including cereals containing gluten)?( see ingredients (highlighted )?in bold)?$', 
+								'^for allergens( including cereals containing gluten)?( see ingredients (highlighted )?in bold)?$',
+								'^including cereals containing gluten( see ingredients (highlighted )?in bold)?$',
+								'^see ingredients in bold$',
+							],
+
 							'fr' => [
 								'(\%|pourcentage|pourcentages) (.*)(exprim)',
 								'(sur|de) produit fini',             # préparé avec 50g de fruits pour 100g de produit fini

--- a/t/allergens_tags.t
+++ b/t/allergens_tags.t
@@ -63,8 +63,9 @@ my @tests = (
 
 	# Currently not supported
 	# [ { lc => "de", ingredients_text => "kann Haselnüsse und andere schalenfrüchte enthalten",}, [], ["en:nuts"] ],
-  
+
 	[ { lc => "de", ingredients_text => "Kann spuren von Erdnüssen" }, [], ["en:peanuts"] ],
+	[ { lc => "en", ingredients_text => "salt, egg, spice. allergen advice: for allergens including cereals containing gluten, see ingredients in bold. May contain traces of nuts."}, ['en:eggs'], ['en:nuts'] ],
 
 );
 

--- a/t/ingredients_tags.t
+++ b/t/ingredients_tags.t
@@ -121,6 +121,12 @@ my @tests = (
 	[ { lc => "es", ingredients_text => "caramelo E-150c"} , ["en:e150c"]],
 	# mismatch between name and number
 	[ { lc => "fr", ingredients_text => "acide citrique E120"} , ["fr:acide citrique e120"]],
+	
+	# removal of "allergy advice..." in %ignore_regexps
+	[ { lc => "en", ingredients_text => "salt, spice. allergy advice! for allergens, see ingredients in bold, water."}, ['en:salt','en:spice','en:water']],
+	[ { lc => "en", ingredients_text => "salt, spice. allergy advice: for allergens, see ingredients in bold. May contain traces of nuts."}, ['en:salt','en:spice']],
+	[ { lc => "en", ingredients_text => "salt, spice. allergen advice: for allergens including cereals containing gluten, see ingredients in bold. May contain traces of nuts."}, ['en:salt','en:spice']],
+
 
 );
 


### PR DESCRIPTION
Several of the top unknown ingredients for the UK are variations of these. These patterns match 1423 lines in the CSV dump.

(also a random comment from me working out how the code worked, and how "suitable for vegetarians" could be in an ingredient text but not parsed...)

Looking at the CSV, French has a similar issue ("Pour les allergènes, voir les ingrédients indiqués en gras" etc), but I'm not as familiar with the ingredient conventions. But if this PR is the right way to do this, I could have a go.