### PR TITLE
Personal Search - Selection and local storage of user product preferences, #4119

### DIFF
--- a/cgi/display.pl
+++ b/cgi/display.pl
@@ -80,6 +80,10 @@ if (defined $request{api}) {
 		# /api/v0/search
 		display_tag(\%request);
 	}
+	elsif (param("api_method") =~ /^preferences(_(\w\w))?$/) {
+		# /api/v0/preferences or /api/v0/preferences_[language code]
+		display_preferences_api(\%request, $2);
+	}	
 	elsif (param("api_method") =~ /^attribute_groups(_(\w\w))?$/) {
 		# /api/v0/attribute_groups or /api/v0/attribute_groups_[language code]
 		display_attribute_groups_api(\%request, $2);

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -10,7 +10,9 @@ if (user_product_preferences_string) {
 	user_product_preferences = JSON.parse(user_product_preferences_string);
 }
 
-function show_user_product_preferences (target) {
+// show_user_product_preferences can be called by other scripts
+
+function show_user_product_preferences (target) { // eslint-disable-line no-unused-vars
 
 	// Retrieve all the supported attribute groups from the server, unless we have them already
 	
@@ -39,18 +41,18 @@ function show_user_product_preferences (target) {
 		var attribute_groups_html = [];
 		
 		// Iterate over attribute groups
-		$.each( attribute_groups, function( key, attribute_group ) {
+		$.each( attribute_groups, function(key, attribute_group) {
 			
 			var attribute_group_html = "<li id='attribute_group_" + attribute_group.id + "' class='attribute_group'>" + attribute_group.name 
 			+ "<ul>";
 			
 			// Iterate over attributes
 			
-			$.each( attribute_group.attributes, function( key, attribute ) {
+			$.each(attribute_group.attributes, function(key, attribute) {
 				
 				attribute_group_html += "<li id='attribute_" + attribute.id + "' class='attribute'><spanc class='attribute_name'>" + attribute.setting_name + "</span><br>";
 								
-				$.each ( preferences, function ( key, preference) {
+				$.each(preferences, function (key, preference) {
 					
 					var checked = '';
 					
@@ -61,17 +63,17 @@ function show_user_product_preferences (target) {
 					attribute_group_html += "<input class='attribute_radio' id='attribute_" + attribute.id + "_" + preference.id
 					+ "' value='" + preference.id + "' type='radio' name='" + attribute.id + "'" + checked + ">"
 					+ "<label for='attribute_" + attribute.id + "_" + preference.id + "'>" + preference.name + "</label>"
-					+ "</input>"
+					+ "</input>";
 				});
 				
-				attribute_group_html + "</li>";
+				attribute_group_html += "</li>";
 			});
 						
 			attribute_group_html += "</ul></li>";
 			
-			attribute_groups_html.push( attribute_group_html );
+			attribute_groups_html.push(attribute_group_html);
 		});
-	 
+
 		$( "<ul/>", {
 			"class": "user_product_preferences",
 			html: attribute_groups_html.join( "" )

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -11,8 +11,9 @@ if (user_product_preferences_string) {
 }
 
 // show_user_product_preferences can be called by other scripts
+/* exported show_user_product_preferences */
 
-function show_user_product_preferences (target) { // eslint-disable-line no-unused-vars
+function show_user_product_preferences (target) {
 
 	// Retrieve all the supported attribute groups from the server, unless we have them already
 	
@@ -32,7 +33,7 @@ function show_user_product_preferences (target) { // eslint-disable-line no-unus
 		
 			preferences = data;
 		
-			show_user_product_preferences(target); // eslint-disable-line no-unused-vars
+			show_user_product_preferences(target);
 		});		
 	}
 	

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -32,7 +32,7 @@ function show_user_product_preferences (target) { // eslint-disable-line no-unus
 		
 			preferences = data;
 		
-			show_user_product_preferences(target);
+			show_user_product_preferences(target); // eslint-disable-line no-unused-vars
 		});		
 	}
 	

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -1,0 +1,85 @@
+var attribute_groups;	// All supported attribute groups and attributes + translated strings
+var preferences;	// All supported preferences + translated strings
+
+// Retrieve user preferences from local storage
+
+var user_product_preferences = {};
+var user_product_preferences_string = localStorage.getItem('user_product_preferences');
+
+if (user_product_preferences_string) {
+	user_product_preferences = JSON.parse(user_product_preferences_string);
+}
+
+function show_user_product_preferences (target) {
+
+	// Retrieve all the supported attribute groups from the server, unless we have them already
+	
+	if (! attribute_groups) {
+		
+		$.getJSON( "/api/v0/attribute_groups", function( data ) {
+		
+			attribute_groups = data;
+		
+			show_user_product_preferences(target);
+		});
+	}
+	
+	if (! preferences) {
+		
+		$.getJSON( "/api/v0/preferences", function( data ) {
+		
+			preferences = data;
+		
+			show_user_product_preferences(target);
+		});		
+	}
+	
+	if (attribute_groups && preferences) {
+		
+		var attribute_groups_html = [];
+		
+		// Iterate over attribute groups
+		$.each( attribute_groups, function( key, attribute_group ) {
+			
+			var attribute_group_html = "<li id='attribute_group_" + attribute_group.id + "' class='attribute_group'>" + attribute_group.name 
+			+ "<ul>";
+			
+			// Iterate over attributes
+			
+			$.each( attribute_group.attributes, function( key, attribute ) {
+				
+				attribute_group_html += "<li id='attribute_" + attribute.id + "' class='attribute'><spanc class='attribute_name'>" + attribute.setting_name + "</span><br>";
+								
+				$.each ( preferences, function ( key, preference) {
+					
+					var checked = '';
+					
+					if (user_product_preferences[attribute.id] == preference.id) {
+						checked = ' checked';
+					}
+					
+					attribute_group_html += "<input class='attribute_radio' id='attribute_" + attribute.id + "_" + preference.id
+					+ "' value='" + preference.id + "' type='radio' name='" + attribute.id + "'" + checked + ">"
+					+ "<label for='attribute_" + attribute.id + "_" + preference.id + "'>" + preference.name + "</label>"
+					+ "</input>"
+				});
+				
+				attribute_group_html + "</li>";
+			});
+						
+			attribute_group_html += "</ul></li>";
+			
+			attribute_groups_html.push( attribute_group_html );
+		});
+	 
+		$( "<ul/>", {
+			"class": "user_product_preferences",
+			html: attribute_groups_html.join( "" )
+		}).replaceAll(target);
+		
+		$( ".attribute_radio").change(function () {
+			user_product_preferences[this.name] = $("input[name='" + this.name + "']:checked").val();
+			localStorage.setItem('user_product_preferences', JSON.stringify(user_product_preferences));
+		});
+	}
+}

--- a/lang/en/texts/product-preferences.html
+++ b/lang/en/texts/product-preferences.html
@@ -1,0 +1,17 @@
+<scripts>
+<script src="/js/product-preferences.js"></script>
+</scripts>
+
+<initjs>
+show_user_product_preferences("#preferences_settings");
+</initjs>
+
+<h1>Your product preferences</h1>
+
+<p>You can define personal preferences to search, filter, recommend and display products.</p>
+
+<p>Your privacy is very important to us. Your preferences are private and are stored and used only inside your browser. They are not sent to the Open Food Facts server.</p>
+
+<div id="preferences_settings">
+Loading your product preferences.
+</div>

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -74,6 +74,7 @@ BEGIN
 		&display_product
 		&display_product_api
 		&display_product_history
+		&display_preferences_api
 		&display_attribute_groups_api
 		&search_and_display_products
 		&search_and_export_products
@@ -9388,6 +9389,48 @@ JS
 	$tt->process('nutrition_facts_table.tt.html', $template_data_ref, \$html) || return "template error: " . $tt->error();
 
 	return $html;
+}
+
+
+=head2 display_preferences_api ( $target_lc )
+
+Return a JSON structure with all available preference values for attributes.
+
+This is used by clients that ask for user preferences to personalize
+filtering and ranking based on product attributes.
+
+=head3 Arguments
+
+=head4 request object reference $request_ref
+
+=head4 language code $target_lc
+
+Sets the desired language for the user facing strings.
+
+=cut
+
+sub display_preferences_api($$)
+{
+	my $request_ref = shift;
+	my $target_lc = shift;
+	
+	if (not defined $target_lc) {
+		$target_lc = $lc;
+	}
+		
+	$request_ref->{structured_response} = [];
+	
+	foreach my $preference ("not_important", "important", "very_important", "mandatory") {
+		
+		push @{$request_ref->{structured_response}}, {
+			id => $preference,
+			name => lang("preference_" . $preference),
+		};
+	}
+
+	display_structured_response($request_ref);
+	
+	return;
 }
 
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4688,6 +4688,10 @@ msgctxt "query_filter"
 msgid "Query filter"
 msgstr "Query filter"
 
+msgctxt "nova_group_producer"	
+msgid "NOVA group"	
+msgstr "NOVA group"
+
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
 msgstr "Unknown organization."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4688,10 +4688,6 @@ msgctxt "query_filter"
 msgid "Query filter"
 msgstr "Query filter"
 
-msgctxt "nova_group_producer"
-msgid "NOVA group"
-msgstr "NOVA group"
-
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
 msgstr "Unknown organization."
@@ -4735,3 +4731,19 @@ msgstr "Additives"
 msgctxt "attribute_additives_setting_name"
 msgid "No or few additives"
 msgstr "No or few additives"
+
+msgctxt "preference_not_important"
+msgid "Not important"
+msgstr "Not important"
+
+msgctxt "preference_important"
+msgid "Important"
+msgstr "Important"
+
+msgctxt "preference_very_important"
+msgid "Very important"
+msgstr "Very important"
+
+msgctxt "preference_mandatory"
+msgid "Mandatory"
+msgstr "Mandatory"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4674,10 +4674,6 @@ msgctxt "query_filter"
 msgid "Query filter"
 msgstr "Query filter"
 
-msgctxt "nova_group_producer"
-msgid "NOVA group"
-msgstr "NOVA group"
-
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
 msgstr "Unknown organization."
@@ -4721,3 +4717,22 @@ msgstr "Additives"
 msgctxt "attribute_additives_setting_name"
 msgid "No or few additives"
 msgstr "No or few additives"
+
+msgctxt "preference_not_important"
+msgid "Not important"
+msgstr "Not important"
+
+msgctxt "preference_important"
+msgid "Important"
+msgstr "Important"
+
+msgctxt "preference_very_important"
+msgid "Very important"
+msgstr "Very important"
+
+msgctxt "preference_mandatory"
+msgid "Mandatory"
+msgstr "Mandatory"
+
+
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4674,6 +4674,10 @@ msgctxt "query_filter"
 msgid "Query filter"
 msgstr "Query filter"
 
+msgctxt "nova_group_producer"	
+msgid "NOVA group"	
+msgstr "NOVA group"
+
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
 msgstr "Unknown organization."


### PR DESCRIPTION
New APIs to retrieve possible values for preferences and all supported product attributes
- https://fr.openfoodfacts.dev/api/v0/preferences
- https://fr.openfoodfacts.dev/api/v0/attribute_groups

New user interface to set preferences that are saved using localstorage in the browser:
- https://world.openfoodfacts.dev/product-preferences

One drawback of localstorage is that it is subdomain specific (but that should not be an issue for most users).

This is just a start, hopefully someone can make a nicer looking UI etc.

![image](https://user-images.githubusercontent.com/8158668/92945894-37dfcc80-f456-11ea-9fa4-2947d61371f8.png)

