### PR TITLE
performance - Make Tags.pm perform its 9600 file-exists checks on demand instead of on load

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1731,6 +1731,8 @@ sub display_list_of_tags($$) {
 			$log->debug("missing_property defined", {missing_property => $missing_property});
 		}
 
+		init_tags_texts_levels() unless %tags_levels;
+
 		foreach my $tagcount_ref (@tags) {
 
 			$i++;
@@ -2831,6 +2833,8 @@ sub display_tag($) {
 
 	local $log->context->{tagtype2} = $tagtype2;
 	local $log->context->{tagid2} = $tagid2;
+
+	init_tags_texts_levels() unless %tags_texts;
 
 	# Add a meta robot noindex for pages related to users
 	if ( ((defined $tagtype) and ($tagtype =~ /^(users|correctors|editors|informers|correctors|photographers|checkers)$/))
@@ -7540,6 +7544,8 @@ JS
 
 	# to compute the number of columns displayed
 	my $ingredients_classes_n = 0;
+
+	init_tags_texts_levels() unless %tags_levels;
 
 	foreach my $class ('additives', 'vitamins', 'minerals', 'amino_acids', 'nucleotides', 'other_nutritional_substances', 'ingredients_from_palm_oil', 'ingredients_that_may_be_from_palm_oil') {
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3355,6 +3355,7 @@ sub init_tags_texts_levels {
 				defined $tags_texts{$lc}{$tagtype} or $tags_texts{$lc}{$tagtype} = {};
 				defined $tags_levels{$lc}{$tagtype} or $tags_levels{$lc}{$tagtype} = {};
 
+				# this runs number-of-languages * number-of-tag-types times.
 				if (-e "$data_root/lang/$langid/$tagtype") {
 					opendir DH, "$data_root/lang/$langid/$tagtype" or die "Couldn't open the current directory: $!";
 					foreach my $file (readdir(DH)) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3332,50 +3332,55 @@ foreach my $l (@Langs) {
 $log->debug("Nutrient levels initialized") if $log->is_debug();
 
 # load all tags texts
+sub init_tags_texts_levels {
+	return if ((%tags_texts) and (%tags_levels));
 
-$log->info("loading tags texts") if $log->is_info();
-opendir DH2, "$data_root/lang" or die "Couldn't open $data_root/lang : $!";
-foreach my $langid (readdir(DH2)) {
-	next if $langid eq '.';
-	next if $langid eq '..';
+	$log->info("loading tags texts") if $log->is_info();
+	opendir DH2, "$data_root/lang" or die "Couldn't open $data_root/lang : $!";
+	foreach my $langid (readdir(DH2)) {
+		next if $langid eq '.';
+		next if $langid eq '..';
 
-	# print STDERR "Tags.pm - reading texts for lang $langid\n";
-	next if ((length($langid) ne 2) and not ($langid eq 'other'));
+		# print STDERR "Tags.pm - reading texts for lang $langid\n";
+		next if ((length($langid) ne 2) and not ($langid eq 'other'));
 
-	my $lc = $langid;
+		my $lc = $langid;
 
-	defined $tags_texts{$lc} or $tags_texts{$lc} = {};
-	defined $tags_levels{$lc} or $tags_levels{$lc} = {};
+		defined $tags_texts{$lc} or $tags_texts{$lc} = {};
+		defined $tags_levels{$lc} or $tags_levels{$lc} = {};
 
-	if (-e "$data_root/lang/$langid") {
-		foreach my $tagtype (sort keys %tag_type_singular) {
+		if (-e "$data_root/lang/$langid") {
+			foreach my $tagtype (sort keys %tag_type_singular) {
 
-			defined $tags_texts{$lc}{$tagtype} or $tags_texts{$lc}{$tagtype} = {};
-			defined $tags_levels{$lc}{$tagtype} or $tags_levels{$lc}{$tagtype} = {};
+				defined $tags_texts{$lc}{$tagtype} or $tags_texts{$lc}{$tagtype} = {};
+				defined $tags_levels{$lc}{$tagtype} or $tags_levels{$lc}{$tagtype} = {};
 
-			if (-e "$data_root/lang/$langid/$tagtype") {
-				opendir DH, "$data_root/lang/$langid/$tagtype" or die "Couldn't open the current directory: $!";
-				foreach my $file (readdir(DH)) {
-					next if $file !~ /(.*)\.html/;
-					my $tagid = $1;
-					open(my $IN, "<:encoding(UTF-8)", "$data_root/lang/$langid/$tagtype/$file") or $log->error("cannot open file", { path => "$data_root/lang/$langid/$tagtype/$file", error => $! });
+				if (-e "$data_root/lang/$langid/$tagtype") {
+					opendir DH, "$data_root/lang/$langid/$tagtype" or die "Couldn't open the current directory: $!";
+					foreach my $file (readdir(DH)) {
+						next if $file !~ /(.*)\.html/;
+						my $tagid = $1;
+						open(my $IN, "<:encoding(UTF-8)", "$data_root/lang/$langid/$tagtype/$file") or $log->error("cannot open file", { path => "$data_root/lang/$langid/$tagtype/$file", error => $! });
 
-					my $text = join("",(<$IN>));
-					close $IN;
-					if ($text =~ /class="level_(\d+)"/) {
-						$tags_levels{$lc}{$tagtype}{$tagid} = $1;
+						my $text = join("",(<$IN>));
+						close $IN;
+						if ($text =~ /class="level_(\d+)"/) {
+							$tags_levels{$lc}{$tagtype}{$tagid} = $1;
+						}
+						$text =~  s/class="(\w+)_level_(\d)"/class="$1_level_$2 level_$2"/g;
+						$tags_texts{$lc}{$tagtype}{$tagid} = $text;
+
 					}
-					$text =~  s/class="(\w+)_level_(\d)"/class="$1_level_$2 level_$2"/g;
-					$tags_texts{$lc}{$tagtype}{$tagid} = $text;
-
+					closedir(DH);
 				}
-				closedir(DH);
 			}
 		}
 	}
+	closedir(DH2);
+	$log->debug("tags texts loaded") if $log->is_debug();
+	
+	return;
 }
-closedir(DH2);
-$log->debug("tags texts loaded") if $log->is_debug();
 
 sub add_tags_to_field($$$$) {
 

--- a/t/tags.t
+++ b/t/tags.t
@@ -658,6 +658,11 @@ is_deeply($tag_ref,
 )
 or diag explain $tag_ref;
 
+# check %tags_texts and %tags_levels are populated on demand
+ProductOpener::Tags::init_tags_texts_levels();
+# Assumes we will always have french additive texts for E100.
+like($tags_texts{'fr'}{'additives'}{'e100'}, qr/curcumine/, 'e100 text contains "curcumine"') or diag explain($tags_texts{'fr'}{'additives'}{'e100'});
+isnt($tags_levels{'fr'}{'additives'}{'e100'}, undef, 'e100 level has a value') or diag explain($tags_levels{'fr'}{'additives'});
 
 
 done_testing();


### PR DESCRIPTION
As part of playing with NYTProf, I discovered why unit tests took so long to run for me.
The population of %tags_texts and %tags_levels happens every time Tags.pm is loaded, and number-of-languages * number-of-tag-types = 9600 file exists checks, for variables that are only used in 3 places in Display.pm. 
This probably isn't noticeable most of the time, but I was running over a network share, where this added 39 seconds to running each unit test file...
I took inspiration from https://github.com/openfoodfacts/openfoodfacts-server/pull/2833, but may have got the perl wrong...