### PR TITLE
performance - make build_tags_taxonomy() use string comparisons instead of regexps

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1080,16 +1080,21 @@ sub build_tags_taxonomy($$$) {
 
 					# replace whole words/phrases only
 
-					if ($tagid =~ /-${tagid2}-/) {
+					# String comparisons are many times faster than the regexps, as long as tags only ever need simple string matching.
+					#if ($tagid =~ /-${tagid2}-/) {
+					if (index($tagid, "-${tagid2}-") >= 0) {
 						$replace = "-${tagid2}-";
 						$before = '-';
 						$after = '-';
 					}
-					elsif ($tagid =~ /-${tagid2}$/) {
+					#elsif ($tagid =~ /-${tagid2}$/) {
+					# despite how convoluted it is, this is still faster than the regexp.
+					elsif (rindex($tagid, "-${tagid2}") + length("-${tagid2}") == length($tagid)) {
 						$replace = "-${tagid2}\$";
 						$before = '-';
 					}
-					elsif ($tagid =~ /^${tagid2}-/) {
+					#elsif ($tagid =~ /^${tagid2}-/) {
+					elsif (index($tagid, "${tagid2}-") == 0) {
 						$replace = "^${tagid2}-";
 						$after = '-';
 					}


### PR DESCRIPTION
Building the categories taxonomy, according to NYTProf the modified code is run approx **141 million times**. (3 regexps, so approx 422 million calls.) 
Borrowing a trick from PHP optimisation, I tried replacing the regexp comparisons with builtin string functions. Sadly, perl's builtin functions are more limited, hence the clumsy "does the string end with this" test - "is the start point of the last match + the length of the needle string equal to the length of the haystack string".
For me, this change reduced the taxonomy build times to 1/5 of the original time for all the taxonomies (apart from the tiny ones, where startup time is larger).

It seems to produce identical .results.txt files (and the same complaints/errors to the console), but different but identical-size .sto files. I don't know if that's significant, maybe they're different every time?
And the other major functions seem to be called exactly the same number of times, suggesting the same code flow.

This does of course assume those comparisons never _need_ to be regexps.


### With regexp comparisons:
_Profile of scripts/build_tags_taxonomy.pl for 3770s (of 4412s), executing 1293706561 statements and 854791389 subroutine calls in 911 source files and 285 string evals._
![image](https://user-images.githubusercontent.com/5736616/92997464-653a8200-f50b-11ea-8c95-dba57098f14c.png) 
![image](https://user-images.githubusercontent.com/5736616/92997471-74b9cb00-f50b-11ea-80df-ee18511c78ac.png)
![image](https://user-images.githubusercontent.com/5736616/92997604-68823d80-f50c-11ea-9fd5-bfa9c9b2ff33.png)


### With string comparisons:
_Profile of scripts/build_tags_taxonomy.pl for 584s (of 1387s), executing 1716511043 statements and 9193823 subroutine calls in 911 source files and 285 string evals._
![image](https://user-images.githubusercontent.com/5736616/92997552-14775900-f50c-11ea-827f-07f46cb5b604.png)
![image](https://user-images.githubusercontent.com/5736616/92997557-1e995780-f50c-11ea-8525-5a3e7666e3b1.png)
![image](https://user-images.githubusercontent.com/5736616/92999153-b56b1180-f516-11ea-9481-2fc20e5f86e3.png)

Output files:
![image](https://user-images.githubusercontent.com/5736616/92999375-4bec0280-f518-11ea-82d1-f8e6656ec106.png)
