### PR TITLE
declare &init_tags_texts_levels

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -100,6 +100,8 @@ BEGIN
 		&compute_field_tags
 		&add_tags_to_field
 
+		&init_tags_texts_levels
+
 		&get_city_code
 		%emb_codes_cities
 		%emb_codes_geo


### PR DESCRIPTION
so that it can be called from Display.pm without prefixing with ProductOpener::Tags::
Otherwise we get an error when accessing a product page:

Software error:
Undefined subroutine &ProductOpener::Display::init_tags_texts_levels called at /srv/off/lib/ProductOpener/Display.pm line 7549.