### PR TITLE
performance - Move two Storable loads from BEGIN to INIT phase, to speed up syntax check

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -5597,16 +5597,21 @@ sub get_canon_local_authority($) {
 	return $canon_local_authority;
 }
 
-if (-e "$data_root/packager-codes/packager_codes.sto") {
-	my $packager_codes_ref = retrieve("$data_root/packager-codes/packager_codes.sto");
-	%packager_codes = %{$packager_codes_ref};
-}
+# Slow, and the variables are only used from within functions or non-resident scripts,
+# so only run this when actually executing (INIT), not just checking syntax (BEGIN).
+INIT {
 
-if (-e "$data_root/packager-codes/geocode_addresses.sto") {
-	my $geocode_addresses_ref = retrieve("$data_root/packager-codes/geocode_addresses.sto");
-	%geocode_addresses = %{$geocode_addresses_ref};
-}
+	if (-e "$data_root/packager-codes/packager_codes.sto") {
+		my $packager_codes_ref = retrieve("$data_root/packager-codes/packager_codes.sto");
+		%packager_codes = %{$packager_codes_ref};
+	}
 
+	if (-e "$data_root/packager-codes/geocode_addresses.sto") {
+		my $geocode_addresses_ref = retrieve("$data_root/packager-codes/geocode_addresses.sto");
+		%geocode_addresses = %{$geocode_addresses_ref};
+	}
+
+}
 
 sub compute_nova_group($) {
 

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -92,9 +92,12 @@ BEGIN
 
 		&compare_nutriments
 
-		$ec_code_regexp
 		%packager_codes
 		%geocode_addresses
+		&init_packager_codes
+		&init_geocode_addresses
+		
+		$ec_code_regexp
 		&normalize_packager_codes
 		&localize_packager_code
 		&get_canon_local_authority
@@ -5597,14 +5600,19 @@ sub get_canon_local_authority($) {
 	return $canon_local_authority;
 }
 
-# Slow, and the variables are only used from within functions or non-resident scripts,
-# so only run this when actually executing (INIT), not just checking syntax (BEGIN).
-INIT {
+
+sub init_packager_codes() {
+	return if (%packager_codes);
 
 	if (-e "$data_root/packager-codes/packager_codes.sto") {
 		my $packager_codes_ref = retrieve("$data_root/packager-codes/packager_codes.sto");
 		%packager_codes = %{$packager_codes_ref};
 	}
+
+}
+
+sub init_geocode_addresses() {
+	return if (%geocode_addresses);
 
 	if (-e "$data_root/packager-codes/geocode_addresses.sto") {
 		my $geocode_addresses_ref = retrieve("$data_root/packager-codes/geocode_addresses.sto");
@@ -5612,6 +5620,13 @@ INIT {
 	}
 
 }
+
+# Slow, so only run these when actually executing, not just checking syntax. See also startup_apache2.pl.
+INIT {
+	init_packager_codes();
+	init_geocode_addresses();
+}
+
 
 sub compute_nova_group($) {
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1796,6 +1796,7 @@ foreach my $langid (readdir($DH2)) {
 closedir($DH2);
 
 
+# It would be nice to move this from BEGIN to INIT, as it's slow, but other BEGIN code depends on it.
 foreach my $taxonomyid (@ProductOpener::Config::taxonomy_fields) {
 
 	# print STDERR "loading taxonomy $taxonomyid\n";

--- a/lib/startup_apache2.pl
+++ b/lib/startup_apache2.pl
@@ -102,6 +102,8 @@ if (!(  (   ( $r->useragent_ip eq '127.0.0.1' )
 }
 
 init_emb_codes();
+init_packager_codes();
+init_geocode_addresses();
 
 # This startup script is run as root, it will create the $data_root/tmp directory
 # if it does not exist, as well as sub-directories for the Template module


### PR DESCRIPTION
The variables packager_codes and geocode_addresses are only used from within functions in Display.pm, not top level code that runs during BEGIN, and in cgi/ & scripts/ code that will only use them on executing anyway.

For one thing, this shaves approx 1 second off syntax checking each script in the pull request workflow, and there are 150 scripts...

(Usual perl-n00b caveat applies, I'm getting my understanding from https://perldoc.perl.org/perlmod.html#BEGIN%2c-UNITCHECK%2c-CHECK%2c-INIT-and-END )

Neither of the variables are referenced directly in any unit tests, but they're loaded conditionally anyway.
```
if (-e "$data_root/packager-codes/packager_codes.sto") {
```

The other big chunk of Storable::* is the loop of ``` retrieve_tags_taxonomy($taxonomyid); ``` in Tags.pm, but it populates variables that other BEGIN-time code relies on, so moving that to INIT breaks things, at least without tackling a lot more of the code.

Doing ``` time perl -d:NYTProf -c -CS -Ilib cgi/change_password.pl ```:

Before:
![image](https://user-images.githubusercontent.com/5736616/93257016-253a0000-f794-11ea-89d3-4f5ea67dfd21.png)

After:
![image](https://user-images.githubusercontent.com/5736616/93257053-3256ef00-f794-11ea-876f-66c755c59d0b.png)