### PR TITLE
Fixed spelling for German Flammkuchen

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -53148,7 +53148,7 @@ nl:St. Jakobs schelpen
 
 <en:Salted pies
 en:Flammekueche, Flamed tart, Thin-crusted onion tart with cream and lardoons
-de:Flammekueche
+de:Flammkuchen
 fr:Flammekueches, Flammekueche, tarte flambée,  tartes flambées, flamme-küche, flamms, Flammkuchen, Flamenkuches, Tartes flambées aux lardons
 it:Flammkuchen
 nl:Flammekueche


### PR DESCRIPTION
**Description:**

I simply changed the word "Flammkueche" (which isn't a German word" to "Flammkuchen".

