### PR TITLE
Sort processing regexes by length

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -480,8 +480,12 @@ sub init_ingredients_processing_regexps() {
 
 			foreach my $synonym ( @{$synonyms_for{ingredients_processing}{$l}{$l_ingredients_processing}} ) {
 				push @{ $ingredients_processing_regexps{$l} },
-					[ $ingredients_processing, $_ ]
-					for ( $synonym, unac_string_perl($synonym) );
+					[ $ingredients_processing, $synonym ];
+
+				if ( ( my $unacc = unac_string_perl($synonym) ) ne $synonym ) {
+					push @{ $ingredients_processing_regexps{$l} },
+						[ $ingredients_processing, $unacc ];
+				}
 			}
 		}
 	}

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -238,6 +238,27 @@ my @tests = (
 #		]
 #	],
 
+	# Assert that processing patterns are in descending length order
+	# i.e 'fi:jauhettu' is matched before 'fi:jauhe'
+	# [   {   lc => "fi",
+	# 		ingredients_text =>
+	# 			"raakamaito, mustikkajauhe, jauhettu vaniljatanko"
+	# 	},
+	# 	[   {   'id'   => 'en:raw-milk',
+	# 			'text' => 'raakamaito'
+	# 		},
+	# 		{   'id'         => 'en:blueberry',
+	# 			'processing' => 'en:powdered',
+	# 			'text'       => 'mustikka'
+	# 		},
+	# 		{   'id'         => 'en:vanilla-pod',
+	# 			'processing' => 'en:ground',
+	# 			'text'       => 'vaniljatanko'
+	# 		}
+	# 	]
+	# ],
+
+
 ##################################################################
 #
 #                           D U T C H ( N L )

--- a/t/ingredients_tags.t
+++ b/t/ingredients_tags.t
@@ -69,7 +69,7 @@ my @tests = (
 	[ { lc => "fr", ingredients_text => "Fromage étrange à pâte cuite"}, [ "fr:Fromage étrange à pâte cuite" ], ],
 	[ { lc => "fr", ingredients_text => "Banane coupée et cuite au naturel"}, [ "en:banana" ], ],
 	[ { lc => "fr", ingredients_text => "Lamelles de bananes déshydratées"}, [ "en:banana" ], ],
-	[ { lc => "fr", ingredients_text => "émincé de filet de poulet traité en salaison cuit rôti, Pourcentages exprimés sur les pâtes alimentaires aux oeufs "}, ["en:chicken-fillet" ], ],
+	[ { lc => "fr", ingredients_text => "émincé de filet de poulet traité en salaison cuit rôti, Pourcentages exprimés sur les pâtes alimentaires aux oeufs "}, ["fr:filet-de-poulet-traite-en-salaison-cuit" ], ],
 	[ { lc => "fr", ingredients_text => "sucre 22g**"}, [ "en:sugar" ], ],
 
 	# [ { lc => "de", ingredients_text => "Wasser, Kohlensäure, Farbstoff Zuckerkulör E 150d, Süßungsmittel Aspartam* und Acesulfam-K, Säuerungsmittel Phosphorsäure und Citronensäure, Säureregulator Natriumcitrat, Aroma Koffein, Aroma. enthält eine Phenylalaninquelle"}, [ "en:sugar" ], ],


### PR DESCRIPTION
**Description:**

Currently only the synonyms for a single process are in sorted order, but the whole array for a language is not. I bumped into this while enabling processing for the Nordic languages and couldn't match `fi:jauhettu` because `fi:jauhe` appeared before it.

I removed other `sort`s from the subroutine because I couldn't see the point in sorting the canonical tags or the languages.