### PR TITLE
Remove title and metadata from SVGs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,8 @@ function icons() {
     pipe(
       svgmin({
       plugins: [
-        { removeMetadata: false },
-        { removeTitle: false },
+        { removeMetadata: true },
+        { removeTitle: true },
         { removeDimensions: true },
           { addClassesToSVGElement: { className: "icon" } },
           {


### PR DESCRIPTION
When the SVG gets inlined, search engines actually index this, so that search keys like "IcoFont Icons" are uselessly used for all OFF pages.