### PR TITLE
performance improvements for scripts/update_all_products.pl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Thumbs.db
 Store.debug.txt
 *.log
 logs/modperl_error_log
+nytprof*.out
 
 # Local databases
 data/mongodb

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1252,7 +1252,7 @@ sub parse_ingredients_text($) {
 									
 									#  match after, do not require a space
 									# currently no language
-									or ( ($product_lc eq 'xx') and ($new_ingredient =~ /($regexp)$/i) )
+									#or ( ($product_lc eq 'xx') and ($new_ingredient =~ /($regexp)$/i) )
 									
 									#  Dutch: match before or after, do not require a space
 									or (

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -4412,16 +4412,27 @@ sub extract_ingredients_classes_from_text($) {
 					#$product_ref->{$tagtype . "_debug_ingredients_ids" } .= " -> no exact match ";
 
 					foreach my $id (@{$ingredients_classes_sorted{$class}}) {
-						if (($ingredient_id =~ /^$id\b/) and (not defined $seen{$ingredients_classes{$class}{$id}{id}})) {
+						
+						if (index($ingredient_id, $id) == 0) {
+							# only compile the regex if we can't avoid it
+							if (
+								($ingredient_id =~ /^$id\b/)
+								and (not defined $seen{$ingredients_classes{$class}{$id}{id}})
+							) {
 
-							next if (($ingredients_classes{$class}{$id}{id} eq 'huile-vegetale') and (defined $all_seen{"huile-de-palme"}));
+								next if (
+									($ingredients_classes{$class}{$id}{id} eq 'huile-vegetale')
+									and (defined $all_seen{"huile-de-palme"})
+								);
 
-							#$product_ref->{$tagtype . "_debug_ingredients_ids" } .= " -> match $id - $ingredients_classes{$class}{$id}{id} ";
+								#$product_ref->{$tagtype . "_debug_ingredients_ids" } .= " -> match $id - $ingredients_classes{$class}{$id}{id} ";
 
-							push @{$product_ref->{$tagtype . '_tags'}}, $ingredients_classes{$class}{$id}{id};
-							$seen{$ingredients_classes{$class}{$id}{id}} = 1;
-							$all_seen{$ingredients_classes{$class}{$id}{id}} = 1;
+								push @{$product_ref->{$tagtype . '_tags'}}, $ingredients_classes{$class}{$id}{id};
+								$seen{$ingredients_classes{$class}{$id}{id}} = 1;
+								$all_seen{$ingredients_classes{$class}{$id}{id}} = 1;
+							}
 						}
+						
 					}
 				}
 			}

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1244,13 +1244,22 @@ sub parse_ingredients_text($) {
 								my $regexp = $ingredient_processing_regexp_ref->[1];
 								if (
 									# English, French etc. match before or after the ingredient, require a space
-									(($product_lc =~ /^(en|es|it|fr)$/) and ($new_ingredient =~ /(^($regexp)\b|\b($regexp)$)/i))
+									(
+										#($product_lc =~ /^(en|es|it|fr)$/)
+										( ($product_lc eq 'en') or ($product_lc eq 'es') or ($product_lc eq 'fr') or ($product_lc eq 'it') )
+										and ($new_ingredient =~ /(^($regexp)\b|\b($regexp)$)/i)
+									)
+									
 									#  match after, do not require a space
 									# currently no language
-									or  (($product_lc =~ /^(xx)$/) and ($new_ingredient =~ /($regexp)$/i))
+									or ( ($product_lc eq 'xx') and ($new_ingredient =~ /($regexp)$/i) )
+									
 									#  Dutch: match before or after, do not require a space
-									or  (($product_lc =~ /^(de|nl)$/) and ($new_ingredient =~ /(^($regexp)|($regexp)$)/i))
-										) {
+									or (
+										( ($product_lc eq 'de') or ($product_lc eq 'nl') )
+										and ($new_ingredient =~ /(^($regexp)|($regexp)$)/i)
+									)
+								) {
 									$new_ingredient = $` . $';
 
 									$debug_ingredients and $log->debug("found processing", { ingredient => $ingredient, new_ingredient => $new_ingredient, processing => $ingredient_processing_regexp_ref->[0], regexp => $regexp }) if $log->is_debug();

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -269,6 +269,7 @@ my $products_collection = get_products_collection();
 my $products_count = $products_collection->count_documents($query_ref);
 
 print STDERR "$products_count documents to update.\n";
+if ($count) { exit(0); }
 
 my $cursor = $products_collection->query($query_ref)->fields({ _id => 1, code => 1, owner => 1 });
 $cursor->immortal(1);

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -51,6 +51,7 @@ it is likely that the MongoDB cursor of products to be updated will expire, and 
 --team		optional team for the user that is credited with the change
 --comment	comment for change in product history
 --pretend	do not actually update products
+--mongodb-to-mongodb	do not use the .sto files at all, and only read from and write to mongodb
 TXT
 ;
 
@@ -117,6 +118,7 @@ my $all_owners = '';
 my $mark_as_obsolete_since_date = '';
 my $reassign_energy_kcal = '';
 my $delete_old_fields = '';
+my $mongodb_to_mongodb = '';
 
 my $query_ref = {};    # filters for mongodb query
 
@@ -159,6 +161,7 @@ GetOptions ("key=s"   => \$key,      # string
 			"mark-as-obsolete-since-date=s" => \$mark_as_obsolete_since_date,
 			"all-owners" => \$all_owners,
 			"delete-old-fields" => \$delete_old_fields,
+			"mongodb-to-mongodb" => \$mongodb_to_mongodb,
 			)
   or die("Error in command line arguments:\n\n$usage");
 
@@ -192,7 +195,8 @@ if ($unknown_fields > 0) {
 	die("Unknown fields, check for typos.");
 }
 
-if ((not $process_ingredients) and (not $compute_nutrition_score) and (not $compute_nova)
+if (
+	(not $process_ingredients) and (not $compute_nutrition_score) and (not $compute_nova)
 	and (not $clean_ingredients) and (not $delete_old_fields)
 	and (not $compute_serving_size) and (not $reassign_energy_kcal)
 	and (not $compute_data_sources) and (not $compute_history)
@@ -203,7 +207,9 @@ if ((not $process_ingredients) and (not $compute_nutrition_score) and (not $comp
 	and (not $remove_team) and (not $remove_label) and (not $remove_nutrient)
 	and (not $mark_as_obsolete_since_date)
 	and (not $assign_categories_properties) and (not $restore_values_deleted_by_user) and not ($delete_debug_tags)
-	and (not $compute_codes) and (not $compute_carbon) and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)) {
+	and (not $compute_codes) and (not $compute_carbon) and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)
+	and (not $mongodb_to_mongodb)
+) {
 	die("Missing fields to update or --count option:\n$usage");
 }
 
@@ -271,7 +277,14 @@ my $products_count = $products_collection->count_documents($query_ref);
 print STDERR "$products_count documents to update.\n";
 if ($count) { exit(0); }
 
-my $cursor = $products_collection->query($query_ref)->fields({ _id => 1, code => 1, owner => 1 });
+my $cursor;
+if ($mongodb_to_mongodb) {
+	# retrieve all fields
+	$cursor = $products_collection->query($query_ref);
+} else {
+	# only retrieve important fields
+	$cursor = $products_collection->query($query_ref)->fields({ _id => 1, code => 1, owner => 1 });
+}
 $cursor->immortal(1);
 
 my $n = 0;    # number of products updated
@@ -302,7 +315,10 @@ while (my $product_ref = $cursor->next) {
 
 	next if $just_print_codes;
 
-	$product_ref = retrieve_product($productid);
+	if (!$mongodb_to_mongodb) {
+		# read product data from .sto file
+		$product_ref = retrieve_product($productid);
+	}
 
 	if ((defined $product_ref) and ($productid ne '')) {
 
@@ -955,8 +971,12 @@ while (my $product_ref = $cursor->next) {
 				# make sure nutrient values are numbers
 				ProductOpener::Products::make_sure_numbers_are_stored_as_numbers($product_ref);
 
-				store("$data_root/products/$path/product.sto", $product_ref);
+				if (!$mongodb_to_mongodb) {
+					# Store data to .sto file
+					store("$data_root/products/$path/product.sto", $product_ref);
+				}
 
+				# Store data to mongodb
 				# Make sure product code is saved as string and not a number
 				# see bug #1077 - https://github.com/openfoodfacts/openfoodfacts-server/issues/1077
 				# make sure that code is saved as a string, otherwise mongodb saves it as number, and leading 0s are removed

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -208,7 +208,6 @@ if (
 	and (not $mark_as_obsolete_since_date)
 	and (not $assign_categories_properties) and (not $restore_values_deleted_by_user) and not ($delete_debug_tags)
 	and (not $compute_codes) and (not $compute_carbon) and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)
-	and (not $mongodb_to_mongodb)
 ) {
 	die("Missing fields to update or --count option:\n$usage");
 }
@@ -1008,4 +1007,3 @@ if ($restore_values_deleted_by_user) {
 }
 
 exit(0);
-


### PR DESCRIPTION
Some low-hanging-fruit in avoiding looping over CORE:regcomp. It feels like there's more to squeeze out, but I don't know the data structures well enough. It's also hard to compare like with like, if you let the code actually update the stored data.

### Possible improvements
### 1)
A section that still has slow regexes looped over a lot is the
```
($new_ingredient =~ /(^($regexp)\b|\b($regexp)$)/i)
($new_ingredient =~ /($regexp)$/i) )
($new_ingredient =~ /(^($regexp)|($regexp)$)/i)
```
expressions in: 
https://github.com/svensven/openfoodfacts-server/blob/01235cb7d8e77b7d62e44efba8528898e828ba19/lib/ProductOpener/Ingredients.pm#L1245-L1263

### 2)
Also, preparse_ingredients_text() is called twice, presumably with the same inputs:
```
# spent 8.49s (914ms+7.57) within ProductOpener::Ingredients::preparse_ingredients_text which was called 490 times, avg 17.3ms/call: 
# 245 times (519ms+4.15s) by ProductOpener::Ingredients::parse_ingredients_text at line 823, avg 19.1ms/call 
# 245 times (395ms+3.42s) by ProductOpener::Ingredients::extract_ingredients_classes_from_text at line 3984, avg 15.6ms/call
```
from update_all_products.pl:
```
			extract_ingredients_from_text($product_ref);
			extract_ingredients_classes_from_text($product_ref);
```
I thought about trying a static/state variable, but it would have to be done in a way that didn't just keep consuming more RAM.

### Pictures
example before & after:

![before](https://user-images.githubusercontent.com/5736616/93671222-1a83b180-fa99-11ea-8268-5b3e1653f419.png)
![after](https://user-images.githubusercontent.com/5736616/93671253-5b7bc600-fa99-11ea-85f6-f2dcea731ffc.png)
