### PR TITLE
New /search endpoint + start of local display of results for personal search

### DIFF
--- a/cgi/display.pl
+++ b/cgi/display.pl
@@ -94,7 +94,7 @@ if (defined $request{api}) {
 	}
 }
 elsif (defined $request{search}) {
-	display_tag(\%request);
+	display_search_results(\%request);
 }
 elsif (defined $request{text}) {
 	display_text(\%request);

--- a/cgi/display.pl
+++ b/cgi/display.pl
@@ -78,6 +78,10 @@ if ( ((defined $server_options{private_products}) and ($server_options{private_p
 if (defined $request{api}) {
 	if (param("api_method") eq "search") {
 		# /api/v0/search
+		# FIXME: for an unknown reason, using display_search_results() here results in some attributes being randomly not set
+		# because of missing fields like nova_group or nutriscore_data, but not for all products.
+		# this does not seem to happen with display_tag()
+		# display_search_results(\%request);
 		display_tag(\%request);
 	}
 	elsif (param("api_method") =~ /^preferences(_(\w\w))?$/) {

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -16,10 +16,10 @@ function get_user_product_preferences () {
 }
 
 
-// show_user_product_preferences can be called by other scripts
-/* exported show_user_product_preferences */
+// display_user_product_preferences can be called by other scripts
+/* exported display_user_product_preferences */
 
-function show_user_product_preferences (target) {
+function display_user_product_preferences (target, change) {
 
 	// Retrieve all the supported attribute groups from the server, unless we have them already
 	
@@ -29,7 +29,7 @@ function show_user_product_preferences (target) {
 		
 			attribute_groups = data;
 		
-			show_user_product_preferences(target);
+			display_user_product_preferences(target, change);
 		});
 	}
 	
@@ -39,7 +39,7 @@ function show_user_product_preferences (target) {
 		
 			preferences = data;
 		
-			show_user_product_preferences(target);
+			display_user_product_preferences(target, change);
 		});		
 	}
 	
@@ -98,9 +98,17 @@ function show_user_product_preferences (target) {
 			html: attribute_groups_html.join( "" )
 		}).replaceAll(target);
 		
-		$( ".attribute_radio").change(function () {
-			user_product_preferences[this.name] = $("input[name='" + this.name + "']:checked").val();
-			localStorage.setItem('user_product_preferences', JSON.stringify(user_product_preferences));
+		$( ".attribute_radio").change( function () {
+			if (this.checked) {
+
+				user_product_preferences[this.name] = $("input[name='" + this.name + "']:checked").val();
+				localStorage.setItem('user_product_preferences', JSON.stringify(user_product_preferences));
+				
+				// Call the change callback if we have one (e.g. to update the search results)
+				if (change) {
+					change();
+				}
+			}
 		});
 	}
 }

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -16,10 +16,63 @@ function get_user_product_preferences () {
 }
 
 
+// display a summary of the selected preferences
+// in the order mandatory, very important, important
+
+function display_selected_preferences (target_selected, target_selection_form, product_preferences) {
+	
+	var selected_preference_groups = {
+		"mandatory" : [],
+		"very_important" : [],
+		"important" : [],
+	};
+	
+	// Iterate over attribute groups
+	$.each( attribute_groups, function(key, attribute_group) {
+		
+		// Iterate over attributes
+		
+		$.each(attribute_group.attributes, function(key, attribute) {
+			
+			if ((product_preferences[attribute.id]) && (product_preferences[attribute.id] != "not_important")) {
+				var attribute_html = '<span>' + attribute.setting_name + '</span>';
+				selected_preference_groups[product_preferences[attribute.id]].push(attribute_html);
+			}
+		});
+	});	
+
+	var selected_preferences_html = '';
+
+	$.each(selected_preference_groups, function(preference, selected_preference_group) {
+		
+		if (selected_preference_group.length > 0) {
+			selected_preferences_html += "<div>"
+			+ "<strong>" + preference + ": </strong>"
+			+ selected_preference_group.join(", ")
+			+ "</div>";
+		}
+	});
+	
+	$( target_selected ).html(selected_preferences_html);
+	
+	// Show a button to edit the preferences
+	if (target_selection_form) {
+		$( target_selected ).append('<a id="show_selection_form">' + "Edit preferences" + '</a>');
+		$( "#show_selection_form").click(function() {
+		  $( target_selected ).hide();
+		  $( target_selection_form ).show();
+		});
+	}
+}
+
+
 // display_user_product_preferences can be called by other scripts
 /* exported display_user_product_preferences */
 
-function display_user_product_preferences (target, change) {
+// Make sure we display the preferences only once when we have both preferences and attribute_groups loaded
+var displayed_user_product_preferences = false;
+
+function display_user_product_preferences (target_selected, target_selection_form, change) {
 
 	// Retrieve all the supported attribute groups from the server, unless we have them already
 	
@@ -29,7 +82,7 @@ function display_user_product_preferences (target, change) {
 		
 			attribute_groups = data;
 		
-			display_user_product_preferences(target, change);
+			display_user_product_preferences(target_selected, target_selection_form, change);
 		});
 	}
 	
@@ -39,11 +92,13 @@ function display_user_product_preferences (target, change) {
 		
 			preferences = data;
 		
-			display_user_product_preferences(target, change);
+			display_user_product_preferences(target_selected, target_selection_form, change);
 		});		
 	}
 	
-	if (attribute_groups && preferences) {
+	if (attribute_groups && preferences && ! displayed_user_product_preferences) {
+		
+		displayed_user_product_preferences = true;
 		
 		var user_product_preferences = get_user_product_preferences();
 		
@@ -93,10 +148,9 @@ function display_user_product_preferences (target, change) {
 			attribute_groups_html.push(attribute_group_html);
 		});
 
-		$( "<ul/>", {
-			"class": "user_product_preferences",
-			html: attribute_groups_html.join( "" )
-		}).replaceAll(target);
+		$(target_selection_form).html( '<ul class="user_product_preferences">'
+			+ attribute_groups_html.join( "" )
+			+ '</ul>');
 		
 		$( ".attribute_radio").change( function () {
 			if (this.checked) {
@@ -104,11 +158,25 @@ function display_user_product_preferences (target, change) {
 				user_product_preferences[this.name] = $("input[name='" + this.name + "']:checked").val();
 				localStorage.setItem('user_product_preferences', JSON.stringify(user_product_preferences));
 				
-				// Call the change callback if we have one (e.g. to update the search results)
+				display_selected_preferences (target_selected, target_selection_form, user_product_preferences);
+				
+				// Call the change callback if we have one (e.g. to update search results)
 				if (change) {
 					change();
 				}
 			}
 		});
+		
+		// Show a button to close the preferences selection form and show the selected preferences
+		if (target_selected) {
+			
+			display_selected_preferences (target_selected, target_selection_form, user_product_preferences);
+			
+			$( target_selection_form ).prepend('<a id="show_selected">' + "Close preferences" + '</a>');
+			$( "#show_selected").click(function() {
+			  $( target_selection_form ).hide();
+			  $( target_selected ).show();
+			});
+		}		
 	}
 }

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -1,14 +1,20 @@
 var attribute_groups;	// All supported attribute groups and attributes + translated strings
 var preferences;	// All supported preferences + translated strings
 
-// Retrieve user preferences from local storage
 
-var user_product_preferences = {};
-var user_product_preferences_string = localStorage.getItem('user_product_preferences');
+function get_user_product_preferences () {
+	// Retrieve user preferences from local storage
 
-if (user_product_preferences_string) {
-	user_product_preferences = JSON.parse(user_product_preferences_string);
+	var user_product_preferences = {};
+	var user_product_preferences_string = localStorage.getItem('user_product_preferences');
+
+	if (user_product_preferences_string) {
+		user_product_preferences = JSON.parse(user_product_preferences_string);
+	}
+	
+	return user_product_preferences;
 }
+
 
 // show_user_product_preferences can be called by other scripts
 /* exported show_user_product_preferences */
@@ -38,6 +44,8 @@ function show_user_product_preferences (target) {
 	}
 	
 	if (attribute_groups && preferences) {
+		
+		var user_product_preferences = get_user_product_preferences();
 		
 		var attribute_groups_html = [];
 		

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -59,8 +59,8 @@ function display_selected_preferences (target_selected, target_selection_form, p
 	if (target_selection_form) {
 		$( target_selected ).append('<a id="show_selection_form">' + "Edit preferences" + '</a>');
 		$( "#show_selection_form").click(function() {
-		  $( target_selected ).hide();
-		  $( target_selection_form ).show();
+			$( target_selected ).hide();
+			$( target_selection_form ).show();
 		});
 	}
 }
@@ -158,7 +158,7 @@ function display_user_product_preferences (target_selected, target_selection_for
 				user_product_preferences[this.name] = $("input[name='" + this.name + "']:checked").val();
 				localStorage.setItem('user_product_preferences', JSON.stringify(user_product_preferences));
 				
-				display_selected_preferences (target_selected, target_selection_form, user_product_preferences);
+				display_selected_preferences(target_selected, target_selection_form, user_product_preferences);
 				
 				// Call the change callback if we have one (e.g. to update search results)
 				if (change) {
@@ -170,12 +170,12 @@ function display_user_product_preferences (target_selected, target_selection_for
 		// Show a button to close the preferences selection form and show the selected preferences
 		if (target_selected) {
 			
-			display_selected_preferences (target_selected, target_selection_form, user_product_preferences);
+			display_selected_preferences(target_selected, target_selection_form, user_product_preferences);
 			
 			$( target_selection_form ).prepend('<a id="show_selected">' + "Close preferences" + '</a>');
 			$( "#show_selected").click(function() {
-			  $( target_selection_form ).hide();
-			  $( target_selected ).show();
+				$( target_selection_form ).hide();
+				$( target_selected ).show();
 			});
 		}		
 	}

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -44,14 +44,24 @@ function show_user_product_preferences (target) {
 		// Iterate over attribute groups
 		$.each( attribute_groups, function(key, attribute_group) {
 			
-			var attribute_group_html = "<li id='attribute_group_" + attribute_group.id + "' class='attribute_group'>" + attribute_group.name 
-			+ "<ul>";
+			var attribute_group_html = "<li id='attribute_group_" + attribute_group.id + "' class='attribute_group'>" 
+			+ "<span class='attribute_group_name'>" + attribute_group.name + "</span>";
+			
+			if (attribute_group.warning) {
+				attribute_group_html += "<p class='attribute_group_warning'>" + attribute_group.warning + "</p>";
+			}
+			
+			attribute_group_html += "<ul>";
 			
 			// Iterate over attributes
 			
 			$.each(attribute_group.attributes, function(key, attribute) {
 				
-				attribute_group_html += "<li id='attribute_" + attribute.id + "' class='attribute'><spanc class='attribute_name'>" + attribute.setting_name + "</span><br>";
+				attribute_group_html += "<li id='attribute_" + attribute.id + "' class='attribute'><span class='attribute_name'>" + attribute.setting_name + "</span><br>";
+				
+				if (attribute.description_short) {
+					attribute_group_html += "<p class='attribute_description_short'>" + attribute.description_short + "</p>";
+				}				
 								
 				$.each(preferences, function (key, preference) {
 					

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -128,7 +128,7 @@ function display_products(target, product_groups ) {
 	
 	$( target ).empty();
 	
-	$.each(product_groups, function(key, product_group) {
+	$.each(product_groups, function(product_group_id, product_group) {
 	
 		var products_html = [];
 		
@@ -161,15 +161,15 @@ function display_products(target, product_groups ) {
 		});
 		
 		$( "<div/>", {
-			"id": "div_products_match_" + key,
-			html: '<h3 style="clear:left;margin-top:2rem;">' + key + "</h3>",
+			"id": "div_products_match_" + product_group_id,
+			html: '<h3 style="clear:left;padding-top:2rem;">' + product_group_id + " : " + product_group.length + " products" + "</h3>",
 		}).appendTo(target);
 
 		$( "<ul/>", {
 			"class": "products search_results",
-			"id": "products_match_" + key,
+			"id": "products_match_" + product_group_id,
 			html: products_html.join( "" )
-		}).appendTo("#div_products_match_" + key);
+		}).appendTo("#div_products_match_" + product_group_id);
 		
 	});
 }

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -126,7 +126,8 @@ function rank_products(products, product_preferences) {
 
 function display_products(target, product_groups ) {
 	
-	$( target ).empty();
+	$( target ).html('<ul id="products_tabs_titles" class="tabs" data-tab></ul>'
+		+ '<div id="products_tabs_content" class="tabs-content"></div>');
 	
 	$.each(product_groups, function(product_group_id, product_group) {
 	
@@ -160,17 +161,25 @@ function display_products(target, product_groups ) {
 			products_html.push(product_html);		
 		});
 		
-		$( "<div/>", {
-			"id": "div_products_match_" + product_group_id,
-			html: '<h3 style="clear:left;padding-top:2rem;">' + product_group_id + " : " + product_group.length + " products" + "</h3>",
-		}).appendTo(target);
-
-		$( "<ul/>", {
-			"class": "products search_results",
-			"id": "products_match_" + product_group_id,
-			html: products_html.join( "" )
-		}).appendTo("#div_products_match_" + product_group_id);
+		var active = "";
+		if (product_group_id == "yes") {
+			active = " active";
+		}
 		
+		$("#products_tabs_titles").append(
+			'<li class="tabs tab-title' + active + '"><a href="#products_' + product_group_id + '">'
+			+ product_group_id + " : " + product_group.length + " products" + "</a></li>"
+		);
+		
+		$("#products_tabs_content").append(
+			'<div class="tabs content' + active + '" id="products_' + product_group_id + '">'
+			+ '<ul class="products search_results" id="products_match_' + product_group_id + '">'
+			+ products_html.join( "" )
+			+ '</ul>'
+		);
+		
+		$(document).foundation('tab', 'reflow');
+
 	});
 }
 

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -1,13 +1,4 @@
 
-// Retrieve user preferences from local storage
-
-var user_product_preferences = {};
-var user_product_preferences_string = localStorage.getItem('user_product_preferences');
-
-if (user_product_preferences_string) {
-	user_product_preferences = JSON.parse(user_product_preferences_string);
-}
-
 // Will hold product data retrieved from the search API
 var products = [];
 
@@ -46,7 +37,7 @@ function match_product_to_preferences (product, product_preferences) {
 			
 			$.each(attribute_group.attributes, function(key, attribute) {
 				
-				if ((! user_product_preferences[attribute.id]) || (product_preferences[attribute.id] == "not_important")) {
+				if ((! product_preferences[attribute.id]) || (product_preferences[attribute.id] == "not_important")) {
 					// Ignore attribute
 					debug += attribute.id + " not_important" + "\n";
 				}
@@ -100,9 +91,9 @@ function match_product_to_preferences (product, product_preferences) {
 	product.match_debug = debug;	
 }
 
-// rank_and_filter_products (products, product_preferences)
+// rank_products (products, product_preferences)
 
-function rank_and_filter_products(products, product_preferences) {
+function rank_products(products, product_preferences) {
 	
 	// Score all products
 	
@@ -132,13 +123,8 @@ function rank_and_filter_products(products, product_preferences) {
 	return product_groups;
 }
 
-/*eslint no-unused-vars: [2, {"args": "after-used", "varsIgnorePattern": "unused"}]*/
 
-function show_products(target, product_groups, product_preferences_currently_unused ) {
-	
-	// product_preferences is currently unused, as we get some of them
-	// indirectly through product.match_icons
-	// but at some point we may display products differently based on the preferences	
+function display_products(target, product_groups ) {
 	
 	$( target ).empty();
 	
@@ -188,6 +174,26 @@ function show_products(target, product_groups, product_preferences_currently_unu
 	});
 }
 
+
+function rank_and_display_products (target) {
+	
+	// Retrieve user preferences from local storage
+
+	var user_product_preferences = {};
+	var user_product_preferences_string = localStorage.getItem('user_product_preferences');
+
+	if (user_product_preferences_string) {
+		user_product_preferences = JSON.parse(user_product_preferences_string);
+	}	
+	
+	var ranked_products = rank_products(products, user_product_preferences);
+			
+	display_products(target, ranked_products);
+			
+	$(document).foundation('equalizer', 'reflow');
+}
+
+
 /* exported search_products */
 
 function search_products (target, search_api_url) {
@@ -200,11 +206,7 @@ function search_products (target, search_api_url) {
 			
 			products = data.products;
 			
-			var ranked_products = rank_and_filter_products(products, user_product_preferences);
-			
-			show_products(target, ranked_products, user_product_preferences);
-			
-			$(document).foundation('equalizer', 'reflow');
+			rank_and_display_products(target);
 		}		
 	});
 }

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -17,14 +17,22 @@ if (user_product_preferences_string) {
 //
 // Output values are returned in the product object
 //
-// match_status: yes, no, unknown
-// match_score: number (maximum depends on the preferences)
+// - match_status: yes, no, unknown
+// - match_score: number (maximum depends on the preferences)
+// - match_icons: array of arrays of urls of icons corresponding to the product and 
+// each set of preferences: mandatory, very_important, important
 
 function match_product_to_preferences (product, product_preferences) {
 
 	var score = 0;
 	var status = "yes";
 	var debug = "";
+	
+	product.match_icons = {
+		"mandatory" : [],
+		"very_important" : [],
+		"important" : []
+	};
 
 	if (! product.attribute_groups) {
 		status = "unknown";
@@ -73,11 +81,14 @@ function match_product_to_preferences (product, product_preferences) {
 								status = "no";
 							}
 						}
+					}
+					
+					if (attribute.icon_url) {
+						product.match_icons[user_product_preferences[attribute.id]].push(attribute.icon_url);
 					}					
 				}
 			});
 		});		
-		
 	}
 	
 	product.match_status = status;
@@ -141,6 +152,11 @@ function show_products(target, product_groups, product_preferences) {
 			product_html += "<span>" + product.product_name + "</span>";
 			
 			product_html += '</a>';
+			
+			$.each (product.match_icons["mandatory"].concat(product.match_icons["very_important"], product.match_icons["important"]), function (key, icon_url) {
+				
+				product_html += '<img src="' + icon_url + '" class="match_icons">';
+			});
 			
 			product_html += '<span title="' + product.match_debug + '">' + Math.round(product.match_score) + '</span>';
 			

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -1,0 +1,70 @@
+
+// Retrieve user preferences from local storage
+
+var user_product_preferences = {};
+var user_product_preferences_string = localStorage.getItem('user_product_preferences');
+
+if (user_product_preferences_string) {
+	user_product_preferences = JSON.parse(user_product_preferences_string);
+}
+
+var products;
+
+
+function rank_and_filter_products() {
+	
+	// TODO
+	
+}
+
+
+function show_products(target) {
+	
+	var products_html = [];
+	
+	$.each( products, function(key, product) {
+	
+		var product_html = "<li>";
+		
+		product_html += '<a href="' + product.url + '"><div>';
+		
+		if (product.image_front_thumb_url) {
+			product_html += '<img src="' + product.image_front_thumb_url + '">';
+		}
+		
+		product_html += "</div>";
+		
+		product_html += "<span>" + product.product_name + "</span>";
+		
+		product_html += '</a>';
+		
+		product_html += "</li>";
+			
+		products_html.push(product_html);		
+	});
+	
+	$( "<ul/>", {
+		"class": "products search_results",
+		html: products_html.join( "" )
+	}).replaceAll(target);	
+}
+
+
+function search_products (target, search_api_url) {
+
+	// Retrieve generic search results from the search API
+	
+	$.getJSON( search_api_url, function( data ) {
+		
+		if (data.products) {
+			
+			products = data.products;
+			
+			rank_and_filter_products();
+			
+			show_products(target);
+			
+			$(document).foundation('equalizer', 'reflow');
+		}		
+	});
+}

--- a/lang/en/texts/product-preferences.html
+++ b/lang/en/texts/product-preferences.html
@@ -3,7 +3,7 @@
 </scripts>
 
 <initjs>
-show_user_product_preferences("#preferences_settings");
+display_user_product_preferences(null, "#preferences_selection_form", null);
 </initjs>
 
 <h1>Your product preferences</h1>
@@ -12,6 +12,6 @@ show_user_product_preferences("#preferences_settings");
 
 <p>Your privacy is very important to us. Your preferences are private and are stored and used only inside your browser. They are not sent to the Open Food Facts server.</p>
 
-<div id="preferences_settings">
+<div id="preferences_selection_form">
 Loading your product preferences.
 </div>

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -376,7 +376,7 @@ sub compute_attribute_nutriscore($$) {
 	my $product_ref = shift;
 	my $target_lc = shift;
 
-	$log->debug("compute nutriscore attribute", { code => $product_ref->{code} }) if $log->is_debug();
+	$log->debug("compute nutriscore attribute", { code => $product_ref->{code}, nutriscore_data => $product_ref->{nutriscore_data} }) if $log->is_debug();
 
 	my $attribute_id = "nutriscore";
 	
@@ -605,8 +605,16 @@ sub compute_attribute_has_tag($$$$) {
 		if ($target_lc ne "data") {
 			$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_" . $attribute_id . "_yes_title");
 			# Override default texts if specific texts are available
-			override_general_value($product_ref, $target_lc, "description", "attribute_" . $attribute_id . "_yes_description");
-			override_general_value($product_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_yes_description_short");	
+			override_general_value($attribute_ref, $target_lc, "description", "attribute_" . $attribute_id . "_yes_description");
+			override_general_value($attribute_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_yes_description_short");	
+		}
+		
+		my $img_url = get_tag_image($target_lc, $tagtype, $tagid);
+		
+		$log->debug("checking for tag image", { target_lc => $target_lc, tagtype => $tagtype, tagid => $tagid, img_url => $img_url}) if $log->is_debug();
+		
+		if (defined $img_url) {
+			$attribute_ref->{icon_url} = $static_subdomain . $img_url;
 		}
 	}
 	else {
@@ -614,8 +622,8 @@ sub compute_attribute_has_tag($$$$) {
 		if ($target_lc ne "data") {
 			$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_" . $attribute_id . "_no_title");
 			# Override default texts if specific texts are available
-			override_general_value($product_ref, $target_lc, "description", "attribute_" . $attribute_id . "_no_description");
-			override_general_value($product_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_no_description_short");
+			override_general_value($attribute_ref, $target_lc, "description", "attribute_" . $attribute_id . "_no_description");
+			override_general_value($attribute_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_no_description_short");
 		}
 	}
 	
@@ -651,7 +659,6 @@ e.g. "salt", "sugars", "fat", "saturated-fat"
 The return value is a reference to the resulting attribute data structure.
 
 =head4 % Match
-
 For "low" levels:
 
 - 100% if the nutrient quantity is 0%

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -72,6 +72,7 @@ use ProductOpener::Products qw/:all/;
 use ProductOpener::Food qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Lang qw/:all/;
+use ProductOpener::Display qw/:all/;
 
 =head1 CONFIGURATION
 
@@ -455,7 +456,7 @@ sub compute_attribute_nutriscore($$) {
 			$attribute_ref->{description} = lang("attribute_nutriscore_" . $grade . "_description");
 			$attribute_ref->{description_short} = lang("attribute_nutriscore_" . $grade . "_description_short");
 		}
-		
+		$attribute_ref->{icon_url} = "$static_subdomain/images/misc/nutriscore-$grade.svg";
 	}
 	else {
 		$attribute_ref->{status} = "unknown";
@@ -531,6 +532,7 @@ sub compute_attribute_nova($$) {
 			$attribute_ref->{description} = lang("attribute_nova_" . $nova_group . "_description");
 			$attribute_ref->{description_short} = lang("attribute_nova_" . $nova_group . "_description_short");
 		}
+		$attribute_ref->{icon_url} = "$static_subdomain/images/misc/nova-group-$nova_group.svg";
 		
 	}
 	else {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -2962,7 +2962,6 @@ sub display_tag($) {
 			$request_ref->{world_current_link} = add_tag_prefix_to_link($request_ref->{world_current_link},$prefix);
 			$log->debug("Found tag prefix 2 " . Dumper($request_ref)) if $log->is_debug();
 		}
-
 	}
 
 	if (defined $request_ref->{groupby_tagtype}) {
@@ -3420,7 +3419,6 @@ HTML
 			else {
 					$log->debug("display_tag - property not defined", { tagtype => $tagtype, property_id => $propertyid{property}, canon_tagid => $canon_tagid }) if $log->is_debug();
 			}
-
 		}
 
 		# Remove titles without content
@@ -3438,7 +3436,6 @@ HTML
 	}
 
 	$description =~ s/<tag>/$title/g;
-
 
 	if (defined $ingredients_classes{$tagtype}) {
 		my $class = $tagtype;
@@ -3883,8 +3880,6 @@ HTML
 		${$request_ref->{content_ref}} .= $html . search_and_display_products($request_ref, $query_ref, $sort_by, undef, undef);
 	}
 
-
-
 	display_new($request_ref);
 
 	return;
@@ -3935,7 +3930,7 @@ sub display_search_results($) {
 	$current_link =~ s/^\&/\?/;
 	$current_link = "/search" . $current_link;
 	
-	if ((defined param("user_preferences")) and (param("user_preferences"))) {
+	if ((defined param("user_preferences")) and (param("user_preferences")) and not ($request_ref->{api}) ) {
 	
 		# The results will be filtered and ranked on the client side
 		
@@ -3963,9 +3958,7 @@ JS
 
 		if (not $tt->process('search_results.tt.html', $template_data_ref, \$html)) {
 			$html = $tt->error();
-		}
-		$request_ref->{content_ref} = \$html;
-		
+		}		
 	}
 	else {
 		
@@ -3982,8 +3975,10 @@ JS
 		
 		$request_ref->{current_link_query} = $current_link;
 		
-		${$request_ref->{content_ref}} .= $html . search_and_display_products($request_ref, $query_ref, $sort_by, undef, undef);
+		$html .= search_and_display_products($request_ref, $query_ref, $sort_by, undef, undef);
 	}
+	
+	$request_ref->{content_ref} = \$html;
 
 	display_new($request_ref);
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3923,6 +3923,7 @@ sub display_search_results($) {
 	foreach my $field (param()) {
 		if (
 			($field eq "page")
+			or ($field eq "fields")
 			or ($field eq "keywords")	# returned by CGI.pm when there are not params: keywords=search
 			) {
 			next;
@@ -3939,6 +3940,11 @@ sub display_search_results($) {
 		# The results will be filtered and ranked on the client side
 		
 		my $search_api_url = $formatted_subdomain . "/api/v0" . $current_link;
+		$search_api_url =~ s/(\&|\?)(page|page_size|limit)=(\d+)//;
+		$search_api_url .= "&fields=product_name,url,images,attribute_groups";
+		if ($search_api_url !~ /\?/) {
+			$search_api_url =~ s/\&/\?/;
+		}
 		
 		$scripts .= <<JS
 <script src="/js/product-preferences.js"></script>
@@ -3949,7 +3955,7 @@ JS
 		$initjs .= <<JS
 
 show_user_product_preferences("#preferences_settings");
-search_products("#search_results", "$search_api_url");
+search_products("#search_results", "$search_api_url", get_user_product_preferences());
 JS
 ;
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3954,7 +3954,7 @@ JS
 
 		$initjs .= <<JS
 
-display_user_product_preferences("#preferences_settings", function () { rank_and_display_products("#search_results"); });
+display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () { rank_and_display_products("#search_results"); });
 search_products("#search_results", "$search_api_url");
 JS
 ;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4118,7 +4118,7 @@ sub add_params_to_query($$) {
 			# xyz_tags=-c	products without the c tag
 			# xyz_tags=a,b,-c,-d
 			
-			my $values = param($field);
+			my $values = remove_tags_and_quote(decode utf8=>param($field));
 			
 			$log->debug("add_params_to_query - tags param", { field => $field, lc => $lc, tag_lc => $tag_lc, values => $values }) if $log->is_debug();
 			

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3954,8 +3954,8 @@ JS
 
 		$initjs .= <<JS
 
-show_user_product_preferences("#preferences_settings");
-search_products("#search_results", "$search_api_url", get_user_product_preferences());
+display_user_product_preferences("#preferences_settings", function () { rank_and_display_products("#search_results"); });
+search_products("#search_results", "$search_api_url");
 JS
 ;
 

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -467,3 +467,8 @@ html[dir="rtl"] {
     }
   }
 }
+
+.match_icons {
+  height:48px;
+  margin-right:4px;
+}

--- a/templates/search_and_display_products.tt.html
+++ b/templates/search_and_display_products.tt.html
@@ -4,11 +4,13 @@
         <p>&rarr; <a href= "[% world_subdomain %][% current_link_query %]"> [% lang('view_results_from_the_entire_world') %]</a></p>
     [% END %]
     &rarr; <a href="[% current_link_query %]">[% lang('search_link') %]</a><br>
+[% END %]
+[% IF (current_link_query_edit.defined) && !(jqm.defined) %]
     &rarr; <a href="[% current_link_query_edit %]">[% lang('search_edit') %]</a><br>
 [% END %]
 
 [% IF count > 0 %]
-    [% IF (current_link_query.defined) && !(jqm.defined) %]
+    [% IF (current_link_query_download.defined) && !(jqm.defined) %]
         &rarr;[% lang('search_download_results') %]<br>
         [% IF count <= export_limit %]
             <ul>

--- a/templates/search_results.tt.html
+++ b/templates/search_results.tt.html
@@ -1,9 +1,9 @@
 <p>Search results:</p>
 	
-<div id="preferences_settings">
-Loading your product preferences.
-</div>
-
+<div id="preferences_selected"></div>
+	
+<div id="preferences_selection_form" style="display:none"></div>
+	
 <div id="search_results">
 Search results
 </div>

--- a/templates/search_results.tt.html
+++ b/templates/search_results.tt.html
@@ -1,0 +1,9 @@
+<p>Search results:</p>
+	
+<div id="preferences_settings">
+Loading your product preferences.
+</div>
+
+<div id="search_results">
+Search results
+</div>


### PR DESCRIPTION
- Displays warnings and descriptions for attributes in the user preferences selection UI
- Creates a new /search endpoint for the new search API (with a dedicated display_search_results() function instead of abusing the display_tag() function
- Solves small issues for pagination
- Start of the /search?user_preferences=1 interface to have the client request search results from the API, and ranking, filtering and displaying on the client. #4121 