### PR TITLE
do not add carbonate to FER ELEMENTAIRE #3838

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3764,11 +3764,11 @@ sub preparse_ingredients_text($$) {
 			$text =~ s/($prefixregexp)\s?(:|\(|\[)\s?($suffixregexp)\b(\s?(\)|\]))/normalize_enumeration($product_lc,$1,$5)/ieg;
 
 			# Huiles végétales de palme, de colza et de tournesol
-			# Carbonate de magnésium, fer élémentaire -> should not trigger carbonate de fer élémentaire.
+			# Carbonate de magnésium, fer élémentaire -> should not trigger carbonate de fer élémentaire. Bug #3838
 			# TODO 18/07/2020 remove when we have a better solution
-			$text =~ s/fer élémentaire/fer_élémentaire/g;
+			$text =~ s/fer (é|e)l(é|e)mentaire/fer_élémentaire/ig;
 			$text =~ s/($prefixregexp)(:|\(|\[| | de | d')+((($suffixregexp)($symbols_regexp|\s)*( |\/| \/ | - |,|, | et | de | et de | et d'| d')+)+($suffixregexp)($symbols_regexp|\s)*)\b(\s?(\)|\]))?/normalize_enumeration($product_lc,$1,$5)/ieg;
-			$text =~ s/fer_élémentaire/fer élémentaire/g;
+			$text =~ s/fer_élémentaire/fer élémentaire/ig;
 		}
 
 		# Caramel ordinaire et curcumine

--- a/t/ingredients_nesting.t
+++ b/t/ingredients_nesting.t
@@ -336,6 +336,26 @@ my @tests = (
 ],
 
 
+	[ { lc => "fr", ingredients_text => "MINERAUX (CARBONATE DE MAGNESIUM, FER ELEMENTAIRE)"},
+[
+  {
+    'id' => 'en:minerals',
+    'text' => 'MINERAUX',
+    'ingredients' => [
+      {
+        'id' => 'en:e504i',
+        'text' => 'CARBONATE DE MAGNESIUM'
+      },
+      {
+        'id' => 'en:elemental-iron',
+        'text' => 'fer élémentaire'
+      }
+    ],
+  },
+]
+],
+
+
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
extend the workaround fix for "carbonate de magnésium, fer élémentaire" to unnaccented "CARBONATE DE MAGNESIUM, FER ELEMENTAIRE"  (bug #3838)