### PR TITLE
Renamed German category to 'Müsli'

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -40566,7 +40566,7 @@ bg:Мюсли
 ca:Musli
 cs:müsli
 da:Müsli
-de:Müsli, Müesli
+de:Müslis, Müeslis
 eo:Muslio
 es:Muesli, Mueslis
 et:Müsli

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -40566,7 +40566,7 @@ bg:Мюсли
 ca:Musli
 cs:müsli
 da:Müsli
-de:Müesli, Müslis
+de:Müsli, Müesli
 eo:Muslio
 es:Muesli, Mueslis
 et:Müsli


### PR DESCRIPTION
Renamed German category to 'Müsli', this is the word everyone in Germany uses, see https://de.wikipedia.org/wiki/M%C3%BCsli