### PR TITLE
Experimentally add some TODO tests

### DIFF
--- a/t/additives.t
+++ b/t/additives.t
@@ -25,15 +25,15 @@ diag explain $product_ref->{additives};
 # vitamine C is not used as an additive (no fuction)
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{vitamins_tags}, [
-        "en:thiamin",
-        "en:vitamin-c",
-        "en:vitamin-e",
-        "en:riboflavin",
-                              ],
+		"en:thiamin",
+		"en:vitamin-c",
+		"en:vitamin-e",
+		"en:riboflavin",
+	],
 );
 
 
@@ -41,9 +41,9 @@ is_deeply($product_ref->{vitamins_tags}, [
 
 # Make sure 100% is not recognized as E-100
 my $product_ref = {
-        lc => "fr",
-        ingredients_text => "Acide citrique, Gorge, foie et gras de fermier, œuf, graines de tournesol (4%), vin blanc, graines de sésame (2%), sel, poivre. Peut contenir des traces de gluten, soja, lait, fruits à coque. À conserver à l'abri de laichateur et de Ihumidité* À consommer de préférence avant la date figurant sur le bocal. Après -ouverture, à conserver au Téfrigérateuretàconsommerrapidernent? Servir frais. Sans colorant ni conservateur ajouté. Mateurs nutritionnelles moyennes pour 100 g : énergie (1584 kJ / 383 kcal), matières grasses (36 g) dont : acides gras saturés (14 g), glucides (2 g) dont : sucres (0,9 g), protéines (14,3 g), sel (1 ,6 g).",
-        ingredients_text_fr => "Acide citrique, Gorge, foie et gras de fermier, œuf, graines de tournesol (4%), vin blanc, graines de sésame (2%), sel, poivre. Peut contenir des traces de gluten, soja, lait, fruits à coque. À conserver à l'abri de laichateur et de Ihumidité* À consommer de préférence avant la date figurant sur le bocal. Après -ouverture, à conserver au Téfrigérateuretàconsommerrapidernent? Servir frais. Sans colorant ni conservateur ajouté. Mateurs nutritionnelles moyennes pour 100 g : énergie (1584 kJ / 383 kcal), matières grasses (36 g) dont : acides gras saturés (14 g), glucides (2 g) dont : sucres (0,9 g), protéines (14,3 g), sel (1 ,6 g).",
+	lc => "fr",
+	ingredients_text => "Acide citrique, Gorge, foie et gras de fermier, œuf, graines de tournesol (4%), vin blanc, graines de sésame (2%), sel, poivre. Peut contenir des traces de gluten, soja, lait, fruits à coque. À conserver à l'abri de laichateur et de Ihumidité* À consommer de préférence avant la date figurant sur le bocal. Après -ouverture, à conserver au Téfrigérateuretàconsommerrapidernent? Servir frais. Sans colorant ni conservateur ajouté. Mateurs nutritionnelles moyennes pour 100 g : énergie (1584 kJ / 383 kcal), matières grasses (36 g) dont : acides gras saturés (14 g), glucides (2 g) dont : sucres (0,9 g), protéines (14,3 g), sel (1 ,6 g).",
+	ingredients_text_fr => "Acide citrique, Gorge, foie et gras de fermier, œuf, graines de tournesol (4%), vin blanc, graines de sésame (2%), sel, poivre. Peut contenir des traces de gluten, soja, lait, fruits à coque. À conserver à l'abri de laichateur et de Ihumidité* À consommer de préférence avant la date figurant sur le bocal. Après -ouverture, à conserver au Téfrigérateuretàconsommerrapidernent? Servir frais. Sans colorant ni conservateur ajouté. Mateurs nutritionnelles moyennes pour 100 g : énergie (1584 kJ / 383 kcal), matières grasses (36 g) dont : acides gras saturés (14 g), glucides (2 g) dont : sucres (0,9 g), protéines (14,3 g), sel (1 ,6 g).",
 };
 
 compute_languages($product_ref);
@@ -52,7 +52,8 @@ extract_ingredients_classes_from_text($product_ref);
 
 is_deeply(
 	$product_ref->{additives_original_tags},
-	[   "en:e330",
+	[
+		"en:e330",
 		"en:e570",    # detected wrongly because of the bogus data after the ingredients list
 	],
 ) or diag explain $product_ref;
@@ -67,7 +68,7 @@ my $product_ref = {
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 
@@ -86,27 +87,29 @@ is($product_ref->{additives},
 
 # vitamine C is not used as an additive (no fuction)
 
-is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e330',
-                                'en:e120',
-                                'en:e500',
-                              ],
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e330',
+		'en:e120',
+		'en:e500',
+	],
 );
 
 # E316 detection - https://github.com/openfoodfacts/openfoodfacts-server/issues/269
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Poitrine de porc, sel, conservateurs : lactate de potassium, nitrite de sodium, arôme naturel, sirop de glucose, antioxydant : érythorbate de sodium"
+	lc => "fr",
+	ingredients_text => "Poitrine de porc, sel, conservateurs : lactate de potassium, nitrite de sodium, arôme naturel, sirop de glucose, antioxydant : érythorbate de sodium"
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
-is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e326',
-                                'en:e250',
-				'en:e316',
-                              ],
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e326',
+		'en:e250',
+		'en:e316',
+	],
 );
 
 is(canonicalize_taxonomy_tag("fr", "additives", "erythorbate de sodium"), "en:e316");
@@ -117,150 +120,162 @@ is(canonicalize_taxonomy_tag("fr", "additives", "acide citrique"), "en:e330");
 # issue/801-wrong-E471
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Farine de blé 46 %, sucre de canne roux non raffiné, farine complète de blé 15 %, graines de sésame 13 %, huile de tournesol oléique 13 %, sel marin non raffiné, poudres à lever : carbonates d'ammonium et de sodium, acide citrique ; extrait de vanille, antioxydant : extraits de romarin.",
+	lc => "fr",
+	ingredients_text => "Farine de blé 46 %, sucre de canne roux non raffiné, farine complète de blé 15 %, graines de sésame 13 %, huile de tournesol oléique 13 %, sel marin non raffiné, poudres à lever : carbonates d'ammonium et de sodium, acide citrique ; extrait de vanille, antioxydant : extraits de romarin.",
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
-is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e503',
-                                'en:e500',
-                                'en:e330',
-                                'en:e392',
-                              ],
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e503',
+		'en:e500',
+		'en:e330',
+		'en:e392',
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "carbonates de sodium et d'ammonium, nitrate de sodium et de potassium, Phosphate d'aluminium et de sodium.",
+	lc => "fr",
+	ingredients_text => "carbonates de sodium et d'ammonium, nitrate de sodium et de potassium, Phosphate d'aluminium et de sodium.",
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 diag explain $product_ref->{additives};
 
-is_deeply($product_ref->{additives_original_tags}, [
-				'en:e502',
-				'en:e251',
-				'en:e541',
-                              ],
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e502',
+		'en:e251',
+		'en:e541',
+	],
 );
 
+
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "poudres à lever : carbonates de sodium et d'ammonium",
+	lc => "fr",
+	ingredients_text => "poudres à lever : carbonates de sodium et d'ammonium",
+};
+
+extract_ingredients_classes_from_text($product_ref);
+
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e500',
+		'en:e503',
+	]
+);
+
+
+
+$product_ref = {
+	lc => "fr",
+	ingredients_text => "calcium, sodium, potassium, aluminium, magnésium, fer, or, argent, sels",
+};
+
+extract_ingredients_classes_from_text($product_ref);
+
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e173',
+		'en:e175',
+		'en:e174',
+	],
+);
+
+
+$product_ref = {
+	lc => "fr",
+	ingredients_text => "sirop de maltitol, Chlorophylle, Sels de sodium et de potassium de complexes cupriques de chlorophyllines, Carotènes végétaux, Carotènes d'algues",
+};
+
+extract_ingredients_classes_from_text($product_ref);
+
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e965ii',
+		'en:e140i',
+		'en:e141ii',
+		'en:e160aii',
+		'en:e160aiv',
+	],
+);
+
+
+$product_ref = {
+	lc => "fr",
+	ingredients_text => "colorants : carotène et extraits de paprika et de curcuma",
+};
+
+extract_ingredients_classes_from_text($product_ref);
+
+0 and is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e160a',
+		'en:e160c',
+		'en:e100',
+	],
+);
+
+
+$product_ref = {
+	lc => "fr",
+	ingredients_text => "colorants : E100 et E120, acidifiant : acide citrique et E331, colorants : lutéine et tartrazine",
+};
+
+extract_ingredients_classes_from_text($product_ref);
+
+
+0 and is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e100',
+		'en:e120',
+		'en:e330',
+		'en:e331',
+		'en:e100',
+		'en:e102',
+	],
+);
+
+
+$product_ref = {
+	lc => "fr",
+	ingredients_text => "colorant: caroténoides mélangés",
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e500',
-                                'en:e503',
-				]
-);
-
-
-
-$product_ref = {
-        lc => "fr",
-        ingredients_text => "calcium, sodium, potassium, aluminium, magnésium, fer, or, argent, sels",
-};
-
-extract_ingredients_classes_from_text($product_ref);
-
-is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e173',
-                                'en:e175',
-                                'en:e174',
-                              ],
-);
-
-$product_ref = {
-        lc => "fr",
-        ingredients_text => "sirop de maltitol, Chlorophylle, Sels de sodium et de potassium de complexes cupriques de chlorophyllines, Carotènes végétaux, Carotènes d'algues",
-};
-
-extract_ingredients_classes_from_text($product_ref);
-
-is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e965ii',
-                                'en:e140i',
-				'en:e141ii',
-                                'en:e160aii',
-                                'en:e160aiv',
-                              ],
-);
-
-$product_ref = {
-        lc => "fr",
-        ingredients_text => "colorants : carotène et extraits de paprika et de curcuma",
-};
-
-extract_ingredients_classes_from_text($product_ref);
-
-0 and is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e160a',
-                                'en:e160c',
-                                'en:e100',
-                              ],
+		'en:e160a',
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "colorants : E100 et E120, acidifiant : acide citrique et E331, colorants : lutéine et tartrazine",
-};
-
-extract_ingredients_classes_from_text($product_ref);
-
-0 and is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e100',
-                                'en:e120',
-                                'en:e330',
-                                'en:e331',
-                                'en:e100',
-                                'en:e102',
-                              ],
-);
-
-$product_ref = {
-        lc => "fr",
-        ingredients_text => "colorant: caroténoides mélangés",
-};
-
-extract_ingredients_classes_from_text($product_ref);
-
-is_deeply($product_ref->{additives_original_tags}, [
-                                'en:e160a',
-                              ],
-);
-
-
-$product_ref = {
-        lc => "fr",
-        ingredients_text => "Eau, huile végétale, amidon, vinaigre, moutarde (eau, vinaigre, graines de moutarde, sel, épices), oignons, jaune d'œuf, sel, amidon modifié, cerfeuil, vinaigre de malt (contient de l'orge), mélasse, sauce soja (contient du blé), sucre, jus de citron, sirop de glucose-fructose, anchois, extrait d'épices, tamarin, extrait d'herbes, épices, herbes. Stabilisateurs : gomme guar, farine de graines de caroube, gomme xanthane. Conservateurs : acide tartrique, acide citrique, acide malique, sorbate de potassium, benzoate de sodium. Colorants : bêta-carotène, carmoisine, caramel. Antioxydant : calcium-dinatrium-EDTA.
+	lc => "fr",
+	ingredients_text => "Eau, huile végétale, amidon, vinaigre, moutarde (eau, vinaigre, graines de moutarde, sel, épices), oignons, jaune d'œuf, sel, amidon modifié, cerfeuil, vinaigre de malt (contient de l'orge), mélasse, sauce soja (contient du blé), sucre, jus de citron, sirop de glucose-fructose, anchois, extrait d'épices, tamarin, extrait d'herbes, épices, herbes. Stabilisateurs : gomme guar, farine de graines de caroube, gomme xanthane. Conservateurs : acide tartrique, acide citrique, acide malique, sorbate de potassium, benzoate de sodium. Colorants : bêta-carotène, carmoisine, caramel. Antioxydant : calcium-dinatrium-EDTA.
 ",
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e14xx',
-          'en:e412',
-          #'en:e410', should now appear as parent
-          'en:e415',
-          'en:e334',
-          'en:e330',
-          'en:e296',
-          'en:e202',
-          'en:e211',
-          'en:e160ai',
-          'en:e122',
-          'en:e150',
-          'en:e385',
-		      ],
+		'en:e14xx',
+		'en:e412',
+		#'en:e410', should now appear as parent
+		'en:e415',
+		'en:e334',
+		'en:e330',
+		'en:e296',
+		'en:e202',
+		'en:e211',
+		'en:e160ai',
+		'en:e122',
+		'en:e150',
+		'en:e385',
+	],
 );
 
 
@@ -268,8 +283,8 @@ is_deeply($product_ref->{additives_original_tags}, [
 # chewing-gum mentos
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Edulcorants (xylitol (32%), erythritol, mannitol, maltitol, sorbitol, sirop de maltitol, aspartame, acésulfame K, sucralose), gomme base, arômes, agent épaissisant (gomme arabique), gélatine, colorant (dioxyde de titane), stabilisant (glycérol), émulsifiant (lécithine de soja), extrait naturel de thé vert, agent d'enrobage (cire de carnauba), antioxydant (E320).
+	lc => "fr",
+	ingredients_text => "Edulcorants (xylitol (32%), erythritol, mannitol, maltitol, sorbitol, sirop de maltitol, aspartame, acésulfame K, sucralose), gomme base, arômes, agent épaissisant (gomme arabique), gélatine, colorant (dioxyde de titane), stabilisant (glycérol), émulsifiant (lécithine de soja), extrait naturel de thé vert, agent d'enrobage (cire de carnauba), antioxydant (E320).
 ",
 };
 
@@ -278,42 +293,59 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives_original_tags};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e967',
-          'en:e968',
-          'en:e421',
-          'en:e965',
-          'en:e420',
-          'en:e965ii',
-          'en:e951',
-          'en:e950',
-          'en:e955',
-          'en:e414',
-          'en:e428',
-          'en:e171',
-          'en:e422',
-          'en:e322i',
-          'en:e903',
-          'en:e320'
-                              ],
+		'en:e967',
+		'en:e968',
+		'en:e421',
+		'en:e965',
+		'en:e420',
+		'en:e965ii',
+		'en:e951',
+		'en:e950',
+		'en:e955',
+		'en:e414',
+		'en:e428',
+		'en:e171',
+		'en:e422',
+		'en:e322i',
+		'en:e903',
+		'en:e320'
+	],
 ) or diag explain $product_ref->{additives_original_tags};
 
 
 # additives that are only additives when preceeded by their function
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Eau, sucre, vitamine C"
+	lc => "fr",
+	ingredients_text => "Eau, sucre, vitamine C"
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
+
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Eau, sucre, antioxydant: vitamine C"
+	lc => "fr",
+	ingredients_text => "Eau, sucre, antioxydant: vitamine C"
+};
+
+extract_ingredients_classes_from_text($product_ref);
+
+diag explain $product_ref->{additives};
+
+is_deeply(
+	$product_ref->{additives_original_tags}, [
+		'en:e300',
+	],
+);
+
+
+$product_ref = {
+	lc => "fr",
+	ingredients_text => "Eau, sucre, anti-oxydants: vitamine C"
 };
 
 extract_ingredients_classes_from_text($product_ref);
@@ -321,42 +353,28 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e300',
-                              ],
-);
-
-$product_ref = {
-        lc => "fr",
-        ingredients_text => "Eau, sucre, anti-oxydants: vitamine C"
-};
-
-extract_ingredients_classes_from_text($product_ref);
-
-diag explain $product_ref->{additives};
-
-is_deeply($product_ref->{additives_original_tags}, [
-          'en:e300',
-                              ],
+		'en:e300',
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Eau, sucre, antioxydants: vitamine C, acide citrique"
+	lc => "fr",
+	ingredients_text => "Eau, sucre, antioxydants: vitamine C, acide citrique"
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e300',
-          'en:e330',
-                              ],
+		'en:e300',
+		'en:e330',
+	],
 );
 
+
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
-"vitamines (A,C)"
+	lc => "fr",
+	ingredients_text => "vitamines (A,C)"
 };
 
 extract_ingredients_classes_from_text($product_ref);
@@ -364,15 +382,15 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
-        "en:vitamin-a",
-        "en:vitamin-c",
-                              ],
+		"en:vitamin-a",
+		"en:vitamin-c",
+	],
 );
 
+
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
-"vitamines E, B6"
+	lc => "fr",
+	ingredients_text => "vitamines E, B6"
 };
 
 extract_ingredients_classes_from_text($product_ref);
@@ -380,15 +398,14 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
-        "en:vitamin-e",
-        "en:vitamin-b6",
-                              ],
+		"en:vitamin-e",
+		"en:vitamin-b6",
+	],
 );
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
-"vitamines B9 et B12"
+	lc => "fr",
+	ingredients_text => "vitamines B9 et B12"
 };
 
 extract_ingredients_classes_from_text($product_ref);
@@ -396,16 +413,16 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
-        "en:folic-acid",
-        "en:vitamin-b12",
-                              ],
+		"en:folic-acid",
+		"en:vitamin-b12",
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "vitamines: D, K et PP"
 };
 
@@ -414,18 +431,18 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
-        "en:vitamin-d",
-        "en:vitamin-k",
-        "en:niacin",
-                              ],
+		"en:vitamin-d",
+		"en:vitamin-k",
+		"en:niacin",
+	],
 );
 
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+		lc => "fr",
+		ingredients_text =>
 "vitamines : C, PP, acide folique et E"
 };
 
@@ -434,17 +451,17 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{vitamins_tags}, [
-        "en:vitamin-c",
-        "en:niacin",
-        "en:folic-acid",
-        "en:vitamin-e",
-                              ],
+		"en:vitamin-c",
+		"en:niacin",
+		"en:folic-acid",
+		"en:vitamin-e",
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Chlorures d'ammonium et de calcium"
 };
 
@@ -454,19 +471,19 @@ diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e510',
-                              ],
+		'en:e510',
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-          'en:calcium-chloride',
-                              ],
+		'en:calcium-chloride',
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Chlorures de calcium et ammonium"
 };
 
@@ -476,19 +493,19 @@ diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e510',
-                              ],
+		'en:e510',
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-          'en:calcium-chloride',
-                              ],
+		'en:calcium-chloride',
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Sulfates de fer, de zinc et de cuivre"
 };
 
@@ -497,14 +514,14 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:ferrous-sulfate",
-	"en:zinc-sulfate",
-	"en:copper-sulfate",
-                              ],
+		"en:ferrous-sulfate",
+		"en:zinc-sulfate",
+		"en:copper-sulfate",
+	],
 );
 
 
@@ -512,8 +529,8 @@ is_deeply($product_ref->{minerals_tags}, [
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Minéraux (carbonate de calcium)"
 };
 
@@ -522,20 +539,20 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:mineral",
-	"en:calcium-carbonate",
-                              ],
+		"en:mineral",
+		"en:calcium-carbonate",
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "carbonate de calcium"
 };
 
@@ -544,19 +561,19 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:calcium-carbonate",
-                              ],
+		"en:calcium-carbonate",
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Mineraux (carbonate de calcium, chlorures de calcium, potassium et magnésium, citrates de potassium et de sodium, phosphate de calcium, sulfates de fer, de zinc, de cuivre et de manganèse, iodure de potassium, sélénite de sodium)."
 };
 
@@ -566,33 +583,33 @@ diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:mineral",
-	"en:calcium-carbonate",
-	"en:calcium-chloride",
-	"en:potassium-chloride",
-	"en:magnesium-chloride",
-	"en:potassium-citrates",
-	"en:sodium-citrate",
-	"en:calcium-phosphate",
-	"en:ferrous-sulfate",
-	"en:zinc-sulfate",
-	"en:copper-sulfate",
-	"en:manganese-sulfate",
-	"en:potassium-iodide",
-	"en:sodium-selenite",
-                              ],
+		"en:mineral",
+		"en:calcium-carbonate",
+		"en:calcium-chloride",
+		"en:potassium-chloride",
+		"en:magnesium-chloride",
+		"en:potassium-citrates",
+		"en:sodium-citrate",
+		"en:calcium-phosphate",
+		"en:ferrous-sulfate",
+		"en:zinc-sulfate",
+		"en:copper-sulfate",
+		"en:manganese-sulfate",
+		"en:potassium-iodide",
+		"en:sodium-selenite",
+	],
 );
 
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "(carbonate de calcium, chlorures de calcium, potassium et magnésium, citrates de potassium et de sodium, phosphate de calcium, sulfates de fer, de zinc, de cuivre et de manganèse, iodure de potassium, sélénite de sodium)."
 };
 
@@ -602,24 +619,24 @@ diag explain $product_ref->{additives};
 
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:calcium-carbonate",
-	"en:calcium-chloride",
-	"en:potassium-chloride",
-	"en:magnesium-chloride",
-	"en:potassium-citrates",
-	"en:sodium-citrate",
-	"en:calcium-phosphate",
-	"en:ferrous-sulfate",
-	"en:zinc-sulfate",
-	"en:copper-sulfate",
-	"en:manganese-sulfate",
-	"en:potassium-iodide",
-	"en:sodium-selenite",
-                              ],
+		"en:calcium-carbonate",
+		"en:calcium-chloride",
+		"en:potassium-chloride",
+		"en:magnesium-chloride",
+		"en:potassium-citrates",
+		"en:sodium-citrate",
+		"en:calcium-phosphate",
+		"en:ferrous-sulfate",
+		"en:zinc-sulfate",
+		"en:copper-sulfate",
+		"en:manganese-sulfate",
+		"en:potassium-iodide",
+		"en:sodium-selenite",
+	],
 );
 
 
@@ -627,8 +644,8 @@ is_deeply($product_ref->{minerals_tags}, [
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Lactosérum déminéralisé (lait) - Huiles végétales (Palme, Colza, Coprah, Tournesol, Mortierella alpina) - Lactose (lait) - Lait écrémé - Galacto- oligosaccharides (GOS) (lait) - Protéines de lactosérum concentrées (lait) - Fructo- oligosaccharides (FOS) - Huile de poisson - Chlorure de choline - Emulsifiant: lécithine de soja - Taurine - Nucléotides - Inositol - L-tryptophane - L-carnitine - Vitamines (C, PP, B5, B9, A, E, B8, B12, BI, D3, B6, K1, B2) - Minéraux (carbonate de calcium, chlorures de potassium et de magnésium, citrates de potassium et de sodium, phosphate de calcium, sulfates de fer, de zinc, de cuivre et de manganèse, iodure de potassium, sélénite de sodium)."
 };
 
@@ -639,14 +656,14 @@ diag explain $product_ref->{additives_original_tags};
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e322i',
-                              ],
+		'en:e322i',
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Purée de pomme 40 %, sirop de glucose-fructose, farine de blé, protéines de lait, sucre, protéines de soja, purée de framboise 5 %, lactosérum, protéines de blé hydrolysées, sirop de glucose, graisse de palme non hydrogénée, humectant : glycérol végétal, huile de tournesol, minéraux (potassium, calcium, magnésium, fer, zinc, cuivre, sélénium, iode), jus concentré de raisin, arômes naturels, jus concentré de citron, levure désactivée, correcteur d'acidité : citrates de sodium, sel marin, acidifiant : acide citrique, vitamines A, B1, B2, B5, B6, B9, B12, C, D, H, PP et E (lactose, protéines de lait), cannelle, poudres à lever (carbonates de sodium, carbonates d'ammonium)."
 };
 
@@ -657,48 +674,48 @@ diag explain $product_ref->{additives_original_tags};
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e422',
-          'en:e331',
-          'en:e330',
-          'en:e500',
-          'en:e503',
-                              ],
+		'en:e422',
+		'en:e331',
+		'en:e330',
+		'en:e500',
+		'en:e503',
+	],
 );
 
 is_deeply($product_ref->{vitamins_tags}, [
-          'en:vitamin-a',
-          'en:thiamin',
-          'en:riboflavin',
-          'en:pantothenic-acid',
-          'en:vitamin-b6',
-          'en:folic-acid',
-          'en:vitamin-b12',
-          'en:vitamin-c',
-          'en:vitamin-d',
-          'en:biotin',
-          'en:niacin',
-          'en:vitamin-e',
-                              ],
+		'en:vitamin-a',
+		'en:thiamin',
+		'en:riboflavin',
+		'en:pantothenic-acid',
+		'en:vitamin-b6',
+		'en:folic-acid',
+		'en:vitamin-b12',
+		'en:vitamin-c',
+		'en:vitamin-d',
+		'en:biotin',
+		'en:niacin',
+		'en:vitamin-e',
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-          'en:mineral',
-          'en:potassium',
-          'en:calcium',
-          'en:magnesium',
-          'en:iron',
-          'en:zinc',
-          'en:copper',
-          'en:selenium',
-          'en:iodine',
-                              ],
+		'en:mineral',
+		'en:potassium',
+		'en:calcium',
+		'en:magnesium',
+		'en:iron',
+		'en:zinc',
+		'en:copper',
+		'en:selenium',
+		'en:iodine',
+	],
 );
 
 
 
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "Calcium phosphate"
 };
 
@@ -707,17 +724,17 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-        "en:calcium-phosphate",
-                              ],
+		"en:calcium-phosphate",
+	],
 );
 
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "acidity regulators: Calcium phosphate"
 };
 
@@ -726,18 +743,18 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-	"en:e341"
-                              ],
+		"en:e341"
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-                              ],
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Dextrines maltées de mais, lait écrémé, huiles végétales non hydrogénées : colza, noix de coco, tournesol, lactose, Bifidus longum maternis. Minéraux : phosphate de calcium naturel de lait, oxyde de magnésium naturel, pyrophosphate de fer, gluconate de zinc, gluconate de cuivre, iodate de potassium, sélénite de sodium Vitamine d'Origine Végétale : L-ascorbate de sodium (vitamine C, cobalamine (vitamine B12), vitamines nature identique : niacine (vitamine PP), acide pantothénique (vitamine B5), riboflavine (vitamine B2), thiamine (vitamine B1), pyridoxine (vitamine B6), rétinol (vitamine A), acide folique (vitamine B9), phytoménadione (vitamine K1), biotine (vitamine B8), ergocalciférol (vitamine D2), vitamine Naturelle : tocophérols naturels extrait de tournesol (vitamine E)"
 };
 
@@ -746,46 +763,46 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-        "en:e1400",
-                              ],
+		"en:e1400",
+	],
 ) or diag explain($product_ref->{mineral_tags});
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:mineral",
-	"en:calcium-phosphate",
-	"en:magnesium-oxide",
-	"en:ferric-diphosphate",
-	"en:zinc-gluconate",
-	"en:copper-gluconate",
-	"en:potassium-iodate",
-	"en:sodium-selenite",
-                             ],
+		"en:mineral",
+		"en:calcium-phosphate",
+		"en:magnesium-oxide",
+		"en:ferric-diphosphate",
+		"en:zinc-gluconate",
+		"en:copper-gluconate",
+		"en:potassium-iodate",
+		"en:sodium-selenite",
+	],
 ) or diag explain($product_ref->{minerals_tags});
 
 is_deeply($product_ref->{vitamins_tags}, [
-	"en:sodium-l-ascorbate",
-	"en:vitamin-c",
-	"en:vitamin-b12",
-	"en:niacin",
-	"en:pantothenic-acid",
-	"en:riboflavin",
-	"en:thiamin",
-	"en:vitamin-b6",
-	"en:retinol",
-	"en:vitamin-a",
-	"en:folic-acid",
-	"en:phylloquinone",
-	"en:biotin",
-	"en:ergocalciferol",
-	"en:vitamin-e",
-                              ],
+		"en:sodium-l-ascorbate",
+		"en:vitamin-c",
+		"en:vitamin-b12",
+		"en:niacin",
+		"en:pantothenic-acid",
+		"en:riboflavin",
+		"en:thiamin",
+		"en:vitamin-b6",
+		"en:retinol",
+		"en:vitamin-a",
+		"en:folic-acid",
+		"en:phylloquinone",
+		"en:biotin",
+		"en:ergocalciferol",
+		"en:vitamin-e",
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Oxyde de magnésium, Acide gluconique, Gluconate de calcium"
 };
 
@@ -794,24 +811,24 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:magnesium-oxide",
-	"en:calcium-gluconate",
-                              ],
+		"en:magnesium-oxide",
+		"en:calcium-gluconate",
+	],
 );
 
 is_deeply($product_ref->{vitamins_tags}, [
-                              ],
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Céréales 90,5 % (farine de blé et gluten de blé 57,8 %, farine complète de blé 31 %, farine de blé malté), sucre, graines de lin, levure, huile de palme, fibres d'avoine, sel, minéraux [calcium (orthophosphate), fer (fumarate), magnésium (oxyde)], agent de traitement de la farine (acide ascorbique), vitamines [E, thiamine (B1), riboflavine (B2), B6, acide folique)]."
 };
 
@@ -820,31 +837,31 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-	"en:e300",
-                              ],
+		"en:e300",
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:mineral",
-	"en:calcium",
-	"en:iron",
-	"en:magnesium",
-                              ],
+		"en:mineral",
+		"en:calcium",
+		"en:iron",
+		"en:magnesium",
+	],
 );
 
 is_deeply($product_ref->{vitamins_tags}, [
-	"en:vitamin-e",
-	"en:thiamin",
-	"en:riboflavin",
-	"en:vitamin-b6",
-	"en:folic-acid",
-                              ],
+		"en:vitamin-e",
+		"en:thiamin",
+		"en:riboflavin",
+		"en:vitamin-b6",
+		"en:folic-acid",
+	],
 );
 
 
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "REAL SUGARCANE, SALT, ANTIOXIDANT (INS 300), ACIDITY REGULATOR (INS 334), STABILIZER (INS 440, INS 337), WATER (FOR MAINTAINING DESIRED BRIX), CONTAINS PERMITTED NATURAL FLAVOUR & NATURAL IDENTICAL COLOURING SUBSTANCES (INS 141[i])"
 };
 
@@ -853,19 +870,19 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-	"en:e300",
-	"en:e334",
-	"en:e440",
-	"en:e337",
-	"en:e141",
-                              ],
+		"en:e300",
+		"en:e334",
+		"en:e440",
+		"en:e337",
+		"en:e141",
+	],
 );
 
 
 # bug 1133
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "water, sugar, tea, lemon juice, flavouring, acidity regulator (330, 331), vitamin C, antioxidant (304)"
 };
 
@@ -874,15 +891,15 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-	"en:e330",
-	"en:e331",
-	"en:e304",
-                              ],
+		"en:e330",
+		"en:e331",
+		"en:e304",
+	],
 );
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "chlorure de choline, taurine, inositol, L-cystéine, sels de sodium de l’AMP, citrate de choline, carnitine"
 };
 
@@ -891,34 +908,33 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{amino_acids_tags}, [
-	"en:l-cysteine",
-                              ],
+		"en:l-cysteine",
+	],
 );
 
 is_deeply($product_ref->{nucleotides_tags}, [
-	"en:sodium-salts-of-amp",
-                              ],
+		"en:sodium-salts-of-amp",
+	],
 );
 
 is_deeply($product_ref->{other_nutritional_substances_tags}, [
-	"en:choline-chloride",
-	"en:taurine",
-	"en:inositol",
-	"en:carnitine",
-
-                              ],
+		"en:choline-chloride",
+		"en:taurine",
+		"en:inositol",
+		"en:carnitine",
+	],
 );
 
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "émulsifiant: chlorure de choline, agent de traitement de la farine:l cystéine"
 };
 
@@ -927,14 +943,14 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-        "en:e1001",
-        "en:e920",
-                              ],
+		"en:e1001",
+		"en:e920",
+	],
 );
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "
 Lait partiellement écrémé, eau, lactose, maltodextrines, huiles végétales (colza, tournesol), vitamines : A, B1, B2, B5, B6, B8, B9, B12, C, D3, E, K1 et PP, substances d'apport minéral : citrate de calcium, sulfates de fer, de magnésium, de zinc, de cuivre et de manganèse, citrate de sodium, iodure et hydroxyde de potassium, sélénite de sodium, émulsifiant : lécithine de colza, éthylvanilline."
 };
@@ -944,31 +960,30 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-        "en:e322i",
-                              ],
+		"en:e322i",
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
-        "en:mineral",
-        "en:calcium-citrate",
-        "en:ferrous-sulfate",
-        "en:magnesium-sulfate",
-        "en:zinc-sulfate",
-        "en:copper-sulfate",
-        "en:manganese-sulfate",
-        "en:sodium-citrate",
-        "en:potassium-iodide",
-        "en:potassium-hydroxide",
-        "en:sodium-selenite",
-
-                              ],
+		"en:mineral",
+		"en:calcium-citrate",
+		"en:ferrous-sulfate",
+		"en:magnesium-sulfate",
+		"en:zinc-sulfate",
+		"en:copper-sulfate",
+		"en:manganese-sulfate",
+		"en:sodium-citrate",
+		"en:potassium-iodide",
+		"en:potassium-hydroxide",
+		"en:sodium-selenite",
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "INFORMATIONS NUTRITIONNELLES PRÉPARATION POUR NOURRISSONS EN potlDRE - Ingrédients du produit reconstitué : Lactose (lait), huiles végétales (palme, colza, tournesol), maltodextrines, proteines de lait hydrolysées, minéraux (phosphate tricalcique, chlorure de potassium, citrate trisodique, phosphate dipotassique, phosphate de magnésium, sulfate ferreux, sulfate de zinc, hydroxyde de potassium, sélénite de sodium, iodure de potassium, sulfate de cuivre, sulfate de manganèse), émulsifiant (esters citriques de mono et diglycérides d'acides gras), vitamines (C,pp, B9,H,B12), L-phénylalanine, chlorure de choline, L-tryptophane, L-tyrosine, taurine, inositol, antioxydants (palmitate d'ascorbyle, tocophérols) (soja), L-carnitine, ferments lactiques (Lactobacillus fermentum CECT5716)"
 };
 
@@ -977,29 +992,29 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-        "en:e472c",
-        "en:e304i",
-        "en:e307c",
-                              ],
+		"en:e472c",
+		"en:e304i",
+		"en:e307c",
+	],
 );
 
 is_deeply($product_ref->{nucleotides_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{amino_acids_tags}, [
-	"en:l-phenylalanine",
-	"en:l-tryptophan",
-	"en:l-tyrosine",
-                              ],
+		"en:l-phenylalanine",
+		"en:l-tryptophan",
+		"en:l-tyrosine",
+	],
 );
 
 is_deeply($product_ref->{other_nutritional_substances_tags}, [
-	"en:choline-chloride",
-	"en:taurine",
-	"en:inositol",
-	"en:l-carnitine",
-                              ],
+		"en:choline-chloride",
+		"en:taurine",
+		"en:inositol",
+		"en:l-carnitine",
+	],
 );
 
 
@@ -1007,26 +1022,26 @@ is_deeply($product_ref->{other_nutritional_substances_tags}, [
 
 
 is_deeply($product_ref->{minerals_tags}, [
-	"en:mineral",
-	"en:calcium-phosphate",
-	"en:potassium-chloride",
-	"en:sodium-citrate",
-	"en:potassium-phosphate",
-	"en:magnesium-phosphate",
-	"en:ferrous-sulfate",
-	"en:zinc-sulfate",
-	"en:potassium-hydroxide",
-	"en:sodium-selenite",
-	"en:potassium-iodide",
-        "en:copper-sulfate",
-        "en:manganese-sulfate",
-                              ],
+		"en:mineral",
+		"en:calcium-phosphate",
+		"en:potassium-chloride",
+		"en:sodium-citrate",
+		"en:potassium-phosphate",
+		"en:magnesium-phosphate",
+		"en:ferrous-sulfate",
+		"en:zinc-sulfate",
+		"en:potassium-hydroxide",
+		"en:sodium-selenite",
+		"en:potassium-iodide",
+		"en:copper-sulfate",
+		"en:manganese-sulfate",
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "huile de colza, orthophosphates de calcium, carbonate de calcium, citrates de potassium"
 };
 
@@ -1035,20 +1050,20 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
 	"en:calcium-phosphate",
 	"en:calcium-carbonate",
 	"en:potassium-citrates",
-                              ],
+	],
 );
 
 
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "copper carbonate"
 };
 
@@ -1057,17 +1072,17 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 is_deeply($product_ref->{minerals_tags}, [
 	"en:cupric-carbonate",
-                              ],
+	],
 );
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Café instantané 100 % pur arabica"
 };
 
@@ -1076,13 +1091,13 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 # 100 % --> no E100 curcumine
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "Instant coffee 100 %."
 };
 
@@ -1091,7 +1106,7 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-                              ],
+	],
 );
 
 
@@ -1100,8 +1115,8 @@ is_deeply($product_ref->{additives_original_tags}, [
 # "water, sugar, tea, lemon juice, flavouring, acidity regulator (330, 331), vitamin C, antioxidant (304)"
 
 $product_ref = {
-        lc => "en",
-        ingredients_text =>
+	lc => "en",
+	ingredients_text =>
 "water, sugar, tea, lemon juice, flavouring, acidity regulator (330, 331), vitamin C, antioxidant (304)"
 };
 
@@ -1113,14 +1128,14 @@ is_deeply($product_ref->{additives_original_tags}, [
 	"en:e330",
 	"en:e331",
 	"en:e304",
-                              ],
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Sucre (France), OEUF entier (reconstitué à partir de poudre d OEUF), huile de colza, farine de riz, amidon de pomme de terre, stabilisants : glycérol et gomme xanthane, amidon de maïs, poudres à lever : diphosphates et carbonates de sodium, arôme naturel de citron, émulsifiant : mono- et diglycérides d'acides gras, conservateur : sorbate de potassium, sel, colorant : riboflavine. Traces éventuelles de soja."
 };
 
@@ -1136,13 +1151,13 @@ is_deeply($product_ref->{additives_original_tags}, [
 	"en:e471",
 	"en:e202",
 	"en:e101i",
-                              ],
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "farine de seigle, sel, poudre à lever : carbonates de sodium,carbonates dlammonium,diphosphates,tartrates d potassium, amidon de blé, poudre de lait écrémé, extrait de malt dlorge, noix de coco 0,1 % arômes, jaune d'œuf en poudre, fécule de pomme de terre, farine dorge, amidon de maïs colorants : caramel ordinaire et curcumine, lactose et protéine de lait en poudre. Colorant: Sels de sodium et de potassium de complexes cupriques de chlorophyllines, Complexe cuivrique des chlorophyllines avec sels de sodium et de potassium, oxyde et hydroxyde de fer rouge, oxyde et hydroxyde de fer jaune et rouge, Tartrate double de sodium et de potassium, Éthylènediaminetétraacétate de calcium et de disodium, Phosphate d'aluminium et de sodium, Diphosphate de potassium et de sodium, Tripoliphosphates de sodium et de potassium, Sels de sodium de potassium et de calcium d'acides gras, Mono- et diglycérides d'acides gras, Esters acétiques des mono- et diglycérides, Esters glycéroliques de l'acide acétique et d'acides gras, Esters glycéroliques de l'acide citrique et d'acides gras, Esters monoacétyltartriques et diacétyltartriques, Esters mixtes acétiques et tartriques des mono- et diglycérides d'acides gras, Esters lactyles d'acides gras du glycérol et du propane-1, Silicate double d'aluminium et de calcium, Silicate d'aluminium et calcium, Silicate d'aluminium et de calcium, Silicate double de calcium et d'aluminium,  Glycine et son sel de sodium, Cire d'abeille blanche et jaune, Acide cyclamique et ses sels, Saccharine et ses sels, Acide glycyrrhizique et sels, Sels et esters de choline, Octénylesuccinate d'amidon et d'aluminium, "
 };
 
@@ -1151,42 +1166,42 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e500',
-#          'en:e503',
-          'en:e502',
-          'en:e450',
-          'en:e336',
-          'en:e150a',
-          'en:e100',
-          'en:e141ii',
-          'en:e172ii',
-          'en:e172iii',
-          'en:e337',
-          'en:e385',
-          'en:e541',
-	  'en:e450i',
-#	  'en:e451',
-	  'en:e340',
-          'en:e470a',
-          'en:e471',
-          'en:e472a',
-          'en:e472c',
-          'en:e472f',
-          'en:e478',
-          'en:e556',
-          'en:e640',
-          'en:e901',
-          'en:e952',
-          'en:e954',
-          'en:e958',
-          'en:e1452'
-],
+		'en:e500',
+		#'en:e503',
+		'en:e502',
+		'en:e450',
+		'en:e336',
+		'en:e150a',
+		'en:e100',
+		'en:e141ii',
+		'en:e172ii',
+		'en:e172iii',
+		'en:e337',
+		'en:e385',
+		'en:e541',
+		'en:e450i',
+		#'en:e451',
+		'en:e340',
+		'en:e470a',
+		'en:e471',
+		'en:e472a',
+		'en:e472c',
+		'en:e472f',
+		'en:e478',
+		'en:e556',
+		'en:e640',
+		'en:e901',
+		'en:e952',
+		'en:e954',
+		'en:e958',
+		'en:e1452'
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Liste des ingrédients : viande de porc, sel, lactose, épices, sucre, dextrose, ail, conservateurs : nitrate de potassium et nitrite de sodium, ferments, boyau naturel de porc. Poudre de fleurage : talc et carbonate de calcium. 164 g de viande de porc utilisée poudre 100 g de produit fini.
 "
 };
@@ -1200,13 +1215,13 @@ is_deeply($product_ref->{additives_original_tags}, [
 	"en:e250",
 	"en:e553b",
 	"en:e170i",
-                              ],
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Fruits* 43,8% (bigarreaux confits 19,3% (bigarreaux, sirop de glucose- fructose, colorant anthocyanes, correcteur d'acidité: acide citrique, conservateur: anhydride sulfureux), raisins secs 11%, raisins secs macérés dans l'extrait aromatique rhum orange 10% (raisins secs, rhum, infusion d'écorces d'oranges douces), écorces d'orange confites 3,5% (écorces d'orange. sirop de glucose-fructose, saccharose, correcteur d'acidité: acide citrique, conservateur: anhydride sulfureux)), farine de blé, eufs entiers, sucre, beurre 14%, sirop de glucose, stabilisant:glycérol, arôme naturel de vanille (contient alcool) et autre arôme, sel, poudres à lever : diphosphates et carbonates de sodium (dont céréales contenant du gluten), émulsifiant mono-et diglycérides d'acides gras, épaississant gommexanthane. *fruits confits, fruits secs et fruits secs macérés.
 "
 };
@@ -1224,13 +1239,13 @@ is_deeply($product_ref->{additives_original_tags}, [
 	"en:e500",
 	"en:e471",
 #	"en:e415",
-                              ],
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Farine de BLE, sucre, chocolat au lait 13% (sucre, beurre de cacao, pâte de cacao, LAIT écrémé en poudre, LACTOSE, matière grasse LAITIERE anhydre, LACTOSERUM en poudre, émulsifiant : lécithines de tournesol), chocolat blanc 8% (sucre, beurre de cacao, LAIT entier en poudre, émulsifiant : lécithines de tournesol), BEURRE pâtissier, chocolat noir 6% (pâte de cacao, sucre, beurre de cacao, matière grasse LAITIERE, émulsifiant : lécithines de tournesol), blancs d'OEUFS, fourrage à la purée de framboise 3.5% (sirop de glucose- fructose, stabilisant : glycérol, purée et brisures de framboise, purée de framboise concentrée, purée de pomme, BEURRE, arômes, acidifiant : acide citrique, gélifiant : pectines de fruits, correcteur d'acidité : citrates de sodium, jus concentré de sureau), huile de tournesol, OEUFS entiers, AMANDES 1.3%, poudre de NOIX DE CAJOU 1.2%, sucre de canne roux, NOISETTES, poudre de florentin 0.6% (sucre, sirop de glucose, BEURRE, émulsifiant : lécithines de SOJA, poudre de LAIT écrémé), sirop de sucre inverti et partiellement inverti, grains de riz soufflés 0.5% (farine de riz, gluten de BLE, malt de BLE, saccharose, sel, dextrose), nougatine 0.4% (sucre, AMANDES et NOISETTES torréfiées), éclat de caramel 0.4% (sucre, sirop de glucose, CREME et BEURRE caramélisés), farine de SEIGLE, sel, poudres à lever : carbonates de sodium - carbonates d'ammonium- diphosphates- tartrates de potassium, amidon de BLE, poudre de LAIT écrémé, extrait de malt d'ORGE, noix de coco 0.1%, arômes, jaune d'OEUF en poudre, fécule de pomme de terre, farine d'ORGE, amidon de maïs, colorants : caramel ordinaire et curcumine, LACTOSERUM en poudre et protéines de LAIT, cannelle en poudre, émulsifiant : lécithines de tournesol, antioxydant : acide ascorbique. Traces éventuelles de graines de sésame et autres fruits à coques.
 ",
 	categories_tags => ["en:debug"],
@@ -1241,25 +1256,24 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e322i',
-          'en:e422',
-          'en:e330',
-          'en:e440',
-          'en:e331',
-          'en:e500',
-          'en:e503',
-          'en:e450',
-          'en:e336',
-          'en:e150a',
-          'en:e100',
-          'en:e300'
-
-                              ],
+		'en:e322i',
+		'en:e422',
+		'en:e330',
+		'en:e440',
+		'en:e331',
+		'en:e500',
+		'en:e503',
+		'en:e450',
+		'en:e336',
+		'en:e150a',
+		'en:e100',
+		'en:e300'
+	],
 );
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Ac1de citrique; or; ar; amidon modfié, carbonate dlammonium, carmims, glycoside de steviol, sel ntrite, vltamine c
 "
 };
@@ -1270,15 +1284,14 @@ diag explain $product_ref->{additives};
 
 # spellchecking of additives is now disabled, commenting the test
 0 and is_deeply($product_ref->{additives_original_tags}, [
-          'en:e330',
-          'en:e175',
-          'en:e14xx',
-          'en:e503i',
-	  #'en:e120', # does not have color before it
-          'en:e960',
-          'en:e250',
-
-                              ],
+		'en:e330',
+		'en:e175',
+		'en:e14xx',
+		'en:e503i',
+		#'en:e120', # does not have color before it
+		'en:e960',
+		'en:e250',
+	],
 );
 
 
@@ -1286,8 +1299,8 @@ diag explain $product_ref->{additives};
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Eau, E501
 "
 };
@@ -1297,16 +1310,15 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e501',
-
-                              ],
+		'en:e501',
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Olives d'import 80 % (vertes, tournantes, noires), poivron et piment, sel, oignon, huile de tournesol, ail, acidifiants (E330, vinaigre), conservateur : sulfites.
 "
 };
@@ -1316,9 +1328,8 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e330',
-
-                              ],
+		'en:e330',
+	],
 );
 
 
@@ -1326,8 +1337,8 @@ is_deeply($product_ref->{additives_original_tags}, [
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "Biscuit 65 % :farine de riz blanche*, amidon de pomme de terre*, huile de palme non hydrogénée, sucre de canne blond, amidon de riz*, œufs*, sirop de glucose de r|z*, farine de pois chiche*, épaississants (gomme d’acacia*, gomme de guar), agents levants (tartrates potassium, carbonates de sodium), sel. Fourrage 35% : sirop de glucose de riz*, purée de pomme*, purée d’abricot* 08%), purée de pêche (7%), gélifiant: pectine, régulateur d’acidité : acide citrique, arôme naturel*. *issus de agriculture biologique. **Ingrédient biologique issu du Commerce Équitable.
 ",
 };
@@ -1337,21 +1348,20 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e414',
-          'en:e412',
-          'en:e336',
-          'en:e500',
-          'en:e440',
-          'en:e330',
-
-                              ],
+		'en:e414',
+		'en:e412',
+		'en:e336',
+		'en:e500',
+		'en:e440',
+		'en:e330',
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "dioxyde titane, le glutamate de sodium,
 ",
 };
@@ -1361,17 +1371,16 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-          'en:e171',
-          'en:e621',
-
-                              ],
+		'en:e171',
+		'en:e621',
+	],
 );
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "boyau, coloré, chlorela, chlorelle, chlorele bio
 ",
 };
@@ -1381,14 +1390,13 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-
-                              ],
+	],
 );
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text =>
+	lc => "fr",
+	ingredients_text =>
 "émulsifiants : E463, E432 et E472, correcteurs d'acidité : E322/E333 E474-E475
 ",
 };
@@ -1398,31 +1406,31 @@ extract_ingredients_classes_from_text($product_ref);
 diag explain $product_ref->{additives};
 
 is_deeply($product_ref->{additives_original_tags}, [
-"en:e463",
-"en:e432",
-"en:e472",
-"en:e322",
-"en:e333",
-"en:e474",
-"en:e475",
-                              ],
+		"en:e463",
+		"en:e432",
+		"en:e472",
+		"en:e322",
+		"en:e333",
+		"en:e474",
+		"en:e475",
+	],
 ) or diag explain $product_ref->{additives_original_tags};
 
 
 $product_ref = {
-        lc => "es",
-        ingredients_text =>
+	lc => "es",
+	ingredients_text =>
 "Leche desnatada de vaca, enzima lactasa y vitaminas A, D, E y ácido fólico.",
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{vitamins_tags}, [
-"en:vitamin-a",
-"en:vitamin-d",
-"en:vitamin-e",
-"en:folic-acid",
-                              ],
+		"en:vitamin-a",
+		"en:vitamin-d",
+		"en:vitamin-e",
+		"en:folic-acid",
+	],
 ) or diag explain $product_ref->{vitamins_tags};
 
 
@@ -1445,6 +1453,7 @@ is_deeply(
 	[ 'en:e330', 'en:e120', 'en:e500', ],
 );
 
+
 $product_ref = {
 	lc => "fi",
 	ingredients_text =>
@@ -1461,6 +1470,7 @@ is_deeply(
 is(canonicalize_taxonomy_tag("fi", "additives", "natriumerytorbaatti"), "en:e316");
 is(canonicalize_taxonomy_tag("fi", "additives", "sitruunahappo"), "en:e330");
 
+
 $product_ref = {
 	lc => "fi",
 	ingredients_text =>
@@ -1470,14 +1480,15 @@ $product_ref = {
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{additives_original_tags}, [
-			  'en:e414',
-			  'en:e420',
-			  'en:e965ii',
-			  'en:e950',
-			  'en:e330',
-			  'en:e100',
-			  'en:e901',
-		  ],
-	);
+		'en:e414',
+		'en:e420',
+		'en:e965ii',
+		'en:e950',
+		'en:e330',
+		'en:e100',
+		'en:e901',
+	],
+);
+
 
 done_testing();

--- a/t/allergens.t
+++ b/t/allergens.t
@@ -161,8 +161,8 @@ is_deeply($product_ref->{allergens_tags}, [
 
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "Noix de St-Jacques"
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "Noix de St-Jacques"
 };
 
 compute_languages($product_ref);
@@ -177,8 +177,8 @@ is_deeply($product_ref->{allergens_tags}, [
 
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "Saint Jacques"
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "Saint Jacques"
 };
 
 compute_languages($product_ref);
@@ -193,8 +193,8 @@ is_deeply($product_ref->{allergens_tags}, [
 
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "St Jacques"
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "St Jacques"
 };
 
 compute_languages($product_ref);
@@ -209,8 +209,8 @@ is_deeply($product_ref->{allergens_tags}, [
 
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "Farine de blé 97%"
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "Farine de blé 97%"
 };
 
 compute_languages($product_ref);
@@ -228,8 +228,8 @@ is($product_ref->{ingredients_text_with_allergens_fr},
 );
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "Farine de blé 97%"
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "Farine de blé 97%"
 };
 
 compute_languages($product_ref);
@@ -248,8 +248,8 @@ is($product_ref->{ingredients_text_with_allergens_fr},
 
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "Farine de blé 97%",
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "Farine de blé 97%",
 	allergens => "Sulfites",
 };
 
@@ -266,8 +266,8 @@ is_deeply($product_ref->{allergens_tags}, [
 
 
 $product_ref = {
-        lc => "fr", lang => "fr",
-        ingredients_text_fr => "farine de graines de moutarde, 100 % semoule de BLE dur de qualité supérieure Traces éventuelles d'oeufs",
+	lc => "fr", lang => "fr",
+	ingredients_text_fr => "farine de graines de moutarde, 100 % semoule de BLE dur de qualité supérieure Traces éventuelles d'oeufs",
 };
 
 compute_languages($product_ref);
@@ -431,8 +431,8 @@ is_deeply($product_ref->{traces_tags},  [
 );
 
 $product_ref = {
-        lc => "fi", lang => "fi",
-        ingredients_text_fi => "vehnäjauho 97%"
+	lc => "fi", lang => "fi",
+	ingredients_text_fi => "vehnäjauho 97%"
 };
 
 compute_languages($product_ref);
@@ -450,8 +450,8 @@ is($product_ref->{ingredients_text_with_allergens_fi},
 );
 
 $product_ref = {
-        lc => "fi", lang => "fi",
-        ingredients_text_fi => "vehnäjauho 97%",
+	lc => "fi", lang => "fi",
+	ingredients_text_fi => "vehnäjauho 97%",
 	allergens => "Sulfiitteja",
 };
 
@@ -467,8 +467,8 @@ is_deeply($product_ref->{allergens_tags}, [
 );
 
 $product_ref = {
-        lc => "fi", lang => "fi",
-        ingredients_text_fi => "sinappijauhe, VEHNÄsuurimo. Saattaa sisältää kananmunaa",
+	lc => "fi", lang => "fi",
+	ingredients_text_fi => "sinappijauhe, VEHNÄsuurimo. Saattaa sisältää kananmunaa",
 };
 
 compute_languages($product_ref);
@@ -509,8 +509,8 @@ detect_allergens_from_text($product_ref);
 is($product_ref->{ingredients_text_with_allergens_fr}, 'Eau, <span class="allergen">BLE</span>, <span class="allergen">CELERI</span>, <span class="allergen">GLUTEN</span>, <span class="allergen">poisson</span>, FRAISE, <span class="allergen">banane</span>, <span class="allergen">lupin</span>, <span class="allergen">mollusque</span>');
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text_fr => "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
+	lc => "fr",
+	ingredients_text_fr => "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
 };
 compute_languages($product_ref);
 detect_allergens_from_text($product_ref);
@@ -518,8 +518,8 @@ detect_allergens_from_text($product_ref);
 is($product_ref->{ingredients_text_with_allergens_fr}, "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)") or diag explain $product_ref;
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text_fr => "Saumon, oeufs, blé, chocolat",
+	lc => "fr",
+	ingredients_text_fr => "Saumon, oeufs, blé, chocolat",
 	allergens => "Moutarde. Traces éventuelles de lupin"
 };
 compute_languages($product_ref);
@@ -527,54 +527,54 @@ detect_allergens_from_text($product_ref);
 delete($product_ref->{allergens_from_user});
 delete($product_ref->{traces_from_user});
 is_deeply($product_ref,
- {
-   'allergens' => 'en:mustard',
-   'allergens_from_ingredients' => "Saumon, oeufs, bl\x{e9}",
-   'allergens_hierarchy' => [
-     'en:eggs',
-     'en:fish',
-     'en:gluten',
-     'en:mustard'
-   ],
-   'allergens_tags' => [
-     'en:eggs',
-     'en:fish',
-     'en:gluten',
-     'en:mustard'
-   ],
-   'ingredients_text_fr' => "Saumon, oeufs, bl\x{e9}, chocolat",
-   'ingredients_text_with_allergens' => "<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">bl\x{e9}</span>, chocolat",
-   'ingredients_text_with_allergens_fr' => "<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">bl\x{e9}</span>, chocolat",
-   'languages' => {
-     'en:french' => 1
-   },
-   'languages_codes' => {
-     'fr' => 1
-   },
-   'languages_hierarchy' => [
-     'en:french'
-   ],
-   'languages_tags' => [
-     'en:french',
-     'en:1'
-   ],
-   'lc' => 'fr',
-   'traces' => 'en:lupin',
-   'traces_from_ingredients' => '',
-   'traces_hierarchy' => [
-     'en:lupin'
-   ],
-   'traces_tags' => [
-     'en:lupin'
-   ]
- }
+{
+	'allergens' => 'en:mustard',
+	'allergens_from_ingredients' => "Saumon, oeufs, bl\x{e9}",
+	'allergens_hierarchy' => [
+		'en:eggs',
+		'en:fish',
+		'en:gluten',
+		'en:mustard'
+	],
+	'allergens_tags' => [
+		'en:eggs',
+		'en:fish',
+		'en:gluten',
+		'en:mustard'
+	],
+	'ingredients_text_fr' => "Saumon, oeufs, bl\x{e9}, chocolat",
+	'ingredients_text_with_allergens' => "<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">bl\x{e9}</span>, chocolat",
+	'ingredients_text_with_allergens_fr' => "<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">bl\x{e9}</span>, chocolat",
+	'languages' => {
+		'en:french' => 1
+	},
+	'languages_codes' => {
+		'fr' => 1
+	},
+	'languages_hierarchy' => [
+		'en:french'
+	],
+	'languages_tags' => [
+		'en:french',
+		'en:1'
+	],
+	'lc' => 'fr',
+	'traces' => 'en:lupin',
+	'traces_from_ingredients' => '',
+	'traces_hierarchy' => [
+		'en:lupin'
+	],
+	'traces_tags' => [
+		'en:lupin'
+	]
+}
 
 ) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text_fr => "Filet de saumon sauvage",
+	lc => "fr",
+	ingredients_text_fr => "Filet de saumon sauvage",
 	allergens => "Céleri, crustacés et lupin. Peut contenir du soja, des sulfites et de la moutarde.",
 	traces => "Oeufs"
 };
@@ -583,58 +583,58 @@ detect_allergens_from_text($product_ref);
 delete($product_ref->{allergens_from_user});
 delete($product_ref->{traces_from_user});
 
-is_deeply($product_ref, 
- {
-   'allergens' => "en:celery,en:crustaceans,en:lupin",
-   'allergens_from_ingredients' => '',
-   'allergens_hierarchy' => [
-     'en:celery',
-     'en:crustaceans',
-     'en:lupin'
-   ],
-   'allergens_tags' => [
-     'en:celery',
-     'en:crustaceans',
-     'en:lupin'
-   ],
-   'ingredients_text_fr' => 'Filet de saumon sauvage',
-   'ingredients_text_with_allergens' => 'Filet de saumon sauvage',
-   'ingredients_text_with_allergens_fr' => 'Filet de saumon sauvage',
-   'languages' => {
-     'en:french' => 1
-   },
-   'languages_codes' => {
-     'fr' => 1
-   },
-   'languages_hierarchy' => [
-     'en:french'
-   ],
-   'languages_tags' => [
-     'en:french',
-     'en:1'
-   ],
-   'lc' => 'fr',
-   'traces' => 'en:eggs,en:mustard,en:soybeans,en:sulphur-dioxide-and-sulphites',
-   'traces_from_ingredients' => '',
-   'traces_hierarchy' => [
-     'en:eggs',
-     'en:mustard',
-     'en:soybeans',
-     'en:sulphur-dioxide-and-sulphites'
-   ],
-   'traces_tags' => [
-     'en:eggs',
-     'en:mustard',
-     'en:soybeans',
-     'en:sulphur-dioxide-and-sulphites'
-   ]
- }
+is_deeply($product_ref,
+{
+	'allergens' => "en:celery,en:crustaceans,en:lupin",
+	'allergens_from_ingredients' => '',
+	'allergens_hierarchy' => [
+		'en:celery',
+		'en:crustaceans',
+		'en:lupin'
+	],
+	'allergens_tags' => [
+		'en:celery',
+		'en:crustaceans',
+		'en:lupin'
+	],
+	'ingredients_text_fr' => 'Filet de saumon sauvage',
+	'ingredients_text_with_allergens' => 'Filet de saumon sauvage',
+	'ingredients_text_with_allergens_fr' => 'Filet de saumon sauvage',
+	'languages' => {
+		'en:french' => 1
+	},
+	'languages_codes' => {
+		'fr' => 1
+	},
+	'languages_hierarchy' => [
+		'en:french'
+	],
+	'languages_tags' => [
+		'en:french',
+		'en:1'
+	],
+	'lc' => 'fr',
+	'traces' => 'en:eggs,en:mustard,en:soybeans,en:sulphur-dioxide-and-sulphites',
+	'traces_from_ingredients' => '',
+	'traces_hierarchy' => [
+		'en:eggs',
+		'en:mustard',
+		'en:soybeans',
+		'en:sulphur-dioxide-and-sulphites'
+	],
+	'traces_tags' => [
+		'en:eggs',
+		'en:mustard',
+		'en:soybeans',
+		'en:sulphur-dioxide-and-sulphites'
+	]
+}
 
- ) or diag explain $product_ref;
+) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
+	lc => "fr",
 	allergens => "GLUTEN. TRACES POTENTIELLES: CRUSTACÉS, ŒUFS, POISSONS, SOJA, LAIT, FRUITS À COQUES, CÉLERI, MOUTARDE ET SULFITES.",
 };
 compute_languages($product_ref);
@@ -643,48 +643,48 @@ delete($product_ref->{ingredients_text_fr});
 delete($product_ref->{allergens_from_user});
 delete($product_ref->{traces_from_user});
 
-is_deeply($product_ref, 
- {
-   'allergens' => 'en:gluten',
-   'allergens_from_ingredients' => '',
-   'allergens_hierarchy' => [
-     'en:gluten'
-   ],
-   'allergens_tags' => [
-     'en:gluten'
-   ],
-   'languages' => {},
-   'languages_codes' => {},
-   'languages_hierarchy' => [],
-   'languages_tags' => [
-     'en:0'
-   ],
-   'lc' => 'fr',
-   'traces' => "en:celery,en:crustaceans,en:eggs,en:fish,en:milk,en:mustard,en:nuts,en:soybeans,en:sulphur-dioxide-and-sulphites",
-   'traces_from_ingredients' => '',
-   'traces_hierarchy' => [
-     'en:celery',
-     'en:crustaceans',
-     'en:eggs',
-     'en:fish',
-     'en:milk',
-     'en:mustard',
-     'en:nuts',
-     'en:soybeans',
-     'en:sulphur-dioxide-and-sulphites'
-   ],
-   'traces_tags' => [
-     'en:celery',
-     'en:crustaceans',
-     'en:eggs',
-     'en:fish',
-     'en:milk',
-     'en:mustard',
-     'en:nuts',
-     'en:soybeans',
-     'en:sulphur-dioxide-and-sulphites'
-   ]
- }
+is_deeply($product_ref,
+{
+	'allergens' => 'en:gluten',
+	'allergens_from_ingredients' => '',
+	'allergens_hierarchy' => [
+		'en:gluten'
+	],
+	'allergens_tags' => [
+		'en:gluten'
+	],
+	'languages' => {},
+	'languages_codes' => {},
+	'languages_hierarchy' => [],
+	'languages_tags' => [
+		'en:0'
+	],
+	'lc' => 'fr',
+	'traces' => "en:celery,en:crustaceans,en:eggs,en:fish,en:milk,en:mustard,en:nuts,en:soybeans,en:sulphur-dioxide-and-sulphites",
+	'traces_from_ingredients' => '',
+	'traces_hierarchy' => [
+		'en:celery',
+		'en:crustaceans',
+		'en:eggs',
+		'en:fish',
+		'en:milk',
+		'en:mustard',
+		'en:nuts',
+		'en:soybeans',
+		'en:sulphur-dioxide-and-sulphites'
+	],
+	'traces_tags' => [
+		'en:celery',
+		'en:crustaceans',
+		'en:eggs',
+		'en:fish',
+		'en:milk',
+		'en:mustard',
+		'en:nuts',
+		'en:soybeans',
+		'en:sulphur-dioxide-and-sulphites'
+	]
+}
 ) or diag explain $product_ref;
 
 done_testing();

--- a/t/food.t
+++ b/t/food.t
@@ -115,10 +115,10 @@ ok( (not has_tag($product_ref, 'categories', 'en:unsweetened-beverages')), 'shou
 is( $product_ref->{pnns_groups_2}, "unknown") || diag explain $product_ref;
 
 $product_ref = {
-        lc => "en",
-        categories_tags => ["en:beverages"],
+	lc => "en",
+	categories_tags => ["en:beverages"],
 	categories => "beverages",
-        ingredients_tags => ["en:water", "en:fruit-juice"],
+	ingredients_tags => ["en:water", "en:fruit-juice"],
 	ingredients_text => "water, fruit juice",
 };
 
@@ -132,10 +132,10 @@ is( $product_ref->{pnns_groups_2}, "Unsweetened beverages") || diag explain $pro
 
 
 $product_ref = {
-        lc => "en",
-        categories_tags => ["en:beverages"],
+	lc => "en",
+	categories_tags => ["en:beverages"],
 	categories => "beverages",
-        ingredients_tags => ["en:sugar"],
+	ingredients_tags => ["en:sugar"],
 };
 
 special_process_product($product_ref);
@@ -146,10 +146,10 @@ special_process_product($product_ref);
 is( $product_ref->{pnns_groups_2}, "Sweetened beverages") || diag explain $product_ref;
 
 $product_ref = {
-        lc => "en",
-        categories_tags => ["en:beverages"],
+	lc => "en",
+	categories_tags => ["en:beverages"],
 	categories => "beverages",
-        ingredients_tags => ["en:sugar"],
+	ingredients_tags => ["en:sugar"],
 	additives_tags => ["en:e950"],
 	with_sweeteners => 1,
 };
@@ -163,12 +163,12 @@ is( $product_ref->{pnns_groups_2}, "Artificially sweetened beverages") || diag e
 
 
 $product_ref = {
-        lc => "en",
-        categories_tags => ["en:beverages", "en:waters", "en:flavored-waters"],
+	lc => "en",
+	categories_tags => ["en:beverages", "en:waters", "en:flavored-waters"],
 	categories => "beverages",
-        ingredients_tags => ["en:sugar"],
-        additives_tags => ["en:e950"],
-        with_sweeteners => 1,
+	ingredients_tags => ["en:sugar"],
+	additives_tags => ["en:e950"],
+	with_sweeteners => 1,
 };
 
 special_process_product($product_ref);
@@ -180,9 +180,9 @@ special_process_product($product_ref);
 is( $product_ref->{pnns_groups_2}, "Artificially sweetened beverages") || diag explain $product_ref;
 
 $product_ref = {
-        lc => "en",
+	lc => "en",
 	categories => "beverages",
-        categories_tags => ["en:beverages", "en:waters", "en:flavored-waters"],
+	categories_tags => ["en:beverages", "en:waters", "en:flavored-waters"],
 };
 
 special_process_product($product_ref);
@@ -192,9 +192,9 @@ is( $product_ref->{pnns_groups_2}, "Waters and flavored waters") || diag explain
 
 
 $product_ref = {
-        lc => "en",
+	lc => "en",
 	categories => "beverages",
-        categories_tags => ["en:beverages", "en:iced-teas"],
+	categories_tags => ["en:beverages", "en:iced-teas"],
 };
 
 special_process_product($product_ref);
@@ -204,12 +204,12 @@ is( $product_ref->{pnns_groups_2}, "Teas and herbal teas and coffees") || diag e
 
 
 $product_ref = {
-        lc => "en",
+	lc => "en",
 	categories => "beverages",
-        categories_tags => ["en:beverages", "en:ice-teas"],
-        ingredients_tags => ["en:sugar"],
-        additives_tags => ["en:e950"],
-        with_sweeteners => 1,
+	categories_tags => ["en:beverages", "en:ice-teas"],
+	ingredients_tags => ["en:sugar"],
+	additives_tags => ["en:e950"],
+	with_sweeteners => 1,
 };
 
 special_process_product($product_ref);
@@ -222,11 +222,11 @@ is( $product_ref->{pnns_groups_2}, "Artificially sweetened beverages") || diag e
 
 
 $product_ref = {
-        lc => "en",
+	lc => "en",
 	categories => "beverages",
-        categories_tags => ["en:beverages"],
-        ingredients_tags => ["en:water", "en:fruit-juice"],
-        ingredients_text => "water, fruit juice",
+	categories_tags => ["en:beverages"],
+	ingredients_tags => ["en:water", "en:fruit-juice"],
+	ingredients_text => "water, fruit juice",
 	with_sweeteners => 1,
 };
 
@@ -241,11 +241,11 @@ ok( not (has_tag($product_ref, 'categories', 'en:artificially-sweetened-beverage
 is( $product_ref->{pnns_groups_2}, "Artificially sweetened beverages") || diag explain $product_ref;
 
 $product_ref = {
-        lc => "en",
+	lc => "en",
 	categories => "beverages",
-        categories_tags => ["en:beverages", "en:unsweetened-beverages"],
-        ingredients_tags => ["en:water", "en:sugar"],
-        ingredients_text => "water, fruit juice",
+	categories_tags => ["en:beverages", "en:unsweetened-beverages"],
+	ingredients_tags => ["en:water", "en:sugar"],
+	ingredients_text => "water, fruit juice",
 };
 
 # with an ingredient list: should add en:unsweetened-beverages
@@ -260,11 +260,11 @@ is( $product_ref->{pnns_groups_2}, "Sweetened beverages") || diag explain $produ
 is($product_ref->{nutrition_score_beverage}, 1);
 
 $product_ref = {
-        lc => "en",
+	lc => "en",
 	categories => "beverages",
-        categories_tags => ["en:beverages", "en:plant-milks"],
-        ingredients_tags => ["en:water", "en:sugar"],
-        ingredients_text => "water, fruit juice",
+	categories_tags => ["en:beverages", "en:plant-milks"],
+	ingredients_tags => ["en:water", "en:sugar"],
+	ingredients_text => "water, fruit juice",
 };
 
 special_process_product($product_ref);
@@ -317,20 +317,20 @@ is (normalize_packager_codes(normalize_packager_codes("EE 110 EÜ")), "EE 110 EC
 is (localize_packager_code(normalize_packager_codes("EE 110 EÜ")), "EE 110 EÜ", "EE: round-tripped code correctly");
 
 $product_ref = {
-    nutriments => { salt => 3, salt_value => 3000, salt_unit => "mg" },
+	nutriments => { salt => 3, salt_value => 3000, salt_unit => "mg" },
 };
 
 fix_salt_equivalent($product_ref);
 
 my $expected_product_ref = {
-    nutriments => {
-        salt => 3,
-        salt_value => 3000,
-        salt_unit => "mg",
-        sodium => 1.2,
-        sodium_value => 1200,
-         sodium_unit => "mg"
-    }
+	nutriments => {
+		salt => 3,
+		salt_value => 3000,
+		salt_unit => "mg",
+		sodium => 1.2,
+		sodium_value => 1200,
+		sodium_unit => "mg"
+	}
 };
 
 
@@ -346,21 +346,19 @@ $product_ref = {
 compute_serving_size_data($product_ref);
 
 my $expected_product_ref =
- {
-    'nutriments' => {
-      'nova-group' => 4,
-      'nova-group_100g' => 4,
-      'nova-group_serving' => 4
-    },
-    'nutrition_data_per' => 'serving',
-    'nutrition_data_prepared_per' => '100g',
-    'product_quantity' => 100,
-    'quantity' => '100 g',
-    'serving_quantity' => 25,
-    'serving_size' => '25 g'
-  }
-
- ;
+{
+	'nutriments' => {
+		'nova-group' => 4,
+		'nova-group_100g' => 4,
+		'nova-group_serving' => 4
+	},
+	'nutrition_data_per' => 'serving',
+	'nutrition_data_prepared_per' => '100g',
+	'product_quantity' => 100,
+	'quantity' => '100 g',
+	'serving_quantity' => 25,
+	'serving_size' => '25 g'
+};
 
 is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
@@ -375,23 +373,20 @@ $product_ref = {
 compute_serving_size_data($product_ref);
 
 my $expected_product_ref =
-
- {
-   'nutriments' => {
-     'sugars' => 4,
-     'sugars_100g' => 16,
-     'sugars_serving' => 4
-   },
-   'nutrition_data' => 'on',
-   'nutrition_data_per' => 'serving',
-   'nutrition_data_prepared_per' => '100g',
-   'product_quantity' => 100,
-   'quantity' => '100 g',
-   'serving_quantity' => 25,
-   'serving_size' => '25 g'
-  }
-
- ;
+{
+	'nutriments' => {
+		'sugars' => 4,
+		'sugars_100g' => 16,
+		'sugars_serving' => 4
+	},
+	'nutrition_data' => 'on',
+	'nutrition_data_per' => 'serving',
+	'nutrition_data_prepared_per' => '100g',
+	'product_quantity' => 100,
+	'quantity' => '100 g',
+	'serving_quantity' => 25,
+	'serving_size' => '25 g'
+};
 
 is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
@@ -406,33 +401,31 @@ $product_ref = {
 compute_serving_size_data($product_ref);
 
 my $expected_product_ref =
- {
-   'nutriments' => {
-     'energy-kcal_prepared' => 58,
-     'energy-kcal_prepared_100g' => 232,
-     'energy-kcal_prepared_serving' => 58,
-     'energy-kcal_prepared_unit' => 'kcal',
-     'energy-kcal_prepared_value' => 58,
-     'energy_prepared' => 243,
-     'energy_prepared_100g' => 972,
-     'energy_prepared_serving' => 243,
-     'energy_prepared_unit' => 'kcal',
-     'energy_prepared_value' => 58,
-     'salt_prepared' => 10,
-     'salt_prepared_100g' => 40,
-     'salt_prepared_serving' => 10,
-     'salt_prepared_value' => 10
-   },
-   'nutrition_data_per' => '100g',
-   'nutrition_data_prepared' => 'on',
-   'nutrition_data_prepared_per' => 'serving',
-   'product_quantity' => 100,
-   'quantity' => '100 g',
-   'serving_quantity' => 25,
-   'serving_size' => '25 g'
- }
-
-;
+{
+	'nutriments' => {
+		'energy-kcal_prepared' => 58,
+		'energy-kcal_prepared_100g' => 232,
+		'energy-kcal_prepared_serving' => 58,
+		'energy-kcal_prepared_unit' => 'kcal',
+		'energy-kcal_prepared_value' => 58,
+		'energy_prepared' => 243,
+		'energy_prepared_100g' => 972,
+		'energy_prepared_serving' => 243,
+		'energy_prepared_unit' => 'kcal',
+		'energy_prepared_value' => 58,
+		'salt_prepared' => 10,
+		'salt_prepared_100g' => 40,
+		'salt_prepared_serving' => 10,
+		'salt_prepared_value' => 10
+	},
+	'nutrition_data_per' => '100g',
+	'nutrition_data_prepared' => 'on',
+	'nutrition_data_prepared_per' => 'serving',
+	'product_quantity' => 100,
+	'quantity' => '100 g',
+	'serving_quantity' => 25,
+	'serving_size' => '25 g'
+};
 
 is(default_unit_for_nid("sugars"), "g");
 is(default_unit_for_nid("energy-kj"), "kJ");

--- a/t/import.t
+++ b/t/import.t
@@ -137,9 +137,9 @@ Sel (g) : 0
 Cette bouteille contient 20 portions de 25ml pour un verre de 200ml de sirop dilué (1 volume de sirop + 7 volumes d'eau).", { 'carbohydrates'=>['16.8','g',''], 'energy-kcal'=>['67','kcal',''], 'energy-kj'=>['285','kJ',''], 'fat'=>['0','g',''], 'fiber'=>['0','g',''], 'proteins'=>['0','g',''], 'salt'=>['0','g',''], 'saturated-fat'=>['0','g',''], 'sugars'=>['16.8','g',''] }
  , "serving", "0.025L"],
 
-	["fr", "Pour 100g : Energie 391 kJ/ 93kcal, Matières grasses 0.8 g dont Acides gras saturés 0.1 g, Glucides 12 g dont Sucres <0.5 g , Fibres alimentaires 6.3 g, Protéines 6.1 g, Sel 0.58 g", 
-	{ 'carbohydrates'=>['12','g',''], 'energy-kcal'=>['93','kcal',''], 'energy-kj'=>['391','kJ',''], 'fat'=>['0.8','g',''], 'fiber'=>['6.3','g',''], 'proteins'=>['6.1','g',''], 'salt'=>['0.58','g',''], 'saturated-fat'=>['0.1','g',''], 'sugars'=>['0.5','g','<'] }
-	 ],
+	["fr", "Pour 100g : Energie 391 kJ/ 93kcal, Matières grasses 0.8 g dont Acides gras saturés 0.1 g, Glucides 12 g dont Sucres <0.5 g , Fibres alimentaires 6.3 g, Protéines 6.1 g, Sel 0.58 g",
+		{ 'carbohydrates'=>['12','g',''], 'energy-kcal'=>['93','kcal',''], 'energy-kj'=>['391','kJ',''], 'fat'=>['0.8','g',''], 'fiber'=>['6.3','g',''], 'proteins'=>['6.1','g',''], 'salt'=>['0.58','g',''], 'saturated-fat'=>['0.1','g',''], 'sugars'=>['0.5','g','<'] }
+	],
 );
 
 foreach my $test_ref (@tests) {
@@ -180,13 +180,13 @@ foreach my $test_ref (@tests) {
 
 # Remove brand at end of product name
 [
-        {lc => "es", product_name_es => "NATILLAS DE SOJA SABOR VAINILLA CARREFOUR", brands => "CARREFOUR"},
-        {lc => "es", product_name_es => "Natillas de soja sabor vainilla", brands => "Carrefour"},
+	{lc => "es", product_name_es => "NATILLAS DE SOJA SABOR VAINILLA CARREFOUR", brands => "CARREFOUR"},
+	{lc => "es", product_name_es => "Natillas de soja sabor vainilla", brands => "Carrefour"},
 ],
 
 [
-        {lc => "es", product_name_es => "NATILLAS DE SOJA SABOR VAINILLA CARREFOUR BIO", brands => "CARREFOUR, CARREFOUR BIO"},
-        {lc => "es", product_name_es => "Natillas de soja sabor vainilla", brands => "Carrefour, carrefour bio"},
+	{lc => "es", product_name_es => "NATILLAS DE SOJA SABOR VAINILLA CARREFOUR BIO", brands => "CARREFOUR, CARREFOUR BIO"},
+	{lc => "es", product_name_es => "Natillas de soja sabor vainilla", brands => "Carrefour, carrefour bio"},
 ],
 
 	# combine serving_size, serving_size_value, serving_size_unit (e.g. US import)
@@ -197,19 +197,19 @@ foreach my $test_ref (@tests) {
 ],
 
 [
-        { serving_size => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
-        { serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ serving_size => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
+	{ serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 [
-        { serving_size_value_unit => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
-        { serving_size_value_unit => "1 biscuit", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ serving_size_value_unit => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
+	{ serving_size_value_unit => "1 biscuit", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 
 [
-        { serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
-        { serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -29,268 +29,268 @@ delete $product_ref->{ingredients_percent_analysis};
 is($product_ref->{ingredients_n}, 19);
 
 my $expected_product_ref =
- {
-   'ingredients' => [
-     {
-       'id' => 'en:flour',
-       'percent' => '12',
-       'rank' => 1,
-       'text' => 'farine',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:chocolate',
-       'ingredients' => [
-         {
-           'id' => 'en:cocoa-butter',
-           'percent' => '15',
-           'text' => 'beurre de cacao'
-         },
-         {
-           'id' => 'en:sugar',
-           'percent' => '10',
-           'text' => 'sucre'
-         },
-         {
-           'id' => 'en:milk-proteins',
-           'text' => "prot\x{e9}ines de lait"
-         },
-         {
-           'id' => 'en:egg',
-           'percent' => '1',
-           'text' => 'oeuf'
-         }
-       ],
-       'rank' => 2,
-       'text' => 'chocolat',
-       'vegan' => 'maybe',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:emulsifier',
-       'ingredients' => [
-         {
-           'id' => 'en:e463',
-           'text' => 'e463'
-         }
-       ],
-       'rank' => 3,
-       'text' => "\x{e9}mulsifiants"
-     },
-     {
-       'from_palm_oil' => 'maybe',
-       'id' => 'en:e432',
-       'rank' => 4,
-       'text' => 'e432',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'from_palm_oil' => 'maybe',
-       'id' => 'en:e472',
-       'rank' => 5,
-       'text' => 'e472',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:acidity-regulator',
-       'ingredients' => [
-         {
-           'id' => 'en:e322',
-           'text' => 'e322'
-         },
-         {
-           'id' => 'en:e333',
-           'text' => 'e333'
-         }
-       ],
-       'rank' => 6,
-       'text' => "correcteurs d'acidit\x{e9}"
-     },
-     {
-       'id' => 'en:e474',
-       'rank' => 7,
-       'text' => 'e474',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'id' => 'en:e475',
-       'rank' => 8,
-       'text' => 'e475',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:acid',
-       'ingredients' => [
-         {
-           'id' => 'en:e330',
-           'text' => 'acide citrique'
-         },
-         {
-           'id' => 'en:e338',
-           'text' => 'acide phosphorique'
-         }
-       ],
-       'rank' => 9,
-       'text' => 'acidifiant'
-     },
-     {
-       'id' => 'en:salt',
-       'rank' => 10,
-       'text' => 'sel',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:cocoa-butter',
-       'percent' => '15',
-       'text' => 'beurre de cacao',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sugar',
-       'percent' => '10',
-       'text' => 'sucre',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:milk-proteins',
-       'text' => "prot\x{e9}ines de lait",
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:egg',
-       'percent' => '1',
-       'text' => 'oeuf',
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e463',
-       'text' => 'e463',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e322',
-       'text' => 'e322',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'id' => 'en:e333',
-       'text' => 'e333',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e330',
-       'text' => 'acide citrique',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e338',
-       'text' => 'acide phosphorique',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     }
-   ],
-   'ingredients_analysis_tags' => [
-     'en:may-contain-palm-oil',
-     'en:non-vegan',
-     'en:maybe-vegetarian'
-   ],
-   'ingredients_hierarchy' => [
-     'en:flour',
-     'en:chocolate',
-     'en:emulsifier',
-     'en:e432',
-     'en:e472',
-     'en:acidity-regulator',
-     'en:e474',
-     'en:e475',
-     'en:acid',
-     'en:salt',
-     'en:cocoa-butter',
-     'en:cocoa',
-     'en:sugar',
-     'en:milk-proteins',
-     'en:protein',
-     'en:animal-protein',
-     'en:egg',
-     'en:e463',
-     'en:e322',
-     'en:e333',
-     'en:e330',
-     'en:e338'
-   ],
-   'ingredients_n' => 19,
-   'ingredients_n_tags' => [
-     '19',
-     '11-20'
-   ],
-   'ingredients_original_tags' => [
-     'en:flour',
-     'en:chocolate',
-     'en:emulsifier',
-     'en:e432',
-     'en:e472',
-     'en:acidity-regulator',
-     'en:e474',
-     'en:e475',
-     'en:acid',
-     'en:salt',
-     'en:cocoa-butter',
-     'en:sugar',
-     'en:milk-proteins',
-     'en:egg',
-     'en:e463',
-     'en:e322',
-     'en:e333',
-     'en:e330',
-     'en:e338'
-   ],
-   'ingredients_tags' => [
-     'en:flour',
-     'en:chocolate',
-     'en:emulsifier',
-     'en:e432',
-     'en:e472',
-     'en:acidity-regulator',
-     'en:e474',
-     'en:e475',
-     'en:acid',
-     'en:salt',
-     'en:cocoa-butter',
-     'en:cocoa',
-     'en:sugar',
-     'en:milk-proteins',
-     'en:protein',
-     'en:animal-protein',
-     'en:egg',
-     'en:e463',
-     'en:e322',
-     'en:e333',
-     'en:e330',
-     'en:e338'
-   ],
-   'ingredients_text' => "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], prot\x{e9}ines de lait, oeuf 1%) - \x{e9}mulsifiants : E463, E432 et E472 - correcteurs d'acidit\x{e9} : E322/E333 E474-E475, acidifiant (acide citrique, acide phosphorique) - sel",
-   'lc' => 'fr',
-   'known_ingredients_n' => 22,
-   'unknown_ingredients_n' => 0
- };
+{
+	'ingredients' => [
+		{
+			'id' => 'en:flour',
+			'percent' => '12',
+			'rank' => 1,
+			'text' => 'farine',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:chocolate',
+			'ingredients' => [
+				{
+					'id' => 'en:cocoa-butter',
+					'percent' => '15',
+					'text' => 'beurre de cacao'
+				},
+				{
+					'id' => 'en:sugar',
+					'percent' => '10',
+					'text' => 'sucre'
+				},
+				{
+					'id' => 'en:milk-proteins',
+					'text' => "prot\x{e9}ines de lait"
+				},
+				{
+					'id' => 'en:egg',
+					'percent' => '1',
+					'text' => 'oeuf'
+				}
+			],
+			'rank' => 2,
+			'text' => 'chocolat',
+			'vegan' => 'maybe',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:emulsifier',
+			'ingredients' => [
+				{
+					'id' => 'en:e463',
+					'text' => 'e463'
+				}
+			],
+			'rank' => 3,
+			'text' => "\x{e9}mulsifiants"
+		},
+		{
+			'from_palm_oil' => 'maybe',
+			'id' => 'en:e432',
+			'rank' => 4,
+			'text' => 'e432',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'from_palm_oil' => 'maybe',
+			'id' => 'en:e472',
+			'rank' => 5,
+			'text' => 'e472',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:acidity-regulator',
+			'ingredients' => [
+				{
+					'id' => 'en:e322',
+					'text' => 'e322'
+				},
+				{
+					'id' => 'en:e333',
+					'text' => 'e333'
+				}
+			],
+			'rank' => 6,
+			'text' => "correcteurs d'acidit\x{e9}"
+		},
+		{
+			'id' => 'en:e474',
+			'rank' => 7,
+			'text' => 'e474',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:e475',
+			'rank' => 8,
+			'text' => 'e475',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:acid',
+			'ingredients' => [
+				{
+					'id' => 'en:e330',
+					'text' => 'acide citrique'
+				},
+				{
+					'id' => 'en:e338',
+					'text' => 'acide phosphorique'
+				}
+			],
+			'rank' => 9,
+			'text' => 'acidifiant'
+		},
+		{
+			'id' => 'en:salt',
+			'rank' => 10,
+			'text' => 'sel',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-butter',
+			'percent' => '15',
+			'text' => 'beurre de cacao',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sugar',
+			'percent' => '10',
+			'text' => 'sucre',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:milk-proteins',
+			'text' => "prot\x{e9}ines de lait",
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:egg',
+			'percent' => '1',
+			'text' => 'oeuf',
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e463',
+			'text' => 'e463',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e322',
+			'text' => 'e322',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:e333',
+			'text' => 'e333',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e330',
+			'text' => 'acide citrique',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e338',
+			'text' => 'acide phosphorique',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
+	'ingredients_analysis_tags' => [
+		'en:may-contain-palm-oil',
+		'en:non-vegan',
+		'en:maybe-vegetarian'
+	],
+	'ingredients_hierarchy' => [
+		'en:flour',
+		'en:chocolate',
+		'en:emulsifier',
+		'en:e432',
+		'en:e472',
+		'en:acidity-regulator',
+		'en:e474',
+		'en:e475',
+		'en:acid',
+		'en:salt',
+		'en:cocoa-butter',
+		'en:cocoa',
+		'en:sugar',
+		'en:milk-proteins',
+		'en:protein',
+		'en:animal-protein',
+		'en:egg',
+		'en:e463',
+		'en:e322',
+		'en:e333',
+		'en:e330',
+		'en:e338'
+	],
+	'ingredients_n' => 19,
+	'ingredients_n_tags' => [
+		'19',
+		'11-20'
+	],
+	'ingredients_original_tags' => [
+		'en:flour',
+		'en:chocolate',
+		'en:emulsifier',
+		'en:e432',
+		'en:e472',
+		'en:acidity-regulator',
+		'en:e474',
+		'en:e475',
+		'en:acid',
+		'en:salt',
+		'en:cocoa-butter',
+		'en:sugar',
+		'en:milk-proteins',
+		'en:egg',
+		'en:e463',
+		'en:e322',
+		'en:e333',
+		'en:e330',
+		'en:e338'
+	],
+	'ingredients_tags' => [
+		'en:flour',
+		'en:chocolate',
+		'en:emulsifier',
+		'en:e432',
+		'en:e472',
+		'en:acidity-regulator',
+		'en:e474',
+		'en:e475',
+		'en:acid',
+		'en:salt',
+		'en:cocoa-butter',
+		'en:cocoa',
+		'en:sugar',
+		'en:milk-proteins',
+		'en:protein',
+		'en:animal-protein',
+		'en:egg',
+		'en:e463',
+		'en:e322',
+		'en:e333',
+		'en:e330',
+		'en:e338'
+	],
+	'ingredients_text' => "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], prot\x{e9}ines de lait, oeuf 1%) - \x{e9}mulsifiants : E463, E432 et E472 - correcteurs d'acidit\x{e9} : E322/E333 E474-E475, acidifiant (acide citrique, acide phosphorique) - sel",
+	'lc' => 'fr',
+	'known_ingredients_n' => 22,
+	'unknown_ingredients_n' => 0
+};
 
 delete $product_ref->{nutriments};
 is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
@@ -299,8 +299,8 @@ is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "graisse de palmiste"
+	lc => "fr",
+	ingredients_text => "graisse de palmiste"
 };
 
 extract_ingredients_from_text($product_ref);
@@ -317,64 +317,64 @@ delete $product_ref->{ingredients_percent_analysis};
 
 
 $expected_product_ref =
- {
-    'additives_n' => 0,
-    'additives_old_n' => 0,
-    'additives_old_tags' => [],
-    'additives_original_tags' => [],
-    'additives_tags' => [],
-    'amino_acids_tags' => [],
-    'ingredients' => [
-      {
-        'from_palm_oil' => 'yes',
-        'id' => 'en:palm-kernel-fat',
-        'rank' => 1,
-        'text' => 'graisse de palmiste',
-        'vegan' => 'yes',
-        'vegetarian' => 'yes'
-      }
-    ],
-    'ingredients_analysis_tags' => [
-      'en:palm-oil',
-      'en:vegan',
-      'en:vegetarian'
-    ],
-    'ingredients_from_or_that_may_be_from_palm_oil_n' => 1,
-    'ingredients_from_palm_oil_n' => 1,
-    'ingredients_from_palm_oil_tags' => [
-      'huile-de-palme'
-    ],
-    'ingredients_hierarchy' => [
-      'en:palm-kernel-fat',
-      'en:oil-and-fat',
-      'en:vegetable-oil-and-fat',
-      'en:palm-kernel-oil-and-fat'
-    ],
-    'ingredients_n' => 1,
-    'ingredients_n_tags' => [
-      '1',
-      '1-10'
-    ],
-    'ingredients_original_tags' => [
-      'en:palm-kernel-fat'
-    ],
-    'ingredients_tags' => [
-      'en:palm-kernel-fat',
-      'en:oil-and-fat',
-      'en:vegetable-oil-and-fat',
-      'en:palm-kernel-oil-and-fat'
-    ],
-    'ingredients_text' => 'graisse de palmiste',
-    'ingredients_that_may_be_from_palm_oil_n' => 0,
-    'ingredients_that_may_be_from_palm_oil_tags' => [],
-    'lc' => 'fr',
-    'minerals_tags' => [],
-    'nucleotides_tags' => [],
-    'other_nutritional_substances_tags' => [],
-    'unknown_ingredients_n' => 0,
-    'known_ingredients_n' => 4,
-    'vitamins_tags' => []
-  };
+{
+	'additives_n' => 0,
+	'additives_old_n' => 0,
+	'additives_old_tags' => [],
+	'additives_original_tags' => [],
+	'additives_tags' => [],
+	'amino_acids_tags' => [],
+	'ingredients' => [
+		{
+			'from_palm_oil' => 'yes',
+			'id' => 'en:palm-kernel-fat',
+			'rank' => 1,
+			'text' => 'graisse de palmiste',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
+	'ingredients_analysis_tags' => [
+		'en:palm-oil',
+		'en:vegan',
+		'en:vegetarian'
+	],
+	'ingredients_from_or_that_may_be_from_palm_oil_n' => 1,
+	'ingredients_from_palm_oil_n' => 1,
+	'ingredients_from_palm_oil_tags' => [
+		'huile-de-palme'
+	],
+	'ingredients_hierarchy' => [
+		'en:palm-kernel-fat',
+		'en:oil-and-fat',
+		'en:vegetable-oil-and-fat',
+		'en:palm-kernel-oil-and-fat'
+	],
+	'ingredients_n' => 1,
+	'ingredients_n_tags' => [
+		'1',
+		'1-10'
+	],
+	'ingredients_original_tags' => [
+		'en:palm-kernel-fat'
+	],
+	'ingredients_tags' => [
+		'en:palm-kernel-fat',
+		'en:oil-and-fat',
+		'en:vegetable-oil-and-fat',
+		'en:palm-kernel-oil-and-fat'
+	],
+	'ingredients_text' => 'graisse de palmiste',
+	'ingredients_that_may_be_from_palm_oil_n' => 0,
+	'ingredients_that_may_be_from_palm_oil_tags' => [],
+	'lc' => 'fr',
+	'minerals_tags' => [],
+	'nucleotides_tags' => [],
+	'other_nutritional_substances_tags' => [],
+	'unknown_ingredients_n' => 0,
+	'known_ingredients_n' => 4,
+	'vitamins_tags' => []
+};
 
 
 
@@ -395,8 +395,8 @@ is_deeply($product_ref, $expected_product_ref) || diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Marmelade d'oranges 41% (sirop de glucose-fructose, sucre, pulpe d'orange 4.5%, jus d'orange concentré 1.4% (équivalent jus d'orange 7.8%), pulpe d'orange concentrée 0.6% (équivalent pulpe d'orange 2.6%), gélifiant (pectines), acidifiant (acide citrique), correcteurs d'acidité (citrate de calcium, citrate de sodium), arôme naturel d'orange, épaississant (gomme xanthane)), chocolat 24.9% (sucre, pâte de cacao, beurre de cacao, graisses végétales (illipe, mangue, sal, karité et palme en proportions variables), arôme, émulsifiant (lécithine de soja), lactose et protéines de lait), farine de blé, sucre, oeufs, sirop de glucose-fructose, huile de colza, poudre à lever (carbonate acide d'ammonium, diphosphate disodique, carbonate acide de sodium), sel, émulsifiant (lécithine de soja)."
+	lc => "fr",
+	ingredients_text => "Marmelade d'oranges 41% (sirop de glucose-fructose, sucre, pulpe d'orange 4.5%, jus d'orange concentré 1.4% (équivalent jus d'orange 7.8%), pulpe d'orange concentrée 0.6% (équivalent pulpe d'orange 2.6%), gélifiant (pectines), acidifiant (acide citrique), correcteurs d'acidité (citrate de calcium, citrate de sodium), arôme naturel d'orange, épaississant (gomme xanthane)), chocolat 24.9% (sucre, pâte de cacao, beurre de cacao, graisses végétales (illipe, mangue, sal, karité et palme en proportions variables), arôme, émulsifiant (lécithine de soja), lactose et protéines de lait), farine de blé, sucre, oeufs, sirop de glucose-fructose, huile de colza, poudre à lever (carbonate acide d'ammonium, diphosphate disodique, carbonate acide de sodium), sel, émulsifiant (lécithine de soja)."
 };
 
 extract_ingredients_from_text($product_ref);
@@ -416,610 +416,610 @@ delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
 $expected_product_ref =
- {
-   'ingredients' => [
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'fr:Marmelade d\'oranges',
-       'ingredients' => [
-         {
-           'id' => 'en:glucose-fructose-syrup',
-           'text' => 'sirop de glucose-fructose'
-         },
-         {
-           'id' => 'en:sugar',
-           'text' => 'sucre'
-         },
-         {
-           'id' => 'en:orange-pulp',
-           'percent' => '4.5',
-           'text' => 'pulpe d\'orange'
-         },
-         {
-           'id' => 'en:concentrated-orange-juice',
-           'ingredients' => [],
-           'percent' => '1.4',
-           'text' => "jus d'orange concentr\x{e9}"
-         },
-         {
-           'id' => 'en:orange-pulp',
-           'ingredients' => [],
-           'percent' => '0.6',
-           'processing' => 'en:concentrated',
-           'text' => 'pulpe d\'orange'
-         },
-         {
-           'id' => 'en:gelling-agent',
-           'ingredients' => [
-             {
-               'id' => 'en:e440a',
-               'text' => 'pectines'
-             }
-           ],
-           'text' => "g\x{e9}lifiant"
-         },
-         {
-           'id' => 'en:acid',
-           'ingredients' => [
-             {
-               'id' => 'en:e330',
-               'text' => 'acide citrique'
-             }
-           ],
-           'text' => 'acidifiant'
-         },
-         {
-           'id' => 'en:acidity-regulator',
-           'ingredients' => [
-             {
-               'id' => 'en:e333',
-               'text' => 'citrate de calcium'
-             },
-             {
-               'id' => 'en:sodium-citrate',
-               'text' => 'citrate de sodium'
-             }
-           ],
-           'text' => "correcteurs d'acidit\x{e9}"
-         },
-         {
-           'id' => 'en:natural-orange-flavouring',
-           'text' => "ar\x{f4}me naturel d'orange"
-         },
-         {
-           'id' => 'en:thickener',
-           'ingredients' => [
-             {
-               'id' => 'en:e415',
-               'text' => 'gomme xanthane'
-             }
-           ],
-           'text' => "\x{e9}paississant"
-         }
-       ],
-       'percent' => '41',
-       'rank' => 1,
-       'text' => 'Marmelade d\'oranges'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:chocolate',
-       'ingredients' => [
-         {
-           'id' => 'en:sugar',
-           'text' => 'sucre'
-         },
-         {
-           'id' => 'en:cocoa-paste',
-           'text' => "p\x{e2}te de cacao"
-         },
-         {
-           'id' => 'en:cocoa-butter',
-           'text' => 'beurre de cacao'
-         },
-         {
-           'id' => 'en:illipe-oil',
-           'text' => "graisses v\x{e9}g\x{e9}tales d'illipe"
-         },
-         {
-           'id' => 'en:mango-kernel-oil',
-           'text' => "graisses v\x{e9}g\x{e9}tales de mangue"
-         },
-         {
-           'id' => 'en:shorea-robusta-seed-oil',
-           'text' => "graisses v\x{e9}g\x{e9}tales de sal"
-         },
-         {
-           'id' => 'en:shea-butter',
-           'text' => "graisses v\x{e9}g\x{e9}tales de karit\x{e9}"
-         },
-         {
-           'id' => 'en:palm-fat',
-           'text' => "graisses v\x{e9}g\x{e9}tales de palme"
-         },
-         {
-           'id' => 'en:flavouring',
-           'text' => "ar\x{f4}me"
-         },
-         {
-           'id' => 'en:emulsifier',
-           'ingredients' => [
-             {
-               'id' => 'en:soya-lecithin',
-               'text' => "l\x{e9}cithine de soja"
-             }
-           ],
-           'text' => "\x{e9}mulsifiant"
-         },
-         {
-           'id' => 'en:lactose-and-milk-proteins',
-           'text' => "lactose et prot\x{e9}ines de lait"
-         }
-       ],
-       'percent' => '24.9',
-       'rank' => 2,
-       'text' => 'chocolat',
-       'vegan' => 'maybe',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:wheat-flour',
-       'rank' => 3,
-       'text' => "farine de bl\x{e9}",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sugar',
-       'rank' => 4,
-       'text' => 'sucre',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:egg',
-       'rank' => 5,
-       'text' => 'oeufs',
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:glucose-fructose-syrup',
-       'rank' => 6,
-       'text' => 'sirop de glucose-fructose',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'no',
-       'id' => 'en:colza-oil',
-       'rank' => 7,
-       'text' => 'huile de colza',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:raising-agent',
-       'ingredients' => [
-         {
-           'id' => 'en:e503ii',
-           'text' => 'carbonate acide d\'ammonium'
-         },
-         {
-           'id' => 'en:e450i',
-           'text' => 'diphosphate disodique'
-         },
-         {
-           'id' => 'en:e500ii',
-           'text' => 'carbonate acide de sodium'
-         }
-       ],
-       'rank' => 8,
-       'text' => "poudre \x{e0} lever"
-     },
-     {
-       'id' => 'en:salt',
-       'rank' => 9,
-       'text' => 'sel',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:emulsifier',
-       'ingredients' => [
-         {
-           'id' => 'en:soya-lecithin',
-           'text' => "l\x{e9}cithine de soja"
-         }
-       ],
-       'rank' => 10,
-       'text' => "\x{e9}mulsifiant"
-     },
-     {
-       'id' => 'en:glucose-fructose-syrup',
-       'text' => 'sirop de glucose-fructose',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sugar',
-       'text' => 'sucre',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:orange-pulp',
-       'percent' => '4.5',
-       'text' => 'pulpe d\'orange',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:concentrated-orange-juice',
-       'percent' => '1.4',
-       'text' => "jus d'orange concentr\x{e9}",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:orange-pulp',
-       'percent' => '0.6',
-       'processing' => 'en:concentrated',
-       'text' => 'pulpe d\'orange',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:gelling-agent',
-       'text' => "g\x{e9}lifiant"
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:acid',
-       'text' => 'acidifiant'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:acidity-regulator',
-       'text' => "correcteurs d'acidit\x{e9}"
-     },
-     {
-       'id' => 'en:natural-orange-flavouring',
-       'text' => "ar\x{f4}me naturel d'orange",
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:thickener',
-       'text' => "\x{e9}paississant"
-     },
-     {
-       'id' => 'en:sugar',
-       'text' => 'sucre',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:cocoa-paste',
-       'text' => "p\x{e2}te de cacao",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:cocoa-butter',
-       'text' => 'beurre de cacao',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'no',
-       'id' => 'en:illipe-oil',
-       'text' => "graisses v\x{e9}g\x{e9}tales d'illipe",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'no',
-       'id' => 'en:mango-kernel-oil',
-       'text' => "graisses v\x{e9}g\x{e9}tales de mangue",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'no',
-       'id' => 'en:shorea-robusta-seed-oil',
-       'text' => "graisses v\x{e9}g\x{e9}tales de sal",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'no',
-       'id' => 'en:shea-butter',
-       'text' => "graisses v\x{e9}g\x{e9}tales de karit\x{e9}",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'yes',
-       'id' => 'en:palm-fat',
-       'text' => "graisses v\x{e9}g\x{e9}tales de palme",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:flavouring',
-       'text' => "ar\x{f4}me",
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:emulsifier',
-       'text' => "\x{e9}mulsifiant"
-     },
-     {
-       'id' => 'en:lactose-and-milk-proteins',
-       'text' => "lactose et prot\x{e9}ines de lait",
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e503ii',
-       'text' => 'carbonate acide d\'ammonium',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e450i',
-       'text' => 'diphosphate disodique',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e500ii',
-       'text' => 'carbonate acide de sodium',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:soya-lecithin',
-       'text' => "l\x{e9}cithine de soja",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e440a',
-       'text' => 'pectines',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e330',
-       'text' => 'acide citrique',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e333',
-       'text' => 'citrate de calcium',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sodium-citrate',
-       'text' => 'citrate de sodium'
-     },
-     {
-       'id' => 'en:e415',
-       'text' => 'gomme xanthane',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:soya-lecithin',
-       'text' => "l\x{e9}cithine de soja",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     }
-   ],
-   'ingredients_analysis_tags' => [
-     'en:palm-oil',
-     'en:non-vegan',
-     'en:vegetarian-status-unknown'
-   ],
-   'ingredients_hierarchy' => [
-     'fr:Marmelade d\'oranges',
-     'en:chocolate',
-     'en:wheat-flour',
-     'en:cereal',
-     'en:flour',
-     'en:wheat',
-     'en:cereal-flour',
-     'en:sugar',
-     'en:egg',
-     'en:glucose-fructose-syrup',
-     'en:glucose',
-     'en:fructose',
-     'en:colza-oil',
-     'en:oil-and-fat',
-     'en:vegetable-oil-and-fat',
-     'en:rapeseed-oil',
-     'en:raising-agent',
-     'en:salt',
-     'en:emulsifier',
-     'en:orange-pulp',
-     'en:fruit',
-     'en:citrus-fruit',
-     'en:orange',
-     'en:concentrated-orange-juice',
-     'en:fruit-juice',
-     'en:orange-juice',
-     'en:gelling-agent',
-     'en:acid',
-     'en:acidity-regulator',
-     'en:natural-orange-flavouring',
-     'en:flavouring',
-     'en:natural-flavouring',
-     'en:thickener',
-     'en:cocoa-paste',
-     'en:cocoa',
-     'en:cocoa-butter',
-     'en:illipe-oil',
-     'en:vegetable-fat',
-     'en:mango-kernel-oil',
-     'en:vegetable-oil',
-     'en:shorea-robusta-seed-oil',
-     'en:shea-butter',
-     'en:palm-fat',
-     'en:palm-oil-and-fat',
-     'en:lactose-and-milk-proteins',
-     'en:protein',
-     'en:animal-protein',
-     'en:milk-proteins',
-     'en:lactose',
-     'en:e503ii',
-	 'en:e503',
-     'en:e450i',
-     'en:e450',
-     'en:e500ii',
-     'en:e500',
-     'en:soya-lecithin',
-     'en:e322',
-     'en:e322i',
-     'en:e440a',
-     'en:e330',
-     'en:e333',
-     'en:sodium-citrate',
-     'en:minerals',
-     'en:sodium',
-     'en:e415'
-   ],
-   'ingredients_n' => 41,
-   'ingredients_n_tags' => [
-     '41',
-     '41-50'
-   ],
-   'ingredients_original_tags' => [
-     'fr:Marmelade d\'oranges',
-     'en:chocolate',
-     'en:wheat-flour',
-     'en:sugar',
-     'en:egg',
-     'en:glucose-fructose-syrup',
-     'en:colza-oil',
-     'en:raising-agent',
-     'en:salt',
-     'en:emulsifier',
-     'en:glucose-fructose-syrup',
-     'en:sugar',
-     'en:orange-pulp',
-     'en:concentrated-orange-juice',
-     'en:orange-pulp',
-     'en:gelling-agent',
-     'en:acid',
-     'en:acidity-regulator',
-     'en:natural-orange-flavouring',
-     'en:thickener',
-     'en:sugar',
-     'en:cocoa-paste',
-     'en:cocoa-butter',
-     'en:illipe-oil',
-     'en:mango-kernel-oil',
-     'en:shorea-robusta-seed-oil',
-     'en:shea-butter',
-     'en:palm-fat',
-     'en:flavouring',
-     'en:emulsifier',
-     'en:lactose-and-milk-proteins',
-     'en:e503ii',
-     'en:e450i',
-     'en:e500ii',
-     'en:soya-lecithin',
-     'en:e440a',
-     'en:e330',
-     'en:e333',
-     'en:sodium-citrate',
-     'en:e415',
-     'en:soya-lecithin'
-   ],
-   'ingredients_tags' => [
-     'fr:marmelade-d-oranges',
-     'en:chocolate',
-     'en:wheat-flour',
-     'en:cereal',
-     'en:flour',
-     'en:wheat',
-     'en:cereal-flour',
-     'en:sugar',
-     'en:egg',
-     'en:glucose-fructose-syrup',
-     'en:glucose',
-     'en:fructose',
-     'en:colza-oil',
-     'en:oil-and-fat',
-     'en:vegetable-oil-and-fat',
-	 'en:rapeseed-oil',
-     'en:raising-agent',
-     'en:salt',
-     'en:emulsifier',
-     'en:orange-pulp',
-     'en:fruit',
-     'en:citrus-fruit',
-     'en:orange',
-     'en:concentrated-orange-juice',
-     'en:fruit-juice',
-     'en:orange-juice',
-     'en:gelling-agent',
-     'en:acid',
-     'en:acidity-regulator',
-     'en:natural-orange-flavouring',
-     'en:flavouring',
-     'en:natural-flavouring',
-     'en:thickener',
-     'en:cocoa-paste',
-     'en:cocoa',
-     'en:cocoa-butter',
-     'en:illipe-oil',
-     'en:vegetable-fat',
-     'en:mango-kernel-oil',
-     'en:vegetable-oil',
-     'en:shorea-robusta-seed-oil',
-     'en:shea-butter',
-     'en:palm-fat',
-     'en:palm-oil-and-fat',
-     'en:lactose-and-milk-proteins',
-     'en:protein',
-     'en:animal-protein',
-     'en:milk-proteins',
-     'en:lactose',
-     'en:e503ii',
-	 'en:e503',
-     'en:e450i',
-     'en:e450',
-     'en:e500ii',
-	 'en:e500',
-     'en:soya-lecithin',
-     'en:e322',
-     'en:e322i',
-     'en:e440a',
-     'en:e330',
-     'en:e333',
-     'en:sodium-citrate',
-     'en:minerals',
-     'en:sodium',
-     'en:e415'
-   ],
-   'ingredients_text' => "Marmelade d'oranges 41% (sirop de glucose-fructose, sucre, pulpe d'orange 4.5%, jus d'orange concentr\x{e9} 1.4% (\x{e9}quivalent jus d'orange 7.8%), pulpe d'orange concentr\x{e9}e 0.6% (\x{e9}quivalent pulpe d'orange 2.6%), g\x{e9}lifiant (pectines), acidifiant (acide citrique), correcteurs d'acidit\x{e9} (citrate de calcium, citrate de sodium), ar\x{f4}me naturel d'orange, \x{e9}paississant (gomme xanthane)), chocolat 24.9% (sucre, p\x{e2}te de cacao, beurre de cacao, graisses v\x{e9}g\x{e9}tales (illipe, mangue, sal, karit\x{e9} et palme en proportions variables), ar\x{f4}me, \x{e9}mulsifiant (l\x{e9}cithine de soja), lactose et prot\x{e9}ines de lait), farine de bl\x{e9}, sucre, oeufs, sirop de glucose-fructose, huile de colza, poudre \x{e0} lever (carbonate acide d'ammonium, diphosphate disodique, carbonate acide de sodium), sel, \x{e9}mulsifiant (l\x{e9}cithine de soja).",
-   'known_ingredients_n' => 64,
-   'lc' => 'fr',
-   'unknown_ingredients_n' => 1
- };
+{
+	'ingredients' => [
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'fr:Marmelade d\'oranges',
+			'ingredients' => [
+				{
+					'id' => 'en:glucose-fructose-syrup',
+					'text' => 'sirop de glucose-fructose'
+				},
+				{
+					'id' => 'en:sugar',
+					'text' => 'sucre'
+				},
+				{
+					'id' => 'en:orange-pulp',
+					'percent' => '4.5',
+					'text' => 'pulpe d\'orange'
+				},
+				{
+					'id' => 'en:concentrated-orange-juice',
+					'ingredients' => [],
+					'percent' => '1.4',
+					'text' => "jus d'orange concentr\x{e9}"
+				},
+				{
+					'id' => 'en:orange-pulp',
+					'ingredients' => [],
+					'percent' => '0.6',
+					'processing' => 'en:concentrated',
+					'text' => 'pulpe d\'orange'
+				},
+				{
+					'id' => 'en:gelling-agent',
+					'ingredients' => [
+						{
+							'id' => 'en:e440a',
+							'text' => 'pectines'
+						}
+					],
+					'text' => "g\x{e9}lifiant"
+				},
+				{
+					'id' => 'en:acid',
+					'ingredients' => [
+						{
+							'id' => 'en:e330',
+							'text' => 'acide citrique'
+						}
+					],
+					'text' => 'acidifiant'
+				},
+				{
+					'id' => 'en:acidity-regulator',
+					'ingredients' => [
+						{
+							'id' => 'en:e333',
+							'text' => 'citrate de calcium'
+						},
+						{
+							'id' => 'en:sodium-citrate',
+							'text' => 'citrate de sodium'
+						}
+					],
+					'text' => "correcteurs d'acidit\x{e9}"
+				},
+				{
+					'id' => 'en:natural-orange-flavouring',
+					'text' => "ar\x{f4}me naturel d'orange"
+				},
+				{
+					'id' => 'en:thickener',
+					'ingredients' => [
+						{
+							'id' => 'en:e415',
+							'text' => 'gomme xanthane'
+						}
+					],
+					'text' => "\x{e9}paississant"
+				}
+			],
+			'percent' => '41',
+			'rank' => 1,
+			'text' => 'Marmelade d\'oranges'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:chocolate',
+			'ingredients' => [
+				{
+					'id' => 'en:sugar',
+					'text' => 'sucre'
+				},
+				{
+					'id' => 'en:cocoa-paste',
+					'text' => "p\x{e2}te de cacao"
+				},
+				{
+					'id' => 'en:cocoa-butter',
+					'text' => 'beurre de cacao'
+				},
+				{
+					'id' => 'en:illipe-oil',
+					'text' => "graisses v\x{e9}g\x{e9}tales d'illipe"
+				},
+				{
+					'id' => 'en:mango-kernel-oil',
+					'text' => "graisses v\x{e9}g\x{e9}tales de mangue"
+				},
+				{
+					'id' => 'en:shorea-robusta-seed-oil',
+					'text' => "graisses v\x{e9}g\x{e9}tales de sal"
+				},
+				{
+					'id' => 'en:shea-butter',
+					'text' => "graisses v\x{e9}g\x{e9}tales de karit\x{e9}"
+				},
+				{
+					'id' => 'en:palm-fat',
+					'text' => "graisses v\x{e9}g\x{e9}tales de palme"
+				},
+				{
+					'id' => 'en:flavouring',
+					'text' => "ar\x{f4}me"
+				},
+				{
+					'id' => 'en:emulsifier',
+					'ingredients' => [
+						{
+							'id' => 'en:soya-lecithin',
+							'text' => "l\x{e9}cithine de soja"
+						}
+					],
+					'text' => "\x{e9}mulsifiant"
+				},
+				{
+					'id' => 'en:lactose-and-milk-proteins',
+					'text' => "lactose et prot\x{e9}ines de lait"
+				}
+			],
+			'percent' => '24.9',
+			'rank' => 2,
+			'text' => 'chocolat',
+			'vegan' => 'maybe',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:wheat-flour',
+			'rank' => 3,
+			'text' => "farine de bl\x{e9}",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sugar',
+			'rank' => 4,
+			'text' => 'sucre',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:egg',
+			'rank' => 5,
+			'text' => 'oeufs',
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:glucose-fructose-syrup',
+			'rank' => 6,
+			'text' => 'sirop de glucose-fructose',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'no',
+			'id' => 'en:colza-oil',
+			'rank' => 7,
+			'text' => 'huile de colza',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:raising-agent',
+			'ingredients' => [
+				{
+					'id' => 'en:e503ii',
+					'text' => 'carbonate acide d\'ammonium'
+				},
+				{
+					'id' => 'en:e450i',
+					'text' => 'diphosphate disodique'
+				},
+				{
+					'id' => 'en:e500ii',
+					'text' => 'carbonate acide de sodium'
+				}
+			],
+			'rank' => 8,
+			'text' => "poudre \x{e0} lever"
+		},
+		{
+			'id' => 'en:salt',
+			'rank' => 9,
+			'text' => 'sel',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:emulsifier',
+			'ingredients' => [
+				{
+					'id' => 'en:soya-lecithin',
+					'text' => "l\x{e9}cithine de soja"
+				}
+			],
+			'rank' => 10,
+			'text' => "\x{e9}mulsifiant"
+		},
+		{
+			'id' => 'en:glucose-fructose-syrup',
+			'text' => 'sirop de glucose-fructose',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sugar',
+			'text' => 'sucre',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:orange-pulp',
+			'percent' => '4.5',
+			'text' => 'pulpe d\'orange',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:concentrated-orange-juice',
+			'percent' => '1.4',
+			'text' => "jus d'orange concentr\x{e9}",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:orange-pulp',
+			'percent' => '0.6',
+			'processing' => 'en:concentrated',
+			'text' => 'pulpe d\'orange',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:gelling-agent',
+			'text' => "g\x{e9}lifiant"
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:acid',
+			'text' => 'acidifiant'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:acidity-regulator',
+			'text' => "correcteurs d'acidit\x{e9}"
+		},
+		{
+			'id' => 'en:natural-orange-flavouring',
+			'text' => "ar\x{f4}me naturel d'orange",
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:thickener',
+			'text' => "\x{e9}paississant"
+		},
+		{
+			'id' => 'en:sugar',
+			'text' => 'sucre',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-paste',
+			'text' => "p\x{e2}te de cacao",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-butter',
+			'text' => 'beurre de cacao',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'no',
+			'id' => 'en:illipe-oil',
+			'text' => "graisses v\x{e9}g\x{e9}tales d'illipe",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'no',
+			'id' => 'en:mango-kernel-oil',
+			'text' => "graisses v\x{e9}g\x{e9}tales de mangue",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'no',
+			'id' => 'en:shorea-robusta-seed-oil',
+			'text' => "graisses v\x{e9}g\x{e9}tales de sal",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'no',
+			'id' => 'en:shea-butter',
+			'text' => "graisses v\x{e9}g\x{e9}tales de karit\x{e9}",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'yes',
+			'id' => 'en:palm-fat',
+			'text' => "graisses v\x{e9}g\x{e9}tales de palme",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:flavouring',
+			'text' => "ar\x{f4}me",
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:emulsifier',
+			'text' => "\x{e9}mulsifiant"
+		},
+		{
+			'id' => 'en:lactose-and-milk-proteins',
+			'text' => "lactose et prot\x{e9}ines de lait",
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e503ii',
+			'text' => 'carbonate acide d\'ammonium',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e450i',
+			'text' => 'diphosphate disodique',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e500ii',
+			'text' => 'carbonate acide de sodium',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:soya-lecithin',
+			'text' => "l\x{e9}cithine de soja",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e440a',
+			'text' => 'pectines',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e330',
+			'text' => 'acide citrique',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e333',
+			'text' => 'citrate de calcium',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sodium-citrate',
+			'text' => 'citrate de sodium'
+		},
+		{
+			'id' => 'en:e415',
+			'text' => 'gomme xanthane',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:soya-lecithin',
+			'text' => "l\x{e9}cithine de soja",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
+	'ingredients_analysis_tags' => [
+		'en:palm-oil',
+		'en:non-vegan',
+		'en:vegetarian-status-unknown'
+	],
+	'ingredients_hierarchy' => [
+		'fr:Marmelade d\'oranges',
+		'en:chocolate',
+		'en:wheat-flour',
+		'en:cereal',
+		'en:flour',
+		'en:wheat',
+		'en:cereal-flour',
+		'en:sugar',
+		'en:egg',
+		'en:glucose-fructose-syrup',
+		'en:glucose',
+		'en:fructose',
+		'en:colza-oil',
+		'en:oil-and-fat',
+		'en:vegetable-oil-and-fat',
+		'en:rapeseed-oil',
+		'en:raising-agent',
+		'en:salt',
+		'en:emulsifier',
+		'en:orange-pulp',
+		'en:fruit',
+		'en:citrus-fruit',
+		'en:orange',
+		'en:concentrated-orange-juice',
+		'en:fruit-juice',
+		'en:orange-juice',
+		'en:gelling-agent',
+		'en:acid',
+		'en:acidity-regulator',
+		'en:natural-orange-flavouring',
+		'en:flavouring',
+		'en:natural-flavouring',
+		'en:thickener',
+		'en:cocoa-paste',
+		'en:cocoa',
+		'en:cocoa-butter',
+		'en:illipe-oil',
+		'en:vegetable-fat',
+		'en:mango-kernel-oil',
+		'en:vegetable-oil',
+		'en:shorea-robusta-seed-oil',
+		'en:shea-butter',
+		'en:palm-fat',
+		'en:palm-oil-and-fat',
+		'en:lactose-and-milk-proteins',
+		'en:protein',
+		'en:animal-protein',
+		'en:milk-proteins',
+		'en:lactose',
+		'en:e503ii',
+		'en:e503',
+		'en:e450i',
+		'en:e450',
+		'en:e500ii',
+		'en:e500',
+		'en:soya-lecithin',
+		'en:e322',
+		'en:e322i',
+		'en:e440a',
+		'en:e330',
+		'en:e333',
+		'en:sodium-citrate',
+		'en:minerals',
+		'en:sodium',
+		'en:e415'
+	],
+	'ingredients_n' => 41,
+	'ingredients_n_tags' => [
+		'41',
+		'41-50'
+	],
+	'ingredients_original_tags' => [
+		'fr:Marmelade d\'oranges',
+		'en:chocolate',
+		'en:wheat-flour',
+		'en:sugar',
+		'en:egg',
+		'en:glucose-fructose-syrup',
+		'en:colza-oil',
+		'en:raising-agent',
+		'en:salt',
+		'en:emulsifier',
+		'en:glucose-fructose-syrup',
+		'en:sugar',
+		'en:orange-pulp',
+		'en:concentrated-orange-juice',
+		'en:orange-pulp',
+		'en:gelling-agent',
+		'en:acid',
+		'en:acidity-regulator',
+		'en:natural-orange-flavouring',
+		'en:thickener',
+		'en:sugar',
+		'en:cocoa-paste',
+		'en:cocoa-butter',
+		'en:illipe-oil',
+		'en:mango-kernel-oil',
+		'en:shorea-robusta-seed-oil',
+		'en:shea-butter',
+		'en:palm-fat',
+		'en:flavouring',
+		'en:emulsifier',
+		'en:lactose-and-milk-proteins',
+		'en:e503ii',
+		'en:e450i',
+		'en:e500ii',
+		'en:soya-lecithin',
+		'en:e440a',
+		'en:e330',
+		'en:e333',
+		'en:sodium-citrate',
+		'en:e415',
+		'en:soya-lecithin'
+	],
+	'ingredients_tags' => [
+		'fr:marmelade-d-oranges',
+		'en:chocolate',
+		'en:wheat-flour',
+		'en:cereal',
+		'en:flour',
+		'en:wheat',
+		'en:cereal-flour',
+		'en:sugar',
+		'en:egg',
+		'en:glucose-fructose-syrup',
+		'en:glucose',
+		'en:fructose',
+		'en:colza-oil',
+		'en:oil-and-fat',
+		'en:vegetable-oil-and-fat',
+		'en:rapeseed-oil',
+		'en:raising-agent',
+		'en:salt',
+		'en:emulsifier',
+		'en:orange-pulp',
+		'en:fruit',
+		'en:citrus-fruit',
+		'en:orange',
+		'en:concentrated-orange-juice',
+		'en:fruit-juice',
+		'en:orange-juice',
+		'en:gelling-agent',
+		'en:acid',
+		'en:acidity-regulator',
+		'en:natural-orange-flavouring',
+		'en:flavouring',
+		'en:natural-flavouring',
+		'en:thickener',
+		'en:cocoa-paste',
+		'en:cocoa',
+		'en:cocoa-butter',
+		'en:illipe-oil',
+		'en:vegetable-fat',
+		'en:mango-kernel-oil',
+		'en:vegetable-oil',
+		'en:shorea-robusta-seed-oil',
+		'en:shea-butter',
+		'en:palm-fat',
+		'en:palm-oil-and-fat',
+		'en:lactose-and-milk-proteins',
+		'en:protein',
+		'en:animal-protein',
+		'en:milk-proteins',
+		'en:lactose',
+		'en:e503ii',
+		'en:e503',
+		'en:e450i',
+		'en:e450',
+		'en:e500ii',
+		'en:e500',
+		'en:soya-lecithin',
+		'en:e322',
+		'en:e322i',
+		'en:e440a',
+		'en:e330',
+		'en:e333',
+		'en:sodium-citrate',
+		'en:minerals',
+		'en:sodium',
+		'en:e415'
+	],
+	'ingredients_text' => "Marmelade d'oranges 41% (sirop de glucose-fructose, sucre, pulpe d'orange 4.5%, jus d'orange concentr\x{e9} 1.4% (\x{e9}quivalent jus d'orange 7.8%), pulpe d'orange concentr\x{e9}e 0.6% (\x{e9}quivalent pulpe d'orange 2.6%), g\x{e9}lifiant (pectines), acidifiant (acide citrique), correcteurs d'acidit\x{e9} (citrate de calcium, citrate de sodium), ar\x{f4}me naturel d'orange, \x{e9}paississant (gomme xanthane)), chocolat 24.9% (sucre, p\x{e2}te de cacao, beurre de cacao, graisses v\x{e9}g\x{e9}tales (illipe, mangue, sal, karit\x{e9} et palme en proportions variables), ar\x{f4}me, \x{e9}mulsifiant (l\x{e9}cithine de soja), lactose et prot\x{e9}ines de lait), farine de bl\x{e9}, sucre, oeufs, sirop de glucose-fructose, huile de colza, poudre \x{e0} lever (carbonate acide d'ammonium, diphosphate disodique, carbonate acide de sodium), sel, \x{e9}mulsifiant (l\x{e9}cithine de soja).",
+	'known_ingredients_n' => 64,
+	'lc' => 'fr',
+	'unknown_ingredients_n' => 1
+};
 
 
 
@@ -1032,8 +1032,8 @@ is_deeply($product_ref, $expected_product_ref) || diag explain $product_ref;
 
 # test synonyms for flavouring/flavour/flavor/flavoring
 $product_ref = {
-        lc => "en",
-        ingredients_text => "Natural orange flavor, Lemon flavouring"
+	lc => "en",
+	ingredients_text => "Natural orange flavor, Lemon flavouring"
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1055,54 +1055,54 @@ delete $product_ref->{ingredients_percent_analysis};
 # diag explain $product_ref;
 
 $expected_product_ref =
- {
-    'ingredients' => [
-      {
-        'id' => 'en:natural-orange-flavouring',
-        'rank' => 1,
-        'text' => 'Natural orange flavor',
-	'vegan' => 'maybe',
-	'vegetarian' => 'maybe'
-      },
-      {
-        'id' => 'en:lemon-flavouring',
-        'rank' => 2,
-        'text' => 'Lemon flavouring',
-	'vegan' => 'maybe',
-	'vegetarian' => 'maybe'
-      }
-    ],
-    'ingredients_analysis_tags' => [
-      'en:palm-oil-free',
-      'en:maybe-vegan',
-      'en:maybe-vegetarian'
-    ],
-    'ingredients_hierarchy' => [
-      'en:natural-orange-flavouring',
-      'en:flavouring',
-      'en:natural-flavouring',
-      'en:lemon-flavouring'
-    ],
-    'ingredients_n' => 2,
-    'ingredients_n_tags' => [
-      '2',
-      '1-10'
-    ],
-    'ingredients_original_tags' => [
-      'en:natural-orange-flavouring',
-      'en:lemon-flavouring'
-    ],
-    'ingredients_tags' => [
-      'en:natural-orange-flavouring',
-      'en:flavouring',
-      'en:natural-flavouring',
-      'en:lemon-flavouring'
-    ],
-    'ingredients_text' => 'Natural orange flavor, Lemon flavouring',
-    'lc' => 'en',
-    'known_ingredients_n' => 4,
-    'unknown_ingredients_n' => 0
-  };
+{
+	'ingredients' => [
+		{
+			'id' => 'en:natural-orange-flavouring',
+			'rank' => 1,
+			'text' => 'Natural orange flavor',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:lemon-flavouring',
+			'rank' => 2,
+			'text' => 'Lemon flavouring',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		}
+	],
+	'ingredients_analysis_tags' => [
+		'en:palm-oil-free',
+		'en:maybe-vegan',
+		'en:maybe-vegetarian'
+	],
+	'ingredients_hierarchy' => [
+		'en:natural-orange-flavouring',
+		'en:flavouring',
+		'en:natural-flavouring',
+		'en:lemon-flavouring'
+	],
+	'ingredients_n' => 2,
+	'ingredients_n_tags' => [
+		'2',
+		'1-10'
+	],
+	'ingredients_original_tags' => [
+		'en:natural-orange-flavouring',
+		'en:lemon-flavouring'
+	],
+	'ingredients_tags' => [
+		'en:natural-orange-flavouring',
+		'en:flavouring',
+		'en:natural-flavouring',
+		'en:lemon-flavouring'
+	],
+	'ingredients_text' => 'Natural orange flavor, Lemon flavouring',
+	'lc' => 'en',
+	'known_ingredients_n' => 4,
+	'unknown_ingredients_n' => 0
+};
 
 
 delete $product_ref->{nutriments};
@@ -1110,8 +1110,8 @@ is_deeply($product_ref, $expected_product_ref) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "pâte de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce équitable et de l'agriculture biologique (100% du poids total)."
+	lc => "fr",
+	ingredients_text => "pâte de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce équitable et de l'agriculture biologique (100% du poids total)."
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1131,72 +1131,72 @@ delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
 $expected_product_ref = {
-	    'ingredients' => [
-	      {
-	        'id' => "fr:p\x{e2}te de cacao de Madagascar",
-	        'labels' => 'en:fair-trade, en:organic',
-	        'percent' => '75',
-	        'rank' => 1,
-	        'text' => "p\x{e2}te de cacao de Madagascar"
-	      },
-	      {
-	        'id' => 'en:cane-sugar',
-	        'labels' => 'en:fair-trade, en:organic',
-	        'rank' => 2,
-	        'text' => 'sucre de canne',
-	        'vegan' => 'yes',
-	        'vegetarian' => 'yes'
-	      },
-	      {
-	        'id' => 'en:cocoa-butter',
-	        'labels' => 'en:fair-trade, en:organic',
-	        'rank' => 3,
-	        'text' => 'beurre de cacao',
-	        'vegan' => 'yes',
-	        'vegetarian' => 'yes'
-	      }
-	    ],
-	    'ingredients_analysis_tags' => [
-	      'en:palm-oil-content-unknown',
-	      'en:vegan-status-unknown',
-	      'en:vegetarian-status-unknown'
-	    ],
-	    'ingredients_hierarchy' => [
-	      "fr:p\x{e2}te de cacao de Madagascar",
-	      'en:cane-sugar',
-	      'en:sugar',
-	      'en:cocoa-butter',
-	      'en:cocoa'
-	    ],
-	    'ingredients_n' => 3,
-	    'ingredients_n_tags' => [
-	      '3',
-	      '1-10'
-	    ],
-	    'ingredients_original_tags' => [
-	      "fr:p\x{e2}te de cacao de Madagascar",
-	      'en:cane-sugar',
-	      'en:cocoa-butter'
-	    ],
-	    'ingredients_tags' => [
-	      'fr:pate-de-cacao-de-madagascar',
-	      'en:cane-sugar',
-	      'en:sugar',
-	      'en:cocoa-butter',
-	      'en:cocoa'
-	    ],
-	    'ingredients_text' => "p\x{e2}te de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce \x{e9}quitable et de l'agriculture biologique (100% du poids total).",
-	    'lc' => 'fr',
-	    'known_ingredients_n' => 4,
-	    'unknown_ingredients_n' => 1
+	'ingredients' => [
+		{
+			'id' => "fr:p\x{e2}te de cacao de Madagascar",
+			'labels' => 'en:fair-trade, en:organic',
+			'percent' => '75',
+			'rank' => 1,
+			'text' => "p\x{e2}te de cacao de Madagascar"
+		},
+		{
+			'id' => 'en:cane-sugar',
+			'labels' => 'en:fair-trade, en:organic',
+			'rank' => 2,
+			'text' => 'sucre de canne',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-butter',
+			'labels' => 'en:fair-trade, en:organic',
+			'rank' => 3,
+			'text' => 'beurre de cacao',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
+	'ingredients_analysis_tags' => [
+		'en:palm-oil-content-unknown',
+		'en:vegan-status-unknown',
+		'en:vegetarian-status-unknown'
+	],
+	'ingredients_hierarchy' => [
+		"fr:p\x{e2}te de cacao de Madagascar",
+		'en:cane-sugar',
+		'en:sugar',
+		'en:cocoa-butter',
+		'en:cocoa'
+	],
+	'ingredients_n' => 3,
+	'ingredients_n_tags' => [
+		'3',
+		'1-10'
+	],
+	'ingredients_original_tags' => [
+		"fr:p\x{e2}te de cacao de Madagascar",
+		'en:cane-sugar',
+		'en:cocoa-butter'
+	],
+	'ingredients_tags' => [
+		'fr:pate-de-cacao-de-madagascar',
+		'en:cane-sugar',
+		'en:sugar',
+		'en:cocoa-butter',
+		'en:cocoa'
+	],
+	'ingredients_text' => "p\x{e2}te de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce \x{e9}quitable et de l'agriculture biologique (100% du poids total).",
+	'lc' => 'fr',
+	'known_ingredients_n' => 4,
+	'unknown_ingredients_n' => 1
 };
 
 delete $product_ref->{nutriments};
 is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "gélifiant (pectines)",
+	lc => "fr",
+	ingredients_text => "gélifiant (pectines)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1205,15 +1205,18 @@ delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
 
-is_deeply ($product_ref->{ingredients_original_tags}, [
-"en:gelling-agent",
-"en:e440a",
-]) or diag explain $product_ref;
+is_deeply (
+	$product_ref->{ingredients_original_tags},
+	[
+		"en:gelling-agent",
+		"en:e440a",
+	]
+) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Fraise 12,3% ; Orange 6.5%, Pomme (3,5%)",
+	lc => "fr",
+	ingredients_text => "Fraise 12,3% ; Orange 6.5%, Pomme (3,5%)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1222,40 +1225,41 @@ delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
 
-is_deeply ($product_ref->{ingredients},
-[
-	     {
-	            'id' => 'en:strawberry',
-	            'percent' => '12.3',
-	            'rank' => 1,
-	            'text' => 'Fraise',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes',
-	          },
-	          {
-	            'id' => 'en:orange',
-	            'percent' => '6.5',
-	            'rank' => 2,
-	            'text' => 'Orange',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes',
-	          },
-	          {
-	            'id' => 'en:apple',
-	            'percent' => '3.5',
-	            'rank' => 3,
-	            'text' => 'Pomme',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes',
-	          }
-	        ]
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:strawberry',
+			'percent' => '12.3',
+			'rank' => 1,
+			'text' => 'Fraise',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes',
+		},
+		{
+			'id' => 'en:orange',
+			'percent' => '6.5',
+			'rank' => 2,
+			'text' => 'Orange',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes',
+		},
+		{
+			'id' => 'en:apple',
+			'percent' => '3.5',
+			'rank' => 3,
+			'text' => 'Pomme',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes',
+		}
+	]
 ) or diag explain $product_ref;
 
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "Fraise origine France, Cassis (origine Afrique du Sud), Framboise (origine : Belgique), Pamplemousse bio, Orange (bio), Citron (issue de l'agriculture biologique), cacao et beurre de cacao (commerce équitable), cerises issues de l'agriculture biologique",
+	lc => "fr",
+	ingredients_text => "Fraise origine France, Cassis (origine Afrique du Sud), Framboise (origine : Belgique), Pamplemousse bio, Orange (bio), Citron (issue de l'agriculture biologique), cacao et beurre de cacao (commerce équitable), cerises issues de l'agriculture biologique",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1263,89 +1267,88 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-	   [
-	        {
-	          'id' => 'en:strawberry',
-	          'origin' => 'en:france',
-	          'rank' => 1,
-	          'text' => 'Fraise',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:blackcurrant',
-	          'origin' => 'en:south-africa',
-	          'rank' => 2,
-	          'text' => 'Cassis',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:raspberry',
-	          'origin' => 'en:belgium',
-	          'rank' => 3,
-	          'text' => 'Framboise',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:grapefruit',
-	          'labels' => 'en:organic',
-	          'rank' => 4,
-	          'text' => 'Pamplemousse',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:orange',
-	          'labels' => 'en:organic',
-	          'rank' => 5,
-	          'text' => 'Orange',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:lemon',
-	          'labels' => 'en:organic',
-	          'rank' => 6,
-	          'text' => 'Citron',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:cocoa',
-	          'labels' => 'en:fair-trade',
-	          'rank' => 7,
-	          'text' => 'cacao',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:cocoa-butter',
-	          'labels' => 'en:fair-trade',
-	          'rank' => 8,
-	          'text' => 'beurre de cacao',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-     {
-            'id' => 'en:cherry',
-            'labels' => 'en:organic',
-            'rank' => 9,
-            'text' => 'cerises',
-            'vegan' => 'yes',
-            'vegetarian' => 'yes'
-          }
-
-	      ],
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:strawberry',
+			'origin' => 'en:france',
+			'rank' => 1,
+			'text' => 'Fraise',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:blackcurrant',
+			'origin' => 'en:south-africa',
+			'rank' => 2,
+			'text' => 'Cassis',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:raspberry',
+			'origin' => 'en:belgium',
+			'rank' => 3,
+			'text' => 'Framboise',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:grapefruit',
+			'labels' => 'en:organic',
+			'rank' => 4,
+			'text' => 'Pamplemousse',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:orange',
+			'labels' => 'en:organic',
+			'rank' => 5,
+			'text' => 'Orange',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:lemon',
+			'labels' => 'en:organic',
+			'rank' => 6,
+			'text' => 'Citron',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa',
+			'labels' => 'en:fair-trade',
+			'rank' => 7,
+			'text' => 'cacao',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-butter',
+			'labels' => 'en:fair-trade',
+			'rank' => 8,
+			'text' => 'beurre de cacao',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cherry',
+			'labels' => 'en:organic',
+			'rank' => 9,
+			'text' => 'cerises',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
 ) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "émulsifiant : lécithines (tournesol), arôme)(UE), farine de blé 33% (France), sucre, beurre concentré* 6,5% (France)",
+	lc => "fr",
+	ingredients_text => "émulsifiant : lécithines (tournesol), arôme)(UE), farine de blé 33% (France), sucre, beurre concentré* 6,5% (France)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1353,70 +1356,68 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-[
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:emulsifier',
-       'ingredients' => [
-         {
-           'id' => 'en:sunflower-lecithin',
-           'text' => "l\x{e9}cithines de tournesol"
-         }
-       ],
-       'rank' => 1,
-       'text' => "\x{e9}mulsifiant"
-     },
-     {
-       'id' => 'en:flavouring',
-       'origin' => 'en:european-union',
-       'rank' => 2,
-       'text' => "ar\x{f4}me",
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'id' => 'en:wheat-flour',
-       'origin' => 'en:france',
-       'percent' => '33',
-       'rank' => 3,
-       'text' => "farine de bl\x{e9}",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sugar',
-       'rank' => 4,
-       'text' => 'sucre',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'from_palm_oil' => 'no',
-       'id' => 'en:butterfat',
-       'origin' => 'en:france',
-       'percent' => '6.5',
-       'rank' => 5,
-       'text' => "beurre concentr\x{e9}",
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sunflower-lecithin',
-       'text' => "l\x{e9}cithines de tournesol",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     }
-
-	        ],
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:emulsifier',
+			'ingredients' => [
+				{
+					'id' => 'en:sunflower-lecithin',
+					'text' => "l\x{e9}cithines de tournesol"
+				}
+			],
+			'rank' => 1,
+			'text' => "\x{e9}mulsifiant"
+		},
+		{
+			'id' => 'en:flavouring',
+			'origin' => 'en:european-union',
+			'rank' => 2,
+			'text' => "ar\x{f4}me",
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:wheat-flour',
+			'origin' => 'en:france',
+			'percent' => '33',
+			'rank' => 3,
+			'text' => "farine de bl\x{e9}",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sugar',
+			'rank' => 4,
+			'text' => 'sucre',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'from_palm_oil' => 'no',
+			'id' => 'en:butterfat',
+			'origin' => 'en:france',
+			'percent' => '6.5',
+			'rank' => 5,
+			'text' => "beurre concentr\x{e9}",
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sunflower-lecithin',
+			'text' => "l\x{e9}cithines de tournesol",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
 ) or diag explain $product_ref;
 
 
-
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "80% jus de pomme biologique, 20% de coing biologique, sel marin, 98% chlorure de sodium (France, Italie)",
+	lc => "fr",
+	ingredients_text => "80% jus de pomme biologique, 20% de coing biologique, sel marin, 98% chlorure de sodium (France, Italie)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1424,50 +1425,48 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-
-[
-	     {
-	            'id' => 'en:apple-juice',
-	            'labels' => 'en:organic',
-	            'percent' => '80',
-	            'rank' => 1,
-	            'text' => 'jus de pomme',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes'
-	          },
-	          {
-	            'id' => 'en:quince',
-	            'labels' => 'en:organic',
-	            'percent' => '20',
-	            'rank' => 2,
-	            'text' => 'coing',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes'
-	          },
-	          {
-	            'id' => 'en:sea-salt',
-	            'rank' => 3,
-	            'text' => 'sel marin',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes'
-	          },
-	          {
-	            'id' => 'en:sodium-chloride',
-	            'origin' => 'en:france,en:italy',
-	            'percent' => '98',
-	            'rank' => 4,
-	            'text' => 'chlorure de sodium'
-	          }
-	        ],
-
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:apple-juice',
+			'labels' => 'en:organic',
+			'percent' => '80',
+			'rank' => 1,
+			'text' => 'jus de pomme',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:quince',
+			'labels' => 'en:organic',
+			'percent' => '20',
+			'rank' => 2,
+			'text' => 'coing',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sea-salt',
+			'rank' => 3,
+			'text' => 'sel marin',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sodium-chloride',
+			'origin' => 'en:france,en:italy',
+			'percent' => '98',
+			'rank' => 4,
+			'text' => 'chlorure de sodium'
+		}
+	],
 ) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "mono - et diglycérides d'acides gras d'origine végétale, huile d'origine végétale, gélatine (origine végétale)",
+	lc => "fr",
+	ingredients_text => "mono - et diglycérides d'acides gras d'origine végétale, huile d'origine végétale, gélatine (origine végétale)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1475,40 +1474,39 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-
-[
-     {
-            'from_palm_oil' => 'maybe',
-            'id' => 'en:e471',
-            'rank' => 1,
-            'text' => "mono- et diglyc\x{e9}rides d'acides gras",
-            'vegan' => 'en:yes',
-            'vegetarian' => 'en:yes'
-          },
-          {
-            'from_palm_oil' => 'maybe',
-            'id' => 'en:oil',
-            'rank' => 2,
-            'text' => 'huile',
-            'vegan' => 'en:yes',
-            'vegetarian' => 'en:yes'
-          },
-          {
-            'id' => 'en:e428',
-            'rank' => 3,
-            'text' => "g\x{e9}latine",
-            'vegan' => 'en:yes',
-            'vegetarian' => 'en:yes'
-          }
-        ],
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'from_palm_oil' => 'maybe',
+			'id' => 'en:e471',
+			'rank' => 1,
+			'text' => "mono- et diglyc\x{e9}rides d'acides gras",
+			'vegan' => 'en:yes',
+			'vegetarian' => 'en:yes'
+		},
+		{
+			'from_palm_oil' => 'maybe',
+			'id' => 'en:oil',
+			'rank' => 2,
+			'text' => 'huile',
+			'vegan' => 'en:yes',
+			'vegetarian' => 'en:yes'
+		},
+		{
+			'id' => 'en:e428',
+			'rank' => 3,
+			'text' => "g\x{e9}latine",
+			'vegan' => 'en:yes',
+			'vegetarian' => 'en:yes'
+		}
+	],
 ) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "jus d'orange (sans conservateur), saumon (msc), sans gluten",
+	lc => "fr",
+	ingredients_text => "jus d'orange (sans conservateur), saumon (msc), sans gluten",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1519,34 +1517,32 @@ delete $product_ref->{ingredients_percent_analysis};
 is ($product_ref->{labels}, "en:gluten-free") or diag explain $product_ref;
 is_deeply ($product_ref->{labels_tags}, ["en:gluten-free"]) or diag explain $product_ref;
 
-is_deeply ($product_ref->{ingredients},
-
-[
-	     {
-	            'id' => 'en:orange-juice',
-	            'labels' => 'en:no-preservatives',
-	            'rank' => 1,
-	            'text' => 'jus d\'orange',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes'
-	          },
-	          {
-	            'id' => 'en:salmon',
-	            'labels' => 'en:sustainable-seafood-msc',
-	            'rank' => 2,
-	            'text' => 'saumon',
-	            'vegan' => 'no',
-	            'vegetarian' => 'no'
-	          }
-
-        ],
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:orange-juice',
+			'labels' => 'en:no-preservatives',
+			'rank' => 1,
+			'text' => 'jus d\'orange',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:salmon',
+			'labels' => 'en:sustainable-seafood-msc',
+			'rank' => 2,
+			'text' => 'saumon',
+			'vegan' => 'no',
+			'vegetarian' => 'no'
+		}
+	],
 ) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "tomates pelées cuites, rondelle de citron, dés de courgette, lait cru, aubergines crues, jambon cru en tranches",
+	lc => "fr",
+	ingredients_text => "tomates pelées cuites, rondelle de citron, dés de courgette, lait cru, aubergines crues, jambon cru en tranches",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -1554,59 +1550,57 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-
-[
-     {
-       'id' => 'en:peeled-tomatoes',
-       'processing' => 'en:cooked',
-       'rank' => 1,
-       'text' => "tomates pel\x{e9}es",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:lemon',
-       'processing' => 'en:sliced',
-       'rank' => 2,
-       'text' => 'citron',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:courgette',
-       'processing' => 'en:diced',
-       'rank' => 3,
-       'text' => 'courgette',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:raw-milk',
-       'rank' => 4,
-       'text' => 'lait cru',
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:aubergine',
-       'processing' => 'en:raw',
-       'rank' => 5,
-       'text' => 'aubergines',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:raw-ham',
-       'processing' => 'en:sliced',
-       'rank' => 6,
-       'text' => 'jambon cru',
-       'vegan' => 'no',
-       'vegetarian' => 'no'
-     }
-   ],
-
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:peeled-tomatoes',
+			'processing' => 'en:cooked',
+			'rank' => 1,
+			'text' => "tomates pel\x{e9}es",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:lemon',
+			'processing' => 'en:sliced',
+			'rank' => 2,
+			'text' => 'citron',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:courgette',
+			'processing' => 'en:diced',
+			'rank' => 3,
+			'text' => 'courgette',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:raw-milk',
+			'rank' => 4,
+			'text' => 'lait cru',
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:aubergine',
+			'processing' => 'en:raw',
+			'rank' => 5,
+			'text' => 'aubergines',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:raw-ham',
+			'processing' => 'en:sliced',
+			'rank' => 6,
+			'text' => 'jambon cru',
+			'vegan' => 'no',
+			'vegetarian' => 'no'
+		}
+	],
 ) or diag explain $product_ref;
 
 # Bugs #3827, #3706, #3826 - truncated purée
@@ -1623,28 +1617,29 @@ delete $product_ref->{ingredients_percent_analysis};
 
 is_deeply(
 	$product_ref->{ingredients},
-	[   {   'id'         => 'en:crushed-tomato',
+	[
+		{	'id'         => 'en:crushed-tomato',
 			'percent'    => 19,
 			'rank'       => 1,
 			'text'       => "pur\x{e9}e de tomate",
 			'vegan'      => 'yes',
 			'vegetarian' => 'yes'
 		},
-		{   'id'         => 'en:beef',
+		{	'id'         => 'en:beef',
 			'percent'    => '90',
 			'rank'       => 2,
 			'text'       => 'boeuf',
 			'vegan'      => 'no',
 			'vegetarian' => 'no'
 		},
-		{   'id'         => 'en:fruit-juice',
+		{	'id'         => 'en:fruit-juice',
 			'percent'    => 100,
 			'rank'       => 3,
 			'text'       => 'jus de fruit',
 			'vegan'      => 'yes',
 			'vegetarian' => 'yes'
 		},
-		{   'from_palm_oil' => 'maybe',
+		{	'from_palm_oil' => 'maybe',
 			'id'            => 'en:oil-and-fat',
 			'percent'       => '45',
 			'rank'          => 4,
@@ -1670,329 +1665,332 @@ delete $product_ref->{ingredients_percent_analysis};
 is($product_ref->{ingredients_n}, 19);
 
 $expected_product_ref =
- {
-   'ingredients' => [
-     {
-       'id' => 'en:flour',
-       'percent' => '12',
-       'rank' => 1,
-       'text' => 'jauho',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:chocolate',
-       'ingredients' => [
-         {
-           'id' => 'en:cocoa-butter',
-           'percent' => '15',
-           'text' => 'kaakaovoi'
-         },
-         {
-           'id' => 'en:sugar',
-           'percent' => '10',
-           'text' => 'sokeri'
-         },
-         {
-           'id' => 'en:milk-proteins',
-           'text' => 'maitoproteiini'
-         },
-         {
-           'id' => 'en:chicken-egg',
-           'percent' => '1',
-           'text' => 'kananmuna'
-         }
-       ],
-       'rank' => 2,
-       'text' => 'suklaa',
-       'vegan' => 'maybe',
-       'vegetarian' => 'yes'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:emulsifier',
-       'ingredients' => [
-         {
-           'id' => 'en:e463',
-           'text' => 'e463'
-         }
-       ],
-       'rank' => 3,
-       'text' => 'emulgointiaineet'
-     },
-     {
-       'from_palm_oil' => 'maybe',
-       'id' => 'en:e432',
-       'rank' => 4,
-       'text' => 'e432',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'from_palm_oil' => 'maybe',
-       'id' => 'en:e472',
-       'rank' => 5,
-       'text' => 'e472',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:acidity-regulator',
-       'ingredients' => [
-         {
-           'id' => 'en:e322',
-           'text' => 'e322'
-         },
-         {
-           'id' => 'en:e333',
-           'text' => 'e333'
-         }
-       ],
-       'rank' => 6,
-       'text' => "happamuudens\x{e4}\x{e4}t\x{f6}aineet"
-     },
-     {
-       'id' => 'en:e474',
-       'rank' => 7,
-       'text' => 'e474',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'id' => 'en:e475',
-       'rank' => 8,
-       'text' => 'e475',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:acid',
-       'ingredients' => [
-         {
-           'id' => 'en:e330',
-           'text' => 'sitruunahappo'
-         },
-         {
-           'id' => 'en:e338',
-           'text' => 'fosforihappo'
-         }
-       ],
-       'rank' => 9,
-       'text' => 'happo'
-     },
-     {
-       'id' => 'en:salt',
-       'rank' => 10,
-       'text' => 'suola',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:cocoa-butter',
-       'percent' => '15',
-       'text' => 'kaakaovoi',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sugar',
-       'percent' => '10',
-       'text' => 'sokeri',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:milk-proteins',
-       'text' => 'maitoproteiini',
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:chicken-egg',
-       'percent' => '1',
-       'text' => 'kananmuna',
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e463',
-       'text' => 'e463',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e322',
-       'text' => 'e322',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'id' => 'en:e333',
-       'text' => 'e333',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e330',
-       'text' => 'sitruunahappo',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e338',
-       'text' => 'fosforihappo',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     }
-   ],
-   'ingredients_analysis_tags' => [
-     'en:may-contain-palm-oil',
-     'en:non-vegan',
-     'en:maybe-vegetarian'
-   ],
-   'ingredients_hierarchy' => [
-     'en:flour',
-     'en:chocolate',
-     'en:emulsifier',
-     'en:e432',
-     'en:e472',
-     'en:acidity-regulator',
-     'en:e474',
-     'en:e475',
-     'en:acid',
-     'en:salt',
-     'en:cocoa-butter',
-     'en:cocoa',
-     'en:sugar',
-     'en:milk-proteins',
-     'en:protein',
-     'en:animal-protein',
-     'en:chicken-egg',
-     'en:egg',
-     'en:e463',
-     'en:e322',
-     'en:e333',
-     'en:e330',
-     'en:e338'
-   ],
-   'ingredients_n' => 19,
-   'ingredients_n_tags' => [
-     '19',
-     '11-20'
-   ],
-   'ingredients_original_tags' => [
-     'en:flour',
-     'en:chocolate',
-     'en:emulsifier',
-     'en:e432',
-     'en:e472',
-     'en:acidity-regulator',
-     'en:e474',
-     'en:e475',
-     'en:acid',
-     'en:salt',
-     'en:cocoa-butter',
-     'en:sugar',
-     'en:milk-proteins',
-     'en:chicken-egg',
-     'en:e463',
-     'en:e322',
-     'en:e333',
-     'en:e330',
-     'en:e338'
-   ],
-   'ingredients_tags' => [
-     'en:flour',
-     'en:chocolate',
-     'en:emulsifier',
-     'en:e432',
-     'en:e472',
-     'en:acidity-regulator',
-     'en:e474',
-     'en:e475',
-     'en:acid',
-     'en:salt',
-     'en:cocoa-butter',
-     'en:cocoa',
-     'en:sugar',
-     'en:milk-proteins',
-     'en:protein',
-     'en:animal-protein',
-     'en:chicken-egg',
-     'en:egg',
-     'en:e463',
-     'en:e322',
-     'en:e333',
-     'en:e330',
-     'en:e338'
-   ],
-   'ingredients_text' => "jauho (12%), suklaa (kaakaovoi (15%), sokeri [10%], maitoproteiini, kananmuna 1%) - emulgointiaineet : E463, E432 ja E472 - happamuudens\x{e4}\x{e4}t\x{f6}aineet : E322/E333 E474-E475, happo (sitruunahappo, fosforihappo) - suola",
-   'lc' => 'fi',
-   'known_ingredients_n' => 23,
-   'unknown_ingredients_n' => 0
-  };
-
+{
+	'ingredients' => [
+		{
+			'id' => 'en:flour',
+			'percent' => '12',
+			'rank' => 1,
+			'text' => 'jauho',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:chocolate',
+			'ingredients' => [
+				{
+					'id' => 'en:cocoa-butter',
+					'percent' => '15',
+					'text' => 'kaakaovoi'
+				},
+				{
+					'id' => 'en:sugar',
+					'percent' => '10',
+					'text' => 'sokeri'
+				},
+				{
+					'id' => 'en:milk-proteins',
+					'text' => 'maitoproteiini'
+				},
+				{
+					'id' => 'en:chicken-egg',
+					'percent' => '1',
+					'text' => 'kananmuna'
+				}
+			],
+			'rank' => 2,
+			'text' => 'suklaa',
+			'vegan' => 'maybe',
+			'vegetarian' => 'yes'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:emulsifier',
+			'ingredients' => [
+				{
+					'id' => 'en:e463',
+					'text' => 'e463'
+				}
+			],
+			'rank' => 3,
+			'text' => 'emulgointiaineet'
+		},
+		{
+			'from_palm_oil' => 'maybe',
+			'id' => 'en:e432',
+			'rank' => 4,
+			'text' => 'e432',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'from_palm_oil' => 'maybe',
+			'id' => 'en:e472',
+			'rank' => 5,
+			'text' => 'e472',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:acidity-regulator',
+			'ingredients' => [
+				{
+					'id' => 'en:e322',
+					'text' => 'e322'
+				},
+				{
+					'id' => 'en:e333',
+					'text' => 'e333'
+				}
+			],
+			'rank' => 6,
+			'text' => "happamuudens\x{e4}\x{e4}t\x{f6}aineet"
+		},
+		{
+			'id' => 'en:e474',
+			'rank' => 7,
+			'text' => 'e474',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:e475',
+			'rank' => 8,
+			'text' => 'e475',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:acid',
+			'ingredients' => [
+				{
+					'id' => 'en:e330',
+					'text' => 'sitruunahappo'
+				},
+				{
+					'id' => 'en:e338',
+					'text' => 'fosforihappo'
+				}
+			],
+			'rank' => 9,
+			'text' => 'happo'
+		},
+		{
+			'id' => 'en:salt',
+			'rank' => 10,
+			'text' => 'suola',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-butter',
+			'percent' => '15',
+			'text' => 'kaakaovoi',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sugar',
+			'percent' => '10',
+			'text' => 'sokeri',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:milk-proteins',
+			'text' => 'maitoproteiini',
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:chicken-egg',
+			'percent' => '1',
+			'text' => 'kananmuna',
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e463',
+			'text' => 'e463',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e322',
+			'text' => 'e322',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:e333',
+			'text' => 'e333',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e330',
+			'text' => 'sitruunahappo',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e338',
+			'text' => 'fosforihappo',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
+	'ingredients_analysis_tags' => [
+		'en:may-contain-palm-oil',
+		'en:non-vegan',
+		'en:maybe-vegetarian'
+	],
+	'ingredients_hierarchy' => [
+		'en:flour',
+		'en:chocolate',
+		'en:emulsifier',
+		'en:e432',
+		'en:e472',
+		'en:acidity-regulator',
+		'en:e474',
+		'en:e475',
+		'en:acid',
+		'en:salt',
+		'en:cocoa-butter',
+		'en:cocoa',
+		'en:sugar',
+		'en:milk-proteins',
+		'en:protein',
+		'en:animal-protein',
+		'en:chicken-egg',
+		'en:egg',
+		'en:e463',
+		'en:e322',
+		'en:e333',
+		'en:e330',
+		'en:e338'
+	],
+	'ingredients_n' => 19,
+	'ingredients_n_tags' => [
+		'19',
+		'11-20'
+	],
+	'ingredients_original_tags' => [
+		'en:flour',
+		'en:chocolate',
+		'en:emulsifier',
+		'en:e432',
+		'en:e472',
+		'en:acidity-regulator',
+		'en:e474',
+		'en:e475',
+		'en:acid',
+		'en:salt',
+		'en:cocoa-butter',
+		'en:sugar',
+		'en:milk-proteins',
+		'en:chicken-egg',
+		'en:e463',
+		'en:e322',
+		'en:e333',
+		'en:e330',
+		'en:e338'
+	],
+	'ingredients_tags' => [
+		'en:flour',
+		'en:chocolate',
+		'en:emulsifier',
+		'en:e432',
+		'en:e472',
+		'en:acidity-regulator',
+		'en:e474',
+		'en:e475',
+		'en:acid',
+		'en:salt',
+		'en:cocoa-butter',
+		'en:cocoa',
+		'en:sugar',
+		'en:milk-proteins',
+		'en:protein',
+		'en:animal-protein',
+		'en:chicken-egg',
+		'en:egg',
+		'en:e463',
+		'en:e322',
+		'en:e333',
+		'en:e330',
+		'en:e338'
+	],
+	'ingredients_text' => "jauho (12%), suklaa (kaakaovoi (15%), sokeri [10%], maitoproteiini, kananmuna 1%) - emulgointiaineet : E463, E432 ja E472 - happamuudens\x{e4}\x{e4}t\x{f6}aineet : E322/E333 E474-E475, happo (sitruunahappo, fosforihappo) - suola",
+	'lc' => 'fi',
+	'known_ingredients_n' => 23,
+	'unknown_ingredients_n' => 0
+};
 
 delete $product_ref->{nutriments};
 is_deeply($product_ref, $expected_product_ref) or diag explain($product_ref);
 
 
 $product_ref = {
-        lc => "fi",
-        ingredients_text => "hyytelöimisaine (pektiinit)",
+	lc => "fi",
+	ingredients_text => "hyytelöimisaine (pektiinit)",
 };
 
 extract_ingredients_from_text($product_ref);
 
-is_deeply ($product_ref->{ingredients_original_tags}, [
-"en:gelling-agent",
-"en:e440a",
-]) or diag explain $product_ref;
-
-
-$product_ref = {
-        lc => "fi",
-        ingredients_text => "Mansikka 12,3% ; Appelsiini 6.5%, Omena (3,5%)",
-};
-
-extract_ingredients_from_text($product_ref);
-
-
-is_deeply ($product_ref->{ingredients},
-[
-	     {
-	            'id' => 'en:strawberry',
-	            'percent' => '12.3',
-	            'rank' => 1,
-	            'text' => 'Mansikka',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes',
-	          },
-	          {
-	            'id' => 'en:orange',
-	            'percent' => '6.5',
-	            'rank' => 2,
-	            'text' => 'Appelsiini',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes',
-	          },
-	          {
-	            'id' => 'en:apple',
-	            'percent' => '3.5',
-	            'rank' => 3,
-	            'text' => 'Omena',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes',
-	          }
-	        ]
+is_deeply (
+	$product_ref->{ingredients_original_tags},
+	[
+		"en:gelling-agent",
+		"en:e440a",
+	]
 ) or diag explain $product_ref;
 
+
 $product_ref = {
-        lc => "fi",
-        ingredients_text => "Mansikka alkuperä Suomi, Mustaherukka (alkuperä Etelä-Afrikka), Vadelma (alkuperä : Ruotsi), Appelsiini (luomu), kaakao ja kaakaovoi (reilu kauppa)",
+	lc => "fi",
+	ingredients_text => "Mansikka 12,3% ; Appelsiini 6.5%, Omena (3,5%)",
+};
+
+extract_ingredients_from_text($product_ref);
+
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:strawberry',
+			'percent' => '12.3',
+			'rank' => 1,
+			'text' => 'Mansikka',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes',
+		},
+		{
+			'id' => 'en:orange',
+			'percent' => '6.5',
+			'rank' => 2,
+			'text' => 'Appelsiini',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes',
+		},
+		{
+			'id' => 'en:apple',
+			'percent' => '3.5',
+			'rank' => 3,
+			'text' => 'Omena',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes',
+		}
+	]
+) or diag explain $product_ref;
+
+
+$product_ref = {
+	lc => "fi",
+	ingredients_text => "Mansikka alkuperä Suomi, Mustaherukka (alkuperä Etelä-Afrikka), Vadelma (alkuperä : Ruotsi), Appelsiini (luomu), kaakao ja kaakaovoi (reilu kauppa)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -2001,62 +1999,62 @@ delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
 is_deeply ($product_ref->{ingredients},
-	   [
-	        {
-	          'id' => 'en:strawberry',
-	          'origin' => 'en:finland',
-	          'rank' => 1,
-	          'text' => 'Mansikka',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:blackcurrant',
-	          'origin' => 'en:south-africa',
-	          'rank' => 2,
-	          'text' => 'Mustaherukka',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:raspberry',
-	          'origin' => 'en:sweden',
-	          'rank' => 3,
-	          'text' => 'Vadelma',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:orange',
-	          'labels' => 'en:organic',
-	          'rank' => 4,
-	          'text' => 'Appelsiini',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:cocoa',
-	          'labels' => 'en:fair-trade',
-	          'rank' => 5,
-	          'text' => 'kaakao',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	        {
-	          'id' => 'en:cocoa-butter',
-	          'labels' => 'en:fair-trade',
-	          'rank' => 6,
-	          'text' => 'kaakaovoi',
-	          'vegan' => 'yes',
-	          'vegetarian' => 'yes'
-	        },
-	      ],
-
+	[
+		{
+			'id' => 'en:strawberry',
+			'origin' => 'en:finland',
+			'rank' => 1,
+			'text' => 'Mansikka',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:blackcurrant',
+			'origin' => 'en:south-africa',
+			'rank' => 2,
+			'text' => 'Mustaherukka',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:raspberry',
+			'origin' => 'en:sweden',
+			'rank' => 3,
+			'text' => 'Vadelma',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:orange',
+			'labels' => 'en:organic',
+			'rank' => 4,
+			'text' => 'Appelsiini',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa',
+			'labels' => 'en:fair-trade',
+			'rank' => 5,
+			'text' => 'kaakao',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:cocoa-butter',
+			'labels' => 'en:fair-trade',
+			'rank' => 6,
+			'text' => 'kaakaovoi',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+	],
 ) or diag explain $product_ref;
 
+
 $product_ref = {
-        lc => "fi",
-        ingredients_text => "emulgointiaine : auringonkukkalesitiini, aromi)(EU), vehnäjauho 33% (Ranska), sokeri",
+	lc => "fi",
+	ingredients_text => "emulgointiaine : auringonkukkalesitiini, aromi)(EU), vehnäjauho 33% (Ranska), sokeri",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -2064,58 +2062,58 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-[
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:emulsifier',
-       'ingredients' => [
-         {
-           'id' => 'en:sunflower-lecithin',
-           'text' => 'auringonkukkalesitiini'
-         }
-       ],
-       'rank' => 1,
-       'text' => 'emulgointiaine'
-     },
-     {
-       'id' => 'en:flavouring',
-       'origin' => 'en:european-union',
-       'rank' => 2,
-       'text' => 'aromi',
-       'vegan' => 'maybe',
-       'vegetarian' => 'maybe'
-     },
-     {
-       'id' => 'en:wheat-flour',
-       'origin' => 'en:france',
-       'percent' => '33',
-       'rank' => 3,
-       'text' => "vehn\x{e4}jauho",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sugar',
-       'rank' => 4,
-       'text' => 'sokeri',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:sunflower-lecithin',
-       'text' => 'auringonkukkalesitiini',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     }
-
-	        ],
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+		'has_sub_ingredients' => 'yes',
+		'id' => 'en:emulsifier',
+		'ingredients' => [
+			{
+				'id' => 'en:sunflower-lecithin',
+				'text' => 'auringonkukkalesitiini'
+			}
+		],
+		'rank' => 1,
+		'text' => 'emulgointiaine'
+		},
+		{
+			'id' => 'en:flavouring',
+			'origin' => 'en:european-union',
+			'rank' => 2,
+			'text' => 'aromi',
+			'vegan' => 'maybe',
+			'vegetarian' => 'maybe'
+		},
+		{
+			'id' => 'en:wheat-flour',
+			'origin' => 'en:france',
+			'percent' => '33',
+			'rank' => 3,
+			'text' => "vehn\x{e4}jauho",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sugar',
+			'rank' => 4,
+			'text' => 'sokeri',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:sunflower-lecithin',
+			'text' => 'auringonkukkalesitiini',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
 ) or diag explain $product_ref;
 
+
 $product_ref = {
-        lc => "fi",
-        ingredients_text => "appelsiinimehu (säilöntäaineeton), lohi (msc), gluteeniton",
+	lc => "fi",
+	ingredients_text => "appelsiinimehu (säilöntäaineeton), lohi (msc), gluteeniton",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -2127,35 +2125,33 @@ delete $product_ref->{ingredients_percent_analysis};
 is ($product_ref->{labels}, "en:gluten-free") or diag explain $product_ref;
 is_deeply ($product_ref->{labels_tags}, ["en:gluten-free"]) or diag explain $product_ref;
 
-is_deeply ($product_ref->{ingredients},
-
-[
-	     {
-	            'id' => 'en:orange-juice',
-	            'labels' => 'en:no-preservatives',
-	            'rank' => 1,
-	            'text' => 'appelsiinimehu',
-	            'vegan' => 'yes',
-	            'vegetarian' => 'yes'
-	          },
-	          {
-	            'id' => 'en:salmon',
-	            'labels' => 'en:sustainable-seafood-msc',
-	            'rank' => 2,
-	            'text' => 'lohi',
-	            'vegan' => 'no',
-	            'vegetarian' => 'no'
-	          }
-
-        ],
-
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'id' => 'en:orange-juice',
+			'labels' => 'en:no-preservatives',
+			'rank' => 1,
+			'text' => 'appelsiinimehu',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:salmon',
+			'labels' => 'en:sustainable-seafood-msc',
+			'rank' => 2,
+			'text' => 'lohi',
+			'vegan' => 'no',
+			'vegetarian' => 'no'
+		}
+	],
 ) or diag explain $product_ref;
 
 
 # bug #3432 - mm. should not match Myanmar
 $product_ref = {
-        lc => "fi",
-        ingredients_text => "mausteet (mm. kurkuma, inkivääri, paprika, valkosipuli, korianteri, sinapinsiemen)",
+	lc => "fi",
+	ingredients_text => "mausteet (mm. kurkuma, inkivääri, paprika, valkosipuli, korianteri, sinapinsiemen)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -2163,80 +2159,82 @@ extract_ingredients_from_text($product_ref);
 delete_ingredients_percent_values($product_ref->{ingredients});
 delete $product_ref->{ingredients_percent_analysis};
 
-is_deeply ($product_ref->{ingredients},
-[
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:spice',
-       'ingredients' => [
-         {
-           'id' => 'en:e100',
-           'text' => 'muun muassa kurkuma'
-         },
-         {
-           'id' => 'en:ginger',
-           'text' => "inkiv\x{e4}\x{e4}ri"
-         },
-         {
-           'id' => 'en:bell-pepper',
-           'text' => 'paprika'
-         },
-         {
-           'id' => 'en:garlic',
-           'text' => 'valkosipuli'
-         },
-         {
-           'id' => 'en:coriander',
-           'text' => 'korianteri'
-         },
-         {
-           'id' => 'en:mustard-seed',
-           'text' => 'sinapinsiemen'
-         }
-       ],
-       'rank' => 1,
-       'text' => 'mausteet',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:e100',
-       'text' => 'muun muassa kurkuma',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:ginger',
-       'text' => "inkiv\x{e4}\x{e4}ri",
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:bell-pepper',
-       'text' => 'paprika',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:garlic',
-       'text' => 'valkosipuli',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:coriander',
-       'text' => 'korianteri',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => 'en:mustard-seed',
-       'text' => 'sinapinsiemen',
-       'vegan' => 'yes',
-       'vegetarian' => 'yes'
-     }
-   ],
+is_deeply (
+	$product_ref->{ingredients},
+	[
+		{
+			'has_sub_ingredients' => 'yes',
+			'id' => 'en:spice',
+			'ingredients' => [
+				{
+					'id' => 'en:e100',
+					'text' => 'muun muassa kurkuma'
+				},
+				{
+					'id' => 'en:ginger',
+					'text' => "inkiv\x{e4}\x{e4}ri"
+				},
+				{
+					'id' => 'en:bell-pepper',
+					'text' => 'paprika'
+				},
+				{
+					'id' => 'en:garlic',
+					'text' => 'valkosipuli'
+				},
+				{
+					'id' => 'en:coriander',
+					'text' => 'korianteri'
+				},
+				{
+					'id' => 'en:mustard-seed',
+					'text' => 'sinapinsiemen'
+				}
+			],
+			'rank' => 1,
+			'text' => 'mausteet',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:e100',
+			'text' => 'muun muassa kurkuma',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:ginger',
+			'text' => "inkiv\x{e4}\x{e4}ri",
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:bell-pepper',
+			'text' => 'paprika',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:garlic',
+			'text' => 'valkosipuli',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:coriander',
+			'text' => 'korianteri',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => 'en:mustard-seed',
+			'text' => 'sinapinsiemen',
+			'vegan' => 'yes',
+			'vegetarian' => 'yes'
+		}
+	],
 ) or diag explain $product_ref;
+
 
 # FI - organic label as part of the ingredient
 
@@ -2255,21 +2253,22 @@ is_deeply ($product_ref->{labels_tags}, undef) or diag explain $product_ref->{la
 
 is_deeply(
 	$product_ref->{ingredients},
-	[   {   'id'         => 'en:green-tea',
+	[
+		{	'id'         => 'en:green-tea',
 			'labels'     => 'en:organic',
 			'rank'       => 1,
 			'text'       => "vihre\x{e4} tee",
 			'vegan'      => 'yes',
 			'vegetarian' => 'yes'
 		},
-		{   'id'         => 'en:milk',
+		{	'id'         => 'en:milk',
 			'labels'     => 'en:organic',
 			'rank'       => 2,
 			'text'       => 'maito',
 			'vegan'      => 'no',
 			'vegetarian' => 'yes'
 		},
-		{   'id'         => 'en:malted-barley',
+		{	'id'         => 'en:malted-barley',
 			'labels'     => 'en:organic',
 			'rank'       => 3,
 			'text'       => 'ohramallas',
@@ -2281,8 +2280,8 @@ is_deeply(
 
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "oeufs (d'élevage au sol, Suisse, France)",
+	lc => "fr",
+	ingredients_text => "oeufs (d'élevage au sol, Suisse, France)",
 };
 
 extract_ingredients_from_text($product_ref);
@@ -2294,45 +2293,45 @@ delete $product_ref->{ingredients_percent_analysis};
 is ($product_ref->{labels}, undef) or diag explain $product_ref->{labels};
 is_deeply ($product_ref->{labels_tags}, undef) or diag explain $product_ref->{labels_tags};
 
-is_deeply ($product_ref->{ingredients},
+is_deeply (
+	$product_ref->{ingredients},
 
-[
-     {
-       'has_sub_ingredients' => 'yes',
-       'id' => 'en:egg',
-       'ingredients' => [
-         {
-           'id' => "fr:d'\x{e9}levage au sol",
-           'text' => "d'\x{e9}levage au sol"
-         },
-         {
-           'id' => 'fr:Suisse',
-           'text' => 'Suisse'
-         },
-         {
-           'id' => 'fr:France',
-           'text' => 'France'
-         }
-       ],
-       'rank' => 1,
-       'text' => 'oeufs',
-       'vegan' => 'no',
-       'vegetarian' => 'yes'
-     },
-     {
-       'id' => "fr:d'\x{e9}levage au sol",
-       'text' => "d'\x{e9}levage au sol"
-     },
-     {
-       'id' => 'fr:Suisse',
-       'text' => 'Suisse'
-     },
-     {
-       'id' => 'fr:France',
-       'text' => 'France'
-     }
-   ],
-
+	[
+		{
+		'has_sub_ingredients' => 'yes',
+		'id' => 'en:egg',
+		'ingredients' => [
+			{
+				'id' => "fr:d'\x{e9}levage au sol",
+				'text' => "d'\x{e9}levage au sol"
+			},
+			{
+				'id' => 'fr:Suisse',
+				'text' => 'Suisse'
+			},
+			{
+				'id' => 'fr:France',
+				'text' => 'France'
+			}
+		],
+			'rank' => 1,
+			'text' => 'oeufs',
+			'vegan' => 'no',
+			'vegetarian' => 'yes'
+		},
+		{
+			'id' => "fr:d'\x{e9}levage au sol",
+			'text' => "d'\x{e9}levage au sol"
+		},
+		{
+			'id' => 'fr:Suisse',
+			'text' => 'Suisse'
+		},
+		{
+			'id' => 'fr:France',
+			'text' => 'France'
+		}
+	],
 
 ) or diag explain $product_ref;
 
@@ -2340,8 +2339,8 @@ is_deeply ($product_ref->{ingredients},
 # Do not mistake single letters for labels, bug #3300
 
 $product_ref = {
-        lc => "fr",
-        ingredients_text => "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,0,1,2,3,4,5,6,7,8,9,10,100,1000,vt,leaf,something(bio),somethingelse(u)",
+	lc => "fr",
+	ingredients_text => "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,0,1,2,3,4,5,6,7,8,9,10,100,1000,vt,leaf,something(bio),somethingelse(u)",
 };
 
 extract_ingredients_from_text($product_ref);

--- a/t/ingredients_clean.t
+++ b/t/ingredients_clean.t
@@ -1,5 +1,7 @@
 #!/usr/bin/perl -w
 
+# Tests of ImportConvert::clean_fields()
+
 use strict;
 use warnings;
 
@@ -62,52 +64,52 @@ crème fraîche
 	# # SCANDINAVIAN LANGUAGES #
 	############################
 	["da",
-	 "ingredienser: 56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt.",
-	 "56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt."
+		"ingredienser: 56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt.",
+		"56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt."
 	],
 	["da",
-	 "56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt.",
-	 "56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt."
+		"56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt.",
+		"56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt."
 	],
 	["da",
-	 "INGREDIENSER : 56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt. NÆRINGSINDHOLD pr. 100 g; Energi 1204 kJ /291 kcal Fedt 24g heraf mættede fedtsyrer 2,89g Kulhydrat 7,3g heraf sukkerarter 0,9g",
-	 "56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt."
+		"INGREDIENSER : 56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt. NÆRINGSINDHOLD pr. 100 g; Energi 1204 kJ /291 kcal Fedt 24g heraf mættede fedtsyrer 2,89g Kulhydrat 7,3g heraf sukkerarter 0,9g",
+		"56 % kogte kikærter (kikærter, vand), solsikkeolie, vand, 9 % sesampuré, citronsaft, sukker, salt."
 	],
 	["is",
-	 "Hveiti, mjólk, egg, jurtafita, maltextrín (Úr hveiti), sykur, E450a, E500, bragðefni. Næringargildi í 100g af þurrefni: Orka 527kJ Fita 3,6g Þar af mettuð 2,7g Kolvetni 19,1g þar af sykurtegundii 3,1g",
-	 "Hveiti, mjólk, egg, jurtafita, maltextrín (Úr hveiti), sykur, E450a, E500, bragðefni."
+		"Hveiti, mjólk, egg, jurtafita, maltextrín (Úr hveiti), sykur, E450a, E500, bragðefni. Næringargildi í 100g af þurrefni: Orka 527kJ Fita 3,6g Þar af mettuð 2,7g Kolvetni 19,1g þar af sykurtegundii 3,1g",
+		"Hveiti, mjólk, egg, jurtafita, maltextrín (Úr hveiti), sykur, E450a, E500, bragðefni."
 	],
 	["is",
-	 "Innihald: Sykur, glúkósi, fondant, bragðefni, mjólkurduft, kakósmjör, kakómassi, sojalesitín (£322), litarefni (E160a). Gæti innihaldið snefil af heslihnetum, möndlum og kókosmjóli.",
-	 "Sykur, glúkósi, fondant, bragðefni, mjólkurduft, kakósmjör, kakómassi, sojalesitín (£322), litarefni (E160a). Gæti innihaldið snefil af heslihnetum, möndlum og kókosmjóli."
+		"Innihald: Sykur, glúkósi, fondant, bragðefni, mjólkurduft, kakósmjör, kakómassi, sojalesitín (£322), litarefni (E160a). Gæti innihaldið snefil af heslihnetum, möndlum og kókosmjóli.",
+		"Sykur, glúkósi, fondant, bragðefni, mjólkurduft, kakósmjör, kakómassi, sojalesitín (£322), litarefni (E160a). Gæti innihaldið snefil af heslihnetum, möndlum og kókosmjóli."
 	],
 	["is",
-	 "INNIHALDSEFNI : Vatn, möndlu (5%), agave-síróp*, sjávarsalt. *Lifrænt. Eftir opnum skal geyma drykkinn í kæli og neyta innan 3-4 daga.",
-	 "Vatn, möndlu (5%), agave-síróp*, sjávarsalt. *Lifrænt."
+		"INNIHALDSEFNI : Vatn, möndlu (5%), agave-síróp*, sjávarsalt. *Lifrænt. Eftir opnum skal geyma drykkinn í kæli og neyta innan 3-4 daga.",
+		"Vatn, möndlu (5%), agave-síróp*, sjávarsalt. *Lifrænt."
 	],
 	["nb",
-	 "pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid).",
-	 "pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid)."
+		"pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid).",
+		"pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid)."
 	],
 	["nb",
-	 "Ingredienser: pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid).",
-	 "Pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid)."
+		"Ingredienser: pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid).",
+		"Pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid)."
 	],
 	["nb",
-	 "INGREDIENSER : pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid). NÆRINGSINNHOLD: 100 g vare gir ca.: energi 1458 kJ (351 kcal), fett 27 g, -hvorav mettede fettsyrer 17 g, karbohydrat 0 g, -hvorav sukkerarter 0 g, protein 27 g, salt 1,2g.",
-	 "Pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid)."
+		"INGREDIENSER : pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid). NÆRINGSINNHOLD: 100 g vare gir ca.: energi 1458 kJ (351 kcal), fett 27 g, -hvorav mettede fettsyrer 17 g, karbohydrat 0 g, -hvorav sukkerarter 0 g, protein 27 g, salt 1,2g.",
+		"Pasteurisert melk, syrekultur, salt, mikrøobiell løpe og surhetsregularnde middel (kalsiumklorid)."
 	],
 	["sv",
-	 "Pastöriserad mjölk, salt, syrningskultur, ystenzym.",
-	 "Pastöriserad mjölk, salt, syrningskultur, ystenzym."
+		"Pastöriserad mjölk, salt, syrningskultur, ystenzym.",
+		"Pastöriserad mjölk, salt, syrningskultur, ystenzym."
 	],
 	["sv",
-	 "INGREDIENSER : Pastöriserad mjölk, salt, syrningskultur, ystenzym. Näringsvärde per 100 g ost Energi 1763 kJ/426 kcal Fett 38g varav mättat fett 24g Kolhydrater 0g varav sockerarter 0g Protein 20g Salt 1,8g",
-	 "Pastöriserad mjölk, salt, syrningskultur, ystenzym."
+		"INGREDIENSER : Pastöriserad mjölk, salt, syrningskultur, ystenzym. Näringsvärde per 100 g ost Energi 1763 kJ/426 kcal Fett 38g varav mättat fett 24g Kolhydrater 0g varav sockerarter 0g Protein 20g Salt 1,8g",
+		"Pastöriserad mjölk, salt, syrningskultur, ystenzym."
 	],
 	["sv",
-	 "Ingredienser: Pastöriserad mjölk, salt, syrningskultur, ystenzym.",
-	 "Pastöriserad mjölk, salt, syrningskultur, ystenzym."
+		"Ingredienser: Pastöriserad mjölk, salt, syrningskultur, ystenzym.",
+		"Pastöriserad mjölk, salt, syrningskultur, ystenzym."
 	],
 
 	############################
@@ -162,11 +164,11 @@ Saattaa sisältää pieniä määrlä soijaa ja seesaminslemeniä"],
 	"Caories per gram: at 9 Carbekydrate 4 . Protein 4 INGREDIENTS: MECHANICALLY SEPARATED CHIGKEN, PORK, CORN SYRUP, WATER, 2% OR LESS OF: MODIFIED FOOD STARCH NATURAL FLAVORINGS, SALT, POTASSIUM LACTATE, BEEF, SODIUM PHOSPHATES, SODIUM DIACETATE, PAPRIKA, SODIUMERYTHORBATE, SODIUM NITRITE, EXTRACTIVES OF PAPRIKA. DIST& SOLD EXCLUSIVELY BY: ALD ALDI Tuice as Nice GLUTEN FREE BATAVIA, IL 610 GUARANTEE NET WT 48 0Z (3 LB) 1. 0. TRANS FATNG Item eplaced money refunded PLASTIC WRAP
 Edit ingredients (en)",
 	"MECHANICALLY SEPARATED CHIGKEN, PORK, CORN SYRUP, WATER, 2% OR LESS OF: MODIFIED FOOD STARCH NATURAL FLAVORINGS, SALT, POTASSIUM LACTATE, BEEF, SODIUM PHOSPHATES, SODIUM DIACETATE, PAPRIKA, SODIUMERYTHORBATE, SODIUM NITRITE, EXTRACTIVES OF PAPRIKA."],
-	
+
 	["en",
 	"INGREDIENTS Almonds (76%), rice malt, dried blueberries (6%), sesame seeds, unrefined cane sugar natural flavours, sea salt. NUTRITIONAL INFORMATION Serving: 1, Serving size: 20g",
 	"Almonds (76%), rice malt, dried blueberries (6%), sesame seeds, unrefined cane sugar natural flavours, sea salt."],
-	
+
 	["en",
 	"Savoury crackers with sesame seeds. Ingredients: Wheat flour, palm oil, sesame seeds 4.9 %, glucose-fructose syrup, sugar, poppy seeds 2.3 %, raising agents (ammonium carbonates, calcium phosphates, sodium carbonates), salt, malted barley flour, dried yeast, wheat gluten, flavouring (contains celery). May contain egg, milk, nuts. Nutrition Information 1 Portion %*/1 Portion (25 g) 100 g (25 g) 2023 kJ",
 	"Wheat flour, palm oil, sesame seeds 4.9 %, glucose-fructose syrup, sugar, poppy seeds 2.3 %, raising agents (ammonium carbonates, calcium phosphates, sodium carbonates), salt, malted barley flour, dried yeast, wheat gluten, flavouring (contains celery). May contain egg, milk, nuts."],
@@ -175,7 +177,7 @@ Edit ingredients (en)",
 	["pl",
 	"jogurt*, cukier, owoce 7%, (maliny 2,3%, ananasy 1,8%, sok ananasowy z koncentratu 1,6%, sok malinowy z koncentratu 1,3%), musli 2,5% (otręby pszenne, płatki owsiane, pszenica, siemię lniane, ziarno słonecznika,orzechy laskowe), koncentrat soku z buraków czerwonych - aromat. *zawiera składniki pochodzące z mleka oraz żywe kultury bakterii.",
 	"jogurt*, cukier, owoce 7%, (maliny 2,3%, ananasy 1,8%, sok ananasowy z koncentratu 1,6%, sok malinowy z koncentratu 1,3%), musli 2,5% (otręby pszenne, płatki owsiane, pszenica, siemię lniane, ziarno słonecznika,orzechy laskowe), koncentrat soku z buraków czerwonych - aromat. *zawiera składniki pochodzące z mleka oraz żywe kultury bakterii."],
-	
+
 	["fr","INGREDIENTS : badiane* (Illicium verum) 30%, anis vert* (Pimpinella anisum) 30%, fenouil* (Foeniculum vulgare) 30%, racine de réglisse* (Glycyrrhiza glabra). *Produits issus de l'agriculture biologique. INGREDIENTS: star anise* 30%, green anise* 30%, fennel* 30%, liquorice*. *Organically grown products. INGREDIËNTEN: steranijs* 30%, groene anijs* 30%, venkel* 30%, zoethout*. *Biologisch geteelde producten.",
 "Badiane* (Illicium verum) 30%, anis vert* (Pimpinella anisum) 30%, fenouil* (Foeniculum vulgare) 30%, racine de réglisse* (Glycyrrhiza glabra). *Produits issus de l'agriculture biologique. INGREDIENTS: star anise* 30%, green anise* 30%, fennel* 30%, liquorice*. *Organically grown products. INGREDIËNTEN: steranijs* 30%, groene anijs* 30%, venkel* 30%, zoethout*. *Biologisch geteelde producten."],
 
@@ -229,7 +231,7 @@ foreach my $test_ref (@tests) {
 
 	my $ingredients_lc = "ingredients_text_" . $test_ref->[0];
 
-	my $product_ref = { 
+	my $product_ref = {
 		lc => $test_ref->[0],
 		$ingredients_lc => $test_ref->[1],
 	};

--- a/t/ingredients_nesting.t
+++ b/t/ingredients_nesting.t
@@ -1,5 +1,7 @@
 #!/usr/bin/perl -w
 
+# Tests of parsing nested ingredients, such as "ingredient (component 1, component 2)", etc.
+
 use strict;
 use warnings;
 
@@ -16,344 +18,344 @@ use ProductOpener::Ingredients qw/:all/;
 # dummy product for testing
 
 my @tests = (
-	[ { lc => "en", ingredients_text => "sugar and water"}, 
-[
-  {
-    'id' => 'en:sugar',
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:water',
-    'text' => 'water'
-  }
-]
-	],
 
-	[ { lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"}, 
-[
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa',
-        'text' => 'cocoa'
-      },
-      {
-        'id' => 'en:sugar',
-        'text' => 'sugar'
-      }
-    ],
-    'text' => 'chocolate'
-  },
-  {
-    'id' => 'en:milk',
-    'text' => 'milk'
-  }
-]
-
-	],
-	[ { lc => "en", ingredients_text => "dough (wheat, water, raising agents: E501, salt), chocolate (cocoa (cocoa butter, cocoa paste), sugar), milk"}, 
-
-[
-  {
-    'id' => 'en:dough',
-    'ingredients' => [
-      {
-        'id' => 'en:wheat',
-        'text' => 'wheat'
-      },
-      {
-        'id' => 'en:water',
-        'text' => 'water'
-      },
-      {
-        'id' => 'en:raising-agent',
-        'ingredients' => [
-          {
-            'id' => 'en:e501',
-            'text' => 'e501'
-          }
-        ],
-        'text' => 'raising agents'
-      },
-      {
-        'id' => 'en:salt',
-        'text' => 'salt'
-      }
-    ],
-    'text' => 'dough'
-  },
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa',
-        'ingredients' => [
-          {
-            'id' => 'en:cocoa-butter',
-            'text' => 'cocoa butter'
-          },
-          {
-            'id' => 'en:cocoa-paste',
-            'text' => 'cocoa paste'
-          }
-        ],
-        'text' => 'cocoa'
-      },
-      {
-        'id' => 'en:sugar',
-        'text' => 'sugar'
-      }
-    ],
-    'text' => 'chocolate'
-  },
-  {
-    'id' => 'en:milk',
-    'text' => 'milk'
-  }
-]
+	[ { lc => "en", ingredients_text => "sugar and water"},
+		[
+			{
+				'id' => 'en:sugar',
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:water',
+				'text' => 'water'
+			}
+		]
 	],
 
 
-	[ { lc => "es", ingredients_text => "sal y acidulante (ácido cítrico)"}, 
-[
-  {
-    'id' => 'en:salt',
-    'text' => 'sal'
-  },
-  {
-    'id' => 'en:acid',
-    'ingredients' => [
-      {
-        'id' => 'en:e330',
-        'text' => "\x{e1}cido c\x{ed}trico"
-      }
-    ],
-    'text' => 'acidulante'
-  }
-
-]
+	[ { lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"},
+		[
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa',
+						'text' => 'cocoa'
+					},
+					{
+						'id' => 'en:sugar',
+						'text' => 'sugar'
+					}
+				],
+				'text' => 'chocolate'
+			},
+			{
+				'id' => 'en:milk',
+				'text' => 'milk'
+			}
+		]
 	],
+
+
+	[ { lc => "en", ingredients_text => "dough (wheat, water, raising agents: E501, salt), chocolate (cocoa (cocoa butter, cocoa paste), sugar), milk"},
+		[
+			{
+				'id' => 'en:dough',
+				'ingredients' => [
+					{
+						'id' => 'en:wheat',
+						'text' => 'wheat'
+					},
+					{
+						'id' => 'en:water',
+						'text' => 'water'
+					},
+					{
+						'id' => 'en:raising-agent',
+						'ingredients' => [
+							{
+								'id' => 'en:e501',
+								'text' => 'e501'
+							}
+						],
+						'text' => 'raising agents'
+					},
+					{
+						'id' => 'en:salt',
+						'text' => 'salt'
+					}
+				],
+				'text' => 'dough'
+			},
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa',
+						'ingredients' => [
+							{
+								'id' => 'en:cocoa-butter',
+								'text' => 'cocoa butter'
+							},
+							{
+								'id' => 'en:cocoa-paste',
+								'text' => 'cocoa paste'
+							}
+						],
+						'text' => 'cocoa'
+					},
+					{
+						'id' => 'en:sugar',
+						'text' => 'sugar'
+					}
+				],
+				'text' => 'chocolate'
+			},
+			{
+				'id' => 'en:milk',
+				'text' => 'milk'
+			}
+		]
+	],
+
+
+	[ { lc => "es", ingredients_text => "sal y acidulante (ácido cítrico)"},
+		[
+			{
+				'id' => 'en:salt',
+				'text' => 'sal'
+			},
+			{
+				'id' => 'en:acid',
+				'ingredients' => [
+					{
+						'id' => 'en:e330',
+						'text' => "\x{e1}cido c\x{ed}trico"
+					}
+				],
+				'text' => 'acidulante'
+			}
+		]
+	],
+
 
 	[ { lc => "fr", ingredients_text => "Teneur en légumes : 74 % : tomate ( Espagne) eau"},
-[
-  {
-    'id' => "fr:Teneur en l\x{e9}gumes",
-    'percent' => '74',
-    'text' => "Teneur en l\x{e9}gumes"
-  },
-  {
-    'id' => 'en:tomato',
-    'origin' => 'en:spain',
-    'text' => 'tomate'
-  },
-  {
-    'id' => 'en:water',
-    'text' => 'eau'
-  }
-]
-
+		[
+			{
+				'id' => "fr:Teneur en l\x{e9}gumes",
+				'percent' => '74',
+				'text' => "Teneur en l\x{e9}gumes"
+			},
+			{
+				'id' => 'en:tomato',
+				'origin' => 'en:spain',
+				'text' => 'tomate'
+			},
+			{
+				'id' => 'en:water',
+				'text' => 'eau'
+			}
+		]
 	],
+
 
 	[ { lc => "fr", ingredients_text => "Teneur en légumes : 74 % : tomate (60 %, Espagne) eau, Sel (France, Italie)"},
-
-
-[
-  {
-    'id' => "fr:Teneur en l\x{e9}gumes",
-    'percent' => '74',
-    'text' => "Teneur en l\x{e9}gumes"
-  },
-  {
-    'id' => 'en:tomato',
-    'origin' => 'en:spain',
-    'percent' => '60',
-    'text' => 'tomate'
-  },
-  {
-    'id' => 'en:water',
-    'text' => 'eau'
-  },
-  {
-    'id' => 'en:salt',
-    'origin' => 'en:france,en:italy',
-    'text' => 'Sel'
-  }
-]
-
+		[
+			{
+				'id' => "fr:Teneur en l\x{e9}gumes",
+				'percent' => '74',
+				'text' => "Teneur en l\x{e9}gumes"
+			},
+			{
+				'id' => 'en:tomato',
+				'origin' => 'en:spain',
+				'percent' => '60',
+				'text' => 'tomate'
+			},
+			{
+				'id' => 'en:water',
+				'text' => 'eau'
+			},
+			{
+				'id' => 'en:salt',
+				'origin' => 'en:france,en:italy',
+				'text' => 'Sel'
+			}
+		]
 	],
 
-	[ { lc => "fr", ingredients_text => "Céréales 63,7% (BLE complet 50,5%*, semoule de maïs*), sucre*, sirop de BLE*, cacao maigre en poudre 3,9%*, cacao en poudre 1,7%*, sel, arôme naturel. *Ingrédients issus de l'agriculture biologique."},
-[
-  {
-    'id' => 'en:cereal',
-    'ingredients' => [
-      {
-        'id' => 'en:whole-wheat',
-        'labels' => 'en:organic',
-        'percent' => '50.5',
-        'text' => 'BLE complet'
-      },
-      {
-        'id' => 'en:cornmeal',
-        'labels' => 'en:organic',
-        'text' => "semoule de ma\x{ef}s"
-      }
-    ],
-    'percent' => '63.7',
-    'text' => "C\x{e9}r\x{e9}ales"
-  },
-  {
-    'id' => 'en:sugar',
-    'labels' => 'en:organic',
-    'text' => 'sucre'
-  },
-  {
-    'id' => 'en:wheat-syrup',
-    'labels' => 'en:organic',
-    'text' => 'sirop de BLE'
-  },
-  {
-    'id' => 'en:fat-reduced-cocoa-powder',
-    'labels' => 'en:organic',
-    'percent' => '3.9',
-    'text' => 'cacao maigre en poudre'
-  },
-  {
-    'id' => 'en:cocoa-powder',
-    'labels' => 'en:organic',
-    'percent' => '1.7',
-    'text' => 'cacao en poudre'
-  },
-  {
-    'id' => 'en:salt',
-    'text' => 'sel'
-  },
-  {
-    'id' => 'en:natural-flavouring',
-    'text' => "ar\x{f4}me naturel"
-  }
-]
 
-],
+	[ { lc => "fr", ingredients_text => "Céréales 63,7% (BLE complet 50,5%*, semoule de maïs*), sucre*, sirop de BLE*, cacao maigre en poudre 3,9%*, cacao en poudre 1,7%*, sel, arôme naturel. *Ingrédients issus de l'agriculture biologique."},
+		[
+			{
+				'id' => 'en:cereal',
+				'ingredients' => [
+					{
+						'id' => 'en:whole-wheat',
+						'labels' => 'en:organic',
+						'percent' => '50.5',
+						'text' => 'BLE complet'
+					},
+					{
+						'id' => 'en:cornmeal',
+						'labels' => 'en:organic',
+						'text' => "semoule de ma\x{ef}s"
+					}
+				],
+				'percent' => '63.7',
+				'text' => "C\x{e9}r\x{e9}ales"
+			},
+			{
+				'id' => 'en:sugar',
+				'labels' => 'en:organic',
+				'text' => 'sucre'
+			},
+			{
+				'id' => 'en:wheat-syrup',
+				'labels' => 'en:organic',
+				'text' => 'sirop de BLE'
+			},
+			{
+				'id' => 'en:fat-reduced-cocoa-powder',
+				'labels' => 'en:organic',
+				'percent' => '3.9',
+				'text' => 'cacao maigre en poudre'
+			},
+			{
+				'id' => 'en:cocoa-powder',
+				'labels' => 'en:organic',
+				'percent' => '1.7',
+				'text' => 'cacao en poudre'
+			},
+			{
+				'id' => 'en:salt',
+				'text' => 'sel'
+			},
+			{
+				'id' => 'en:natural-flavouring',
+				'text' => "ar\x{f4}me naturel"
+			}
+		]
+	],
+
 
 	[ { lc => "es", ingredients_text => "Hortalizas frescas (91 %) (tomate, pimiento. pepino y ajo), aceite de oliva virgen extra (3 %), vinagre de vino y sal."},
+		[
+			{
+				'id' => 'en:vegetable',
+				'ingredients' => [
+					{
+						'id' => 'en:tomato',
+						'text' => 'tomate'
+					},
+					{
+						'id' => 'en:bell-pepper',
+						'text' => 'pimiento'
+					},
+					{
+						'id' => 'en:cucumber',
+						'text' => 'pepino'
+					},
+					{
+						'id' => 'en:garlic',
+						'text' => 'ajo'
+					}
+				],
+				'percent' => '91',
+				'text' => 'Hortalizas',
+				'processing' => 'en:fresh'
+			},
+			{
+				'id' => 'en:extra-virgin-olive-oil',
+				'percent' => '3',
+				'text' => 'aceite de oliva virgen extra'
+			},
+			{
+				'id' => 'en:wine-vinegar',
+				'text' => 'vinagre de vino'
+			},
+			{
+				'id' => 'en:salt',
+				'text' => 'sal'
+			}
+		]
+	],
 
-[
-  {
-    'id' => 'en:vegetable',
-    'ingredients' => [
-      {
-        'id' => 'en:tomato',
-        'text' => 'tomate'
-      },
-      {
-        'id' => 'en:bell-pepper',
-        'text' => 'pimiento'
-      },
-      {
-        'id' => 'en:cucumber',
-        'text' => 'pepino'
-      },
-      {
-        'id' => 'en:garlic',
-        'text' => 'ajo'
-      }
-    ],
-    'percent' => '91',
-    'text' => 'Hortalizas',
-    'processing' => 'en:fresh'
-  },
-  {
-    'id' => 'en:extra-virgin-olive-oil',
-    'percent' => '3',
-    'text' => 'aceite de oliva virgen extra'
-  },
-  {
-    'id' => 'en:wine-vinegar',
-    'text' => 'vinagre de vino'
-  },
-  {
-    'id' => 'en:salt',
-    'text' => 'sal'
-  }
-]
-
-
-],
 
 	[ { lc => "fr", ingredients_text => "Tomates bio coupées en tranches cuites"},
-[
-  {
-    'id' => 'en:tomato',
-    'labels' => 'en:organic',
-    'processing' => 'en:cooked, en:sliced, en:cut',
-    'text' => 'Tomates'
-  }
-]
-],
+		[
+			{
+				'id' => 'en:tomato',
+				'labels' => 'en:organic',
+				'processing' => 'en:cooked, en:sliced, en:cut',
+				'text' => 'Tomates'
+			}
+		]
+	],
+
 
 	[ { lc => "fr", ingredients_text => "minéraux (carbonate de calcium, carbonate de magnésium, fer élémentaire)"},
-[
-  {
-    'id' => 'en:minerals',
-    'text' => 'minéraux',
-    'ingredients' => [
-      {
-        'id' => 'en:e170i',
-        'text' => 'carbonate de calcium'
-      },
-      {
-        'id' => 'en:e504i',
-        'text' => 'carbonate de magnésium'
-      },
-      {
-        'id' => 'en:elemental-iron',
-        'text' => 'fer élémentaire'
-      }
-    ],
-  },
-]
-],
+		[
+			{
+				'id' => 'en:minerals',
+				'text' => 'minéraux',
+				'ingredients' => [
+					{
+						'id' => 'en:e170i',
+						'text' => 'carbonate de calcium'
+					},
+					{
+						'id' => 'en:e504i',
+						'text' => 'carbonate de magnésium'
+					},
+					{
+						'id' => 'en:elemental-iron',
+						'text' => 'fer élémentaire'
+					}
+				],
+			},
+		]
+	],
+
 
 	[ { lc => "fr", ingredients_text => "minéraux (carbonate de magnésium, fer élémentaire)"},
-[
-  {
-    'id' => 'en:minerals',
-    'text' => 'minéraux',
-    'ingredients' => [
-      {
-        'id' => 'en:e504i',
-        'text' => 'carbonate de magnésium'
-      },
-      {
-        'id' => 'en:elemental-iron',
-        'text' => 'fer élémentaire'
-      }
-    ],
-  },
-]
-],
+		[
+			{
+				'id' => 'en:minerals',
+				'text' => 'minéraux',
+				'ingredients' => [
+					{
+						'id' => 'en:e504i',
+						'text' => 'carbonate de magnésium'
+					},
+					{
+						'id' => 'en:elemental-iron',
+						'text' => 'fer élémentaire'
+					}
+				],
+			},
+		]
+	],
 
 
 	[ { lc => "fr", ingredients_text => "MINERAUX (CARBONATE DE MAGNESIUM, FER ELEMENTAIRE)"},
-[
-  {
-    'id' => 'en:minerals',
-    'text' => 'MINERAUX',
-    'ingredients' => [
-      {
-        'id' => 'en:e504i',
-        'text' => 'CARBONATE DE MAGNESIUM'
-      },
-      {
-        'id' => 'en:elemental-iron',
-        'text' => 'fer élémentaire'
-      }
-    ],
-  },
-]
-],
+		[
+			{
+				'id' => 'en:minerals',
+				'text' => 'MINERAUX',
+				'ingredients' => [
+					{
+						'id' => 'en:e504i',
+						'text' => 'CARBONATE DE MAGNESIUM'
+					},
+					{
+						'id' => 'en:elemental-iron',
+						'text' => 'fer élémentaire'
+					}
+				],
+			},
+		]
+	],
 
 
 );

--- a/t/ingredients_nutriscore.t
+++ b/t/ingredients_nutriscore.t
@@ -46,13 +46,15 @@ my @tests = (
 
 foreach my $test_ref (@tests) {
 
-        my $product_ref = $test_ref->[0];
-        my $expected_fruits = $test_ref->[1];
+	my $product_ref = $test_ref->[0];
+	my $expected_fruits = $test_ref->[1];
 
-        extract_ingredients_from_text($product_ref);
+	extract_ingredients_from_text($product_ref);
 
-        is ((defined $product_ref->{nutriments} ? $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate-from-ingredients_100g"} : undef),
-                $expected_fruits) or diag explain $product_ref->{ingredients};
+	is (
+		(defined $product_ref->{nutriments} ? $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate-from-ingredients_100g"} : undef),
+		$expected_fruits
+	) or diag explain $product_ref->{ingredients};
 }
 
 done_testing();

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -1,5 +1,7 @@
 #!/usr/bin/perl -w
 
+# Tests of Ingredients::preparse_ingredients_text()
+
 use strict;
 use warnings;
 
@@ -95,32 +97,32 @@ my @lists =(
 	# SCANDINAVIAN LANGUAGES  #
 	###########################
 	[ "da",
-	  "bl. a. inkl. mod. past. emulgator E322 E103, E140, E250 og E100",
-	  "blandt andet inklusive modificeret pasteuriserede emulgator E322, E103, E140, E250, E100"
+		"bl. a. inkl. mod. past. emulgator E322 E103, E140, E250 og E100",
+		"blandt andet inklusive modificeret pasteuriserede emulgator E322, E103, E140, E250, E100"
 	],
 	[ "nb",
-	  "bl. a. inkl. E322 E103, E140, E250 og E100",
-	  "blant annet inklusive E322, E103, E140, E250, E100"
+		"bl. a. inkl. E322 E103, E140, E250 og E100",
+		"blant annet inklusive E322, E103, E140, E250, E100"
 	],
 	[ "sv",
-	  "bl. a. förtjockn.medel inkl. emulgeringsmedel E322 E103, E140, E250 och E100",
-	  "bland annat förtjockningsmedel inklusive emulgeringsmedel E322, E103, E140, E250, E100"
+		"bl. a. förtjockn.medel inkl. emulgeringsmedel E322 E103, E140, E250 och E100",
+		"bland annat förtjockningsmedel inklusive emulgeringsmedel E322, E103, E140, E250, E100"
 	],
 	[ "da",
-	  "Vitaminer A, B og C. Vitaminer (B2, E, D), Hvede**. Indeholder mælk. Kan indeholde spor af soja, mælk, mandler og sesam. ** = Økologisk",
-	  "Vitaminer, Vitamin A, Vitamin B, Vitamin C. Vitaminer, Vitamin B2, Vitamin E, Vitamin D, Hvede Økologisk. Stoffer, eller produkter, som forårsager allergi eller overfølsomhed : mælk. Spor : soja, Spor : mælk, Spor : mandler, Spor : sesam."
+		"Vitaminer A, B og C. Vitaminer (B2, E, D), Hvede**. Indeholder mælk. Kan indeholde spor af soja, mælk, mandler og sesam. ** = Økologisk",
+		"Vitaminer, Vitamin A, Vitamin B, Vitamin C. Vitaminer, Vitamin B2, Vitamin E, Vitamin D, Hvede Økologisk. Stoffer, eller produkter, som forårsager allergi eller overfølsomhed : mælk. Spor : soja, Spor : mælk, Spor : mandler, Spor : sesam."
 	],
 	[ "is",
-	  "Vítamín (B2, E og D). Getur innihaldið hnetur, soja og mjólk í snefilmagni.",
-	  "Vítamín, B2-Vítamín, E-Vítamín, D-Vítamín. Leifar : hnetur, Leifar : Soja, Leifar : mjólk."
+		"Vítamín (B2, E og D). Getur innihaldið hnetur, soja og mjólk í snefilmagni.",
+		"Vítamín, B2-Vítamín, E-Vítamín, D-Vítamín. Leifar : hnetur, Leifar : Soja, Leifar : mjólk."
 	],
 	[ "nb",
-	  "Vitaminer A, B og C. Vitaminer (B2, E, D). Kan inneholde spor av andre nøtter, soya og melk.",
-	  "Vitaminer, Vitamin A, Vitamin B, Vitamin C. Vitaminer, Vitamin B2, Vitamin E, Vitamin D. Spor : andre nøtter, Spor : soya, Spor : melk."
+		"Vitaminer A, B og C. Vitaminer (B2, E, D). Kan inneholde spor av andre nøtter, soya og melk.",
+		"Vitaminer, Vitamin A, Vitamin B, Vitamin C. Vitaminer, Vitamin B2, Vitamin E, Vitamin D. Spor : andre nøtter, Spor : soya, Spor : melk."
 	],
 	[ "sv",
-	  "Vitaminer (B2, E och D), Vete*. Innehåller hasselnötter. Kan innehålla spår av råg, jordnötter, mandel, hasselnötter, cashewnötter och valnötter. *Ekologisk",
-	  "Vitaminer, Vitamin B2, Vitamin E, Vitamin D, Vete Ekologisk. Ämnen eller produkter som orsakar allergi eller intolerans : hasselnötter. Spår : råg, Spår : jordnötter, Spår : mandel, Spår : hasselnötter, Spår : cashewnötter, Spår : valnötter."
+		"Vitaminer (B2, E och D), Vete*. Innehåller hasselnötter. Kan innehålla spår av råg, jordnötter, mandel, hasselnötter, cashewnötter och valnötter. *Ekologisk",
+		"Vitaminer, Vitamin B2, Vitamin E, Vitamin D, Vete Ekologisk. Ämnen eller produkter som orsakar allergi eller intolerans : hasselnötter. Spår : råg, Spår : jordnötter, Spår : mandel, Spår : hasselnötter, Spår : cashewnötter, Spår : valnötter."
 	],
 	###########################
 
@@ -272,7 +274,7 @@ my @lists =(
 	# do not separate acide acétique into acide : acétique
 	["fr","Esters glycéroliques de l'acide acétique et d'acides gras","Esters glycéroliques de l'acide acétique et d'acides gras"],
 	["fr","acide acétique","acide acétique"],
-	
+
 	# russian abbreviations
 	["ru","мука пшеничная х/п в/с","мука пшеничная хлебопекарная высшего сорта"],
 

--- a/t/ingredients_parsing_todo.t
+++ b/t/ingredients_parsing_todo.t
@@ -145,6 +145,29 @@ my @tests = (
 		]
 	],
 
+	# interpret animal attribute in brackets as part of the ingredient name, instead of a separate ingredient.
+	# présure (animale) -> présure animale
+	[
+		"Issue #3882 - 'présure (animale) -> présure animale' - https://github.com/openfoodfacts/openfoodfacts-server/issues/3882",
+		{
+			lc => "fr",
+			ingredients_text => "ferments lactiques, présure (animale), sucre",
+		},
+		[
+			{
+				'id' => 'en:lactic-ferments',
+				'text' => 'ferments lactiques',
+			},
+			{
+				'id' => 'en:animal-based-rennet',
+				'text' => 'présure animale',
+			},
+			{
+				'id' => 'en:sugar',
+				'text' => 'sucre',
+			},
+		]
+	],
 
 
 

--- a/t/ingredients_parsing_todo.t
+++ b/t/ingredients_parsing_todo.t
@@ -1,0 +1,166 @@
+#!/usr/bin/perl -w
+
+# "TODO" Tests for known issues, to track if they get fixed while fixing something else.
+# See https://perldoc.perl.org/Test/More.html#*TODO%3a-BLOCK*
+
+use strict;
+use warnings;
+
+use utf8;
+
+use Test::More;
+#use Log::Any::Adapter 'TAP';
+use Log::Any::Adapter 'TAP', filter => 'trace';
+
+#use Text::Diff;
+
+use ProductOpener::Tags qw/:all/;
+use ProductOpener::TagsEntries qw/:all/;
+use ProductOpener::Ingredients qw/:all/;
+
+# dummy product for testing
+
+my @tests = (
+
+	# The "contient Gluten" without brackets is making the whole first ingredient and children get deleted.
+	[
+		"Issue #4232 - fr - 'Farine de blé contient Gluten (...)' - https://github.com/openfoodfacts/openfoodfacts-server/issues/4232",
+		{
+			lc => "fr",
+			ingredients_text => "Farine de blé contient Gluten (avec Farine de blé, Carbonate de calcium, Fer, Niacine, Thiamine), Lait entier • Eau",
+			#ingredients_text => "Farine de blé (avec Farine de blé, Carbonate de calcium, Fer, Niacine, Thiamine), Lait entier • Eau",
+			#ingredients_text => "Farine de blé (avec Farine de blé, Fer, Niacine, Thiamine), Lait entier • Eau",
+		},
+		[
+			{
+				'id' => 'en:wheat-flour',
+				'ingredients' => [
+					{
+						'id' => 'en:wheat-flour',
+						'text' => "avec Farine de bl\x{e9}",
+					},
+					{
+						'id' => 'en:e170i',
+						'text' => 'Carbonate de calcium',
+					},
+					{
+						'id' => 'en:iron',
+						'text' => 'Fer',
+					},
+					{
+						'id' => 'en:e375',
+						'text' => 'Niacine',
+					},
+					{
+						'id' => 'en:thiamin',
+						'text' => 'Thiamine',
+					}
+				],
+				'text' => "Farine de bl\x{e9}",
+			},
+			{
+				'id' => 'en:whole-milk',
+				'text' => 'Lait entier',
+			},
+			{
+				'id' => 'en:water',
+				'text' => 'Eau',
+			}
+		]
+	],
+
+	# Same issue as above in english.
+	[
+		"Issue #4232 - en - 'Wheatflour contains Gluten (...)' - https://github.com/openfoodfacts/openfoodfacts-server/issues/4232",
+		{
+			lc => "en",
+			ingredients_text => "Wheatflour contains Gluten (with Wheatflour, Calcium Carbonate, Iron, Niacin, Thiamin)· Sugar, Palm Oil",
+		},
+		[
+			{
+				'id' => 'en:wheat-flour',
+				'text' => 'Wheatflour',
+				'ingredients' => [
+					{
+						'id' => 'en:wheat-flour',
+						'text' => 'Wheatflour',
+					},
+					{
+						'id' => 'en:e170i',
+						'text' => 'Calcium Carbonate',
+					},
+					{
+						'id' => 'en:iron',
+						'text' => 'Iron',
+					},
+					{
+						'id' => 'en:e375',
+						'text' => 'Niacine',
+					},
+					{
+						'id' => 'en:thiamin',
+						'text' => 'Thiamin',
+					}
+				],
+			},
+			{
+				'id' => 'en:sugar',
+				'text' => 'Sugar',
+			},
+			{
+				'id' => 'en:palm-oil',
+				'text' => 'Palm Oil',
+			}
+		]
+	],
+
+
+
+
+
+
+);
+
+
+
+foreach my $test_ref (@tests) {
+
+	# tell the testing framework it's okay to fail these
+	TODO: {
+		local $TODO = $test_ref->[0]; # human readable reason for the test
+
+		my $product_ref = $test_ref->[1];
+		my $expected_ingredients_ref = $test_ref->[2];
+
+		print STDERR "ingredients_text: " . $product_ref->{ingredients_text} . "\n";
+
+		parse_ingredients_text($product_ref);
+
+		is_deeply ($product_ref->{ingredients}, $expected_ingredients_ref)
+			# using print + join instead of diag so that we don't have
+			# hashtags. It makes copy/pasting the resulting structure
+			# inside the test file much easier when tests results need
+			# to be updated. Caveat is that it might interfere with
+			# test output.
+
+			#or print STDERR join("\n", explain $product_ref->{ingredients});
+			#or diag explain $product_ref->{ingredients};
+
+			or do {
+				print STDERR "# Got:\n";
+				print STDERR join("\n", explain $product_ref->{ingredients});
+				print STDERR "# Expected:\n";
+				print STDERR join("\n", explain $expected_ingredients_ref );
+			};
+
+#			or do {
+#				my $str_got = join("\n", explain $product_ref->{ingredients});
+#				my $str_expected = join("\n", explain $expected_ingredients_ref );
+#				print STDERR diff(\$str_expected, \$str_got);
+#			};
+
+	}
+
+}
+
+done_testing();

--- a/t/ingredients_parsing_todo.t
+++ b/t/ingredients_parsing_todo.t
@@ -114,6 +114,36 @@ my @tests = (
 		]
 	],
 
+	# ingredient group: (element1, element2, element3) needs to be parsed as ingredient group (element1, element2, element3)
+	#комплексная пищевая добавка: (порошок сыра гауда, данбо, камамбер, голубой сыр, эмульгирующая соль Е 339)
+	# using english, because the explain() output \x-escapes utf8.
+	[
+		"Issue #3959 - 'ingredient with colon before subingredients opening bracket' - https://github.com/openfoodfacts/openfoodfacts-server/issues/3959",
+		{
+			lc => "en",
+			ingredients_text => "meat: (beef, pork, lamb)",
+		},
+		[
+			{
+				'id' => 'en:meat',
+				'text' => 'meat',
+				'ingredients' => [
+					{
+						'id' => 'en:beef',
+						'text' => 'beef',
+					},
+					{
+						'id' => 'en:pork',
+						'text' => 'pork',
+					},
+					{
+						'id' => 'en:lamb',
+						'text' => 'lamb',
+					},
+				],
+			},
+		]
+	],
 
 
 

--- a/t/ingredients_percent.t
+++ b/t/ingredients_percent.t
@@ -1,5 +1,7 @@
 #!/usr/bin/perl -w
 
+# Tests of Ingredients::compute_ingredients_percent_values()
+
 use strict;
 use warnings;
 
@@ -16,234 +18,240 @@ use ProductOpener::Ingredients qw/:all/;
 # dummy product for testing
 
 my @tests = (
-	[ { lc => "en", ingredients_text => "sugar"}, 
-[
-  {
-    'id' => 'en:sugar',
-    'percent_max' => 100,
-    'percent_min' => 100,
-    'text' => 'sugar'
-  }
-]
+
+	[ { lc => "en", ingredients_text => "sugar"},
+		[
+			{
+				'id' => 'en:sugar',
+				'percent_max' => 100,
+				'percent_min' => 100,
+				'text' => 'sugar'
+			}
+		]
 	],
 
-        [ { lc => "en", ingredients_text => "sugar, milk"},
-[
-  {
-    'id' => 'en:sugar',
-    'percent_max' => 100,
-    'percent_min' => 50,
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:milk',
-    'percent_max' => 50,
-    'percent_min' => 0,
-    'text' => 'milk'
-  }
-]
-        ],
+
+	[ { lc => "en", ingredients_text => "sugar, milk"},
+		[
+			{
+				'id' => 'en:sugar',
+				'percent_max' => 100,
+				'percent_min' => 50,
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:milk',
+				'percent_max' => 50,
+				'percent_min' => 0,
+				'text' => 'milk'
+			}
+		]
+	],
+
 
 	[ { lc => "en", ingredients_text => "sugar, milk, water"},
-[
-  {
-    'id' => 'en:sugar',
-    'percent_max' => 100,
-    'percent_min' => '33.3333333333333',
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:milk',
-    'percent_max' => 50,
-    'percent_min' => 0,
-    'text' => 'milk'
-  },
-  {
-    'id' => 'en:water',
-    'percent_max' => '33.3333333333333',
-    'percent_min' => 0,
-    'text' => 'water'
-  }
-
-]
+		[
+			{
+				'id' => 'en:sugar',
+				'percent_max' => 100,
+				'percent_min' => '33.3333333333333',
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:milk',
+				'percent_max' => 50,
+				'percent_min' => 0,
+				'text' => 'milk'
+			},
+			{
+				'id' => 'en:water',
+				'percent_max' => '33.3333333333333',
+				'percent_min' => 0,
+				'text' => 'water'
+			}
+		]
 	],
 
-        [ { lc => "en", ingredients_text => "sugar 90%, milk"},
-[
-  {
-    'id' => 'en:sugar',
-    'percent' => '90',
-    'percent_max' => 90,
-    'percent_min' => 90,
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:milk',
-    'percent_max' => 10,
-    'percent_min' => 10,
-    'text' => 'milk'
-  }
-]
+
+	[ { lc => "en", ingredients_text => "sugar 90%, milk"},
+		[
+			{
+				'id' => 'en:sugar',
+				'percent' => '90',
+				'percent_max' => 90,
+				'percent_min' => 90,
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:milk',
+				'percent_max' => 10,
+				'percent_min' => 10,
+				'text' => 'milk'
+			}
+		]
 	],
 
-        [ { lc => "en", ingredients_text => "sugar, milk 10%"},
-[
-  {
-    'id' => 'en:sugar',
-    'percent_max' => 90,
-    'percent_min' => 90,
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:milk',
-    'percent' => '10',
-    'percent_max' => 10,
-    'percent_min' => 10,
-    'text' => 'milk'
-  }
-]
-        ],
 
-        [ { lc => "en", ingredients_text => "sugar, milk 10%, water"},
-[
-  {
-    'id' => 'en:sugar',
-    'percent_max' => 90,
-    'percent_min' => 80,
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:milk',
-    'percent' => '10',
-    'percent_max' => 10,
-    'percent_min' => 10,
-    'text' => 'milk'
-  },
-  {
-    'id' => 'en:water',
-    'percent_max' => 10,
-    'percent_min' => 0,
-    'text' => 'water'
-  }
-]
-        ],
+	[ { lc => "en", ingredients_text => "sugar, milk 10%"},
+		[
+			{
+				'id' => 'en:sugar',
+				'percent_max' => 90,
+				'percent_min' => 90,
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:milk',
+				'percent' => '10',
+				'percent_max' => 10,
+				'percent_min' => 10,
+				'text' => 'milk'
+			}
+		]
+	],
 
-        [ { lc => "en", ingredients_text => "sugar, water, milk 10%"},
-[
-  {
-    'id' => 'en:sugar',
-    'percent_max' => 80,
-    'percent_min' => 45,
-    'text' => 'sugar'
-  },
-  {
-    'id' => 'en:water',
-    'percent_max' => 45,
-    'percent_min' => 10,
-    'text' => 'water'
-  },
-  {
-    'id' => 'en:milk',
-    'percent' => '10',
-    'percent_max' => 10,
-    'percent_min' => 10,
-    'text' => 'milk'
-  }
-]
-        ],
+
+	[ { lc => "en", ingredients_text => "sugar, milk 10%, water"},
+		[
+			{
+				'id' => 'en:sugar',
+				'percent_max' => 90,
+				'percent_min' => 80,
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:milk',
+				'percent' => '10',
+				'percent_max' => 10,
+				'percent_min' => 10,
+				'text' => 'milk'
+			},
+			{
+				'id' => 'en:water',
+				'percent_max' => 10,
+				'percent_min' => 0,
+				'text' => 'water'
+			}
+		]
+	],
+
+
+	[ { lc => "en", ingredients_text => "sugar, water, milk 10%"},
+		[
+			{
+				'id' => 'en:sugar',
+				'percent_max' => 80,
+				'percent_min' => 45,
+				'text' => 'sugar'
+			},
+			{
+				'id' => 'en:water',
+				'percent_max' => 45,
+				'percent_min' => 10,
+				'text' => 'water'
+			},
+			{
+				'id' => 'en:milk',
+				'percent' => '10',
+				'percent_max' => 10,
+				'percent_min' => 10,
+				'text' => 'milk'
+			}
+		]
+	],
 
 	# Ingredients with sub-ingredients
 
-        [ { lc => "en", ingredients_text => "chocolate (cocoa)"},
-[
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa',
-        'percent_max' => 100,
-        'percent_min' => 100,
-        'text' => 'cocoa'
-      }
-    ],
-    'percent_max' => 100,
-    'percent_min' => 100,
-    'text' => 'chocolate'
-  }
-
-]
+	[ { lc => "en", ingredients_text => "chocolate (cocoa)"},
+		[
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa',
+						'percent_max' => 100,
+						'percent_min' => 100,
+						'text' => 'cocoa'
+					}
+				],
+				'percent_max' => 100,
+				'percent_min' => 100,
+				'text' => 'chocolate'
+			}
+		]
 	],
 
-        [ { lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"},
-[
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa',
-        'percent_max' => 100,
-        'percent_min' => 25,
-        'text' => 'cocoa'
-      },
-      {
-        'id' => 'en:sugar',
-        'percent_max' => 50,
-        'percent_min' => 0,
-        'text' => 'sugar'
-      }
-    ],
-    'percent_max' => 100,
-    'percent_min' => 50,
-    'text' => 'chocolate'
-  },
-  {
-    'id' => 'en:milk',
-    'percent_max' => 50,
-    'percent_min' => 0,
-    'text' => 'milk'
-  }
-]
+
+	[ { lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"},
+		[
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa',
+						'percent_max' => 100,
+						'percent_min' => 25,
+						'text' => 'cocoa'
+					},
+					{
+						'id' => 'en:sugar',
+						'percent_max' => 50,
+						'percent_min' => 0,
+						'text' => 'sugar'
+					}
+				],
+				'percent_max' => 100,
+				'percent_min' => 50,
+				'text' => 'chocolate'
+			},
+			{
+				'id' => 'en:milk',
+				'percent_max' => 50,
+				'percent_min' => 0,
+				'text' => 'milk'
+			}
+		]
 	],
 
-        [ { lc => "en", ingredients_text => "chocolate (cocoa [cocoa paste 70%, cocoa butter], sugar)"},
-[
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa',
-        'ingredients' => [
-          {
-            'id' => 'en:cocoa-paste',
-            'percent' => '70',
-            'percent_max' => 70,
-            'percent_min' => 70,
-            'text' => 'cocoa paste'
-          },
-          {
-            'id' => 'en:cocoa-butter',
-            'percent_max' => 30,
-            'percent_min' => 0,
-            'text' => 'cocoa butter'
-          }
-        ],
-        'percent_max' => 100,
-        'percent_min' => 70,
-        'text' => 'cocoa'
-      },
-      {
-        'id' => 'en:sugar',
-        'percent_max' => 30,
-        'percent_min' => 0,
-        'text' => 'sugar'
-      }
-    ],
-    'percent_max' => 100,
-    'percent_min' => 100,
-    'text' => 'chocolate'
-  }
 
-]
+	[ { lc => "en", ingredients_text => "chocolate (cocoa [cocoa paste 70%, cocoa butter], sugar)"},
+		[
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa',
+						'ingredients' => [
+							{
+								'id' => 'en:cocoa-paste',
+								'percent' => '70',
+								'percent_max' => 70,
+								'percent_min' => 70,
+								'text' => 'cocoa paste'
+							},
+							{
+								'id' => 'en:cocoa-butter',
+								'percent_max' => 30,
+								'percent_min' => 0,
+								'text' => 'cocoa butter'
+							}
+						],
+						'percent_max' => 100,
+						'percent_min' => 70,
+						'text' => 'cocoa'
+					},
+					{
+						'id' => 'en:sugar',
+						'percent_max' => 30,
+						'percent_min' => 0,
+						'text' => 'sugar'
+					}
+				],
+				'percent_max' => 100,
+				'percent_min' => 100,
+				'text' => 'chocolate'
+			}
+		]
 	],
 
 # Make sure we can handle impossible values gracefully
@@ -251,237 +259,236 @@ my @tests = (
 # This ingredient string caused an infinite loop:
 #  "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%) - émulsifiants : E463, E432 et E472 - correcteurs d'acidité : E322/E333 E474-E475, acidifiant (acide citrique, acide phosphorique) - sel"
 
-        [ { lc => "fr", ingredients_text => "beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%"},
-[
-  {
-    'id' => 'en:cocoa-butter',
-    'percent' => '15',
-    'text' => 'beurre de cacao'
-  },
-  {
-    'id' => 'en:sugar',
-    'percent' => '10',
-    'text' => 'sucre'
-  },
-  {
-    'id' => 'en:milk-proteins',
-    'text' => "prot\x{e9}ines de lait"
-  },
-  {
-    'id' => 'en:egg',
-    'percent' => '1',
-    'text' => 'oeuf'
-  }
-
-]
+	[ { lc => "fr", ingredients_text => "beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%"},
+		[
+			{
+				'id' => 'en:cocoa-butter',
+				'percent' => '15',
+				'text' => 'beurre de cacao'
+			},
+			{
+				'id' => 'en:sugar',
+				'percent' => '10',
+				'text' => 'sucre'
+			},
+			{
+				'id' => 'en:milk-proteins',
+				'text' => "prot\x{e9}ines de lait"
+			},
+			{
+				'id' => 'en:egg',
+				'percent' => '1',
+				'text' => 'oeuf'
+			}
+		]
 	],
 
-        [ { lc => "fr", ingredients_text => "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%)"},
-[
-  {
-    'id' => 'en:flour',
-    'percent' => '12',
-    'text' => 'farine'
-  },
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa-butter',
-        'percent' => '15',
-        'text' => 'beurre de cacao'
-      },
-      {
-        'id' => 'en:sugar',
-        'percent' => '10',
-        'text' => 'sucre'
-      },
-      {
-        'id' => 'en:milk-proteins',
-        'text' => "prot\x{e9}ines de lait"
-      },
-      {
-        'id' => 'en:egg',
-        'percent' => '1',
-        'text' => 'oeuf'
-      }
-    ],
-    'text' => 'chocolat'
-  }
 
-]
-        ],
+	[ { lc => "fr", ingredients_text => "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%)"},
+		[
+			{
+				'id' => 'en:flour',
+				'percent' => '12',
+				'text' => 'farine'
+			},
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa-butter',
+						'percent' => '15',
+						'text' => 'beurre de cacao'
+					},
+					{
+						'id' => 'en:sugar',
+						'percent' => '10',
+						'text' => 'sucre'
+					},
+					{
+						'id' => 'en:milk-proteins',
+						'text' => "prot\x{e9}ines de lait"
+					},
+					{
+						'id' => 'en:egg',
+						'percent' => '1',
+						'text' => 'oeuf'
+					}
+				],
+				'text' => 'chocolat'
+			}
+		]
+	],
 
-        [ { lc => "en", ingredients_text => "Flour, chocolate (cocoa, sugar, soy lecithin), egg"},
-[
-  {
-    'id' => 'en:flour',
-    'percent_max' => 100,
-    'percent_min' => '33.3333333333333',
-    'text' => 'Flour'
-  },
-  {
-    'id' => 'en:chocolate',
-    'ingredients' => [
-      {
-        'id' => 'en:cocoa',
-        'percent_max' => 50,
-        'percent_min' => 0,
-        'text' => 'cocoa'
-      },
-      {
-        'id' => 'en:sugar',
-        'percent_max' => 25,
-        'percent_min' => 0,
-        'text' => 'sugar'
-      },
-      {
-        'id' => 'en:soya-lecithin',
-        'percent_max' => '16.6666666666667',
-        'percent_min' => 0,
-        'text' => 'soy lecithin'
-      }
-    ],
-    'percent_max' => 50,
-    'percent_min' => 0,
-    'text' => 'chocolate'
-  },
-  {
-    'id' => 'en:egg',
-    'percent_max' => '33.3333333333333',
-    'percent_min' => 0,
-    'text' => 'egg'
-  }
-]
 
-],
+	[ { lc => "en", ingredients_text => "Flour, chocolate (cocoa, sugar, soy lecithin), egg"},
+		[
+			{
+				'id' => 'en:flour',
+				'percent_max' => 100,
+				'percent_min' => '33.3333333333333',
+				'text' => 'Flour'
+			},
+			{
+				'id' => 'en:chocolate',
+				'ingredients' => [
+					{
+						'id' => 'en:cocoa',
+						'percent_max' => 50,
+						'percent_min' => 0,
+						'text' => 'cocoa'
+					},
+					{
+						'id' => 'en:sugar',
+						'percent_max' => 25,
+						'percent_min' => 0,
+						'text' => 'sugar'
+					},
+					{
+						'id' => 'en:soya-lecithin',
+						'percent_max' => '16.6666666666667',
+						'percent_min' => 0,
+						'text' => 'soy lecithin'
+					}
+				],
+				'percent_max' => 50,
+				'percent_min' => 0,
+				'text' => 'chocolate'
+			},
+			{
+				'id' => 'en:egg',
+				'percent_max' => '33.3333333333333',
+				'percent_min' => 0,
+				'text' => 'egg'
+			}
+		]
+	],
 
-		# For lists like  "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"
-		# we can set a maximum on Sugar, Cornflour etc. that takes into account that all ingredients
-		# that appear before will have an higher quantity.
-		# e.g. the percent max of Water to be set to 100 - 52 -33 = 15%
-		# the max of sugar to be set to 15 / 2 = 7.5 %
-		# the max of cornflour to be set to 15 / 3 etc.
+	# For lists like  "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"
+	# we can set a maximum on Sugar, Cornflour etc. that takes into account that all ingredients
+	# that appear before will have an higher quantity.
+	# e.g. the percent max of Water to be set to 100 - 52 -33 = 15%
+	# the max of sugar to be set to 15 / 2 = 7.5 %
+	# the max of cornflour to be set to 15 / 3 etc.
 
-        [ { lc => "en", ingredients_text => "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"},
-[
-  {
-    'id' => 'en:beans',
-    'percent' => '52',
-    'percent_max' => 52,
-    'percent_min' => 52,
-    'text' => 'Beans'
-  },
-  {
-    'id' => 'en:tomato',
-    'percent' => '33',
-    'percent_max' => 33,
-    'percent_min' => 33,
-    'text' => 'Tomatoes'
-  },
-  {
-    'id' => 'en:water',
-    'percent_max' => 15,
-    'percent_min' => 3,
-    'text' => 'Water'
-  },
-  {
-    'id' => 'en:sugar',
-    'percent_max' => '7.5',
-    'percent_min' => 0,
-    'text' => 'Sugar'
-  },
-  {
-    'id' => 'en:corn-flour',
-    'percent_max' => 5,
-    'percent_min' => 0,
-    'text' => 'Cornflour'
-  },
-  {
-    'id' => 'en:salt',
-    'percent_max' => '3.75',
-    'percent_min' => 0,
-    'text' => 'Salt'
-  },
-  {
-    'id' => 'en:spirit-vinegar',
-    'percent_max' => 3,
-    'percent_min' => 0,
-    'text' => 'Spirit Vinegar'
-  }
-]
+	[ { lc => "en", ingredients_text => "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"},
+		[
+			{
+				'id' => 'en:beans',
+				'percent' => '52',
+				'percent_max' => 52,
+				'percent_min' => 52,
+				'text' => 'Beans'
+			},
+			{
+				'id' => 'en:tomato',
+				'percent' => '33',
+				'percent_max' => 33,
+				'percent_min' => 33,
+				'text' => 'Tomatoes'
+			},
+			{
+				'id' => 'en:water',
+				'percent_max' => 15,
+				'percent_min' => 3,
+				'text' => 'Water'
+			},
+			{
+				'id' => 'en:sugar',
+				'percent_max' => '7.5',
+				'percent_min' => 0,
+				'text' => 'Sugar'
+			},
+			{
+				'id' => 'en:corn-flour',
+				'percent_max' => 5,
+				'percent_min' => 0,
+				'text' => 'Cornflour'
+			},
+			{
+				'id' => 'en:salt',
+				'percent_max' => '3.75',
+				'percent_min' => 0,
+				'text' => 'Salt'
+			},
+			{
+				'id' => 'en:spirit-vinegar',
+				'percent_max' => 3,
+				'percent_min' => 0,
+				'text' => 'Spirit Vinegar'
+			}
+		]
+	],
 
-],
 
 	[ { lc=>"es", ingredients_text=>"Leche. Cacao: 27% mínimo"},
-[
-  {
-    'id' => 'en:milk',
-    'percent_max' => 73,
-    'percent_min' => 73,
-    'text' => 'Leche'
-  },
-  {
-    'id' => 'en:cocoa',
-    'percent' => '27',
-    'percent_max' => 27,
-    'percent_min' => 27,
-    'text' => 'Cacao'
-  }
-]
-],
+		[
+			{
+				'id' => 'en:milk',
+				'percent_max' => 73,
+				'percent_min' => 73,
+				'text' => 'Leche'
+			},
+			{
+				'id' => 'en:cocoa',
+				'percent' => '27',
+				'percent_max' => 27,
+				'percent_min' => 27,
+				'text' => 'Cacao'
+			}
+		]
+	],
+
 
 	[ { lc=>"es", ingredients_text=>"Leche min 12.2%, Cacao: min 7%, Avellanas (mínimo 3%)"},
-[
-  {
-    'id' => 'en:milk',
-    'percent' => '12.2',
-    'text' => 'Leche'
-  },
-  {
-    'id' => 'en:cocoa',
-    'percent' => '7',
-    'text' => 'Cacao'
-  },
-  {
-    'id' => 'en:hazelnut',
-    'percent' => '3',
-    'text' => 'Avellanas'
-  }
-]
-],
+		[
+			{
+				'id' => 'en:milk',
+				'percent' => '12.2',
+				'text' => 'Leche'
+			},
+			{
+				'id' => 'en:cocoa',
+				'percent' => '7',
+				'text' => 'Cacao'
+			},
+			{
+				'id' => 'en:hazelnut',
+				'percent' => '3',
+				'text' => 'Avellanas'
+			}
+		]
+	],
 
 	# bug #3762 "min" in "cumin"
 	[ { lc =>"fr", ingredients_text=>"sel (min 20%), poivre (min. 10%), piment (min : 5%), cumin 0,4%, ail : 0.1%"},
-[
-  {
-    'id' => 'en:salt',
-    'percent' => '20',
-    'text' => 'sel'
-  },
-  {
-    'id' => 'en:pepper',
-    'percent' => '10',
-    'text' => 'poivre'
-  },
-  {
-    'id' => 'en:chili-pepper',
-    'percent' => '5',
-    'text' => 'piment'
-  },
-  {
-    'id' => 'en:cumin-seeds',
-    'percent' => '0.4',
-    'text' => 'cumin'
-  },
-  {
-    'id' => 'en:garlic',
-    'percent' => '0.1',
-    'text' => 'ail'
-  }
-
-]
-],
+		[
+			{
+				'id' => 'en:salt',
+				'percent' => '20',
+				'text' => 'sel'
+			},
+			{
+				'id' => 'en:pepper',
+				'percent' => '10',
+				'text' => 'poivre'
+			},
+			{
+				'id' => 'en:chili-pepper',
+				'percent' => '5',
+				'text' => 'piment'
+			},
+			{
+				'id' => 'en:cumin-seeds',
+				'percent' => '0.4',
+				'text' => 'cumin'
+			},
+			{
+				'id' => 'en:garlic',
+				'percent' => '0.1',
+				'text' => 'ail'
+			}
+		]
+	],
 
 );
 

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -1,5 +1,7 @@
 #!/usr/bin/perl -w
 
+# Tests of detecting food-processing terms from taxonomies/ingredients_processing.txt
+
 use strict;
 use warnings;
 
@@ -22,53 +24,53 @@ my @tests = (
 #
 ##################################################################
 
-	[ { lc => "en", ingredients_text => "raw milk, sliced tomatoes, garlic powder, powdered eggplant, 
-			courgette powder, sieved ham"}, 
+	[ { lc => "en", ingredients_text => "raw milk, sliced tomatoes, garlic powder, powdered eggplant,
+			courgette powder, sieved ham"},
 		[
-	  		{
-	    		'id' => 'en:raw-milk',
-	    		'text' => 'raw milk'
-	  		},
-	  		{
-	    		'id' => 'en:tomato',
-	    		'processing' => 'en:sliced',
-	    		'text' => 'tomatoes'
-	  		},
-	  		{
-	    		'id' => 'en:garlic-powder',
-	    		'text' => 'garlic powder'
-	  		},
-	  		{
-	    		'id' => 'en:aubergine',
-	    		'processing' => 'en:powdered',
-	    		'text' => 'eggplant'
-	  		},
-	  		{
-	    		'id' => 'en:courgette',
-	    		'processing' => 'en:powdered',
-	    		'text' => 'courgette'
-	  		},
-	  		{
-	    		'id' => 'en:ham',
-	    		'processing' => 'en:sieved',
-	    		'text' => 'ham'
-	  		}
+			{
+				'id' => 'en:raw-milk',
+				'text' => 'raw milk'
+			},
+			{
+				'id' => 'en:tomato',
+				'processing' => 'en:sliced',
+				'text' => 'tomatoes'
+			},
+			{
+				'id' => 'en:garlic-powder',
+				'text' => 'garlic powder'
+			},
+			{
+				'id' => 'en:aubergine',
+				'processing' => 'en:powdered',
+				'text' => 'eggplant'
+			},
+			{
+				'id' => 'en:courgette',
+				'processing' => 'en:powdered',
+				'text' => 'courgette'
+			},
+			{
+				'id' => 'en:ham',
+				'processing' => 'en:sieved',
+				'text' => 'ham'
+			}
 		]
 	],
 
 # en:dried (children are lef out at the moment)
-	[ { lc => "en", ingredients_text => "dried milk"}, 
+	[ { lc => "en", ingredients_text => "dried milk"},
 		[
 			{
 				'id' => 'en:milk',
 				'processing' => 'en:dried',
 				'text' => 'milk'
 			}
-			]
+		]
 	],
 
 # en: smoked (children are lef out at the moment)
-	[ { lc => "en", ingredients_text => "smoked milk, not smoked tomatoes"}, 
+	[ { lc => "en", ingredients_text => "smoked milk, not smoked tomatoes"},
 		[
 			{
 				'id' => 'en:milk',
@@ -80,11 +82,11 @@ my @tests = (
 				'processing' => 'en:not-smoked',
 				'text' => 'tomatoes'
 			}
-			]
+		]
 	],
 
 # en: smoked (children are lef out at the moment)
-	[ { lc => "en", ingredients_text => "sweetened milk, unsweetened tomatoes, sugared ham"}, 
+	[ { lc => "en", ingredients_text => "sweetened milk, unsweetened tomatoes, sugared ham"},
 		[
 			{
 				'id' => 'en:milk',
@@ -100,13 +102,12 @@ my @tests = (
 				'id' => 'en:ham',
 				'processing' => 'en:sugared',
 				'text' => 'ham'
-				
 			}
-			]
+		]
 	],
 
 # en: halved
-	[ { lc => "en", ingredients_text => "halved milk, tomatoes halves"}, 
+	[ { lc => "en", ingredients_text => "halved milk, tomatoes halves"},
 		[
 			{
 				'id' => 'en:milk',
@@ -127,7 +128,7 @@ my @tests = (
 #
 ##################################################################
 
-	[ { lc => "es", ingredients_text => "tomate endulzado, berenjena endulzada, calabacín endulzados, jamón endulzadas" }, 
+	[ { lc => "es", ingredients_text => "tomate endulzado, berenjena endulzada, calabacín endulzados, jamón endulzadas" },
 		[
 			{
 				'id' => 'en:tomato',
@@ -152,7 +153,8 @@ my @tests = (
 		]
 	],
 
-	[ { lc => "es", ingredients_text => "pimientos amarillos deshidratados" }, 
+
+	[ { lc => "es", ingredients_text => "pimientos amarillos deshidratados" },
 		[
 			{
 				'id' => 'en:yellow-bell-pepper',
@@ -161,56 +163,47 @@ my @tests = (
 			}
 		]
 	],
-	
+
 ##################################################################
 #
 #                           F R E N C H ( F R )
 #
 ##################################################################
 
-	[ { lc => "fr", ingredients_text => "dés de jambon frits, tomates crues en dés, 
-			tomates bio pré-cuites, poudre de noisettes, banane tamisé"}, 
+	[ { lc => "fr", ingredients_text => "dés de jambon frits, tomates crues en dés,
+			tomates bio pré-cuites, poudre de noisettes, banane tamisé"},
 		[
-  {
-    'id' => 'en:ham',
-    'processing' => 'en:diced, en:fried',
-    'text' => 'jambon'
-  },
-  {
-    'id' => 'en:tomato',
-    'processing' => 'en:diced, en:raw',
-    'text' => 'tomates'
-  },
-  {
-    'id' => 'en:tomato',
-    'labels' => 'en:organic',
-    'processing' => 'en:pre-cooked',
-    'text' => 'tomates'
-  },
-  {
-    'id' => 'en:hazelnut',
-    'processing' => 'en:powdered',
-    'text' => 'noisettes'
-  },
-  {
-    'id' => 'en:banana',
-    'processing' => 'en:sieved',
-    'text' => 'banane'
-  }
+			{
+				'id' => 'en:ham',
+				'processing' => 'en:diced, en:fried',
+				'text' => 'jambon'
+			},
+			{
+				'id' => 'en:tomato',
+				'processing' => 'en:diced, en:raw',
+				'text' => 'tomates'
+			},
+			{
+				'id' => 'en:tomato',
+				'labels' => 'en:organic',
+				'processing' => 'en:pre-cooked',
+				'text' => 'tomates'
+			},
+			{
+				'id' => 'en:hazelnut',
+				'processing' => 'en:powdered',
+				'text' => 'noisettes'
+			},
+			{
+				'id' => 'en:banana',
+				'processing' => 'en:sieved',
+				'text' => 'banane'
+			}
 		]
 	],
 
-		[ { lc => "fr", ingredients_text => "banane coupée et cuite au naturel"}, 
-			[
-	  			{
-	    			'id' => 'en:banana',
-	    			'processing' => 'en:cooked, en:cut',
-	    			'text' => 'banane'
-	  			}
-			]
-		],
 
-	[ { lc => "fr", ingredients_text => "banane coupée et cuite au naturel"}, 
+	[ { lc => "fr", ingredients_text => "banane coupée et cuite au naturel"},
 		[
 			{
 				'id' => 'en:banana',
@@ -219,6 +212,18 @@ my @tests = (
 			}
 		]
 	],
+
+
+	[ { lc => "fr", ingredients_text => "banane coupée et cuite au naturel"},
+		[
+			{
+				'id' => 'en:banana',
+				'processing' => 'en:cooked, en:cut',
+				'text' => 'banane'
+			}
+		]
+	],
+
 
 # test for jus and concentré with extra "de"
 #	[ { lc => "fr", ingredients_text => "jus concentré de baies de sureau"},
@@ -229,43 +234,44 @@ my @tests = (
 ##################################################################
 #
 #                           F I N N I SH ( F I )
-	#
+#
 ##################################################################
 # test for mehu inside an ingredient
 
-#	[ { lc => "fi", ingredients_text => "hedelmätäysmehutiivisteet"}, 
+#	[ { lc => "fi", ingredients_text => "hedelmätäysmehutiivisteet"},
 #		[
 #		]
 #	],
 
-	# Assert that processing patterns are in descending length order
-	# i.e 'fi:jauhettu' is matched before 'fi:jauhe'
-	# [   {   lc => "fi",
-	# 		ingredients_text =>
-	# 			"raakamaito, mustikkajauhe, jauhettu vaniljatanko"
-	# 	},
-	# 	[   {   'id'   => 'en:raw-milk',
-	# 			'text' => 'raakamaito'
-	# 		},
-	# 		{   'id'         => 'en:blueberry',
-	# 			'processing' => 'en:powdered',
-	# 			'text'       => 'mustikka'
-	# 		},
-	# 		{   'id'         => 'en:vanilla-pod',
-	# 			'processing' => 'en:ground',
-	# 			'text'       => 'vaniljatanko'
-	# 		}
-	# 	]
-	# ],
+# Assert that processing patterns are in descending length order
+# i.e 'fi:jauhettu' is matched before 'fi:jauhe'
+# [
+# 	{	lc => "fi",
+# 		ingredients_text =>
+# 			"raakamaito, mustikkajauhe, jauhettu vaniljatanko"
+# 	},
+# 	[	{	'id'   => 'en:raw-milk',
+# 			'text' => 'raakamaito'
+# 		},
+# 		{	'id'         => 'en:blueberry',
+# 			'processing' => 'en:powdered',
+# 			'text'       => 'mustikka'
+# 		},
+# 		{	'id'         => 'en:vanilla-pod',
+# 			'processing' => 'en:ground',
+# 			'text'       => 'vaniljatanko'
+# 		}
+# 	]
+# ],
 
 
 ##################################################################
 #
 #                           D U T C H ( N L )
-	#
+#
 ##################################################################
 
-	[ { lc => "nl", ingredients_text => "sjalotpoeder, wei-poeder, vanillepoeder, gemalen sjalot, geraspte sjalot, gepelde goudsbloem"}, 
+	[ { lc => "nl", ingredients_text => "sjalotpoeder, wei-poeder, vanillepoeder, gemalen sjalot, geraspte sjalot, gepelde goudsbloem"},
 		[
 			{
 				'id' => 'en:shallot',
@@ -305,27 +311,27 @@ my @tests = (
 ##################################################################
 
 # de:pulver and variants
-	[ { lc => "de", ingredients_text => "bourbon-vanillepulver, Sauerkrautpulver, acerola-pulver" }, 
+	[ { lc => "de", ingredients_text => "bourbon-vanillepulver, Sauerkrautpulver, acerola-pulver" },
 		[
-	  		{
-	    		'id' => 'en:bourbon-vanilla-powder',
-	    		'text' => 'bourbon-vanillepulver'
-	  		},
 			{
-    			'id' => 'en:sauerkraut',
-    			'processing' => 'en:powdered',
-    			'text' => 'Sauerkraut'
+				'id' => 'en:bourbon-vanilla-powder',
+				'text' => 'bourbon-vanillepulver'
 			},
 			{
-    			'id' => 'en:acerola',
-    			'processing' => 'en:powdered',
-    			'text' => 'acerola'
+				'id' => 'en:sauerkraut',
+				'processing' => 'en:powdered',
+				'text' => 'Sauerkraut'
+			},
+			{
+				'id' => 'en:acerola',
+				'processing' => 'en:powdered',
+				'text' => 'acerola'
 			}
 		]
 	],
 
 # de:gehackt and variants
-	[ { lc => "de", ingredients_text => "gehacktes Buttermilch, gehackter Dickmilch"}, 
+	[ { lc => "de", ingredients_text => "gehacktes Buttermilch, gehackter Dickmilch"},
 		[
 			{
 				'id' => 'en:buttermilk',
@@ -333,40 +339,40 @@ my @tests = (
 				'text' => 'Buttermilch'
 			},
 			{
-	    		'id' => 'en:soured-milk',
-	    		'processing' => 'en:chopped',
-	    		'text' => 'Dickmilch'
+				'id' => 'en:soured-milk',
+				'processing' => 'en:chopped',
+				'text' => 'Dickmilch'
 			}
 		]
 	],
 
-# de:gehobelt and variants	
-	[ { lc => "de", ingredients_text => "gehobelt passionsfrucht" }, 
+# de:gehobelt and variants
+	[ { lc => "de", ingredients_text => "gehobelt passionsfrucht" },
 		[
 			{
-    			'id' => 'en:passion-fruit',
-    			'processing' => 'en:sliced',
-    			'text' => 'passionsfrucht'
-  			}
+				'id' => 'en:passion-fruit',
+				'processing' => 'en:sliced',
+				'text' => 'passionsfrucht'
+			}
 		]
 	],
 
 
 # Test for de:püree (and for process placing de:püree without space)
-	[ { lc => "de", ingredients_text => "Schalottepüree" }, 
+	[ { lc => "de", ingredients_text => "Schalottepüree" },
 		[
 			{
-	    		'id' => 'en:shallot',
-	    		'processing' => 'en:pureed',
-	    		'text' => 'Schalotte'
+				'id' => 'en:shallot',
+				'processing' => 'en:pureed',
+				'text' => 'Schalotte'
 			}
 		]
 	],
-	
+
 # Test for process de:püree placing with space (not really necessary as it has been tested with the other)
-	[ { lc => "de", ingredients_text => "Schalotte püree" }, 
+	[ { lc => "de", ingredients_text => "Schalotte püree" },
 		[
-		  	{
+			{
 				'id' => 'en:shallot',
 				'processing' => 'en:pureed',
 				'text' => 'Schalotte'
@@ -375,8 +381,8 @@ my @tests = (
 	],
 
 # de:gegart and variants
-	[ { lc => "de", ingredients_text => "Schalotte gegart, gegarte haselnüsse, gegarter mandeln, gegartes passionsfrucht, 
-					gurken dampfgegart, dampfgegarte acerola, dampfgegarter spinat" }, 
+	[ { lc => "de", ingredients_text => "Schalotte gegart, gegarte haselnüsse, gegarter mandeln, gegartes passionsfrucht,
+			gurken dampfgegart, dampfgegarte acerola, dampfgegarter spinat" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -417,7 +423,7 @@ my @tests = (
 	],
 
 # Test for de:geölt
-	[ { lc => "de", ingredients_text => "Schalotte geölt, geölte haselnüsse" }, 
+	[ { lc => "de", ingredients_text => "Schalotte geölt, geölte haselnüsse" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -433,8 +439,8 @@ my @tests = (
 	],
 
 # de:gepökelt and variants
-	[ { lc => "de", ingredients_text => "Schalotte gepökelt, gepökeltes haselnüsse, 
-				passionsfrucht ungepökelt" }, 
+	[ { lc => "de", ingredients_text => "Schalotte gepökelt, gepökeltes haselnüsse,
+			passionsfrucht ungepökelt" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -453,10 +459,10 @@ my @tests = (
 			}
 		]
 	],
-	
+
 # de:gepoppt and variants
-	[ { lc => "de", ingredients_text => "Schalotte gepoppt, gepuffte haselnüsse, 
-				passionsfrucht gepufft, gepuffter passionsfrucht, gepufftes gurken" }, 
+	[ { lc => "de", ingredients_text => "Schalotte gepoppt, gepuffte haselnüsse,
+			passionsfrucht gepufft, gepuffter passionsfrucht, gepufftes gurken" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -485,10 +491,10 @@ my @tests = (
 			}
 		]
 	],
-	
+
 # de:geschält and variants
-	[ { lc => "de", ingredients_text => "Schalotte geschält, geschälte haselnüsse, geschälter mandeln, 
-				passionsfrucht ungeschält, ungeschälte gurken" }, 
+	[ { lc => "de", ingredients_text => "Schalotte geschält, geschälte haselnüsse, geschälter mandeln,
+			passionsfrucht ungeschält, ungeschälte gurken" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -519,34 +525,34 @@ my @tests = (
 	],
 
 # de:geschwefelt and variants
-	[ { lc => "de", ingredients_text => "Schalotte geschwefelt, geschwefelte haselnüsse, 
-				passionsfrucht ungeschwefelt, geschwefelte gurken" },
+	[ { lc => "de", ingredients_text => "Schalotte geschwefelt, geschwefelte haselnüsse,
+			passionsfrucht ungeschwefelt, geschwefelte gurken" },
 		[
 			{
-			    'id' => 'en:shallot',
-			    'processing' => 'de:geschwefelt',
-			    'text' => 'Schalotte'
+				'id' => 'en:shallot',
+				'processing' => 'de:geschwefelt',
+				'text' => 'Schalotte'
 			},
 			{
-			    'id' => 'en:hazelnut',
-			    'processing' => 'de:geschwefelt',
-			    'text' => "haseln\x{fc}sse"
+				'id' => 'en:hazelnut',
+				'processing' => 'de:geschwefelt',
+				'text' => "haseln\x{fc}sse"
 			},
 			{
-			    'id' => 'en:passion-fruit',
-			    'processing' => 'de:ungeschwefelt',
-			    'text' => 'passionsfrucht'
+				'id' => 'en:passion-fruit',
+				'processing' => 'de:ungeschwefelt',
+				'text' => 'passionsfrucht'
 			},
 			{
-			    'id' => 'en:gherkin',
-			    'processing' => 'de:geschwefelt',
-			    'text' => 'gurken'
+				'id' => 'en:gherkin',
+				'processing' => 'de:geschwefelt',
+				'text' => 'gurken'
 			}
 		]
 	],
 
-#  de:gesüßt 
-	[ { lc => "de", ingredients_text => "Schalotte gesüßt, gesüßte haselnüsse" }, 
+#  de:gesüßt
+	[ { lc => "de", ingredients_text => "Schalotte gesüßt, gesüßte haselnüsse" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -562,7 +568,7 @@ my @tests = (
 	],
 
 # de:gezuckert and variants
-	[ { lc => "de", ingredients_text => "Schalotte gezuckert, gezuckerte haselnüsse, mandeln leicht gezuckert, passionsfrucht ungezuckert" }, 
+	[ { lc => "de", ingredients_text => "Schalotte gezuckert, gezuckerte haselnüsse, mandeln leicht gezuckert, passionsfrucht ungezuckert" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -588,7 +594,7 @@ my @tests = (
 	],
 
 	# de:halbiert and variants
-	[ { lc => "de", ingredients_text => "Schalotte halbiert, halbierte haselnüsse, halbe mandeln" }, 
+	[ { lc => "de", ingredients_text => "Schalotte halbiert, halbierte haselnüsse, halbe mandeln" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -609,116 +615,118 @@ my @tests = (
 	],
 
 # de:konzentriert (and children) and synonyms
-	[ { lc => "de", ingredients_text => "konzentriert schalotte, konzentrierter haselnüsse, konzentrierte mandeln, konzentriertes acerolakirschen, 
-		zweifach konzentriert, 2 fach konzentriert, doppelt konzentriertes, zweifach konzentriertes, 2-fach konzentriert, dreifach konzentriert, 
-		200fach konzentriertes, eingekochter" }, 
-		[   {   'id'         => 'en:shallot',
+	[ { lc => "de", ingredients_text => "konzentriert schalotte, konzentrierter haselnüsse, konzentrierte mandeln, konzentriertes acerolakirschen,
+			zweifach konzentriert, 2 fach konzentriert, doppelt konzentriertes, zweifach konzentriertes, 2-fach konzentriert, dreifach konzentriert,
+			200fach konzentriertes, eingekochter" },
+		[
+			{	'id'         => 'en:shallot',
 				'processing' => 'en:concentrated',
 				'text'       => 'schalotte'
 			},
-			{   'id'         => 'en:hazelnut',
+			{	'id'         => 'en:hazelnut',
 				'processing' => 'en:concentrated',
 				'text'       => "haseln\x{fc}sse"
 			},
-			{   'id'         => 'en:almond',
+			{	'id'         => 'en:almond',
 				'processing' => 'en:concentrated',
 				'text'       => 'mandeln'
 			},
-			{   'id'         => 'en:acerola',
+			{	'id'         => 'en:acerola',
 				'processing' => 'en:concentrated',
 				'text'       => 'acerolakirschen'
 			},
-			{   'id'   => 'de:zweifach konzentriert',
+			{	'id'   => 'de:zweifach konzentriert',
 				'text' => 'zweifach konzentriert'
 			},
-			{   'id'   => 'de:2 fach konzentriert',
+			{	'id'   => 'de:2 fach konzentriert',
 				'text' => '2 fach konzentriert'
 			},
-			{   'id'   => 'de:doppelt konzentriertes',
+			{	'id'   => 'de:doppelt konzentriertes',
 				'text' => 'doppelt konzentriertes'
 			},
-			{   'id'   => 'de:zweifach konzentriertes',
+			{	'id'   => 'de:zweifach konzentriertes',
 				'text' => 'zweifach konzentriertes'
 			},
-			{   'id'   => 'de:2-fach konzentriert',
+			{	'id'   => 'de:2-fach konzentriert',
 				'text' => '2-fach konzentriert'
 			},
-			{   'id'   => 'de:dreifach konzentriert',
+			{	'id'   => 'de:dreifach konzentriert',
 				'text' => 'dreifach konzentriert'
 			},
-			{   'id'   => 'de:200fach konzentriertes',
+			{	'id'   => 'de:200fach konzentriertes',
 				'text' => '200fach konzentriertes'
 			},
-			{   'id'   => 'de:eingekochter',
+			{	'id'   => 'de:eingekochter',
 				'text' => 'eingekochter'
 			}
 		]
 	],
 
 # de:zerkleinert and variants
-	[ { lc => "de", ingredients_text => "Schalotte zerkleinert, zerkleinerte haselnüsse, zerkleinerter mandeln, zerkleinertes passionsfrucht, 
-						gurken grob zerkleinert, 
-						acerolakirschen fein zerkleinert, fein zerkleinerte spinat, 
-						zwiebel zum teil fein zerkleinert,
-						haselnüsse feinst zerkleinert,
-						überwiegend feinst zerkleinert Feigen" }, 
-						[
-						  {
-						    'id' => 'en:shallot',
-						    'processing' => 'de:zerkleinert',
-						    'text' => 'Schalotte'
-						  },
-						  {
-						    'id' => 'en:hazelnut',
-						    'processing' => 'de:zerkleinert',
-						    'text' => "haseln\x{fc}sse"
-						  },
-						  {
-						    'id' => 'en:almond',
-						    'processing' => 'de:zerkleinert',
-						    'text' => 'mandeln'
-						  },
-						  {
-						    'id' => 'en:passion-fruit',
-						    'processing' => 'de:zerkleinert',
-						    'text' => 'passionsfrucht'
-						  },
-						  {
-						    'id' => 'en:gherkin',
-						    'processing' => 'de:grob-zerkleinert',
-						    'text' => 'gurken'
-						  },
-						  {
-						    'id' => 'en:acerola',
-						    'processing' => 'de:fein-zerkleinert',
-						    'text' => 'acerolakirschen'
-						  },
-						  {
-						    'id' => 'en:spinach',
-						    'processing' => 'de:fein-zerkleinert',
-						    'text' => 'spinat'
-						  },
-						  {
-						    'id' => 'en:onion',
-						    'processing' => 'de:zum-teil-fein-zerkleinert',
-						    'text' => 'zwiebel'
-						  },
-						  {
-						    'id' => 'en:hazelnut',
-						    'processing' => 'de:feinst-zerkleinert',
-						    'text' => "haseln\x{fc}sse"
-						  },
-						  {
-						    'id' => 'en:fig',
-						    'processing' => "de:\x{fc}berwiegend-feinst-zerkleinert",
-						    'text' => 'Feigen'
-						  }
-						]
+	[ { lc => "de", ingredients_text => "Schalotte zerkleinert, zerkleinerte haselnüsse, zerkleinerter mandeln, zerkleinertes passionsfrucht,
+			gurken grob zerkleinert,
+			acerolakirschen fein zerkleinert, fein zerkleinerte spinat,
+			zwiebel zum teil fein zerkleinert,
+			haselnüsse feinst zerkleinert,
+			überwiegend feinst zerkleinert Feigen"
+		},
+		[
+			{
+				'id' => 'en:shallot',
+				'processing' => 'de:zerkleinert',
+				'text' => 'Schalotte'
+			},
+			{
+				'id' => 'en:hazelnut',
+				'processing' => 'de:zerkleinert',
+				'text' => "haseln\x{fc}sse"
+			},
+			{
+				'id' => 'en:almond',
+				'processing' => 'de:zerkleinert',
+				'text' => 'mandeln'
+			},
+			{
+				'id' => 'en:passion-fruit',
+				'processing' => 'de:zerkleinert',
+				'text' => 'passionsfrucht'
+			},
+			{
+				'id' => 'en:gherkin',
+				'processing' => 'de:grob-zerkleinert',
+				'text' => 'gurken'
+			},
+			{
+				'id' => 'en:acerola',
+				'processing' => 'de:fein-zerkleinert',
+				'text' => 'acerolakirschen'
+			},
+			{
+				'id' => 'en:spinach',
+				'processing' => 'de:fein-zerkleinert',
+				'text' => 'spinat'
+			},
+			{
+				'id' => 'en:onion',
+				'processing' => 'de:zum-teil-fein-zerkleinert',
+				'text' => 'zwiebel'
+			},
+			{
+				'id' => 'en:hazelnut',
+				'processing' => 'de:feinst-zerkleinert',
+				'text' => "haseln\x{fc}sse"
+			},
+			{
+				'id' => 'en:fig',
+				'processing' => "de:\x{fc}berwiegend-feinst-zerkleinert",
+				'text' => 'Feigen'
+			}
+		]
 	],
 
 # combinations
-	[ { lc => "de", ingredients_text => "haselnüsse gehackt und geröstet, 
-		gehackte und geröstete haselnuss, gehobelte und gehackte mandeln" },
+	[ { lc => "de", ingredients_text => "haselnüsse gehackt und geröstet,
+			gehackte und geröstete haselnuss, gehobelte und gehackte mandeln" },
 		[
 		# change on 17:01
 			{
@@ -727,9 +735,9 @@ my @tests = (
 				'text' => "haselnüsse"
 			},
 			{
-			    'id' => 'en:toasted-hazelnut',
-			    'processing' => 'en:chopped',
-			    'text' => "geröstete haselnuss"
+				'id' => 'en:toasted-hazelnut',
+				'processing' => 'en:chopped',
+				'text' => "geröstete haselnuss"
 			},
 			{
 				'id' => 'en:almond',
@@ -740,8 +748,8 @@ my @tests = (
 	],
 
 # Test for de:gemahlen and synonyms
-	[ { lc => "de", ingredients_text => "Schalotte gemahlen, gemahlene mandeln, gemahlener zwiebel, 
-			fein gemahlen haselnüsse, grob gemahlen spinat, frischgemahlen gurken" }, 
+	[ { lc => "de", ingredients_text => "Schalotte gemahlen, gemahlene mandeln, gemahlener zwiebel,
+			fein gemahlen haselnüsse, grob gemahlen spinat, frischgemahlen gurken" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -777,102 +785,102 @@ my @tests = (
 	],
 
 	# Test for de:getrocknet and synonyms
-		[ { lc => "de", ingredients_text => "Schalotte getrocknet, getrocknete mandeln, getrockneter zwiebel, 
-				 haselnüsse in getrockneter form, halbgetrocknete spinat, halbgetrocknet gurken, Feigen halb getrocknet, 
-				 Holunder gefriergetrocknet, gefriergetrocknete Papaye, gefriergetrocknetes Kiwi, sonnengetrocknet Ananas, 
-				 sonnengetrocknete Pflaumen, an der Sonne getrocknete Grapefruit, Guaven luftgetrocknet, luftgetrockneter Hagebutten, 
-				 Traube sprühgetrocknet, sprühgetrockneter Tamarinde" }, 
-				[
-				  {
-				    'id' => 'en:shallot',
-				    'processing' => 'en:dried',
-				    'text' => 'Schalotte'
-				  },
-				  {
-				    'id' => 'en:almond',
-				    'processing' => 'en:dried',
-				    'text' => 'mandeln'
-				  },
-				  {
-				    'id' => 'en:onion',
-				    'processing' => 'en:dried',
-				    'text' => 'zwiebel'
-				  },
-				  {
-				    'id' => 'en:hazelnut',
-				    'processing' => 'en:dried',
-				    'text' => "haseln\x{fc}sse"
-				  },
-				  {
-				    'id' => 'en:spinach',
-				    'processing' => 'en:semi-dried',
-				    'text' => 'spinat'
-				  },
-				  {
-				    'id' => 'en:gherkin',
-				    'processing' => 'en:semi-dried',
-				    'text' => 'gurken'
-				  },
-				  {
-				    'id' => 'en:fig',
-				    'processing' => 'en:semi-dried',
-				    'text' => 'Feigen'
-				  },
-				  {
-				    'id' => 'en:elder',
-				    'processing' => 'en:freeze-dried',
-				    'text' => 'Holunder'
-				  },
-				  {
-				    'id' => 'en:papaya',
-				    'processing' => 'en:freeze-dried',
-				    'text' => 'Papaye'
-				  },
-				  {
-				    'id' => 'en:kiwi',
-				    'processing' => 'en:freeze-dried',
-				    'text' => 'Kiwi'
-				  },
-				  {
-				    'id' => 'en:pineapple',
-				    'processing' => 'en:sundried',
-				    'text' => 'Ananas'
-				  },
-				  {
-				    'id' => 'en:plum',
-				    'processing' => 'en:sundried',
-				    'text' => 'Pflaumen'
-				  },
-				  {
-				    'id' => 'en:grapefruit',
-				    'processing' => 'en:sundried',
-				    'text' => 'Grapefruit'
-				  },
-				  {
-				    'id' => 'en:guava',
-				    'processing' => 'en:air-dried',
-				    'text' => 'Guaven'
-				  },
-				  {
-				    'id' => 'en:rose-hip',
-				    'processing' => 'en:air-dried',
-				    'text' => 'Hagebutten'
-				  },
-				  {
-				    'id' => 'en:grape',
-				    'processing' => "en:spray-dried",
-				    'text' => 'Traube'
-				  },
-				  {
-				    'id' => 'en:tamarind',
-				    'processing' => "en:spray-dried",
-				    'text' => 'Tamarinde'
-				  }
-			]
-		],
+	[ { lc => "de", ingredients_text => "Schalotte getrocknet, getrocknete mandeln, getrockneter zwiebel,
+			 haselnüsse in getrockneter form, halbgetrocknete spinat, halbgetrocknet gurken, Feigen halb getrocknet,
+			 Holunder gefriergetrocknet, gefriergetrocknete Papaye, gefriergetrocknetes Kiwi, sonnengetrocknet Ananas,
+			 sonnengetrocknete Pflaumen, an der Sonne getrocknete Grapefruit, Guaven luftgetrocknet, luftgetrockneter Hagebutten,
+			 Traube sprühgetrocknet, sprühgetrockneter Tamarinde" },
+		[
+			{
+				'id' => 'en:shallot',
+				'processing' => 'en:dried',
+				'text' => 'Schalotte'
+			},
+			{
+				'id' => 'en:almond',
+				'processing' => 'en:dried',
+				'text' => 'mandeln'
+			},
+			{
+				'id' => 'en:onion',
+				'processing' => 'en:dried',
+				'text' => 'zwiebel'
+			},
+			{
+				'id' => 'en:hazelnut',
+				'processing' => 'en:dried',
+				'text' => "haseln\x{fc}sse"
+			},
+			{
+				'id' => 'en:spinach',
+				'processing' => 'en:semi-dried',
+				'text' => 'spinat'
+			},
+			{
+				'id' => 'en:gherkin',
+				'processing' => 'en:semi-dried',
+				'text' => 'gurken'
+			},
+			{
+				'id' => 'en:fig',
+				'processing' => 'en:semi-dried',
+				'text' => 'Feigen'
+			},
+			{
+				'id' => 'en:elder',
+				'processing' => 'en:freeze-dried',
+				'text' => 'Holunder'
+			},
+			{
+				'id' => 'en:papaya',
+				'processing' => 'en:freeze-dried',
+				'text' => 'Papaye'
+			},
+			{
+				'id' => 'en:kiwi',
+				'processing' => 'en:freeze-dried',
+				'text' => 'Kiwi'
+			},
+			{
+				'id' => 'en:pineapple',
+				'processing' => 'en:sundried',
+				'text' => 'Ananas'
+			},
+			{
+				'id' => 'en:plum',
+				'processing' => 'en:sundried',
+				'text' => 'Pflaumen'
+			},
+			{
+				'id' => 'en:grapefruit',
+				'processing' => 'en:sundried',
+				'text' => 'Grapefruit'
+			},
+			{
+				'id' => 'en:guava',
+				'processing' => 'en:air-dried',
+				'text' => 'Guaven'
+			},
+			{
+				'id' => 'en:rose-hip',
+				'processing' => 'en:air-dried',
+				'text' => 'Hagebutten'
+			},
+			{
+				'id' => 'en:grape',
+				'processing' => "en:spray-dried",
+				'text' => 'Traube'
+			},
+			{
+				'id' => 'en:tamarind',
+				'processing' => "en:spray-dried",
+				'text' => 'Tamarinde'
+			}
+		]
+	],
 
 # Test for de:passiert
-	[ { lc => "de", ingredients_text => "Schalotte passiert" }, 
+	[ { lc => "de", ingredients_text => "Schalotte passiert" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -883,8 +891,8 @@ my @tests = (
 	],
 
 # Test for de:ungesalzen
-	[ { lc => "de", ingredients_text => "hartkäse gesalzen, haselnüsse gesalzene, haselnüsse gesalzenes, 
-	gesalzener haselnuss, ungesalzen schalotte, ungesalzene mandeln" },
+	[ { lc => "de", ingredients_text => "hartkäse gesalzen, haselnüsse gesalzene, haselnüsse gesalzenes,
+			gesalzener haselnuss, ungesalzen schalotte, ungesalzene mandeln" },
 		[
 			{
 				'id' => "en:hard-cheese",
@@ -910,7 +918,7 @@ my @tests = (
 				'id' => 'en:shallot',
 				'processing' => 'en:unsalted',
 				'text' => 'schalotte'
- 			},
+			},
 			{
 				'id' => 'en:almond',
 				'processing' => 'en:unsalted',
@@ -918,12 +926,12 @@ my @tests = (
 			}
 		]
 	],
-	
+
 
 # Test for process de:entsteint
-	[ { lc => "de", ingredients_text => "Schalotte entsteint" }, 
+	[ { lc => "de", ingredients_text => "Schalotte entsteint" },
 		[
-		  	{
+			{
 				'id' => 'en:shallot',
 				'processing' => 'en:pitted',
 				'text' => 'Schalotte'
@@ -932,19 +940,19 @@ my @tests = (
 	],
 
 # Test for process de:eingelegt
-	[ { lc => "de", ingredients_text => "Schalotte eingelegt" }, 
+	[ { lc => "de", ingredients_text => "Schalotte eingelegt" },
 		[
-		  	{
+			{
 				'id' => 'en:shallot',
 				'processing' => 'en:pickled',
 				'text' => 'Schalotte'
 			}
 		]
 	],
-	
+
 
 # Test for de: ingredients, that should NOT be detected through processing
-	[ { lc => "de", ingredients_text => "Markerbsen, Deutsche Markenbutter" }, 
+	[ { lc => "de", ingredients_text => "Markerbsen, Deutsche Markenbutter" },
 		[
 			{
 				'id' => 'en:garden-peas',
@@ -979,7 +987,7 @@ my @tests = (
 	#],
 
 	# Various tests
-	[ { lc => "de", ingredients_text => "hartkäse gehobelt, haselnüsse gehackt, 
+	[ { lc => "de", ingredients_text => "hartkäse gehobelt, haselnüsse gehackt,
 		, gehobelte und gehackte mandeln, Dickmilch in scheiben geschnitten" },
 		[
 			{
@@ -1027,7 +1035,7 @@ my @tests = (
 	],
 
 # All variants of de:mariniert
-	[ { lc => "de", ingredients_text => "Schalotte mariniert, zwiebel marinierte, spinat marinierter, 
+	[ { lc => "de", ingredients_text => "Schalotte mariniert, zwiebel marinierte, spinat marinierter,
 		mariniertes gurken" },
 		[
 			{
@@ -1054,8 +1062,8 @@ my @tests = (
 	],
 
 # All variants of de:geschnitten
-	[ { lc => "de", ingredients_text => "Schalotte geschnitten, zwiebel mittelfein geschnittenen, spinat feingeschnitten, 
-		fein geschnittenen gurken, feingeschnittener Mandeln, handgeschnittene haselnüsse" },
+	[ { lc => "de", ingredients_text => "Schalotte geschnitten, zwiebel mittelfein geschnittenen, spinat feingeschnitten,
+			fein geschnittenen gurken, feingeschnittener Mandeln, handgeschnittene haselnüsse" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -1089,6 +1097,7 @@ my @tests = (
 			}
 		]
 	],
+
 
 	[ { lc => "de", ingredients_text => "Schalottepüree, zwiebel püree, spinat-püree, gurkenmark" },
 		[
@@ -1135,10 +1144,10 @@ my @tests = (
 			}
 		]
 	],
-	
+
 # de würfel and synonyms tests
-	[ { lc => "de", ingredients_text => "Schalottewürfel, spinat gewürfelt, gewürfelte gurken, 
-zwiebel in würfel geschnitten, mandeln in würfel" },
+	[ { lc => "de", ingredients_text => "Schalottewürfel, spinat gewürfelt, gewürfelte gurken,
+			zwiebel in würfel geschnitten, mandeln in würfel" },
 		[
 			{
 				'id' => 'en:shallot',
@@ -1168,101 +1177,105 @@ zwiebel in würfel geschnitten, mandeln in würfel" },
 		]
 	],
 
-	[ { lc => "en", ingredients_text => "smoked sea salt, smoked turkey"},
-[
-  {
-    'id' => 'en:sea-salt',
-    'processing' => 'en:smoked',
-    'text' => 'sea salt'
-  },
-  {
-    'id' => 'en:turkey',
-    'processing' => 'en:smoked',
-    'text' => 'turkey'
-  }
-]
 
+	[ { lc => "en", ingredients_text => "smoked sea salt, smoked turkey"},
+		[
+			{
+				'id' => 'en:sea-salt',
+				'processing' => 'en:smoked',
+				'text' => 'sea salt'
+			},
+			{
+				'id' => 'en:turkey',
+				'processing' => 'en:smoked',
+				'text' => 'turkey'
+			}
+		]
 	],
 
+
 	[ { lc => "fr", ingredients_text => "sel marin fumé, jambon fumé, arôme de fumée, lardons fumés au bois de hêtre "},
-[
-  {
-    'id' => 'en:sea-salt',
-    'processing' => 'en:smoked',
-    'text' => 'sel marin'
-  },
-  {
-    'id' => 'en:ham',
-    'processing' => 'en:smoked',
-    'text' => 'jambon'
-  },
-  {
-    'id' => 'en:smoke-flavouring',
-    'text' => "ar\x{f4}me de fum\x{e9}e"
-  },
-  {
-    'id' => 'en:lardon',
-    'processing' => 'en:beech-smoked',
-    'text' => 'lardons'
-  }
-]
-        ],
+		[
+			{
+				'id' => 'en:sea-salt',
+				'processing' => 'en:smoked',
+				'text' => 'sel marin'
+			},
+			{
+				'id' => 'en:ham',
+				'processing' => 'en:smoked',
+				'text' => 'jambon'
+			},
+			{
+				'id' => 'en:smoke-flavouring',
+				'text' => "ar\x{f4}me de fum\x{e9}e"
+			},
+			{
+				'id' => 'en:lardon',
+				'processing' => 'en:beech-smoked',
+				'text' => 'lardons'
+			}
+		]
+	],
 
 
 	[ { lc => "es", ingredients_text => "tofu ahumado, panceta ahumada"},
-[
-  {
-    'id' => 'en:tofu',
-    'processing' => 'en:smoked',
-    'text' => 'tofu'
-  },
-  {
-    'id' => 'en:bacon',
-    'processing' => 'en:smoked',
-    'text' => 'panceta'
-  }
-
-]
+		[
+			{
+				'id' => 'en:tofu',
+				'processing' => 'en:smoked',
+				'text' => 'tofu'
+			},
+			{
+				'id' => 'en:bacon',
+				'processing' => 'en:smoked',
+				'text' => 'panceta'
+			}
+		]
 	],
 
 	# ingredient with (processing) in parenthesis
 	[ { lc => "en", ingredients_text => "garlic (powdered)",},
-[
-  {
-    'id' => 'en:garlic',
-    'processing' => 'en:powdered',
-    'text' => 'garlic'
-  }
-]
+		[
+			{
+				'id' => 'en:garlic',
+				'processing' => 'en:powdered',
+				'text' => 'garlic'
+			}
+		]
 	],
+
+
 	[ { lc => "fr", ingredients_text => "piment (en poudre)"},
-[
-  {
-    'id' => 'en:chili-pepper',
-    'processing' => 'en:powdered',
-    'text' => 'piment'
-  }
-]
+		[
+			{
+				'id' => 'en:chili-pepper',
+				'processing' => 'en:powdered',
+				'text' => 'piment'
+			}
+		]
 	],
+
 
 	[ { lc => "en", ingredients_text => "pasteurized eggs" },
-[
-  {
-    'id' => 'en:egg',
-    'processing' => 'en:pasteurised',
-    'text' => 'eggs'
-  }
-]
+		[
+			{
+				'id' => 'en:egg',
+				'processing' => 'en:pasteurised',
+				'text' => 'eggs'
+			}
+		]
 	],
 
+
 	[ { lc => "es", ingredients_text => "pimientos amarillos deshidratados" },
-[
-  {
-    'id' => 'en:yellow-bell-pepper',
-    'processing' => 'en:dehydrated',
-    'text' => 'pimientos amarillos'
-  }
-]
+		[
+			{
+				'id' => 'en:yellow-bell-pepper',
+				'processing' => 'en:dehydrated',
+				'text' => 'pimientos amarillos'
+			}
+		]
 	],
 
 );

--- a/t/ingredients_tags.t
+++ b/t/ingredients_tags.t
@@ -73,15 +73,15 @@ my @tests = (
 	[ { lc => "fr", ingredients_text => "sucre 22g**"}, [ "en:sugar" ], ],
 
 	# [ { lc => "de", ingredients_text => "Wasser, Kohlensäure, Farbstoff Zuckerkulör E 150d, Süßungsmittel Aspartam* und Acesulfam-K, Säuerungsmittel Phosphorsäure und Citronensäure, Säureregulator Natriumcitrat, Aroma Koffein, Aroma. enthält eine Phenylalaninquelle"}, [ "en:sugar" ], ],
-	 [ { lc => "de", ingredients_text => "Wasser, Kohlensäure, Süßungsmittel Aspartam* und Acesulfam-K. *enthält eine Phenylalaninquelle"}, [ "en:water", "en:e290", "en:sweetener", "en:e951", "en:e950" ], ],
-	 [ { lc => "de", ingredients_text => "Aspartam und Acesulfam-K"}, [ "en:e951", "en:e950" ], ],
-	 [ { lc => "de", ingredients_text => "Farbstoffe (Betenrot, Paprikaextrakt, Kurkumin)"}, [ "en:colour", "en:e162", "en:e160c", "en:e100" ], ],
+	[ { lc => "de", ingredients_text => "Wasser, Kohlensäure, Süßungsmittel Aspartam* und Acesulfam-K. *enthält eine Phenylalaninquelle"}, [ "en:water", "en:e290", "en:sweetener", "en:e951", "en:e950" ], ],
+	[ { lc => "de", ingredients_text => "Aspartam und Acesulfam-K"}, [ "en:e951", "en:e950" ], ],
+	[ { lc => "de", ingredients_text => "Farbstoffe (Betenrot, Paprikaextrakt, Kurkumin)"}, [ "en:colour", "en:e162", "en:e160c", "en:e100" ], ],
 
-	 [ { lc => "fr", ingredients_text => "graisse végétale bio (colza)"}, ["en:colza-oil"]],
+	[ { lc => "fr", ingredients_text => "graisse végétale bio (colza)"}, ["en:colza-oil"]],
 
-	 [ { lc => "fr", ingredients_text => "lait cru de lapin"}, ["fr:lait cru de lapin"]],
-	 [ { lc => "fr", ingredients_text => "aubergine crue, dés de jambon cru coupés, jambon de montagne cru"}, ["en:aubergine", "en:raw-ham", "fr:jambon de montagne cru"]],
-	 [ { lc => "en", ingredients_text => "raw cane sugar, raw bananas, raw sliced tomatoes, cooked raw sugar"}, ["en:unrefined-cane-sugar", "en:banana", "en:tomato", "en:unrefined-sugar"]],
+	[ { lc => "fr", ingredients_text => "lait cru de lapin"}, ["fr:lait cru de lapin"]],
+	[ { lc => "fr", ingredients_text => "aubergine crue, dés de jambon cru coupés, jambon de montagne cru"}, ["en:aubergine", "en:raw-ham", "fr:jambon de montagne cru"]],
+	[ { lc => "en", ingredients_text => "raw cane sugar, raw bananas, raw sliced tomatoes, cooked raw sugar"}, ["en:unrefined-cane-sugar", "en:banana", "en:tomato", "en:unrefined-sugar"]],
 
 	[ { lc => "en", ingredients_text => "vegetable oil (coconut & rapeseed)" }, ["en:vegetable-oil", "en:coconut", "en:rapeseed"]],
 

--- a/t/lang.t
+++ b/t/lang.t
@@ -12,14 +12,14 @@ use ProductOpener::Config qw/:all/;
 
 sub test_links {
 
-    my $regex = shift;
-    my @links = shift;
+	my $regex = shift;
+	my @links = shift;
 
-    foreach my $key (@links) {
-	foreach my $lang (keys %{$Lang{$key}}) {
-            like($Lang{$key}{$lang}, $regex, "'$key' in '$lang' should be a link");
-        }
-    }
+	foreach my $key (@links) {
+		foreach my $lang (keys %{$Lang{$key}}) {
+			like($Lang{$key}{$lang}, $regex, "'$key' in '$lang' should be a link");
+		}
+	}
 
 	return;
 }

--- a/t/tags.t
+++ b/t/tags.t
@@ -58,36 +58,36 @@ is (display_tags_hierarchy_taxonomy("en", "categories", ["en:doesnotexist"]), '<
 # test add_tags_to_field
 
 $product_ref = {
-        lc => "fr",
+	lc => "fr",
 };
 
 add_tags_to_field($product_ref, "fr", "categories", "pommes, bananes");
 
 is_deeply($product_ref,
 {
-   'categories' => 'pommes, bananes',
-   'lc' => 'fr',
-   'categories_hierarchy' => [
-     'en:plant-based-foods-and-beverages',
-     'en:plant-based-foods',
-     'en:fruits-and-vegetables-based-foods',
-     'en:fruits-based-foods',
-     'en:fruits',
-     'en:apples',
-     'en:tropical-fruits',
-     'en:bananas'
-   ],
-   'categories_lc' => 'fr',
-   'categories_tags' => [
-     'en:plant-based-foods-and-beverages',
-     'en:plant-based-foods',
-     'en:fruits-and-vegetables-based-foods',
-     'en:fruits-based-foods',
-     'en:fruits',
-     'en:apples',
-     'en:tropical-fruits',
-     'en:bananas'
-   ],
+	'categories' => 'pommes, bananes',
+	'lc' => 'fr',
+	'categories_hierarchy' => [
+		'en:plant-based-foods-and-beverages',
+		'en:plant-based-foods',
+		'en:fruits-and-vegetables-based-foods',
+		'en:fruits-based-foods',
+		'en:fruits',
+		'en:apples',
+		'en:tropical-fruits',
+		'en:bananas'
+	],
+	'categories_lc' => 'fr',
+	'categories_tags' => [
+		'en:plant-based-foods-and-beverages',
+		'en:plant-based-foods',
+		'en:fruits-and-vegetables-based-foods',
+		'en:fruits-based-foods',
+		'en:fruits',
+		'en:apples',
+		'en:tropical-fruits',
+		'en:bananas'
+	],
 
 }
 ) or diag explain $product_ref;
@@ -101,31 +101,31 @@ delete($product_ref->{categories_next_hierarchy});
 delete($product_ref->{categories_next_tags});
 
 is_deeply($product_ref,
- {
-   'categories' => 'pommes, bananes',
-   'categories_hierarchy' => [
-     'en:plant-based-foods-and-beverages',
-     'en:plant-based-foods',
-     'en:fruits-and-vegetables-based-foods',
-     'en:fruits-based-foods',
-     'en:fruits',
-     'en:apples',
-     'en:tropical-fruits',
-     'en:bananas',
-   ],
-   'categories_lc' => 'fr',
-   'categories_tags' => [
-     'en:plant-based-foods-and-beverages',
-     'en:plant-based-foods',
-     'en:fruits-and-vegetables-based-foods',
-     'en:fruits-based-foods',
-     'en:fruits',
-     'en:apples',
-     'en:tropical-fruits',
-     'en:bananas',
-   ],
-   'lc' => 'fr'
- }
+{
+	'categories' => 'pommes, bananes',
+	'categories_hierarchy' => [
+		'en:plant-based-foods-and-beverages',
+		'en:plant-based-foods',
+		'en:fruits-and-vegetables-based-foods',
+		'en:fruits-based-foods',
+		'en:fruits',
+		'en:apples',
+		'en:tropical-fruits',
+		'en:bananas',
+	],
+	'categories_lc' => 'fr',
+	'categories_tags' => [
+		'en:plant-based-foods-and-beverages',
+		'en:plant-based-foods',
+		'en:fruits-and-vegetables-based-foods',
+		'en:fruits-based-foods',
+		'en:fruits',
+		'en:apples',
+		'en:tropical-fruits',
+		'en:bananas',
+	],
+	'lc' => 'fr'
+}
 
 ) or diag explain $product_ref;
 
@@ -147,20 +147,20 @@ add_tags_to_field($product_ref, "fr", "categories", "en:raspberries, en:plum");
 compute_field_tags($product_ref, "fr", "categories");
 
 is_deeply($product_ref->{categories_tags},
- [
-   'en:plant-based-foods-and-beverages',
-   'en:plant-based-foods',
-   'en:fruits-and-vegetables-based-foods',
-   'en:fruits-based-foods',
-   'en:fruits',
-   'en:apples',
-   'en:berries',
-   'en:tropical-fruits',
-   'en:bananas',
-   'en:plums',
-   'en:raspberries',
-   'en:strawberries',
- ]
+[
+	'en:plant-based-foods-and-beverages',
+	'en:plant-based-foods',
+	'en:fruits-and-vegetables-based-foods',
+	'en:fruits-based-foods',
+	'en:fruits',
+	'en:apples',
+	'en:berries',
+	'en:tropical-fruits',
+	'en:bananas',
+	'en:plums',
+	'en:raspberries',
+	'en:strawberries',
+]
 
 ) or diag explain $product_ref->{categories_tags};
 
@@ -169,23 +169,23 @@ compute_field_tags($product_ref, "es", "categories");
 
 
 is_deeply($product_ref->{categories_tags},
- [
-   'en:plant-based-foods-and-beverages',
-   'en:plant-based-foods',
-   'en:fruits-and-vegetables-based-foods',
-   'en:fruits-based-foods',
-   'en:fruits',
-   'en:apples',
-   'en:berries',
-   'en:citrus',
-   'en:tropical-fruits',
-   'en:bananas',
-   'en:lemons',
-   'en:oranges',
-   'en:plums',
-   'en:raspberries',
-   'en:strawberries',
- ]
+[
+	'en:plant-based-foods-and-beverages',
+	'en:plant-based-foods',
+	'en:fruits-and-vegetables-based-foods',
+	'en:fruits-based-foods',
+	'en:fruits',
+	'en:apples',
+	'en:berries',
+	'en:citrus',
+	'en:tropical-fruits',
+	'en:bananas',
+	'en:lemons',
+	'en:oranges',
+	'en:plums',
+	'en:raspberries',
+	'en:strawberries',
+]
 
 ) or diag explain $product_ref->{categories_tags};
 
@@ -195,60 +195,60 @@ add_tags_to_field($product_ref, "it", "categories", "bogus, mele");
 compute_field_tags($product_ref, "it", "categories");
 
 is_deeply($product_ref->{categories_tags},
- [
-   'en:plant-based-foods-and-beverages',
-   'en:plant-based-foods',
-   'en:fruits-and-vegetables-based-foods',
-   'en:fruits-based-foods',
-   'en:fruits',
-   'en:apples',
-   'en:berries',
-   'en:citrus',
-   'en:tropical-fruits',
-   'en:bananas',
-   'en:lemons',
-   'en:oranges',
-   'en:plums',
-   'en:raspberries',
-   'en:strawberries',
-   'it:bogus',
- ]
+[
+	'en:plant-based-foods-and-beverages',
+	'en:plant-based-foods',
+	'en:fruits-and-vegetables-based-foods',
+	'en:fruits-based-foods',
+	'en:fruits',
+	'en:apples',
+	'en:berries',
+	'en:citrus',
+	'en:tropical-fruits',
+	'en:bananas',
+	'en:lemons',
+	'en:oranges',
+	'en:plums',
+	'en:raspberries',
+	'en:strawberries',
+	'it:bogus',
+]
 
 #) or diag explain $product_ref->{categories_tags};
 ) or diag explain $product_ref;
 
 
 $product_ref = {
-        lc => "fr",
+	lc => "fr",
 };
 
 add_tags_to_field($product_ref, "fr", "countries", "france, en:spain, deutschland, fr:bolivie, italie, de:suisse, colombia, bidon");
 
 is_deeply($product_ref,
 {
-   'countries' => 'france, en:spain, deutschland, fr:bolivie, italie, de:suisse, colombia, bidon',
-   'lc' => 'fr',
-   'countries_hierarchy' => [
-     'en:bolivia',
-     'en:colombia',
-     'en:france',
-     'en:italy',
-     'en:spain',
-     'en:switzerland',
-     'fr:bidon',
-     'fr:deutschland'
-   ],
-   'countries_lc' => 'fr',
-   'countries_tags' => [
-     'en:bolivia',
-     'en:colombia',
-     'en:france',
-     'en:italy',
-     'en:spain',
-     'en:switzerland',
-     'fr:bidon',
-     'fr:deutschland'
-   ],
+	'countries' => 'france, en:spain, deutschland, fr:bolivie, italie, de:suisse, colombia, bidon',
+	'lc' => 'fr',
+	'countries_hierarchy' => [
+		'en:bolivia',
+		'en:colombia',
+		'en:france',
+		'en:italy',
+		'en:spain',
+		'en:switzerland',
+		'fr:bidon',
+		'fr:deutschland'
+	],
+	'countries_lc' => 'fr',
+	'countries_tags' => [
+		'en:bolivia',
+		'en:colombia',
+		'en:france',
+		'en:italy',
+		'en:spain',
+		'en:switzerland',
+		'fr:bidon',
+		'fr:deutschland'
+	],
 
 
 }) or diag explain($product_ref);
@@ -258,14 +258,14 @@ compute_field_tags($product_ref, "fr", "countries");
 
 is_deeply($product_ref->{countries_tags},
 [
-   'en:bolivia',
-   'en:colombia',
-   'en:france',
-   'en:italy',
-   'en:spain',
-   'en:switzerland',
-   'fr:bidon',
-   'fr:deutschland',
+	'en:bolivia',
+	'en:colombia',
+	'en:france',
+	'en:italy',
+	'en:spain',
+	'en:switzerland',
+	'fr:bidon',
+	'fr:deutschland',
 ]
 )  or diag explain $product_ref->{countries_tags};
 
@@ -274,35 +274,35 @@ compute_field_tags($product_ref, "es", "countries");
 
 is_deeply($product_ref->{countries_tags},
 [
-   'en:bolivia',
-   'en:colombia',
-   'en:france',
-   'en:italy',
-   'en:peru',
-   'en:spain',
-   'en:switzerland',
-   'es:bogus',
-   'fr:bidon',
-   'fr:deutschland',
+	'en:bolivia',
+	'en:colombia',
+	'en:france',
+	'en:italy',
+	'en:peru',
+	'en:spain',
+	'en:switzerland',
+	'es:bogus',
+	'fr:bidon',
+	'fr:deutschland',
 ]
 )  or diag explain $product_ref->{countries_tags};
 
 
 $product_ref = {
-        lc => "fr",
+	lc => "fr",
 };
 
 add_tags_to_field($product_ref, "fr", "brands", "Baba, Bobo");
 
 is_deeply($product_ref,
 {
-   'brands' => 'Baba, Bobo',
-  'brands_tags' => [
-     'baba',
-     'bobo'
-   ],
+	'brands' => 'Baba, Bobo',
+	'brands_tags' => [
+		'baba',
+		'bobo'
+	],
 
-   'lc' => 'fr'
+	'lc' => 'fr'
 }) or diag explain($product_ref);
 
 
@@ -310,8 +310,8 @@ compute_field_tags($product_ref, "fr", "brands");
 
 is_deeply($product_ref->{brands_tags},
 [
-   'baba',
-   'bobo',
+	'baba',
+	'bobo',
 ]
 )  or diag explain $product_ref->{brands_tags};
 
@@ -321,14 +321,14 @@ delete $product_ref->{brands_debug_tags};
 
 is_deeply($product_ref,
 {
-   'brands' => 'Baba, Bobo, Bibi',
-   'brands_tags' => [
-     'baba',
-     'bobo',
-     'bibi',
-   ],
+	'brands' => 'Baba, Bobo, Bibi',
+	'brands_tags' => [
+		'baba',
+		'bobo',
+		'bibi',
+	],
 
-   'lc' => 'fr'
+	'lc' => 'fr'
 }) or diag explain($product_ref);
 
 
@@ -338,9 +338,9 @@ delete $product_ref->{brands_debug_tags};
 
 is_deeply($product_ref->{brands_tags},
 [
-   'baba',
-   'bobo',
-   'bibi',
+	'baba',
+	'bobo',
+	'bibi',
 ]
 )  or diag explain $product_ref->{brands_tags};
 
@@ -349,16 +349,16 @@ my @tags = ();
 @tags = gen_tags_hierarchy_taxonomy("en", "ingredients", "en:concentrated-orange-juice, en:sugar, en:salt, en:orange");
 
 is_deeply (\@tags, [
-   'en:fruit',
-   'en:citrus-fruit',
-   'en:fruit-juice',
-   'en:salt',
-   'en:sugar',
-   'en:orange',
-   'en:orange-juice',
-   'en:concentrated-orange-juice'
- ]
- ) or diag explain(\@tags);
+	'en:fruit',
+	'en:citrus-fruit',
+	'en:fruit-juice',
+	'en:salt',
+	'en:sugar',
+	'en:orange',
+	'en:orange-juice',
+	'en:concentrated-orange-juice'
+]
+) or diag explain(\@tags);
 
 
 foreach my $tag (@tags) {
@@ -370,16 +370,16 @@ foreach my $tag (@tags) {
 @tags = gen_ingredients_tags_hierarchy_taxonomy("en", "en:concentrated-orange-juice, en:sugar, en:salt, en:orange");
 
 is_deeply (\@tags, [
-   'en:concentrated-orange-juice',
-   'en:fruit',
-   'en:citrus-fruit',
-   'en:fruit-juice',
-   'en:orange',
-   'en:orange-juice',
-   'en:sugar',
-   'en:salt',
- ]
- ) or diag explain(\@tags);
+	'en:concentrated-orange-juice',
+	'en:fruit',
+	'en:citrus-fruit',
+	'en:fruit-juice',
+	'en:orange',
+	'en:orange-juice',
+	'en:sugar',
+	'en:salt',
+]
+) or diag explain(\@tags);
 
 ProductOpener::Tags::retrieve_tags_taxonomy("test");
 
@@ -439,26 +439,24 @@ $product_ref = {
 compute_field_tags($product_ref, "de", "test");
 
 is_deeply($product_ref,
-	 {
-	    'lc' => 'de',
-	    'test' => "Gr\x{fc}nkohl, \x{c4}pfel, caf\x{e9}, test",
-	    'test_hierarchy' => [
-	      'en:kale',
-	      "de:caf\x{e9}",
-	      'de:test',
-	      "de:\x{c4}pfel"
-	    ],
-	    'test_lc' => 'de',
-	    'test_tags' => [
-	      'en:kale',
-	      "de:caf\x{e9}",
-	      'de:test',
-	      "de:\x{e4}pfel"
-	    ]
-	  }
-
-)
-	or diag explain $product_ref;
+	{
+		'lc' => 'de',
+		'test' => "Gr\x{fc}nkohl, \x{c4}pfel, caf\x{e9}, test",
+		'test_hierarchy' => [
+			'en:kale',
+			"de:caf\x{e9}",
+			'de:test',
+			"de:\x{c4}pfel"
+		],
+		'test_lc' => 'de',
+		'test_tags' => [
+			'en:kale',
+			"de:caf\x{e9}",
+			'de:test',
+			"de:\x{e4}pfel"
+		]
+	}
+) or diag explain $product_ref;
 
 
 $product_ref = { "stores" => "Intermarché" };
@@ -485,16 +483,16 @@ is(ProductOpener::Tags::remove_stopwords("ingredients", "fr", "fruits-en-proport
 is(ProductOpener::Tags::remove_stopwords("ingredients", "fr", "des-de-tomate"), "des-de-tomate");
 
 my $tag_ref = get_taxonomy_tag_and_link_for_lang("fr", "categories", "en:strawberry-yogurts");
-is_deeply($tag_ref,  {
-'css_class' => 'tag known ',
-'display' => "Yaourts \x{e0} la fraise",
-'display_lc' => 'fr',
-'html_lang' => ' lang="fr"',
-'known' => 1,
-'tagid' => 'en:strawberry-yogurts',
-'tagurl' => 'yaourts-a-la-fraise'
-}
-   ) or diag explain $tag_ref;
+is_deeply($tag_ref, {
+		'css_class' => 'tag known ',
+		'display' => "Yaourts \x{e0} la fraise",
+		'display_lc' => 'fr',
+		'html_lang' => ' lang="fr"',
+		'known' => 1,
+		'tagid' => 'en:strawberry-yogurts',
+		'tagurl' => 'yaourts-a-la-fraise'
+	}
+) or diag explain $tag_ref;
 
 is(get_string_id_for_lang("fr", "Yaourts à la fraise"), "yaourts-a-la-fraise");
 
@@ -502,35 +500,35 @@ is(get_string_id_for_lang("fr", "Yaourts à la fraise"), "yaourts-a-la-fraise");
 @tags = gen_tags_hierarchy_taxonomy("en", "labels", "gmo free and organic");
 
 is_deeply (\@tags, [
-   'en:organic',
-   'en:no-gmos',
- ]
- ) or diag explain(\@tags);
+		'en:organic',
+		'en:no-gmos',
+	]
+) or diag explain(\@tags);
 
 @tags = gen_tags_hierarchy_taxonomy("fr", "labels", "commerce équitable, label rouge et bio");
 
 is_deeply (\@tags, [
-   'en:organic',
-   'en:fair-trade',
-   'en:label-rouge',
- ]
- ) or diag explain(\@tags);
+		'en:organic',
+		'en:fair-trade',
+		'en:label-rouge',
+	]
+) or diag explain(\@tags);
 
 @tags = gen_tags_hierarchy_taxonomy("fr", "labels", "Déconseillé aux enfants et aux femmes enceintes");
 
 is_deeply (\@tags, [
- 'en:not-advised-for-specific-people',
- 'en:not-advised-for-children-and-pregnant-women'
- ]
- ) or diag explain(\@tags);
+		'en:not-advised-for-specific-people',
+		'en:not-advised-for-children-and-pregnant-women'
+	]
+) or diag explain(\@tags);
 
 @tags = gen_tags_hierarchy_taxonomy("fr", "traces", "MOUTARDE ET SULFITES");
 
 is_deeply (\@tags, [
-   'en:mustard',
-   'en:sulphur-dioxide-and-sulphites'
- ]
- ) or diag explain(\@tags);
+	'en:mustard',
+	'en:sulphur-dioxide-and-sulphites'
+]
+) or diag explain(\@tags);
 
 is_deeply(canonicalize_taxonomy_tag("fr", "test", "yaourts au maracuja"), "en:passion-fruit-yogurts");
 is_deeply(canonicalize_taxonomy_tag("fr", "test", "yaourt banane"), "en:banana-yogurts");
@@ -545,9 +543,9 @@ is_deeply(canonicalize_taxonomy_tag("en", "labels", "au jus"), "en:au jus");
 
 $product_ref = {
 	lc => "fr",
-          'categories_hierarchy' => [
-                                 'en:meals',
-                               ],
+	'categories_hierarchy' => [
+		'en:meals',
+	],
 };
 
 
@@ -564,18 +562,18 @@ add_tags_to_field($product_ref, "es", "categories", "en:peaches");
 compute_field_tags($product_ref, "es", "categories");
 
 is_deeply($product_ref->{categories_tags},  [
-     'en:plant-based-foods-and-beverages',
-     'en:plant-based-foods',
-     'en:fruits-and-vegetables-based-foods',
-     'en:meals',
-     'en:fruits-based-foods',
-     'en:fruits',
-     'en:apples',
-     'en:peaches',
-     'en:tropical-fruits',
-     'en:bananas',
-     'en:pears',
-   ],
+		'en:plant-based-foods-and-beverages',
+		'en:plant-based-foods',
+		'en:fruits-and-vegetables-based-foods',
+		'en:meals',
+		'en:fruits-based-foods',
+		'en:fruits',
+		'en:apples',
+		'en:peaches',
+		'en:tropical-fruits',
+		'en:bananas',
+		'en:pears',
+	],
 ) or diag explain $product_ref;
 
 $product_ref = {
@@ -586,60 +584,57 @@ $product_ref = {
 compute_field_tags($product_ref, "fr", "categories");
 
 is_deeply($product_ref->{categories_tags}, [
-     'en:plant-based-foods-and-beverages',
-     'en:plant-based-foods',
-     'en:fruits-and-vegetables-based-foods',
-     'en:fruits-based-foods',
-     'en:fruits',
-     'en:apples',
-     'en:berries',
-     'en:citrus',
-     'en:tropical-fruits',
-     'en:bananas',
-     'en:lemons',
-     'en:pears',
-     'en:strawberries'
+	'en:plant-based-foods-and-beverages',
+	'en:plant-based-foods',
+	'en:fruits-and-vegetables-based-foods',
+	'en:fruits-based-foods',
+	'en:fruits',
+	'en:apples',
+	'en:berries',
+	'en:citrus',
+	'en:tropical-fruits',
+	'en:bananas',
+	'en:lemons',
+	'en:pears',
+	'en:strawberries'
 ]) or diag explain $product_ref;
 
 $product_ref = {
-'categories' => "Plats pr\x{e9}par\x{e9}s, Plats pr\x{e9}par\x{e9}s au poisson, Plats \x{e0} base de p\x{e2}tes, Lasagnes pr\x{e9}par\x{e9}es, Plats au saumon",
-'categories_lc' => 'fr',
-         'categories_tags' => [
-                                 'en:meals',
-                                 'en:pasta-dishes',
-                                 'en:prepared-lasagne',
-                                 'en:meals-with-fish',
-                                 'en:meals-with-salmon',
-                               ],
-
-lc => 'fr',
-lang => 'fr',
-
+	'categories' => "Plats pr\x{e9}par\x{e9}s, Plats pr\x{e9}par\x{e9}s au poisson, Plats \x{e0} base de p\x{e2}tes, Lasagnes pr\x{e9}par\x{e9}es, Plats au saumon",
+	'categories_lc' => 'fr',
+	'categories_tags' => [
+		'en:meals',
+		'en:pasta-dishes',
+		'en:prepared-lasagne',
+		'en:meals-with-fish',
+		'en:meals-with-salmon',
+	],
+	lc => 'fr',
+	lang => 'fr',
 };
 
 add_tags_to_field($product_ref, "en", "categories", "Meals,Pasta dishes,Prepared lasagne,Meals with fish,Meals with salmon");
 
-is_deeply($product_ref->{categories_tags}, 
+is_deeply($product_ref->{categories_tags},
 [
-     'en:meals',
-     'en:pasta-dishes',
-     'en:prepared-lasagne',
-     'en:meals-with-fish',
-     'en:meals-with-salmon',
-
+	'en:meals',
+	'en:pasta-dishes',
+	'en:prepared-lasagne',
+	'en:meals-with-fish',
+	'en:meals-with-salmon',
 ]
 ) or diag explain $product_ref;
 
 my $tag_ref = get_taxonomy_tag_and_link_for_lang("fr","labels","en:organic");
-is_deeply($tag_ref, 
+is_deeply($tag_ref,
 {
-  'css_class' => 'tag known ',
-  'display' => 'Bio',
-  'display_lc' => 'fr',
-  'html_lang' => ' lang="fr"',
-  'known' => 1,
-  'tagid' => 'en:organic',
-  'tagurl' => 'bio'
+	'css_class' => 'tag known ',
+	'display' => 'Bio',
+	'display_lc' => 'fr',
+	'html_lang' => ' lang="fr"',
+	'known' => 1,
+	'tagid' => 'en:organic',
+	'tagurl' => 'bio'
 }
 )
 or diag explain $tag_ref;
@@ -647,13 +642,13 @@ or diag explain $tag_ref;
 $tag_ref = get_taxonomy_tag_and_link_for_lang("fr","labels","fr:some unknown label");
 is_deeply($tag_ref,
 {
-  'css_class' => 'tag user_defined ',
-  'display' => 'some unknown label',
-  'display_lc' => 'fr',
-  'html_lang' => ' lang="fr"',
-  'known' => 0,
-  'tagid' => 'fr:some unknown label',
-  'tagurl' => 'some-unknown-label'
+	'css_class' => 'tag user_defined ',
+	'display' => 'some unknown label',
+	'display_lc' => 'fr',
+	'html_lang' => ' lang="fr"',
+	'known' => 0,
+	'tagid' => 'fr:some unknown label',
+	'tagurl' => 'some-unknown-label'
 }
 )
 or diag explain $tag_ref;

--- a/t/vitamins.t
+++ b/t/vitamins.t
@@ -14,19 +14,19 @@ use ProductOpener::Ingredients qw/:all/;
 # dummy product for testing
 
 my $product_ref = {
-        lc => "es",
-        ingredients_text =>
-"Leche desnatada de vaca, enzima lactasa y vitaminas A, D, E y ácido fólico.",
+	lc => "es",
+	ingredients_text =>
+	"Leche desnatada de vaca, enzima lactasa y vitaminas A, D, E y ácido fólico.",
 };
 
 extract_ingredients_classes_from_text($product_ref);
 
 is_deeply($product_ref->{vitamins_tags}, [
-"en:vitamin-a",
-"en:vitamin-d",
-"en:vitamin-e",
-"en:folic-acid",
-                              ],
+		"en:vitamin-a",
+		"en:vitamin-d",
+		"en:vitamin-e",
+		"en:folic-acid",
+	],
 ) or diag explain $product_ref->{vitamins_tags};
 
 


### PR DESCRIPTION
The testing process should allow TODO tests to fail without complaining, but they're a way to track known issues, and see if they get fixed in the process of doing something else.
https://perldoc.perl.org/Test/More.html#*TODO%3a-BLOCK*

Also normalised the leading whitespace in the test files to be the tabs .editorconfig says they should be. 
(We could probably lose the first level or two of indentation, as in some other test files, but I thought I'd at least start out trying to be Correct.)