### PR TITLE
Fix use of undefined translation

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5229,6 +5229,7 @@ JS
 				my $g = $nutrition_grades_colors{$nutrition_grade}{g};
 				my $b = $nutrition_grades_colors{$nutrition_grade}{b};
 				my $seriesid = $nutrition_grade;
+				$series_n{$seriesid} //= 0;
 				$series_data .= <<JS
 {
 	name: '$title : $series_n{$seriesid} $Lang{products}{$lc}',

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5231,7 +5231,7 @@ JS
 				my $seriesid = $nutrition_grade;
 				$series_data .= <<JS
 {
-	name: '$title : $series_n{$seriesid} $Lang{products_p}{$lc}',
+	name: '$title : $series_n{$seriesid} $Lang{products}{$lc}',
 	color: 'rgba($r, $g, $b, .9)',
 	turboThreshold : 0,
 	data: [ $series{$seriesid} ]
@@ -5276,7 +5276,7 @@ JS
 
 				$series_data .= <<JS
 {
-	name: '$title : $series_n{$seriesid} $Lang{products_p}{$lc}',
+	name: '$title : $series_n{$seriesid} $Lang{products}{$lc}',
 	color: 'rgba($r, $g, $b, .9)',
 	turboThreshold : 0,
 	data: [ $series{$seriesid} ]

--- a/scripts/gen_top_tags_per_country.pl
+++ b/scripts/gen_top_tags_per_country.pl
@@ -771,7 +771,7 @@ Highcharts.setOptions({
             },
             yAxis: {
                 title: {
-                    text: '$Lang{products_p}{$lang}'
+                    text: '$Lang{products}{$lang}'
                 },
                 labels: {
                     formatter: function() {
@@ -913,7 +913,7 @@ HTML
             },
             yAxis: {
                 title: {
-                    text: '$Lang{products_p}{$lang}'
+                    text: '$Lang{products}{$lang}'
                 },
                 labels: {
                     formatter: function() {


### PR DESCRIPTION
**Description:**

As pointed out by @svensven in https://github.com/openfoodfacts/openfoodfacts-server/pull/4258#issuecomment-699492604, `products_p` is not defined in the gettext catalog. Switch references to it to the actually defined `products`.

Also, noticed that `$series_n{$seriesid}` can be undefined when using nutrition grade colors for a graph and the grade has 0 products. Initialize it to 0 before interpolating it.