### PR TITLE
clear most of the warnings on the unit tests

### DIFF
--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -695,12 +695,12 @@ drained_weight => '(peso )?(neto )?(escurrido)',
 		}
 
 		# 1/2 , 3/4
-		if ($product_ref->{quantity} =~ /^'?\s*\d+((\/)\d+)\s*$/i) {
+		elsif ($product_ref->{quantity} =~ /^'?\s*\d+((\/)\d+)\s*$/i) {
 			delete $product_ref->{quantity};
 		}
 
 		# No numbers (e.g. "sachet", "bouteille")
-		if ($product_ref->{quantity} !~ /[1-9]/) {
+		elsif ($product_ref->{quantity} !~ /[1-9]/) {
 			delete $product_ref->{quantity};
 		}
 	}

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -620,7 +620,9 @@ sub init_fields_columns_names_for_lang($) {
 	}
 	$fields_columns_names_for_lang{$l}{"kj"} = { field=>"energy-kj_100g_value_unit", value_unit=>"value_in_kj" };
 
-	(! -e "$data_root/debug") and mkdir("$data_root/debug", 0755) or $log->warn("Could not create debug dir", { dir => "$data_root/debug", error=> $!}) if $log->is_warn();
+	if (! -e "$data_root/debug") {
+		mkdir("$data_root/debug", 0755) or $log->warn("Could not create debug dir", { dir => "$data_root/debug", error=> $!}) if $log->is_warn();
+	}
 
 	store("$data_root/debug/fields_columns_names_$l.sto", $fields_columns_names_for_lang{$l});
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -2322,7 +2322,7 @@ sub compute_languages($) {
 
 	foreach my $field (keys %{$product_ref}) {
 
-		if (($field =~ /_([a-z]{2})$/) and (defined $language_fields{$`}) and ($product_ref->{$field} ne '')) {
+		if (($field =~ /_([a-z]{2})$/) and (defined $language_fields{$`}) and (defined $product_ref->{$field}) and ($product_ref->{$field} ne '')) {
 			my $language_code = $1;
 			my $language = undef;
 			if (defined $language_codes{$language_code}) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2160,7 +2160,7 @@ sub display_taxonomy_tag_link($$$) {
 		$tag = $';
 	}
 
-	my $path = $tag_type_singular{$tagtype}{$target_lc};
+	my $path = $tag_type_singular{$tagtype}{$target_lc} // '';
 
 	my $css_class = get_tag_css_class($target_lc, $tagtype, $tag);
 

--- a/t/additives.t
+++ b/t/additives.t
@@ -40,7 +40,7 @@ is_deeply($product_ref->{vitamins_tags}, [
 # false positives: acides gras -> E-570
 
 # Make sure 100% is not recognized as E-100
-my $product_ref = {
+$product_ref = {
 	lc => "fr",
 	ingredients_text => "Acide citrique, Gorge, foie et gras de fermier, œuf, graines de tournesol (4%), vin blanc, graines de sésame (2%), sel, poivre. Peut contenir des traces de gluten, soja, lait, fruits à coque. À conserver à l'abri de laichateur et de Ihumidité* À consommer de préférence avant la date figurant sur le bocal. Après -ouverture, à conserver au Téfrigérateuretàconsommerrapidernent? Servir frais. Sans colorant ni conservateur ajouté. Mateurs nutritionnelles moyennes pour 100 g : énergie (1584 kJ / 383 kcal), matières grasses (36 g) dont : acides gras saturés (14 g), glucides (2 g) dont : sucres (0,9 g), protéines (14,3 g), sel (1 ,6 g).",
 	ingredients_text_fr => "Acide citrique, Gorge, foie et gras de fermier, œuf, graines de tournesol (4%), vin blanc, graines de sésame (2%), sel, poivre. Peut contenir des traces de gluten, soja, lait, fruits à coque. À conserver à l'abri de laichateur et de Ihumidité* À consommer de préférence avant la date figurant sur le bocal. Après -ouverture, à conserver au Téfrigérateuretàconsommerrapidernent? Servir frais. Sans colorant ni conservateur ajouté. Mateurs nutritionnelles moyennes pour 100 g : énergie (1584 kJ / 383 kcal), matières grasses (36 g) dont : acides gras saturés (14 g), glucides (2 g) dont : sucres (0,9 g), protéines (14,3 g), sel (1 ,6 g).",
@@ -60,7 +60,7 @@ is_deeply(
 
 
 # Make sure 100% is not recognized as E-100
-my $product_ref = {
+$product_ref = {
 	lc => "fr",
 	ingredients_text => "pâte de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce équitable et de l'agriculture biologique (100% du poids total)."
 };
@@ -73,7 +73,7 @@ is_deeply($product_ref->{additives_original_tags}, [
 
 
 
-my $product_ref = {
+$product_ref = {
 	lc => "fr",
 	ingredients_text => "Acide citrique, colorant : e120, vitamine C, E-500",
 	categories_tags => ["en:debug"],

--- a/t/food.t
+++ b/t/food.t
@@ -322,7 +322,9 @@ $product_ref = {
 
 fix_salt_equivalent($product_ref);
 
-my $expected_product_ref = {
+my $expected_product_ref;
+
+$expected_product_ref = {
 	nutriments => {
 		salt => 3,
 		salt_value => 3000,
@@ -345,7 +347,7 @@ $product_ref = {
 
 compute_serving_size_data($product_ref);
 
-my $expected_product_ref =
+$expected_product_ref =
 {
 	'nutriments' => {
 		'nova-group' => 4,
@@ -372,7 +374,7 @@ $product_ref = {
 
 compute_serving_size_data($product_ref);
 
-my $expected_product_ref =
+$expected_product_ref =
 {
 	'nutriments' => {
 		'sugars' => 4,
@@ -400,7 +402,7 @@ $product_ref = {
 
 compute_serving_size_data($product_ref);
 
-my $expected_product_ref =
+$expected_product_ref =
 {
 	'nutriments' => {
 		'energy-kcal_prepared' => 58,

--- a/t/import.t
+++ b/t/import.t
@@ -192,24 +192,24 @@ foreach my $test_ref (@tests) {
 	# combine serving_size, serving_size_value, serving_size_unit (e.g. US import)
 
 [
-	{ serving_size_value => "10", serving_size_unit => "g" },
-	{ serving_size => "10 g", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size => "10 g", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 [
-	{ serving_size => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
-	{ serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 [
-	{ serving_size_value_unit => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
-	{ serving_size_value_unit => "1 biscuit", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size_value_unit => "1 biscuit", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size_value_unit => "1 biscuit", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 
 [
-	{ serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
-	{ serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
+	{ lc => "en", serving_size => "1 biscuit (10 g)", serving_size_value => "10", serving_size_unit => "g" },
 ],
 
 

--- a/t/products.t
+++ b/t/products.t
@@ -82,6 +82,7 @@ $product_ref->{uploaded_images}->{foo} = 'bar';
 $product_ref->{selected_images}->{front_de} = 'bar';
 $product_ref->{selected_images}->{ingredients_de} = 'bar';
 $product_ref->{selected_images}->{nutrition_de} = 'bar';
+$product_ref->{last_modified_t} = time();
 foreach my $field (@string_fields) {
 	$product_ref->{$field} = 'foo';
 }

--- a/t/tags.t
+++ b/t/tags.t
@@ -421,7 +421,7 @@ is(display_taxonomy_tag("en", "ingredients_analysis", "en:non-vegan"), "Non-vega
 
 is(canonicalize_taxonomy_tag("de","test","Grünkohl"), "en:kale");
 is(display_taxonomy_tag("de","test","en:kale"), "Grünkohl");
-is(display_taxonomy_tag_link("de","test","en:kale"), '<a href="//gr%C3%BCnkohl" class="tag well_known">Grünkohl</a>');
+is(display_taxonomy_tag_link("de","test","en:kale"), '<a href="//gr%C3%BCnkohl" class="tag well_known">Grünkohl</a>'); # "test" taxonomy causes warning in Tags.pm
 is(display_tags_hierarchy_taxonomy("de","test",["en:kale"]), '<a href="//gr%C3%BCnkohl" class="tag well_known">Grünkohl</a>');
 is(canonicalize_taxonomy_tag("fr","test","Pâte de cacao"), "fr:Pâte de cacao");
 is(display_taxonomy_tag("fr","test","fr:Pâte de cacao"), "Pâte de cacao");
@@ -625,7 +625,7 @@ is_deeply($product_ref->{categories_tags},
 ]
 ) or diag explain $product_ref;
 
-my $tag_ref = get_taxonomy_tag_and_link_for_lang("fr","labels","en:organic");
+$tag_ref = get_taxonomy_tag_and_link_for_lang("fr","labels","en:organic");
 is_deeply($tag_ref,
 {
 	'css_class' => 'tag known ',


### PR DESCRIPTION
There are still 2 uses of a "test" taxonomy in tags.t that cause
> Use of uninitialized value $path in concatenation (.) or string at /home/runner/work/openfoodfacts-server/openfoodfacts-server/lib/ProductOpener/Tags.pm line 2171.

Dunno if that's an intentional test of a bogus taxonomy, as the test expects the incorrect URL it gets.