### PR TITLE
Capture signal when refreshing taxonomies

### DIFF
--- a/scripts/refresh_taxonomies.js
+++ b/scripts/refresh_taxonomies.js
@@ -59,11 +59,16 @@ async function main() {
         );
         spawns.push(perl);
 
-        perl.on('close', (code) => {
-          console.log(`[${file}] child process exited with code ${code}`);
+        perl.on('close', (code, signal) => {
+          if (code !== null) {
+            console.log(`[${file}] child process exited with code ${code}`);
 
-          if (code != 0) {
-            process.exitCode = code;
+            if (code != 0) {
+              process.exitCode = code;
+            }
+          }
+          else if ( signal !== null ) {
+            console.log(`[${file}] child process exited with signal ${signal}`);
           }
         });
       } catch (e) {
@@ -74,7 +79,7 @@ async function main() {
     }
   }
 
-  console.log('Waiting for spawned processed to exit.');
+  console.log('Waiting for spawned processes to exit.');
   let running = Number.MAX_SAFE_INTEGER;
   let lastMsg = new Date();
   while (running > 0) {


### PR DESCRIPTION
**Description:**

Lately the taxonomy build script has been sporadically exiting with a null exitcode. This change logs the received signal when the exit code is null for more information about the failure.

I suspect it's getting killed with SIGKILL from the oomkiller, and it's probably something that should be taken into account when waiting for the spawned processes to exit.