### PR TITLE
startup_apache2.pl - setup error log before running code

### DIFF
--- a/lib/startup_apache2.pl
+++ b/lib/startup_apache2.pl
@@ -103,6 +103,11 @@ if (!(  (   ( $r->useragent_ip eq '127.0.0.1' )
   return Apache2::Const::OK;
 }
 
+# set up error logging
+open *STDERR, '>', "/$data_root/logs/modperl_error_log" or Carp::croak('Could not open modperl_error_log');
+print {*STDERR} $log or Carp::croak('Unable to write to *STDERR');
+
+# load large data files into mod_perl memory
 init_emb_codes();
 init_packager_codes();
 init_geocode_addresses();
@@ -115,9 +120,5 @@ load_agribalyse_data();
 chmod_recursive( S_IRWXU | S_IRWXG | S_IRWXO, "$data_root/tmp" );
 
 $log->info('product opener started', { version => $version });
-
-open *STDERR, '>', "/$data_root/logs/modperl_error_log" or Carp::croak('Could not open modperl_error_log');
-
-print {*STDERR} $log or Carp::croak('Unable to write to *STDERR');
 
 1;


### PR DESCRIPTION
currently, if one of the data load functions errors out, it doesn't show up in the modperl_error_log.

I had to find `/var/lib/docker/overlay2/adffa9fb9f296d41361990c3b653a8acb26d1f9d0c0ef79f3b0c1d29ee452fa4/diff/var/log/apache2/error.log` to find out why apache wasn't starting.