### PR TITLE
po-foreground.sh - add ecoscore folder into dev docker

### DIFF
--- a/docker/backend-dev/conf/po-foreground.sh
+++ b/docker/backend-dev/conf/po-foreground.sh
@@ -41,6 +41,11 @@ then
   ln -sf /opt/product-opener/packager-codes /mnt/podata/packager-codes
 fi
 
+if [ ! -e /mnt/podata/ecoscore ]
+then
+  ln -sf /opt/product-opener/ecoscore /mnt/podata/ecoscore
+fi
+
 if [ ! -e /mnt/podata/templates ]
 then
   ln -sf /opt/product-opener/templates /mnt/podata/templates


### PR DESCRIPTION
load_agribalyse_data() in startup_apache2.pl was failing:

> Could not open agribalyse CSV /mnt/podata/ecoscore/agribalyse/AGRIBALYSE3.0.1_vf.csv.2: No such file or directory at /opt/product-opener/lib/ProductOpener/Ecoscore.pm line 120.\nCompilation failed in require at (eval 2) line 1.\n
