### PR TITLE
perl syntax checking in parallel, but limit the number of processes.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,10 +36,21 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 50
+    
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: '12.x'
+    
     - run: npm install
+    
+    - name: find changed perl files
+      uses: futuratrepadeira/changed-files@v3.3.0
+      id: changed-perl
+      with:
+        repo-token: ${{ github.token }}
+        pattern: '^(cgi|scripts)/.*\.pl$'
+        result-encoding: 'string'
+    
     - name: prepare, build, and test
       run: |
         sudo apt-get update
@@ -123,16 +134,20 @@ jobs:
         libsafe-isa-perl \
         libspreadsheet-parseexcel-perl \
         libtest-number-delta-perl
+        
         # 
         # Not available in Ubuntu 18.04 LTS
         # libmath-random-secure-perl
         # libgeoip2-perl
         # libmodule-build-pluggable-perl
         #
+        
         # setup local::lib
         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+        
         # install perl dependencies
         cpanm --quiet --installdeps --notest --skip-satisfied .
+        
         # Prepare config
         export BUILD_DIR=`pwd`
         ln -s $BUILD_DIR/lib/ProductOpener/Config_off.pm $BUILD_DIR/lib/ProductOpener/Config.pm
@@ -140,12 +155,16 @@ jobs:
         ln -s $BUILD_DIR/lib/ProductOpener/SiteLang_off.pm $BUILD_DIR/lib/ProductOpener/SiteLang.pm
         sed -i -e 's|\$server_domain = "openfoodfacts.org";|\$server_domain = "off.travis-ci.org";|g' $BUILD_DIR/lib/ProductOpener/Config2.pm
         sed -i -e 's|\/home\/off|'$BUILD_DIR'|g' $BUILD_DIR/lib/ProductOpener/Config2.pm
+        
         # Ensure everything compiles
         perl -c -CS -Ilib lib/startup_apache2.pl
-        node scripts/check_perl.js cgi/*.pl
-        node scripts/check_perl.js scripts/*.pl
+        # node scripts/check_perl.js cgi/*.pl
+        # node scripts/check_perl.js scripts/*.pl
+        node scripts/check_perl.js ${{ steps.changed-perl.outputs.files_created }} ${{ steps.changed-perl.outputs.files_updated }}
+        
         # Rebuild taxonomies
         perl -CS -I$BUILD_DIR/lib $BUILD_DIR/scripts/build_lang.pl
         node scripts/refresh_taxonomies.js
+        
         # Run unit tests
         prove -l

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
       id: changed-perl
       with:
         repo-token: ${{ github.token }}
-        pattern: '^(cgi|scripts)/.*\.pl$'
+        pattern: '^(cgi|scripts)/.*\.pl$|^lib/ProductOpener/.*\.pm$'
         result-encoding: 'string'
     
     - name: prepare, build, and test

--- a/scripts/check_perl.js
+++ b/scripts/check_perl.js
@@ -42,7 +42,7 @@ async function main() {
 
     // count how many spawned processes don't have an exit code yet
     running = spawns.reduce((pv, cv) => {
-      if (cv.exitCode === null) {
+      if (cv.exitCode === null && cv.signalCode === null) {
         return pv + 1;
       }
       else {
@@ -99,7 +99,7 @@ async function main() {
   running = Number.MAX_SAFE_INTEGER;
   while (running > 0) {
     running = spawns.reduce((pv, cv) => {
-      if (cv.exitCode === null) {
+      if (cv.exitCode === null && cv.signalCode === null) {
         return pv + 1;
       }
       else {

--- a/scripts/check_perl.js
+++ b/scripts/check_perl.js
@@ -2,37 +2,113 @@
 /*eslint no-await-in-loop: "off"*/
 
 const process = require("process");
-const util = require("util");
+const util = require('util');
 const glob = util.promisify(require("glob").glob);
-const { spawn } = require("child_process");
+const { spawn } = require('child_process');
 
-function checkFile(path, doneCallback) {
-  console.log(`Checking ${path}`);
-  try {
-    const child = spawn(`perl`, ["-c", "-CS", "-Ilib", path]);
-    child.stdout.on("data", (data) => console.log("[" + path + "] " + data));
-    child.stderr.on("data", (data) => console.error("[" + path + "] " + data));
-    child.on("close", (code) => {
-      console.log("[" + path + "] result: " + code);
-      process.exitCode = code;
-      doneCallback();
-    });
-  } catch (e) {
-    console.error("[" + path + "] " + e);
-    process.exitCode = e.code;
-    throw e;
-  }
+// Github actions have 2 CPUs: 
+// https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
+// Travis also seems to have 2 CPUs:
+// https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+
+const maxRunning = 2;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const check = util.promisify(checkFile);
-
 async function main() {
+
+  const filesToCheck = [];
+
+  // build array of paths from given arguments
   // 0 = node; 1 = check_perl.js
   for (const arg of process.argv.slice(2)) {
     const files = await glob(arg);
     for (var i = 0; i < files.length; ++i) {
-      const path = files[i];
-      await check(path);
+      filesToCheck.push(files[i]);
+    }
+  }
+  const numFilesToCheck = filesToCheck.length;
+
+  const spawns = [];
+
+  console.log(`Checking ${numFilesToCheck} files, max ${maxRunning} processes...`);
+
+  let running = Number.MAX_SAFE_INTEGER;
+
+  // loop until we've popped all the files off the array
+  while (filesToCheck.length > 0) {
+
+    // count how many spawned processes don't have an exit code yet
+    running = spawns.reduce((pv, cv) => {
+      if (cv.exitCode === null) {
+        return pv + 1;
+      }
+      else {
+        return pv;
+      }
+    }, 0);
+
+    // if we're not at the maximum number of processes, fire off another
+    if (running < maxRunning) {
+      try {
+
+        const file = filesToCheck.shift();
+        console.log(`Queueing ${file}`);
+
+        const perl = spawn(
+          'perl', 
+          ["-c", "-CS", "-Ilib", file ],
+        );
+        spawns.push(perl);
+
+        // prefix any output with the relevant file name. trim() for double newlines.
+        perl.stdout.on("data", (data) => console.log("[" + file + "] " + data.toString().trim() ));
+        perl.stderr.on("data", (data) => console.error("[" + file + "] " + data.toString().trim() ));
+
+        perl.on('close', (code, signal) => {
+          if (code !== null) {
+            console.log(`[${file}] child process exited with code ${code}`);
+            if (code != 0) {
+              process.exitCode = code;
+            }
+          }
+          else if ( signal !== null ) {
+            console.log(`[${file}] child process exited with signal ${signal}`);
+          }
+        });
+
+      } catch (e) {
+        console.error(e);
+        process.exitCode = e.code;
+        throw e;
+      }
+    }
+
+    // wait before looping
+    if (running > 0) {
+      await sleep(100);
+    }
+
+  }
+
+  console.log('Finished queueing files.');
+
+  // don't return until all child processes have finished
+  running = Number.MAX_SAFE_INTEGER;
+  while (running > 0) {
+    running = spawns.reduce((pv, cv) => {
+      if (cv.exitCode === null) {
+        return pv + 1;
+      }
+      else {
+        return pv;
+      }
+    }, 0);
+
+    if (running > 0) {
+      await sleep(100);
     }
   }
 

--- a/scripts/check_perl.js
+++ b/scripts/check_perl.js
@@ -76,6 +76,7 @@ async function main() {
           }
           else if ( signal !== null ) {
             console.log(`[${file}] child process exited with signal ${signal}`);
+            process.exitCode = 128; // consider a spawn getting killed a failure
           }
         });
 


### PR DESCRIPTION
Adapted from the refresh_taxonomies.js script.

The syntax checking is slow (5-6 mins on github), but checking over 100 scripts simultaneously is also unworkable:
https://github.com/openfoodfacts/openfoodfacts-server/pull/3368

The limit is configurable, in case the environment running the checks ever has more than the 2 cores it currently does. Increasing the limit on 2 cores works (at least with 3 & 4), but is no faster.

Should shave another 2-3 mins off the pull request workflow.

Update: With the changed files workflow plugin, it removes the whole 5-6 mins.