### PR TITLE
refresh_taxonomies.js - handle signals & limit parallelism (for Travis)

### DIFF
--- a/scripts/refresh_taxonomies.js
+++ b/scripts/refresh_taxonomies.js
@@ -69,6 +69,7 @@ async function main() {
           }
           else if ( signal !== null ) {
             console.log(`[${file}] child process exited with signal ${signal}`);
+            process.exitCode = 128; // consider a spawn getting killed a failure
           }
         });
       } catch (e) {

--- a/scripts/refresh_taxonomies.js
+++ b/scripts/refresh_taxonomies.js
@@ -6,6 +6,13 @@ const util = require('util');
 const { spawn, execFile } = require('child_process');
 const execFilePromise = util.promisify(execFile);
 
+// Github actions have 2 CPUs: 
+// https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
+// Travis also seems to have 2 CPUs:
+// https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+
+const maxRunning = 2;
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -36,8 +43,8 @@ async function main() {
     'test',
     'vitamins'
   ];
+  const taxonomiesToBuild = [];
 
-  const spawns = [];
   for (const file of files) {
     const txtPath = `taxonomies/${file}.txt`;
     const stoPath = `taxonomies/${file}.result.sto`;
@@ -49,8 +56,36 @@ async function main() {
     }
     else {
       console.log(`${txtPath} needs to be rebuilt; ${txtMtimeMs} vs ${stoMtimeMs}`);
+      taxonomiesToBuild.push(file);
+    }
+  }
+  const numToBuild = taxonomiesToBuild.length;
 
+  const spawns = [];
+  
+  console.log(`Building ${numToBuild} taxonomies, max ${maxRunning} processes...`);
+  
+  let running = Number.MAX_SAFE_INTEGER;
+
+  // loop until we've popped all the files off the array
+  while (taxonomiesToBuild.length > 0) {
+
+    // count how many spawned processes don't have an exit code yet
+    running = spawns.reduce((pv, cv) => {
+      if (cv.exitCode === null && cv.signalCode === null) {
+        return pv + 1;
+      }
+      else {
+        return pv;
+      }
+    }, 0);
+
+    // if we're not at the maximum number of processes, fire off another
+    if (running < maxRunning) {
       try {
+
+        const file = taxonomiesToBuild.shift();
+        
         // Launch the Perl script to rebuild the taxonomy
         const perl = spawn(
           'perl',
@@ -79,11 +114,19 @@ async function main() {
         throw e;
       }
     }
+
+    // wait before looping
+    if (running > 0) {
+      await sleep(250);
+    }
+
   }
 
   console.log('Waiting for spawned processes to exit.');
-  let running = Number.MAX_SAFE_INTEGER;
+  
+  // don't return until all child processes have finished
   let lastMsg = new Date();
+  running = Number.MAX_SAFE_INTEGER;
   while (running > 0) {
     running = spawns.reduce((pv, cv) => {
       if (cv.exitCode === null && cv.signalCode === null) {

--- a/scripts/refresh_taxonomies.js
+++ b/scripts/refresh_taxonomies.js
@@ -84,7 +84,7 @@ async function main() {
   let lastMsg = new Date();
   while (running > 0) {
     running = spawns.reduce((pv, cv) => {
-      if (cv.exitCode === null) {
+      if (cv.exitCode === null && cv.signalCode === null) {
         return pv + 1;
       }
       else {

--- a/scripts/refresh_taxonomies.js
+++ b/scripts/refresh_taxonomies.js
@@ -69,6 +69,7 @@ async function main() {
           }
           else if ( signal !== null ) {
             console.log(`[${file}] child process exited with signal ${signal}`);
+            console.log('If this is in Travis: To make it rerun the workflow, close the pull request, wait a minute, and reopen it.');
             process.exitCode = 128; // consider a spawn getting killed a failure
           }
         });


### PR DESCRIPTION
Applying the same quick fix as in #4328. See https://github.com/openfoodfacts/openfoodfacts-server/pull/4328#discussion_r501245467

After the previous change, this Travis run now logs that one of the processes had been SIGKILLed, but the script still counted it as running. https://travis-ci.org/github/openfoodfacts/openfoodfacts-server/builds/733734997
> [additives] child process exited with signal SIGKILL