### PR TITLE
"do we need the Travis check?"

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -57895,7 +57895,7 @@ nl:Kippendijen, Kipdij
 
 <en:Poultry hams
 en:Cooked chicken breast slices, chicken ham
-de:Hähnchen-brustfilet in Scheiben, Geflügelschinken
+de:Hähnchen-brustfilet in Scheiben
 fi:kanaleikkele
 fr:Blancs de poulet en tranches, Blancs de poulet, Blanc de poulet, Jambons de poulet, Jambon de poulet
 nl:Kippendijen, Kippendij


### PR DESCRIPTION
Errors in the categories taxonomy definition:
ERROR - de:geflügelschinken already is a synonym of de:hähnchen-brustfilet-in-scheiben for entry en:cooked-chicken-breast-slices - de:geflügelschinken cannot be mapped to entry en:poultry-hams

Broken in #4139. 
Clearly the duplicate detection isn't deterministic. I'm guessing that if one term is a primary translation (which aren't checked for duplicates), and the other a synonym of a translation, it won't flag an error if it happens to process the synonym before the primary translation.