### PR TITLE
more performance tweaks for update_all_products.pl

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3335,6 +3335,20 @@ sub preparse_ingredients_text($$) {
 
 	$log->debug("preparse_ingredients_text", { text => $text }) if $log->is_debug();
 
+
+	# if we're called twice with the same input in succession, such as in update_all_products.pl,
+	# cache the result, so we can instantly return the 2nd time.
+	state $prev_lc = '';
+	state $prev_text = '';
+	state $prev_return = '';
+	
+	if (($product_lc eq $prev_lc) && ($text eq $prev_text)) {
+		return $prev_return;
+	}
+	$prev_lc = $product_lc;
+	$prev_text = $text;
+
+
 	# Symbols to indicate labels like organic, fairtrade etc.
 	my @symbols = ('\*\*\*', '\*\*', '\*', '°°°', '°°', '°', '\(1\)', '\(2\)');
 	my $symbols_regexp = join('|', @symbols);
@@ -3985,6 +3999,7 @@ INFO
 
 	$log->debug("preparse_ingredients_text result", { text => $text }) if $log->is_debug();
 
+	$prev_return = $text;
 	return $text;
 }
 

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -54,20 +54,28 @@ use Log::Any qw($log);
 # Text::Unaccent unac_string causes Apache core dumps with Apache 2.4 and mod_perl 2.0.9 on jessie
 
 sub unac_string_perl($) {
-        my $s = shift;
+	my $s = shift;
 
-        $s =~ s/à|á|â|ã|ä|å/a/ig;
-        $s =~ s/ç/c/ig;
-        $s =~ s/è|é|ê|ë/e/ig;
-        $s =~ s/ì|í|î|ï/i/ig;
-        $s =~ s/ñ/n/ig;
-        $s =~ s/ò|ó|ô|õ|ö/o/ig;
-        $s =~ s/ù|ú|û|ü/u/ig;
-        $s =~ s/ý|ÿ/y/ig;
-        $s =~ s/œ|Œ/oe/g;
-        $s =~ s/æ|Æ/ae/g;
+	$s =~ tr/àáâãäåçèéêëìíîïñòóôõöùúûüýÿÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ/aaaaaaceeeeiiiinooooouuuuyyaaaaaaceeeeiiiinooooouuuuyy/;
 
-        return $s;
+	# alternative methods, slower than above, but more readable and still faster than s///.
+
+	#$s =~ tr/àáâãäåçèéêëìíîïñòóôõöùúûüýÿ/aaaaaaceeeeiiiinooooouuuuyy/;
+	#$s =~ tr/ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ/aaaaaaceeeeiiiinooooouuuuyy/;
+
+	#$s =~ tr/àáâãäåÀÁÂÃÄÅ/a/;
+	#$s =~ tr/çÇ/c/;
+	#$s =~ tr/èéêëÈÉÊË/e/;
+	#$s =~ tr/ìíîïÌÍÎÏ/i/;
+	#$s =~ tr/ñÑ/n/;
+	#$s =~ tr/òóôõöÒÓÔÕÖ/o/;
+	#$s =~ tr/ùúûüÙÚÛÜ/u/;
+	#$s =~ tr/ýÿÝŸ/y/;
+
+	$s =~ s/œ|Œ/oe/g;
+	$s =~ s/æ|Æ/ae/g;
+
+	return $s;
 }
 
 # Tags in European characters (iso-8859-1 / Latin-1 / Windows-1252) are canonicalized:


### PR DESCRIPTION
### unac_string_perl()
After [learning about tr/// the other day](https://github.com/openfoodfacts/openfoodfacts-server/pull/4316#discussion_r499659223), this seemed like a good candidate, _assuming I'm understanding how it works correctly_.
For a test of 1500ish records, it went from 13.4s to approx 3s for 644k calls.
> ![image](https://user-images.githubusercontent.com/5736616/95516977-0ce68b00-09b8-11eb-9161-e745806e97c1.png)

vs
> ![image](https://user-images.githubusercontent.com/5736616/95517060-32739480-09b8-11eb-99cb-84ff05d0669f.png)


### preparse_ingredients_text()
This is called twice with the same inputs for each product. 
> ![image](https://user-images.githubusercontent.com/5736616/95517479-fb51b300-09b8-11eb-9a7e-79ef5340ee8e.png)


Adding a simple cache using state variables means we can return immediately on the 2nd invocation, as shown by the calls from extract...() being 1000x faster:
> ![image](https://user-images.githubusercontent.com/5736616/95517451-ed9c2d80-09b8-11eb-9874-6f5fbbbbaf3d.png)


(This also means we're calling unac_string_perl() half as much.)


### Overall
> ![image](https://user-images.githubusercontent.com/5736616/95517199-7d8da780-09b8-11eb-80de-94eba21406f1.png)

to
> ![image](https://user-images.githubusercontent.com/5736616/95517261-91d1a480-09b8-11eb-9e56-e1ac52d29a02.png)

