### PR TITLE
default userid for logged in users

### DIFF
--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -59,7 +59,11 @@ if (($type eq "add") and (defined param('prdct_mult'))) {
 
 ProductOpener::Display::init();
 
-my $userid = get_fileid(param('userid'), 1);
+my $userid = $User_id;
+
+if (defined param('userid')) {
+	$userid = get_fileid(param('userid'), 1);
+}
 
 $log->debug("user form - start", { type => $type, action => $action, userid => $userid, User_id => $User_id }) if $log->is_debug();
 


### PR DESCRIPTION
This is to allow to create links to change the logged in user profile without putting the userid explicitly in the link.

In particular, we can create links for moderators of the producers platform of the form
https://fr.pro.openfoodfacts.dev/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-carrefour-espana
to change the org to org-carrefour-espana