### PR TITLE
Run unit tests in parallel

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -167,4 +167,4 @@ jobs:
         node scripts/refresh_taxonomies.js
         
         # Run unit tests
-        prove -l
+        prove -l --jobs 2

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:lang": "npm run test:lang:common && npm run test:lang:en",
     "test:lang:en": "perl scripts/check_po_file.pl po/tags/en.po",
     "test:lang:common": "perl scripts/check_po_file.pl po/common/en.po",
-    "prove": "prove -l",
+    "prove": "prove -l --jobs 2",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:scss",
     "lint:js": "eslint gulpfile.js html/js/*.js scripts/*.js",
     "lint:css": "stylelint html/css/*.css",


### PR DESCRIPTION
Github/Travis VMs have 2 CPUs, so we can run 2 tests at once.
Should shave 1-2 more mins off the pull request workflow.