### PR TITLE
Add ability to pass a wait timeout to the mongodb connection

### DIFF
--- a/docker/backend-dev/conf/Config.pm
+++ b/docker/backend-dev/conf/Config.pm
@@ -48,6 +48,7 @@ BEGIN
 
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 
 		$memd_servers
 
@@ -219,6 +220,7 @@ $server_domain = $ProductOpener::Config2::server_domain;
 @ssl_subdomains = @ProductOpener::Config2::ssl_subdomains;
 $mongodb = $ProductOpener::Config2::mongodb;
 $mongodb_host = $ProductOpener::Config2::mongodb_host;
+$mongodb_timeout_ms = $ProductOpener::Config2::mongodb_timeout_ms;
 $memd_servers = $ProductOpener::Config2::memd_servers;
 
 # server paths

--- a/docker/backend-dev/conf/Config2.pm
+++ b/docker/backend-dev/conf/Config2.pm
@@ -35,6 +35,7 @@ BEGIN
 		$geolite2_path
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 		$memd_servers
 		$facebook_app_id
 	    $facebook_app_secret
@@ -58,6 +59,7 @@ $geolite2_path = '/usr/local/share/GeoLite2-Country/GeoLite2-Country.mmdb';
 
 $mongodb = "off";
 $mongodb_host = "mongodb://mongodb:27017";
+$mongodb_timeout_ms = 50000; # config option max_time_ms/maxTimeMS
 
 $memd_servers = [ "memcached:11211" ];
 

--- a/docker/productopener/templates/backend-conf.yaml
+++ b/docker/productopener/templates/backend-conf.yaml
@@ -75,6 +75,7 @@ data:
 
     		$mongodb
     		$mongodb_host
+    		$mongodb_timeout_ms
 
     		$memd_servers
 
@@ -245,6 +246,7 @@ data:
     @ssl_subdomains = @ProductOpener::Config2::ssl_subdomains;
     $mongodb = $ProductOpener::Config2::mongodb;
     $mongodb_host = $ProductOpener::Config2::mongodb_host;
+    $mongodb_timeout_ms = $ProductOpener::Config2::mongodb_timeout_ms;
     $memd_servers = $ProductOpener::Config2::memd_servers;
 
     # server paths
@@ -528,6 +530,7 @@ data:
         $geolite2_path
     		$mongodb
         $mongodb_host
+        $mongodb_timeout_ms
         $memd_servers
     		$facebook_app_id
     	  $facebook_app_secret
@@ -552,6 +555,7 @@ data:
 
     $mongodb = "off";
     $mongodb_host = "mongodb://{{ .Release.Name }}-mongodb:27017";
+    $mongodb_timeout_ms = 50000; # config option max_time_ms/maxTimeMS
 
     $memd_servers = [ "{{ .Release.Name }}-memcached:11211" ];
 

--- a/lib/ProductOpener/Config2_sample.pm
+++ b/lib/ProductOpener/Config2_sample.pm
@@ -35,6 +35,7 @@ BEGIN
 		$geolite2_path
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 		$memd_servers
 		$facebook_app_id
 		$facebook_app_secret
@@ -64,6 +65,7 @@ $geolite2_path = '/usr/local/share/GeoLite2-Country/GeoLite2-Country.mmdb';
 
 $mongodb = "off";
 $mongodb_host = "mongodb://localhost";
+$mongodb_timeout_ms = 50000; # config option max_time_ms/maxTimeMS
 
 $memd_servers = [ "127.0.0.1:11211" ];
 

--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -54,6 +54,7 @@ BEGIN
 
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 
 		$memd_servers
 
@@ -185,6 +186,7 @@ $server_domain = $ProductOpener::Config2::server_domain;
 @ssl_subdomains = @ProductOpener::Config2::ssl_subdomains;
 $mongodb = $ProductOpener::Config2::mongodb;
 $mongodb_host = $ProductOpener::Config2::mongodb_host;
+$mongodb_timeout_ms = $ProductOpener::Config2::mongodb_timeout_ms;
 $memd_servers = $ProductOpener::Config2::memd_servers;
 
 # server paths

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -53,6 +53,7 @@ BEGIN
 
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 
 		$memd_servers
 
@@ -319,6 +320,7 @@ $server_domain = $ProductOpener::Config2::server_domain;
 @ssl_subdomains = @ProductOpener::Config2::ssl_subdomains;
 $mongodb = $ProductOpener::Config2::mongodb;
 $mongodb_host = $ProductOpener::Config2::mongodb_host;
+$mongodb_timeout_ms = $ProductOpener::Config2::mongodb_timeout_ms;
 $memd_servers = $ProductOpener::Config2::memd_servers;
 
 # server paths

--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -54,6 +54,7 @@ BEGIN
 
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 
 		$memd_servers
 
@@ -183,6 +184,7 @@ $server_domain = $ProductOpener::Config2::server_domain;
 @ssl_subdomains = @ProductOpener::Config2::ssl_subdomains;
 $mongodb = $ProductOpener::Config2::mongodb;
 $mongodb_host = $ProductOpener::Config2::mongodb_host;
+$mongodb_timeout_ms = $ProductOpener::Config2::mongodb_timeout_ms;
 $memd_servers = $ProductOpener::Config2::memd_servers;
 
 # server paths

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -54,6 +54,7 @@ BEGIN
 
 		$mongodb
 		$mongodb_host
+		$mongodb_timeout_ms
 
 		$memd_servers
 
@@ -181,6 +182,7 @@ $server_domain = $ProductOpener::Config2::server_domain;
 @ssl_subdomains = @ProductOpener::Config2::ssl_subdomains;
 $mongodb = $ProductOpener::Config2::mongodb;
 $mongodb_host = $ProductOpener::Config2::mongodb_host;
+$mongodb_timeout_ms = $ProductOpener::Config2::mongodb_timeout_ms;
 $memd_servers = $ProductOpener::Config2::memd_servers;
 
 # server paths

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -110,7 +110,7 @@ sub get_mongodb_client() {
 	);
 
 	if (!defined($client)) {
-		$log->info("Creating new DB connection, socket_timeout_ms ${client_options{socket_timeout_ms}}");
+		$log->info("Creating new DB connection", { socket_timeout_ms => $client_options{socket_timeout_ms} });
 		$client = MongoDB::MongoClient->new(%client_options);
 	} else {
 		$log->info("DB connection already exists");

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -99,6 +99,8 @@ sub get_database {
 }
 
 sub get_mongodb_client() {
+	# Note that for web pages, $client will be cached in mod_perl,
+	# so passing in different options for different queries won't do anything after the first call.
 	my ($timeout) = @_;
 
 	my $max_time_ms = $timeout // $mongodb_timeout_ms;

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -94,7 +94,7 @@ sub get_collection {
 }
 
 sub get_database {
-	$database = $_[0] // $mongodb;
+	my $database = $_[0] // $mongodb;
 	return get_mongodb_client()->get_database($database);
 }
 

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -94,7 +94,7 @@ sub get_collection {
 }
 
 sub get_database {
-	my ($database) = @_ // $mongodb;
+	$database = $_[0] // $mongodb;
 	return get_mongodb_client()->get_database($database);
 }
 

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -101,12 +101,18 @@ sub get_database {
 sub get_mongodb_client() {
 	my ($timeout) = @_;
 
+	my $max_time_ms = $timeout // $mongodb_timeout_ms;
+
 	my %client_options = (
 		host => $mongodb_host,
 
+		# https://metacpan.org/pod/MongoDB::MongoClient#max_time_ms
+		# default is 0, meaning failures cause socket timeouts instead.
+		max_time_ms => $max_time_ms,
+
 		# https://metacpan.org/pod/MongoDB::MongoClient#socket_timeout_ms
 		# default is 30000 ms
-		socket_timeout_ms => $timeout // 30000,
+		socket_timeout_ms => $max_time_ms + 5000,
 	);
 
 	if (!defined($client)) {

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -269,7 +269,8 @@ print STDERR "Update key: $key\n\n";
 use Data::Dumper;
 print STDERR "MongoDB query:\n" . Dumper($query_ref);
 
-my $products_collection = get_products_collection();
+my $socket_timeout_ms = 2 * 60000; # 2 mins, instead of 30s default, to not die as easily if mongodb is busy.
+my $products_collection = get_products_collection($socket_timeout_ms);
 
 my $products_count = $products_collection->count_documents($query_ref);
 


### PR DESCRIPTION
The default timeout for waiting for mongodb to respond is 30s, after which the script will die with a socket error.
https://metacpan.org/pod/MongoDB::MongoClient#socket_timeout_ms

Long running scripts may want to wait a bit longer, in case mongodb is just temporarily overloaded.

Also `get_database()` was hard-coded to `$mongodb`, despite being called with a parameter in `get_collection()`.

There's an argument for increasing the default to 50s or something, given nginx will timeout after 60s.

(I may have got my `$`/`%`/`@`s confused, but it _seems_ to work in my docker instance.)
I thought about passing in a general options hash, and then forcibly setting any options like `host`, but got scared off by https://perldoc.perl.org/perlsub#Pass-by-Reference, and also I'm not sure there are any other client options we'd want to change.