### PR TITLE
create owners facet (for producers platform administration)

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -172,7 +172,7 @@ binmode STDERR, ":encoding(UTF-8)";
 %tags_fields = (packaging => 1, brands => 1, categories => 1, labels => 1, origins => 1, manufacturing_places => 1, emb_codes => 1,
  allergens => 1, traces => 1, purchase_places => 1, stores => 1, countries => 1, states=>1, codes=>1, debug => 1,
  environment_impact_level=>1, data_sources => 1, teams => 1, categories_properties => 1,
- editors => 1, photographers => 1, informers => 1, checkers => 1, correctors => 1);
+ editors => 1, photographers => 1, informers => 1, checkers => 1, correctors => 1, owners => 1);
 %hierarchy_fields = ();
 
 %taxonomy_fields = (); # populated by retrieve_tags_taxonomy

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4855,3 +4855,12 @@ msgstr "Does not contain: %s"
 msgctxt "without_s"
 msgid "Without %s"
 msgstr "Without %s"
+
+msgctxt "owners_p"
+msgid "owners"
+msgstr "owners"
+
+msgctxt "owners_s"
+msgid "owner"
+msgstr "owner"
+

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -4726,3 +4726,12 @@ msgstr "Ne contient pas : %s"
 msgctxt "without_s"
 msgid "Without %s"
 msgstr "Sans %s"
+
+msgctxt "owners_p"
+msgid "owners"
+msgstr "owners"
+
+msgctxt "owners_s"
+msgid "owner"
+msgstr "owner"
+

--- a/po/tags/en.po
+++ b/po/tags/en.po
@@ -525,3 +525,11 @@ msgstr "categories-properties"
 msgctxt "categories_properties:plural"
 msgid "categories-properties"
 msgstr "categories-properties"
+
+msgctxt "owners:plural"
+msgid "owners"
+msgstr "owners"
+
+msgctxt "owners:singular"
+msgid "owner"
+msgstr "owner"

--- a/po/tags/tags.pot
+++ b/po/tags/tags.pot
@@ -620,3 +620,11 @@ msgctxt "categories_properties:plural"
 msgid "categories-properties"
 msgstr "categories-properties"
 
+msgctxt "owners:plural"
+msgid "owners"
+msgstr "owners"
+
+msgctxt "owners:singular"
+msgid "owner"
+msgstr "owner"
+


### PR DESCRIPTION
This facet will be useful for admins of the producers platform, so that they can see products from the different producers.

It is to be used in combination with the "all" owner that allows admins to see all products of all owners.

Here is how it looks like on the test server:

![image](https://user-images.githubusercontent.com/8158668/95999677-6aeef480-0e36-11eb-904c-f3ba7340ad06.png)
