### PR TITLE
display.js - fix searching in country dropdown

### DIFF
--- a/html/js/display.js
+++ b/html/js/display.js
@@ -110,7 +110,9 @@ $(function () {
         results.sort(function (a, b) {
           return a.text.localeCompare(b.text, locale);
         });
-        results.unshift(worldresult);
+        if (typeof worldresult === 'object') {
+          results.unshift(worldresult);
+        }
 
         return {
           results: results


### PR DESCRIPTION
adding undefined worldresult breaks searching for a country.

![image](https://user-images.githubusercontent.com/5736616/96683489-29000a00-1372-11eb-8bbe-049d867f05fc.png)
