### PR TITLE
Display "at a glance" attributes on top of product page based on user preferences

### DIFF
--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -11,6 +11,10 @@ function get_user_product_preferences () {
 	if (user_product_preferences_string) {
 		user_product_preferences = JSON.parse(user_product_preferences_string);
 	}
+	else {
+		// Default preferences
+		user_product_preferences = { "nutriscore" : "very_important", "nova" : "important", "ecoscore" : "important" };
+	}
 	
 	return user_product_preferences;
 }
@@ -35,7 +39,7 @@ function display_selected_preferences (target_selected, target_selection_form, p
 		$.each(attribute_group.attributes, function(key, attribute) {
 			
 			if ((product_preferences[attribute.id]) && (product_preferences[attribute.id] != "not_important")) {
-				var attribute_html = '<span>' + attribute.setting_name + '</span>';
+				var attribute_html = '<li>' + attribute.setting_name + '</li>';
 				selected_preference_groups[product_preferences[attribute.id]].push(attribute_html);
 			}
 		});
@@ -57,7 +61,7 @@ function display_selected_preferences (target_selected, target_selection_form, p
 		if (selected_preference_group.length > 0) {
 			selected_preferences_html += "<div>"
 			+ "<strong>" + selected_preference_name + " - </strong>"
-			+ selected_preference_group.join(", ")
+			+ "<ul>" + selected_preference_group.join("") + "</ul>"
 			+ "</div>";
 		}
 	});
@@ -69,7 +73,10 @@ function display_selected_preferences (target_selected, target_selection_form, p
 		+ '<img src="/images/icons/dist/food-cog.svg" class="icon" style="filter:invert(1)">'
 		+ " Edit your food preferences" + '</a></div>'
 		+ "<h2>" + "Your food preferences" + "</h2>"
+		+ '<a id="preferences_link" data-dropdown="selected_preferences">Currently selected preferences &raquo;</a>'
+		+ '<div id="selected_preferences" data-dropdown-content class="f-dropdown content medium">' 
 		+ selected_preferences_html
+		+ '</div>'
 		+ '</div>'
 	);
 		

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -196,6 +196,8 @@ function display_products(target, product_groups ) {
 	});
 }
 
+/* global get_user_product_preferences */
+/* exported display_product_summary */
 
 function display_product_summary(target, product) {
 	
@@ -234,7 +236,7 @@ function display_product_summary(target, product) {
 		+ '<h4>' + attribute.title + '</h4>';
 		
 		if (attribute.description_short) {
-			attributes_html += '<span>' + attribute.description_short + '</span>'
+			attributes_html += '<span>' + attribute.description_short + '</span>';
 		}
 		
 		attributes_html += '</div>'

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -28,6 +28,12 @@ function match_product_to_preferences (product, product_preferences) {
 		"important" : []
 	};
 
+	product.match_attributes = {
+		"mandatory" : [],
+		"very_important" : [],
+		"important" : []
+	};
+
 	if (product.attribute_groups) {
 		
 		// Iterate over attribute groups
@@ -76,7 +82,9 @@ function match_product_to_preferences (product, product_preferences) {
 					
 					if (attribute.icon_url) {
 						product.match_icons[product_preferences[attribute.id]].push(attribute.icon_url);
-					}					
+					}
+					
+					product.match_attributes[product_preferences[attribute.id]].push(attribute);
 				}
 			});
 		});		
@@ -189,16 +197,61 @@ function display_products(target, product_groups ) {
 }
 
 
+function display_product_summary(target, product) {
+	
+	var user_product_preferences = get_user_product_preferences();
+	
+	match_product_to_preferences(product, user_product_preferences);
+	
+	var attributes_html = '';
+	
+	$.each(product.match_attributes.mandatory.concat(product.match_attributes.very_important, product.match_attributes.important), function (key, attribute) {
+		
+		// vary the color from green to red
+		var color = "#eee";
+		
+		if (attribute.status == "known") {
+			if (attribute.match <= 20) {
+				color = "hsl(0, 100%, 90%)";
+			}
+			else if (attribute.match <= 40) {
+				color = "hsl(30, 100%, 90%)";
+			}
+			else if (attribute.match <= 60) {
+				color = "hsl(60, 100%, 90%)";
+			}
+			else if (attribute.match <= 80) {
+				color = "hsl(90, 100%, 90%)";
+			}
+			else {
+				color = "hsl(120, 100%, 90%)";
+			}
+		}
+		
+		attributes_html += '<div class="small-12 medium-6 large-4 columns">'
+		+ '<div style="border-radius:12px;background-color:' + color + ';padding:1rem;margin-bottom:1rem;min-height:96px;">'
+		+ '<img src="' + attribute.icon_url + '" style="height:72px;float:right;">'
+		+ '<h4>' + attribute.title + '</h4>';
+		
+		if (attribute.description_short) {
+			attributes_html += '<span>' + attribute.description_short + '</span>'
+		}
+		
+		attributes_html += '</div>'
+		+ '</div>';
+	});
+	
+	$( target ).html('<div class="row" id="attributes_row">' + attributes_html + '</div>');
+		
+	$(document).foundation('equalizer', 'reflow');
+}
+
+
 function rank_and_display_products (target) {
 	
 	// Retrieve user preferences from local storage
 
-	var user_product_preferences = {};
-	var user_product_preferences_string = localStorage.getItem('user_product_preferences');
-
-	if (user_product_preferences_string) {
-		user_product_preferences = JSON.parse(user_product_preferences_string);
-	}	
+	var user_product_preferences = get_user_product_preferences();
 	
 	var ranked_products = rank_products(products, user_product_preferences);
 			

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -206,7 +206,7 @@ function display_product_summary(target, product) {
 	match_product_to_preferences(product, user_product_preferences);
 	
 	var attributes_html = '';
-	
+		
 	$.each(product.match_attributes.mandatory.concat(product.match_attributes.very_important, product.match_attributes.important), function (key, attribute) {
 		
 		// vary the color from green to red
@@ -229,21 +229,20 @@ function display_product_summary(target, product) {
 				color = "hsl(120, 100%, 90%)";
 			}
 		}
-		
-		attributes_html += '<div class="small-12 medium-6 large-4 columns">'
-		+ '<div style="border-radius:12px;background-color:' + color + ';padding:1rem;margin-bottom:1rem;min-height:96px;">'
+
+		attributes_html += '<li>'
+		+ '<div style="border-radius:12px;background-color:' + color + ';padding:1rem;min-height:96px;">'
 		+ '<img src="' + attribute.icon_url + '" style="height:72px;float:right;">'
 		+ '<h4>' + attribute.title + '</h4>';
 		
 		if (attribute.description_short) {
 			attributes_html += '<span>' + attribute.description_short + '</span>';
 		}
-		
-		attributes_html += '</div>'
-		+ '</div>';
+
+		attributes_html += '</div></li>';
 	});
 	
-	$( target ).html('<div class="row" id="attributes_row">' + attributes_html + '</div>');
+	$( target ).html('<ul id="attributes_grid" class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">' + attributes_html + '</ul>');
 		
 	$(document).foundation('equalizer', 'reflow');
 }

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -742,6 +742,13 @@ $options{attribute_groups} = [
 	],
 ];
 
+# default preferences for attributes
+$options{attribute_default_preferences} = {
+	"nutriscore" => "very_important",
+	"nova" => "important",
+	"ecoscore" => "important",
+};
+
 # Used to generate the sample import file for the producers platform
 # possible values: mandatory, recommended, optional.
 # when not specified, fields are considered optional

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4978,3 +4978,8 @@ msgstr "Edit your user profile"
 msgctxt "attribute_group_ingredients_analysis"
 msgid "Ingredients"
 msgstr "Ingredients"
+
+# keep the %s, it will be replaced by an allergen
+msgctxt "not_known_s"
+msgid "Not known: %s"
+msgstr "Not known: %s"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4967,3 +4967,8 @@ msgstr "Edit your user profile"
 msgctxt "attribute_group_ingredients_analysis"
 msgid "Ingredients"
 msgstr "Ingredients"
+
+# keep the %s, it will be replaced by an allergen
+msgctxt "not_known_s"
+msgid "Not known: %s"
+msgstr "Not known: %s"


### PR DESCRIPTION
This is a start to personalize (and later redesign) the product page (see #4391 )

What it does is to display some colored boxes on top of the individual product page to show the information that users have selected to be important.

Users can edit their preferences on page, and see the changes right away without reloading the page.

Those are the default preferences:

![image](https://user-images.githubusercontent.com/8158668/96757813-3c44c100-13d6-11eb-8829-728f29483f4f.png)

Of course the more preferences are selected, the more crowded it can get at the top:

![image](https://user-images.githubusercontent.com/8158668/96758050-93e32c80-13d6-11eb-91c3-b854eeafa565.png)


