### PR TITLE
[WIP] Fix broken redirects in the search form

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -394,9 +394,9 @@ sub init()
 
 		$log->debug("subdomain matches known country name", { subdomain => $subdomain, lc => $lc, cc => $cc, country => $country }) if $log->is_debug();
 	}
-	elsif ($ENV{QUERY_STRING} !~ /(cgi|api)\//) {
+	elsif ($ENV{REQUEST_URI} !~ /(cgi|api)\//) {
 		# redirect
-		my $redirect = "$world_subdomain/" . $ENV{QUERY_STRING};
+		my $redirect = "$world_subdomain/" . $ENV{REQUEST_URI};
 		$log->info("request could not be matched to a known format, redirecting", { subdomain => $subdomain, lc => $lc, cc => $cc, country => $country, redirect => $redirect }) if $log->is_info();
 		$r->headers_out->set(Location => $redirect);
 		$r->status(301);
@@ -414,10 +414,10 @@ sub init()
 	$lang = $lc;
 
 	# If the language is equal to the first language of the country, but we are on a different subdomain, redirect to the main country subdomain. (fr-fr => fr)
-	if ((defined $lc) and (defined $cc) and (defined $country_languages{$cc}[0]) and ($country_languages{$cc}[0] eq $lc) and ($subdomain ne $cc) and ($subdomain !~ /^(ssl-)?api/) and ($r->method() eq 'GET') and ($ENV{QUERY_STRING} !~ /(cgi|api)\//)) {
+	if ((defined $lc) and (defined $cc) and (defined $country_languages{$cc}[0]) and ($country_languages{$cc}[0] eq $lc) and ($subdomain ne $cc) and ($subdomain !~ /^(ssl-)?api/) and ($r->method() eq 'GET') and ($ENV{REQUEST_URI} !~ /(cgi|api)\//)) {
 		# redirect
 		my $ccdom = format_subdomain($cc);
-		my $redirect = "$ccdom/" . $ENV{QUERY_STRING};
+		my $redirect = "$ccdom/" . $ENV{REQUEST_URI};
 		$log->info("lc is equal to first lc of the country, redirecting to countries main domain", { subdomain => $subdomain, lc => $lc, cc => $cc, country => $country, redirect => $redirect }) if $log->is_info();
 		$r->headers_out->set(Location => $redirect);
 		$r->status(301);


### PR DESCRIPTION
### What

- QUERY_STRING doesn't include the path, so redirecting to domain+query_string will lose the path. 
- REQUEST_URI is path+query_string.
- It also means the checks for `($ENV{QUERY_STRING} !~ /(cgi|api)\//)` aren't currently working.

E.g. 
https://world-en.openfoodfacts.org/cgi/search.pl?action=process&search_terms=Mehl&sort_by=unique_scans_n&json=true
currently redirects to 
https://world.openfoodfacts.org/action=process&search_terms=Mehl&sort_by=unique_scans_n&json=true


### Part of
- #5492 