### PR TITLE
new generic icons for Organic and Fair trade attributes

### DIFF
--- a/html/images/icons/fair-trade-unknown.svg
+++ b/html/images/icons/fair-trade-unknown.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="fair-trade-unknown.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:export-filename="/home/stephane/Projets/Blogs/OpenFoodFacts/fish.png"
+   inkscape:export-xdpi="1600"
+   inkscape:export-ydpi="1600">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="6.9532168"
+     inkscape:cx="17.52353"
+     inkscape:cy="7.5868537"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid822" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,20 c -3.863703,1.035276 -6.8762762,-1.464466 -7,-3 2.8977768,-0.776457 6.223543,0.102223 7,3 z"
+     id="path955"
+     sodipodi:nodetypes="ccc" />
+  <path
+     id="path885"
+     style="fill:#ffffff;stroke-width:0.898207"
+     d="M 9.5 6 C 7 6 4 7 2 12 C 4 17 7 18 9.5 18 C 13.642136 18 17 15.313708 17 12 C 17 8.6862915 13.642135 6 9.5 6 z M 5.3984375 8.9667969 A 1 1 0 0 1 6.3984375 9.9667969 A 1 1 0 0 1 5.3984375 10.966797 A 1 1 0 0 1 4.3984375 9.9667969 A 1 1 0 0 1 5.3984375 8.9667969 z " />
+  <path
+     id="path931"
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22,7 c -3,1e-7 -5,2 -5,5 0,3 2,5 5,5 C 21.728674,14.496989 21,12 19.015625,11.978516 21,12 22,10.461271 22,7 Z"
+     sodipodi:nodetypes="csccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 14,4 C 10.136297,2.9647239 7.1237238,5.464466 7,7 9.8977768,7.7764571 13.223543,6.8977775 14,4 Z"
+     id="path2352"
+     sodipodi:nodetypes="ccc" />
+  <rect
+     style="fill:#b3b3b3"
+     id="rect1213"
+     width="24"
+     height="24"
+     x="0"
+     y="0" />
+  <circle
+     style="fill:#e6e6e6;stroke-width:1.33334"
+     id="circle1215"
+     cx="12"
+     cy="12"
+     r="10" />
+  <path
+     id="path1217"
+     style="fill:#cccccc;stroke-width:1.33334"
+     d="M 11.980469,2 A 10,10 0 0 0 2,12 10,10 0 0 0 12,22 V 2 a 10,10 0 0 0 -0.01953,0 z" />
+  <circle
+     style="fill:#e6e6e6;stroke:none"
+     id="circle1219"
+     cx="8"
+     cy="9.8667793"
+     r="2" />
+  <circle
+     style="fill:#cccccc;stroke:none"
+     id="circle1221"
+     cx="16"
+     cy="9.8667793"
+     r="2" />
+  <path
+     id="path1223"
+     style="fill:#e6e6e6;stroke:none;stroke-width:0.8"
+     d="M 12,16 A 3,3 0 0 1 9,13 H 8 a 4,4 0 0 0 4,4 z" />
+  <path
+     id="path1225"
+     style="fill:#cccccc;stroke:none;stroke-width:0.8"
+     d="m 12,16 v 1 a 4,4 0 0 0 4,-4 h -1 a 3,3 0 0 1 -3,3 z" />
+  <path
+     id="circle1227"
+     style="fill:#f2f2f2;stroke-width:1.33334"
+     d="M 11.980469,2 A 10,10 0 0 0 2,12 10,10 0 0 0 12,22 10,10 0 0 0 22,12 10,10 0 0 0 12,2 10,10 0 0 0 11.980469,2 Z M 12,4 a 8,8 0 0 1 8,8 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 z" />
+</svg>

--- a/html/images/icons/fair-trade.svg
+++ b/html/images/icons/fair-trade.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="fair-trade.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:export-filename="/home/stephane/Projets/Blogs/OpenFoodFacts/fish.png"
+   inkscape:export-xdpi="1600"
+   inkscape:export-ydpi="1600">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="17.52353"
+     inkscape:cy="7.5868537"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid822" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,20 c -3.863703,1.035276 -6.8762762,-1.464466 -7,-3 2.8977768,-0.776457 6.223543,0.102223 7,3 z"
+     id="path955"
+     sodipodi:nodetypes="ccc" />
+  <path
+     id="path885"
+     style="fill:#ffffff;stroke-width:0.898207"
+     d="M 9.5 6 C 7 6 4 7 2 12 C 4 17 7 18 9.5 18 C 13.642136 18 17 15.313708 17 12 C 17 8.6862915 13.642135 6 9.5 6 z M 5.3984375 8.9667969 A 1 1 0 0 1 6.3984375 9.9667969 A 1 1 0 0 1 5.3984375 10.966797 A 1 1 0 0 1 4.3984375 9.9667969 A 1 1 0 0 1 5.3984375 8.9667969 z " />
+  <path
+     id="path931"
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22,7 c -3,1e-7 -5,2 -5,5 0,3 2,5 5,5 C 21.728674,14.496989 21,12 19.015625,11.978516 21,12 22,10.461271 22,7 Z"
+     sodipodi:nodetypes="csccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 14,4 C 10.136297,2.9647239 7.1237238,5.464466 7,7 9.8977768,7.7764571 13.223543,6.8977775 14,4 Z"
+     id="path2352"
+     sodipodi:nodetypes="ccc" />
+  <g
+     id="g1276"
+     transform="translate(55,-30)">
+    <rect
+       style="fill:#0088aa"
+       id="rect1213"
+       width="24"
+       height="24"
+       x="-55"
+       y="30" />
+    <circle
+       style="fill:#ffe680;stroke-width:1.33334"
+       id="circle1215"
+       cx="-43"
+       cy="42"
+       r="10" />
+    <path
+       id="path1217"
+       style="fill:#999999;stroke-width:1.33334"
+       d="M -43.019531,32 A 10,10 0 0 0 -53,42 10,10 0 0 0 -43,52 V 32 a 10,10 0 0 0 -0.01953,0 z" />
+    <circle
+       style="fill:#ffe680;stroke:none"
+       id="circle1219"
+       cx="-47"
+       cy="39.866779"
+       r="2" />
+    <circle
+       style="fill:#999999;stroke:none"
+       id="circle1221"
+       cx="-39"
+       cy="39.866779"
+       r="2" />
+    <path
+       id="path1223"
+       style="fill:#ffe680;stroke:none;stroke-width:0.8"
+       d="m -43,46 a 3,3 0 0 1 -3,-3 h -1 a 4,4 0 0 0 4,4 z" />
+    <path
+       id="path1225"
+       style="fill:#999999;stroke:none;stroke-width:0.8"
+       d="m -43,46 v 1 a 4,4 0 0 0 4,-4 h -1 a 3,3 0 0 1 -3,3 z" />
+    <path
+       id="circle1227"
+       style="fill:#fff6d5;stroke-width:1.33334"
+       d="M -43.019531,32 A 10,10 0 0 0 -53,42 a 10,10 0 0 0 10,10 10,10 0 0 0 10,-10 10,10 0 0 0 -10,-10 10,10 0 0 0 -0.01953,0 z M -43,34 a 8,8 0 0 1 8,8 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 z" />
+  </g>
+</svg>

--- a/html/images/icons/not-fair-trade.svg
+++ b/html/images/icons/not-fair-trade.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="not-fair-trade.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:export-filename="/home/stephane/Projets/Blogs/OpenFoodFacts/fish.png"
+   inkscape:export-xdpi="1600"
+   inkscape:export-ydpi="1600">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="27.812867"
+     inkscape:cx="17.52353"
+     inkscape:cy="13.303632"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid822" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,20 c -3.863703,1.035276 -6.8762762,-1.464466 -7,-3 2.8977768,-0.776457 6.223543,0.102223 7,3 z"
+     id="path955"
+     sodipodi:nodetypes="ccc" />
+  <path
+     id="path885"
+     style="fill:#ffffff;stroke-width:0.898207"
+     d="M 9.5 6 C 7 6 4 7 2 12 C 4 17 7 18 9.5 18 C 13.642136 18 17 15.313708 17 12 C 17 8.6862915 13.642135 6 9.5 6 z M 5.3984375 8.9667969 A 1 1 0 0 1 6.3984375 9.9667969 A 1 1 0 0 1 5.3984375 10.966797 A 1 1 0 0 1 4.3984375 9.9667969 A 1 1 0 0 1 5.3984375 8.9667969 z " />
+  <path
+     id="path931"
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22,7 c -3,1e-7 -5,2 -5,5 0,3 2,5 5,5 C 21.728674,14.496989 21,12 19.015625,11.978516 21,12 22,10.461271 22,7 Z"
+     sodipodi:nodetypes="csccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 14,4 C 10.136297,2.9647239 7.1237238,5.464466 7,7 9.8977768,7.7764571 13.223543,6.8977775 14,4 Z"
+     id="path2352"
+     sodipodi:nodetypes="ccc" />
+  <rect
+     style="fill:#b3b3b3"
+     id="rect1213"
+     width="24"
+     height="24"
+     x="0"
+     y="0" />
+  <circle
+     style="fill:#e6e6e6;stroke-width:1.33334"
+     id="circle1215"
+     cx="12"
+     cy="12"
+     r="10" />
+  <path
+     id="path1217"
+     style="fill:#cccccc;stroke-width:1.33334"
+     d="M 11.980469,2 A 10,10 0 0 0 2,12 10,10 0 0 0 12,22 V 2 a 10,10 0 0 0 -0.01953,0 z" />
+  <circle
+     style="fill:#e6e6e6;stroke:none"
+     id="circle1219"
+     cx="8"
+     cy="9.8667793"
+     r="2" />
+  <circle
+     style="fill:#cccccc;stroke:none"
+     id="circle1221"
+     cx="16"
+     cy="9.8667793"
+     r="2" />
+  <path
+     id="path1223"
+     style="fill:#e6e6e6;stroke:none;stroke-width:0.8"
+     d="M 12,16 A 3,3 0 0 1 9,13 H 8 a 4,4 0 0 0 4,4 z" />
+  <path
+     id="path1225"
+     style="fill:#cccccc;stroke:none;stroke-width:0.8"
+     d="m 12,16 v 1 a 4,4 0 0 0 4,-4 h -1 a 3,3 0 0 1 -3,3 z" />
+  <path
+     id="circle1227"
+     style="fill:#f2f2f2;stroke-width:1.33334"
+     d="M 11.980469,2 A 10,10 0 0 0 2,12 10,10 0 0 0 12,22 10,10 0 0 0 22,12 10,10 0 0 0 12,2 10,10 0 0 0 11.980469,2 Z M 12,4 a 8,8 0 0 1 8,8 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 z" />
+  <path
+     style="fill:#808080;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 0,24 H 2 L 24,2 V 0 H 22 L 0,22 Z"
+     id="path3143"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/html/images/icons/not-organic.svg
+++ b/html/images/icons/not-organic.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="not-organic.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:export-filename="/home/stephane/Projets/Blogs/OpenFoodFacts/fish.png"
+   inkscape:export-xdpi="1600"
+   inkscape:export-ydpi="1600">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="17.52353"
+     inkscape:cy="9.620752"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid822" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,20 c -3.863703,1.035276 -6.8762762,-1.464466 -7,-3 2.8977768,-0.776457 6.223543,0.102223 7,3 z"
+     id="path955"
+     sodipodi:nodetypes="ccc" />
+  <path
+     id="path885"
+     style="fill:#ffffff;stroke-width:0.898207"
+     d="M 9.5 6 C 7 6 4 7 2 12 C 4 17 7 18 9.5 18 C 13.642136 18 17 15.313708 17 12 C 17 8.6862915 13.642135 6 9.5 6 z M 5.3984375 8.9667969 A 1 1 0 0 1 6.3984375 9.9667969 A 1 1 0 0 1 5.3984375 10.966797 A 1 1 0 0 1 4.3984375 9.9667969 A 1 1 0 0 1 5.3984375 8.9667969 z " />
+  <path
+     id="path931"
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22,7 c -3,1e-7 -5,2 -5,5 0,3 2,5 5,5 C 21.728674,14.496989 21,12 19.015625,11.978516 21,12 22,10.461271 22,7 Z"
+     sodipodi:nodetypes="csccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 14,4 C 10.136297,2.9647239 7.1237238,5.464466 7,7 9.8977768,7.7764571 13.223543,6.8977775 14,4 Z"
+     id="path2352"
+     sodipodi:nodetypes="ccc" />
+  <rect
+     style="fill:#b3b3b3;fill-opacity:1"
+     id="rect886"
+     width="24"
+     height="24"
+     x="0"
+     y="0"
+     ry="0" />
+  <circle
+     style="fill:#ffffff;stroke-width:1.33334"
+     id="path892"
+     cx="12"
+     cy="12"
+     r="10" />
+  <circle
+     style="fill:#cccccc;stroke-width:1.06666;fill-opacity:1"
+     id="circle894"
+     cx="12"
+     cy="12"
+     r="8" />
+  <path
+     id="circle896"
+     style="fill:#b3b3b3;stroke-width:1.06666;fill-opacity:1"
+     d="M 4.585938,15 A 8,8 0 0 0 12,20 8,8 0 0 0 19.416016,15 Z" />
+  <path
+     style="fill:#b3b3b3;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+     d="m 18,8 c -4,0 -7,1 -7,6 4,0 7,-1 7,-6 z"
+     id="path902"
+     sodipodi:nodetypes="ccc" />
+  <rect
+     style="fill:#999999;stroke-width:1.11803;fill-opacity:1"
+     id="rect898"
+     width="1"
+     height="5"
+     x="11"
+     y="14" />
+  <path
+     style="fill:#999999;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+     d="m 6,9 c 3,0 6,1 6,5 C 8,14 6,12 6,9 Z"
+     id="path900"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:#808080;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 0,24 H 2 L 24,2 V 0 H 22 L 0,22 Z"
+     id="path3143"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/html/images/icons/organic-unknown.svg
+++ b/html/images/icons/organic-unknown.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="organic-unknown.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:export-filename="/home/stephane/Projets/Blogs/OpenFoodFacts/fish.png"
+   inkscape:export-xdpi="1600"
+   inkscape:export-ydpi="1600">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="17.52353"
+     inkscape:cy="9.620752"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid822" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,20 c -3.863703,1.035276 -6.8762762,-1.464466 -7,-3 2.8977768,-0.776457 6.223543,0.102223 7,3 z"
+     id="path955"
+     sodipodi:nodetypes="ccc" />
+  <path
+     id="path885"
+     style="fill:#ffffff;stroke-width:0.898207"
+     d="M 9.5 6 C 7 6 4 7 2 12 C 4 17 7 18 9.5 18 C 13.642136 18 17 15.313708 17 12 C 17 8.6862915 13.642135 6 9.5 6 z M 5.3984375 8.9667969 A 1 1 0 0 1 6.3984375 9.9667969 A 1 1 0 0 1 5.3984375 10.966797 A 1 1 0 0 1 4.3984375 9.9667969 A 1 1 0 0 1 5.3984375 8.9667969 z " />
+  <path
+     id="path931"
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22,7 c -3,1e-7 -5,2 -5,5 0,3 2,5 5,5 C 21.728674,14.496989 21,12 19.015625,11.978516 21,12 22,10.461271 22,7 Z"
+     sodipodi:nodetypes="csccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 14,4 C 10.136297,2.9647239 7.1237238,5.464466 7,7 9.8977768,7.7764571 13.223543,6.8977775 14,4 Z"
+     id="path2352"
+     sodipodi:nodetypes="ccc" />
+  <rect
+     style="fill:#b3b3b3;fill-opacity:1"
+     id="rect886"
+     width="24"
+     height="24"
+     x="0"
+     y="0"
+     ry="0" />
+  <circle
+     style="fill:#ffffff;stroke-width:1.33334"
+     id="path892"
+     cx="12"
+     cy="12"
+     r="10" />
+  <circle
+     style="fill:#cccccc;stroke-width:1.06666;fill-opacity:1"
+     id="circle894"
+     cx="12"
+     cy="12"
+     r="8" />
+  <path
+     id="circle896"
+     style="fill:#b3b3b3;stroke-width:1.06666;fill-opacity:1"
+     d="M 4.585938,15 A 8,8 0 0 0 12,20 8,8 0 0 0 19.416016,15 Z" />
+  <path
+     style="fill:#808080;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+     d="m 18,8 c -4,0 -7,1 -7,6 4,0 7,-1 7,-6 z"
+     id="path902"
+     sodipodi:nodetypes="ccc" />
+  <rect
+     style="fill:#999999;stroke-width:1.11803;fill-opacity:1"
+     id="rect898"
+     width="1"
+     height="5"
+     x="11"
+     y="14" />
+  <path
+     style="fill:#999999;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+     d="m 6,9 c 3,0 6,1 6,5 C 8,14 6,12 6,9 Z"
+     id="path900"
+     sodipodi:nodetypes="ccc" />
+</svg>

--- a/html/images/icons/organic.svg
+++ b/html/images/icons/organic.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="organic.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:export-filename="/home/stephane/Projets/Blogs/OpenFoodFacts/fish.png"
+   inkscape:export-xdpi="1600"
+   inkscape:export-ydpi="1600">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="17.52353"
+     inkscape:cy="7.5868537"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid822" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 14,20 c -3.863703,1.035276 -6.8762762,-1.464466 -7,-3 2.8977768,-0.776457 6.223543,0.102223 7,3 z"
+     id="path955"
+     sodipodi:nodetypes="ccc" />
+  <path
+     id="path885"
+     style="fill:#ffffff;stroke-width:0.898207"
+     d="M 9.5 6 C 7 6 4 7 2 12 C 4 17 7 18 9.5 18 C 13.642136 18 17 15.313708 17 12 C 17 8.6862915 13.642135 6 9.5 6 z M 5.3984375 8.9667969 A 1 1 0 0 1 6.3984375 9.9667969 A 1 1 0 0 1 5.3984375 10.966797 A 1 1 0 0 1 4.3984375 9.9667969 A 1 1 0 0 1 5.3984375 8.9667969 z " />
+  <path
+     id="path931"
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22,7 c -3,1e-7 -5,2 -5,5 0,3 2,5 5,5 C 21.728674,14.496989 21,12 19.015625,11.978516 21,12 22,10.461271 22,7 Z"
+     sodipodi:nodetypes="csccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 14,4 C 10.136297,2.9647239 7.1237238,5.464466 7,7 9.8977768,7.7764571 13.223543,6.8977775 14,4 Z"
+     id="path2352"
+     sodipodi:nodetypes="ccc" />
+  <g
+     id="g1241"
+     transform="translate(26)">
+    <rect
+       style="fill:#00d400"
+       id="rect886"
+       width="24"
+       height="24"
+       x="-26"
+       y="0"
+       ry="0" />
+    <circle
+       style="fill:#ffffff;stroke-width:1.33334"
+       id="path892"
+       cx="-14"
+       cy="12"
+       r="10" />
+    <circle
+       style="fill:#55ddff;stroke-width:1.06666"
+       id="circle894"
+       cx="-14"
+       cy="12"
+       r="8" />
+    <path
+       id="circle896"
+       style="fill:#784421;stroke-width:1.06666"
+       d="M -21.414062,15 A 8,8 0 0 0 -14,20 8,8 0 0 0 -6.5839844,15 Z" />
+    <path
+       style="fill:#008000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -8,8 c -4,0 -7,1 -7,6 4,0 7,-1 7,-6 z"
+       id="path902"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:#00aa00;stroke-width:1.11803"
+       id="rect898"
+       width="1"
+       height="5"
+       x="-15"
+       y="14" />
+    <path
+       style="fill:#00aa00;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -20,9 c 3,0 6,1 6,5 -4,0 -6,-2 -6,-5 z"
+       id="path900"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/templates/display_product.tt.html
+++ b/templates/display_product.tt.html
@@ -83,6 +83,16 @@
 
 <!-- photos and data sources -->
 [% html_manufacturer_source %]
+
+<!-- product summary -->
+
+<div id="product_summary"></div>
+
+<div id="preferences_selected"></div>
+	
+<div id="preferences_selection_form" style="display:none"></div>
+	
+
 <!-- product_characteristics -->
 <h2>[% lang('product_characteristics') %]</h2>
 <div class="row">


### PR DESCRIPTION
Drawing more icons for attributes.

* Organic is a O with a growing plant (I tried to avoid just having one leaf as we already use the leaf icon for vegan products).
* Fair Trade is a coin / planet with a smile / 2 people shaking hands

![image](https://user-images.githubusercontent.com/8158668/96997339-e127e100-1531-11eb-9893-4f3147e15431.png)

+ some small changes to how preferences are displayed (will change again with a slider probably)
