### PR TITLE
new US labels: use mg instead of %DV, #4377

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -1861,8 +1861,13 @@ HTML
 				if (lc($unit) eq lc($u)) {
 					$selected = 'selected="selected" ';
 				}
+				my $label = $u;
+				# Display both mcg and µg as different food labels show the unit differently
+				if ($u eq 'µg') {
+					$label = "mcg/µg";
+				}
 				$input .= <<HTML
-<option value="$u" $selected>$u</option>
+<option value="$u" $selected>$label</option>
 HTML
 ;
 			}

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -3231,7 +3231,8 @@ sub mmoll_to_unit {
 		unit    => "mg",
 		dv      => 1000,
 		dv_2016 => 1300,
-		unit_us => "% DV",
+		# 2020: US now also indicate value in mg (preferred as %DV is based on changing daily values)
+		# unit_us => "% DV",
 		unit_ca => "% DV",
 	},
 	phosphorus => {
@@ -3299,7 +3300,8 @@ sub mmoll_to_unit {
 		unit    => "mg",
 		dv      => 18,
 		dv_2016 => 18,
-		unit_us => "% DV",
+		# 2020: US now also indicate value in mg (preferred as %DV is based on changing daily values)
+		# unit_us => "% DV",
 		unit_ca => "% DV",
 	},
 	magnesium => {

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -77,7 +77,7 @@ input.nutriment_value {
 
 select.nutriment_unit {
   margin-bottom: 0;
-  width: 4rem;
+  width: 5rem;
 }
 
 thead,


### PR DESCRIPTION
* fixes #4377 : the mg value is preferred as the FDA changes the reference values for %DV
* display the unit as mcg/µg instead of just µg (US labels show "mcg")