### PR TITLE
fixes #4365, allergen 0%

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -4722,7 +4722,7 @@ sub replace_allergen_between_separators($$$$$$) {
 
 	#print STDERR "before_allergen: $before_allergen - allergen: $allergen - tagid: $tagid\n";
 
-	if (exists_taxonomy_tag("allergens", $tagid)) {
+	if (($tagid ne "en:none") and (exists_taxonomy_tag("allergens", $tagid))) {
 		#$allergen = display_taxonomy_tag($product_ref->{lang},"allergens", $tagid);
 		# to build the product allergens list, just use the ingredients in the main language
 		if ($language eq $product_ref->{lc}) {

--- a/t/allergens.t
+++ b/t/allergens.t
@@ -687,4 +687,18 @@ is_deeply($product_ref,
 }
 ) or diag explain $product_ref;
 
+# bug https://github.com/openfoodfacts/openfoodfacts-server/issues/4365
+
+$product_ref = {
+        lc => "en", lang => "en",
+        ingredients_text_en => "Whole Grain Oat Flakes (65.0%)"
+};
+
+compute_languages($product_ref);
+detect_allergens_from_text($product_ref);
+
+is($product_ref->{ingredients_text_with_allergens_en}, "Whole Grain Oat Flakes (65.0%)");
+
+
+
 done_testing();


### PR DESCRIPTION
The cause for the bug was that as we now recognize "0" as "no allergens", 0 is also matched when looking for allergens in ingredients.

fixes #4365