### PR TITLE
temporary redirect instead of permanent

### DIFF
--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -200,8 +200,8 @@ if (($type eq "edit_owner") and ($action eq "process")) {
 
 	my $r = shift;
 	$r->headers_out->set(Location =>"/");
-	$r->status(301);
-	return 301;
+	$r->status(302);
+	return 302;
 }
 else {
 	


### PR DESCRIPTION
This is for URLs like https://world.pro.openfoodfacts.dev/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-some-org that moderators of the producers platform can use to see the products of a specific organization. There was a permanent redirect to / after the update, which means nginx would bypass the cgi entirely after the first time.