### PR TITLE
convert Eco-Score tests to new system

### DIFF
--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -7,6 +7,10 @@ use Test::More;
 use Test::Number::Delta relative => 1.001;
 use Log::Any::Adapter 'TAP';
 
+use JSON;
+use Getopt::Long;
+
+use ProductOpener::Config qw/:all/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Ecoscore qw/:all/;
 
@@ -53,24 +57,118 @@ foreach my $tagtype (keys %tags) {
 	}
 }
 
+my $testdir = "ecoscore";
+
+my $usage = <<TXT
+
+The expected results of the tests are saved in $data_root/t/expected_test_results/$testdir
+
+To verify differences and update the expected test results, actual test results
+can be saved to a directory by passing --results [path of results directory]
+
+The directory will be created if it does not already exist.
+
+TXT
+;
+
+my $resultsdir;
+
+GetOptions ("results=s"   => \$resultsdir)
+  or die("Error in command line arguments.\n\n" . $usage);
+  
+if ((defined $resultsdir) and (! -e $resultsdir)) {
+	mkdir($resultsdir, 0755) or die("Could not create $resultsdir directory: $!\n");
+}
+
 my @tests = (
-
-[ { lc=>"en" }, undef ],
-[ { lc=>"en", categories_tags=>["en:some-unknown-category"] }, undef ],
-[ { lc=>"en", categories_tags=>["en:butters"] }, 35.3946474732019 ],
-[ { lc=>"en", categories_tags=>["en:butters"], labels_tags=>["fr:ab-agriculture-biologique"] }, 50.3946474732019 ],
-[ { lc=>"en", categories_tags=>["en:margarines"] }, 70.230149592005 ],
-[ { lc=>"en", categories_tags=>["en:margarines"], ingredients_analysis_tags=>["en:palm-oil"] }, 60.230149592005 ],
-[ { lc=>"en", categories_tags=>["en:margarines"], ingredients_analysis_tags=>["en:palm-oil"], labels_tags=>["en:roundtable-on-sustainable-palm-oil"] }, 70.230149592005 ],
-
+	
+	[
+		'empty-product',
+		{
+			lc => "en",
+		}
+	],		
+	[
+		'unknown-category',
+		{
+			lc => "en",
+			categories_tags=>["en:some-unknown-category"],
+		}
+	],
+	[
+		'known-category-butters',
+		{
+			lc => "en",
+			categories_tags=>["en:butters"],
+		}
+	],	
+	[
+		'label-organic',
+		{
+			lc => "en",
+			categories_tags=>["en:butters"],
+			labels_tags=>["fr:ab-agriculture-biologique"],
+		}
+	],
+	[
+		'known-category-margarines',
+		{
+			lc => "en",
+			categories_tags=>["en:margarines"],
+		}
+	],
+	[
+		'ingredient-palm-oil',
+		{
+			lc => "en",
+			categories_tags=>["en:margarines"],
+			ingredients_analysis_tags=>["en:palm-oil"],
+		}
+	],
+	[
+		'ingredient-palm-oil-rspo',
+		{
+			lc => "en",
+			categories_tags=>["en:margarines"],
+			ingredients_analysis_tags=>["en:palm-oil"],
+			labels_tags=>["en:roundtable-on-sustainable-palm-oil"],
+		}
+	],		
 );
+
+
+my $json = JSON->new->allow_nonref->canonical;
 
 foreach my $test_ref (@tests) {
 
-	my $product_ref = $test_ref->[0];
+	my $testid = $test_ref->[0];
+	my $product_ref = $test_ref->[1];
+	
+	# Run the test
+	
 	compute_ecoscore($product_ref);
+	
+	# Save the result
+	
+	if (defined $resultsdir) {
+		open (my $result, ">:encoding(UTF-8)", "$resultsdir/$testid.json") or die("Could not create $resultsdir/$testid.json: $!\n");
+		print $result $json->pretty->encode($product_ref);
+		close ($result);
+	}
+	
+	# Compare the result with the expected result
+	
+	if (open (my $expected_result, "<:encoding(UTF-8)", "$data_root/t/expected_test_results/$testdir/$testid.json")) {
 
-	is($product_ref->{ecoscore_score}, $test_ref->[1]) or diag explain $product_ref->{ecoscore_data};
+		local $/; #Enable 'slurp' mode
+		my $expected_product_ref = $json->decode(<$expected_result>);
+		is_deeply ($product_ref, $expected_product_ref) or diag explain $product_ref;
+	}
+	else {
+		fail("could not load expected_test_results/$testdir/$testid.json");
+	}
 }
+
+# 
 
 done_testing();

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -1,0 +1,14 @@
+{
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {},
+         "threatened_species" : {}
+      },
+      "agribalyse" : {},
+      "missing" : {
+         "categories" : 1
+      },
+      "status" : "unknown"
+   },
+   "lc" : "en"
+}

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -1,0 +1,30 @@
+{
+   "categories_tags" : [
+      "en:margarines"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {},
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_ef_total" : 0.33526651,
+         "agribalyse_food_name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
+         "agribalyse_food_name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
+         "agribalyse_proxy_food_code" : "16737",
+         "score" : 70.230149592005
+      },
+      "grade" : "b",
+      "score" : 70.230149592005,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 70.230149592005,
+   "ingredients_analysis_tags" : [
+      "en:palm-oil"
+   ],
+   "labels_tags" : [
+      "en:roundtable-on-sustainable-palm-oil"
+   ],
+   "lc" : "en"
+}

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -1,0 +1,30 @@
+{
+   "categories_tags" : [
+      "en:margarines"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {},
+         "threatened_species" : {
+            "ingredient" : "en:palm-oil",
+            "value" : -10
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_ef_total" : 0.33526651,
+         "agribalyse_food_name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
+         "agribalyse_food_name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
+         "agribalyse_proxy_food_code" : "16737",
+         "score" : 70.230149592005
+      },
+      "grade" : "b",
+      "score" : 60.230149592005,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 60.230149592005,
+   "ingredients_analysis_tags" : [
+      "en:palm-oil"
+   ],
+   "lc" : "en"
+}

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -1,0 +1,24 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {},
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_ef_total" : "1.1514725",
+         "agribalyse_food_name_en" : "Butter, 82% fat, unsalted",
+         "agribalyse_food_name_fr" : "Beurre à 82% MG, doux",
+         "agribalyse_proxy_food_code" : "16400",
+         "score" : 35.3946474732019
+      },
+      "grade" : "d",
+      "score" : 35.3946474732019,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 35.3946474732019,
+   "lc" : "en"
+}

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -1,0 +1,24 @@
+{
+   "categories_tags" : [
+      "en:margarines"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {},
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_ef_total" : "0.33526651",
+         "agribalyse_food_name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
+         "agribalyse_food_name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
+         "agribalyse_proxy_food_code" : "16737",
+         "score" : 70.230149592005
+      },
+      "grade" : "b",
+      "score" : 70.230149592005,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 70.230149592005,
+   "lc" : "en"
+}

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -1,0 +1,30 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {
+            "label" : "fr:ab-agriculture-biologique",
+            "value" : 15
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_ef_total" : 1.1514725,
+         "agribalyse_food_name_en" : "Butter, 82% fat, unsalted",
+         "agribalyse_food_name_fr" : "Beurre à 82% MG, doux",
+         "agribalyse_proxy_food_code" : "16400",
+         "score" : 35.3946474732019
+      },
+      "grade" : "c",
+      "score" : 50.3946474732019,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 50.3946474732019,
+   "labels_tags" : [
+      "fr:ab-agriculture-biologique"
+   ],
+   "lc" : "en"
+}

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -1,0 +1,17 @@
+{
+   "categories_tags" : [
+      "en:some-unknown-category"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "production_system" : {},
+         "threatened_species" : {}
+      },
+      "agribalyse" : {},
+      "missing" : {
+         "agb_category" : 1
+      },
+      "status" : "unknown"
+   },
+   "lc" : "en"
+}


### PR DESCRIPTION
This is the same refactoring as the one I did for ingredients: the expected test results are now stored in files outside the test file, so that they can easily be updated.

This allows also to test all Eco-Score values (computations details etc.) and not just the final score, which makes it easier to see what changed if we get different results.

It is also very useful for updates as I'm adding components of the Eco-Score computation one by one, and some parts of all existing expected test results are going to change for each new component added.