### PR TITLE
Display attributes on top of product page (for moderators for now), i18n + small visual changes

### DIFF
--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -1,3 +1,5 @@
+/*global lang */
+
 var attribute_groups;	// All supported attribute groups and attributes + translated strings
 var preferences;	// All supported preferences + translated strings
 
@@ -60,7 +62,7 @@ function display_selected_preferences (target_selected, target_selection_form, p
 		
 		if (selected_preference_group.length > 0) {
 			selected_preferences_html += "<div>"
-			+ "<strong>" + selected_preference_name + " - </strong>"
+			+ "<strong>" + selected_preference_name + "</strong>"
 			+ "<ul>" + selected_preference_group.join("") + "</ul>"
 			+ "</div>";
 		}
@@ -71,9 +73,10 @@ function display_selected_preferences (target_selected, target_selection_form, p
 		+ '<div class="edit_button">'
 		+ '<a id="show_selection_form" class="button small">'
 		+ '<img src="/images/icons/dist/food-cog.svg" class="icon" style="filter:invert(1)">'
-		+ " Edit your food preferences" + '</a></div>'
-		+ "<h2>" + "Your food preferences" + "</h2>"
-		+ '<a id="preferences_link" data-dropdown="selected_preferences">Currently selected preferences &raquo;</a>'
+		+ " " + lang().preferences_edit_your_food_preferences + '</a></div>'
+		+ "<h2>" + lang().preferences_your_preferences + "</h2>"
+		+ '<a id="preferences_link" data-dropdown="selected_preferences">'
+		+ lang().preferences_currently_selected_preferences + ' &raquo;</a>'
 		+ '<div id="selected_preferences" data-dropdown-content class="f-dropdown content medium">' 
 		+ selected_preferences_html
 		+ '</div>'
@@ -147,13 +150,9 @@ function display_user_product_preferences (target_selected, target_selection_for
 			$.each(attribute_group.attributes, function(key, attribute) {
 				
 				attribute_group_html += "<li id='attribute_" + attribute.id + "' class='attribute'>"
-				+ "<div style='display:inline-block;width:96px'><img src='" + attribute.icon_url + "' class='match_icons'></div>"
+				+ "<div style='width:96px;float:left;margin-right:1em;'><img src='" + attribute.icon_url + "' class='match_icons'></div>"
 				+ "<span class='attribute_name'>" + attribute.setting_name + "</span><br>";
-				
-				if (attribute.description_short) {
-					attribute_group_html += "<p class='attribute_description_short'>" + attribute.description_short + "</p>";
-				}				
-								
+							
 				$.each(preferences, function (key, preference) {
 					
 					var checked = '';
@@ -168,6 +167,12 @@ function display_user_product_preferences (target_selected, target_selection_for
 					+ "</input>";
 				});
 				
+				if (attribute.description_short) {
+					attribute_group_html += "<p class='attribute_description_short'>" + attribute.description_short + "</p>";
+				}
+				
+				attribute_group_html += "<hr style='clear:left;border:none;margin:0;margin-bottom:0.5rem;padding:0;'>";
+				
 				attribute_group_html += "</li>";
 			});
 						
@@ -181,9 +186,9 @@ function display_user_product_preferences (target_selected, target_selection_for
 			+ '<div class="edit_button">'
 			+ '<a class="show_selected button small">'
 			+ '<img src="/images/icons/dist/cancel.svg" class="icon" style="filter:invert(1)">'
-			+ " Close" + '</a></div>'
-			+ "<h2>" + "Edit your food preferences" + "</h2>"
-			+ "<p>Your food preferences are kept in your browser and never sent to Open Food Facts or anyone else.</p>"
+			+ " " + lang().close + '</a></div>'
+			+ "<h2>" + lang().preferences_edit_your_food_preferences + "</h2>"
+			+ "<p>" + lang().preferences_locally_saved + "</p>"
 			+ '<ul id="user_product_preferences" class="accordion" data-accordion>'
 			+ attribute_groups_html.join( "" )
 			+ '</ul>'
@@ -191,7 +196,7 @@ function display_user_product_preferences (target_selected, target_selection_for
 			+ '<div class="edit_button">'
 			+ '<a class="show_selected button small">'
 			+ '<img src="/images/icons/dist/cancel.svg" class="icon" style="filter:invert(1)">'
-			+ " Close" + '</a></div><br><br>'
+			+ " " + lang().close + '</a></div><br><br>'
 			+ '</div>'
 		);
 		

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -232,7 +232,7 @@ function display_product_summary(target, product) {
 
 		attributes_html += '<li>'
 		+ '<div style="border-radius:12px;background-color:' + color + ';padding:1rem;min-height:96px;">'
-		+ '<img src="' + attribute.icon_url + '" style="height:72px;float:right;">'
+		+ '<img src="' + attribute.icon_url + '" style="height:72px;float:right;margin-left:0.5rem;">'
 		+ '<h4>' + attribute.title + '</h4>';
 		
 		if (attribute.description_short) {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8065,8 +8065,11 @@ HTML
 ;
 
 	# Compute attributes and embed them as JSON
+	# enable feature for moderators
 	
-	if ((defined param("user_preferences")) and (param("user_preferences"))) {
+	if (((defined $options{product_type}) and ($options{product_type} eq "food"))
+		and (not $server_options{producers_platform})
+		and (($User{moderator}) or ((defined param("user_preferences")) and (param("user_preferences"))))) {
 	
 		# A result summary will be computed according to user preferences on the client side
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4574,9 +4574,13 @@ msgctxt "attribute_labels_organic_no_title"
 msgid "Not an organic product"
 msgstr "Not an organic product"
 
-msgctxt "attribute_labels_organic_description_short"
+msgctxt "attribute_labels_organic_yes_description_short"
 msgid "Promotes ecological sustainability and biodiversity."
 msgstr "Promotes ecological sustainability and biodiversity."
+
+msgctxt "attribute_labels_organic_description_short"
+msgid "Organic products promote ecological sustainability and biodiversity."
+msgstr "Organic products promote ecological sustainability and biodiversity."
 
 msgctxt "attribute_labels_organic_description"
 msgid "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives."
@@ -5001,3 +5005,26 @@ msgstr "Eco-score grade"
 msgctxt "ecoscore_calculation_details"
 msgid "Details of the calculation of the Eco-score"
 msgstr "Details of the calculation of the Eco-score"
+
+# do not translate Eco-score
+msgctxt "ecoscore_information"
+msgid "Information about the Eco-score"
+msgstr "Information about the Eco-score"
+
+msgctxt "preferences_edit_your_food_preferences"
+msgid "Edit your food preferences"
+msgstr "Edit your food preferences"
+
+msgctxt "preferences_your_preferences"
+msgid "Your food preferences"
+msgstr "Your food preferences"
+
+msgctxt "preferences_currently_selected_preferences"
+msgid "Currently selected preferences"
+msgstr "Currently selected preferences"
+
+msgctxt "preferences_locally_saved"
+msgid "Your food preferences are kept in your browser and never sent to Open Food Facts or anyone else."
+msgstr "Your food preferences are kept in your browser and never sent to Open Food Facts or anyone else."
+
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4564,9 +4564,13 @@ msgctxt "attribute_labels_organic_no_title"
 msgid "Not an organic product"
 msgstr "Not an organic product"
 
-msgctxt "attribute_labels_organic_description_short"
+msgctxt "attribute_labels_organic_yes_description_short"
 msgid "Promotes ecological sustainability and biodiversity."
 msgstr "Promotes ecological sustainability and biodiversity."
+
+msgctxt "attribute_labels_organic_description_short"
+msgid "Organic products promote ecological sustainability and biodiversity."
+msgstr "Organic products promote ecological sustainability and biodiversity."
 
 msgctxt "attribute_labels_organic_description"
 msgid "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives."
@@ -4991,3 +4995,25 @@ msgstr "Eco-score grade"
 msgctxt "ecoscore_calculation_details"
 msgid "Details of the calculation of the Eco-score"
 msgstr "Details of the calculation of the Eco-score"
+
+# do not translate Eco-score
+msgctxt "ecoscore_information"
+msgid "Information about the Eco-score"
+msgstr "Information about the Eco-score"
+
+msgctxt "preferences_edit_your_food_preferences"
+msgid "Edit your food preferences"
+msgstr "Edit your food preferences"
+
+msgctxt "preferences_your_preferences"
+msgid "Your food preferences"
+msgstr "Your food preferences"
+
+msgctxt "preferences_currently_selected_preferences"
+msgid "Currently selected preferences"
+msgstr "Currently selected preferences"
+
+msgctxt "preferences_locally_saved"
+msgid "Your food preferences are kept in your browser and never sent to Open Food Facts or anyone else."
+msgstr "Your food preferences are kept in your browser and never sent to Open Food Facts or anyone else."
+


### PR DESCRIPTION
This enables displaying the attributes that correspond to user preferences on top of product pages.

The feature is quite new and will need polishing, so it will be enabled only for moderators for now. (if you are not a moderator yet, let me know your OFF username so that I can add you)

![image](https://user-images.githubusercontent.com/8158668/97804853-b38a1880-1c52-11eb-99b1-d93be32d036d.png)
