### PR TITLE
A few more French regional origins

### DIFF
--- a/t/expected_test_results/ingredients/fr-origins-agriculture-ue-non-ue.json
+++ b/t/expected_test_results/ingredients/fr-origins-agriculture-ue-non-ue.json
@@ -1,0 +1,46 @@
+{
+   "ingredients" : [
+      {
+         "id" : "en:strawberry",
+         "origins" : "en:european-union-and-non-european-union",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "rank" : 1,
+         "text" : "Fraises",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:strawberry",
+      "en:fruit",
+      "en:berries"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:strawberry"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:strawberry",
+      "en:fruit",
+      "en:berries"
+   ],
+   "ingredients_text" : "Fraises (agriculture UE/Non UE)",
+   "known_ingredients_n" : 3,
+   "lc" : "fr",
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 100
+   },
+   "unknown_ingredients_n" : 0
+}

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -283,6 +283,14 @@ my @tests = (
 			ingredients_text => "Fraises de Bretagne, beurre doux de Normandie, tomates cerises (Bretagne), pommes (origine : Normandie)"
 		}
 	],
+	[
+                "fr-origins-agriculture-ue-non-ue",
+                {
+                        lc => "fr",
+                        ingredients_text => "Fraises (agriculture UE/Non UE)"
+                }
+        ],
+
 );
 
 
@@ -315,6 +323,7 @@ foreach my $test_ref (@tests) {
 		is_deeply ($product_ref, $expected_product_ref) or diag explain $product_ref;
 	}
 	else {
+		diag explain $product_ref;
 		fail("could not load expected_test_results/$testdir/$testid.json");
 	}
 }

--- a/taxonomies/origins.result.txt
+++ b/taxonomies/origins.result.txt
@@ -1,3 +1,5 @@
+stopwords:en:agriculture
+stopwords:fr:agriculture
 
 
 en:Afghanistan, Islamic Republic of Afghanistan, AF, AFG
@@ -5439,6 +5441,9 @@ country_code_2:en: CF
 country_code_3:en: CAF
 languages:en: fr,sg
 
+en:Central America
+fr:Amérique centrale
+
 en:Chad, Republic of Chad, République du Tchad, جمهورية تشاد, Ǧumhūriyyat Tšād, Tchad, TD, TCD
 af:Tsjad
 am:ቻድ
@@ -8981,6 +8986,9 @@ yo:Ìṣọ̀kan Europe
 zh:欧洲联盟
 languages:en: en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
 
+en:European Union and Non European Union, EU and non EU, EU non EU
+fr:Union Européenne et Non Union Européenne, UE et non UE, UE non UE
+
 en:Falkland Islands, Falklands, Malvinas, Islas Malvinas, FK, FLK
 af:Falkland-eilande
 an:Islas Malvinas
@@ -9709,12 +9717,56 @@ country_code_3:en: FRA
 languages:en: fr
 
 < en:France
+en:Alsace
+fr:Alsace
+
+< en:France
+en:Aquitaine
+fr:Aquitaine
+
+< en:France
+en:Ardèche
+fr:Ardèche
+
+< en:France
 en:Brittany
 fr:Bretagne
 
 < en:France
+en:Burgundy
+fr:Bourgogne
+
+< en:France
+en:Camargue
+fr:Camargue
+
+< en:France
+en:Corsica
+fr:Corse
+
+< en:France
+en:Loire-Atlantique
+fr:Loire-Atlantique
+
+< en:France
+en:Loire valley
+fr:Val de Loire
+
+< en:France
 en:Normandy
 fr:Normandie
+
+< en:France
+en:Provence
+fr:Provence
+
+< en:France
+en:Savoy
+fr:Savoie
+
+< en:France
+en:South-western France, South-west of France
+fr:Sud-ouest de la France, Sud-ouest français
 
 en:French Guiana, GF, GUF
 af:Frans-Guyana
@@ -13747,6 +13799,11 @@ zu:ITaliya
 country_code_2:en: IT
 country_code_3:en: ITA
 languages:en: it
+
+< en:Italy
+en:Sicily
+fr:Sicile
+it:Sicilia
 
 en:Jamaica, JA, Commonwealth of Jamaica, Jamdung, JM, JAM
 af:Jamaika
@@ -29508,6 +29565,9 @@ zh:美国本土外小岛屿
 country_code_2:en: UM
 country_code_3:en: UMI
 languages:en: 
+
+en:Unknown, not specified
+fr:Inconnu, inconnue, inconnus, inconnues, non-spécifié, non-spécifiée
 
 en:Uruguay, Oriental Republic of Uruguay, Eastern Republic of Uruguay, República Oriental del Uruguay, UY, URY
 af:Uruguay

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -4,8 +4,18 @@
 # that need origins that can be specified at different levels of granularity (and not just countries).
 # example includes ingredients parsing and computing the Eco-Score
 
-# It may not be useful to add many entries to it as we will most likely try to create it automatically
-# from sources such as Wikidata.
+# Please include only regions for which we have actual products
+# that list ingredients for those regions.
+# -> look at the /origins facet
+#
+# Also please don't add translations in many languages unless you are sure that they are not ambiguous
+# and may not refer to a different region / country. (e.g. "Georgia" is a country and a US state)
+
+stopwords:en:agriculture
+stopwords:fr:agriculture
+
+en:Unknown, not specified
+fr:Inconnu, inconnue, inconnus, inconnues, non-spécifié, non-spécifiée
 
 # World regions
 
@@ -14,6 +24,9 @@ fr:Afrique
 
 en:Latin America
 fr:Amérique Latine
+
+en:Central America
+fr:Amérique centrale
 
 en:North-America
 fr:Amérique du Nord
@@ -33,16 +46,77 @@ fr:Union Européenne, UE
 en:Non European Union, Non EU
 fr:Non Union Européenne, Non UE
 
+en:European Union and Non European Union, EU and non EU, EU non EU
+fr:Union Européenne et Non Union Européenne, UE et non UE, UE non UE
+
 
 # Country regions
+
+
+# France regions
+
+<en:france
+en:Alsace
+fr:Alsace
+
+<en:france
+en:Ardèche
+fr:Ardèche
+
+<en:france
+en:Aquitaine
+fr:Aquitaine
+
+<en:france
+en:Burgundy
+fr:Bourgogne
 
 <en:france
 en:Brittany
 fr:Bretagne
 
 <en:france
+en:Camargue
+fr:Camargue
+
+<en:france
+en:Corsica
+fr:Corse
+
+<en:france
+en:Loire-Atlantique
+fr:Loire-Atlantique
+
+<en:france
 en:Normandy
 fr:Normandie
+
+<en:france
+en:Provence
+fr:Provence
+
+<en:france
+en:Savoy
+fr:Savoie
+
+<en:france
+en:South-western France, South-west of France
+fr:Sud-ouest de la France, Sud-ouest français
+
+<en:france
+en:Loire valley
+fr:Val de Loire
+
+
+# Italy regions
+
+<en:italy
+en:Sicily
+fr:Sicile
+it:Sicilia
+
+
+# US states
 
 <en:united-states
 en:California
@@ -51,3 +125,7 @@ fr:Californie
 <en:united-states
 en:Florida
 fr:Floride
+
+<en:United States	
+en:South Carolina	
+fr:Caroline du Sud


### PR DESCRIPTION
- added "agriculture" as a stopword (often found in phrases like "agriculture France").
- added a few more regions (the most represented on https://fr.openfoodfacts.org/origines?status=unknown )