### PR TITLE
Fix translations breaking html & translating slack channel name

### DIFF
--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -4293,7 +4293,7 @@ msgstr "다국어 성분 목록, 성분 처리 방법 및 라벨에 새로운 �
 # Do not translate #ingredients
 msgctxt "help_improve_ingredients_analysis_instructions"
 msgid "Join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingredients analysis on our wiki</a>, if you would like to help. Thank you!"
-msgstr "도움이 필요하면 우리의 Slack 토론방인 <a href=\"https://slack.openfoodfacts.org\">  #ingredients channel에 가입하거나 우리의 성분 분석 wiki인 <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">에서 정보를 얻으세요. 감사합니다! "
+msgstr "도움이 필요하면 우리의 Slack 토론방인 <a href=\"https://slack.openfoodfacts.org\">#ingredients channel</a>에 가입하거나 우리의 성분 분석 <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">wiki</a>인 에서 정보를 얻으세요. 감사합니다!"
 
 msgctxt "footer_producers_link"
 msgid "https://world.pro.openfoodfacts.org/"

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -4293,7 +4293,7 @@ msgstr "Voeg nieuwe items, synoniemen of vertalingen toe aan onze meertalige lij
 # Do not translate #ingredients
 msgctxt "help_improve_ingredients_analysis_instructions"
 msgid "Join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingredients analysis on our wiki</a>, if you would like to help. Thank you!"
-msgstr "Volg het #ingrediëntenkanaal op <a href=\"https://slack.openfoodfacts.org\">onze Slack discussieruimte</a> en/of leer over <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingrediëntenanalyse op onze wiki</a>, als je wilt helpen. Dank u wel!"
+msgstr "Volg het #ingredients kanaal op <a href=\"https://slack.openfoodfacts.org\">onze Slack discussieruimte</a> en/of leer over <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingrediëntenanalyse op onze wiki</a>, als je wilt helpen. Dank u wel!"
 
 msgctxt "footer_producers_link"
 msgid "https://world.pro.openfoodfacts.org/"

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -4293,7 +4293,7 @@ msgstr "Voeg nieuwe items, synoniemen of vertalingen toe aan onze meertalige lij
 # Do not translate #ingredients
 msgctxt "help_improve_ingredients_analysis_instructions"
 msgid "Join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingredients analysis on our wiki</a>, if you would like to help. Thank you!"
-msgstr "Volg het #ingrediëntenkanaal op <a href=\"https://slack.openfoodfacts.org\">onze Slack discussieruimte</a> en/of leer over <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingrediëntenanalyse op onze wiki</a>, als je wilt helpen. Dank u wel!"
+msgstr "Volg het #ingredients kanaal op <a href=\"https://slack.openfoodfacts.org\">onze Slack discussieruimte</a> en/of leer over <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingrediëntenanalyse op onze wiki</a>, als je wilt helpen. Dank u wel!"
 
 msgctxt "footer_producers_link"
 msgid "https://world.pro.openfoodfacts.org/"

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -1230,7 +1230,7 @@ msgctxt "login_to_add_products"
 msgid "<p>Please sign-in to add or edit a product.</p>\n\n"
 "<p>If you do not yet have an account on <<site_name>>, you can <a href=\"/cgi/user.pl\">register in 30 seconds</a>.</p>\n"
 msgstr "<p>Выполните вход, чтобы добавить или отредактировать продукт.</p>\n\n"
-"<p>Если у вас еще нет аккаунта на сайте <<site_name>> вы можете <а href=\"/cgi/user.pl\">зарегистрироваться за 30 секунд</a>.</p>\n"
+"<p>Если у вас еще нет аккаунта на сайте <<site_name>> вы можете <a href=\"/cgi/user.pl\">зарегистрироваться за 30 секунд</a>.</p>\n"
 
 msgctxt "login_username_email"
 msgid "Username or e-mail address:"

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -4290,7 +4290,7 @@ msgstr "Çok dilli içerik listelerimize, içerik işleme yöntemlerine ve etike
 # Do not translate #ingredients
 msgctxt "help_improve_ingredients_analysis_instructions"
 msgid "Join the #ingredients channel on <a href=\"https://slack.openfoodfacts.org\">our Slack discussion space</a> and/or learn about <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">ingredients analysis on our wiki</a>, if you would like to help. Thank you!"
-msgstr "Eğer yardımcı olmak isterseniz, #içerik kanalımıza Slack tartışma alanımız</a> <a href=\"https://slack.openfoodfacts.org\"> üzerinden katılın ve/veya Wiki'miz </a> üzerinden içerik analizini öğrenin <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\"> . Teşekkürler!"
+msgstr "Eğer yardımcı olmak isterseniz, #ingredients kanalımıza <a href=\"https://slack.openfoodfacts.org\">Slack</a> tartışma alanımız üzerinden katılın ve/veya <a href=\"https://wiki.openfoodfacts.org/Ingredients_Extraction_and_Analysis\">Wiki'miz</a> üzerinden içerik analizini öğrenin. Teşekkürler!"
 
 msgctxt "footer_producers_link"
 msgid "https://world.pro.openfoodfacts.org/"

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -12,6 +12,7 @@ use ProductOpener::Config qw/:all/;
 
 # Ensure that <<site_name>> is not translated - https://github.com/openfoodfacts/openfoodfacts-server/issues/1648
 my $site_name_regex = qr/<<site_name>>/;
+my $link_tag_regex = qr'<a\s[^>]+>.*</a>'is;
 
 foreach my $dir ('common', 'openbeautyfacts', 'openfoodfacts', 'openpetfoodfacts', 'openproductsfacts', 'tags') {
 	
@@ -25,6 +26,14 @@ foreach my $dir ('common', 'openbeautyfacts', 'openfoodfacts', 'openpetfoodfacts
 				like($terms{$key}{$lang}, $site_name_regex, "$dir: '$key' in '$lang' should contain '<<site_name>>'");
 			}
 		}
+
+		# check for mismatched A tags
+		if ((defined $terms{$key}{en}) and ($terms{$key}{en} =~ /$link_tag_regex/)) {
+			foreach my $lang (keys %{$terms{$key}}) {
+				like($terms{$key}{$lang}, $link_tag_regex, "$dir: '$key' in '$lang' should have matching html <a...>...</a> tags");
+			}
+		}
+
 	}
 
 	if ($dir eq 'common') {

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -26,13 +26,26 @@ foreach my $dir ('common', 'openbeautyfacts', 'openfoodfacts', 'openpetfoodfacts
 			}
 		}
 	}
-	
-	# check that text_direction is only ltr or rtl.
-	my $key = 'text_direction';
-	my $regex = qr/^(ltr|rtl)$/;
-	if (defined $terms{$key}) {
-		foreach my $alang (keys %{$terms{$key}}) {
-			like($terms{$key}{$alang}, $regex, "$dir: '$key' in '$alang' must be 'ltr' or 'rtl'");
+
+	if ($dir eq 'common') {
+		my @tests = (
+			# check that text_direction is only ltr or rtl.
+			{ key => 'text_direction', regex => qr/^(ltr|rtl)$/, test_name => "must be 'ltr' or 'rtl'" },
+			
+			# slack channel mustn't be translated
+			{ key => 'help_improve_ingredients_analysis_instructions', regex => qr/#ingredients/, test_name => "Slack channel name must not be translated" },
+			
+			# check for mismatched tags
+			{ key => 'help_improve_ingredients_analysis_instructions', regex => qr'(<a [^>]+>.+</a>.*){2}'is, test_name => "Should have 2 html <a...>...</a> tags" },
+		);
+
+		foreach my $test_ref (@tests) {
+			my $key = $test_ref->{key};
+			if (defined $terms{$key}) {
+				foreach my $alang (keys %{$terms{$key}}) {
+					like($terms{$key}{$alang}, $test_ref->{regex}, "$dir: '$key' in '$alang': " . $test_ref->{test_name} );
+				}
+			}
 		}
 	}
 	


### PR DESCRIPTION
Noticed mismatched A tags on the turkish site, turning everything after them into a link.
Also the slack channel name was translated, despite the comment saying not to.
Added tests to prevent recurrence, which showed up 2 more errors. Fixed on crowdin too.

Update: Added test to check _all_ A tags are matched, and consequently found another error.

![image](https://user-images.githubusercontent.com/5736616/98067893-7ee4af80-1e52-11eb-8979-81b59c2e4da3.png)

