### PR TITLE
Perform GetText checks on all translation files

### DIFF
--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Validate .po files
         uses: Tar-Minyatur/gettext-validation@master
         with:
-          folder: translations/
+          folder: po/

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -1,0 +1,11 @@
+name: Validate translation files
+on: [push, pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate .po files
+        uses: Tar-Minyatur/gettext-validation@master
+        with:
+          folder: translations/

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4291,26 +4291,6 @@ msgctxt "add_tag_field"
 msgid "Add a field"
 msgstr "Add a field"
 
-msgctxt "scanned_code"
-msgid "Scanned code"
-msgstr "Scanned code"
-
-msgctxt "code_from_filename"
-msgid "Code from file name"
-msgstr "Code from file name"
-
-msgctxt "using_previous_code"
-msgid "Using previous code"
-msgstr "Using previous code"
-
-msgctxt "add_field_values"
-msgid "You can specify field values that will be added to all products for which you will send images."
-msgstr "You can specify field values that will be added to all products for which you will send images."
-
-msgctxt "add_tag_field"
-msgid "Add a field"
-msgstr "Add a field"
-
 msgctxt "remove_products"
 msgid "Remove all the products"
 msgstr "Remove all the products"


### PR DESCRIPTION
### Perform GetText checks on all translation files.
This is a standard action that executes a classic GetText command `msgfmt "$filename"`. We can tweak the arguments of the command to be more or less aggressive.
https://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html

Already it has flagged many double strings definitions, and possibly false positive in the Crowdin LOL locale.

### TODO
I'd very much like to add PoFilter, which I've used over the years:
http://docs.translatehouse.org/projects/translate-toolkit/en/latest/guides/using_pofilter.html
http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/index.html#commands-quality-assurance


### Example output

Occurence 1:
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/th.po#L4117

Occurence 2:
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/th.po#L4138

https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L78: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L67: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4124: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4105: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4128: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4109: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4132: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4113: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4136: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4117: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4140: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4121: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4517: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4501: ...this is the location of the first definition
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4521: duplicate message definition...
https://github.com/openfoodfacts/openfoodfacts-server/blob/master/po/common/crs.po#L4505: ...this is the location of the first definition