### PR TITLE
Display search results with cards using user preferences

### DIFF
--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -88,7 +88,8 @@ function display_selected_preferences (target_selected, target_selection_form, p
 		$( target_selection_form ).show();
 		$(document).foundation('equalizer', 'reflow');
 	});
-
+	
+	$(document).foundation('reflow');
 }
 
 
@@ -169,7 +170,7 @@ function display_user_product_preferences (target_selected, target_selection_for
 				
 				if (attribute.description_short) {
 					attribute_group_html += "<p class='attribute_description_short'>" + attribute.description_short + "</p>";
-				}
+				}			
 				
 				attribute_group_html += "<hr style='clear:left;border:none;margin:0;margin-bottom:0.5rem;padding:0;'>";
 				

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -146,16 +146,8 @@ function display_products(target, product_groups ) {
 		$.each( product_group, function(key, product) {
 		
 			var product_html = "";
-			
-			var color = '#eee';
-			if (product.match_status == "yes") {
-				color = '#cfc';
-			}
-			else if (product.match_status == "no") {
-				color = '#fcc';
-			}
 						
-			product_html += '<li><a href="' + product.url + '" class="list_product_a" style="background-color:' + color + ';">';
+			product_html += '<li><a href="' + product.url + '" class="list_product_a list_product_a_match_' + product.match_status + '">';
 			product_html += '<div class="list_product_img_div">';
 			
 			if (product.image_front_thumb_url) {

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -118,6 +118,7 @@ function rank_products(products, product_preferences) {
 	});
 	
 	var product_groups = {
+		"all" : [],
 		"yes" : [],
 		"unknown" : [],
 		"no" : [],
@@ -126,6 +127,7 @@ function rank_products(products, product_preferences) {
 	$.each( products, function(key, product) {
 
 		product_groups[product.match_status].push(product);
+		product_groups["all"].push(product);
 	});
 	
 	return product_groups;
@@ -143,45 +145,50 @@ function display_products(target, product_groups ) {
 		
 		$.each( product_group, function(key, product) {
 		
-			var product_html = "<li>";
+			var product_html = "";
 			
-			product_html += '<a href="' + product.url + '"><div>';
+			var color = '#eee';
+			if (product.match_status == "yes") {
+				color = '#cfc';
+			}
+			else if (product.match_status == "no") {
+				color = '#fcc';
+			}
+						
+			product_html += '<li><a href="' + product.url + '" style="background-color:' + color + ';border-radius:12px;padding:1rem;display:block;">';
+			product_html += '<div style="height:100px;line-height:100x;text-align:center;">';
 			
 			if (product.image_front_thumb_url) {
-				product_html += '<img src="' + product.image_front_thumb_url + '">';
+				product_html += '<img src="' + product.image_front_thumb_url + '" style="display:block:margin-left:auto;margin-right:auto;height:auto;display:inline-block;vertical-align:middle;">';
 			}
 			
 			product_html += "</div>";
 			
-			product_html += "<span>" + product.product_name + "</span>";
-			
-			product_html += '</a>';
-			
+			product_html += '<div style="height:80px;overflow:hidden;">' + product.product_name + "</div>";
+									
 			$.each(product.match_icons.mandatory.concat(product.match_icons.very_important, product.match_icons.important), function (key, icon_url) {
 				
-				product_html += '<img src="' + icon_url + '" class="match_icons">';
+				product_html += '<img src="' + icon_url + '" style="height:24px;margin-right:0.2rem;margin-top:0.2rem;">';
 			});
 			
-			product_html += '<span title="' + product.match_debug + '">' + Math.round(product.match_score) + '</span>';
-			
-			product_html += "</li>";
+			product_html += "</a></li>";
 				
 			products_html.push(product_html);		
 		});
 		
 		var active = "";
-		if (product_group_id == "yes") {
+		if (product_group_id == "all") {
 			active = " active";
 		}
 		
 		$("#products_tabs_titles").append(
-			'<li class="tabs tab-title' + active + '"><a href="#products_' + product_group_id + '">'
+			'<li class="tabs tab-title' + active + '" style="border:none"><a href="#products_' + product_group_id + '">'
 			+ product_group_id + " : " + product_group.length + " products" + "</a></li>"
 		);
 		
 		$("#products_tabs_content").append(
 			'<div class="tabs content' + active + '" id="products_' + product_group_id + '">'
-			+ '<ul class="products search_results" id="products_match_' + product_group_id + '">'
+			+ '<ul class="search_results small-block-grid-1 medium-block-grid-2 large-block-grid-4 xlarge-block-grid-6 xxlarge-block-grid-8" id="products_match_' + product_group_id + ' style="list-style:none">'
 			+ products_html.join( "" )
 			+ '</ul>'
 		);
@@ -238,6 +245,10 @@ function display_product_summary(target, product) {
 		if (attribute.description_short) {
 			attributes_html += '<span>' + attribute.description_short + '</span>';
 		}
+		
+		if (attribute.missing) {
+			attributes_html += "<p class='attribute_missing'>" + attribute.missing + "</p>";
+		}		
 
 		attributes_html += '</div></li>';
 	});

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -155,20 +155,20 @@ function display_products(target, product_groups ) {
 				color = '#fcc';
 			}
 						
-			product_html += '<li><a href="' + product.url + '" style="background-color:' + color + ';border-radius:12px;padding:1rem;display:block;">';
-			product_html += '<div style="height:100px;line-height:100x;text-align:center;">';
+			product_html += '<li><a href="' + product.url + '" class="list_product_a" style="background-color:' + color + ';">';
+			product_html += '<div class="list_product_img_div">';
 			
 			if (product.image_front_thumb_url) {
-				product_html += '<img src="' + product.image_front_thumb_url + '" style="display:block:margin-left:auto;margin-right:auto;height:auto;display:inline-block;vertical-align:middle;">';
+				product_html += '<img src="' + product.image_front_thumb_url + '" class="list_product_img">';
 			}
 			
 			product_html += "</div>";
 			
-			product_html += '<div style="height:80px;overflow:hidden;">' + product.product_name + "</div>";
+			product_html += '<div class="list_product_name">' + product.product_name + "</div>";
 									
 			$.each(product.match_icons.mandatory.concat(product.match_icons.very_important, product.match_icons.important), function (key, icon_url) {
 				
-				product_html += '<img src="' + icon_url + '" style="height:24px;margin-right:0.2rem;margin-top:0.2rem;">';
+				product_html += '<img class="list_product_icons" src="' + icon_url + '">';
 			});
 			
 			product_html += "</a></li>";
@@ -188,7 +188,7 @@ function display_products(target, product_groups ) {
 		
 		$("#products_tabs_content").append(
 			'<div class="tabs content' + active + '" id="products_' + product_group_id + '">'
-			+ '<ul class="search_results small-block-grid-1 medium-block-grid-2 large-block-grid-4 xlarge-block-grid-6 xxlarge-block-grid-8" id="products_match_' + product_group_id + ' style="list-style:none">'
+			+ '<ul class="search_results small-block-grid-1 medium-block-grid-4 large-block-grid-6 xlarge-block-grid-8 xxlarge-block-grid-10" id="products_match_' + product_group_id + ' style="list-style:none">'
 			+ products_html.join( "" )
 			+ '</ul>'
 		);

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -483,7 +483,30 @@ html[dir="rtl"] {
   border-radius:12px;
   padding:10px;
   display:block;
+  background-color:#eee;
 }
+
+.list_product_a:hover {
+  background-color:#ddd;
+  text-decoration:none;
+}
+
+.list_product_a_match_yes {
+  background-color:#cfc;
+}
+
+.list_product_a_match_yes:hover {
+  background-color:#afa;
+}
+
+.list_product_a_match_no {
+  background-color:#fcc;
+}
+
+.list_product_a_match_no:hover {
+  background-color:#faa;
+}
+
 
 // Horizontally and vertically center images
 .list_product_img_div {
@@ -526,3 +549,14 @@ html[dir="rtl"] {
   }
 }
 
+.tabs a:focus {
+  outline:none;
+}
+
+.tabs a:hover {
+  text-decoration:none;
+}
+
+.tab-title.active {
+  font-weight:bold;
+}

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -475,3 +475,54 @@ html[dir="rtl"] {
 
 .additives_efsa_evaluation_overexposure_risk_high { color:red }
 .additives_efsa_evaluation_overexposure_risk_moderate { color:#ff6600 }
+
+
+// List of products with cards (e.g. search results, facets)
+
+.list_product_a {
+  border-radius:12px;
+  padding:10px;
+  display:block;
+}
+
+// Horizontally and vertically center images
+.list_product_img_div {
+  height:100px;
+  text-align:center;
+  line-height:100px;
+}
+
+.list_product_img {
+  height:auto;
+  display:inline-block;
+  vertical-align:middle;
+}
+
+.list_product_name {
+  margin-top:0.2rem;
+  line-height:20px;
+}
+
+.list_product_icons {
+  height:24px;
+  margin-right:0.2rem;
+  margin-top:0.2rem;
+}
+
+
+// For small screen, cards take the full width, move the image to the left
+@media #{$small-only} { 
+  .list_product_img_div { width:100px;float:left;margin-right:1em; }
+  .list_product_a { min-height:120px; }
+  .list_product_icons { height:36px; }
+}
+
+// For medium screen, force the height of the product name so that icons
+// below are vertically aligned with other cards on the same line
+@media #{$medium-up} {
+  .list_product_name {
+    height:80px;
+    overflow:hidden;
+  }
+}
+

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -397,6 +397,7 @@ $include-xl-html-block-grid-classes: true;
 // We use this to control the maximum number of block grid elements per row
 // $block-grid-elements: 12;
 // $block-grid-default-spacing: rem-calc(20);
+$block-grid-default-spacing: rem-calc(10);
 
 // $align-block-grid-to-grid: false;
 // @if $align-block-grid-to-grid {$block-grid-default-spacing: $column-gutter;}

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -392,6 +392,7 @@ $microformat-abbr-font-decoration: none;
 
 // $include-html-block-grid-classes: $include-html-classes;
 // $include-xl-html-block-grid-classes: false;
+$include-xl-html-block-grid-classes: true;
 
 // We use this to control the maximum number of block grid elements per row
 // $block-grid-elements: 12;

--- a/templates/display_new.tt.html
+++ b/templates/display_new.tt.html
@@ -122,7 +122,7 @@
 		[% top_banner %]
 		<!-- main row - comment used to remove left column and center content on some pages -->
 		<div class="row full-width" style="max-width: 100% !important;" data-equalizer>
-			<div class="xxlarge-1 xlarge-2 large-3 medium-4 columns hide-for-small" style="background-color:#fafafa;padding-top:1rem;" data-equalizer-watch>
+			<div class="xxlarge-2 xlarge-2 large-3 medium-4 columns hide-for-small" style="background-color:#fafafa;padding-top:1rem;" data-equalizer-watch>
 				<div class="sidebar">
 					<div style="text-align:center">
 						<a href="/"><img id="logo" src="/images/misc/[% lang('logo') %]" srcset="/images/misc/[% lang('logo2x') %] 2x" width="178" height="150" alt="[% lang('site_name') %]" style="margin-bottom:0.5rem"></a>
@@ -148,7 +148,7 @@
 					[% blocks %]
 				</div>
 			</div>
-			<div id="main_column" class="xxlarge-11 xlarge-10 large-9 medium-8 columns" style="padding-top:1rem" data-equalizer-watch>
+			<div id="main_column" class="xxlarge-10 xlarge-10 large-9 medium-8 columns" style="padding-top:1rem" data-equalizer-watch>
         <!-- main column content - comment used to remove left column and center content on some pages -->
         [% INCLUDE 'donate_banner.tt.html' %]
 				[% h1_title %]


### PR DESCRIPTION
This is currently only for the new /search endpoint, to test personal search.

Each product is shown on a card with the photo + name, as well as small icons for the attributes that correspond to selected user preferences.

The background of the card is green, red or grey, depending on whether the product matches the user preferences.

Once we finalize this display, the goal is to make it the display for facets as well, not just search results.

With a lot of attributes selected:

![image](https://user-images.githubusercontent.com/8158668/98369287-01c75f00-2039-11eb-9efc-ec250bacc23e.png)

"normal" usage would have much less attributes selected. By default it would be Nutri-Score + NOVA + Eco-score.