### PR TITLE
remove press-and-blogs from translatable pages

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -298,23 +298,6 @@ files:
         sr: sr_RS
         ku : kmr_TR
         kmr: kmr
-  - source: /lang/en/texts/press-and-blogs.html
-    translation: /lang/%two_letters_code%/texts/press-and-blogs.html
-    languages_mapping:
-      two_letters_code:
-        zh-HK: zh_HK
-        zh-CN: zh_CN
-        en-AU: en_AU
-        en-GB: en_GB
-        pt-BR: pt_BR
-        pt-PT: pt_PT
-        nl-BE: nl_BE
-        nl-NL: nl_NL
-        zh-TW: zh_TW
-        sr-CS: sr_CS
-        sr: sr_RS
-        ku : kmr_TR
-        kmr: kmr
   - source: /lang/en/texts/press.html
     translation: /lang/%two_letters_code%/texts/press.html
     languages_mapping:
@@ -436,23 +419,6 @@ files:
         kmr: kmr
   - source: /lang/obf/en/texts/open-beauty-hunt.html
     translation: /lang/obf/%two_letters_code%/texts/open-beauty-hunt.html
-    languages_mapping:
-      two_letters_code:
-        zh-HK: zh_HK
-        zh-CN: zh_CN
-        en-AU: en_AU
-        en-GB: en_GB
-        pt-BR: pt_BR
-        pt-PT: pt_PT
-        nl-BE: nl_BE
-        nl-NL: nl_NL
-        zh-TW: zh_TW
-        sr-CS: sr_CS
-        sr: sr_RS
-        ku : kmr_TR
-        kmr: kmr
-  - source: /lang/obf/en/texts/press-and-blogs.html
-    translation: /lang/obf/%two_letters_code%/texts/press-and-blogs.html
     languages_mapping:
       two_letters_code:
         zh-HK: zh_HK


### PR DESCRIPTION
remove press-and-blogs from translatable pages. This is superseded by press.