### PR TITLE
Disable translation of the "vending-machines" page

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -383,23 +383,6 @@ files:
         sr: sr_RS
         ku : kmr_TR
         kmr: kmr
-  - source: /lang/en/texts/rateyourvendingmachine.html
-    translation: /lang/%two_letters_code%/texts/rateyourvendingmachine.html
-    languages_mapping:
-      two_letters_code:
-        zh-HK: zh_HK
-        zh-CN: zh_CN
-        en-AU: en_AU
-        en-GB: en_GB
-        pt-BR: pt_BR
-        pt-PT: pt_PT
-        nl-BE: nl_BE
-        nl-NL: nl_NL
-        zh-TW: zh_TW
-        sr-CS: sr_CS
-        sr: sr_RS
-        ku : kmr_TR
-        kmr: kmr
   - source: /lang/en/texts/scan-parties.html
     translation: /lang/%two_letters_code%/texts/scan-parties.html
     languages_mapping:


### PR DESCRIPTION
Disable translation of the "vending-machines" page since it's mostly a collections of Humorous tweets in French. 
The translations are consistently bad and we need to create similar but homegrown page for various countries.