### PR TITLE
Fix search sort key for search API v2

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -101,11 +101,18 @@ function match_product_to_preferences (product, product_preferences) {
 
 // rank_products (products, product_preferences)
 
+// keep the initial order of each result
+var initial_order = 0;
+
 function rank_products(products, product_preferences) {
 	
 	// Score all products
 	
 	$.each(products, function (key, product) {
+		
+		if (! product.initial_order) {
+			product.initial_order = initial_order++;
+		}
 		
 		match_product_to_preferences(product, product_preferences);
 		
@@ -114,7 +121,7 @@ function rank_products(products, product_preferences) {
 	// Rank all products, and return them in 3 arrays: "yes", "no", "unknown"
 	
 	products.sort(function(a, b) {
-		return b.match_score - a.match_score;
+		return (b.match_score - a.match_score) || (a.initial_order - b.initial_order);
 	});
 	
 	var product_groups = {

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -111,7 +111,8 @@ function rank_products(products, product_preferences) {
 	$.each(products, function (key, product) {
 		
 		if (! product.initial_order) {
-			product.initial_order = initial_order++;
+			product.initial_order = initial_order;
+			initial_order += 1;
 		}
 		
 		match_product_to_preferences(product, product_preferences);


### PR DESCRIPTION
As we changed how we parse query parameters, the sort key was not properly passed to Mongo for the search API v2.

Also changed the client-side ranking code so that we keep the original sort order of results when no preferences are set at all.