### PR TITLE
add title for unknown organic/fair trade attributes, fixes #4479

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -860,36 +860,34 @@ sub compute_attribute_has_tag($$$$) {
 	
 	$attribute_ref->{status} = "known";
 	
+	my $value = "";
+	
 	# If we don't have any tags for the tagtype, mark the status unknown (e.g. new products)
 	
 	if ((not defined $product_ref->{$tagtype . "_tags"}) or ($product_ref->{$tagtype . "_tags"} == 0)) {
 		
 		$attribute_ref->{status} = "unknown";
-		
+		$value = "unknown";
 		$attribute_ref->{icon_url} = "$static_subdomain/images/icons/${tag}-unknown.svg";
 	}
 	elsif (has_tag($product_ref, $tagtype, $tagid)) {
 		
 		$attribute_ref->{match} = 100;
-		if ($target_lc ne "data") {
-			$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_" . $attribute_id . "_yes_title");
-			# Override default texts if specific texts are available
-			override_general_value($attribute_ref, $target_lc, "description", "attribute_" . $attribute_id . "_yes_description");
-			override_general_value($attribute_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_yes_description_short");	
-		}
-		
+		$value = "yes";
 		$attribute_ref->{icon_url} = "$static_subdomain/images/icons/${tag}.svg";
 	}
 	else {
 		$attribute_ref->{match} = 0;
-		if ($target_lc ne "data") {
-			$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_" . $attribute_id . "_no_title");
-			# Override default texts if specific texts are available
-			override_general_value($attribute_ref, $target_lc, "description", "attribute_" . $attribute_id . "_no_description");
-			override_general_value($attribute_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_no_description_short");
-		}
+		$value = "no";
 		$attribute_ref->{icon_url} = "$static_subdomain/images/icons/not-${tag}.svg";
 	}
+	
+	if ($target_lc ne "data") {
+		$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_" . $attribute_id . "_" . $value . "_title");
+		# Override default texts if specific texts are available
+		override_general_value($attribute_ref, $target_lc, "description", "attribute_" . $attribute_id . "_" . $value . "_description");
+		override_general_value($attribute_ref, $target_lc, "description_short", "attribute_" . $attribute_id . "_" . $value . "_description_short");
+	}	
 	
 	return $attribute_ref;
 }

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4554,6 +4554,10 @@ msgctxt "attribute_labels_organic_no_title"
 msgid "Not an organic product"
 msgstr "Not an organic product"
 
+msgctxt "attribute_labels_organic_unknown_title"
+msgid "Missing information: organic product?"
+msgstr "Missing information: organic product?"
+
 msgctxt "attribute_labels_organic_yes_description_short"
 msgid "Promotes ecological sustainability and biodiversity."
 msgstr "Promotes ecological sustainability and biodiversity."
@@ -4577,6 +4581,10 @@ msgstr "Fair trade product"
 msgctxt "attribute_labels_fair_trade_no_title"
 msgid "Not a fair trade product"
 msgstr "Not a fair trade product"
+
+msgctxt "attribute_labels_fair_trade_unknown_title"
+msgid "Missing information: fair trade product?"
+msgstr "Missing information: fair trade product?"
 
 msgctxt "attribute_labels_fair_trade_yes_description_short"
 msgid "Helps producers in developping countries."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4564,6 +4564,10 @@ msgctxt "attribute_labels_organic_no_title"
 msgid "Not an organic product"
 msgstr "Not an organic product"
 
+msgctxt "attribute_labels_organic_unknown_title"
+msgid "Missing information: organic product?"
+msgstr "Missing information: organic product?"
+
 msgctxt "attribute_labels_organic_yes_description_short"
 msgid "Promotes ecological sustainability and biodiversity."
 msgstr "Promotes ecological sustainability and biodiversity."
@@ -4587,6 +4591,10 @@ msgstr "Fair trade product"
 msgctxt "attribute_labels_fair_trade_no_title"
 msgid "Not a fair trade product"
 msgstr "Not a fair trade product"
+
+msgctxt "attribute_labels_fair_trade_unknown_title"
+msgid "Missing information: fair trade product?"
+msgstr "Missing information: fair trade product?"
 
 msgctxt "attribute_labels_fair_trade_yes_description_short"
 msgid "Helps producers in developping countries."


### PR DESCRIPTION
Adds titles like "Missing information: organic product?"