### PR TITLE
update github workflows using checkout@v1 to v2

### DIFF
--- a/.github/workflows/containerimage.yml
+++ b/.github/workflows/containerimage.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
     - name: Publish frontend image to Registry

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
   gulp:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
     - uses: actions/setup-node@v2.1.2
@@ -21,7 +21,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
     - uses: actions/setup-node@v2.1.2
@@ -33,7 +33,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 50
     


### PR DESCRIPTION
see https://github.com/actions/checkout/blob/main/CHANGELOG.md.
the other workflows are already using v2.

for one thing it's a tiny bit faster, because of:
>Improved fetch performance
>    The default behavior now fetches only the SHA being checked-out
