### PR TITLE
Better packaging parsing (quantity contained and number of units) and display #219

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -40,7 +40,7 @@ use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Images qw/:all/;
 use ProductOpener::DataQuality qw/:all/;
 use ProductOpener::Ecoscore qw/:all/;
-
+use ProductOpener::Packaging qw/:all/;
 
 use Apache2::RequestRec ();
 use Apache2::Const ();
@@ -542,6 +542,13 @@ else {
 	compute_nutrient_levels($product_ref);
 
 	compute_unknown_nutrients($product_ref);
+	
+	# Until we provide an interface to directly change the packaging data structure
+	# erase it before reconstructing it
+	# (otherwise there is no way to remove incorrect entries)
+	$product_ref->{packagings} = [];	
+	
+	analyze_and_combine_packaging_data($product_ref);
 	
 	compute_ecoscore($product_ref);
 

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -41,6 +41,7 @@ use ProductOpener::Images qw/:all/;
 use ProductOpener::URL qw/:all/;
 use ProductOpener::DataQuality qw/:all/;
 use ProductOpener::Ecoscore qw/:all/;
+use ProductOpener::Packaging qw/:all/;
 
 use Apache2::RequestRec ();
 use Apache2::Const ();
@@ -739,6 +740,13 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 	compute_nutrient_levels($product_ref);
 
 	compute_unknown_nutrients($product_ref);
+	
+	# Until we provide an interface to directly change the packaging data structure
+	# erase it before reconstructing it
+	# (otherwise there is no way to remove incorrect entries)
+	$product_ref->{packagings} = [];	
+	
+	analyze_and_combine_packaging_data($product_ref);
 	
 	compute_ecoscore($product_ref);
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7333,6 +7333,9 @@ sub display_product($)
 		lang => \&lang,
 		request_ref => $request_ref,
 		display_icon => \&display_icon,
+		display_taxonomy_tag => sub ($$) {
+			return display_taxonomy_tag($lc, $_[0], $_[1]);
+		},
 	};
 
 		$scripts .= <<SCRIPTS
@@ -7944,6 +7947,9 @@ HTML
 	
 	$template_data_ref->{packaging_text} = $packaging_text;
 	$template_data_ref->{packaging_text_lang} = $packaging_text_lang;
+
+	# packagings data structure
+	$template_data_ref->{packagings} = $product_ref->{packagings};
 	
 	# Environmental impact and Eco-Score
 	# Limit to France as the Eco-Score is currently valid only for products sold in France

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -872,15 +872,15 @@ sub compute_ecoscore_packaging_adjustment($) {
 
 	my $product_ref = shift;
 	
-	# Create or update the packagings data structure
-	# (can be removed from here once we systematically do it for all products)
-	
-	analyze_and_combine_packaging_data($product_ref);
-	
 	$log->debug("compute_ecoscore_packaging_adjustment - packagings data structure", { packagings => $product_ref->{packagings} }) if $log->is_debug();
 	
 	# Sum the scores of all packagings components
 	# Create a copy of the packagings structure, so that we can add Eco-score elements to it
+	
+	if (not defined $product_ref->{packagings}) {
+		$product_ref->{packagings} = [];
+	}
+	
 	my $packagings_ref = dclone($product_ref->{packagings});
 	
 	my $packaging_score = 0;

--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -245,11 +245,6 @@ sub analyze_and_combine_packaging_data($) {
 		$product_ref->{packagings} = [];
 	}
 	
-	# Until we provide an interface to directly change the packaging data structure
-	# erase it before reconstructing it
-	# (otherwise there is no way to remove incorrect entries)
-	$product_ref->{packagings} = [];
-	
 	# Parse the packaging_text and the packaging tags field
 	
 	my @phrases = ();

--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -183,12 +183,38 @@ sub parse_packaging_from_text_phrase($$) {
 							
 							$packaging_ref->{$property} = $tagid;
 						}
+						
+						# If we have a shape, check if we have a quantity contained (volume or weight)
+						# or if there is a number of units at the beginning
+						
+						if ($property eq "shape") {
+							
+							my $before = $`;
+							
+							# Quantity contained: 25cl plastic bottle, plastic bottle (25cl)
+							if ($text =~ /\b((\d+((\.|,)\d+)?)\s?(l|dl|cl|ml|g|kg))\b/i) {
+								$packaging_ref->{quantity} = lc($1);
+								$packaging_ref->{quantity_value} = lc($2);
+								$packaging_ref->{quantity_unit} = lc($5);
+								
+								# Remove the quantity from $before so that we don't mistake it for a number of units
+								$before =~ s/$1//g;
+							}
+							
+							# Number of units: e.g. 4 plastic bottles (but we should not match the 2 in "2 PEHD plastic bottles")
+							# match numbers starting with 1 to 9 to avoid matching 02 PEHD
+							if ($before =~ /^([1-9]\d*) /) {
+								if (not defined $packaging_ref->{number}) {
+									$packaging_ref->{number} = $1;
+								}
+							}
+						}
 					}
 				}
 			}
 		}
 	}
-	
+		
 	$log->debug("parse_packaging_from_text_phrase - result", { text => $text, text_language => $text_language, packaging_ref => $packaging_ref }) if $log->is_debug();
 	
 	return $packaging_ref;
@@ -218,6 +244,11 @@ sub analyze_and_combine_packaging_data($) {
 	if (not defined $product_ref->{packagings}) {
 		$product_ref->{packagings} = [];
 	}
+	
+	# Until we provide an interface to directly change the packaging data structure
+	# erase it before reconstructing it
+	# (otherwise there is no way to remove incorrect entries)
+	$product_ref->{packagings} = [];
 	
 	# Parse the packaging_text and the packaging tags field
 	

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5064,3 +5064,28 @@ msgctxt "ecoscore_s"
 msgid "ecoscore"
 msgstr "ecoscore"
 
+msgctxt "packaging_parts"
+msgid "Packaging parts"
+msgstr "Packaging parts"
+
+# Number of packaging parts
+msgctxt "packaging_number"
+msgid "Number"
+msgstr "Nombre"
+
+msgctxt "packaging_shape"
+msgid "Shape"
+msgstr "Shape"
+
+msgctxt "packaging_quantity"
+msgid "Quantity contained"
+msgstr "Quantity contained"
+
+msgctxt "packaging_material"
+msgid "Material"
+msgstr "Material"
+
+msgctxt "packaging_recycling"
+msgid "Recycling"
+msgstr "Recycling"
+

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5071,7 +5071,7 @@ msgstr "Packaging parts"
 # Number of packaging parts
 msgctxt "packaging_number"
 msgid "Number"
-msgstr "Nombre"
+msgstr "Number"
 
 msgctxt "packaging_shape"
 msgid "Shape"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5081,7 +5081,7 @@ msgstr "Packaging parts"
 # Number of packaging parts
 msgctxt "packaging_number"
 msgid "Number"
-msgstr "Nombre"
+msgstr "Number"
 
 msgctxt "packaging_shape"
 msgid "Shape"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5073,3 +5073,29 @@ msgstr "ecoscore"
 msgctxt "ecoscore_s"
 msgid "ecoscore"
 msgstr "ecoscore"
+
+msgctxt "packaging_parts"
+msgid "Packaging parts"
+msgstr "Packaging parts"
+
+# Number of packaging parts
+msgctxt "packaging_number"
+msgid "Number"
+msgstr "Nombre"
+
+msgctxt "packaging_shape"
+msgid "Shape"
+msgstr "Shape"
+
+msgctxt "packaging_quantity"
+msgid "Quantity contained"
+msgstr "Quantity contained"
+
+msgctxt "packaging_material"
+msgid "Material"
+msgstr "Material"
+
+msgctxt "packaging_recycling"
+msgid "Recycling"
+msgstr "Recycling"
+

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -91,6 +91,7 @@ my $count = '';
 my $just_print_codes = '',
 my $pretend = '';
 my $process_ingredients = '';
+my $process_packagings = '';
 my $clean_ingredients = '';
 my $compute_nutrition_score = '';
 my $compute_serving_size = '';
@@ -135,6 +136,7 @@ GetOptions ("key=s"   => \$key,      # string
 			"pretend" => \$pretend,
 			"clean-ingredients" => \$clean_ingredients,
 			"process-ingredients" => \$process_ingredients,
+			"process-packagings" => \$process_packagings,
 			"assign-categories-properties" => \$assign_categories_properties,
 			"compute-nutrition-score" => \$compute_nutrition_score,
 			"compute-history" => \$compute_history,
@@ -212,7 +214,7 @@ if (
 	and (not $remove_team) and (not $remove_label) and (not $remove_nutrient)
 	and (not $mark_as_obsolete_since_date)
 	and (not $assign_categories_properties) and (not $restore_values_deleted_by_user) and not ($delete_debug_tags)
-	and (not $compute_codes) and (not $compute_carbon) and (not $compute_ecoscore)
+	and (not $compute_codes) and (not $compute_carbon) and (not $compute_ecoscore) and (not $process_packagings)
 	and (not $check_quality) and (scalar @fields_to_update == 0) and (not $count) and (not $just_print_codes)
 ) {
 	die("Missing fields to update or --count option:\n$usage");
@@ -879,6 +881,10 @@ while (my $product_ref = $cursor->next) {
 				compute_nutrient_levels($product_ref);
 			}
 		}
+		
+		if ($process_packagings) {
+			analyze_and_combine_packaging_data($product_ref);
+		}	
 		
 		if ($compute_ecoscore) {
 			compute_ecoscore($product_ref);

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -286,6 +286,7 @@ foreach my $test_ref (@tests) {
 		extract_ingredients_from_text($product_ref);
 	}
 	
+	analyze_and_combine_packaging_data($product_ref);
 	compute_ecoscore($product_ref);
 	
 	# Save the result

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -27,6 +27,7 @@
                   "ecoscore_material_score" : 91.25,
                   "ecoscore_shape_ratio" : 1,
                   "material" : "en:cardboard",
+                  "number" : "1",
                   "shape" : "en:box"
                },
                {
@@ -34,6 +35,7 @@
                   "ecoscore_material_score" : 0,
                   "ecoscore_shape_ratio" : 0.1,
                   "material" : "en:plastic",
+                  "number" : "1",
                   "shape" : "en:film"
                },
                {
@@ -41,6 +43,10 @@
                   "ecoscore_material_score" : 75.5,
                   "ecoscore_shape_ratio" : 1,
                   "material" : "en:steel",
+                  "number" : "6",
+                  "quantity" : "33cl",
+                  "quantity_unit" : "cl",
+                  "quantity_value" : "33",
                   "shape" : "en:drink-can"
                }
             ],
@@ -71,14 +77,20 @@
    "packagings" : [
       {
          "material" : "en:cardboard",
+         "number" : "1",
          "shape" : "en:box"
       },
       {
          "material" : "en:plastic",
+         "number" : "1",
          "shape" : "en:film"
       },
       {
          "material" : "en:steel",
+         "number" : "6",
+         "quantity" : "33cl",
+         "quantity_unit" : "cl",
+         "quantity_value" : "33",
          "shape" : "en:drink-can"
       }
    ]

--- a/t/expected_test_results/packaging/packaging_text_en_plastic_bottle.json
+++ b/t/expected_test_results/packaging/packaging_text_en_plastic_bottle.json
@@ -4,6 +4,10 @@
    "packagings" : [
       {
          "material" : "en:plastic",
+         "number" : "6",
+         "quantity" : "25cl",
+         "quantity_unit" : "cl",
+         "quantity_value" : "25",
          "recycling" : "en:recycle",
          "shape" : "en:bottle"
       }

--- a/t/expected_test_results/packaging/packaging_text_en_plurals.json
+++ b/t/expected_test_results/packaging/packaging_text_en_plurals.json
@@ -3,16 +3,24 @@
    "packaging_text" : "6 cans, 2 boxes, 2 knives, 3 spoons, 1 utensil",
    "packagings" : [
       {
+         "number" : "6",
          "shape" : "en:can"
       },
       {
+         "number" : "2",
          "shape" : "en:box"
       },
       {
+         "number" : "2",
          "shape" : "en:knife"
       },
       {
+         "number" : "3",
          "shape" : "en:spoon"
+      },
+      {
+         "number" : "1",
+         "shape" : "en:eating-utensils"
       }
    ]
 }

--- a/t/expected_test_results/packaging/packaging_text_en_quantity_1_l_plastic_bottles.json
+++ b/t/expected_test_results/packaging/packaging_text_en_quantity_1_l_plastic_bottles.json
@@ -1,0 +1,13 @@
+{
+   "lc" : "en",
+   "packaging_text" : "1 L plastic bottle",
+   "packagings" : [
+      {
+         "material" : "en:plastic",
+         "quantity" : "1 l",
+         "quantity_unit" : "l",
+         "quantity_value" : "1",
+         "shape" : "en:bottle"
+      }
+   ]
+}

--- a/t/expected_test_results/packaging/packaging_text_en_quantity_25_cl_bottles.json
+++ b/t/expected_test_results/packaging/packaging_text_en_quantity_25_cl_bottles.json
@@ -1,0 +1,12 @@
+{
+   "lc" : "en",
+   "packaging_text" : "25 cl bottle",
+   "packagings" : [
+      {
+         "quantity" : "25 cl",
+         "quantity_unit" : "cl",
+         "quantity_value" : "25",
+         "shape" : "en:bottle"
+      }
+   ]
+}

--- a/t/expected_test_results/packaging/packaging_text_en_quantity_6_plastic_bottles.json
+++ b/t/expected_test_results/packaging/packaging_text_en_quantity_6_plastic_bottles.json
@@ -1,0 +1,11 @@
+{
+   "lc" : "en",
+   "packaging_text" : "6 plastic bottles",
+   "packagings" : [
+      {
+         "material" : "en:plastic",
+         "number" : "6",
+         "shape" : "en:bottle"
+      }
+   ]
+}

--- a/t/expected_test_results/packaging/packaging_text_fr_quantity_6_bouteilles_plastiques_de_25_cl.json
+++ b/t/expected_test_results/packaging/packaging_text_fr_quantity_6_bouteilles_plastiques_de_25_cl.json
@@ -1,0 +1,13 @@
+{
+   "lc" : "fr",
+   "packaging_text" : "6 bouteilles plastiques de 25 cl",
+   "packagings" : [
+      {
+         "number" : "6",
+         "quantity" : "25 cl",
+         "quantity_unit" : "cl",
+         "quantity_value" : "25",
+         "shape" : "en:bottle"
+      }
+   ]
+}

--- a/t/packaging.t
+++ b/t/packaging.t
@@ -177,6 +177,38 @@ my @tests = (
 			lc => "fr",
 			packaging_text => "bouteille en plastique pet recyclé",
 		}
+	],
+	
+	# Quantity contained and number of units
+	# the quantity contained must not be mistaken for the number of units
+	
+	[
+		'packaging_text_en_quantity_6_plastic_bottles',
+		{
+			lc => "en",
+			packaging_text => "6 plastic bottles"
+		}
+	],
+	[
+		'packaging_text_en_quantity_1_l_plastic_bottles',
+		{
+			lc => "en",
+			packaging_text => "1 L plastic bottle"
+		}
+	],
+	[
+		'packaging_text_en_quantity_25_cl_bottles',
+		{
+			lc => "en",
+			packaging_text => "25 cl bottle"
+		}
+	],
+	[
+		'packaging_text_fr_quantity_6_bouteilles_plastiques_de_25_cl',
+		{
+			lc => "fr",
+			packaging_text => "6 bouteilles plastiques de 25 cl"
+		}
 	],	
 );
 

--- a/templates/display_product.tt.html
+++ b/templates/display_product.tt.html
@@ -231,11 +231,11 @@
     <div class="show-for-large-up large-4 xlarge-4 xxlarge-4 columns" style="padding-left:0">[% packaging_image %]</div>
 </div>
 
-[% IF packagings %]
-	<p class="field">[% lang("packaging_parts") %][% sep %]:</p>
+[% IF packagings && packagings.size %]
 	<table id="packagings_table">
+		<caption style="text-align:left">[% lang("packaging_parts") %][% sep %]:</caption>
 	[% FOREACH property IN ["number", "shape", "material", "recycling"] %]
-		<th>[% lang("packaging_${property}") %]</th>
+		<th scope="col">[% lang("packaging_${property}") %]</th>
 	[% END %]
 	[% FOREACH packaging IN packagings %]
 		<tr>

--- a/templates/display_product.tt.html
+++ b/templates/display_product.tt.html
@@ -224,12 +224,31 @@
 <div class="row">
     <div class="hide-for-large-up medium-12 columns">[% packaging_image %]</div>
     <div class="medium-12 large-8 xlarge-8 xxlarge-8 columns">
-        <div><span class="field">[% lang("packaging_text") %]:</span>
-            <div id="packaging_text">[% packaging_text %]</div>
+        <div><span class="field">[% lang("packaging_text") %][% sep %]:</span>
+            <p id="packaging_text">[% packaging_text %]</p>
         </div>
     </div>
     <div class="show-for-large-up large-4 xlarge-4 xxlarge-4 columns" style="padding-left:0">[% packaging_image %]</div>
 </div>
+
+[% IF packagings %]
+	<p class="field">[% lang("packaging_parts") %][% sep %]:</p>
+	<table id="packagings_table">
+	[% FOREACH property IN ["number", "shape", "material", "recycling"] %]
+		<th>[% lang("packaging_${property}") %]</th>
+	[% END %]
+	[% FOREACH packaging IN packagings %]
+		<tr>
+			<td>[% packaging.number %]</td>
+			<td>[% display_taxonomy_tag("packaging_shapes",packaging.shape) %]
+				[% IF packaging.quantity %]([% packaging.quantity %])[% END %]
+			</td>
+			<td>[% display_taxonomy_tag("packaging_materials",packaging.material) %]</td>
+			<td>[% display_taxonomy_tag("packaging_recycling",packaging.recycling) %]</td>
+		</tr>
+	[% END %]
+	</table>
+[% END %]
 
 <!-- other fields -->
 [% IF other_fields != "" %]


### PR DESCRIPTION
This continues the work to extract and structure packaging data outlined in https://wiki.openfoodfacts.org/Packagings_data_structure

- The number of units of a packaging component is now extracted (e.g. "6 bottles")
- The quantity contained (volume or weight) is now extracted (e.g. "25 cl plastic bottles")
- The product page now displays a table that indicates the packaging components that have been extracted

Here what it looks like (the packagings data is extracted from the French packagings text, and displayed in the language of the interface (here English)):

![image](https://user-images.githubusercontent.com/8158668/98704255-bc7a9880-237c-11eb-9034-716dc32f366c.png)
