### PR TITLE
Personal search - Enable user preferences for facets pages and search results

### DIFF
--- a/html/images/icons/match-no.svg
+++ b/html/images/icons/match-no.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="match-no.svg"
+   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1082"
+     inkscape:window-height="897"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="4.6875"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M 12,2 C 6.47,2 2,6.47 2,12 2,17.53 6.47,22 12,22 17.53,22 22,17.53 22,12 22,6.47 17.53,2 12,2 Z M 17,15.59 15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 Z"
+     id="path4"
+     style="fill:#d40000;stroke-width:1" />
+</svg>

--- a/html/images/icons/match-unknown.svg
+++ b/html/images/icons/match-unknown.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="match-unknown.svg"
+   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="777"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="9.375"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+     id="path4"
+     style="fill:#808080" />
+</svg>

--- a/html/images/icons/match-yes.svg
+++ b/html/images/icons/match-yes.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="match-yes.svg"
+   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="777"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="9.375"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+     id="path4"
+     style="fill:#008000" />
+</svg>

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -181,12 +181,12 @@ function display_products(target, product_groups ) {
 				text_or_icon = product_group.length + ' ' + lang()["1_product"];
 			}
 			else {
-				text_or_icon = product_group.length + ' ' + lang()["products"];
+				text_or_icon = product_group.length + ' ' + lang().products;
 			}
 		}
 		else {
 			text_or_icon = '<img src="/images/icons/match-' + product_group_id + '.svg" class="icon">'
-			+ ' <span style="color:grey">' + product_group.length + "</span>"
+			+ ' <span style="color:grey">' + product_group.length + "</span>";
 		}
 		
 		$("#products_tabs_titles").append(

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -1,9 +1,5 @@
 /*global lang */
 
-// Will hold product data retrieved from the search API
-var products = [];
-
-
 // match_product_to_preference checks if a product matches
 // a given set of preferences and scores the product according to
 // the preferences
@@ -260,7 +256,7 @@ function display_product_summary(target, product) {
 }
 
 
-function rank_and_display_products (target) {
+function rank_and_display_products (target, products) {
 	
 	// Retrieve user preferences from local storage
 
@@ -276,7 +272,7 @@ function rank_and_display_products (target) {
 
 /* exported search_products */
 
-function search_products (target, search_api_url) {
+function search_products (target, products, search_api_url) {
 
 	// Retrieve generic search results from the search API
 	
@@ -285,8 +281,7 @@ function search_products (target, search_api_url) {
 		if (data.products) {
 			
 			products = data.products;
-			
-			rank_and_display_products(target);
+			rank_and_display_products(target, products);
 		}		
 	});
 }

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -174,13 +174,26 @@ function display_products(target, product_groups ) {
 		});
 		
 		var active = "";
+		var text_or_icon = "";
 		if (product_group_id == "all") {
 			active = " active";
+			if (product_group.length == 1) {
+				text_or_icon = product_group.length + ' ' + lang()["1_product"];
+			}
+			else {
+				text_or_icon = product_group.length + ' ' + lang()["products"];
+			}
+		}
+		else {
+			text_or_icon = '<img src="/images/icons/match-' + product_group_id + '.svg" class="icon">'
+			+ ' <span style="color:grey">' + product_group.length + "</span>"
 		}
 		
 		$("#products_tabs_titles").append(
-			'<li class="tabs tab-title' + active + '" style="border:none"><a href="#products_' + product_group_id + '">'
-			+ lang()["match_" + product_group_id] + ' <span style="color:grey">(' + product_group.length + ")</span>" + "</a></li>"
+			'<li class="tabs tab-title tab_products-title' + active + '">'
+			+ '<a  id="tab_products_' + product_group_id + '" href="#products_' + product_group_id + '" title="' + lang()["products_match_" + product_group_id] +  '">'
+			+ text_or_icon
+			+ "</a></li>"
 		);
 		
 		$("#products_tabs_content").append(

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -280,7 +280,7 @@ function search_products (target, products, search_api_url) {
 		
 		if (data.products) {
 			
-			products = data.products;
+			Array.prototype.push.apply(products, data.products);
 			rank_and_display_products(target, products);
 		}		
 	});

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -355,7 +355,7 @@ $small_size = 200;
 $display_size = 400;
 $zoom_size = 800;
 
-$page_size = 20;
+$page_size = 24;
 
 
 $google_analytics = <<HTML

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3972,7 +3972,7 @@ sub display_search_results($) {
 		$scripts .= <<JS
 <script type="text/javascript">
 var preferences_text = "$preferences_text";
-var products;
+var products = [];
 </script>
 JS
 ;		

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5089,9 +5089,9 @@ msgctxt "packaging_recycling"
 msgid "Recycling"
 msgstr "Recycling"
 
-msgctxt "products_are_sorted_according_to_your_preferences"
-msgid "Products are sorted according to your preferences:"
-msgstr "Products are sorted according to your preferences:"
+msgctxt "products_on_this_page_are_sorted_according_to_your_preferences"
+msgid "Products on this page are sorted according to your preferences:"
+msgstr "Products on this page are sorted according to your preferences:"
 
 msgctxt "choose_which_information_you_prefer_to_see_first"
 msgid "Choose which information you prefer to see first."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5105,26 +5105,22 @@ msgctxt "delete_all_preferences"
 msgid "Delete all preferences"
 msgstr "Delete all preferences"
 
-# "All" as in "All products"
-msgctxt "match_all"
-msgid "All"
-msgstr "All" 
+msgctxt "products_are_being_loaded_please_wait"
+msgid "Products are being loaded, please wait."
+msgstr "Products are being loaded, please wait."
 
-# Used to indicate if a product is ok for a specific diet. It needs to be very short, keep "OK" if it's commonly used in the language
-msgctxt "match_yes"
-msgid "OK"
-msgstr "OK"
+msgctxt "products_match_all"
+msgid "All products"
+msgstr "All products"
 
-# Used to indicate if a product is ok for a specific diet. It needs to be very short, keep "OK" if it's commonly used in the language
-msgctxt "match_no"
-msgid "Not OK"
-msgstr "Not OK"
+msgctxt "products_match_yes"
+msgid "Products that match your preferences"
+msgstr "Products that match your preferences"
 
-# Used to indicate if a product is ok for a specific diet. It needs to be very short, keep "OK" if it's commonly used in the language
-msgctxt "match_unknown"
-msgid "Maybe OK"
-msgstr "Maybe OK"
+msgctxt "products_match_no"
+msgid "Products that do not match your preferences"
+msgstr "Products that do not match your preferences"
 
-msgctxt "products_are_being_loaded"
-msgid "Products are being loaded."
-msgstr "Products are being loaded."
+msgctxt "products_match_unknown"
+msgid "Products for which we currently miss data to determine if they match your preferences"
+msgstr "Products for which we currently miss data to determine if they match your preferences"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5115,26 +5115,23 @@ msgctxt "delete_all_preferences"
 msgid "Delete all preferences"
 msgstr "Delete all preferences"
 
-# "All" as in "All products"
-msgctxt "match_all"
-msgid "All"
-msgstr "All" 
+msgctxt "products_are_being_loaded_please_wait"
+msgid "Products are being loaded, please wait."
+msgstr "Products are being loaded, please wait."
 
-# Used to indicate if a product is ok for a specific diet. It needs to be very short, keep "OK" if it's commonly used in the language
-msgctxt "match_yes"
-msgid "OK"
-msgstr "OK"
+msgctxt "products_match_all"
+msgid "All products"
+msgstr "All products"
 
-# Used to indicate if a product is ok for a specific diet. It needs to be very short, keep "OK" if it's commonly used in the language
-msgctxt "match_no"
-msgid "Not OK"
-msgstr "Not OK"
+msgctxt "products_match_yes"
+msgid "Products that match your preferences"
+msgstr "Products that match your preferences"
 
-# Used to indicate if a product is ok for a specific diet. It needs to be very short, keep "OK" if it's commonly used in the language
-msgctxt "match_unknown"
-msgid "Maybe OK"
-msgstr "Maybe OK"
+msgctxt "products_match_no"
+msgid "Products that do not match your preferences"
+msgstr "Products that do not match your preferences"
 
-msgctxt "products_are_being_loaded"
-msgid "Products are being loaded."
-msgstr "Products are being loaded."
+msgctxt "products_match_unknown"
+msgid "Products for which we currently miss data to determine if they match your preferences"
+msgstr "Products for which we currently miss data to determine if they match your preferences"
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5099,9 +5099,9 @@ msgctxt "packaging_recycling"
 msgid "Recycling"
 msgstr "Recycling"
 
-msgctxt "products_are_sorted_according_to_your_preferences"
-msgid "Products are sorted according to your preferences:"
-msgstr "Products are sorted according to your preferences:"
+msgctxt "products_on_this_page_are_sorted_according_to_your_preferences"
+msgid "Products on this page are sorted according to your preferences:"
+msgstr "Products on this page are sorted according to your preferences:"
 
 msgctxt "choose_which_information_you_prefer_to_see_first"
 msgid "Choose which information you prefer to see first."

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -557,6 +557,7 @@ html[dir="rtl"] {
   text-decoration:none;
 }
 
-.tab-title.active {
-  font-weight:bold;
+.tab_products-title.active {
+  border-bottom:1px solid grey;
 }
+

--- a/templates/search_and_display_products.tt.html
+++ b/templates/search_and_display_products.tt.html
@@ -1,3 +1,4 @@
+
 <p>[% error %]</p>
 [% IF (current_link_query.defined) && !(jqm.defined) %]
     [% IF country != 'en:world' %]
@@ -23,7 +24,7 @@
     [% IF explore_products == 'true' %]
         <ul class="button-group">
             <li>
-                <div style="font-size:1.2rem;background-color:#eeeeee;padding:0.3rem 1rem;height:2.75rem;margin:0">[% html_count %]</div>
+                <div style="font-weight:bold;margin-right:2em;">[% html_count %]</div>
             </li>
             <li>
                 <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button dropdown small">[% lang('explore_products_by') %]</button>
@@ -40,9 +41,14 @@
         </p>
     [% END %]
 
+	<div id="preferences_selected"></div>
+
+	<div id="preferences_selection_form" style="display:none"></div>
+
     [% IF (jqm.defined) && !(jqm_loadmore.defined) %]
         <ul data-role="listview" data-theme="c" id="search_results_list">
     [% ELSE %]
+    <div id="search_results">
         <ul class="products">
     [% END %]
     
@@ -68,6 +74,12 @@
         [% END %]
 
     [% END %]
+    
+    [% IF (jqm.defined) && !(jqm_loadmore.defined) %]
+        </ul>
+    [% ELSE %]
+		</ul></div>
+    [% END %]    
     
     <!-- Pagination -->
     [% display_pagination(request, page_count, page_limit, page) %]

--- a/templates/search_results.tt.html
+++ b/templates/search_results.tt.html
@@ -4,5 +4,5 @@
 <div id="preferences_selection_form" style="display:none"></div>
 	
 <div id="search_results">
-[% lang("products_are_being_loaded") %]
+[% lang("products_are_being_loaded_please_wait") %]
 </div>


### PR DESCRIPTION
This makes the new products cards view the default (only for moderators at this point) for facets pages and search results.

![image](https://user-images.githubusercontent.com/8158668/99067723-76efe280-25ab-11eb-961d-509aebc27dc7.png)
Currently live on the dev server, product images not shown because their are not on the dev server)

In practice the search results are still generated as HTML, but also added as JSON data so that they can be displayed with cards. (that way we still display results when javascript is OFF, and search engines can continue to easily index them).

This is only for moderators so that we can use it, see how well it works in practice (for regular users but also for contributors).

Some caveats:

1. The ranking according to user preferences only applies to the results loaded on the page. (I changed the number of results per page from 20 to 24 so that we have full rows for all breakpoints (1, 2, 4, 6 and 8). (before we did not have breakpoints, it was just a list of floats)

2. I'm not sure what's the best thing to do with the tabs, in terms of what goes in them, and whether to show them or not, and with what wording.

Currently products can go into "Not OK" if the user has set a "mandatory" preference. And they can go in "maybe" if there is an "important" preference for which we don't have enough data.

On small screens the 4 tabs can be on 2 lines which is not very good. One way could be to remove the numbers of products in each tab, or we could replace the text by icons (check mark, question mark, cross mark)

3. This completely changes the HTML structure of the results page, so user scripts like the power user script will not work (unless they are changed to use the new format).

