### PR TITLE
keep track of exported products, bug #4560

### DIFF
--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -86,8 +86,15 @@ if ($action eq "display") {
 		}
 	}
 	
+	# Number of products matching the optional query
 	my $count = count_products({}, $query_ref);
+	
+	# Number of products matching the query with changes that have not yet been imported
+	$query_ref->{states_tags} = "en:to-be-exported";
+	my $count_to_be_exported = count_products({}, $query_ref);
+	
 	$template_data_ref->{count} = $count;
+	$template_data_ref->{count_to_be_exported} = $count_to_be_exported;
 	
 	if ($count == 0) {
 		$template_data_ref->{n_products_will_be_exported} = lang("no_products_to_export");
@@ -106,9 +113,11 @@ if ($action eq "display") {
 		$export_photos_value = "checked";
 		$replace_selected_photos_value = "checked";
 	}
+	my $only_export_products_with_changes_value = "checked";
 	
 	$template_data_ref->{export_photos_value} = $export_photos_value;
 	$template_data_ref->{replace_selected_photos_value} = $replace_selected_photos_value;
+	$template_data_ref->{only_export_products_with_changes_value} = $only_export_products_with_changes_value;
 
 	# Require moderator status to launch the export / import process,
 	# unless there is only one product specified through the ?query_code= parameter
@@ -141,8 +150,13 @@ elsif (($action eq "process") and (($User{moderator}) or (defined param("query_c
 	if (not ((defined param("export_photos")) and (param("export_photos")))) {
 		$args_ref->{do_not_upload_images} = 1;
 	}
+	
 	if (not ((defined param("replace_selected_photos")) and (param("replace_selected_photos")))) {
 		$args_ref->{only_select_not_existing_images} = 1;
+	}
+	
+	if ((defined param("only_export_products_with_changes")) and (param("only_export_products_with_changes"))) {
+		$args_ref->{query}{states_tags} = 'en:to-be-exported';
 	}
 	
 	# Create Minion tasks for export and import

--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -151,6 +151,7 @@ elsif (($action eq "process") and (($User{moderator}) or (defined param("query_c
 	
 	my $local_export_job_id = $results_ref->{local_export_job_id};
 	my $remote_import_job_id = $results_ref->{remote_import_job_id};
+	my $local_export_status_job_id = $results_ref->{local_export_status_job_id};
 	my $export_id = $results_ref->{export_id};
 	
 
@@ -162,6 +163,10 @@ elsif (($action eq "process") and (($User{moderator}) or (defined param("query_c
 	. "<a href=\"/cgi/minion_job_status.pl?job_id=$remote_import_job_id\">Status</a>"
 	. " - <span id=\"result2\"></span></p>";
 
+	$html .= "<p>Local export status update job_id: " . $local_export_status_job_id . " - "
+	. "<a href=\"/cgi/minion_job_status.pl?job_id=$local_export_status_job_id\">Status</a>"
+	. " - <span id=\"result3\"></span></p>";
+
 	$initjs .= <<JS
 
 var poll_n1 = 0;
@@ -171,6 +176,10 @@ var job_info_state1;
 var poll_n2 = 0;
 var timeout2 = 5000;
 var job_info_state2;
+
+var poll_n3 = 0;
+var timeout3 = 5000;
+var job_info_state3;
 
 (function poll1() {
   \$.ajax({
@@ -203,7 +212,25 @@ var job_info_state2;
 		setTimeout(poll2, timeout2);
 		timeout2 += 1000;
 	}
-	  poll_n1++;
+	  poll_n2++;
+    }
+  });
+})();
+
+(function poll3() {
+  \$.ajax({
+    url: '/cgi/minion_job_status.pl?job_id=$local_export_status_job_id',
+    success: function(data) {
+      \$('#result3').html(data.job_info.state);
+	  job_info_state3 = data.job_info.state;
+    },
+    complete: function() {
+      // Schedule the next request when the current one's complete
+	  if ((job_info_state3 == "inactive") || (job_info_state3 == "active")) {
+		setTimeout(poll3, timeout3);
+		timeout2 += 1000;
+	}
+	  poll_n3++;
     }
   });
 })();

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -94,6 +94,7 @@ use ProductOpener::Data qw/:all/;
 use ProductOpener::ImportConvert qw/clean_fields clean_weights assign_quantity_from_field/;
 use ProductOpener::Users qw/:all/;
 use ProductOpener::Orgs qw/:all/;
+use ProductOpener::Data qw/:all/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;
@@ -1643,6 +1644,142 @@ EMAIL
 	print STDERR ((scalar @edited) . " products updated\n");
 
 	return \%stats;
+}
+
+
+=head2 update_export_status_for_csv_file( ARGUMENTS )
+
+Once products from a CSV file have been exported from the producers platform
+and imported on the public platform, update_export_status_for_csv_file()
+marks them as exported on the producers platform.
+
+=head3 Arguments
+
+Arguments are passed through a single hash reference with the following keys:
+
+=head4 user_id - required
+
+User id to which the changes (new products, added or changed values, new images)
+will be attributed.
+
+=head4 org_id - optional
+
+Organisation id to which the changes (new products, added or changed values, new images)
+will be attributed.
+
+=head4 owner_id - optional
+
+For databases with private products, owner (user or org) that the products belong to.
+Values are of the form user-[user id] or org-[organization id].
+
+If not set, for databases with private products, it will be constructed from the user_id
+and org_id parameters.
+
+The owner can be overriden if the CSV file contains a org_name field.
+In that case, the owner is set to the value of the org_name field, and
+a new org is created if it does not exist yet.
+
+=head4 csv_file - required
+
+Path and file name of the CSV file to import.
+
+The CSV file needs to be in the Open Food Facts CSV format, encoded in UTF-8
+with tabs as separators.
+
+=head4 exported_t - required
+
+Time of the export.
+
+=cut
+
+sub update_export_status_for_csv_file($) {
+
+	my $args_ref = shift;
+
+	$User_id = $args_ref->{user_id};
+	$Org_id = $args_ref->{org_id};
+	$Owner_id = get_owner_id($User_id, $Org_id, $args_ref->{owner_id});
+
+	$log->debug("starting update_export_status_for_csv_file", { User_id => $User_id, Org_id => $Org_id, Owner_id => $Owner_id }) if $log->is_debug();
+
+	my $csv = Text::CSV->new ( { binary => 1 , sep_char => "\t" } )  # should set binary attribute.
+					 or die "Cannot use CSV: ".Text::CSV->error_diag ();
+
+	my $i = 0;
+
+	$log->debug("updating export status for products", { }) if $log->is_debug();
+
+	open (my $io, '<:encoding(UTF-8)', $args_ref->{csv_file}) or die("Could not open " . $args_ref->{csv_file} . ": $!");
+
+	my $columns_ref = $csv->getline ($io);
+
+	# We may have duplicate columns (e.g. image_other_url),
+	# turn them to image_other_url.2 etc.
+
+	my %seen_columns = ();
+	my @column_names = ();
+
+	foreach my $column (@{$columns_ref}) {
+		if (defined $seen_columns{$column}) {
+			$seen_columns{$column}++;
+			push @column_names, $column . "." . $seen_columns{$column};
+		}
+		else {
+			$seen_columns{$column} = 1;
+			push @column_names, $column;
+		}
+	}
+
+	$csv->column_names (@column_names);
+	
+	my $products_collection = get_products_collection();
+
+	while (my $imported_product_ref = $csv->getline_hr ($io)) {
+
+		$i++;
+
+		my $code = $imported_product_ref->{code};
+		$code = normalize_code($code);
+		my $product_id = product_id_for_owner($Owner_id, $code);
+
+		$log->debug("update export status for product", { i => $i, code => $code, product_id => $product_id }) if $log->is_debug();
+
+		if ($code eq '') {
+			$log->error("Error - empty code", { i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_error();
+			next;
+		}
+
+		if ($code !~ /^\d\d\d\d\d\d\d\d(\d*)$/) {
+			$log->error("Error - code not a number with 8 or more digits", { i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_error();
+			next;
+		}
+		
+		my $product_ref = retrieve_product($product_id);
+
+		if (defined $product_ref) {
+			$product_ref->{last_exported_t} = $args_ref->{exported_t};
+			if ($product_ref->{last_exported_t} > $product_ref->{last_modified_t}) {
+				add_tag($product_ref, "states", "en:exported");
+				remove_tag($product_ref, "states", "en:to-be-exported");
+			}
+			else {
+				add_tag($product_ref, "states", "en:to-be-exported");
+				remove_tag($product_ref, "states", "en:exported");
+			}
+			$product_ref->{states} = join(',', @{$product_ref->{states_tags}});
+			compute_field_tags($product_ref, $product_ref->{lc}, "states");
+			
+			my $path = product_path($product_ref);
+			store("$data_root/products/$path/product.sto", $product_ref);
+			$product_ref->{code} = $product_ref->{code} . '';
+			$products_collection->replace_one({"_id" => $product_ref->{_id}}, $product_ref, { upsert => 1 });			
+		}
+	}
+
+	$log->debug("update export status done", { products => $i }) if $log->is_debug();
+
+	print STDERR "\n\nupdate export status done\n\n";
+
 }
 
 

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -68,6 +68,7 @@ BEGIN
 
 		&import_csv_file_task
 		&export_csv_file_task
+		&update_export_status_for_csv_file_task
 		&import_products_categories_from_public_database_task
 
 		);    # symbols to export on request
@@ -1347,6 +1348,7 @@ sub export_and_import_to_public_database($) {
 	$args_ref->{export_id}            = $export_id;
 	$args_ref->{comment}              = "Import from producers platform";
 	$args_ref->{include_images_paths} = 1;                                  # Export file paths to images
+	$args_ref->{exported_t}	= $started_t;
 
 
 	if (defined $Org_id) {
@@ -1379,17 +1381,27 @@ sub export_and_import_to_public_database($) {
 	else {
 		$args_ref->{no_source} = 1;
 	}
+	
+	# Local export
 
 	my $local_export_job_id = $minion->enqueue(export_csv_file => [$args_ref]
 		=> { queue => $server_options{minion_local_queue}});
 
 	$args_ref->{export_job_id} = $local_export_job_id;
 
+	# Remote import
+	
 	my $remote_import_job_id = $minion->enqueue(import_csv_file => [$args_ref]
 		=> { queue => $server_options{minion_export_queue}, parents => [$local_export_job_id]});
+		
+	# Local export status update
+	
+	my $local_export_status_job_id = $minion->enqueue(update_export_status_for_csv_file => [$args_ref]
+		=> { queue => $server_options{minion_local_queue}, parents => [$remote_import_job_id]});
 
 	$exports_ref->{$export_id}{local_export_job_id} = $local_export_job_id;
 	$exports_ref->{$export_id}{remote_import_job_id} = $remote_import_job_id;
+	$exports_ref->{$export_id}{local_export_status_job_id} = $local_export_status_job_id;
 
 	(-e "$data_root/export_files") or mkdir("$data_root/export_files", 0755);
 	(-e "$data_root/export_files/${Owner_id}") or mkdir("$data_root/export_files/${Owner_id}", 0755);
@@ -1401,6 +1413,7 @@ sub export_and_import_to_public_database($) {
 			exported_file => $exported_file,
 			local_export_job_id => $local_export_job_id,
 			remote_import_job_id => $remote_import_job_id,
+			local_export_status_job_id => $local_export_status_job_id,
 	};
 }
 
@@ -1515,6 +1528,35 @@ sub import_products_categories_from_public_database_task() {
 
 	open(my $log, ">>", "$data_root/logs/minion.log");
 	print $log "import_products_categories_from_public_database_file_task - job: $job_id done\n";
+	close($log);
+
+	$job->finish("done");
+
+	return;
+}
+
+
+sub update_export_status_for_csv_file_task() {
+
+	my $job = shift;
+	my $args_ref = shift;
+
+	return if not defined $job;
+
+	my $job_id = $job->{id};
+
+	open(my $minion_log, ">>", "$data_root/logs/minion.log");
+	print $minion_log "update_export_status_for_csv_file_task - job: $job_id started - args: " . encode_json($args_ref) . "\n";
+	close($minion_log);
+
+	print STDERR "update_export_status_for_csv_file_task - job: $job_id started - args: " . encode_json($args_ref) . "\n";
+
+	ProductOpener::Import::update_export_status_for_csv_file($args_ref);
+
+	print STDERR "update_export_status_for_csv_file_task - job: $job_id - done\n";
+
+	open(my $log, ">>", "$data_root/logs/minion.log");
+	print $log "update_export_status_file_task - job: $job_id done\n";
 	close($log);
 
 	$job->finish("done");

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1408,6 +1408,16 @@ sub compute_completeness_and_missing_tags($$$) {
 	else {
 		delete $product_ref->{empty};
 	}
+	
+	# On the producers platform, keep track of which products have changes to be exported
+	if ((defined $server_options{private_products}) and ($server_options{private_products})) {
+		if ((defined $product_ref->{last_exported_t}) and ($product_ref->{last_exported_t} > $product_ref->{last_modified_t})) {
+			push @states_tags, "en:exported";
+		}
+		else {
+			push @states_tags, "en:to-be-exported";
+		}
+	}
 
 	$product_ref->{complete} = $complete;
 	$current_ref->{complete} = $complete;

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5168,3 +5168,11 @@ msgstr "% in product"
 msgctxt "forest_footprint_calculation_details"
 msgid "Details of the calculation of the forest footprint"
 msgstr "Details of the calculation of the forest footprint"
+
+msgctxt "number_of_products_with_changes_since_last_export"
+msgid "Number of products with changes since last export"
+msgstr "Number of products with changes since last export"
+
+msgctxt "only_export_products_with_changes"
+msgid "Only export products with changes"
+msgstr "Only export products with changes"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5186,3 +5186,12 @@ msgstr "% in product"
 msgctxt "forest_footprint_calculation_details"
 msgid "Details of the calculation of the forest footprint"
 msgstr "Details of the calculation of the forest footprint"
+
+msgctxt "number_of_products_with_changes_since_last_export"
+msgid "Number of products with changes since last export"
+msgstr "Number of products with changes since last export"
+
+msgctxt "only_export_products_with_changes"
+msgid "Only export products with changes"
+msgstr "Only export products with changes"
+

--- a/scripts/minion_producers.pl
+++ b/scripts/minion_producers.pl
@@ -52,6 +52,8 @@ app->minion->add_task(import_csv_file => \&ProductOpener::Producers::import_csv_
 
 app->minion->add_task(export_csv_file => \&ProductOpener::Producers::export_csv_file_task);
 
+app->minion->add_task(update_export_status_for_csv_file => \&ProductOpener::Producers::update_export_status_for_csv_file_task);
+
 app->minion->add_task(import_products_categories_from_public_database => \&import_products_categories_from_public_database_task);
 
 app->config(

--- a/scripts/minion_producers_test.pl
+++ b/scripts/minion_producers_test.pl
@@ -30,7 +30,9 @@ use Minion;
 
 $minion->add_task(import_csv_file => \&ProductOpener::Producers::import_csv_file_task);
 $minion->add_task(export_csv_file => \&ProductOpener::Producers::export_csv_file_task);
-$minion->add_task(import_products_categories_from_public_database => \&import_products_categories_from_public_database_task);
+$minion->add_task(import_products_categories_from_public_database => \&ProductOpener::Producers::import_products_categories_from_public_database_task);
+$minion->add_task(update_export_status_for_csv_file => \&ProductOpener::Producers::update_export_status_for_csv_file_task);
+
 
 print STDERR "Perform 1 job in current process\n";
 

--- a/templates/export_products.tt.html
+++ b/templates/export_products.tt.html
@@ -15,6 +15,7 @@
 	[% END %]
 
 	<p>[% n_products_will_be_exported %]</p>
+	<p>[% lang('number_of_products_with_changes_since_last_export') %][% sep %]: [% count_to_be_exported %]</p>
 
 	[% IF count > 0 %]
 		[% IF allow_submit %]
@@ -27,6 +28,11 @@
 			<label for="replace_selected_photos">
 				<input type="checkbox" name="replace_selected_photos" [% replace_selected_photos_value %]>	
 				[% lang('replace_selected_photos') %]
+			</label>
+
+			<label for="only_export_products_with_changes">
+				<input type="checkbox" name="only_export_products_with_changes" [% only_export_products_with_changes_value %]>	
+				[% lang('only_export_products_with_changes') %]
 			</label>
 
 			<input type="submit" class="button small" value="[% lang('export_product_data_photos') %]">


### PR DESCRIPTION
This will be used on the producers platform to display information about which products have changes that have not been exported to the public database, and also allow exporting only such products.