### PR TITLE
Correct invalid pot file

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -2769,8 +2769,8 @@ msgid "Some of the data for this product has been provided directly by the manuf
 msgstr "Some of the data for this product has been provided directly by the manufacturer %s."
 
 msgctxt "list_of_sources"
-msgid "Some of the data for this product has been collected in collaboration with %s"	msgid "Some of the data and/or photos for this product come from those sources:"
-msgstr "Some of the data for this product has been collected in collaboration with %s"	msgstr "Some of the data and/or photos for this product come from those sources:"
+msgid "Some of the data and/or photos for this product come from those sources:"
+msgstr "Some of the data and/or photos for this product come from those sources:"
 
 msgctxt "warning_not_complete"
 msgid ""


### PR DESCRIPTION
Correct invalid pot file. Such mistakes would not happen every time if the files were compiled with poedit or checked with translatetoolkit.

msgctxt "list_of_sources"
msgid "Some of the data for this product has been collected in collaboration with %s"	msgid "Some of the data and/or photos for this product come from those sources:"
msgstr "Some of the data for this product has been collected in collaboration with %s"	msgstr "Some of the data and/or photos for this product come from those sources:"
