### PR TITLE
fix id for attribute_group_ingredients_analysis_name

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4952,7 +4952,7 @@ msgctxt "edit_user_profile"
 msgid "Edit your user profile"
 msgstr "Edit your user profile"
 
-msgctxt "attribute_group_ingredients_analysis"
+msgctxt "attribute_group_ingredients_analysis_name"
 msgid "Ingredients"
 msgstr "Ingredients"
 

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4980,7 +4980,7 @@ msgctxt "edit_user_profile"
 msgid "Edit your user profile"
 msgstr "Edit your user profile"
 
-msgctxt "attribute_group_ingredients_analysis"
+msgctxt "attribute_group_ingredients_analysis_name"
 msgid "Ingredients"
 msgstr "Ingredients"
 


### PR DESCRIPTION
This is a string needed when displaying the food preferences form, the id was wrong so it wasn't used.