### PR TITLE
Ecoscore - add Eco-Score warning when origins are 100% unknown

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1070,6 +1070,32 @@ sub check_ingredients_percent_analysis($) {
 	return;
 }
 
+
+=head2 check_ecoscore_data( PRODUCT_REF )
+
+Checks for data needed to compute the Eco-score.
+
+=cut
+
+sub check_ecoscore_data($) {
+	my $product_ref = shift;
+
+	if (defined $product_ref->{ecoscore_data}) {
+
+		foreach my $adjustment (sort keys %{$product_ref->{ecoscore_data}{adjustments}}) {
+				
+			if (defined $product_ref->{ecoscore_data}{adjustments}{$adjustment}{warning}) {
+				my $warning = $adjustment . '-' . $product_ref->{ecoscore_data}{adjustments}{$adjustment}{warning};
+				$warning =~ s/_/-/g;
+				push @{$product_ref->{data_quality_warnings_tags}}, 'en:ecoscore-' . $warning ;
+			}
+		}
+	}
+
+	return;
+}
+
+
 =head2 check_quality_food( PRODUCT_REF )
 
 Run all quality checks defined in the module.
@@ -1090,6 +1116,7 @@ sub check_quality_food($) {
 	detect_categories($product_ref);
 	check_categories($product_ref);
 	compare_nutriscore_with_value_from_producer($product_ref);
+	check_ecoscore_data($product_ref);
 
 	return;
 }

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -201,6 +201,8 @@ sub load_ecoscore_data_origins_of_ingredients() {
 		if ($errors) {
 			die("$errors unrecognized origins in CSV $csv_file");
 		}
+		
+		$ecoscore_data{origins}{"en:unspecified"} = $ecoscore_data{origins}{"en:unknown"};
 	}
 	else {
 		die("Could not open ecoscore origins CSV $csv_file: $!");
@@ -865,8 +867,12 @@ sub compute_ecoscore_origins_of_ingredients_adjustment($) {
 		transportation_value => $transportation_value,
 		epi_value => $epi_value,
 		value => $transportation_value + $epi_value,
-	};	
+	};
 	
+	# Add a warning if the only origin is en:unknown
+	if (($#aggregated_origins == 0) and ($aggregated_origins[0]{origin} eq "en:unknown")) {
+		$product_ref->{ecoscore_data}{adjustments}{origins_of_ingredients}{warning} = "origins_are_100_percent_unknown";
+	}
 }
 
 

--- a/t/dataqualityfood.t
+++ b/t/dataqualityfood.t
@@ -208,14 +208,43 @@ ok( has_tag($product_ref, 'data_quality', 'en:missing-nutrition-data-prepared-wi
 'dried product category with no nutrition data checked prepared data is flagged for issue 1466' ) or diag explain $product_ref;
 
 
+$product_ref = {
+	categories_tags => ['en:dried-products-to-be-rehydrated'],
+	nutrition_data_prepared => 'on',
+	nutriments => {
+		energy_prepared_100g => 5
+	},
+	no_nutrition_data => 'on'
+
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok( has_tag($product_ref, 'data_quality', 'en:missing-nutrition-data-prepared-with-category-dried-products-to-be-rehydrated'),
+'dried product category with no nutrition data checked prepared data is flagged for issue 1466' ) or diag explain $product_ref;
+
 use Log::Any::Adapter 'TAP', filter => "none";
 
 check_quality_and_test_product_has_quality_tag({
-	categories_tags => ["en:cakes"],
-	nutriments => { 
-		salt_100g => 10,
-		fat_100g => 99,
-	},
-}, "en:nutrition-value-very-high-for-category-fat", "very high salt value", 1);
+	 'ecoscore_data' => {
+     'adjustments' => {
+       'origins_of_ingredients' => {
+         'aggregated_origins' => [
+           {
+             'origin' => 'en:unknown',
+             'percent' => 100
+           }
+         ],
+         'epi_score' => 0,
+         'epi_value' => -5,
+         'origins_from_origins_field' => [
+           'en:unknown'
+         ],
+         'transportation_score' => 0,
+         'transportation_value' => 0,
+         'value' => -5,
+         'warning' => 'origins_are_100_percent_unknown'
+       },
+      }
+	}
+}, "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown", "origins 100 percent unknown", 1);
 
 done_testing();

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -221,6 +221,16 @@ my @tests = (
 		}
 	],
 	
+	[
+		'origins-of-ingredients-unspecified-origin',
+		{
+			lc => "en",
+			categories_tags=>["en:cheeses"],
+			origins_tags=>["en:unspecified"],
+			ingredients_text=>"Milk",
+		}
+	],	
+	
 	# Packaging adjustment
 	
 	[

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -15,7 +15,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -1,0 +1,107 @@
+{
+   "categories_tags" : [
+      "en:cheeses"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unspecified",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unspecified"
+            ],
+            "transportation_score" : 0,
+            "transportation_value" : 0,
+            "value" : -5
+         },
+         "packaging" : {
+            "packagings" : [],
+            "score" : 100,
+            "value" : 0
+         },
+         "production_system" : {},
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "12001",
+         "co2_agriculture" : "4.7126103",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.029050683",
+         "co2_packaging" : "0.26662691",
+         "co2_processing" : "0.22452742",
+         "co2_total" : "5.4920327",
+         "co2_transportation" : "0.25844052",
+         "code" : "12001",
+         "dqr" : "1.81",
+         "ef_agriculture" : "0.41632178999999997",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0088270864",
+         "ef_packaging" : "0.019721226",
+         "ef_processing" : "0.028839787",
+         "ef_total" : "0.49584621999999995",
+         "ef_transportation" : "0.020064567000000002",
+         "name_en" : "Camembert cheese, from cow's milk",
+         "name_fr" : "Camembert, sans précision",
+         "score" : 61.604062231297
+      },
+      "grade" : "c",
+      "score" : 56.604062231297,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 56.604062231297,
+   "ecoscore_tags" : [
+      "c"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:milk",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "rank" : 1,
+         "text" : "Milk",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:milk",
+      "en:dairy"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:milk"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:milk",
+      "en:dairy"
+   ],
+   "ingredients_text" : "Milk",
+   "known_ingredients_n" : 2,
+   "lc" : "en",
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "origins_tags" : [
+      "en:unspecified"
+   ],
+   "packagings" : [],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -18,7 +18,8 @@
             ],
             "transportation_score" : 0,
             "transportation_value" : 0,
-            "value" : -5
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
             "packagings" : [],

--- a/taxonomies/origins.result.txt
+++ b/taxonomies/origins.result.txt
@@ -29642,8 +29642,11 @@ country_code_2:en: UM
 country_code_3:en: UMI
 languages:en: 
 
-en:Unknown, not specified
-fr:Inconnu, inconnue, inconnus, inconnues, non-spécifié, non-spécifiée
+en:Unknown
+fr:Inconnu, inconnue, inconnus, inconnues
+
+en:Unspecified, not specified, non specified, nonspecified, not available, n/a
+fr:Non indiqué, non indiquée, non indiqués, non indiquées, non spécifié, non spécifiée, non spécifiées, non précisé, non précisée, non précisés, non précisées
 
 en:Uruguay, Oriental Republic of Uruguay, Eastern Republic of Uruguay, República Oriental del Uruguay, UY, URY
 af:Uruguay

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -14,8 +14,12 @@
 stopwords:en:agriculture
 stopwords:fr:agriculture
 
-en:Unknown, not specified
-fr:Inconnu, inconnue, inconnus, inconnues, non-spécifié, non-spécifiée
+# Unknown origin: no value has been entered (it's possible that there is one specified on the product but that we don't have the data)
+en:Unknown
+fr:Inconnu, inconnue, inconnus, inconnues
+
+en:Unspecified, not specified, non specified, nonspecified, not available, n/a
+fr:Non indiqué, non indiquée, non indiqués, non indiquées, non spécifié, non spécifiée, non spécifiée, non spécifiées, non précisé, non précisée, non précisés, non précisées
 
 # World regions
 


### PR DESCRIPTION
- Add an "Unspecified" entry in the origins taxonomy. That way we can add "Unspecified" in the origins of ingredients field if the origins are not specified in the label. It will be different than the "Unknown" entry which means we don't have data.

- Add a warning in the ecoscore_data structure when 100% of the origins of ingredients are "Unknown" (the warning won't be triggered if the origin is "Unspecified" or if we have at least one origin for an ingredient).

- Add a corresponding data quality warning so that we can easily identify the products with 100% unknown origins.

This will partially solve #4686 .