### PR TITLE
add default unknown packaging for ecoscore ° better warnings #4686

### DIFF
--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -306,9 +306,9 @@ sub analyze_and_combine_packaging_data($) {
 		
 		my $packaging_ref = parse_packaging_from_text_phrase($phrase, $product_ref->{lc});
 		
-		# For phrases corresponding to the packaging text field, mark the shape as en:unrecognized if it was not identified
+		# For phrases corresponding to the packaging text field, mark the shape as en:unknown if it was not identified
 		if (($i <= $number_of_packaging_text_entries) and (not defined $packaging_ref->{shape})) {
-			$packaging_ref->{shape} = "en:unrecognized";
+			$packaging_ref->{shape} = "en:unknown";
 		}
 		
 		# Non empty packaging?
@@ -329,7 +329,7 @@ sub analyze_and_combine_packaging_data($) {
 					
 					# If there is an existing value for the property,
 					# check if it is either a child or a parent of the value extracted from the packaging text
-					if ((defined $existing_packaging_ref->{$property})
+					if ((defined $existing_packaging_ref->{$property}) and ($existing_packaging_ref->{$property} ne "en:unknown")
 						and ($existing_packaging_ref->{$property} ne $packaging_ref->{$property})
 						and (not is_a($tagtype, $existing_packaging_ref->{$property}, $packaging_ref->{$property}))
 						and (not is_a($tagtype, $packaging_ref->{$property}, $existing_packaging_ref->{$property})) ) {
@@ -360,7 +360,7 @@ sub analyze_and_combine_packaging_data($) {
 					# If we already have a value for the property,
 					# apply the new value only if it is a child of the existing value
 					# e.g. if we already have "plastic", we can override it with "PET"
-					if ((not defined $matching_packaging_ref->{$property})
+					if ((not defined $matching_packaging_ref->{$property}) or ($matching_packaging_ref->{$property} eq "en:unknown")
 						or (is_a($tagtype, $packaging_ref->{$property}, $matching_packaging_ref->{$property}))) {
 						
 						$matching_packaging_ref->{$property} = $packaging_ref->{$property};

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -19,9 +19,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -36,5 +44,10 @@
       "unknown"
    ],
    "lc" : "en",
-   "packagings" : []
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
 }

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {
@@ -55,11 +63,11 @@
          "score" : 71.9485117508868
       },
       "grade" : "c",
-      "score" : 56.9485117508868,
+      "score" : 46.9485117508868,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56.9485117508868,
+   "ecoscore_score" : 46.9485117508868,
    "ecoscore_tags" : [
       "c"
    ],
@@ -67,5 +75,10 @@
       "en:palm-oil"
    ],
    "lc" : "en",
-   "packagings" : []
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
 }

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -52,14 +60,19 @@
          "score" : 37.3668003567537
       },
       "grade" : "d",
-      "score" : 32.3668003567537,
+      "score" : 22.3668003567537,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 32.3668003567537,
+   "ecoscore_score" : 22.3668003567537,
    "ecoscore_tags" : [
       "d"
    ],
    "lc" : "en",
-   "packagings" : []
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
 }

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -51,15 +59,20 @@
          "name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
          "score" : 71.9485117508868
       },
-      "grade" : "b",
-      "score" : 66.9485117508868,
+      "grade" : "c",
+      "score" : 56.9485117508868,
       "status" : "known"
    },
-   "ecoscore_grade" : "b",
-   "ecoscore_score" : 66.9485117508868,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 56.9485117508868,
    "ecoscore_tags" : [
-      "b"
+      "c"
    ],
    "lc" : "en",
-   "packagings" : []
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
 }

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {
             "label" : "fr:ab-agriculture-biologique",
@@ -54,18 +62,23 @@
          "name_fr" : "Beurre à 82% MG, doux",
          "score" : 37.3668003567537
       },
-      "grade" : "c",
-      "score" : 47.3668003567537,
+      "grade" : "d",
+      "score" : 37.3668003567537,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 47.3668003567537,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 37.3668003567537,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "labels_tags" : [
       "fr:ab-agriculture-biologique"
    ],
    "lc" : "en",
-   "packagings" : []
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -30,9 +30,17 @@
             "value" : 12.9361614917843
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -60,11 +68,11 @@
          "score" : 58.6020808480656
       },
       "grade" : "b",
-      "score" : 71.5382423398499,
+      "score" : 61.5382423398499,
       "status" : "known"
    },
    "ecoscore_grade" : "b",
-   "ecoscore_score" : 71.5382423398499,
+   "ecoscore_score" : 61.5382423398499,
    "ecoscore_tags" : [
       "b"
    ],
@@ -146,6 +154,11 @@
       "en:dordogne",
       "en:belgium"
    ],
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -25,9 +25,17 @@
             "value" : 14.5970235934909
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -55,11 +63,11 @@
          "score" : 58.6020808480656
       },
       "grade" : "b",
-      "score" : 73.1991044415565,
+      "score" : 63.1991044415565,
       "status" : "known"
    },
    "ecoscore_grade" : "b",
-   "ecoscore_score" : 73.1991044415565,
+   "ecoscore_score" : 63.1991044415565,
    "ecoscore_tags" : [
       "b"
    ],
@@ -139,6 +147,11 @@
    "origins_tags" : [
       "en:france"
    ],
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -52,11 +60,11 @@
          "score" : 61.604062231297
       },
       "grade" : "c",
-      "score" : 56.604062231297,
+      "score" : 46.604062231297,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56.604062231297,
+   "ecoscore_score" : 46.604062231297,
    "ecoscore_tags" : [
       "c"
    ],
@@ -206,6 +214,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -52,11 +60,11 @@
          "score" : 61.604062231297
       },
       "grade" : "c",
-      "score" : 56.604062231297,
+      "score" : 46.604062231297,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56.604062231297,
+   "ecoscore_score" : 46.604062231297,
    "ecoscore_tags" : [
       "c"
    ],
@@ -146,6 +154,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -52,11 +60,11 @@
          "score" : 58.6020808480656
       },
       "grade" : "c",
-      "score" : 53.6020808480656,
+      "score" : 43.6020808480656,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 53.6020808480656,
+   "ecoscore_score" : 43.6020808480656,
    "ecoscore_tags" : [
       "c"
    ],
@@ -132,6 +140,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -25,9 +25,17 @@
             "value" : 9.57107901658939
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -54,14 +62,14 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 58.6020808480656
       },
-      "grade" : "b",
-      "score" : 68.173159864655,
+      "grade" : "c",
+      "score" : 58.173159864655,
       "status" : "known"
    },
-   "ecoscore_grade" : "b",
-   "ecoscore_score" : 68.173159864655,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 58.173159864655,
    "ecoscore_tags" : [
-      "b"
+      "c"
    ],
    "ingredients" : [
       {
@@ -136,6 +144,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -41,9 +41,17 @@
             "value" : 9.18734476198028
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -70,14 +78,14 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 58.6020808480656
       },
-      "grade" : "b",
-      "score" : 67.7894256100459,
+      "grade" : "c",
+      "score" : 57.7894256100459,
       "status" : "known"
    },
-   "ecoscore_grade" : "b",
-   "ecoscore_score" : 67.7894256100459,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 57.7894256100459,
    "ecoscore_tags" : [
-      "b"
+      "c"
    ],
    "ingredients" : [
       {
@@ -153,6 +161,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -29,9 +29,17 @@
             "value" : 13.6787192354265
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -59,11 +67,11 @@
          "score" : 58.6020808480656
       },
       "grade" : "b",
-      "score" : 72.2808000834921,
+      "score" : 62.2808000834921,
       "status" : "known"
    },
    "ecoscore_grade" : "b",
-   "ecoscore_score" : 72.2808000834921,
+   "ecoscore_score" : 62.2808000834921,
    "ecoscore_tags" : [
       "b"
    ],
@@ -142,6 +150,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -52,11 +60,11 @@
          "score" : 61.604062231297
       },
       "grade" : "c",
-      "score" : 56.604062231297,
+      "score" : 46.604062231297,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56.604062231297,
+   "ecoscore_score" : 46.604062231297,
    "ecoscore_tags" : [
       "c"
    ],
@@ -101,6 +109,11 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -21,9 +21,17 @@
             "value" : -5
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -51,11 +59,11 @@
          "score" : 61.604062231297
       },
       "grade" : "c",
-      "score" : 56.604062231297,
+      "score" : 46.604062231297,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56.604062231297,
+   "ecoscore_score" : 46.604062231297,
    "ecoscore_tags" : [
       "c"
    ],
@@ -102,6 +110,11 @@
    "origins_tags" : [
       "en:unspecified"
    ],
-   "packagings" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -24,7 +24,6 @@
          "packaging" : {
             "packagings" : [
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 91.25,
                   "ecoscore_shape_ratio" : 1,
                   "material" : "en:cardboard",
@@ -32,7 +31,6 @@
                   "shape" : "en:box"
                },
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 0,
                   "ecoscore_shape_ratio" : 0.1,
                   "material" : "en:plastic",
@@ -40,7 +38,6 @@
                   "shape" : "en:film"
                },
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 75.5,
                   "ecoscore_shape_ratio" : 1,
                   "material" : "en:steel",

--- a/t/expected_test_results/ecoscore/packaging-en-no-packaging.json
+++ b/t/expected_test_results/ecoscore/packaging-en-no-packaging.json
@@ -1,6 +1,6 @@
 {
    "categories_tags" : [
-      "en:margarines"
+      "en:sodas"
    ],
    "ecoscore_data" : {
       "adjustments" : {
@@ -38,41 +38,35 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_proxy_food_code" : "16737",
-         "co2_agriculture" : "0.85619568",
+         "agribalyse_proxy_food_code" : "18340",
+         "co2_agriculture" : "0.0052740241",
          "co2_consumption" : "0.0047993021",
-         "co2_distribution" : "0.030254944",
-         "co2_packaging" : "0.20585948",
-         "co2_processing" : "0.12042224",
-         "co2_total" : "1.4400484",
-         "co2_transportation" : "0.22241292",
-         "code" : "16737",
-         "dqr" : "3.31",
-         "ef_agriculture" : "0.2785495",
+         "co2_distribution" : "0.028932423",
+         "co2_packaging" : "0.18274931",
+         "co2_processing" : "0",
+         "co2_total" : "0.40246995",
+         "co2_transportation" : "0.18071489",
+         "code" : "18340",
+         "dqr" : "2.97",
+         "ef_agriculture" : "0.00091374504",
          "ef_consumption" : "0.0024293397",
-         "ef_distribution" : "0.009194265200000001",
-         "ef_packaging" : "0.015478282000000001",
-         "ef_processing" : "0.01151692",
-         "ef_total" : 0.33526651,
-         "ef_transportation" : "0.018090858",
-         "name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
-         "name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
-         "score" : 71.9485117508868
+         "ef_distribution" : "0.0088128735",
+         "ef_packaging" : "0.018005260999999998",
+         "ef_processing" : "0",
+         "ef_total" : 0.043941445,
+         "ef_transportation" : "0.013780225",
+         "name_en" : "Fruit soft drink, carbonated (less than 10% of fruit juice), without sugar and with artificial sweetener(s)",
+         "name_fr" : "Boisson gazeuse aux fruits (à moins de 10% de jus), non sucrée, avec édulcorants",
+         "score" : 97.8336969127427
       },
-      "grade" : "c",
-      "score" : 56.9485117508868,
+      "grade" : "a",
+      "score" : 82.8336969127427,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 56.9485117508868,
+   "ecoscore_grade" : "a",
+   "ecoscore_score" : 82.8336969127427,
    "ecoscore_tags" : [
-      "c"
-   ],
-   "ingredients_analysis_tags" : [
-      "en:palm-oil"
-   ],
-   "labels_tags" : [
-      "en:roundtable-on-sustainable-palm-oil"
+      "a"
    ],
    "lc" : "en",
    "packagings" : [

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -24,7 +24,6 @@
          "packaging" : {
             "packagings" : [
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 50,
                   "ecoscore_shape_ratio" : 1,
                   "material" : "en:pet-polyethylene-terephthalate",

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -24,7 +24,6 @@
          "packaging" : {
             "packagings" : [
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 0,
                   "ecoscore_shape_ratio" : 1,
                   "material" : "en:plastic",

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -24,15 +24,15 @@
          "packaging" : {
             "packagings" : [
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 0,
-                  "ecoscore_material_warning" : "unspecified_material",
                   "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
                   "shape" : "en:bottle"
                }
             ],
             "score" : 0,
-            "value" : -10
+            "value" : -10,
+            "warning" : "unspecified_material"
          },
          "production_system" : {},
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -24,15 +24,15 @@
          "packaging" : {
             "packagings" : [
                {
-                  "ecoscore_counted" : 1,
                   "ecoscore_material_score" : 0,
-                  "ecoscore_material_warning" : "unspecified_material",
                   "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
                   "shape" : "en:can"
                }
             ],
             "score" : 0,
-            "value" : -10
+            "value" : -10,
+            "warning" : "unspecified_material"
          },
          "production_system" : {},
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -22,9 +22,17 @@
             "warning" : "origins_are_100_percent_unknown"
          },
          "packaging" : {
-            "packagings" : [],
-            "score" : 100,
-            "value" : 0
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
          },
          "production_system" : {},
          "threatened_species" : {}
@@ -39,5 +47,10 @@
       "unknown"
    ],
    "lc" : "en",
-   "packagings" : []
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
 }

--- a/t/expected_test_results/packaging/merge_en_merge_packaging_tag_and_packaging_text_2.json
+++ b/t/expected_test_results/packaging/merge_en_merge_packaging_tag_and_packaging_text_2.json
@@ -9,7 +9,7 @@
       },
       {
          "material" : "en:kraft-paper",
-         "shape" : "en:unrecognized"
+         "shape" : "en:unknown"
       },
       {
          "material" : "en:paper",

--- a/t/expected_test_results/packaging/merge_en_merge_packaging_tag_and_packaging_text_2.json
+++ b/t/expected_test_results/packaging/merge_en_merge_packaging_tag_and_packaging_text_2.json
@@ -9,10 +9,6 @@
       },
       {
          "material" : "en:kraft-paper",
-         "shape" : "en:unknown"
-      },
-      {
-         "material" : "en:paper",
          "shape" : "en:bag"
       }
    ]

--- a/t/expected_test_results/packaging/packaging_text_fr_unknown_shape.json
+++ b/t/expected_test_results/packaging/packaging_text_fr_unknown_shape.json
@@ -25,7 +25,7 @@
       {
          "material" : "en:paper",
          "recycling" : "en:recycle",
-         "shape" : "en:unrecognized"
+         "shape" : "en:unknown"
       }
    ]
 }

--- a/taxonomies/packaging_materials.txt
+++ b/taxonomies/packaging_materials.txt
@@ -7,6 +7,9 @@ synonyms:fr:transparent,transparente
 
 synonyms:fr:coloré,colorée
 
+en:Unknown
+fr:Inconnu, inconnue, inconnus, inconnues
+
 en:Plastic
 de:Kunststoff
 fr:Plastique

--- a/taxonomies/packaging_shapes.txt
+++ b/taxonomies/packaging_shapes.txt
@@ -1,9 +1,7 @@
 # Containers
 
-# Special entries for packaging parts for which the shape was not recognized
-en:Unrecognized
-de:Unerkannt, Nicht erkannt
-fr:Non-reconnue, non-reconnu
+en:Unknown
+fr:Inconnu, inconnue, inconnus, inconnues
 
 # Use singular as the main name, and add plural as synonym
 en:Tray, trays


### PR DESCRIPTION
When we don't have packaging information, we now count an unknown shape of an unknown material which results of a malus of -10 (the malus for packaging can range from 0 to -15). This is a much better default than a malus of 0 (which happens only for products that really do not have a packaging and are sold in bulk).

This also adds warnings in the ecoscore_data structure + associated data-quality-warnings tags.

It will also allow us to add better prompts to add data in the Eco-score details template.