### PR TITLE
Always use smaller products_tags collection for MongoDB aggregate queries unless nocache is set

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1539,11 +1539,10 @@ sub query_list_of_tags($$) {
 
 	if ((not defined $results) or (ref($results) ne "ARRAY") or (not defined $results->[0])) {
 
-		# do not used the smaller cached products_tags collection if ?nocache=1
-		# or if on the producers platform
+		# do not use the smaller cached products_tags collection if ?nocache=1
+		# or if we are on the producers platform
 		if ( ((defined param("nocache")) and (param("nocache")))
-			or ((defined $User_id) and not ((defined param("nocache")) and (param("nocache") == 0)))
-			) {
+			or ($server_options{producers_platform})) {
 
 			eval {
 				$log->debug("Executing MongoDB aggregate query on products collection", { query => $aggregate_parameters }) if $log->is_debug();

--- a/scripts/refresh_products_tags.js
+++ b/scripts/refresh_products_tags.js
@@ -63,7 +63,10 @@ db.products.aggregate( [
 	data_quality_info_tags:1,
 	data_quality_warnings_tags:1,
 	data_quality_errors_tags:1,
-	teams_tags:1
+	teams_tags:1,
+	categories_properties_tags:1,
+	ecoscore_tags:1,
+	owners_tags:1
 	}},
 {"$out": "products_tags"}
 ]);


### PR DESCRIPTION
or if we are on the producers platform.

This will help large queries like https://fr.openfoodfacts.org/labels made by logged in users: they will be run on the smaller products_tags collection.