### PR TITLE
add abbreviated_product_name field + changes for LDC import

### DIFF
--- a/cgi/import_file_select_format.pl
+++ b/cgi/import_file_select_format.pl
@@ -158,9 +158,12 @@ HTML
 		if ((defined $columns_fields_ref->{$column}{min}) and ($columns_fields_ref->{$column}{letters} == 0)) {
 			$examples .= "<br><p>" . lang("min") . " " . $columns_fields_ref->{$column}{min} . "<br>" . lang("max") . " " . $columns_fields_ref->{$column}{max} . "</p>";
 		}
+		
+		my $column_without_tags = $column;
+		$column_without_tags =~ s/<(([^>]|\n)*)>//g;
 
 		$html .= <<HTML
-<tr id="column_$col" class="column_row"><td>$column</td>
+<tr id="column_$col" class="column_row"><td>$column_without_tags</td>
 <td>
 <select class="select2_field" name="select_field_$col" id="select_field_$col" style="width:420px">
 <option></option>

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -612,6 +612,7 @@ improvements origins packaging_shapes packaging_materials packaging_recycling
 	created_t
 	last_modified_t
 	product_name
+	abbreviated_product_name
 	generic_name
 	quantity
 	packaging
@@ -652,7 +653,8 @@ $options{import_export_fields_groups} = [
 	[   "identification",
 		[   "code",                      "producer_product_id",
 			"producer_version_id",       "lc",
-			"product_name",              "generic_name",
+			"product_name",              "abbreviated_product_name",
+			"generic_name",
 			"quantity_value_unit",       "net_weight_value_unit",
 			"drained_weight_value_unit", "volume_value_unit",
 			"serving_size_value_unit",   "packaging",
@@ -764,6 +766,7 @@ $options{import_export_fields_importance} = {
 	code => "mandatory",
 	lc => "mandatory",
 	product_name => "mandatory",
+	abbreviated_product_name => "optional",
 	generic_name => "recommended",
 	quantity => "mandatory",
 	serving_size => "recommended",

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -653,7 +653,7 @@ EMAIL
 
 		my @param_fields = ();
 
-		foreach my $field ('owner', 'lc', 'lang', 'product_name', 'generic_name', 'packaging_text',
+		foreach my $field ('owner', 'lc', 'lang', 'product_name', 'abbreviated_product_name', 'generic_name', 'packaging_text',
 			@ProductOpener::Config::product_fields, @ProductOpener::Config::product_other_fields,
 			'obsolete', 'obsolete_since_date',
 			'no_nutrition_data', 'nutrition_data_per', 'nutrition_data_prepared_per', 'serving_size', 'allergens', 'traces', 'ingredients_text', 'data_sources', 'imports') {

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -1366,6 +1366,18 @@ EMAIL
 				compute_nutrient_levels($product_ref);
 
 				compute_unknown_nutrients($product_ref);
+				
+				# Until we provide an interface to directly change the packaging data structure
+				# erase it before reconstructing it
+				# (otherwise there is no way to remove incorrect entries)
+				$product_ref->{packagings} = [];	
+				
+				analyze_and_combine_packaging_data($product_ref);
+				
+				if ((defined $options{product_type}) and ($options{product_type} eq "food")) {
+					compute_ecoscore($product_ref);
+					compute_forest_footprint($product_ref);
+				}				
 
 				ProductOpener::DataQuality::check_quality($product_ref);
 

--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -873,15 +873,19 @@ sub clean_fields($) {
 			$product_ref->{$field} =~ s/\s?(;|( \/ )|\n)+\s?/, /g;
 		}
 
-
-		# Lowercase fields in ALL CAPS
-		if ($field =~ /^(ingredients_text|product_name|generic_name|brands)/) {
+		if ($field =~ /^(ingredients_text|product_name|abbreviated_product_name|generic_name|brands)/) {
+			
+			# Lowercase fields in ALL CAPS
+			
 			if (($product_ref->{$field} =~ /[A-Z]{4}/)
 				and ($product_ref->{$field} !~ /[a-z]/)
 				) {
 				$product_ref->{$field} = ucfirst(lc($product_ref->{$field}));
 				$log->debug("clean_fields - after lowercase", { field=>$field, value=>$product_ref->{$field} }) if $log->is_debug();
 			}
+			
+			# Remove fields with "0" or "-"
+			$product_ref->{$field} =~ s/^( |0|-|\.|\/)+$//;
 		}
 
 

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -472,6 +472,10 @@ sub convert_file($$$$) {
 sub normalize_column_name($) {
 
 	my $name = shift;
+	
+	# remove HTML tags
+	
+	$name =~ s/<(([^>]|\n)*)>//g;
 
 	# non-alpha chars will be turned to -, change the ones we want to keep
 
@@ -497,7 +501,7 @@ sub normalize_column_name($) {
 
 	# fr
 	$name =~ s/^(teneur|taux) (en |de |d')?//i;
-	$name =~ s/^dont //i;
+	$name =~ s/^(dont|soit) //i;
 	$name =~ s/ en / /i;
 
 	$name =~ s/pourcentage/percent/i;
@@ -556,9 +560,11 @@ fr => {
 	code => ["code barre", "codebarre", "codes barres", "code barre EAN/GTIN", "code barre EAN", "code barre GTIN"],
 	producer_product_id => ["code interne", "code int"],
 	categories => ["Catégorie(s)"],
+	brands => ["Marque(s)", "libellé marque"],
 	product_name_fr => ["nom", "nom produit", "nom du produit", "produit", "nom commercial", "dénomination", "dénomination commerciale", "libellé", "désignation"],
+	abbreviated_product_name_fr => ["nom abrégé", "nom du produit abrégé", "nom du produit avec abbréviations"],
 	generic_name_fr => ["dénomination légale", "déno légale", "dénomination légale de vente"],
-	ingredients_text_fr => ["ingrédients", "ingredient", "liste des ingrédients", "liste d'ingrédients", "liste ingrédients"],
+	ingredients_text_fr => ["ingrédients", "ingredient", "liste des ingrédients", "liste d'ingrédients", "liste ingrédients", "listes d'ingrédients"],
 	allergens => ["Substances ou produits provoquant des allergies ou intolérances", "Allergènes et Traces Potentielles", "allergènes et traces"],
 	traces => ["Traces éventuelles"],
 	image_front_url_fr => ["visuel", "photo", "photo produit"],
@@ -574,6 +580,7 @@ fr => {
 	link => ["lien", "lien du produit", "lien internet", "lien vers la page internet"],
 	manufacturing_places => ["lieu de conditionnement", "lieux de conditionnement", "lieu de fabrication", "lieux du fabrication", "lieu de fabrication du produit"],
 	nutriscore_grade_producer => ["note nutri-score", "note nutriscore", "lettre nutri-score", "lettre nutriscore"],
+	nutriscore_score_producer => ["score nutri-score", "score nutritionnel"],
 	emb_codes => ["estampilles sanitaires / localisation", "codes emballeurs / localisation"],
 	lc => ["langue", "langue du produit"],
 	obsolete => ["Le produit n'est plus en vente."],
@@ -1177,6 +1184,10 @@ sub init_columns_fields_match($$) {
 				and ($columns_fields_ref->{$column}{numbers}) and (not $columns_fields_ref->{$column}{letters}) and (not $columns_fields_ref->{$column}{both})) {
 				$columns_fields_ref->{$column}{field} = "nutriscore_score_producer";
 			}
+			if (($columns_fields_ref->{$column}{field} eq "nutriscore_score_producer")
+				and ($columns_fields_ref->{$column}{numbers}) and (not $columns_fields_ref->{$column}{numbers}) and (not $columns_fields_ref->{$column}{both})) {
+				$columns_fields_ref->{$column}{field} = "nutriscore_grade_producer";
+			}			
 		}
 
 		delete $columns_fields_ref->{$column}{existing_examples};

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -2160,6 +2160,12 @@ sub product_name_brand($) {
 	elsif ((defined $ref->{product_name}) and ($ref->{product_name} ne '')) {
 		$full_name = $ref->{product_name};
 	}
+	elsif ((defined $ref->{"abbreviated_product_name_$lc"}) and ($ref->{"abbreviated_product_name_$lc"} ne '')) {
+		$full_name = $ref->{"abbreviated_product_name_$lc"};
+	}
+	elsif ((defined $ref->{abbreviated_product_name}) and ($ref->{abbreviated_product_name} ne '')) {
+		$full_name = $ref->{abbreviated_product_name};
+	}
 
 	if (defined $ref->{brands}) {
 		my $brand = $ref->{brands};

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5269,3 +5269,11 @@ msgstr ""
 msgctxt "not_applicable"
 msgid "Not applicable"
 msgstr ""
+
+msgctxt "abbreviated_product_name"
+msgid "Abbreviated product name"
+msgstr "Abbreviated product name"
+
+msgctxt "abbreviated_product_name_note"
+msgid "Product name with abbreviations shown on receipts"
+msgstr "Product name with abbreviations shown on receipts"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5298,3 +5298,10 @@ msgctxt "not_applicable"
 msgid "Not applicable"
 msgstr "Not applicable"
 
+msgctxt "abbreviated_product_name"
+msgid "Abbreviated product name"
+msgstr "Abbreviated product name"
+
+msgctxt "abbreviated_product_name_note"
+msgid "Product name with abbreviations shown on receipts"
+msgstr "Product name with abbreviations shown on receipts"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5140,3 +5140,11 @@ msgstr "%d produits par page"
 msgctxt "not_applicable"
 msgid "Not applicable"
 msgstr "Non applicable"
+
+msgctxt "abbreviated_product_name"
+msgid "Abbreviated product name"
+msgstr "Nom abrégé du produit"
+
+msgctxt "abbreviated_product_name_note"
+msgid "Product name with abbreviations shown on receipts"
+msgstr "Nom du produit avec des abbréviations figurant sur les tickets de caisse"


### PR DESCRIPTION
- add an abbreviated_product_name language field as a lot of producers send us the identifier that is found on receipts.
e.g.

BQ 2X75g +20%OFT.LARDON CND FUME LG
BQ 2 ESC. FINES PLT S/ATM (GAUL)

- use this field as the display field if we don't have a full non abbreviated product name