### PR TITLE
add misc tags for ecoscore

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -494,9 +494,11 @@ sub compute_ecoscore($) {
 		if ($missing_data_warning) {
 			$product_ref->{ecoscore_data}{missing_data_warning} = 1;
 			add_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
+			remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
 		}
 		else {
 			remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
+			add_tag($product_ref,"misc","en:ecoscore-no-missing-data");
 		}
 		
 		add_tag($product_ref,"misc","en:ecoscore-computed");
@@ -512,6 +514,7 @@ sub compute_ecoscore($) {
 		add_tag($product_ref,"misc","en:ecoscore-not-computed");
 		remove_tag($product_ref,"misc","en:ecoscore-computed");
 		remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
+		remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
 	}
 }
 

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -493,7 +493,14 @@ sub compute_ecoscore($) {
 		
 		if ($missing_data_warning) {
 			$product_ref->{ecoscore_data}{missing_data_warning} = 1;
+			add_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
 		}
+		else {
+			remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
+		}
+		
+		add_tag($product_ref,"misc","en:ecoscore-computed");
+		remove_tag($product_ref,"misc","en:ecoscore-not-computed");		
 	}
 	else {
 		# No AgriBalyse category match
@@ -501,6 +508,10 @@ sub compute_ecoscore($) {
 		$product_ref->{ecoscore_data}{status} = "unknown";
 		$product_ref->{ecoscore_tags} = ["unknown"];
 		$product_ref->{ecoscore_grade} = "unknown";
+		
+		add_tag($product_ref,"misc","en:ecoscore-not-computed");
+		remove_tag($product_ref,"misc","en:ecoscore-computed");
+		remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
 	}
 }
 

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -50,6 +50,9 @@
       "unknown"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-not-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -80,6 +80,10 @@
       "en:roundtable-on-sustainable-palm-oil"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -80,6 +80,10 @@
       "en:palm-oil"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -74,6 +74,10 @@
       "d"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -74,6 +74,10 @@
       "c"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -80,6 +80,10 @@
       "fr:ab-agriculture-biologique"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -150,6 +150,10 @@
    "ingredients_text" : "60% apricots, 30% cane sugar (Martinique), lemon juice",
    "known_ingredients_n" : 6,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -145,6 +145,10 @@
    "ingredients_text" : "60% apricots, 30% cane sugar (Martinique), lemon juice",
    "known_ingredients_n" : 6,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -216,6 +216,10 @@
    "ingredients_text" : "Milk, chocolate (cocoa, cocoa butter, sweetener: aspartame), salt",
    "known_ingredients_n" : 8,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -156,6 +156,10 @@
    "ingredients_text" : "Milk, salt, coloring: E160b",
    "known_ingredients_n" : 5,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -142,6 +142,10 @@
    "ingredients_text" : "60% apricots, 30% cane sugar, lemon juice",
    "known_ingredients_n" : 6,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -145,6 +145,10 @@
    "ingredients_text" : "60% apricots (France), 30% cane sugar, lemon juice",
    "known_ingredients_n" : 6,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -162,6 +162,10 @@
    "ingredients_text" : "60% apricots (France, Spain), 30% cane sugar (Martinique, Guadeloupe, Dominican Republic), lemon juice",
    "known_ingredients_n" : 6,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -151,6 +151,10 @@
    "ingredients_text" : "60% apricots (France), 30% cane sugar (Martinique), lemon juice (Italy)",
    "known_ingredients_n" : 6,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -111,6 +111,10 @@
    "ingredients_text" : "Milk (origin: Milky way)",
    "known_ingredients_n" : 2,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -108,6 +108,10 @@
    "ingredients_text" : "Milk",
    "known_ingredients_n" : 2,
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -90,6 +90,10 @@
       "a"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packaging_text" : "1 cardboard box, 1 plastic film wrap, 6 33cl steel beverage cans",
    "packagings" : [
       {

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -73,6 +73,10 @@
       "a"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packaging_text" : "PET bottle",
    "packagings" : [
       {

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -72,6 +72,10 @@
       "a"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packaging_text" : "Plastic bottle",
    "packagings" : [
       {

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -74,6 +74,10 @@
       "a"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packaging_text" : "bottle",
    "packagings" : [
       {

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -74,6 +74,10 @@
       "a"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
    "packaging_text" : "can",
    "packagings" : [
       {

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -53,6 +53,9 @@
       "unknown"
    ],
    "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-not-computed"
+   ],
    "packagings" : [
       {
          "material" : "en:unknown",


### PR DESCRIPTION
needs ?nocache=1 at the end of the URL, or results will be from the small product collection generated every night


en:ecoscore-computed | 58 | *
en:ecoscore-missing-data-warning | 57 | *
en:ecoscore-not-computed | 33 | *


![image](https://user-images.githubusercontent.com/8158668/103662517-566f5380-4f70-11eb-838b-107d20911910.png)

https://mq.openfoodfacts.dev/misc?nocache=1