### PR TITLE
removed incorrect Russian translation in categories.txt

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -4036,7 +4036,6 @@ hu:Szénsavas gyümölcs ital, gyümölcs fröccs
 it:Bibite gassate alla frutta, Bibite gassate al gusto di frutta
 nl:Vruchtenfrisdranken
 ro:Băuturi carbogazoase cu fructe, Bauturi carbogazoase cu fructe, Băuturi carbogazoase din fructe, Bauturi carbogazoase din fructe
-ru:Напитки на основе фруктов
 zh:水果汽水
 
 <en:Diet sodas


### PR DESCRIPTION
see issue "en:Fruit sodas" category is incorrectly translated as "ru:Напитки на основе фруктов" #3892