### PR TITLE
make save button green in product edit form

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -2192,7 +2192,7 @@ JS
 		<input id="comment" name="comment" placeholder="$Lang{edit_comment}{$lang}" value="" type="text" class="text" />
 	</div>
 	<div class="small-6 medium-6 large-2 xlarge-2 columns">
-		<button type="submit" name=".submit" class="button postfix small">
+		<button type="submit" name=".submit" class="button postfix small success">
 			@{[ display_icon('check') ]} $Lang{save}{$lc}
 		</button>
 	</div>
@@ -2211,7 +2211,7 @@ HTML
 <div class="small-12 medium-12 large-8 xlarge-10 columns">
 </div>
 <div class="small-12 medium-12 large-4 xlarge-2 columns">
-<input type="submit" name=".submit" value="$Lang{save}{$lc}" class="button small">
+<input type="submit" name=".submit" value="$Lang{save}{$lc}" class="button small success">
 </div>
 </div>
 HTML


### PR DESCRIPTION
Suggestion from @CharlesNepote in https://github.com/openfoodfacts/openfoodfacts-server/pull/4777#issuecomment-764697968

"Small suggestion: all buttons are blue but this can lead to confusion. For example, I often click on "Save" instead of "Validate and/or resize image" because there are not far from each other (see below)... Maybe the "non-return" buttons should be different ("Save", "Erase something", "Delete product", etc.)."

![image](https://user-images.githubusercontent.com/8158668/105480576-3943c000-5ca6-11eb-827c-5421dbcfb20c.png)
