### PR TITLE
Imports - Load data needed for packaging and ecoscore, fixes #4791

### DIFF
--- a/scripts/minion_producers.pl
+++ b/scripts/minion_producers.pl
@@ -25,6 +25,12 @@ use utf8;
 
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Producers qw/:all/;
+use ProductOpener::Tags qw/:all/;
+use ProductOpener::Food qw/:all/;
+use ProductOpener::Nutriscore qw/:all/;
+use ProductOpener::Ecoscore qw/:all/;
+use ProductOpener::Packaging qw/:all/;
+use ProductOpener::ForestFootprint qw/:all/;
 
 use Log::Any qw($log);
 use Log::Log4perl;
@@ -40,6 +46,17 @@ use Minion;
 
 $log->info("starting minion producers workers", { minion_backend => $server_options{minion_backend} }) if $log->is_info();
 
+# load large data files into mod_perl memory
+init_emb_codes();
+init_packager_codes();
+init_geocode_addresses();
+init_packaging_taxonomies_regexps();
+
+if ((defined $options{product_type}) and ($options{product_type} eq "food")) {
+	load_agribalyse_data();
+	load_ecoscore_data();
+	load_forest_footprint_data();
+}
 
 if (not defined $server_options{minion_backend}) {
 


### PR DESCRIPTION
The minion processes that process imports did not load all the data needed to process packagings and the Eco-Score, and it was causing issues.

fixes #4791