### PR TITLE
ecoscore fixes : orange juice, coffee/tea/chocolate

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -640,6 +640,12 @@ sub compute_ecoscore_agribalyse($) {
 				$product_ref->{ecoscore_data}{agribalyse}{is_beverage} = 0;
 				$product_ref->{ecoscore_data}{agribalyse}{score} = -15 * log($agribalyse{$agb}{ef_total} * $agribalyse{$agb}{ef_total} * (1000 * 1000 / 100) + 220 ) + 180;			
 			}
+			if ($product_ref->{ecoscore_data}{agribalyse}{score} < 0) {
+				$product_ref->{ecoscore_data}{agribalyse}{score} = 0;
+			}
+			elsif ($product_ref->{ecoscore_data}{agribalyse}{score} > 100) {
+				$product_ref->{ecoscore_data}{agribalyse}{score} = 100;
+			}
 		}
 	}
 	else {

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -56,40 +56,40 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_food_code" : "2013",
-         "co2_agriculture" : "0.40923055",
+         "agribalyse_proxy_food_code" : "2011",
+         "co2_agriculture" : "0.22282021",
          "co2_consumption" : "0.0047993021",
          "co2_distribution" : "0.028932423",
-         "co2_packaging" : "0.098786634",
-         "co2_processing" : "0.10433272",
-         "co2_total" : "1.0328872",
-         "co2_transportation" : "0.38680556",
-         "code" : "2013",
-         "dqr" : "2.27",
-         "ef_agriculture" : "0.18761485",
+         "co2_packaging" : "0.17256359",
+         "co2_processing" : "0.036217",
+         "co2_total" : "0.80120163",
+         "co2_transportation" : "0.33586911",
+         "code" : "2011",
+         "dqr" : "3.68",
+         "ef_agriculture" : "0.08590882100000001",
          "ef_consumption" : "0.0024293397",
          "ef_distribution" : "0.0088128735",
-         "ef_packaging" : "0.014974093",
-         "ef_processing" : "0.019422825",
-         "ef_total" : 0.26561763,
-         "ef_transportation" : "0.032363646999999995",
+         "ef_packaging" : "0.014792145999999999",
+         "ef_processing" : "0.0056288216",
+         "ef_total" : 0.14687612,
+         "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
-         "name_en" : "Orange juice, home-made",
-         "name_fr" : "Jus d'orange, maison",
-         "score" : 30.6085411096605
+         "name_en" : "Mixed fruits juice, orange based, multivitamin",
+         "name_fr" : "Jus multifruit - base orange, multivitaminé",
+         "score" : 50.8966311728851
       },
-      "grade" : "d",
+      "grade" : "c",
       "missing" : {
          "origins" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 21.2835411096606,
+      "score" : 41.5716311728851,
       "status" : "known"
    },
-   "ecoscore_grade" : "d",
-   "ecoscore_score" : 21.2835411096606,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 41.5716311728851,
    "ecoscore_tags" : [
-      "d"
+      "c"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -39,40 +39,40 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_food_code" : "2013",
-         "co2_agriculture" : "0.40923055",
+         "agribalyse_proxy_food_code" : "2011",
+         "co2_agriculture" : "0.22282021",
          "co2_consumption" : "0.0047993021",
          "co2_distribution" : "0.028932423",
-         "co2_packaging" : "0.098786634",
-         "co2_processing" : "0.10433272",
-         "co2_total" : "1.0328872",
-         "co2_transportation" : "0.38680556",
-         "code" : "2013",
-         "dqr" : "2.27",
-         "ef_agriculture" : "0.18761485",
+         "co2_packaging" : "0.17256359",
+         "co2_processing" : "0.036217",
+         "co2_total" : "0.80120163",
+         "co2_transportation" : "0.33586911",
+         "code" : "2011",
+         "dqr" : "3.68",
+         "ef_agriculture" : "0.08590882100000001",
          "ef_consumption" : "0.0024293397",
          "ef_distribution" : "0.0088128735",
-         "ef_packaging" : "0.014974093",
-         "ef_processing" : "0.019422825",
-         "ef_total" : 0.26561763,
-         "ef_transportation" : "0.032363646999999995",
+         "ef_packaging" : "0.014792145999999999",
+         "ef_processing" : "0.0056288216",
+         "ef_total" : 0.14687612,
+         "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
-         "name_en" : "Orange juice, home-made",
-         "name_fr" : "Jus d'orange, maison",
-         "score" : 30.6085411096605
+         "name_en" : "Mixed fruits juice, orange based, multivitamin",
+         "name_fr" : "Jus multifruit - base orange, multivitaminé",
+         "score" : 50.8966311728851
       },
-      "grade" : "d",
+      "grade" : "c",
       "missing" : {
          "origins" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 20.6085411096605,
+      "score" : 40.8966311728851,
       "status" : "known"
    },
-   "ecoscore_grade" : "d",
-   "ecoscore_score" : 20.6085411096605,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 40.8966311728851,
    "ecoscore_tags" : [
-      "d"
+      "c"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -38,40 +38,40 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_food_code" : "2013",
-         "co2_agriculture" : "0.40923055",
+         "agribalyse_proxy_food_code" : "2011",
+         "co2_agriculture" : "0.22282021",
          "co2_consumption" : "0.0047993021",
          "co2_distribution" : "0.028932423",
-         "co2_packaging" : "0.098786634",
-         "co2_processing" : "0.10433272",
-         "co2_total" : "1.0328872",
-         "co2_transportation" : "0.38680556",
-         "code" : "2013",
-         "dqr" : "2.27",
-         "ef_agriculture" : "0.18761485",
+         "co2_packaging" : "0.17256359",
+         "co2_processing" : "0.036217",
+         "co2_total" : "0.80120163",
+         "co2_transportation" : "0.33586911",
+         "code" : "2011",
+         "dqr" : "3.68",
+         "ef_agriculture" : "0.08590882100000001",
          "ef_consumption" : "0.0024293397",
          "ef_distribution" : "0.0088128735",
-         "ef_packaging" : "0.014974093",
-         "ef_processing" : "0.019422825",
-         "ef_total" : 0.26561763,
-         "ef_transportation" : "0.032363646999999995",
+         "ef_packaging" : "0.014792145999999999",
+         "ef_processing" : "0.0056288216",
+         "ef_total" : 0.14687612,
+         "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
-         "name_en" : "Orange juice, home-made",
-         "name_fr" : "Jus d'orange, maison",
-         "score" : 30.6085411096605
+         "name_en" : "Mixed fruits juice, orange based, multivitamin",
+         "name_fr" : "Jus multifruit - base orange, multivitaminé",
+         "score" : 50.8966311728851
       },
-      "grade" : "e",
+      "grade" : "d",
       "missing" : {
          "origins" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 15.6085411096605,
+      "score" : 35.8966311728851,
       "status" : "known"
    },
-   "ecoscore_grade" : "e",
-   "ecoscore_score" : 15.6085411096605,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 35.8966311728851,
    "ecoscore_tags" : [
-      "e"
+      "d"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -39,41 +39,41 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_food_code" : "2013",
-         "co2_agriculture" : "0.40923055",
+         "agribalyse_proxy_food_code" : "2011",
+         "co2_agriculture" : "0.22282021",
          "co2_consumption" : "0.0047993021",
          "co2_distribution" : "0.028932423",
-         "co2_packaging" : "0.098786634",
-         "co2_processing" : "0.10433272",
-         "co2_total" : "1.0328872",
-         "co2_transportation" : "0.38680556",
-         "code" : "2013",
-         "dqr" : "2.27",
-         "ef_agriculture" : "0.18761485",
+         "co2_packaging" : "0.17256359",
+         "co2_processing" : "0.036217",
+         "co2_total" : "0.80120163",
+         "co2_transportation" : "0.33586911",
+         "code" : "2011",
+         "dqr" : "3.68",
+         "ef_agriculture" : "0.08590882100000001",
          "ef_consumption" : "0.0024293397",
          "ef_distribution" : "0.0088128735",
-         "ef_packaging" : "0.014974093",
-         "ef_processing" : "0.019422825",
-         "ef_total" : 0.26561763,
-         "ef_transportation" : "0.032363646999999995",
+         "ef_packaging" : "0.014792145999999999",
+         "ef_processing" : "0.0056288216",
+         "ef_total" : 0.14687612,
+         "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
-         "name_en" : "Orange juice, home-made",
-         "name_fr" : "Jus d'orange, maison",
-         "score" : 30.6085411096605
+         "name_en" : "Mixed fruits juice, orange based, multivitamin",
+         "name_fr" : "Jus multifruit - base orange, multivitaminé",
+         "score" : 50.8966311728851
       },
-      "grade" : "e",
+      "grade" : "d",
       "missing" : {
          "origins" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 15.6085411096605,
+      "score" : 35.8966311728851,
       "status" : "known"
    },
-   "ecoscore_grade" : "e",
-   "ecoscore_score" : 15.6085411096605,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 35.8966311728851,
    "ecoscore_tags" : [
-      "e"
+      "d"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -39,41 +39,41 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_food_code" : "2013",
-         "co2_agriculture" : "0.40923055",
+         "agribalyse_proxy_food_code" : "2011",
+         "co2_agriculture" : "0.22282021",
          "co2_consumption" : "0.0047993021",
          "co2_distribution" : "0.028932423",
-         "co2_packaging" : "0.098786634",
-         "co2_processing" : "0.10433272",
-         "co2_total" : "1.0328872",
-         "co2_transportation" : "0.38680556",
-         "code" : "2013",
-         "dqr" : "2.27",
-         "ef_agriculture" : "0.18761485",
+         "co2_packaging" : "0.17256359",
+         "co2_processing" : "0.036217",
+         "co2_total" : "0.80120163",
+         "co2_transportation" : "0.33586911",
+         "code" : "2011",
+         "dqr" : "3.68",
+         "ef_agriculture" : "0.08590882100000001",
          "ef_consumption" : "0.0024293397",
          "ef_distribution" : "0.0088128735",
-         "ef_packaging" : "0.014974093",
-         "ef_processing" : "0.019422825",
-         "ef_total" : 0.26561763,
-         "ef_transportation" : "0.032363646999999995",
+         "ef_packaging" : "0.014792145999999999",
+         "ef_processing" : "0.0056288216",
+         "ef_total" : 0.14687612,
+         "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
-         "name_en" : "Orange juice, home-made",
-         "name_fr" : "Jus d'orange, maison",
-         "score" : 30.6085411096605
+         "name_en" : "Mixed fruits juice, orange based, multivitamin",
+         "name_fr" : "Jus multifruit - base orange, multivitaminé",
+         "score" : 50.8966311728851
       },
-      "grade" : "e",
+      "grade" : "d",
       "missing" : {
          "origins" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 15.6085411096605,
+      "score" : 35.8966311728851,
       "status" : "known"
    },
-   "ecoscore_grade" : "e",
-   "ecoscore_score" : 15.6085411096605,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 35.8966311728851,
    "ecoscore_tags" : [
-      "e"
+      "d"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/taxonomies/categories.result.txt
+++ b/taxonomies/categories.result.txt
@@ -14589,7 +14589,6 @@ ciqual_food_name:fr: Poudre maltée, cacaotée ou au chocolat pour boisson, sucr
 < en:Cocoa powders
 en:Cocoa powder for beverages with sugar, Chocolate powder for beverages with sugar
 fr:Poudre cacaotée pour boisson sucrée, Poudre au chocolat pour boisson sucrée
-agribalyse_food_code:en: 18101
 ciqual_food_code:en: 18101
 ciqual_food_name:en: Cocoa or chocolate powder, for beverages, with sugar
 ciqual_food_name:fr: Poudre cacaotée ou au chocolat pour boisson, sucrée
@@ -14597,7 +14596,6 @@ ciqual_food_name:fr: Poudre cacaotée ou au chocolat pour boisson, sucrée
 < en:Cocoa powders
 en:Cocoa powder for beverages with sugar fortified with vitamins, Chocolate powder for beverages with sugar fortified with vitamins
 fr:Poudre cacaotée pour boisson sucrée enrichie en vitamines, Poudre au chocolat pour boisson sucrée enrichie en vitamines
-agribalyse_food_code:en: 18168
 ciqual_food_code:en: 18168
 ciqual_food_name:en: Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins
 ciqual_food_name:fr: Poudre cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines
@@ -14605,7 +14603,6 @@ ciqual_food_name:fr: Poudre cacaotée ou au chocolat pour boisson, sucrée, enri
 < en:Cocoa powders
 en:Cocoa powder for beverages with sugar fortified with vitamins and chemical elements, Chocolate powder for beverages with sugar fortified with vitamins and chemical elements
 fr:Poudre cacaotée sucrée pour boisson enrichie en vitamines et minéraux, Poudre au chocolat sucrée pour boisson enrichie en vitamines et minéraux
-agribalyse_food_code:en: 18167
 ciqual_food_code:en: 18167
 ciqual_food_name:en: Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins and chemical elements
 ciqual_food_name:fr: Poudre cacaotée ou au chocolat sucrée pour boisson, enrichie en vitamines et minéraux
@@ -27806,13 +27803,13 @@ agribalyse_proxy_food_name:en: Mixed fruits juice, pure juice, multivitamin
 agribalyse_proxy_food_name:fr: Jus multifruit, pur jus, multivitaminé
 
 < en:Fruit juices
-en:Orange juices, Home-made orange juices
+en:Orange juices
 ca:Sucs de taronja
 da:Appelsinjuice
 de:Orangensäfte, Orangensaft
 es:Zumos de naranja, zumos de naranjas, zumo de naranja
 fi:appelsiinimehut
-fr:Jus d'orange, jus d'oranges, Jus d'orange maison, Jus d'oranges maison
+fr:Jus d'orange, jus d'oranges
 he:מיצי תפוזים
 hu:Narancslék
 it:Succo di arancia
@@ -27821,10 +27818,8 @@ pl:Soki pomarańczowe
 pt:Sumos de laranja
 ru:Апельсиновые соки
 zh:橙子汁, 橙汁
-agribalyse_food_code:en: 2013
-ciqual_food_code:en: 2013
-ciqual_food_name:en: Orange juice, home-made
-ciqual_food_name:fr: Jus d'orange, maison
+agribalyse_proxy_food_code:en: 2011
+agribalyse_proxy_food_name:en: Mixed fruits juice, orange based, multivitamin
 wikidata:en: Q1781317
 
 < en:Fruit juices
@@ -33462,10 +33457,6 @@ nl:Mieren
 zh:蚂蚁
 wikidata:en: Q7386
 
-< en:Instant beverages
-en:Ready-to-drink instant cocoa with sugar reconstituted with semi-skimmed milk
-fr:Boisson cacaotée instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé
-
 < en:Cocoa and chocolate powders
 < en:Instant beverages
 en:Chocolate powders, Instant chocolate drinks, Instant hot chocolates
@@ -33477,9 +33468,8 @@ it:Cioccolata in polvere
 nl:Oplospoeder voor chocolademelk, Oploschocoladepoede
 pt:Pós de chocolate
 ro:Ciocolată caldă instant, Pudră de ciocolată
-agribalyse_proxy_food_code:en: 18101
-agribalyse_proxy_food_name:en: Cocoa or chocolate powder, for beverages, with sugar
-agribalyse_proxy_food_name:fr: Poudre cacaotée ou au chocolat pour boisson, sucrée
+agribalyse_food_code:en: 18104
+agribalyse_food_name:en: Instant cocoa or chocolate beverage, with sugar, ready-to-drink -reconstituted with standard semi-skimmed milk-
 
 < en:Coffees
 < en:Instant beverages
@@ -33495,7 +33485,8 @@ nl:Oploskoffies, Oploskoffie
 pt:Cafés instantâneos
 ru:Растворимый кофе, кофе растворимый
 zh:速溶咖啡, 即时咖啡
-agribalyse_food_code:en: 18005
+agribalyse_food_code:en: 18073
+agribalyse_food_name:en: Instant coffee, without sugar, ready-to-drink
 ciqual_food_code:en: 18005
 ciqual_food_name:en: Coffee, powder, instant
 ciqual_food_name:fr: Café, poudre soluble
@@ -33507,7 +33498,8 @@ en:Instant chicory, Instant chicory powder
 fr:Chicorée soluble, chicorée en poudre, Chicorée en poudre soluble
 nl:Oploscichorei
 ru:Цикорий растворимый, растворимый цикорий
-agribalyse_food_code:en: 18152
+agribalyse_food_code:en: 18162
+agribalyse_food_name:en: Mix of chicory and coffee, instant, without sugar, ready-to-drink -reconstituted with water-
 ciqual_food_code:en: 18152
 ciqual_food_name:en: Chicory, powder, instant
 ciqual_food_name:fr: Chicorée, poudre soluble
@@ -33526,7 +33518,8 @@ ciqual_food_name:en: Mix of chicory and coffee, instant, without sugar, ready-to
 < en:Plant-based beverages
 en:Instant mix of chicory and coffee powder
 fr:Chicorée et café en poudre soluble
-agribalyse_food_code:en: 18150
+agribalyse_food_code:en: 18162
+agribalyse_food_name:en: Mix of chicory and coffee, instant, without sugar, ready-to-drink -reconstituted with water-
 ciqual_food_code:en: 18150
 ciqual_food_name:en: Mix of chicory and coffee, powder, instant
 ciqual_food_name:fr: Chicorée et café, poudre soluble
@@ -33548,9 +33541,7 @@ it:Orzo solubile
 en:Sugar free ready-to-drink instant chicory with artificial sweeteners reconstituted with standard semi-skimmed milk
 fr:Chicorée instantanée non sucrée prête à boire reconstituée avec du lait demi-écrémé standard
 agribalyse_food_code:en: 18161
-ciqual_food_code:en: 18161
-ciqual_food_name:en: Instant chicory, without sugar and artificial sweeteners, ready-to-drink -reconstituted with standard semi-skimmed milk-
-ciqual_food_name:fr: Chicorée, instantanée, non sucrée, prête à boire -reconstituée avec du lait demi-écrémé standard-
+agribalyse_food_name:en: Instant chicory, without sugar and artificial sweeteners, ready-to-drink -reconstituted with standard semi-skimmed milk-
 
 < en:Decaffeinated coffees
 < en:Instant coffees
@@ -33561,7 +33552,8 @@ fi:kofeiinittomat pikakahvit
 fr:Cafés en poudre décaféinés, Cafés instantanés décaféinés, Cafés solubles décaféinés, Café décaféiné en poudre soluble
 nl:Cafeïnevrije oploskoffies, Cafeïnevrije oploskoffie
 ru:растворимый кофе без кофеина, декофеинизированный растворимый кофе
-agribalyse_food_code:en: 18069
+agribalyse_food_code:en: 18072
+agribalyse_food_name:en: Decaffeinated instant coffee, without sugar, ready-to-drink
 ciqual_food_code:en: 18069
 ciqual_food_name:en: Decaffeinated coffee, powder, instant
 ciqual_food_name:fr: Café, décaféiné, poudre soluble
@@ -33593,7 +33585,8 @@ ciqual_food_name:fr: Café, instantané, non sucré, prêt à boire
 < en:Instant coffees
 en:Instant powder for cappuccino with chocolate
 fr:Cappuccino au chocolat en poudre soluble
-agribalyse_food_code:en: 18163
+agribalyse_food_code:en: 18151
+agribalyse_food_name:en: Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_code:en: 18163
 ciqual_food_name:en: Coffee with milk or Cappuccino with chocolate, powder, instant
 ciqual_food_name:fr: Café au lait ou cappuccino au chocolat, poudre soluble
@@ -33601,7 +33594,8 @@ ciqual_food_name:fr: Café au lait ou cappuccino au chocolat, poudre soluble
 < en:Instant coffees
 en:Instant powder for coffee with milk
 fr:Café au lait en poudre soluble
-agribalyse_food_code:en: 18163
+agribalyse_food_code:en: 18151
+agribalyse_food_name:en: Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_code:en: 18163
 ciqual_food_name:en: Coffee with milk or Cappuccino with chocolate, powder, instant
 ciqual_food_name:fr: Café au lait ou cappuccino au chocolat, poudre soluble
@@ -33614,7 +33608,8 @@ fi:Cappuccino-pikakahvit
 fr:Cappuccino en poudre, Cappuccino en poudre soluble
 it:Cappuccino in polvere
 nl:Cappucinopoeders, Cappucinopoeder
-agribalyse_food_code:en: 18160
+agribalyse_food_code:en: 18151
+agribalyse_food_name:en: Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_code:en: 18160
 ciqual_food_name:en: Coffee with milk or Cappuccino, powder, instant
 ciqual_food_name:fr: Café au lait ou cappuccino, poudre soluble
@@ -46443,6 +46438,8 @@ it:Tisane, Infusi
 nl:Kruidentheeën, Kruidenthee
 pt:Chás de ervas, infusões de ervas, infusões
 ru:Травяные чаи и настойки
+agribalyse_proxy_food_code:en: 18020
+agribalyse_proxy_food_name:en: Tea, brewed, without sugar
 wikidata:en: Q379932
 
 < en:Hot beverages
@@ -51754,22 +51751,6 @@ agribalyse_food_code:en: 26031
 ciqual_food_code:en: 26031
 ciqual_food_name:en: Ray, roasted/baked
 ciqual_food_name:fr: Raie, rôtie/cuite au four
-
-< en:Ready-to-drink instant cocoa with sugar reconstituted with semi-skimmed milk
-en:Ready-to-drink instant cocoa with sugar fortified with vitamins and chemical elements reconstituted with standard semi-skimmed milk, Ready-to-drink instant chocolate beverage with sugar fortified with vitamins and chemical elements reconstituted with standard semi-skimmed milk
-fr:Boisson cacaotée instantanée sucrée enrichie en vitamines prête à boire reconstituée avec du lait demi-écrémé, Boisson au chocolat instantanée sucrée enrichie en vitamines prête à boire reconstituée avec du lait demi-écrémé
-agribalyse_food_code:en: 18106
-ciqual_food_code:en: 18106
-ciqual_food_name:en: Instant cocoa or chocolate beverage, with sugar, fortified with vitamins and chemical elements, ready-to-drink -reconstituted with standard semi-skimm
-ciqual_food_name:fr: Boisson cacaotée ou au chocolat, instantanée, sucrée, enrichie en vitamines, prête à boire -reconstituée avec du lait demi-écrémé standard-
-
-< en:Ready-to-drink instant cocoa with sugar reconstituted with semi-skimmed milk
-en:Ready-to-drink instant cocoa with sugar reconstituted with standard semi-skimmed milk, Ready-to-drink instant chocolate beverage with sugar reconstituted with standard semi-skimmed milk
-fr:Boisson cacaotée instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé standard, Boisson au chocolat instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé standard
-agribalyse_food_code:en: 18104
-ciqual_food_code:en: 18104
-ciqual_food_name:en: Instant cocoa or chocolate beverage, with sugar, ready-to-drink -reconstituted with standard semi-skimmed milk-
-ciqual_food_name:fr: Boisson cacaotée ou au chocolat, instantanée, sucrée, prête à boire -reconstituée avec du lait demi-écrémé standard-
 
 < en:Ready to feed baby milks
 en:Ready to feed baby first milk

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -4911,13 +4911,13 @@ fi:puristetut monihedelmämehut
 nl:Verse Multivruchtensappen, Verse Multivruchtensap
 
 <en:Fruit juices
-en:Orange juices, Home-made orange juices
+en:Orange juices
 ca:Sucs de taronja
 da:Appelsinjuice
 de:Orangensäfte, Orangensaft
 es:Zumos de naranja, zumos de naranjas, zumo de naranja
 fi:appelsiinimehut
-fr:Jus d'orange, jus d'oranges, Jus d'orange maison, Jus d'oranges maison
+fr:Jus d'orange, jus d'oranges
 he:מיצי תפוזים
 hu:Narancslék
 it:Succo di arancia
@@ -4927,10 +4927,9 @@ pt:Sumos de laranja
 ru:Апельсиновые соки
 zh:橙子汁, 橙汁
 wikidata:en:Q1781317
-agribalyse_food_code:en:2013
-ciqual_food_code:en:2013
-ciqual_food_name:en:Orange juice, home-made
-ciqual_food_name:fr:Jus d'orange, maison
+agribalyse_proxy_food_code:en:2011
+agribalyse_proxy_food_name:en:Mixed fruits juice, orange based, multivitamin
+# Note: do not put the Agribalyse for home made orange juice, it is not relevant for industrial orange juice.
 
 <en:Orange juices
 en:Blood orange juices
@@ -5633,6 +5632,8 @@ nl:Kruidentheeën, Kruidenthee
 pt:Chás de ervas, infusões de ervas, infusões
 ru:Травяные чаи и настойки
 wikidata:en:Q379932
+agribalyse_proxy_food_code:en:18020
+agribalyse_proxy_food_name:en:Tea, brewed, without sugar
 
 <en:Herbal teas
 en:Herbal teas in tea bags, Herbal teas in bags
@@ -7011,10 +7012,12 @@ pt:Cafés instantâneos
 ru:Растворимый кофе, кофе растворимый
 zh:速溶咖啡, 即时咖啡
 wikidata:en:Q858049
-agribalyse_food_code:en:18005
+agribalyse_food_code:en:18073
+agribalyse_food_name:en:Instant coffee, without sugar, ready-to-drink
 ciqual_food_code:en:18005
 ciqual_food_name:en:Coffee, powder, instant
 ciqual_food_name:fr:Café, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Coffees
 en:Coffee without sugar
@@ -7093,10 +7096,12 @@ fi:kofeiinittomat pikakahvit
 fr:Cafés en poudre décaféinés, Cafés instantanés décaféinés, Cafés solubles décaféinés, Café décaféiné en poudre soluble
 nl:Cafeïnevrije oploskoffies, Cafeïnevrije oploskoffie
 ru:растворимый кофе без кофеина, декофеинизированный растворимый кофе
-agribalyse_food_code:en:18069
+agribalyse_food_code:en:18072
+agribalyse_food_name:en:Decaffeinated instant coffee, without sugar, ready-to-drink
 ciqual_food_code:en:18069
 ciqual_food_name:en:Decaffeinated coffee, powder, instant
 ciqual_food_name:fr:Café, décaféiné, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Instant coffees
 <en:Decaffeinated coffees
@@ -7126,18 +7131,22 @@ ciqual_food_name:fr:Café, instantané, non sucré, prêt à boire
 <en:Instant coffees
 en:Instant powder for cappuccino with chocolate
 fr:Cappuccino au chocolat en poudre soluble
-agribalyse_food_code:en:18163
+agribalyse_food_code:en:18151
+agribalyse_food_name:en:Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_code:en:18163
 ciqual_food_name:en:Coffee with milk or Cappuccino with chocolate, powder, instant
 ciqual_food_name:fr:Café au lait ou cappuccino au chocolat, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Instant coffees
 en:Instant powder for coffee with milk
 fr:Café au lait en poudre soluble
-agribalyse_food_code:en:18163
+agribalyse_food_code:en:18151
+agribalyse_food_name:en:Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_code:en:18163
 ciqual_food_name:en:Coffee with milk or Cappuccino with chocolate, powder, instant
 ciqual_food_name:fr:Café au lait ou cappuccino au chocolat, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Instant coffees
 en:Powdered cappucino, Instant powder for cappuccino
@@ -7147,10 +7156,12 @@ fi:Cappuccino-pikakahvit
 fr:Cappuccino en poudre, Cappuccino en poudre soluble
 it:Cappuccino in polvere
 nl:Cappucinopoeders, Cappucinopoeder
-agribalyse_food_code:en:18160
+agribalyse_food_code:en:18151
+agribalyse_food_name:en:Coffee with milk or white coffee or cappuccino, instant coffee or not, without sugar, ready-to-drink
 ciqual_food_code:en:18160
 ciqual_food_name:en:Coffee with milk or Cappuccino, powder, instant
 ciqual_food_name:fr:Café au lait ou cappuccino, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 #I don't know if натуральный (natural) makes any difference; most coffees have that anyway.
 <en:Freeze-dried plant-based foods
@@ -7166,27 +7177,30 @@ en:Instant chicory, Instant chicory powder
 fr:Chicorée soluble, chicorée en poudre, Chicorée en poudre soluble
 nl:Oploscichorei
 ru:Цикорий растворимый, растворимый цикорий
-agribalyse_food_code:en:18152
+agribalyse_food_code:en:18162
+agribalyse_food_name:en:Mix of chicory and coffee, instant, without sugar, ready-to-drink (reconstituted with water)
 ciqual_food_code:en:18152
 ciqual_food_name:en:Chicory, powder, instant
 ciqual_food_name:fr:Chicorée, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Instant beverages
 <en:Plant-based beverages
 en:Instant mix of chicory and coffee powder
 fr:Chicorée et café en poudre soluble
-agribalyse_food_code:en:18150
+agribalyse_food_code:en:18162
+agribalyse_food_name:en:Mix of chicory and coffee, instant, without sugar, ready-to-drink (reconstituted with water)
 ciqual_food_code:en:18150
 ciqual_food_name:en:Mix of chicory and coffee, powder, instant
 ciqual_food_name:fr:Chicorée et café, poudre soluble
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Instant chicory
 en:Sugar free ready-to-drink instant chicory with artificial sweeteners reconstituted with standard semi-skimmed milk
 fr:Chicorée instantanée non sucrée prête à boire reconstituée avec du lait demi-écrémé standard
 agribalyse_food_code:en:18161
-ciqual_food_code:en:18161
-ciqual_food_name:en:Instant chicory, without sugar and artificial sweeteners, ready-to-drink (reconstituted with standard semi-skimmed milk)
-ciqual_food_name:fr:Chicorée, instantanée, non sucrée, prête à boire (reconstituée avec du lait demi-écrémé standard)
+agribalyse_food_name:en:Instant chicory, without sugar and artificial sweeteners, ready-to-drink (reconstituted with standard semi-skimmed milk)
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Instant beverages
 <en:Plant-based beverages
@@ -25337,9 +25351,9 @@ it:Cioccolata in polvere
 nl:Oplospoeder voor chocolademelk, Oploschocoladepoede
 pt:Pós de chocolate
 ro:Ciocolată caldă instant, Pudră de ciocolată
-agribalyse_proxy_food_code:en:18101
-agribalyse_proxy_food_name:en:Cocoa or chocolate powder, for beverages, with sugar
-agribalyse_proxy_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée
+agribalyse_food_code:en:18104
+agribalyse_food_name:en:Instant cocoa or chocolate beverage, with sugar, ready-to-drink (reconstituted with standard semi-skimmed milk)
+# we need to associate the agribalyse category for the reconstituted product
 
 <en:Cocoa and chocolate powders
 en:Cocoa powders
@@ -25348,7 +25362,6 @@ fr:Poudres cacaotées
 <en:Cocoa powders
 en:Cocoa powder for beverages with sugar, Chocolate powder for beverages with sugar
 fr:Poudre cacaotée pour boisson sucrée, Poudre au chocolat pour boisson sucrée
-agribalyse_food_code:en:18101
 ciqual_food_code:en:18101
 ciqual_food_name:en:Cocoa or chocolate powder, for beverages, with sugar
 ciqual_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée
@@ -25356,7 +25369,6 @@ ciqual_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée
 <en:Cocoa powders
 en:Cocoa powder for beverages with sugar fortified with vitamins and chemical elements, Chocolate powder for beverages with sugar fortified with vitamins and chemical elements
 fr:Poudre cacaotée sucrée pour boisson enrichie en vitamines et minéraux, Poudre au chocolat sucrée pour boisson enrichie en vitamines et minéraux
-agribalyse_food_code:en:18167
 ciqual_food_code:en:18167
 ciqual_food_name:en:Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins and chemical elements
 ciqual_food_name:fr:Poudre cacaotée ou au chocolat sucrée pour boisson, enrichie en vitamines et minéraux
@@ -25364,7 +25376,6 @@ ciqual_food_name:fr:Poudre cacaotée ou au chocolat sucrée pour boisson, enrich
 <en:Cocoa powders
 en:Cocoa powder for beverages with sugar fortified with vitamins, Chocolate powder for beverages with sugar fortified with vitamins
 fr:Poudre cacaotée pour boisson sucrée enrichie en vitamines, Poudre au chocolat pour boisson sucrée enrichie en vitamines
-agribalyse_food_code:en:18168
 ciqual_food_code:en:18168
 ciqual_food_name:en:Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins
 ciqual_food_name:fr:Poudre cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines
@@ -25376,28 +25387,6 @@ fr:Poudre maltée cacaotée, Poudre maltée cacaotée sucrée pour boisson enric
 ciqual_food_code:en:18102
 ciqual_food_name:en:Malted cocoa or chocolate powder for beverage, with sugar
 ciqual_food_name:fr:Poudre maltée, cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines et minéraux
-
-#TODO Nesquik 
-<en:Instant beverages
-en:Ready-to-drink instant cocoa with sugar reconstituted with semi-skimmed milk
-fr:Boisson cacaotée instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé
-
-<en:Ready-to-drink instant cocoa with sugar reconstituted with semi-skimmed milk
-en:Ready-to-drink instant cocoa with sugar reconstituted with standard semi-skimmed milk, Ready-to-drink instant chocolate beverage with sugar reconstituted with standard semi-skimmed milk
-fr:Boisson cacaotée instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé standard, Boisson au chocolat instantanée sucrée prête à boire reconstituée avec du lait demi-écrémé standard
-agribalyse_food_code:en:18104
-ciqual_food_code:en:18104
-ciqual_food_name:en:Instant cocoa or chocolate beverage, with sugar, ready-to-drink (reconstituted with standard semi-skimmed milk)
-ciqual_food_name:fr:Boisson cacaotée ou au chocolat, instantanée, sucrée, prête à boire (reconstituée avec du lait demi-écrémé standard)
-
-#TODO Nesquik 
-<en:Ready-to-drink instant cocoa with sugar reconstituted with semi-skimmed milk
-en:Ready-to-drink instant cocoa with sugar fortified with vitamins and chemical elements reconstituted with standard semi-skimmed milk, Ready-to-drink instant chocolate beverage with sugar fortified with vitamins and chemical elements reconstituted with standard semi-skimmed milk
-fr:Boisson cacaotée instantanée sucrée enrichie en vitamines prête à boire reconstituée avec du lait demi-écrémé, Boisson au chocolat instantanée sucrée enrichie en vitamines prête à boire reconstituée avec du lait demi-écrémé
-agribalyse_food_code:en:18106
-ciqual_food_code:en:18106
-ciqual_food_name:en:Instant cocoa or chocolate beverage, with sugar, fortified with vitamins and chemical elements, ready-to-drink (reconstituted with standard semi-skimm
-ciqual_food_name:fr:Boisson cacaotée ou au chocolat, instantanée, sucrée, enrichie en vitamines, prête à boire (reconstituée avec du lait demi-écrémé standard)
 
 
 # description:en:CAKE is a form of sweet food that is usually baked. The most commonly used cake ingredients include flour, sugar, eggs, butter or oil or margarine, a liquid, and leavening agents, such as baking soda or baking powder. Common additional ingredients and flavourings include dried, candied, or fresh fruit, nuts, cocoa, and extracts such as vanilla, with numerous substitutions for the primary ingredients. Cakes can also be filled with fruit preserves, nuts or dessert sauces (like pastry cream), iced with buttercream or other icings, and decorated with marzipan, piped borders, or candied fruit.
@@ -82193,16 +82182,6 @@ nl:Eendenfoie gras
 ciqual_food_code:en:8331
 ciqual_food_name:en:Foie gras, block (average)
 ciqual_food_name:fr:Foie gras, canard, bloc (aliment moyen)
-
-#<en:Foies gras from ducks
-#en:duck foie gras
-#fr:Foie gras de canard
-#ciqual_food_code:en:8328
-#ciqual_food_name:en:Foie gras, duck, raw
-#ciqual_food_name:fr:Foie gras de canard, cru
-agribalyse_proxy_food_code:en:40120
-agribalyse_proxy_food_name:en:Liver, goose, raw
-agribalyse_proxy_food_name:fr:Foie, oie, cru
 
 <en:duck meat
 en:duck liver


### PR DESCRIPTION
Better agribalyse matches. In particular, we need to use the agribalyse categories that correspond to the reconstituted product (e.g. coffee with water or chocolate powder with milk)