### PR TITLE
disable ecoscore for other countries than France

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -1446,6 +1446,12 @@ This parameter sets the desired language for the user facing strings.
 
 If $target_lc is equal to "data", no strings are returned.
 
+=head4 options $options_ref
+
+Defines how some attributes should be computed (or not computed)
+
+- skip_[attribute_id] : do not compute a specific attribute
+
 =head3 Return values
 
 Attributes are returned in the "attribute_groups_[$target_lc]" array of the product reference
@@ -1455,10 +1461,11 @@ The array contains attribute groups, and each attribute group contains individua
 
 =cut
 
-sub compute_attributes($$) {
+sub compute_attributes($$$) {
 
 	my $product_ref = shift;
-	my $target_lc = shift;	
+	my $target_lc = shift;
+	my $options_ref = shift;	
 
 	$log->debug("compute attributes for product", { code => $product_ref->{code}, target_lc => $target_lc }) if $log->is_debug();
 
@@ -1503,11 +1510,15 @@ sub compute_attributes($$) {
 	
 	# Environment
 	
-	$attribute_ref = compute_attribute_ecoscore($product_ref, $target_lc);
-	add_attribute_to_group($product_ref, $target_lc, "environment", $attribute_ref);
+	if ((not defined $options_ref) or (not defined $options_ref->{skip_ecoscore}) or (not $options_ref->{skip_ecoscore})) {
+		$attribute_ref = compute_attribute_ecoscore($product_ref, $target_lc);
+		add_attribute_to_group($product_ref, $target_lc, "environment", $attribute_ref);
+	}
 	
-	$attribute_ref = compute_attribute_forest_footprint($product_ref, $target_lc);
-	add_attribute_to_group($product_ref, $target_lc, "environment", $attribute_ref);
+	if ((not defined $options_ref) or (not defined $options_ref->{skip_forest_footprint}) or (not $options_ref->{skip_forest_footprint})) {
+		$attribute_ref = compute_attribute_forest_footprint($product_ref, $target_lc);	
+		add_attribute_to_group($product_ref, $target_lc, "environment", $attribute_ref);
+	}
 		
 	# Labels groups
 	

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -118,6 +118,9 @@ BEGIN
 		$nutriment_table
 
 		%file_timestamps
+		
+		$show_ecoscore
+		$attributes_options_ref
 
 		);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
@@ -580,6 +583,19 @@ CSS
 	}
 	else {
 		$user_preferences = 0;
+	}
+	
+	if (((defined $options{product_type}) and ($options{product_type} eq "food"))
+		and (($cc eq "fr") or ($User{moderator}))) {
+		$show_ecoscore = 1;
+		$attributes_options_ref = {};
+	}
+	else {
+		$show_ecoscore = 0;
+		$attributes_options_ref = {
+			skip_ecoscore => 1,
+			skip_forest_footprint => 1,
+		};
 	}
 
 	$log->debug("owner, org and user", { private_products => $server_options{private_products}, owner_id => $Owner_id, user_id => $User_id, org_id => $Org_id }) if $log->is_debug();
@@ -4492,9 +4508,6 @@ sub customize_response_for_product($$) {
 		# Eco-Score
 		elsif ($field =~ /^ecoscore/) {
 
-			if (not defined $product_ref->{ecoscore_data}) {
-				compute_ecoscore($product_ref);
-			}
 			if (defined $product_ref->{$field}) {
 				$customized_product_ref->{$field} = $product_ref->{$field};
 			}
@@ -4502,12 +4515,12 @@ sub customize_response_for_product($$) {
 		# Product attributes requested in a specific language (or data only)
 		elsif ($field =~ /^attribute_groups_([a-z]{2}|data)$/) {
 			my $target_lc = $1;
-			compute_attributes($product_ref, $target_lc);
+			compute_attributes($product_ref, $target_lc, $attributes_options_ref);
 			$customized_product_ref->{$field} = $product_ref->{$field};
 		}
 		# Product attributes in the $lc language
 		elsif ($field eq "attribute_groups") {
-			compute_attributes($product_ref, $lc);
+			compute_attributes($product_ref, $lc, $attributes_options_ref);
 			$customized_product_ref->{$field} = $product_ref->{"attribute_groups_" . $lc};
 		}
 		
@@ -4668,8 +4681,7 @@ sub search_and_display_products($$$$$) {
 	push @{$template_data_ref->{sort_options}}, { value => "nutriscore_score", link => $request_ref->{current_link} . "?sort_by=nutriscore_score", name => lang("sort_by_nutriscore_score") };
 	
 	# Show Eco-score sort only for France or moderators
-	if (((defined $options{product_type}) and ($options{product_type} eq "food"))
-		and (($cc eq "fr") or ($User{moderator}))) {
+	if ($show_ecoscore) {
 		push @{$template_data_ref->{sort_options}}, { value => "ecoscore_score", link => $request_ref->{current_link} . "?sort_by=ecoscore_score", name => lang("sort_by_ecoscore_score") };
 	}
 	
@@ -4937,8 +4949,7 @@ sub search_and_display_products($$$$$) {
 				# Eco-score: currently only for moderators
 				
 				if ($newtagtype eq 'ecoscore') {
-					next if not (((defined $options{product_type}) and ($options{product_type} eq "food"))
-						and (($cc eq "fr") or ($User{moderator})));
+					next if not ($show_ecoscore);
 				}
 
 				push @{$template_data_ref->{current_drilldown_fields}}, {
@@ -8294,12 +8305,8 @@ HTML
 	# Limit to France as the Eco-Score is currently valid only for products sold in France
 	# for alpha test to moderators, display eco-score for all countries
 	
-	if (((defined $options{product_type}) and ($options{product_type} eq "food"))
-		and (($cc eq "fr") or ($User{moderator}))) {
+	if ($show_ecoscore) {
 		
-		if (not defined $product_ref->{ecoscore_data}) {
-			compute_ecoscore($product_ref);
-		}
 		$template_data_ref->{ecoscore_grade} = uc($product_ref->{ecoscore_grade});
 		$template_data_ref->{ecoscore_grade_lc} = $product_ref->{ecoscore_grade};
 		$template_data_ref->{ecoscore_score} = $product_ref->{ecoscore_score};
@@ -8434,7 +8441,7 @@ HTML
 	
 		# A result summary will be computed according to user preferences on the client side
 
-		compute_attributes($product_ref, $lc);
+		compute_attributes($product_ref, $lc, $attributes_options_ref);
 		
 		my $product_attribute_groups_json = decode_utf8(encode_json({"attribute_groups" => $product_ref->{"attribute_groups_" . $lc}}));
 		my $preferences_text = lang("choose_which_information_you_prefer_to_see_first");

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8305,7 +8305,7 @@ HTML
 	# Limit to France as the Eco-Score is currently valid only for products sold in France
 	# for alpha test to moderators, display eco-score for all countries
 	
-	if ($show_ecoscore) {
+	if (($show_ecoscore) and (defined $product_ref->{ecoscore_data})) {
 		
 		$template_data_ref->{ecoscore_grade} = uc($product_ref->{ecoscore_grade});
 		$template_data_ref->{ecoscore_grade_lc} = $product_ref->{ecoscore_grade};


### PR DESCRIPTION
The Eco-Score display was already disabled on the product pages on the web site for countries other than France, but it was still visible through the attributes if it was selected.

This change disables the Eco-Score and the forest footprint attributes unless the query or subdomain indicates France. For apps, that means API queries will not return the ecoscore in attributes, unless they are sent to fr.openfoodfacts.org or the cc parameter is set to "fr".

@aleene @VaiTon : do the OFF apps and Foodviewer use the attribute_groups field to display the Eco-Score, or they use the ecoscore_grade or ecoscore_data fields directly?

--

for logged-in users that have moderator status, the ecoscore will still be shown for all countries