### PR TITLE
Allow displaying a list of products specified by barcodes - fixes #4399

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4141,7 +4141,7 @@ sub add_country_and_owner_filters_to_query($$) {
 
 	if (defined $country) {
 		
-		# Do not add a country restriction iff the query specifies a list of codes
+		# Do not add a country restriction if the query specifies a list of codes
 		
 		if (($country ne 'en:world') and (not defined $query_ref->{code})) {
 			# we may already have a condition on countries (e.g. from the URL /country/germany )


### PR DESCRIPTION
- Adds a new /products endpoint similar to /product, but with multiple products:
e.g.https://world.openfoodfacts.dev/products/8024884500403,3263855093192,3045320001570,3021762383344,4008400402222,3330720237255,3608580823513,3700278403936,3302747010029,3608580823490,3250391660995,3760020506605,8722700202387,3330720237330,3535800940005,20000691,3270190127512

- Adds the corresponding support in Search API V2 with the ?code=a,b,c parameter -- fixes #4399
https://world.openfoodfacts.dev/api/v2/search?code=8024884500403,3263855093192&fields=code,product_name

- As usual, adding .json is also supported, as well as passing extra parameters:
https://world.openfoodfacts.dev/products/8024884500403,3263855093192,3045320001570,3021762383344,4008400402222,3330720237255,3608580823513,3700278403936,3302747010029,3608580823490,3250391660995,3760020506605,8722700202387,3330720237330,3535800940005,20000691,3270190127512.json?fields=code,product_name
