### PR TITLE
Migrate Crowdin to GitHub actions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -2,7 +2,7 @@ name: Crowdin Sync
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
 
 jobs:
   synchronize-with-crowdin:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,79 @@
+name: Crowdin Sync
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  synchronize-with-crowdin:
+    name: Synchronize with crowdin
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: crowdin action
+      uses: crowdin/github-action@1.0.17
+      with:
+        upload_translations: true # default is false
+        # Use this option to upload translations for a single specified language
+        download_translations: true
+        # Upload sources to Crowdin
+        # upload_sources: # default is true
+        # Upload translations to Crowdin
+        # upload_language: # optional
+        # Automatically approves uploaded translations
+        # auto_approve_imported: # default is false
+        # Defines whether to add translation if it is equal to source string in Crowdin project
+        # import_eq_suggestions: # default is false
+        # Make pull request of Crowdin translations
+        # Use this option to download translations for a single specified language
+        # download_language: # optional
+        # Skip untranslated strings in exported files (does not work with .docx, .html, .md and other document files)
+        skip_untranslated_strings: true
+        # Omit downloading not fully downloaded files
+        skip_untranslated_files: true
+        # Include approved translations only in exported files. If not combined with --skip-untranslated-strings option, strings without approval are fulfilled with the source language
+        # export_only_approved: # default is false
+        # Download translations with pushing to branch
+        # push_translations: # default is true
+        # Commit message for download translations
+        commit_message: "New Crowdin translations by Github Action"
+        # To download translations to the specified version branch
+        localization_branch_name: l10n_develop_gh
+        # Create pull request after pushing to branch
+        # create_pull_request: # default is true
+        # The title of the new pull request
+        pull_request_title: "New Crowdin translations to review and merge"
+        # The contents of the pull request
+        # pull_request_body: # optional
+        # To add labels for created pull request
+        pull_request_labels: "translations"
+        # Create pull request to specified branch instead of default one
+        # pull_request_base_branch_name: # optional
+        # Option to upload or download files to the specified version branch in your Crowdin project
+        # crowdin_branch_name: # optional
+        # Option to specify a path to user-specific credentials, without / at the beginning
+        # identity: # optional
+        # Option to specify a path to the configuration file, without / at the beginning
+        # config: # optional
+        # Option to preview the list of managed files
+        # dryrun_action: # default is false
+        # Numerical ID of the project
+        # project_id: # optional
+        # Personal access token required for authentication
+        # token: # optional
+        # Base URL of Crowdin server for API requests execution
+        #base_url: 'https://crowdin.com'
+        # Path to your project directory on a local machine
+        #base_path: '/openfoodfacts'
+        # Path to the source files
+        # source: # optional
+        # TODO source: 'packages/smooth_app/lib/l10n/app_en.arb'
+        # Path to the translation files
+        # TODO translation: 'packages/smooth_app/lib/l10n/app_%two_letters_code%.arb'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+        CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -41,7 +41,7 @@ jobs:
         # Commit message for download translations
         commit_message: "New Crowdin translations by Github Action"
         # To download translations to the specified version branch
-        localization_branch_name: l10n_develop_gh
+        localization_branch_name: l10n_master_gh
         # Create pull request after pushing to branch
         # create_pull_request: # default is true
         # The title of the new pull request


### PR DESCRIPTION
Probably another personal hell week in perspective…
It seems that many translations are bortched on the repo, and some are bortched on Crowdin. 
I want to avoid mutual reinfection.