### PR TITLE
query owner field instead of owners_tags, fix #4827

### DIFF
--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -136,7 +136,7 @@ elsif (($action eq "process") and (($User{moderator}) or (defined param("query_c
 	# First export CSV from the producers platform, then import on the public platform
 	
 	my $args_ref = {
-		query => { owners_tags => $Owner_id, "data_quality_errors_producers_tags.0" => { '$exists' => false }},
+		query => { owner => $Owner_id, "data_quality_errors_producers_tags.0" => { '$exists' => false }},
 	};
 	
 	# Add query filters

--- a/cgi/remove_products.pl
+++ b/cgi/remove_products.pl
@@ -83,10 +83,10 @@ HTML
 
 elsif ($action eq "process") {
 
-	$log->debug("Deleting products for owner in mongodb", { owners_tags => $Owner_id }) if $log->is_debug();
+	$log->debug("Deleting products for owner in mongodb", { owner => $Owner_id }) if $log->is_debug();
 
 	my $products_collection = get_products_collection();
-	$products_collection->delete_many({"owners_tags" => $Owner_id});
+	$products_collection->delete_many({"owner" => $Owner_id});
 
 	require File::Copy::Recursive;
 	File::Copy::Recursive->import( qw( dirmove ) );
@@ -94,7 +94,7 @@ elsif ($action eq "process") {
 	my $deleted_dir = $data_root . "/deleted_private_products/" . $Owner_id . "." . time();
 	(-e $data_root . "/deleted_private_products") or mkdir($data_root . "/deleted_private_products", oct(755));
 
-	$log->debug("Moving data to deleted dir", { owners_tags => $Owner_id, deleted_dir => $deleted_dir }) if $log->is_debug();
+	$log->debug("Moving data to deleted dir", { owner => $Owner_id, deleted_dir => $deleted_dir }) if $log->is_debug();
 
 	mkdir($deleted_dir, oct(755));
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4177,7 +4177,7 @@ sub add_country_and_owner_filters_to_query($$) {
 		and ( $server_options{private_products} ) )
 	{
 		if ( $Owner_id ne 'all' ) {    # Administrator mode to see all products
-			$query_ref->{owners_tags} = $Owner_id;
+			$query_ref->{owner} = $Owner_id;
 		}
 	}
 

--- a/mongodb_indexes.txt
+++ b/mongodb_indexes.txt
@@ -1,4 +1,3 @@
-
 db.products.createIndex({"last_modified_t": -1}, { background: true });
 db.products.createIndex({"created_t": -1}, { background: true });
 db.products.createIndex({countries_tags:1,"popularity_key": -1}, { background: true });
@@ -61,4 +60,8 @@ db.products.createIndex({ecoscore_tags:1,"last_modified_t": -1}, { background: t
 db.products.createIndex({nutriscore_score_opposite: -1}, { background: true });
 db.products.createIndex({ecoscore_score: -1}, { background: true });
 db.products.createIndex({popularity_key: -1}, { background: true });
+db.products.createIndex({countries_tags:1,"last_modified_t": -1}, { background: true });
 
+
+# for off-pro only:
+db.products.createIndex({owner:1, countries_tags:1, "last_modified_t": -1}, { background: true });

--- a/scripts/export_and_import_to_public_database.pl
+++ b/scripts/export_and_import_to_public_database.pl
@@ -103,7 +103,7 @@ if (defined $days) {
 	$query_ref->{last_modified_t} = { '$gt' => time() - $days * 86400 };
 }
 
-$query_ref->{owners_tags} = $Owner_id;
+$query_ref->{owner} = $Owner_id;
 $query_ref->{"data_quality_errors_producers_tags.0"} = { '$exists' => false };
 
 my $args_ref = {


### PR DESCRIPTION
fix #4827