### PR TITLE
Simplify how we store the result of ingredients analysis + fix Nutri-Score for dairy drinks

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -355,15 +355,6 @@ else {
 		}
 	}
 
-
-	# Food category rules for sweeetened/sugared beverages
-	# French PNNS groups from categories
-
-	if ((defined $options{product_type}) and ($options{product_type} eq "food")) {
-		ProductOpener::Food::special_process_product($product_ref);
-	}
-
-
 	if ((defined $product_ref->{nutriments}{"carbon-footprint"}) and ($product_ref->{nutriments}{"carbon-footprint"} ne '')) {
 		push @{$product_ref->{"labels_hierarchy" }}, "en:carbon-footprint";
 		push @{$product_ref->{"labels_tags" }}, "en:carbon-footprint";
@@ -388,6 +379,13 @@ else {
 	detect_allergens_from_text($product_ref);
 	compute_carbon_footprint_from_ingredients($product_ref);
 	compute_carbon_footprint_from_meat_or_fish($product_ref);
+	
+	# Food category rules for sweeetened/sugared beverages
+	# French PNNS groups from categories
+
+	if ((defined $options{product_type}) and ($options{product_type} eq "food")) {
+		ProductOpener::Food::special_process_product($product_ref);
+	}	
 
 	# Nutrition data
 

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -465,15 +465,6 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 		}
 	}
 
-
-	# Food category rules for sweeetened/sugared beverages
-	# French PNNS groups from categories
-
-	if ((defined $options{product_type}) and ($options{product_type} eq "food")) {
-		$log->debug("Food::special_process_product") if $log->is_debug();
-		ProductOpener::Food::special_process_product($product_ref);
-	}
-
 	if ((defined $product_ref->{nutriments}{"carbon-footprint"}) and ($product_ref->{nutriments}{"carbon-footprint"} ne '')) {
 		push @{$product_ref->{"labels_hierarchy" }}, "en:carbon-footprint";
 		push @{$product_ref->{"labels_tags" }}, "en:carbon-footprint";
@@ -509,6 +500,14 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 	detect_allergens_from_text($product_ref);
 	compute_carbon_footprint_from_ingredients($product_ref);
 	compute_carbon_footprint_from_meat_or_fish($product_ref);
+	
+	# Food category rules for sweeetened/sugared beverages
+	# French PNNS groups from categories
+
+	if ((defined $options{product_type}) and ($options{product_type} eq "food")) {
+		$log->debug("Food::special_process_product") if $log->is_debug();
+		ProductOpener::Food::special_process_product($product_ref);
+	}	
 
 	# Nutrition data
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5067,12 +5067,12 @@ sub search_and_display_products($$$$$) {
 		
 		# 2021-02-25: we now store only nested ingredients, flatten them if the API is <= 1
 		
-		if ((defined param("api_version")) and (param("api_version") > 1)) {
+		if ((defined param("api_version")) and (param("api_version") <= 1)) {
 
 			for my $product_ref (@{$request_ref->{structured_response}{products}}) {
 				if (defined $product_ref->{ingredients}) {
 					
-					flatten_sub_ingredients_and_compute_ingredients_tags($product_ref);
+					flatten_sub_ingredients($product_ref);
 
 					foreach my $ingredient_ref (@{$product_ref->{ingredients}}) {
 						# Delete sub-ingredients, keep only flattened ingredients
@@ -10255,11 +10255,11 @@ HTML
 		
 		# 2021-02-25: we now store only nested ingredients, flatten them if the API is <= 1
 		
-		if ((defined param("api_version")) and (param("api_version") > 1)) {
+		if ((defined param("api_version")) and (param("api_version") <= 1)) {
 
 			if (defined $product_ref->{ingredients}) {
 				
-				flatten_sub_ingredients_and_compute_ingredients_tags($product_ref);
+				flatten_sub_ingredients($product_ref);
 
 				foreach my $ingredient_ref (@{$product_ref->{ingredients}}) {
 					# Delete sub-ingredients, keep only flattened ingredients

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10255,13 +10255,18 @@ HTML
 		
 		# 2021-02-25: we now store only nested ingredients, flatten them if the API is <= 1
 		
-		if (defined $product_ref->{ingredients}) {
+		if ((defined param("api_version")) and (param("api_version") > 1)) {
 
-			foreach my $ingredient_ref (@{$product_ref->{ingredients}}) {
-				# Delete sub-ingredients, keep only flattened ingredients
-				exists $ingredient_ref->{ingredients} and delete $ingredient_ref->{ingredients};
+			if (defined $product_ref->{ingredients}) {
+				
+				flatten_sub_ingredients_and_compute_ingredients_tags($product_ref);
+
+				foreach my $ingredient_ref (@{$product_ref->{ingredients}}) {
+					# Delete sub-ingredients, keep only flattened ingredients
+					exists $ingredient_ref->{ingredients} and delete $ingredient_ref->{ingredients};
+				}
 			}
-		}
+		}		
 
 		# Return blame information
 		if (defined param("blame")) {

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -833,27 +833,11 @@ sub aggregate_origins_of_ingredients($$$) {
 	my $aggregated_origins_ref = shift;
 	my $ingredients_ref = shift;
 	
-	# The ingredients array contains sub-ingredients in nested ingredients properties
-	# and they are also listed at the end on the ingredients array, without the rank property
-	# For this aggregation, we want to use the nested sub-ingredients,
-	# and ignore the same sub-ingredients listed at the end
-	my $ranked = 0;
-	
+	# The ingredients array contains sub-ingredients in nested ingredients
+		
 	foreach my $ingredient_ref (@$ingredients_ref) {
 		
 		my $ingredient_origins_ref;
-		
-		# If we are at the first level of the ingredients array,
-		# ingredients have a rank, except the sub-ingredients listed at the end
-		if ($ingredient_ref->{rank}) {
-			$ranked = 1;
-		}
-		elsif ($ranked) {
-			# The ingredient does not have a rank, but a previous ingredient had one:
-			# we are at the first level of the ingredients array,
-			# and we are at the end where the sub-ingredients have been added
-			last;
-		}
 		
 		# If the ingredient has specified origins, use them
 		if (defined $ingredient_ref->{origins}) {

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -82,7 +82,8 @@ BEGIN
 		&preparse_ingredients_text
 		&parse_ingredients_text
 		&analyze_ingredients
-		&flatten_sub_ingredients_and_compute_ingredients_tags
+		&flatten_sub_ingredients
+		&compute_ingredients_tags
 
 		&compute_ingredients_percent_values
 		&init_percent_values
@@ -1638,11 +1639,9 @@ sub flatten_sub_ingredients($) {
 			# Add a rank for all first level ingredients
 			$product_ref->{ingredients}[$i]{rank} = $rank++;
 		}
-		else {
-			# For sub-ingredients, do not list again the sub-ingredients
-			delete $product_ref->{ingredients}[$i]{ingredients};
-		}
-		push @{$product_ref->{ingredients_tags}}, $product_ref->{ingredients}[$i]{id};
+
+		# Delete the sub-ingredients, as they have been pushed at the end of the list
+		delete $product_ref->{ingredients}[$i]{ingredients};
 	}
 }
 

--- a/t/expected_test_results/ecoscore/carrots-plastic.json
+++ b/t/expected_test_results/ecoscore/carrots-plastic.json
@@ -80,7 +80,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Carottes",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/carrots.json
+++ b/t/expected_test_results/ecoscore/carrots.json
@@ -83,7 +83,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Carottes",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/category-without-ecoscore-sodas.json
+++ b/t/expected_test_results/ecoscore/category-without-ecoscore-sodas.json
@@ -17,7 +17,6 @@
          "percent_estimate" : 75,
          "percent_max" : 100,
          "percent_min" : 50,
-         "rank" : 1,
          "text" : "Water",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -27,7 +26,6 @@
          "percent_estimate" : 25,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
@@ -97,7 +97,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "Aubergine",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -108,7 +107,6 @@
          "percent_estimate" : 39,
          "percent_max" : 39,
          "percent_min" : 39,
-         "rank" : 2,
          "text" : "Pomme de terre",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -120,7 +118,6 @@
          "percent_estimate" : 1,
          "percent_max" : 1,
          "percent_min" : 1,
-         "rank" : 3,
          "text" : "Huile de colza",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
@@ -97,7 +97,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "Aubergine",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -108,7 +107,6 @@
          "percent_estimate" : 39,
          "percent_max" : 39,
          "percent_min" : 39,
-         "rank" : 2,
          "text" : "Pomme de terre",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -120,7 +118,6 @@
          "percent_estimate" : 1,
          "percent_max" : 1,
          "percent_min" : 1,
-         "rank" : 3,
          "text" : "Huile de colza",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -90,7 +90,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -102,7 +101,6 @@
          "percent_estimate" : 30,
          "percent_max" : 30,
          "percent_min" : 30,
-         "rank" : 2,
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -112,7 +110,6 @@
          "percent_estimate" : 10,
          "percent_max" : 10,
          "percent_min" : 10,
-         "rank" : 3,
          "text" : "lemon juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -85,7 +85,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -97,7 +96,6 @@
          "percent_estimate" : 30,
          "percent_max" : 30,
          "percent_min" : 30,
-         "rank" : 2,
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -107,7 +105,6 @@
          "percent_estimate" : 10,
          "percent_max" : 10,
          "percent_min" : 10,
-         "rank" : 3,
          "text" : "lemon juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -82,13 +82,11 @@
          "percent_estimate" : 66.6666666666667,
          "percent_max" : 100,
          "percent_min" : 33.3333333333333,
-         "rank" : 1,
          "text" : "Milk",
          "vegan" : "no",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:chocolate",
          "ingredients" : [
             {
@@ -96,14 +94,18 @@
                "percent_estimate" : 8.33333333333333,
                "percent_max" : 50,
                "percent_min" : 0,
-               "text" : "cocoa"
+               "text" : "cocoa",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:cocoa-butter",
                "percent_estimate" : 4.16666666666667,
                "percent_max" : 25,
                "percent_min" : 0,
-               "text" : "cocoa butter"
+               "text" : "cocoa butter",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:sweetener",
@@ -113,7 +115,9 @@
                      "percent_estimate" : 4.16666666666667,
                      "percent_max" : 16.6666666666667,
                      "percent_min" : 0,
-                     "text" : "aspartame"
+                     "text" : "aspartame",
+                     "vegan" : "yes",
+                     "vegetarian" : "yes"
                   }
                ],
                "percent_estimate" : 4.16666666666667,
@@ -125,7 +129,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "chocolate",
          "vegan" : "maybe",
          "vegetarian" : "yes"
@@ -135,43 +138,7 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "salt",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:cocoa",
-         "percent_estimate" : 8.33333333333333,
-         "percent_max" : 50,
-         "percent_min" : 0,
-         "text" : "cocoa",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:cocoa-butter",
-         "percent_estimate" : 4.16666666666667,
-         "percent_max" : 25,
-         "percent_min" : 0,
-         "text" : "cocoa butter",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:sweetener",
-         "percent_estimate" : 4.16666666666667,
-         "percent_max" : 16.6666666666667,
-         "percent_min" : 0,
-         "text" : "sweetener"
-      },
-      {
-         "id" : "en:e951",
-         "percent_estimate" : 4.16666666666667,
-         "percent_max" : 16.6666666666667,
-         "percent_min" : 0,
-         "text" : "aspartame",
          "vegan" : "yes",
          "vegetarian" : "yes"
       }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -82,7 +82,6 @@
          "percent_estimate" : 66.6666666666667,
          "percent_max" : 100,
          "percent_min" : 33.3333333333333,
-         "rank" : 1,
          "text" : "Milk",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -92,13 +91,11 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "salt",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:colour",
          "ingredients" : [
             {
@@ -106,23 +103,15 @@
                "percent_estimate" : 16.6666666666667,
                "percent_max" : 33.3333333333333,
                "percent_min" : 0,
-               "text" : "e160b"
+               "text" : "e160b",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "coloring"
-      },
-      {
-         "id" : "en:e160b",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 33.3333333333333,
-         "percent_min" : 0,
-         "text" : "e160b",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -83,7 +83,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -94,7 +93,6 @@
          "percent_estimate" : 30,
          "percent_max" : 30,
          "percent_min" : 30,
-         "rank" : 2,
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -104,7 +102,6 @@
          "percent_estimate" : 10,
          "percent_max" : 10,
          "percent_min" : 10,
-         "rank" : 3,
          "text" : "lemon juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -86,7 +86,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -97,7 +96,6 @@
          "percent_estimate" : 30,
          "percent_max" : 30,
          "percent_min" : 30,
-         "rank" : 2,
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -107,7 +105,6 @@
          "percent_estimate" : 10,
          "percent_max" : 10,
          "percent_min" : 10,
-         "rank" : 3,
          "text" : "lemon juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -102,7 +102,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -114,7 +113,6 @@
          "percent_estimate" : 30,
          "percent_max" : 30,
          "percent_min" : 30,
-         "rank" : 2,
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -124,7 +122,6 @@
          "percent_estimate" : 10,
          "percent_max" : 10,
          "percent_min" : 10,
-         "rank" : 3,
          "text" : "lemon juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -90,7 +90,6 @@
          "percent_estimate" : 60,
          "percent_max" : 60,
          "percent_min" : 60,
-         "rank" : 1,
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -102,7 +101,6 @@
          "percent_estimate" : 30,
          "percent_max" : 30,
          "percent_min" : 30,
-         "rank" : 2,
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -113,7 +111,6 @@
          "percent_estimate" : 10,
          "percent_max" : 10,
          "percent_min" : 10,
-         "rank" : 3,
          "text" : "lemon juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -83,7 +83,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Milk",
          "vegan" : "no",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -80,7 +80,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Milk",
          "vegan" : "no",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
+++ b/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
@@ -83,7 +83,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Poulet",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/forest_footprint/fr-ingredients-filet-de-poulet-bio-oeuf-label-rouge-os-de-poulet-igp.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-filet-de-poulet-bio-oeuf-label-rouge-os-de-poulet-igp.json
@@ -75,7 +75,6 @@
          "percent_estimate" : 66.6666666666667,
          "percent_max" : 100,
          "percent_min" : 33.3333333333333,
-         "rank" : 1,
          "text" : "Filet de poulet",
          "vegan" : "no",
          "vegetarian" : "no"
@@ -86,7 +85,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "oeuf",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -97,7 +95,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "os de poulet",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/forest_footprint/fr-ingredients-filet-de-poulet-bio.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-filet-de-poulet-bio.json
@@ -33,7 +33,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Filet de poulet",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/forest_footprint/fr-ingredients-lait.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-lait.json
@@ -5,7 +5,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Lait",
          "vegan" : "no",
          "vegetarian" : "yes"

--- a/t/expected_test_results/forest_footprint/fr-ingredients-nested-matching-ingredient.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-nested-matching-ingredient.json
@@ -23,7 +23,6 @@
    },
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "fr:viande-de-poulet-traitee-en-salaison",
          "ingredients" : [
             {
@@ -38,7 +37,9 @@
                "percent_estimate" : 16.6666666666667,
                "percent_max" : 50,
                "percent_min" : 0,
-               "text" : "eau"
+               "text" : "eau",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:brine",
@@ -51,33 +52,9 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "viande de poulet traitée en salaison",
          "vegan" : "no",
          "vegetarian" : "no"
-      },
-      {
-         "id" : "fr:kangourou",
-         "percent_estimate" : 66.6666666666667,
-         "percent_max" : 100,
-         "percent_min" : 33.3333333333333,
-         "text" : "kangourou"
-      },
-      {
-         "id" : "en:water",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 50,
-         "percent_min" : 0,
-         "text" : "eau",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:brine",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 33.3333333333333,
-         "percent_min" : 0,
-         "text" : "saumure"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/forest_footprint/fr-ingredients-nested-matching-sub-ingredient.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-nested-matching-sub-ingredient.json
@@ -28,7 +28,6 @@
    },
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "fr:viande-de-poulet-traitee-en-salaison",
          "ingredients" : [
             {
@@ -37,14 +36,18 @@
                "percent_estimate" : 66.6666666666667,
                "percent_max" : 100,
                "percent_min" : 33.3333333333333,
-               "text" : "viande de poulet"
+               "text" : "viande de poulet",
+               "vegan" : "no",
+               "vegetarian" : "no"
             },
             {
                "id" : "en:water",
                "percent_estimate" : 16.6666666666667,
                "percent_max" : 50,
                "percent_min" : 0,
-               "text" : "eau"
+               "text" : "eau",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:brine",
@@ -57,36 +60,9 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "viande de poulet traitée en salaison",
          "vegan" : "no",
          "vegetarian" : "no"
-      },
-      {
-         "id" : "en:chicken-meat",
-         "origins" : "en:france",
-         "percent_estimate" : 66.6666666666667,
-         "percent_max" : 100,
-         "percent_min" : 33.3333333333333,
-         "text" : "viande de poulet",
-         "vegan" : "no",
-         "vegetarian" : "no"
-      },
-      {
-         "id" : "en:water",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 50,
-         "percent_min" : 0,
-         "text" : "eau",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:brine",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 33.3333333333333,
-         "percent_min" : 0,
-         "text" : "saumure"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/forest_footprint/fr-ingredients-poulet-du-gers.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-poulet-du-gers.json
@@ -33,7 +33,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Poulet",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/forest_footprint/fr-ingredients-poulet.json
+++ b/t/expected_test_results/forest_footprint/fr-ingredients-poulet.json
@@ -27,7 +27,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Poulet",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/ingredients/en-flavour-synonyms.json
+++ b/t/expected_test_results/ingredients/en-flavour-synonyms.json
@@ -5,7 +5,6 @@
          "percent_estimate" : 75,
          "percent_max" : 100,
          "percent_min" : 50,
-         "rank" : 1,
          "text" : "Natural orange flavor",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -15,7 +14,6 @@
          "percent_estimate" : 25,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "Lemon flavouring",
          "vegan" : "maybe",
          "vegetarian" : "maybe"

--- a/t/expected_test_results/ingredients/en-origins-u.json
+++ b/t/expected_test_results/ingredients/en-origins-u.json
@@ -1,7 +1,6 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:Something",
          "ingredients" : [
             {
@@ -15,15 +14,7 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Something"
-      },
-      {
-         "id" : "en:U",
-         "percent_estimate" : 100,
-         "percent_max" : 100,
-         "percent_min" : 100,
-         "text" : "U"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ingredients/en-origins.json
+++ b/t/expected_test_results/ingredients/en-origins.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 58.3333333333333,
          "percent_max" : 100,
          "percent_min" : 16.6666666666667,
-         "rank" : 1,
          "text" : "almonds",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 20.8333333333333,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "peaches",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -28,7 +26,6 @@
          "percent_estimate" : 10.4166666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "black olives",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -39,7 +36,6 @@
          "percent_estimate" : 5.20833333333333,
          "percent_max" : 25,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "fresh tomatoes",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -50,7 +46,6 @@
          "percent_estimate" : 2.60416666666666,
          "percent_max" : 20,
          "percent_min" : 0,
-         "rank" : 5,
          "text" : "Oranges",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -62,7 +57,6 @@
          "percent_max" : 16.6666666666667,
          "percent_min" : 0,
          "processing" : "en:concentrated",
-         "rank" : 6,
          "text" : "orange juice",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/es-percent-loop.json
+++ b/t/expected_test_results/ingredients/es-percent-loop.json
@@ -5,7 +5,6 @@
          "percent_estimate" : 62.125,
          "percent_max" : 68,
          "percent_min" : 56.25,
-         "rank" : 1,
          "text" : "Tomate",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -16,7 +15,6 @@
          "percent_estimate" : "12",
          "percent_max" : "12",
          "percent_min" : "12",
-         "rank" : 2,
          "text" : "pimiento",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -27,7 +25,6 @@
          "percent_estimate" : "10",
          "percent_max" : "10",
          "percent_min" : "10",
-         "rank" : 3,
          "text" : "atún",
          "vegan" : "no",
          "vegetarian" : "no"
@@ -39,7 +36,6 @@
          "percent_estimate" : "4",
          "percent_max" : "4",
          "percent_min" : "4",
-         "rank" : 4,
          "text" : "aceite de oliva virgen extra",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -50,7 +46,6 @@
          "percent_estimate" : "3",
          "percent_max" : "3",
          "percent_min" : "3",
-         "rank" : 5,
          "text" : "huevo",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -61,7 +56,6 @@
          "percent_estimate" : "3",
          "percent_max" : "3",
          "percent_min" : "3",
-         "rank" : 6,
          "text" : "cebolla",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -71,7 +65,6 @@
          "percent_estimate" : 1.5,
          "percent_max" : "3",
          "percent_min" : 0,
-         "rank" : 7,
          "text" : "azúcar",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -81,7 +74,6 @@
          "percent_estimate" : 1.5,
          "percent_max" : "3",
          "percent_min" : 0,
-         "rank" : 8,
          "text" : "almidón de maíz",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -91,13 +83,11 @@
          "percent_estimate" : 1.4375,
          "percent_max" : "3",
          "percent_min" : 0,
-         "rank" : 9,
          "text" : "sal",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:acid",
          "ingredients" : [
             {
@@ -105,23 +95,15 @@
                "percent_estimate" : 1.4375,
                "percent_max" : 2.75,
                "percent_min" : 0,
-               "text" : "ácido cítrico"
+               "text" : "ácido cítrico",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 1.4375,
          "percent_max" : 2.75,
          "percent_min" : 0,
-         "rank" : 10,
          "text" : "acidulante"
-      },
-      {
-         "id" : "en:e330",
-         "percent_estimate" : 1.4375,
-         "percent_max" : 2.75,
-         "percent_min" : 0,
-         "text" : "ácido cítrico",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ingredients/fi-additive.json
+++ b/t/expected_test_results/ingredients/fi-additive.json
@@ -1,7 +1,6 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:gelling-agent",
          "ingredients" : [
             {
@@ -9,23 +8,15 @@
                "percent_estimate" : 100,
                "percent_max" : 100,
                "percent_min" : 100,
-               "text" : "pektiinit"
+               "text" : "pektiinit",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "hyytelöimisaine"
-      },
-      {
-         "id" : "en:e440a",
-         "percent_estimate" : 100,
-         "percent_max" : 100,
-         "percent_min" : 100,
-         "text" : "pektiinit",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ingredients/fi-additives-origins.json
+++ b/t/expected_test_results/ingredients/fi-additives-origins.json
@@ -1,7 +1,6 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:emulsifier",
          "ingredients" : [
             {
@@ -9,13 +8,14 @@
                "percent_estimate" : 33.5,
                "percent_max" : 34,
                "percent_min" : 33,
-               "text" : "auringonkukkalesitiini"
+               "text" : "auringonkukkalesitiini",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 33.5,
          "percent_max" : 34,
          "percent_min" : "33",
-         "rank" : 1,
          "text" : "emulgointiaine"
       },
       {
@@ -24,7 +24,6 @@
          "percent_estimate" : 33.25,
          "percent_max" : 33.5,
          "percent_min" : "33",
-         "rank" : 2,
          "text" : "aromi",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -36,7 +35,6 @@
          "percent_estimate" : "33",
          "percent_max" : "33",
          "percent_min" : "33",
-         "rank" : 3,
          "text" : "vehnäjauho",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -46,17 +44,7 @@
          "percent_estimate" : 0.25,
          "percent_max" : 1,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "sokeri",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:sunflower-lecithin",
-         "percent_estimate" : 33.5,
-         "percent_max" : 34,
-         "percent_min" : 33,
-         "text" : "auringonkukkalesitiini",
          "vegan" : "yes",
          "vegetarian" : "yes"
       }

--- a/t/expected_test_results/ingredients/fi-additives-percents.json
+++ b/t/expected_test_results/ingredients/fi-additives-percents.json
@@ -4,64 +4,68 @@
          "id" : "en:flour",
          "percent" : "12",
          "percent_estimate" : "12",
-         "rank" : 1,
          "text" : "jauho",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:chocolate",
          "ingredients" : [
             {
                "id" : "en:cocoa-butter",
                "percent" : "15",
                "percent_estimate" : "15",
-               "text" : "kaakaovoi"
+               "text" : "kaakaovoi",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:sugar",
                "percent" : "10",
                "percent_estimate" : "10",
-               "text" : "sokeri"
+               "text" : "sokeri",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:milk-proteins",
                "percent_estimate" : 9.5,
-               "text" : "maitoproteiini"
+               "text" : "maitoproteiini",
+               "vegan" : "no",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:chicken-egg",
                "percent" : "1",
                "percent_estimate" : 9.5,
-               "text" : "kananmuna"
+               "text" : "kananmuna",
+               "vegan" : "no",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 44,
-         "rank" : 2,
          "text" : "suklaa",
          "vegan" : "maybe",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:emulsifier",
          "ingredients" : [
             {
                "id" : "en:e463",
                "percent_estimate" : 22,
-               "text" : "e463"
+               "text" : "e463",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 22,
-         "rank" : 3,
          "text" : "emulgointiaineet"
       },
       {
          "from_palm_oil" : "maybe",
          "id" : "en:e432",
          "percent_estimate" : 11,
-         "rank" : 4,
          "text" : "e432",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -70,34 +74,34 @@
          "from_palm_oil" : "maybe",
          "id" : "en:e472",
          "percent_estimate" : 5.5,
-         "rank" : 5,
          "text" : "e472",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:acidity-regulator",
          "ingredients" : [
             {
                "id" : "en:e322",
                "percent_estimate" : 1.375,
-               "text" : "e322"
+               "text" : "e322",
+               "vegan" : "maybe",
+               "vegetarian" : "maybe"
             },
             {
                "id" : "en:e333",
                "percent_estimate" : 1.375,
-               "text" : "e333"
+               "text" : "e333",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 2.75,
-         "rank" : 6,
          "text" : "happamuudensäätöaineet"
       },
       {
          "id" : "en:e474",
          "percent_estimate" : 1.375,
-         "rank" : 7,
          "text" : "e474",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -105,101 +109,35 @@
       {
          "id" : "en:e475",
          "percent_estimate" : 0.6875,
-         "rank" : 8,
          "text" : "e475",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:acid",
          "ingredients" : [
             {
                "id" : "en:e330",
                "percent_estimate" : 0.171875,
-               "text" : "sitruunahappo"
+               "text" : "sitruunahappo",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:e338",
                "percent_estimate" : 0.171875,
-               "text" : "fosforihappo"
+               "text" : "fosforihappo",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 0.34375,
-         "rank" : 9,
          "text" : "happo"
       },
       {
          "id" : "en:salt",
          "percent_estimate" : 0.34375,
-         "rank" : 10,
          "text" : "suola",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:cocoa-butter",
-         "percent" : "15",
-         "percent_estimate" : "15",
-         "text" : "kaakaovoi",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:sugar",
-         "percent" : "10",
-         "percent_estimate" : "10",
-         "text" : "sokeri",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:milk-proteins",
-         "percent_estimate" : 9.5,
-         "text" : "maitoproteiini",
-         "vegan" : "no",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:chicken-egg",
-         "percent" : "1",
-         "percent_estimate" : 9.5,
-         "text" : "kananmuna",
-         "vegan" : "no",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e463",
-         "percent_estimate" : 22,
-         "text" : "e463",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e322",
-         "percent_estimate" : 1.375,
-         "text" : "e322",
-         "vegan" : "maybe",
-         "vegetarian" : "maybe"
-      },
-      {
-         "id" : "en:e333",
-         "percent_estimate" : 1.375,
-         "text" : "e333",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e330",
-         "percent_estimate" : 0.171875,
-         "text" : "sitruunahappo",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e338",
-         "percent_estimate" : 0.171875,
-         "text" : "fosforihappo",
          "vegan" : "yes",
          "vegetarian" : "yes"
       }

--- a/t/expected_test_results/ingredients/fi-do-not-match-myanmar.json
+++ b/t/expected_test_results/ingredients/fi-do-not-match-myanmar.json
@@ -1,7 +1,6 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:spice",
          "ingredients" : [
             {
@@ -9,103 +8,60 @@
                "percent_estimate" : 58.3333333333333,
                "percent_max" : 100,
                "percent_min" : 16.6666666666667,
-               "text" : "muun muassa kurkuma"
+               "text" : "muun muassa kurkuma",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:ginger",
                "percent_estimate" : 20.8333333333333,
                "percent_max" : 50,
                "percent_min" : 0,
-               "text" : "inkivääri"
+               "text" : "inkivääri",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:bell-pepper",
                "percent_estimate" : 10.4166666666667,
                "percent_max" : 33.3333333333333,
                "percent_min" : 0,
-               "text" : "paprika"
+               "text" : "paprika",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:garlic",
                "percent_estimate" : 5.20833333333333,
                "percent_max" : 25,
                "percent_min" : 0,
-               "text" : "valkosipuli"
+               "text" : "valkosipuli",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:coriander",
                "percent_estimate" : 2.60416666666666,
                "percent_max" : 20,
                "percent_min" : 0,
-               "text" : "korianteri"
+               "text" : "korianteri",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:mustard-seed",
                "percent_estimate" : 2.60416666666666,
                "percent_max" : 16.6666666666667,
                "percent_min" : 0,
-               "text" : "sinapinsiemen"
+               "text" : "sinapinsiemen",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "mausteet",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e100",
-         "percent_estimate" : 58.3333333333333,
-         "percent_max" : 100,
-         "percent_min" : 16.6666666666667,
-         "text" : "muun muassa kurkuma",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:ginger",
-         "percent_estimate" : 20.8333333333333,
-         "percent_max" : 50,
-         "percent_min" : 0,
-         "text" : "inkivääri",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:bell-pepper",
-         "percent_estimate" : 10.4166666666667,
-         "percent_max" : 33.3333333333333,
-         "percent_min" : 0,
-         "text" : "paprika",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:garlic",
-         "percent_estimate" : 5.20833333333333,
-         "percent_max" : 25,
-         "percent_min" : 0,
-         "text" : "valkosipuli",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:coriander",
-         "percent_estimate" : 2.60416666666666,
-         "percent_max" : 20,
-         "percent_min" : 0,
-         "text" : "korianteri",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:mustard-seed",
-         "percent_estimate" : 2.60416666666666,
-         "percent_max" : 16.6666666666667,
-         "percent_min" : 0,
-         "text" : "sinapinsiemen",
          "vegan" : "yes",
          "vegetarian" : "yes"
       }

--- a/t/expected_test_results/ingredients/fi-labels.json
+++ b/t/expected_test_results/ingredients/fi-labels.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 75,
          "percent_max" : 100,
          "percent_min" : 50,
-         "rank" : 1,
          "text" : "appelsiinimehu",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 25,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "lohi",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/ingredients/fi-organic-label-part-of-ingredient.json
+++ b/t/expected_test_results/ingredients/fi-organic-label-part-of-ingredient.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 66.6666666666667,
          "percent_max" : 100,
          "percent_min" : 33.3333333333333,
-         "rank" : 1,
          "text" : "vihreä tee",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "maito",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -28,7 +26,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "ohramallas",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fi-origins.json
+++ b/t/expected_test_results/ingredients/fi-origins.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 58.3333333333333,
          "percent_max" : 100,
          "percent_min" : 16.6666666666667,
-         "rank" : 1,
          "text" : "Mansikka",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 20.8333333333333,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "Mustaherukka",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -28,7 +26,6 @@
          "percent_estimate" : 10.4166666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "Vadelma",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -39,7 +36,6 @@
          "percent_estimate" : 5.20833333333333,
          "percent_max" : 25,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "Appelsiini",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -50,7 +46,6 @@
          "percent_estimate" : 2.60416666666666,
          "percent_max" : 20,
          "percent_min" : 0,
-         "rank" : 5,
          "text" : "kaakao",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -61,7 +56,6 @@
          "percent_estimate" : 2.60416666666666,
          "percent_max" : 16.6666666666667,
          "percent_min" : 0,
-         "rank" : 6,
          "text" : "kaakaovoi",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fi-percents.json
+++ b/t/expected_test_results/ingredients/fi-percents.json
@@ -4,7 +4,6 @@
          "id" : "en:strawberry",
          "percent" : 12.3,
          "percent_estimate" : 12.3,
-         "rank" : 1,
          "text" : "Mansikka",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -13,7 +12,6 @@
          "id" : "en:orange",
          "percent" : 6.5,
          "percent_estimate" : 6.5,
-         "rank" : 2,
          "text" : "Appelsiini",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -22,7 +20,6 @@
          "id" : "en:apple",
          "percent" : 3.5,
          "percent_estimate" : 81.2,
-         "rank" : 3,
          "text" : "Omena",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-additive.json
+++ b/t/expected_test_results/ingredients/fr-additive.json
@@ -1,7 +1,6 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:gelling-agent",
          "ingredients" : [
             {
@@ -9,23 +8,15 @@
                "percent_estimate" : 100,
                "percent_max" : 100,
                "percent_min" : 100,
-               "text" : "pectines"
+               "text" : "pectines",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "gélifiant"
-      },
-      {
-         "id" : "en:e440a",
-         "percent_estimate" : 100,
-         "percent_max" : 100,
-         "percent_min" : 100,
-         "text" : "pectines",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ingredients/fr-chocolate-cake.json
+++ b/t/expected_test_results/ingredients/fr-chocolate-cake.json
@@ -4,64 +4,68 @@
          "id" : "en:flour",
          "percent" : "12",
          "percent_estimate" : "12",
-         "rank" : 1,
          "text" : "farine",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:chocolate",
          "ingredients" : [
             {
                "id" : "en:cocoa-butter",
                "percent" : "15",
                "percent_estimate" : "15",
-               "text" : "beurre de cacao"
+               "text" : "beurre de cacao",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:sugar",
                "percent" : "10",
                "percent_estimate" : "10",
-               "text" : "sucre"
+               "text" : "sucre",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:milk-proteins",
                "percent_estimate" : 9.5,
-               "text" : "protéines de lait"
+               "text" : "protéines de lait",
+               "vegan" : "no",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:egg",
                "percent" : "1",
                "percent_estimate" : 9.5,
-               "text" : "oeuf"
+               "text" : "oeuf",
+               "vegan" : "no",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 44,
-         "rank" : 2,
          "text" : "chocolat",
          "vegan" : "maybe",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:emulsifier",
          "ingredients" : [
             {
                "id" : "en:e463",
                "percent_estimate" : 22,
-               "text" : "e463"
+               "text" : "e463",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 22,
-         "rank" : 3,
          "text" : "émulsifiants"
       },
       {
          "from_palm_oil" : "maybe",
          "id" : "en:e432",
          "percent_estimate" : 11,
-         "rank" : 4,
          "text" : "e432",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -70,34 +74,34 @@
          "from_palm_oil" : "maybe",
          "id" : "en:e472",
          "percent_estimate" : 5.5,
-         "rank" : 5,
          "text" : "e472",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:acidity-regulator",
          "ingredients" : [
             {
                "id" : "en:e322",
                "percent_estimate" : 1.375,
-               "text" : "e322"
+               "text" : "e322",
+               "vegan" : "maybe",
+               "vegetarian" : "maybe"
             },
             {
                "id" : "en:e333",
                "percent_estimate" : 1.375,
-               "text" : "e333"
+               "text" : "e333",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 2.75,
-         "rank" : 6,
          "text" : "correcteurs d'acidité"
       },
       {
          "id" : "en:e474",
          "percent_estimate" : 1.375,
-         "rank" : 7,
          "text" : "e474",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -105,101 +109,35 @@
       {
          "id" : "en:e475",
          "percent_estimate" : 0.6875,
-         "rank" : 8,
          "text" : "e475",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:acid",
          "ingredients" : [
             {
                "id" : "en:e330",
                "percent_estimate" : 0.171875,
-               "text" : "acide citrique"
+               "text" : "acide citrique",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:e338",
                "percent_estimate" : 0.171875,
-               "text" : "acide phosphorique"
+               "text" : "acide phosphorique",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 0.34375,
-         "rank" : 9,
          "text" : "acidifiant"
       },
       {
          "id" : "en:salt",
          "percent_estimate" : 0.34375,
-         "rank" : 10,
          "text" : "sel",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:cocoa-butter",
-         "percent" : "15",
-         "percent_estimate" : "15",
-         "text" : "beurre de cacao",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:sugar",
-         "percent" : "10",
-         "percent_estimate" : "10",
-         "text" : "sucre",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:milk-proteins",
-         "percent_estimate" : 9.5,
-         "text" : "protéines de lait",
-         "vegan" : "no",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:egg",
-         "percent" : "1",
-         "percent_estimate" : 9.5,
-         "text" : "oeuf",
-         "vegan" : "no",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e463",
-         "percent_estimate" : 22,
-         "text" : "e463",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e322",
-         "percent_estimate" : 1.375,
-         "text" : "e322",
-         "vegan" : "maybe",
-         "vegetarian" : "maybe"
-      },
-      {
-         "id" : "en:e333",
-         "percent_estimate" : 1.375,
-         "text" : "e333",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e330",
-         "percent_estimate" : 0.171875,
-         "text" : "acide citrique",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e338",
-         "percent_estimate" : 0.171875,
-         "text" : "acide phosphorique",
          "vegan" : "yes",
          "vegetarian" : "yes"
       }

--- a/t/expected_test_results/ingredients/fr-label-and-multiple-origins.json
+++ b/t/expected_test_results/ingredients/fr-label-and-multiple-origins.json
@@ -1,7 +1,6 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:egg",
          "ingredients" : [
             {
@@ -29,31 +28,9 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "oeufs",
          "vegan" : "no",
          "vegetarian" : "yes"
-      },
-      {
-         "id" : "fr:d'élevage au sol",
-         "percent_estimate" : 66.6666666666667,
-         "percent_max" : 100,
-         "percent_min" : 33.3333333333333,
-         "text" : "d'élevage au sol"
-      },
-      {
-         "id" : "fr:Suisse",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 50,
-         "percent_min" : 0,
-         "text" : "Suisse"
-      },
-      {
-         "id" : "fr:France",
-         "percent_estimate" : 16.6666666666667,
-         "percent_max" : 33.3333333333333,
-         "percent_min" : 0,
-         "text" : "France"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ingredients/fr-labels.json
+++ b/t/expected_test_results/ingredients/fr-labels.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 75,
          "percent_max" : 100,
          "percent_min" : 50,
-         "rank" : 1,
          "text" : "jus d'orange",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 25,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "saumon",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/ingredients/fr-marmelade.json
+++ b/t/expected_test_results/ingredients/fr-marmelade.json
@@ -1,31 +1,38 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "fr:Marmelade d'oranges",
          "ingredients" : [
             {
                "id" : "en:glucose-fructose-syrup",
                "percent_estimate" : 20.5,
-               "text" : "sirop de glucose-fructose"
+               "text" : "sirop de glucose-fructose",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:sugar",
                "percent_estimate" : 10.25,
-               "text" : "sucre"
+               "text" : "sucre",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:orange-pulp",
                "percent" : "4.5",
                "percent_estimate" : "4.5",
-               "text" : "pulpe d'orange"
+               "text" : "pulpe d'orange",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:concentrated-orange-juice",
                "ingredients" : [],
                "percent" : "1.4",
                "percent_estimate" : "1.4",
-               "text" : "jus d'orange concentré"
+               "text" : "jus d'orange concentré",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:orange-pulp",
@@ -33,7 +40,9 @@
                "percent" : "0.6",
                "percent_estimate" : "0.6",
                "processing" : "en:concentrated",
-               "text" : "pulpe d'orange"
+               "text" : "pulpe d'orange",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:gelling-agent",
@@ -41,7 +50,9 @@
                   {
                      "id" : "en:e440a",
                      "percent_estimate" : 1.875,
-                     "text" : "pectines"
+                     "text" : "pectines",
+                     "vegan" : "yes",
+                     "vegetarian" : "yes"
                   }
                ],
                "percent_estimate" : 1.875,
@@ -53,7 +64,9 @@
                   {
                      "id" : "en:e330",
                      "percent_estimate" : 0.9375,
-                     "text" : "acide citrique"
+                     "text" : "acide citrique",
+                     "vegan" : "yes",
+                     "vegetarian" : "yes"
                   }
                ],
                "percent_estimate" : 0.9375,
@@ -65,7 +78,9 @@
                   {
                      "id" : "en:e333",
                      "percent_estimate" : 0.234375,
-                     "text" : "citrate de calcium"
+                     "text" : "citrate de calcium",
+                     "vegan" : "yes",
+                     "vegetarian" : "yes"
                   },
                   {
                      "id" : "en:sodium-citrate",
@@ -79,7 +94,9 @@
             {
                "id" : "en:natural-orange-flavouring",
                "percent_estimate" : 0.234375,
-               "text" : "arôme naturel d'orange"
+               "text" : "arôme naturel d'orange",
+               "vegan" : "maybe",
+               "vegetarian" : "maybe"
             },
             {
                "id" : "en:thickener",
@@ -87,7 +104,9 @@
                   {
                      "id" : "en:e415",
                      "percent_estimate" : 0.234375,
-                     "text" : "gomme xanthane"
+                     "text" : "gomme xanthane",
+                     "vegan" : "yes",
+                     "vegetarian" : "yes"
                   }
                ],
                "percent_estimate" : 0.234375,
@@ -96,57 +115,78 @@
          ],
          "percent" : "41",
          "percent_estimate" : "41",
-         "rank" : 1,
          "text" : "Marmelade d'oranges"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:chocolate",
          "ingredients" : [
             {
                "id" : "en:sugar",
                "percent_estimate" : 12.45,
-               "text" : "sucre"
+               "text" : "sucre",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:cocoa-paste",
                "percent_estimate" : 6.225,
-               "text" : "pâte de cacao"
+               "text" : "pâte de cacao",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:cocoa-butter",
                "percent_estimate" : 3.1125,
-               "text" : "beurre de cacao"
+               "text" : "beurre de cacao",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
+               "from_palm_oil" : "no",
                "id" : "en:illipe-oil",
                "percent_estimate" : 1.55625,
-               "text" : "graisses végétales d'illipe"
+               "text" : "graisses végétales d'illipe",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
+               "from_palm_oil" : "no",
                "id" : "en:mango-kernel-oil",
                "percent_estimate" : 0.778124999999999,
-               "text" : "graisses végétales de mangue"
+               "text" : "graisses végétales de mangue",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
+               "from_palm_oil" : "no",
                "id" : "en:shorea-robusta-seed-oil",
                "percent_estimate" : 0.3890625,
-               "text" : "graisses végétales de sal"
+               "text" : "graisses végétales de sal",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
+               "from_palm_oil" : "no",
                "id" : "en:shea-butter",
                "percent_estimate" : 0.194531250000001,
-               "text" : "graisses végétales de karité"
+               "text" : "graisses végétales de karité",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
+               "from_palm_oil" : "yes",
                "id" : "en:palm-fat",
                "percent_estimate" : 0.0972656250000004,
-               "text" : "graisses végétales de palme"
+               "text" : "graisses végétales de palme",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:flavouring",
                "percent_estimate" : 0.0486328124999993,
-               "text" : "arôme"
+               "text" : "arôme",
+               "vegan" : "maybe",
+               "vegetarian" : "maybe"
             },
             {
                "id" : "en:emulsifier",
@@ -154,7 +194,9 @@
                   {
                      "id" : "en:soya-lecithin",
                      "percent_estimate" : 0.0243164062499996,
-                     "text" : "lécithine de soja"
+                     "text" : "lécithine de soja",
+                     "vegan" : "yes",
+                     "vegetarian" : "yes"
                   }
                ],
                "percent_estimate" : 0.0243164062499996,
@@ -163,12 +205,13 @@
             {
                "id" : "en:lactose-and-milk-proteins",
                "percent_estimate" : 0.0243164062500014,
-               "text" : "lactose et protéines de lait"
+               "text" : "lactose et protéines de lait",
+               "vegan" : "no",
+               "vegetarian" : "yes"
             }
          ],
          "percent" : "24.9",
          "percent_estimate" : "24.9",
-         "rank" : 2,
          "text" : "chocolat",
          "vegan" : "maybe",
          "vegetarian" : "yes"
@@ -176,7 +219,6 @@
       {
          "id" : "en:wheat-flour",
          "percent_estimate" : 17.05,
-         "rank" : 3,
          "text" : "farine de blé",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -184,7 +226,6 @@
       {
          "id" : "en:sugar",
          "percent_estimate" : 8.525,
-         "rank" : 4,
          "text" : "sucre",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -192,7 +233,6 @@
       {
          "id" : "en:egg",
          "percent_estimate" : 4.2625,
-         "rank" : 5,
          "text" : "oeufs",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -200,7 +240,6 @@
       {
          "id" : "en:glucose-fructose-syrup",
          "percent_estimate" : 2.13125,
-         "rank" : 6,
          "text" : "sirop de glucose-fructose",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -209,277 +248,58 @@
          "from_palm_oil" : "no",
          "id" : "en:colza-oil",
          "percent_estimate" : 1.065625,
-         "rank" : 7,
          "text" : "huile de colza",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:raising-agent",
          "ingredients" : [
             {
                "id" : "en:e503ii",
                "percent_estimate" : 0.266406249999999,
-               "text" : "carbonate acide d'ammonium"
+               "text" : "carbonate acide d'ammonium",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:e450i",
                "percent_estimate" : 0.133203125,
-               "text" : "diphosphate disodique"
+               "text" : "diphosphate disodique",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "id" : "en:e500ii",
                "percent_estimate" : 0.133203125,
-               "text" : "carbonate acide de sodium"
+               "text" : "carbonate acide de sodium",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 0.532812499999999,
-         "rank" : 8,
          "text" : "poudre à lever"
       },
       {
          "id" : "en:salt",
          "percent_estimate" : 0.266406250000003,
-         "rank" : 9,
          "text" : "sel",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:emulsifier",
          "ingredients" : [
             {
                "id" : "en:soya-lecithin",
                "percent_estimate" : 0.266406250000003,
-               "text" : "lécithine de soja"
+               "text" : "lécithine de soja",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 0.266406250000003,
-         "rank" : 10,
          "text" : "émulsifiant"
-      },
-      {
-         "id" : "en:glucose-fructose-syrup",
-         "percent_estimate" : 20.5,
-         "text" : "sirop de glucose-fructose",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:sugar",
-         "percent_estimate" : 10.25,
-         "text" : "sucre",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:orange-pulp",
-         "percent" : "4.5",
-         "percent_estimate" : "4.5",
-         "text" : "pulpe d'orange",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:concentrated-orange-juice",
-         "percent" : "1.4",
-         "percent_estimate" : "1.4",
-         "text" : "jus d'orange concentré",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:orange-pulp",
-         "percent" : "0.6",
-         "percent_estimate" : "0.6",
-         "processing" : "en:concentrated",
-         "text" : "pulpe d'orange",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:gelling-agent",
-         "percent_estimate" : 1.875,
-         "text" : "gélifiant"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:acid",
-         "percent_estimate" : 0.9375,
-         "text" : "acidifiant"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:acidity-regulator",
-         "percent_estimate" : 0.46875,
-         "text" : "correcteurs d'acidité"
-      },
-      {
-         "id" : "en:natural-orange-flavouring",
-         "percent_estimate" : 0.234375,
-         "text" : "arôme naturel d'orange",
-         "vegan" : "maybe",
-         "vegetarian" : "maybe"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:thickener",
-         "percent_estimate" : 0.234375,
-         "text" : "épaississant"
-      },
-      {
-         "id" : "en:sugar",
-         "percent_estimate" : 12.45,
-         "text" : "sucre",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:cocoa-paste",
-         "percent_estimate" : 6.225,
-         "text" : "pâte de cacao",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:cocoa-butter",
-         "percent_estimate" : 3.1125,
-         "text" : "beurre de cacao",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "from_palm_oil" : "no",
-         "id" : "en:illipe-oil",
-         "percent_estimate" : 1.55625,
-         "text" : "graisses végétales d'illipe",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "from_palm_oil" : "no",
-         "id" : "en:mango-kernel-oil",
-         "percent_estimate" : 0.778124999999999,
-         "text" : "graisses végétales de mangue",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "from_palm_oil" : "no",
-         "id" : "en:shorea-robusta-seed-oil",
-         "percent_estimate" : 0.3890625,
-         "text" : "graisses végétales de sal",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "from_palm_oil" : "no",
-         "id" : "en:shea-butter",
-         "percent_estimate" : 0.194531250000001,
-         "text" : "graisses végétales de karité",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "from_palm_oil" : "yes",
-         "id" : "en:palm-fat",
-         "percent_estimate" : 0.0972656250000004,
-         "text" : "graisses végétales de palme",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:flavouring",
-         "percent_estimate" : 0.0486328124999993,
-         "text" : "arôme",
-         "vegan" : "maybe",
-         "vegetarian" : "maybe"
-      },
-      {
-         "has_sub_ingredients" : "yes",
-         "id" : "en:emulsifier",
-         "percent_estimate" : 0.0243164062499996,
-         "text" : "émulsifiant"
-      },
-      {
-         "id" : "en:lactose-and-milk-proteins",
-         "percent_estimate" : 0.0243164062500014,
-         "text" : "lactose et protéines de lait",
-         "vegan" : "no",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e503ii",
-         "percent_estimate" : 0.266406249999999,
-         "text" : "carbonate acide d'ammonium",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e450i",
-         "percent_estimate" : 0.133203125,
-         "text" : "diphosphate disodique",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e500ii",
-         "percent_estimate" : 0.133203125,
-         "text" : "carbonate acide de sodium",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:soya-lecithin",
-         "percent_estimate" : 0.266406250000003,
-         "text" : "lécithine de soja",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e440a",
-         "percent_estimate" : 1.875,
-         "text" : "pectines",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e330",
-         "percent_estimate" : 0.9375,
-         "text" : "acide citrique",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:e333",
-         "percent_estimate" : 0.234375,
-         "text" : "citrate de calcium",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:sodium-citrate",
-         "percent_estimate" : 0.234375,
-         "text" : "citrate de sodium"
-      },
-      {
-         "id" : "en:e415",
-         "percent_estimate" : 0.234375,
-         "text" : "gomme xanthane",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:soya-lecithin",
-         "percent_estimate" : 0.0243164062499996,
-         "text" : "lécithine de soja",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/expected_test_results/ingredients/fr-origins-agriculture-ue-non-ue.json
+++ b/t/expected_test_results/ingredients/fr-origins-agriculture-ue-non-ue.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "Fraises",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-origins-emmental-allemagne-france-pays-bas-contient-lait.json
+++ b/t/expected_test_results/ingredients/fr-origins-emmental-allemagne-france-pays-bas-contient-lait.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "emmental",
          "vegan" : "no",
          "vegetarian" : "maybe"

--- a/t/expected_test_results/ingredients/fr-origins-labels.json
+++ b/t/expected_test_results/ingredients/fr-origins-labels.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 55.5555555555556,
          "percent_max" : 100,
          "percent_min" : 11.1111111111111,
-         "rank" : 1,
          "text" : "Fraise",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 22.2222222222222,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "Cassis",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -28,7 +26,6 @@
          "percent_estimate" : 11.1111111111111,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "Framboise",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -39,7 +36,6 @@
          "percent_estimate" : 5.55555555555556,
          "percent_max" : 25,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "Pamplemousse",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -50,7 +46,6 @@
          "percent_estimate" : 2.77777777777778,
          "percent_max" : 20,
          "percent_min" : 0,
-         "rank" : 5,
          "text" : "Orange",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -61,7 +56,6 @@
          "percent_estimate" : 1.38888888888889,
          "percent_max" : 16.6666666666667,
          "percent_min" : 0,
-         "rank" : 6,
          "text" : "Citron",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -72,7 +66,6 @@
          "percent_estimate" : 0.694444444444443,
          "percent_max" : 14.2857142857143,
          "percent_min" : 0,
-         "rank" : 7,
          "text" : "cacao",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -83,7 +76,6 @@
          "percent_estimate" : 0.347222222222221,
          "percent_max" : 12.5,
          "percent_min" : 0,
-         "rank" : 8,
          "text" : "beurre de cacao",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -94,7 +86,6 @@
          "percent_estimate" : 0.347222222222229,
          "percent_max" : 11.1111111111111,
          "percent_min" : 0,
-         "rank" : 9,
          "text" : "cerises",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-origins.json
+++ b/t/expected_test_results/ingredients/fr-origins.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 62.5,
          "percent_max" : 100,
          "percent_min" : 25,
-         "rank" : 1,
          "text" : "Fraises",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 18.75,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "beurre doux",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -28,7 +26,6 @@
          "percent_estimate" : 9.375,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "tomates cerises",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -39,7 +36,6 @@
          "percent_estimate" : 9.375,
          "percent_max" : 25,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "pommes",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/ingredients/fr-palm-kernel-fat.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 100,
          "percent_max" : 100,
          "percent_min" : 100,
-         "rank" : 1,
          "text" : "graisse de palmiste",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-percents-origins-2.json
+++ b/t/expected_test_results/ingredients/fr-percents-origins-2.json
@@ -1,24 +1,23 @@
 {
    "ingredients" : [
       {
-         "has_sub_ingredients" : "yes",
          "id" : "en:emulsifier",
          "ingredients" : [
             {
                "id" : "en:sunflower-lecithin",
                "percent_estimate" : 50,
-               "text" : "lécithines de tournesol"
+               "text" : "lécithines de tournesol",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "percent_estimate" : 50,
-         "rank" : 1,
          "text" : "émulsifiant"
       },
       {
          "id" : "en:flavouring",
          "origins" : "en:european-union",
          "percent_estimate" : 25,
-         "rank" : 2,
          "text" : "arôme",
          "vegan" : "maybe",
          "vegetarian" : "maybe"
@@ -28,7 +27,6 @@
          "origins" : "en:france",
          "percent" : "33",
          "percent_estimate" : 25,
-         "rank" : 3,
          "text" : "farine de blé",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -36,7 +34,6 @@
       {
          "id" : "en:sugar",
          "percent_estimate" : 0,
-         "rank" : 4,
          "text" : "sucre",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -47,16 +44,8 @@
          "origins" : "en:france",
          "percent" : "6.5",
          "percent_estimate" : 0,
-         "rank" : 5,
          "text" : "beurre concentré",
          "vegan" : "no",
-         "vegetarian" : "yes"
-      },
-      {
-         "id" : "en:sunflower-lecithin",
-         "percent_estimate" : 50,
-         "text" : "lécithines de tournesol",
-         "vegan" : "yes",
          "vegetarian" : "yes"
       }
    ],

--- a/t/expected_test_results/ingredients/fr-percents-origins.json
+++ b/t/expected_test_results/ingredients/fr-percents-origins.json
@@ -5,7 +5,6 @@
          "labels" : "en:organic",
          "percent" : 80,
          "percent_estimate" : 80,
-         "rank" : 1,
          "text" : "jus de pomme",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -15,7 +14,6 @@
          "labels" : "en:organic",
          "percent" : 20,
          "percent_estimate" : 20,
-         "rank" : 2,
          "text" : "coing",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -23,7 +21,6 @@
       {
          "id" : "en:sea-salt",
          "percent_estimate" : 0,
-         "rank" : 3,
          "text" : "sel marin",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -33,7 +30,6 @@
          "origins" : "en:france,en:italy",
          "percent" : "98",
          "percent_estimate" : 0,
-         "rank" : 4,
          "text" : "chlorure de sodium"
       }
    ],

--- a/t/expected_test_results/ingredients/fr-percents.json
+++ b/t/expected_test_results/ingredients/fr-percents.json
@@ -4,7 +4,6 @@
          "id" : "en:strawberry",
          "percent" : 12.3,
          "percent_estimate" : 12.3,
-         "rank" : 1,
          "text" : "Fraise",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -13,7 +12,6 @@
          "id" : "en:orange",
          "percent" : 6.5,
          "percent_estimate" : 6.5,
-         "rank" : 2,
          "text" : "Orange",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -22,7 +20,6 @@
          "id" : "en:apple",
          "percent" : 3.5,
          "percent_estimate" : 81.2,
-         "rank" : 3,
          "text" : "Pomme",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-processing-multi.json
+++ b/t/expected_test_results/ingredients/fr-processing-multi.json
@@ -6,7 +6,6 @@
          "percent_max" : 100,
          "percent_min" : 16.6666666666667,
          "processing" : "en:cooked",
-         "rank" : 1,
          "text" : "tomates pelées",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -17,7 +16,6 @@
          "percent_max" : 50,
          "percent_min" : 0,
          "processing" : "en:sliced",
-         "rank" : 2,
          "text" : "citron",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -28,7 +26,6 @@
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
          "processing" : "en:diced",
-         "rank" : 3,
          "text" : "courgette",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -38,7 +35,6 @@
          "percent_estimate" : 5.20833333333333,
          "percent_max" : 25,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "lait cru",
          "vegan" : "no",
          "vegetarian" : "yes"
@@ -49,7 +45,6 @@
          "percent_max" : 20,
          "percent_min" : 0,
          "processing" : "en:raw",
-         "rank" : 5,
          "text" : "aubergines",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -60,7 +55,6 @@
          "percent_max" : 16.6666666666667,
          "percent_min" : 0,
          "processing" : "en:sliced",
-         "rank" : 6,
          "text" : "jambon cru",
          "vegan" : "no",
          "vegetarian" : "no"

--- a/t/expected_test_results/ingredients/fr-starred-label.json
+++ b/t/expected_test_results/ingredients/fr-starred-label.json
@@ -8,7 +8,6 @@
          "percent_estimate" : "75",
          "percent_max" : "75",
          "percent_min" : "75",
-         "rank" : 1,
          "text" : "pâte de cacao",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -19,7 +18,6 @@
          "percent_estimate" : 18.75,
          "percent_max" : 25,
          "percent_min" : 12.5,
-         "rank" : 2,
          "text" : "sucre de canne",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -30,7 +28,6 @@
          "percent_estimate" : 6.25,
          "percent_max" : 12.5,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "beurre de cacao",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ingredients/fr-truncated-puree.json
+++ b/t/expected_test_results/ingredients/fr-truncated-puree.json
@@ -4,7 +4,6 @@
          "id" : "en:crushed-tomato",
          "percent" : "19",
          "percent_estimate" : "19",
-         "rank" : 1,
          "text" : "purée de tomate",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -13,7 +12,6 @@
          "id" : "en:beef",
          "percent" : "90",
          "percent_estimate" : 81,
-         "rank" : 2,
          "text" : "boeuf",
          "vegan" : "no",
          "vegetarian" : "no"
@@ -22,7 +20,6 @@
          "id" : "en:fruit-juice",
          "percent" : "100",
          "percent_estimate" : 0,
-         "rank" : 3,
          "text" : "jus de fruit",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -32,7 +29,6 @@
          "id" : "en:oil-and-fat",
          "percent" : "45",
          "percent_estimate" : 0,
-         "rank" : 4,
          "text" : "matière grasses",
          "vegan" : "maybe",
          "vegetarian" : "maybe"

--- a/t/expected_test_results/ingredients/fr-vegetal-origin.json
+++ b/t/expected_test_results/ingredients/fr-vegetal-origin.json
@@ -6,7 +6,6 @@
          "percent_estimate" : 66.6666666666667,
          "percent_max" : 100,
          "percent_min" : 33.3333333333333,
-         "rank" : 1,
          "text" : "mono- et diglycérides d'acides gras",
          "vegan" : "en:yes",
          "vegetarian" : "en:yes"
@@ -17,7 +16,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "huile",
          "vegan" : "en:yes",
          "vegetarian" : "en:yes"
@@ -27,7 +25,6 @@
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "gélatine",
          "vegan" : "en:yes",
          "vegetarian" : "en:yes"

--- a/t/expected_test_results/ingredients/xx-single-letters.json
+++ b/t/expected_test_results/ingredients/xx-single-letters.json
@@ -5,7 +5,6 @@
          "percent_estimate" : 51.3888888888889,
          "percent_max" : 100,
          "percent_min" : 2.77777777777778,
-         "rank" : 1,
          "text" : "a"
       },
       {
@@ -13,7 +12,6 @@
          "percent_estimate" : 24.3055555555556,
          "percent_max" : 50,
          "percent_min" : 0,
-         "rank" : 2,
          "text" : "b"
       },
       {
@@ -21,7 +19,6 @@
          "percent_estimate" : 12.1527777777778,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "rank" : 3,
          "text" : "c"
       },
       {
@@ -29,7 +26,6 @@
          "percent_estimate" : 6.07638888888889,
          "percent_max" : 25,
          "percent_min" : 0,
-         "rank" : 4,
          "text" : "d"
       },
       {
@@ -37,7 +33,6 @@
          "percent_estimate" : 3.03819444444444,
          "percent_max" : 20,
          "percent_min" : 0,
-         "rank" : 5,
          "text" : "e"
       },
       {
@@ -45,7 +40,6 @@
          "percent_estimate" : 1.51909722222222,
          "percent_max" : 16.6666666666667,
          "percent_min" : 0,
-         "rank" : 6,
          "text" : "f"
       },
       {
@@ -53,7 +47,6 @@
          "percent_estimate" : 0.759548611111114,
          "percent_max" : 14.2857142857143,
          "percent_min" : 0,
-         "rank" : 7,
          "text" : "g"
       },
       {
@@ -61,7 +54,6 @@
          "percent_estimate" : 0.379774305555557,
          "percent_max" : 12.5,
          "percent_min" : 0,
-         "rank" : 8,
          "text" : "h"
       },
       {
@@ -69,7 +61,6 @@
          "percent_estimate" : 0.189887152777779,
          "percent_max" : 11.1111111111111,
          "percent_min" : 0,
-         "rank" : 9,
          "text" : "i"
       },
       {
@@ -77,7 +68,6 @@
          "percent_estimate" : 0.0949435763888857,
          "percent_max" : 10,
          "percent_min" : 0,
-         "rank" : 10,
          "text" : "j"
       },
       {
@@ -85,7 +75,6 @@
          "percent_estimate" : 0.0474717881944429,
          "percent_max" : 9.09090909090909,
          "percent_min" : 0,
-         "rank" : 11,
          "text" : "k"
       },
       {
@@ -93,7 +82,6 @@
          "percent_estimate" : 0.0237358940972214,
          "percent_max" : 8.33333333333333,
          "percent_min" : 0,
-         "rank" : 12,
          "text" : "l"
       },
       {
@@ -101,7 +89,6 @@
          "percent_estimate" : 0.0118679470486143,
          "percent_max" : 7.69230769230769,
          "percent_min" : 0,
-         "rank" : 13,
          "text" : "m"
       },
       {
@@ -109,7 +96,6 @@
          "percent_estimate" : 0.00593397352430713,
          "percent_max" : 7.14285714285714,
          "percent_min" : 0,
-         "rank" : 14,
          "text" : "n"
       },
       {
@@ -117,7 +103,6 @@
          "percent_estimate" : 0.00296698676215357,
          "percent_max" : 6.66666666666667,
          "percent_min" : 0,
-         "rank" : 15,
          "text" : "o",
          "vegan" : "no",
          "vegetarian" : "no"
@@ -127,7 +112,6 @@
          "percent_estimate" : 0.00148349338107323,
          "percent_max" : 6.25,
          "percent_min" : 0,
-         "rank" : 16,
          "text" : "p"
       },
       {
@@ -135,7 +119,6 @@
          "percent_estimate" : 0.000741746690536615,
          "percent_max" : 5.88235294117647,
          "percent_min" : 0,
-         "rank" : 17,
          "text" : "q"
       },
       {
@@ -143,7 +126,6 @@
          "percent_estimate" : 0.000370873345268308,
          "percent_max" : 5.55555555555556,
          "percent_min" : 0,
-         "rank" : 18,
          "text" : "r"
       },
       {
@@ -151,7 +133,6 @@
          "percent_estimate" : 0.000185436672637707,
          "percent_max" : 5.26315789473684,
          "percent_min" : 0,
-         "rank" : 19,
          "text" : "s"
       },
       {
@@ -159,7 +140,6 @@
          "percent_estimate" : 9.27183363188533e-05,
          "percent_max" : 5,
          "percent_min" : 0,
-         "rank" : 20,
          "text" : "t"
       },
       {
@@ -167,7 +147,6 @@
          "percent_estimate" : 4.63591681594266e-05,
          "percent_max" : 4.76190476190476,
          "percent_min" : 0,
-         "rank" : 21,
          "text" : "u"
       },
       {
@@ -175,7 +154,6 @@
          "percent_estimate" : 2.31795840761606e-05,
          "percent_max" : 4.54545454545455,
          "percent_min" : 0,
-         "rank" : 22,
          "text" : "v"
       },
       {
@@ -183,7 +161,6 @@
          "percent_estimate" : 1.15897920380803e-05,
          "percent_max" : 4.34782608695652,
          "percent_min" : 0,
-         "rank" : 23,
          "text" : "w"
       },
       {
@@ -191,7 +168,6 @@
          "percent_estimate" : 5.79489601904015e-06,
          "percent_max" : 4.16666666666667,
          "percent_min" : 0,
-         "rank" : 24,
          "text" : "x"
       },
       {
@@ -199,7 +175,6 @@
          "percent_estimate" : 2.89744801307279e-06,
          "percent_max" : 4,
          "percent_min" : 0,
-         "rank" : 25,
          "text" : "y"
       },
       {
@@ -207,7 +182,6 @@
          "percent_estimate" : 1.44872400653639e-06,
          "percent_max" : 3.84615384615385,
          "percent_min" : 0,
-         "rank" : 26,
          "text" : "z"
       },
       {
@@ -215,7 +189,6 @@
          "percent_estimate" : 7.24362003268197e-07,
          "percent_max" : 3.7037037037037,
          "percent_min" : 0,
-         "rank" : 27,
          "text" : "0‚1"
       },
       {
@@ -223,7 +196,6 @@
          "percent_estimate" : 3.62180998081385e-07,
          "percent_max" : 3.57142857142857,
          "percent_min" : 0,
-         "rank" : 28,
          "text" : "2‚3"
       },
       {
@@ -231,7 +203,6 @@
          "percent_estimate" : 1.81090499040693e-07,
          "percent_max" : 3.44827586206897,
          "percent_min" : 0,
-         "rank" : 29,
          "text" : "4‚5"
       },
       {
@@ -239,7 +210,6 @@
          "percent_estimate" : 9.05452495203463e-08,
          "percent_max" : 3.33333333333333,
          "percent_min" : 0,
-         "rank" : 30,
          "text" : "6‚7"
       },
       {
@@ -247,7 +217,6 @@
          "percent_estimate" : 4.52726283128868e-08,
          "percent_max" : 3.2258064516129,
          "percent_min" : 0,
-         "rank" : 31,
          "text" : "8‚9"
       },
       {
@@ -255,7 +224,6 @@
          "percent_estimate" : 2.26363141564434e-08,
          "percent_max" : 3.125,
          "percent_min" : 0,
-         "rank" : 32,
          "text" : "10‚100‚1000"
       },
       {
@@ -263,7 +231,6 @@
          "percent_estimate" : 1.13181570782217e-08,
          "percent_max" : 3.03030303030303,
          "percent_min" : 0,
-         "rank" : 33,
          "text" : "vt"
       },
       {
@@ -271,7 +238,6 @@
          "percent_estimate" : 5.65907498639717e-09,
          "percent_max" : 2.94117647058824,
          "percent_min" : 0,
-         "rank" : 34,
          "text" : "leaf"
       },
       {
@@ -280,11 +246,9 @@
          "percent_estimate" : 2.82953749319859e-09,
          "percent_max" : 2.94117647058824,
          "percent_min" : 0,
-         "rank" : 35,
          "text" : "something"
       },
       {
-         "has_sub_ingredients" : "yes",
          "id" : "fr:somethingelse",
          "ingredients" : [
             {
@@ -298,15 +262,7 @@
          "percent_estimate" : 2.82953749319859e-09,
          "percent_max" : 2.77777777777778,
          "percent_min" : 0,
-         "rank" : 36,
          "text" : "somethingelse"
-      },
-      {
-         "id" : "fr:u",
-         "percent_estimate" : 2.82953749319859e-09,
-         "percent_max" : 2.77777777777778,
-         "percent_min" : 0,
-         "text" : "u"
       }
    ],
    "ingredients_analysis_tags" : [

--- a/t/ingredients_nutriscore.t
+++ b/t/ingredients_nutriscore.t
@@ -32,7 +32,7 @@ foreach my $test_ref (@ingredients) {
 }
 
 
-# dummy product for testing
+# test the estimate percent of fruits and vegetables
 
 my @tests = (
 [ { lc => "fr", ingredients_text => "" }, undef ],
@@ -56,6 +56,37 @@ foreach my $test_ref (@tests) {
 		$expected_fruits
 	) or diag explain $product_ref->{ingredients};
 }
+
+# test the estimate percent of milk
+
+@tests = (
+[ { lc => "fr", ingredients_text => "" }, 0 ],
+[ { lc => "fr", ingredients_text => "lait" }, 100 ],
+[ { lc => "fr", ingredients_text => "lait entier" }, 100 ],
+[ { lc => "fr", ingredients_text => "lait frais" }, 100 ],
+[ { lc => "fr", ingredients_text => "lait de vache" }, 100 ],
+[ { lc => "fr", ingredients_text => "lait pasteurisé" }, 100 ],
+[ { lc => "fr", ingredients_text => "lait de coco" }, 0 ],
+[ { lc => "fr", ingredients_text => "lait, sucre, noisettes" }, 33.3333333333333 ],
+[ { lc => "fr", ingredients_text => "lait écrémé 50%, fraise 30%, eau" }, 50 ],
+[ { lc => "fr", ingredients_text => "banane 50%, gâteau (fraise, framboise, lait demi-écrémé), eau" }, 0 ],
+[ { lc => "fr", ingredients_text => "lait frais, gâteau (lait 30%, framboise 5%, farine), eau" }, 65 ],
+);
+
+
+foreach my $test_ref (@tests) {
+
+	my $product_ref = $test_ref->[0];
+	my $expected_milk = $test_ref->[1];
+
+	extract_ingredients_from_text($product_ref);
+
+	is (
+		estimate_milk_percent_from_ingredients($product_ref),
+		$expected_milk
+	) or diag explain $product_ref->{ingredients};
+}
+
 
 done_testing();
 

--- a/t/nutriscore.t
+++ b/t/nutriscore.t
@@ -9,6 +9,7 @@ use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Food qw/:all/;
+use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Nutriscore qw/:all/;
 
 init_emb_codes();
@@ -24,12 +25,24 @@ my @tests = (
 # saturated fat 1.03 should be rounded to 1.0 which is not strictly greater than 1.0
 [{ lc=>"en", categories=>"breakfast cereals", nutriments=>{energy_100g=>2450, fat_100g=>100, "saturated-fat_100g"=>1.03, sugars_100g=>31, sodium_100g=>0.221, fiber_100g=>6.9, proteins_100g=>10.3}}, 10, "c"],
 
+# dairy drink with milk >= 80% are considered food and not beverages
+
+[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Water, sugar"}, 19, "e"],
+[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Milk"}, 14, "d"],
+[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Fresh milk 80%, sugar"}, 14, "d"],
+[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Milk, sugar"}, 19, "e"],
+
 );
 
 foreach my $test_ref (@tests) {
 
 	my $product_ref = $test_ref->[0];
 	compute_field_tags($product_ref, $product_ref->{lc}, "categories");
+	extract_ingredients_from_text($product_ref);
 	special_process_product($product_ref);
 	compute_nutrition_score($product_ref);
 


### PR DESCRIPTION
Fixes #4901 and #4902 .

This is a rather big change: when I added support for nested ingredients in the ingredients analysis, I stored both the new nested ingredients structure + the old flattened ingredients structure in the ingredients array. And then depending on the API version requested, we return only the flattened part, or only the nested part.

But it doubles the amount of data stored for ingredients analysis and it makes things complex.

So now we only store the nested structure, and if requested, we generate a flattened structure.