### PR TITLE
Make exports more flexible, fixes #4932

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4229,6 +4229,32 @@ Reference to the MongoDB query object.
 
 =cut
 
+# Parameters that are not query filters
+
+my %ignore_params = (
+	fields => 1,
+	format => 1,
+	json => 1,
+	jsonp => 1,
+	xml => 1,
+	keywords => 1,	# added by CGI.pm
+	api_version => 1,
+	api_method => 1,
+	search_simple => 1,
+	search_terms => 1,
+	userid => 1,
+	password => 1,
+	action => 1,
+	type => 1,
+);
+
+# Parameters that can be query filters
+# It is safer to use a positive list, instead of just the %ignore_params list
+
+my %valid_params = (
+	code => 1,
+);
+
 sub add_params_to_query($$) {
 	
 	my $request_ref = shift;
@@ -4243,8 +4269,7 @@ sub add_params_to_query($$) {
 		$log->debug("add_params_to_query - field", { field => $field }) if $log->is_debug();		
 		
 		# skip params that are not query filters
-		# warning: keywords is added by CGI.pm and should be ignored
-		next if (($field eq "fields") or ($field eq "format") or ($field =~ /^api_/) or ($field eq "json") or ($field eq "jsonp") or ($field eq "xml") or ($field eq "keywords") or ($field eq "userid") or ($field eq "password"));
+		next if (defined $ignore_params{$field});
 		
 		if (($field eq "page") or ($field eq "page_size")) {
 			$request_ref->{$field} = param($field) + 0;	# Make sure we have a number
@@ -4403,7 +4428,7 @@ sub add_params_to_query($$) {
 		}
 		
 		# Exact match on a specific field (e.g. "code")
-		elsif ($field =~ /^[a-z0-9-_]+$/) {
+		elsif (defined $valid_params{$field}) {
 			
 			my $values = remove_tags_and_quote(decode utf8=>param($field));
 			

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4242,6 +4242,10 @@ sub add_params_to_query($$) {
 		
 		$log->debug("add_params_to_query - field", { field => $field }) if $log->is_debug();		
 		
+		# skip params that are not query filters
+		# warning: keywords is added by CGI.pm and should be ignored
+		next if (($field eq "fields") or ($field eq "format") or ($field =~ /^api_/) or ($field eq "json") or ($field eq "jsonp") or ($field eq "xml") or ($field eq "keywords") or ($field eq "userid") or ($field eq "password"));
+		
 		if (($field eq "page") or ($field eq "page_size")) {
 			$request_ref->{$field} = param($field) + 0;	# Make sure we have a number
 		}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -89,6 +89,7 @@ BEGIN
 		&display_ingredients_analysis
 
 		&count_products
+		&add_params_to_query
 		
 		&process_template
 
@@ -4249,24 +4250,6 @@ sub add_params_to_query($$) {
 			$request_ref->{$field} = param($field);
 		}
 		
-		# Exact match on a specific field
-		elsif ($field eq "code") {
-			
-			my $values = remove_tags_and_quote(decode utf8=>param($field));
-			
-			# Possible values:
-			# xyz=a
-			# xyz=a|b xyz=a,b xyz=a+b	products with either xyz a or xyz b
-			
-			if ($values =~ /\||\+|,/) {
-				my @values = split(/\||\+|,/, $values);
-				$query_ref->{$field} = { '$in' => \@values };
-			}
-			else {
-				$query_ref->{$field} = $values;
-			}
-		}
-		
 		# Tags fields can be passed with taxonomy ids as values (e.g labels_tags=en:organic)
 		# or with values in a given language (e.g. labels_tags_fr=bio)
 		
@@ -4414,6 +4397,24 @@ sub add_params_to_query($$) {
 				}			
 			}
 		}
+		
+		# Exact match on a specific field (e.g. "code")
+		elsif ($field =~ /^[a-z0-9-_]+$/) {
+			
+			my $values = remove_tags_and_quote(decode utf8=>param($field));
+			
+			# Possible values:
+			# xyz=a
+			# xyz=a|b xyz=a,b xyz=a+b	products with either xyz a or xyz b
+			
+			if ($values =~ /\||\+|,/) {
+				my @values = split(/\||\+|,/, $values);
+				$query_ref->{$field} = { '$in' => \@values };
+			}
+			else {
+				$query_ref->{$field} = $values;
+			}
+		}		
 	}
 }
 

--- a/lib/ProductOpener/Export.pm
+++ b/lib/ProductOpener/Export.pm
@@ -448,6 +448,8 @@ sub export_csv($) {
 						# Remove tags
 						$value =~ s/<(([^>]|\n)*)>//g;
 					}
+					# Allow returning fields that are not at the root of the product structure
+					# e.g. ecoscore_data.agribalyse.score  -> $product_ref->{ecoscore_data}{agribalyse}{score}
 					elsif ($field =~ /^([^\.]+)\.([^\.]+)\.([^\.]+)$/) {
 						if ((defined $product_ref->{$1}) and (defined $product_ref->{$1}{$2})) {
 							$value = $product_ref->{$1}{$2}{$3};

--- a/lib/ProductOpener/Export.pm
+++ b/lib/ProductOpener/Export.pm
@@ -450,6 +450,11 @@ sub export_csv($) {
 					}
 					# Allow returning fields that are not at the root of the product structure
 					# e.g. ecoscore_data.agribalyse.score  -> $product_ref->{ecoscore_data}{agribalyse}{score}
+					elsif ($field =~ /^([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)$/) {
+						if ((defined $product_ref->{$1}) and (defined $product_ref->{$1}{$2}) and (defined $product_ref->{$1}{$2}{$3})) {
+							$value = $product_ref->{$1}{$2}{$3}{$4};
+						}
+					}
 					elsif ($field =~ /^([^\.]+)\.([^\.]+)\.([^\.]+)$/) {
 						if ((defined $product_ref->{$1}) and (defined $product_ref->{$1}{$2})) {
 							$value = $product_ref->{$1}{$2}{$3};

--- a/lib/ProductOpener/Export.pm
+++ b/lib/ProductOpener/Export.pm
@@ -448,6 +448,16 @@ sub export_csv($) {
 						# Remove tags
 						$value =~ s/<(([^>]|\n)*)>//g;
 					}
+					elsif ($field =~ /^([^\.]+)\.([^\.]+)\.([^\.]+)$/) {
+						if ((defined $product_ref->{$1}) and (defined $product_ref->{$1}{$2})) {
+							$value = $product_ref->{$1}{$2}{$3};
+						}
+					}
+					elsif ($field =~ /^([^\.]+)\.([^\.]+)$/) {
+						if (defined $product_ref->{$1}) {
+							$value = $product_ref->{$1}{$2};
+						}
+					}
 					else {
 						$value = $product_ref->{$field};
 					}


### PR DESCRIPTION
fixes #4932 

- make all fields available for filtering in the Search API V2
- use the same filter parsing code than the Search API V2 for the export_csv_file.pl script
- support advanced query filters (similar to the search V2 API : products without a tag, with multiple tags, with one of many tags etc.)
- exporting data for a specific set of barcodes (from a file)
- exporting fields that are not at the root of the product structure

e.g. it's now possible to do things like this:

./export_csv_file.pl --query 'additives_tags=en:e101|en:e102' --query ecoscore_grade=exists --fields=code,ecoscore_grade,ecoscore_data.score,ecoscore_data.agribalyse.agribalyse_food_code --query-codes-from-file codes

The corresponding changes will also make it easier to do things like this through a web interface at a future point.