### PR TITLE
Ecoscore fixes for milks and energy drinks

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -452,7 +452,7 @@ sub compute_ecoscore($) {
 	
 	# Special case for waters and sodas: disable the Eco-Score
 	
-	my @categories_without_ecoscore = ("en:waters", "en:sodas");
+	my @categories_without_ecoscore = ("en:waters", "en:sodas", "en:energy-drinks");
 	my $category_without_ecoscore;
 	
 	foreach my $category (@categories_without_ecoscore) {
@@ -664,7 +664,8 @@ sub compute_ecoscore_agribalyse($) {
 			# Formula to transform the Environmental Footprint single score to a 0 to 100 scale
 			# Note: EF score are for mPt / kg in Agribalyse, we need it in micro points per 100g
 			
-			if (has_tag($product_ref, 'categories', 'en:beverages')) {
+			# Milk is considered to be a beverage
+			if (has_tag($product_ref, 'categories', 'en:beverages') or (has_tag($product_ref, 'categories', 'en:milks'))) {
 				# Beverages case: score = -36*\ln(x+1)+150score=− 36 * ln(x+1) + 150
 				$product_ref->{ecoscore_data}{agribalyse}{is_beverage} = 1;
 				$product_ref->{ecoscore_data}{agribalyse}{score} = round(-36 * log($agribalyse{$agb}{ef_total} * (1000 / 10) + 1 ) + 150);

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -363,7 +363,33 @@ my @tests = (
 			origins_tags => ["en:france"],
 			ingredients_text => "Aubergine 60%, Pomme de terre 39%, Huile de colza 1%",
 		},
-	],		
+	],
+	
+	# Milks should be considered as beverages for the Eco-Score
+	
+	[
+		'milk',
+		{
+			lc => "fr",
+			categories_tags=>["en:milks"],
+			packaging_text => "1 bouteille en plastique PET, 1 bouchon PEHD",
+			labels_tags => ["en:eu-organic"],
+			origins_tags => ["en:france"],
+			ingredients_text => "Lait",
+		},
+	],
+	
+	# Energy drinks should not have an Eco-Score (like waters and sodas)
+	
+	[
+		'energy-drink',
+		{
+			lc => "fr",
+			categories_tags=>["en:energy-drinks"],
+			packaging_text => "1 bouteille en plastique PET, 1 bouchon PEHD",
+			ingredients_text => "Water",
+		},
+	],	
 
 );
 

--- a/t/expected_test_results/ecoscore/energy-drink.json
+++ b/t/expected_test_results/ecoscore/energy-drink.json
@@ -1,0 +1,67 @@
+{
+   "categories_tags" : [
+      "en:energy-drinks"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {},
+      "ecoscore_not_applicable_for_category" : "en:energy-drinks",
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "not-applicable",
+   "ecoscore_tags" : [
+      "not-applicable"
+   ],
+   "ingredients" : [
+      {
+         "id" : "fr:Water",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Water"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "fr:Water"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "fr:Water"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "fr:water"
+   ],
+   "ingredients_text" : "Water",
+   "known_ingredients_n" : 0,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:ecoscore-not-applicable",
+      "en:ecoscore-not-computed"
+   ],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "packaging_text" : "1 bouteille en plastique PET, 1 bouchon PEHD",
+   "packagings" : [
+      {
+         "material" : "en:pet-polyethylene-terephthalate",
+         "number" : "1",
+         "shape" : "en:bottle"
+      },
+      {
+         "material" : "en:hdpe-high-density-polyethylene",
+         "number" : "1",
+         "shape" : "en:bottle-cap"
+      }
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/t/expected_test_results/ecoscore/milk.json
+++ b/t/expected_test_results/ecoscore/milk.json
@@ -1,0 +1,149 @@
+{
+   "categories_tags" : [
+      "en:milks"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:france",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 93.0663626138272,
+            "epi_value" : 4,
+            "origins_from_origins_field" : [
+               "en:france"
+            ],
+            "transportation_score" : 99.7567795833333,
+            "transportation_value" : 15,
+            "value" : 19
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 0,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 50,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:pet-polyethylene-terephthalate",
+                  "material_shape" : "en:pet-polyethylene-terephthalate.en:bottle",
+                  "non_recyclable_and_non_biodegradable" : "no",
+                  "number" : "1",
+                  "shape" : "en:bottle"
+               },
+               {
+                  "ecoscore_material_score" : 50,
+                  "ecoscore_shape_ratio" : 0.1,
+                  "material" : "en:hdpe-high-density-polyethylene",
+                  "material_shape" : "en:hdpe-high-density-polyethylene.en:bottle-cap",
+                  "non_recyclable_and_non_biodegradable" : "no",
+                  "number" : "1",
+                  "shape" : "en:bottle-cap"
+               }
+            ],
+            "score" : 45,
+            "value" : -6
+         },
+         "production_system" : {
+            "label" : "en:eu-organic",
+            "value" : 15
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "19041",
+         "co2_agriculture" : "1.1888463",
+         "co2_consumption" : "0",
+         "co2_distribution" : "0.012078628",
+         "co2_packaging" : "0.17188731",
+         "co2_processing" : "0.01061493",
+         "co2_total" : "1.4865868",
+         "co2_transportation" : "0.10315961",
+         "code" : "19041",
+         "dqr" : "2.47",
+         "ef_agriculture" : "0.10502456",
+         "ef_consumption" : "0",
+         "ef_distribution" : "0.004287772",
+         "ef_packaging" : "0.014723027999999999",
+         "ef_processing" : "0.0014905525",
+         "ef_total" : 0.13351659,
+         "ef_transportation" : "0.0079906595",
+         "is_beverage" : 1,
+         "name_en" : "Milk, semi-skimmed, UHT",
+         "name_fr" : "Lait demi-écrémé, UHT",
+         "score" : 54
+      },
+      "grade" : "b",
+      "score" : 79,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 79,
+   "ecoscore_tags" : [
+      "b"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:milk",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Lait",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:milk",
+      "en:dairy"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:milk"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:milk",
+      "en:dairy"
+   ],
+   "ingredients_text" : "Lait",
+   "known_ingredients_n" : 2,
+   "labels_tags" : [
+      "en:eu-organic"
+   ],
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:ecoscore-no-missing-data",
+      "en:ecoscore-computed"
+   ],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "origins_tags" : [
+      "en:france"
+   ],
+   "packaging_text" : "1 bouteille en plastique PET, 1 bouchon PEHD",
+   "packagings" : [
+      {
+         "material" : "en:pet-polyethylene-terephthalate",
+         "number" : "1",
+         "shape" : "en:bottle"
+      },
+      {
+         "material" : "en:hdpe-high-density-polyethylene",
+         "number" : "1",
+         "shape" : "en:bottle-cap"
+      }
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/taxonomies/categories.result.txt
+++ b/taxonomies/categories.result.txt
@@ -5633,6 +5633,10 @@ fr:Bonbons de chocolat au lait
 nl:Melkchocolabonbons
 
 < en:Bonbons
+en:Peanut butter cups
+wikidata:en: Q7157931
+
+< en:Bonbons
 fr:Gingembrettes
 
 < en:Bonbons
@@ -13818,16 +13822,6 @@ es:Turrones de chocolate con arroz inflado, Turrones de chocolate negro con arro
 fr:Turrón au chocolat avec riz soufflé, turrón au chocolat noir avec riz soufflé
 
 < en:Chocolates
-< en:Christmas foods and drinks
-en:Christmas chocolates
-de:Weihnachtsschokolade
-es:Chocolates de navidad
-fi:joulusuklaat
-fr:Chocolats de Noël
-it:Cioccolatini di Natale
-nl:Kerstmischocola
-
-< en:Chocolates
 en:Assorted chocolates
 de:Verschiedene Pralinen, Pralinensortimente
 fi:suklaasekoitus
@@ -14194,6 +14188,16 @@ nl:Adventskalender
 pl:Kalendarz adwentowy
 pt:Calendário do Advento
 ru:Рождественский календарь
+
+< en:Christmas foods and drinks
+< en:Cocoa and its products
+en:Christmas chocolates
+de:Weihnachtsschokolade
+es:Chocolates de navidad
+fi:joulusuklaat
+fr:Chocolats de Noël
+it:Cioccolatini di Natale
+nl:Kerstmischocola
 
 < en:Christmas foods and drinks
 < en:Confectioneries
@@ -14580,18 +14584,6 @@ origins:en: en:France
 protected_name_file_number:en: PDO-FR-0062
 protected_name_type:en: pdo
 
-en:Cocoa and chocolate powders, chocolate and cocoa powders
-ca:Pols de coco i xocolata
-de:Kakao- und Schokoladenpulver, Schkoladen- und Kakaopulver
-es:Cacaos y chocolates en polvo, chocolates y cacaos en polvo
-fi:Kaakao- ja suklaajauheet
-fr:Cacaos et chocolats en poudre, chocolats et cacaos en poudre
-hu:Kakaó- és csokoládéporok
-it:Cacao e cioccolato in polvere
-nl:Cacao en cacaopoeders, cacao en cacapoeder
-agribalyse_proxy_food_code:en: 18167
-agribalyse_proxy_food_name:en: Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins and chemical elements
-
 < en:Cocoa and chocolate powders
 en:Cocoa powders, cocoa powder, Cocoa, Cacao, Cacao powders, Instant cocoa powder without sugar
 ca:Cacau en pols, Cacau
@@ -14612,6 +14604,60 @@ fr:Poudre maltée cacaotée, Poudre maltée cacaotée sucrée pour boisson enric
 ciqual_food_code:en: 18102
 ciqual_food_name:en: Malted cocoa or chocolate powder for beverage, with sugar
 ciqual_food_name:fr: Poudre maltée, cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines et minéraux
+
+en:Cocoa and its products
+fr:Cacao et dérivés
+
+< en:Cocoa and its products
+en:Cocoa and chocolate powders, chocolate and cocoa powders
+ca:Pols de coco i xocolata
+de:Kakao- und Schokoladenpulver, Schkoladen- und Kakaopulver
+es:Cacaos y chocolates en polvo, chocolates y cacaos en polvo
+fi:Kaakao- ja suklaajauheet
+fr:Cacaos et chocolats en poudre, chocolats et cacaos en poudre
+hu:Kakaó- és csokoládéporok
+it:Cacao e cioccolato in polvere
+nl:Cacao en cacaopoeders, cacao en cacapoeder
+agribalyse_proxy_food_code:en: 18167
+agribalyse_proxy_food_name:en: Cocoa or chocolate powder, for beverages, with sugar, fortified with vitamins and chemical elements
+
+< en:Cocoa and its products
+en:Cocoa beans
+fr:Fèves de cacao
+
+< en:Cocoa and its products
+< en:Sweet snacks
+en:Chocolates, chocolate products
+ca:Xocolata
+cs:Čokolády
+da:Chokolader, chokolade
+de:Schokoladen, Schokolade, Schokoladenprodukte
+es:Chocolates
+fi:suklaat
+fr:Chocolats, chocolat, produits chocolatés, produits au chocolat
+he:שוקולדים
+hu:Csokoládék, csokoládé termékek
+it:Cioccolato
+nl:Chocoladeproducten
+pl:Czekolada, Produkty czekoladowe
+pt:Chocolates, produtos com chocolate
+ru:Шоколад, шоколадные продукты
+sv:Choklad, Chokladprodukter
+th:ช็อกโกแลต
+zh:巧克力
+nova:en: 3
+pnns_group_2:en: Chocolate products
+
+< en:Cocoa beans
+en:Raw cocoa beans
+fr:Fèves de cacao crues
+
+< en:Cocoa beans
+en:Roasted cocoa beans
+fr:Fèves de cacao torréfiées
+
+< en:Cocoa beans
+fr:Grué de cacao
 
 < en:Cocoa powders
 en:Cocoa powder for beverages with sugar, Chocolate powder for beverages with sugar
@@ -15473,6 +15519,25 @@ nl:Kruiderijen
 pl:Przyprawy, przyprawa
 wikidata:en: Q773108
 
+< en:Cocoa and its products
+< en:Confectioneries
+en:Chocolate candies
+ca:Caramels de xocolata
+de:Schokoladenkonfekt
+es:Dulces de chocolate
+fi:suklaamakeiset
+fr:Confiseries chocolatées
+he:ממתקי שוקולד
+hu:Csokoládés cukorka
+it:Confetti al cioccolato
+nl:Chocoladesnoep
+pl:Cukierki czekoladowe
+pt:Bombons de chocolate
+ru:Шоколад и шоколадные конфеты
+sv:Chokladgodis
+th:ลูกอมช็อกโกแลต
+zh:巧克力糖果
+
 < en:Confectioneries
 en:Calissons
 de:Calissons
@@ -15543,24 +15608,6 @@ ciqual_food_code:en: 31121
 ciqual_food_name:en: Chewing gum, sugar level unknown -average-
 ciqual_food_name:fr: Chewing-gum, teneur en sucre inconnue -aliment moyen-
 wikidata:en: Q130878
-
-< en:Confectioneries
-en:Chocolate candies
-ca:Caramels de xocolata
-de:Schokoladenkonfekt
-es:Dulces de chocolate
-fi:suklaamakeiset
-fr:Confiseries chocolatées
-he:ממתקי שוקולד
-hu:Csokoládés cukorka
-it:Confetti al cioccolato
-nl:Chocoladesnoep
-pl:Cukierki czekoladowe
-pt:Bombons de chocolate
-ru:Шоколад и шоколадные конфеты
-sv:Chokladgodis
-th:ลูกอมช็อกโกแลต
-zh:巧克力糖果
 
 < en:Confectioneries
 en:Cotton candy, fairy floss, candy floss
@@ -18067,6 +18114,9 @@ ru:Молоко
 sv:Mjölk
 th:กลุ่มผลิตภัณฑ์นม
 zh:奶
+agribalyse_proxy_food_code:en: 19041
+agribalyse_proxy_food_name:en: Milk, semi-skimmed, UHT
+agribalyse_proxy_food_name:fr: Lait demi-écrémé, UHT
 pnns_group_2:en: Milk and yogurt
 wikidata:en: Q8495
 
@@ -62414,28 +62464,6 @@ ro:Batoane
 ru:Батончики
 zh:棒状零食
 pnns_group_2:en: Biscuits and cakes
-
-< en:Sweet snacks
-en:Chocolates, chocolate products
-ca:Xocolata
-cs:Čokolády
-da:Chokolader, chokolade
-de:Schokoladen, Schokolade, Schokoladenprodukte
-es:Chocolates
-fi:suklaat
-fr:Chocolats, chocolat, produits chocolatés, produits au chocolat
-he:שוקולדים
-hu:Csokoládék, csokoládé termékek
-it:Cioccolato
-nl:Chocoladeproducten
-pl:Czekolada, Produkty czekoladowe
-pt:Chocolates, produtos com chocolate
-ru:Шоколад, шоколадные продукты
-sv:Choklad, Chokladprodukter
-th:ช็อกโกแลต
-zh:巧克力
-nova:en: 3
-pnns_group_2:en: Chocolate products
 
 < en:Sweet snacks
 en:Confectioneries, confectionary, confectionery

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -35559,7 +35559,9 @@ krc:Сют
 ksh:Milesch
 wikidata:en:Q8495
 pnns_group_2:en:Milk and yogurt
-
+agribalyse_proxy_food_code:en:19041
+agribalyse_proxy_food_name:en:Milk, semi-skimmed, UHT
+agribalyse_proxy_food_name:fr:Lait demi-écrémé, UHT
 
 <en:Milks
 en:Austrian milks


### PR DESCRIPTION
- milk should be considered as a beverage for the ecoscore
- energy drinks should not an ecoscore computed