### PR TITLE
fix: handle cyrillic e character in Russian additives names

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3800,7 +3800,8 @@ sub preparse_ingredients_text($$) {
 
 	# in India: INS 240 instead of E 240, bug #1133)
 	# also INS N°420, bug #3618
-	$text =~ s/\b(ins|sin|i-n-s|s-i-n|i\.n\.s\.?|s\.i\.n\.?)( |-| n| nb|#|°|'|"|\.|\W)*(\d{3}|\d{4})/E$3/ig;
+	# Russian е (!= e), https://github.com/openfoodfacts/openfoodfacts-server/issues/4931
+	$text =~ s/\b(е|ins|sin|i-n-s|s-i-n|i\.n\.s\.?|s\.i\.n\.?)( |-| n| nb|#|°|'|"|\.|\W)*(\d{3}|\d{4})/E$3/ig;
 	
 	# E 240, E.240, E-240..
 	# E250-E251-E260

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2713,7 +2713,8 @@ sub canonicalize_taxonomy_tag($$$)
 		# check E + 1 digit in order to not convert Erythorbate-de-sodium to Erythorbate
 		$tagid =~ s/^e(\d.*?)-(.*)$/e$1/i;
 	}
-	elsif ($tagtype eq "ingredients") {
+	
+	if (($tagtype eq "ingredients") or ($tagtype =~ /^additives/)) {
 		# convert E-number + name to E-number only if the number match the name
 		my $additive_tagid;
 		my $name;
@@ -2733,7 +2734,6 @@ sub canonicalize_taxonomy_tag($$$)
 			}
 		}
 	}
-
 
 	if ((defined $synonyms{$tagtype}) and (defined $synonyms{$tagtype}{$tag_lc}) and (defined $synonyms{$tagtype}{$tag_lc}{$tagid})) {
 		$tagid = $synonyms{$tagtype}{$tag_lc}{$tagid};

--- a/t/additives_tags.t
+++ b/t/additives_tags.t
@@ -48,7 +48,9 @@ my @tests = (
 
 # Russian "е" character
 
-[ { lc => "ru", ingredients_text => "е322, Куркумины e100, е-1442, (е621)" }, []],
+[ { lc => "ru", ingredients_text => "е322, Куркумины e100, е-1442, (е621)" }, ["en:e322", "en:e100", "en:e1442", "en:e621"]],
+
+[ { lc => "fr", ingredients_text => "acide citrique E-330, E-102 tartrazine" }, ["en:e330","en:e102"]],
 
 );
 

--- a/t/additives_tags.t
+++ b/t/additives_tags.t
@@ -45,6 +45,11 @@ my @tests = (
 [ { lc => "fr", ingredients_text => "colorant: caramel" }, ["en:e150"]],
 [ { lc => "fr", ingredients_text => "caramel" }, []],
 [ { lc => "fr", ingredients_text => "caramel aromatique" }, []],
+
+# Russian "е" character
+
+[ { lc => "ru", ingredients_text => "е322, Куркумины e100, е-1442, (е621)" }, []],
+
 );
 
 foreach my $test_ref (@tests) {

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -298,9 +298,10 @@ my @lists =(
 
 	# ¹ and ² symbols
 	["fr", "Sel, sucre², graisse de palme¹, amidons¹ (maïs¹, pomme de terre¹), oignon¹ : 8,9%, ail¹, oignon grillé¹ : 1,4%, épices¹ et aromate¹ (livèche¹ : 0,4%, curcuma¹, noix de muscade¹), carotte¹ : 0,5%. Peut contenir : céleri, céréales contenant du gluten, lait, moutarde, œuf, soja. ¹Ingrédients issus de l'Agriculture Biologique. ² Ingrédients issus du commerce équitable",
-"sel, sucre commerce équitable, graisse de palme bio, amidons bio (maïs bio, pomme de terre bio ), oignon bio : 8,9%, ail bio, oignon grillé bio : 1,4%, épices bio et aromate bio (livèche bio : 0,4%, curcuma bio, noix de muscade bio ), carotte bio : 0,5%. traces éventuelles : céleri, traces éventuelles : céréales contenant du gluten, traces éventuelles : lait, traces éventuelles : moutarde, traces éventuelles : œuf, traces éventuelles : soja."],
+"Farine de blé, sucre, huiles végétales non hydrogénées (huile de palme certifiée durable, huile de colza), sirop de sucre candi, poudre à lever (carbonate acide de sodium), sel, cannelle. Substances ou produits provoquant des allergies ou intolérances : gluten."],
 
-
+	# Russian е character
+	["ru", "е322, Куркумины e100, е-1442, (е621)", "e322, куркумины e100, e1442, (e621)"],
 );
 
 foreach my $test_ref (@lists) {

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -298,8 +298,7 @@ my @lists =(
 
 	# ¹ and ² symbols
 	["fr", "Sel, sucre², graisse de palme¹, amidons¹ (maïs¹, pomme de terre¹), oignon¹ : 8,9%, ail¹, oignon grillé¹ : 1,4%, épices¹ et aromate¹ (livèche¹ : 0,4%, curcuma¹, noix de muscade¹), carotte¹ : 0,5%. Peut contenir : céleri, céréales contenant du gluten, lait, moutarde, œuf, soja. ¹Ingrédients issus de l'Agriculture Biologique. ² Ingrédients issus du commerce équitable",
-"Farine de blé, sucre, huiles végétales non hydrogénées (huile de palme certifiée durable, huile de colza), sirop de sucre candi, poudre à lever (carbonate acide de sodium), sel, cannelle. Substances ou produits provoquant des allergies ou intolérances : gluten."],
-
+"Sel, sucre Commerce équitable, graisse de palme Bio, amidons Bio (maïs Bio, pomme de terre Bio ), oignon Bio : 8,9%, ail Bio, oignon grillé Bio : 1,4%, épices Bio et aromate Bio (livèche Bio : 0,4%, curcuma Bio, noix de muscade Bio ), carotte Bio : 0,5%. Traces éventuelles : céleri, Traces éventuelles : céréales contenant du gluten, Traces éventuelles : lait, Traces éventuelles : moutarde, Traces éventuelles : œuf, Traces éventuelles : soja."],
 	# Russian е character
 	["ru", "е322, Куркумины e100, е-1442, (е621)", "e322, куркумины e100, e1442, (e621)"],
 );


### PR DESCRIPTION
converts the Russian character to the latin "e" when it looks like an E-number additive.

fixes #4931 reported by @blazern 