### PR TITLE
better missing data warnings for Eco-Score (easy reviews)

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -759,6 +759,13 @@ sub compute_ecoscore_production_system_adjustment($) {
 		}
 	}
 	
+	# No labels warning
+	if (not defined $product_ref->{ecoscore_data}{adjustments}{production_system}{label}) {
+		$product_ref->{ecoscore_data}{adjustments}{production_system}{warning} = "no_label";
+		defined $product_ref->{ecoscore_data}{missing} or $product_ref->{ecoscore_data}{missing} = {};
+		$product_ref->{ecoscore_data}{missing}{labels} = 1;
+	}	
+	
 }
 
 
@@ -796,6 +803,13 @@ sub compute_ecoscore_threatened_species_adjustment($) {
 		
 		$product_ref->{ecoscore_data}{adjustments}{threatened_species}{value} = -10;
 		$product_ref->{ecoscore_data}{adjustments}{threatened_species}{ingredient} = "en:palm-oil";
+	}
+	
+	# No ingredients warning
+	if ((not defined $product_ref->{ingredients}) or (scalar @{$product_ref->{ingredients}} == 0)) {
+		$product_ref->{ecoscore_data}{adjustments}{threatened_species}{warning} = "ingredients_missing";
+		defined $product_ref->{ecoscore_data}{missing} or $product_ref->{ecoscore_data}{missing} = {};
+		$product_ref->{ecoscore_data}{missing}{ingredients} = 1;
 	}
 	
 }

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -33,14 +33,20 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "warning" : "missing_agribalyse_match"
       },
       "missing" : {
          "categories" : 1,
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -36,8 +36,12 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "16737",
@@ -64,6 +68,8 @@
       },
       "grade" : "c",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -36,8 +36,12 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "16737",
@@ -64,6 +68,8 @@
       },
       "grade" : "c",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -36,8 +36,12 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "16400",
@@ -64,6 +68,8 @@
       },
       "grade" : "e",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -36,8 +36,12 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "16737",
@@ -64,6 +68,8 @@
       },
       "grade" : "c",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -40,7 +40,9 @@
             "label" : "fr:ab-agriculture-biologique",
             "value" : 15
          },
-         "threatened_species" : {}
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "16400",
@@ -67,6 +69,7 @@
       },
       "grade" : "d",
       "missing" : {
+         "ingredients" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -44,7 +44,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -72,6 +74,7 @@
       },
       "grade" : "c",
       "missing" : {
+         "labels" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -39,7 +39,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -67,6 +69,7 @@
       },
       "grade" : "c",
       "missing" : {
+         "labels" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -36,7 +36,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -64,6 +66,7 @@
       },
       "grade" : "d",
       "missing" : {
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -36,7 +36,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -64,6 +66,7 @@
       },
       "grade" : "d",
       "missing" : {
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -36,7 +36,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -64,6 +66,7 @@
       },
       "grade" : "d",
       "missing" : {
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -39,7 +39,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -67,6 +69,7 @@
       },
       "grade" : "c",
       "missing" : {
+         "labels" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -55,7 +55,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -83,6 +85,7 @@
       },
       "grade" : "c",
       "missing" : {
+         "labels" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -43,7 +43,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -71,6 +73,7 @@
       },
       "grade" : "c",
       "missing" : {
+         "labels" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -36,7 +36,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -64,6 +66,7 @@
       },
       "grade" : "d",
       "missing" : {
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -35,7 +35,9 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
+         "production_system" : {
+            "warning" : "no_label"
+         },
          "threatened_species" : {}
       },
       "agribalyse" : {
@@ -63,6 +65,7 @@
       },
       "grade" : "d",
       "missing" : {
+         "labels" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/packaging-en-bulk.json
+++ b/t/expected_test_results/ecoscore/packaging-en-bulk.json
@@ -36,8 +36,12 @@
             "value" : 0,
             "warning" : "unspecified_material"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "2011",
@@ -64,6 +68,8 @@
       },
       "grade" : "c",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -54,8 +54,12 @@
             "score" : 58,
             "value" : -4
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "2011",
@@ -82,6 +86,8 @@
       },
       "grade" : "c",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -37,8 +37,12 @@
             "score" : 50,
             "value" : -5
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "2011",
@@ -65,6 +69,8 @@
       },
       "grade" : "c",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -36,8 +36,12 @@
             "score" : 0,
             "value" : -10
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "2011",
@@ -64,6 +68,8 @@
       },
       "grade" : "d",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1
       },
       "missing_data_warning" : 1,

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -36,8 +36,12 @@
             "value" : -10,
             "warning" : "unspecified_material"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "2011",
@@ -64,6 +68,8 @@
       },
       "grade" : "d",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -36,8 +36,12 @@
             "value" : -10,
             "warning" : "unspecified_material"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "agribalyse_proxy_food_code" : "2011",
@@ -64,6 +68,8 @@
       },
       "grade" : "d",
       "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -36,14 +36,20 @@
             "value" : -10,
             "warning" : "packaging_data_missing"
          },
-         "production_system" : {},
-         "threatened_species" : {}
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
       },
       "agribalyse" : {
          "warning" : "missing_agribalyse_match"
       },
       "missing" : {
          "agb_category" : 1,
+         "ingredients" : 1,
+         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },

--- a/templates/ecoscore_details.tt.html
+++ b/templates/ecoscore_details.tt.html
@@ -118,7 +118,7 @@
 	[% ELSE %]
 		<p>Pas de labels pris en compte pour le système de production.</p>
 		
-	[% IF adjustments.origins_of_ingredients.warning %]
+	[% IF adjustments.production_system.warning %]
 		<div class="panel warning">
 			Si ce produit a un label caractérisant le système de production (bio, commerce équitable, Label Rouge, Bleu Blanc Coeur etc.), vous pouvez modifier la fiche produit pour l'ajouter.<br><br>
 			Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="https://fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
@@ -172,6 +172,15 @@
 	[% ELSE %]
 		<p>Aucun ingrédient dont la culture menace des espèces n'a été détecté.</p>
 	[% END %]
+	
+	[% IF adjustments.threatened_species.warning %]
+		<div class="panel warning">
+			<strong>Les informations sur les ingrédients de ce produit ne sont pas renseignées.</strong><br><br>
+			Pour un calcul plus précis de l'Eco-Score, vous pouvez modifier la fiche produit et les ajouter.<br><br>
+			Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="https://fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
+		</div>
+	[% END %]	
+	
 	</div>
 	</div>
 	
@@ -197,13 +206,20 @@
 		<p><strong>Emballage : [% IF adjustments.packaging.value > 0 %]+[% END %][% adjustments.packaging.value %]</strong></p>
 	[% END %]
 	
-	[% IF adjustments.origins_of_ingredients.warning %]
+	[% IF adjustments.packaging.warning %]
 		<div class="panel warning">
-			<strong>Les informations sur l'emballage de ce produit ne sont pas renseignées.</strong><br><br>
+			<strong>
+				[% IF adjustments.packaging.warning == "packaging_data_missing" %]
+					Les informations sur l'emballage de ce produit ne sont pas renseignées.
+				[% ELSE %]
+					Les informations sur l'emballage de ce produit ne sont pas suffisamment précises (formes et matériaux exacts de tous les composants de l'emballage).
+				[% END %]
+			</strong>
+			<br><br>
 			Pour un calcul plus précis de l'Eco-Score, vous pouvez modifier la fiche produit et les ajouter.<br><br>
 			Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="https://fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
 		</div>
-	[% END %]		
+	[% END %]
 
 	</div>
 	</div>

--- a/templates/ecoscore_details_simple_html.tt.html
+++ b/templates/ecoscore_details_simple_html.tt.html
@@ -1,4 +1,4 @@
-<h2>[% lang('ecoscore_calculation_details') %]</h2>
+<h2>[% lang('ecoscore_calculation_details') %]</h2>>
 
 	<h3>Score de référence de la catégorie du produit</h3>
 
@@ -129,7 +129,14 @@
 	
 	[% IF adjustments.packaging.warning %]
 		<div class="panel warning">
-			<strong>Les informations sur l'emballage de ce produit ne sont pas renseignées.</strong><br><br>
+			<strong>
+				[% IF adjustments.packaging.warning == "packaging_data_missing" %]
+					Les informations sur l'emballage de ce produit ne sont pas renseignées.
+				[% ELSE %]
+					Les informations sur l'emballage de ce produit ne sont pas suffisamment précises (formes et matériaux exacts de tous les composants de l'emballage).
+				[% END %]
+			</strong>
+			<br><br>
 			Pour un calcul plus précis de l'Eco-Score, vous pouvez modifier la fiche produit et les ajouter.<br><br>
 			Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="https://fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
 		</div>

--- a/templates/ecoscore_details_simple_html.tt.html
+++ b/templates/ecoscore_details_simple_html.tt.html
@@ -1,4 +1,4 @@
-<h2>[% lang('ecoscore_calculation_details') %]</h2>>
+<h2>[% lang('ecoscore_calculation_details') %]</h2>
 
 	<h3>Score de référence de la catégorie du produit</h3>
 
@@ -147,5 +147,4 @@
 
 	<p><strong>[% lang('ecoscore_score') %][% sep %]: [% round(score) %]</strong>
 	- <strong>[% lang('ecoscore_grade') %][% sep %]: [% grade FILTER ucfirst %]</strong></p>
-
 


### PR DESCRIPTION
fixes a bug in the template and provides slightly more specific messages about what's missing (e.g. no packaging info or information that is not precise enough)