### PR TITLE
Producers platform improvements

### DIFF
--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -61,6 +61,14 @@ if (not defined $Owner_id) {
 	display_error(lang("no_owner_defined"), 200);
 }
 
+# Require moderator status to launch the export / import process,
+# unless there is only one product specified through the ?query_code= parameter
+# or if the organization has the permission enable_manual_export_to_public_platform checked
+
+my $allow_submit = ($User{moderator}
+		or (defined param("query_code"))
+		or ((defined $Org{enable_manual_export_to_public_platform}) and ($Org{enable_manual_export_to_public_platform} eq "on")));
+
 if ($action eq "display") {
 	
 	my $template_data_ref = {
@@ -119,9 +127,7 @@ if ($action eq "display") {
 	$template_data_ref->{replace_selected_photos_value} = $replace_selected_photos_value;
 	$template_data_ref->{only_export_products_with_changes_value} = $only_export_products_with_changes_value;
 
-	# Require moderator status to launch the export / import process,
-	# unless there is only one product specified through the ?query_code= parameter
-	if (($User{moderator}) or (defined param("query_code"))) {
+	if ($allow_submit) {
 		$template_data_ref->{allow_submit} = 1;
 	}
 	
@@ -129,9 +135,7 @@ if ($action eq "display") {
 
 }
 
-# Require moderator status to launch the export / import process,
-# unless there is only one product specified through the ?query_code= parameter
-elsif (($action eq "process") and (($User{moderator}) or (defined param("query_code")))) {
+elsif (($action eq "process") and $allow_submit) {
 	
 	# First export CSV from the producers platform, then import on the public platform
 	
@@ -168,20 +172,20 @@ elsif (($action eq "process") and (($User{moderator}) or (defined param("query_c
 	my $local_export_status_job_id = $results_ref->{local_export_status_job_id};
 	my $export_id = $results_ref->{export_id};
 	
-
-	$html .= "<p>Local export job_id: " . $local_export_job_id . " - "
-	. "<a href=\"/cgi/minion_job_status.pl?job_id=$local_export_job_id\">Status</a>"
-	. " - <span id=\"result1\"></span></p>";
+	$html .= "<p>" . lang("export_in_progress") . "</p>";
 	
-	$html .= "<p>Remote import job_id: " . $remote_import_job_id . " - "
-	. "<a href=\"/cgi/minion_job_status.pl?job_id=$remote_import_job_id\">Status</a>"
-	. " - <span id=\"result2\"></span></p>";
-
-	$html .= "<p>Local export status update job_id: " . $local_export_status_job_id . " - "
-	. "<a href=\"/cgi/minion_job_status.pl?job_id=$local_export_status_job_id\">Status</a>"
-	. " - <span id=\"result3\"></span></p>";
+	$html .= "<p>" . lang("export_job_export") .  " - <span id=\"result1\"></span></p>";
+	$html .= "<p>" . lang("export_job_import") .  " - <span id=\"result2\"></span></p>";
+	$html .= "<p>" . lang("export_job_status_update") .  " - <span id=\"result3\"></span></p>";
 
 	$initjs .= <<JS
+	
+var minion_status = {
+	"inactive" : "$Lang{minion_status_inactive}{$lc}",
+	"active" : "$Lang{minion_status_active}{$lc}",
+	"finished" : "$Lang{minion_status_finished}{$lc}",
+	"failed" : "$Lang{minion_status_failed}{$lc}"
+};
 
 var poll_n1 = 0;
 var timeout1 = 5000;
@@ -199,7 +203,7 @@ var job_info_state3;
   \$.ajax({
     url: '/cgi/minion_job_status.pl?job_id=$local_export_job_id',
     success: function(data) {
-      \$('#result1').html(data.job_info.state);
+      \$('#result1').html(minion_status[data.job_info.state]);
 	  job_info_state1 = data.job_info.state;
     },
     complete: function() {
@@ -217,7 +221,7 @@ var job_info_state3;
   \$.ajax({
     url: '/cgi/minion_job_status.pl?job_id=$remote_import_job_id',
     success: function(data) {
-      \$('#result2').html(data.job_info.state);
+      \$('#result2').html(minion_status[data.job_info.state]);
 	  job_info_state2 = data.job_info.state;
     },
     complete: function() {
@@ -235,7 +239,7 @@ var job_info_state3;
   \$.ajax({
     url: '/cgi/minion_job_status.pl?job_id=$local_export_status_job_id',
     success: function(data) {
-      \$('#result3').html(data.job_info.state);
+      \$('#result3').html(minion_status[data.job_info.state]);
 	  job_info_state3 = data.job_info.state;
     },
     complete: function() {
@@ -251,6 +255,27 @@ var job_info_state3;
 JS
 ;
 
+}
+else {
+	
+	# The organization does not have the permission enable_manual_export_to_public_platform checked
+	
+	my $admin_mail_body = <<EMAIL
+org_id: $Org_id
+user id: $User_id
+user name: $User{name}
+user email: $User{email}
+
+https://world.pro.openfoodfacts.org/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-$Org_id
+
+EMAIL
+;
+	send_email_to_producers_admin(
+		"Export to public database requested: user: $User_id - org: $Org_id",
+		$admin_mail_body );
+		
+	$html .= "<p>" . lang('export_products_to_public_database_request_email') . "</p>";
+	
 }
 
 display_new( {

--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -91,6 +91,16 @@ if ($action eq 'process') {
 		}
 		else {
 			
+			# Administrator fields
+			
+			if ($admin) {
+				foreach my $field ("list_of_gs1_gln", "enable_manual_export_to_public_platform", "activate_automated_daily_export_to_public_platform") {
+					$org_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));
+				}
+			}
+			
+			# Other fields
+			
 			foreach my $field ("name", "link") {
 				$org_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));
 				if ($org_ref->{$field} eq "") {
@@ -101,6 +111,8 @@ if ($action eq 'process') {
 			if (not defined $org_ref->{name}) {
 				push @errors, $Lang{error_missing_org_name}{$lang};
 			}
+			
+			# Contact sections
 			
 			foreach my $contact ("customer_service", "commercial_service") {
 				
@@ -138,23 +150,48 @@ if ($action eq 'display') {
 	
 	# Create the list of sections and fields
 	
-	$template_data_ref->{sections} = [
-		{
+	$template_data_ref->{sections} = [];
+	
+	# Admin
+	
+	if ($admin) {
+		push @{$template_data_ref->{sections}}, {
+			id => "admin",
 			fields => [
 				{
-					field => "name",
+					field => "list_of_gs1_gln",
 				},
 				{
-					field => "link",
+					field => "enable_manual_export_to_public_platform",
+					type => "checkbox",
+				},
+				{
+					field => "activate_automated_daily_export_to_public_platform",
+					type => "checkbox",
 				},
 			]
-		}
-	];
+		};		
+	}
+	
+	# Name and information of the organization
+	
+	push @{$template_data_ref->{sections}}, {
+		fields => [
+			{
+				field => "name",
+			},
+			{
+				field => "link",
+			},
+		]
+	};
+	
+	# Contact information
 	
 	foreach my $contact ("customer_service", "commercial_service") {
 		
 		push @{$template_data_ref->{sections}}, {
-			section => $contact,
+			id => $contact,
 			fields => [
 				{ field => $contact . "_name" },
 				{ field => $contact . "_address", type => "textarea" },
@@ -171,15 +208,15 @@ if ($action eq 'display') {
 	foreach my $section_ref (@{$template_data_ref->{sections}}) {
 		
 		# Descriptions and notes for sections
-		if (defined $section_ref->{section}) {
-			if (lang("org_" . $section_ref->{section})) {
-				$section_ref->{name} = lang("org_" . $section_ref->{section});
+		if (defined $section_ref->{id}) {
+			if (lang("org_" . $section_ref->{id})) {
+				$section_ref->{name} = lang("org_" . $section_ref->{id});
 			}			
-			if (lang("org_" . $section_ref->{section} . "_description")) {
-				$section_ref->{description} = lang("org_" . $section_ref->{section} . "_description");
+			if (lang("org_" . $section_ref->{id} . "_description")) {
+				$section_ref->{description} = lang("org_" . $section_ref->{id} . "_description");
 			}
-			if (lang("org_" . $section_ref->{section} . "_note")) {
-				$section_ref->{note} = lang("org_" . $section_ref->{section} . "_note");
+			if (lang("org_" . $section_ref->{id} . "_note")) {
+				$section_ref->{note} = lang("org_" . $section_ref->{id} . "_note");
 			}
 		}
 		

--- a/icons/material/publish-24px.svg
+++ b/icons/material/publish-24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M5 4v2h14V4H5zm0 10h4v6h6v-6h4l-7-7-7 7z"/></svg>

--- a/icons/publish.svg
+++ b/icons/publish.svg
@@ -1,0 +1,1 @@
+material/publish-24px.svg

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -979,13 +979,11 @@ sub init_user()
 		%User = ();
 	}
 
-	# The org and org_id fields are currently properties of the user object (created by administrators through user.pl)
-	# Populate $Org_id and %org_ref from the user profile.
-	# TODO: create org profiles with customer service info etc.
+	# Load the user org profile
 
 	if (defined $user_ref->{org_id}) {
 		$Org_id = $user_ref->{org_id};
-		$org_ref = { org => $user_ref->{org}, org_id => $user_ref->{org_id} };
+		$org_ref = retrieve_or_create_org($User_id, $Org_id);
 	}
 
 	if (defined $Org_id) {

--- a/templates/display_product.tt.html
+++ b/templates/display_product.tt.html
@@ -37,9 +37,12 @@
 [% IF server_options_producers_platform %]
     <div class="delete_button">
         <a href="/cgi/export_products.pl?query_code=[% code %]" class="button small" title="[% lang('export_product_page') %]">
+			[% display_icon('publish') %]
             <span class="show-for-large-up"> [% lang('export_product_page') %]</span>
         </a>
     </div>
+    
+    <p>&rarr; <a href="[% public_product_url %]">[% lang("product_page_on_the_public_database") %]</a></p>
 [% END %]
 
 [% IF (user_id.defined) && (robotoff_url.defined) && (robotoff_url.length > 0) %]
@@ -52,7 +55,7 @@
 <!-- Display UPC code if the EAN starts with 0 -->
 [% IF upc_code == 'defined' %]
     <p id="barcode_paragraph">
-        [% lang("barcode") %]:  <span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">[% code %]</span>[% upc %]
+        [% lang("barcode") %]:  <span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">[% code %]</span> [% upc %]
     </p>
     <div property="gr:hasEAN_UCC-13" content="[% code %]" datatype="xsd:string"></div>
 [% END %]

--- a/templates/export_products.tt.html
+++ b/templates/export_products.tt.html
@@ -34,11 +34,10 @@
 				<input type="checkbox" name="only_export_products_with_changes" [% only_export_products_with_changes_value %]>	
 				[% lang('only_export_products_with_changes') %]
 			</label>
-
-			<input type="submit" class="button small" value="[% lang('export_product_data_photos') %]">
-		[% ELSE %]
-			<p>[% lang('export_products_to_public_database_email') %]</p>
 		[% END %]
+			
+		<input type="submit" class="button small" value="[% lang('export_product_data_photos') %]">
+		
 	[% END %]
 
 </form>

--- a/templates/org_form.tt.html
+++ b/templates/org_form.tt.html
@@ -12,7 +12,7 @@
     <form method="post" action="/cgi/org.pl" enctype="multipart/form-data">
 
 		[% IF admin %]
-			<div>
+			<div class="panel callout">
 				<label>
 					<input type="checkbox" name="delete" value="on" />
 					[% lang("delete_org") %]
@@ -22,40 +22,53 @@
 		
 		[% FOREACH section IN sections %]
 		
-			[% IF section.name %]
-				<fieldset>
-					<legend>[% section.name %]</legend>
-			[% END %]
-			
-			[% IF section.description %]
-				<p>[% section.description %]</p>
-			[% END %]
-			[% IF section.note %]
-				<p>[% section.note %]</p>
-			[% END %]
-
-			[% FOREACH field IN section.fields %]
-
-				[% IF field.description %]
-					<p>[% field.description %]</p>
-				[% END %]			
-			
-				<label for="[% field.field %]">[% field.label %]</label>
-
-				[% IF field.type == 'text' %]
-					<input type="text" id="[% field.field %]" name="[% field.field %]" value="[% field.value %]" />
-				[% ELSIF field.type == 'textarea' %]
-					<textarea id="[% field.field %]" name="[% field.field %]" style="height:100px;">[% field.value %]</textarea>
+			[% IF admin OR section.id != "admin" %]
+		
+				[% IF section.name %]
+					<fieldset[% IF section.id == "admin" %] class="panel callout"[% END %]>
+						<legend>[% section.name %]</legend>
 				[% END %]
 				
-				[% IF field.note %]
-					<p>[% field.note %]</p>
+				[% IF section.description %]
+					<p>[% section.description %]</p>
+				[% END %]
+				[% IF section.note %]
+					<p>[% section.note %]</p>
 				[% END %]
 
-			[% END %]
+				[% FOREACH field IN section.fields %]
+
+					[% IF field.description %]
+						<p>[% field.description %]</p>
+					[% END %]								
+
+					[% IF field.type == 'text' %]
+						<label for="[% field.field %]">[% field.label %]</label>
+						<input type="text" id="[% field.field %]" name="[% field.field %]" value="[% field.value %]" />
+					[% ELSIF field.type == 'textarea' %]
+						<label for="[% field.field %]">[% field.label %]</label>
+						<textarea id="[% field.field %]" name="[% field.field %]" style="height:100px;">[% field.value %]</textarea>
+					[% ELSIF field.type == 'checkbox' %]
+						<label for="[% field.field %]">
+							<input type="checkbox" id="[% field.field %]" name="[% field.field %]" [% IF field.value == 'on' %]checked="checked"[% END %] />
+							[% field.label %]
+							value: [% field.value %]
+						</label>
+					[% END %]
+					
+					[% IF field.note %]
+						<p style="font-size:.8em">&rarr; [% field.note %]</p>
+					[% END %]
+
+				[% END %]
+				
+				[% IF section.name %]
+					</fieldset>
+					[% IF section.name == "admin" %]
+						</div>
+					[% END %]
+				[% END %]
 			
-			[% IF section.name %]
-				</fieldset>
 			[% END %]
 
 		[% END %]
@@ -63,7 +76,7 @@
 		<input type="hidden" name="action" value="process" />
 		<input type="hidden" name="type" value="[% type %]" />
 		<input type="hidden" name="orgid" value="[% orgid %]" />
-		<input type="submit" name=".submit" class="button" />
+		<input type="submit" name=".submit" class="button" value="[% lang("save") %]"/>
     </form>
 
     <!-- End form -->


### PR DESCRIPTION
- Org edit form now has an administrator section to enable organization members to:
--  launch exports to the public platform
-- indicate that data should be exported every night (not in use yet)
-- list GS1 GLNs that should be associated to the organization (not in use yet)

- Org owners can now launch exports to the public database directly, if authorized. If not authorized, we send an email to producers admins.

- Localized the export / import / update status for the minion jobs, and display them to org owners

- Display a message on the index of the pro platform if some products have data that has not been exported yet

- Display a link to the product on the public database on product pages on the producers platform