### PR TITLE
User edit form for admins: allow passing email in userid field

### DIFF
--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -59,10 +59,24 @@ if (($type eq "add") and (defined param('prdct_mult'))) {
 
 ProductOpener::Display::init();
 
+# $userid will contain the user to be edited, possibly different than $User_id
+# if an administrator edits another user
+
 my $userid = $User_id;
 
 if (defined param('userid')) {
-	$userid = get_fileid(param('userid'), 1);
+	
+	$userid = param('userid');
+	
+	# The userid looks like an e-mail
+	if ($userid =~ /\@/) {
+		my $emails_ref = retrieve("$data_root/users_emails.sto");
+		if (defined $emails_ref->{$userid}) {
+			$userid = $emails_ref->{$userid}[0];
+		}
+	}
+	
+	$userid = get_fileid($userid, 1);
 }
 
 $log->debug("user form - start", { type => $type, action => $action, userid => $userid, User_id => $User_id }) if $log->is_debug();

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -69,7 +69,7 @@ if (defined param('userid')) {
 	$userid = param('userid');
 	
 	# The userid looks like an e-mail
-	if ($userid =~ /\@/) {
+	if ($admin and ($userid =~ /\@/)) {
 		my $emails_ref = retrieve("$data_root/users_emails.sto");
 		if (defined $emails_ref->{$userid}) {
 			$userid = $emails_ref->{$userid}[0];


### PR DESCRIPTION
This is to make it easier for admins to edit/delete user profiles when requested by users.