### PR TITLE
Fix palm oil attributes, add tests

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -95,6 +95,17 @@ $options{attribute_groups} = [
 	],
 [..]
 
+=cut
+
+# Build a hash of attribute groups to make it easier to retrieve all attributes of a specific group
+my %attribute_groups = ();
+
+if (defined $options{attribute_groups}) {
+	foreach my $attribute_group_ref (@{$options{attribute_groups}}) {
+		$attribute_groups{$attribute_group_ref->[0]} = $attribute_group_ref->[1];
+	}
+}
+
 
 =head1 FUNCTIONS
 
@@ -123,12 +134,12 @@ The return value is a reference to an array of attribute groups that contains in
 
 =head3 Caching
 
-The return value is cached for each language in the %attribute_groups hash.
+The return value is cached for each language in the %localized_attribute_groups hash.
 
 =cut
 
 # Global structure to cache the return structure for each language
-my %attribute_groups = ();
+my %localized_attribute_groups = ();
 
 sub list_attributes($) {
 
@@ -138,13 +149,13 @@ sub list_attributes($) {
 
 	# Construct the return structure only once for each language
 	
-	if (not defined $attribute_groups{$target_lc}) {
+	if (not defined $localized_attribute_groups{$target_lc}) {
 		
-		$attribute_groups{$target_lc} = [];
+		$localized_attribute_groups{$target_lc} = [];
 		
-		if (defined $options{attribute_groups}) {
+		if (defined $options{localized_attribute_groups}) {
 			
-			foreach my $options_attribute_group_ref (@{$options{attribute_groups}}) {
+			foreach my $options_attribute_group_ref (@{$options{localized_attribute_groups}}) {
 				
 				my $group_id = $options_attribute_group_ref->[0];
 				my $attributes_ref = $options_attribute_group_ref->[1];
@@ -157,12 +168,12 @@ sub list_attributes($) {
 					push @{$group_ref->{attributes}}, $attribute_ref;
 				}
 				
-				push @{$attribute_groups{$target_lc}}, $group_ref;
+				push @{$localized_attribute_groups{$target_lc}}, $group_ref;
 			}
 		}
 	}
 	
-	return $attribute_groups{$target_lc};
+	return $localized_attribute_groups{$target_lc};
 }
 
 
@@ -1489,7 +1500,9 @@ sub compute_attributes($$$) {
 	}
 	
 	# Allergens
-	foreach my $allergen (keys %{$translations_to{allergens}}) {
+	foreach my $allergen_attribute_id (@{$attribute_groups{"allergens"}}) {
+		my $allergen = $allergen_attribute_id;
+		$allergen =~ s/^allergens_no_//;
 		$attribute_ref = compute_attribute_allergen($product_ref, $target_lc, $allergen);
 		add_attribute_to_group($product_ref, $target_lc, "allergens", $attribute_ref);
 	}

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -1282,10 +1282,10 @@ sub compute_attribute_ingredients_analysis($$$) {
 
 	my $product_ref = shift;
 	my $target_lc = shift;
-	my $attribute_id = shift;
+	my $analysis = shift;
 	
-	my $analysis = $attribute_id;
-	$analysis =~ s/_/-/g;
+	my $attribute_id = $analysis;
+	$attribute_id =~ s/-/_/g;
 	
 	$log->debug("compute attributes ingredients analysis", { code => $product_ref->{code}, attribute_id => $attribute_id, analysis => $analysis }) if $log->is_debug();
 	

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -5679,7 +5679,7 @@ sub compute_nova_group($) {
 
 	if (defined $options{nova_groups_tags}) {
 
-		foreach my $tag (sort {$options{nova_groups_tags}{$a} <=> $options{nova_groups_tags}{$b}} keys %{$options{nova_groups_tags}}) {
+		foreach my $tag (sort {($options{nova_groups_tags}{$a} <=> $options{nova_groups_tags}{$b}) || ($a cmp $b)} keys %{$options{nova_groups_tags}}) {			
 
 			if ($tag =~ /\//) {
 
@@ -5719,7 +5719,7 @@ sub compute_nova_group($) {
 					# don't move group 2 to group 3
 					and not (($properties{$tag_type}{$tag}{"nova:en"} == 3) and ($product_ref->{nova_group} == 2))
 					) {
-					$product_ref->{nova_group_debug} .= " -- $tag_type : $tag : " . $properties{$tag_type}{$tag}{"nova:en"} ;
+					$product_ref->{nova_group_debug} .= " --- $tag_type : $tag : " . $properties{$tag_type}{$tag}{"nova:en"} ;
 					$product_ref->{nova_group} = $properties{$tag_type}{$tag}{"nova:en"};
 				}
 			}

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -4681,6 +4681,7 @@ msgstr "Eco-Score non calculé"
 msgctxt "attribute_ecoscore_unknown_description_short"
 msgid "Unknown environmental impact"
 msgstr "Impact environnemental inconnu"
+
 msgctxt "attribute_ecoscore_a_description_short"
 msgid "Very low environmental impact"
 msgstr "Très faible impact environnemental"

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -1,0 +1,170 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use utf8;
+
+use Test::More;
+use Log::Any::Adapter 'TAP';
+
+use JSON;
+use Getopt::Long;
+
+use ProductOpener::Config qw/:all/;
+use ProductOpener::Tags qw/:all/;
+use ProductOpener::TagsEntries qw/:all/;
+use ProductOpener::Products qw/:all/;
+use ProductOpener::Food qw/:all/;
+use ProductOpener::ForestFootprint qw/:all/;
+use ProductOpener::Ecoscore qw/:all/;
+use ProductOpener::Ingredients qw/:all/;
+use ProductOpener::Attributes qw/:all/;
+use ProductOpener::Packaging qw/:all/;
+use ProductOpener::ForestFootprint qw/:all/;
+
+load_agribalyse_data();
+load_ecoscore_data();
+
+init_packaging_taxonomies_regexps();
+
+load_forest_footprint_data();
+
+my $testdir = "attributes";
+
+my $usage = <<TXT
+
+The expected results of the tests are saved in $data_root/t/expected_test_results/$testdir
+
+To verify differences and update the expected test results, actual test results
+can be saved to a directory by passing --results [path of results directory]
+
+The directory will be created if it does not already exist.
+
+TXT
+;
+
+my $resultsdir;
+
+GetOptions ("results=s"   => \$resultsdir)
+  or die("Error in command line arguments.\n\n" . $usage);
+  
+if ((defined $resultsdir) and (! -e $resultsdir)) {
+	mkdir($resultsdir, 0755) or die("Could not create $resultsdir directory: $!\n");
+}
+
+my @tests = (
+
+	# FR - palm oil
+	
+	[
+		'fr-palm-oil-free',
+		{
+			lc => "fr",
+			ingredients_text => "eau, farine, sucre, chocolat",
+		}
+	],
+	
+	[
+		'fr-palm-oil',
+		{
+			lc => "fr",
+			ingredients_text => "pommes de terres, huile de palme",
+		}
+	],	
+		
+	[
+		'fr-palm-kernel-fat',
+		{
+			lc => "fr",
+			ingredients_text => "graisse de palmiste",
+		}
+	],
+	
+	[
+		'fr-vegetable-oils',
+		{
+			lc => "fr",
+			ingredients_text => "farine de maïs, huiles végétales, sel",
+		}
+	],		
+
+	# EN
+	
+	[
+		'en-attributes',
+		{
+			lc => "en",
+			categories => "biscuits",
+			categories_tags => ["en:biscuits"],
+			ingredients_text => "wheat flour (origin: UK), sugar (Paraguay), eggs, strawberries, high fructose corn syrup, rapeseed oil, macadamia nuts, milk proteins, salt, E102, E120",
+			labels_tags => ["en:organic", "en:fair-trade"],
+			nutrition_data_per => "100g",
+			nutriments => {
+				"energy_100g" => 800,
+				"fat_100g" => 12,
+				"saturated-fat_100g" => 4,
+				"sugars_100g" => 25,
+				"salt_100g" => 0.25,
+				"sodium_100g" => 0.1,
+				"proteins_100g" => 2,
+				"fiber_100g" => 3,
+			},
+			countries_tags => ["en:united-kingdom", "en:france"],
+			packaging_text => "Cardboard box, film wrap",
+		}
+	],
+);
+
+
+
+my $json = JSON->new->allow_nonref->canonical;
+
+foreach my $test_ref (@tests) {
+
+	my $testid = $test_ref->[0];
+	my $product_ref = $test_ref->[1];
+	my $options_ref = $test_ref->[2];
+	
+	# Run the test
+	
+	compute_languages($product_ref); # need languages for allergens detection and cleaning ingredients
+	extract_ingredients_from_text($product_ref);
+	extract_ingredients_classes_from_text($product_ref);
+	detect_allergens_from_text($product_ref);
+	special_process_product($product_ref);
+	fix_salt_equivalent($product_ref);
+	compute_nutrition_score($product_ref);
+	compute_nova_group($product_ref);
+	compute_nutrient_levels($product_ref);
+	compute_unknown_nutrients($product_ref);
+	analyze_and_combine_packaging_data($product_ref);
+	compute_ecoscore($product_ref);
+	compute_forest_footprint($product_ref);
+			
+	compute_attributes($product_ref, $product_ref->{lc}, $options_ref);
+	
+	# Save the result
+	
+	if (defined $resultsdir) {
+		open (my $result, ">:encoding(UTF-8)", "$resultsdir/$testid.json") or die("Could not create $resultsdir/$testid.json: $!\n");
+		print $result $json->pretty->encode($product_ref);
+		close ($result);
+	}
+	
+	# Compare the result with the expected result
+	
+	if (open (my $expected_result, "<:encoding(UTF-8)", "$data_root/t/expected_test_results/$testdir/$testid.json")) {
+
+		local $/; #Enable 'slurp' mode
+		my $expected_product_ref = $json->decode(<$expected_result>);
+		is_deeply ($product_ref, $expected_product_ref) or diag explain $product_ref;
+	}
+	else {
+		diag explain $product_ref;
+		fail("could not load expected_test_results/$testdir/$testid.json");
+	}
+}
+
+
+done_testing();

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -143,6 +143,35 @@ foreach my $test_ref (@tests) {
 	compute_forest_footprint($product_ref);
 			
 	compute_attributes($product_ref, $product_ref->{lc}, $options_ref);
+
+	# Travis has a different $server_domain, so we need to change the resulting URLs
+	#          $got->{attribute_groups_fr}[0]{attributes}[0]{icon_url} = 'https://static.off.travis-ci.org/images/attributes/nutriscore-unknown.svg'
+	#     $expected->{attribute_groups_fr}[0]{attributes}[0]{icon_url} = 'https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg'
+	
+	# code below from https://www.perlmonks.org/?node_id=1031287
+	
+	use Scalar::Util qw/reftype/;
+
+	sub walk {
+	  my ($entry,$code) =@_;
+	  my $type = reftype($entry);
+	  $type //= "SCALAR";
+
+	  if    ($type eq "HASH") {
+		walk($_,$code) for values %$entry;
+	  }
+	  elsif ($type eq "ARRAY") {
+		walk($_,$code) for @$entry;
+	  }
+	  elsif ($type eq "SCALAR" ) {
+		$code->($_[0]);        # alias of entry
+	  }
+	  else {
+		warn "unknown type $type";
+	  }
+	}
+	
+	walk $product_ref, sub { $_[0] =~ s/https:\/\/([^\/]+)\//https:\/\/server_domain\//; };	
 	
 	# Save the result
 	

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -1,0 +1,799 @@
+{
+   "additives_n" : 2,
+   "additives_old_n" : 2,
+   "additives_old_tags" : [
+      "en:e102",
+      "en:e120"
+   ],
+   "additives_original_tags" : [
+      "en:e102",
+      "en:e120"
+   ],
+   "additives_tags" : [
+      "en:e102",
+      "en:e120"
+   ],
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_from_user" : "(en) ",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "amino_acids_tags" : [],
+   "attribute_groups_en" : [
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Average nutritional quality",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-c.svg",
+               "id" : "nutriscore",
+               "match" : 45,
+               "name" : "Nutri-Score",
+               "status" : "known",
+               "title" : "Nutri-Score C"
+            },
+            {
+               "description_short" : "0.25 g / 100 g",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-low.svg",
+               "id" : "low_salt",
+               "match" : 83.3333333333333,
+               "name" : "Salt",
+               "status" : "known",
+               "title" : "Salt in low quantity"
+            },
+            {
+               "description_short" : "12 g / 100 g",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-medium.svg",
+               "id" : "low_fat",
+               "match" : 48.2352941176471,
+               "name" : "Fat",
+               "status" : "known",
+               "title" : "Fat in moderate quantity"
+            },
+            {
+               "description_short" : "25 g / 100 g",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-high.svg",
+               "id" : "low_sugars",
+               "match" : 0,
+               "name" : "Sugars",
+               "status" : "known",
+               "title" : "Sugars in high quantity"
+            },
+            {
+               "description_short" : "4 g / 100 g",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-medium.svg",
+               "id" : "low_saturated_fat",
+               "match" : 37.1428571428571,
+               "name" : "Saturated fat",
+               "status" : "known",
+               "title" : "Saturated fat in moderate quantity"
+            }
+         ],
+         "id" : "nutritional_quality",
+         "name" : "Nutritional quality"
+      },
+      {
+         "attributes" : [
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soybeans",
+               "status" : "known",
+               "title" : "Does not contain: Soybeans"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Peanuts",
+               "status" : "known",
+               "title" : "Does not contain: Peanuts"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Sesame seeds",
+               "status" : "known",
+               "title" : "Does not contain: Sesame seeds"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "None",
+               "status" : "known",
+               "title" : "Does not contain: None"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Nuts",
+               "status" : "known",
+               "title" : "Does not contain: Nuts"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Milk",
+               "status" : "known",
+               "title" : "Does not contain: Milk"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Does not contain: Lupin"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Molluscs",
+               "status" : "known",
+               "title" : "Does not contain: Molluscs"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Fish",
+               "status" : "known",
+               "title" : "Does not contain: Fish"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustaceans",
+               "status" : "known",
+               "title" : "Does not contain: Crustaceans"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Does not contain: Gluten"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Oats",
+               "status" : "known",
+               "title" : "Does not contain: Oats"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Mustard",
+               "status" : "known",
+               "title" : "Does not contain: Mustard"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Celery",
+               "status" : "known",
+               "title" : "Does not contain: Celery"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "match" : 100,
+               "name" : "Sulphur dioxide and sulphites",
+               "status" : "known",
+               "title" : "Does not contain: Sulphur dioxide and sulphites"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Eggs",
+               "status" : "known",
+               "title" : "Does not contain: Eggs"
+            }
+         ],
+         "id" : "allergens",
+         "name" : "Allergens",
+         "warning" : "There is always a possibility that data about allergens may be missing, incomplete, incorrect or that the product's composition has changed. If you are allergic, always check the information on the actual product packaging."
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/non-vegan.svg",
+               "id" : "vegan",
+               "match" : 0,
+               "name" : "Vegan",
+               "status" : "known",
+               "title" : "Non-vegan"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/non-vegetarian.svg",
+               "id" : "vegetarian",
+               "match" : 0,
+               "name" : "Vegetarian",
+               "status" : "known",
+               "title" : "Non-vegetarian"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/palm-oil-free.svg",
+               "id" : "palm_oil_free",
+               "match" : 100,
+               "name" : "Palm oil free",
+               "status" : "known",
+               "title" : "Palm oil free"
+            }
+         ],
+         "id" : "ingredients_analysis",
+         "name" : "Ingredients"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Ultra processed foods",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-4.svg",
+               "id" : "nova",
+               "match" : 0,
+               "name" : "NOVA group",
+               "status" : "known",
+               "title" : "NOVA 4"
+            }
+         ],
+         "id" : "processing",
+         "name" : "Food processing"
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/2-additives.svg",
+               "id" : "additives",
+               "match" : 60,
+               "name" : "Additives",
+               "status" : "known",
+               "title" : "2 additives"
+            }
+         ],
+         "id" : "ingredients",
+         "name" : ""
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Low environmental impact",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-b.svg",
+               "id" : "ecoscore",
+               "match" : 62,
+               "name" : "Eco-Score",
+               "status" : "known",
+               "title" : "Eco-Score B"
+            },
+            {
+               "description" : "",
+               "description_short" : "Almost no risk of deforestation",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-a.svg",
+               "id" : "forest_footprint",
+               "match" : 99.9292929292929,
+               "name" : "Forest footprint",
+               "status" : "known",
+               "title" : "Very small forest footprint"
+            }
+         ],
+         "id" : "environment",
+         "name" : "Environment"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
+               "description_short" : "Promotes ecological sustainability and biodiversity.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic.svg",
+               "id" : "labels_organic",
+               "match" : 100,
+               "name" : "Organic farming",
+               "status" : "known",
+               "title" : "Organic product"
+            },
+            {
+               "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
+               "description_short" : "Helps producers in developping countries.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade.svg",
+               "id" : "labels_fair_trade",
+               "match" : 100,
+               "name" : "Fair trade",
+               "status" : "known",
+               "title" : "Fair trade product"
+            }
+         ],
+         "id" : "labels",
+         "name" : "Labels"
+      }
+   ],
+   "categories" : "biscuits",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "24000"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-24000",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-unknown",
+      "agribalyse-known",
+      "agribalyse-24000"
+   ],
+   "categories_tags" : [
+      "en:biscuits"
+   ],
+   "countries_tags" : [
+      "en:united-kingdom",
+      "en:france"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:united-kingdom",
+                  "percent" : 54.5454545454545
+               },
+               {
+                  "origin" : "en:paraguay",
+                  "percent" : 22.7272727272727
+               },
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 22.7272727272727
+               }
+            ],
+            "epi_score" : 52.7301022116202,
+            "epi_value" : 0,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score" : 41.6054002272727,
+            "transportation_value" : 6,
+            "value" : 6
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 0,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 92,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:cardboard",
+                  "shape" : "en:box"
+               },
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 0.1,
+                  "material" : "en:unknown",
+                  "shape" : "en:film"
+               }
+            ],
+            "score" : 82,
+            "value" : -2,
+            "warning" : "unspecified_material"
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "24000",
+         "co2_agriculture" : "3.8424243",
+         "co2_consumption" : "0",
+         "co2_distribution" : "0.029120657",
+         "co2_packaging" : "0.10869536",
+         "co2_processing" : "0.32913764",
+         "co2_total" : "4.4447267",
+         "co2_transportation" : "0.135384",
+         "code" : "24000",
+         "dqr" : "2.14",
+         "ef_agriculture" : "0.36061353999999995",
+         "ef_consumption" : "0",
+         "ef_distribution" : "0.0098990521",
+         "ef_packaging" : "0.016471127999999998",
+         "ef_processing" : "0.051325736000000004",
+         "ef_total" : 0.44895118,
+         "ef_transportation" : "0.010645482000000001",
+         "is_beverage" : 0,
+         "name_en" : "Biscuit (cookie)",
+         "name_fr" : "Biscuit sec, sans précision",
+         "score" : 58
+      },
+      "grade" : "b",
+      "missing" : {
+         "labels" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 62,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 62,
+   "ecoscore_tags" : [
+      "b"
+   ],
+   "forest_footprint_data" : {
+      "footprint_per_kg" : 0.00176767676767677,
+      "grade" : "a",
+      "ingredients" : [
+         {
+            "conditions_tags" : [
+               [
+                  "labels",
+                  "en:organic"
+               ]
+            ],
+            "footprint_per_kg" : 0.00176767676767677,
+            "matching_tag_id" : "en:egg",
+            "percent" : 11.3636363636364,
+            "percent_estimate" : 11.3636363636364,
+            "processing_factor" : 1,
+            "tag_id" : "en:egg",
+            "tag_type" : "ingredients",
+            "type" : {
+               "deforestation_risk" : 0.1,
+               "name" : "Oeufs Bio",
+               "soy_feed_factor" : 0.028,
+               "soy_yield" : 0.18
+            }
+         }
+      ]
+   },
+   "ingredients" : [
+      {
+         "id" : "en:wheat-flour",
+         "origins" : "en:united-kingdom",
+         "percent_estimate" : 54.5454545454545,
+         "percent_max" : 100,
+         "percent_min" : 9.09090909090909,
+         "text" : "wheat flour",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "origins" : "en:paraguay",
+         "percent_estimate" : 22.7272727272727,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:egg",
+         "percent_estimate" : 11.3636363636364,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "eggs",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:strawberry",
+         "percent_estimate" : 5.68181818181818,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "text" : "strawberries",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:high-fructose-corn-syrup",
+         "percent_estimate" : 2.84090909090909,
+         "percent_max" : 20,
+         "percent_min" : 0,
+         "text" : "high fructose corn syrup",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "from_palm_oil" : "no",
+         "id" : "en:rapeseed-oil",
+         "percent_estimate" : 1.42045454545455,
+         "percent_max" : 16.6666666666667,
+         "percent_min" : 0,
+         "text" : "rapeseed oil",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:macadamia-nut",
+         "percent_estimate" : 0.710227272727273,
+         "percent_max" : 14.2857142857143,
+         "percent_min" : 0,
+         "text" : "macadamia nuts",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:milk-proteins",
+         "percent_estimate" : 0.35511363636364,
+         "percent_max" : 12.5,
+         "percent_min" : 0,
+         "text" : "milk proteins",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:salt",
+         "percent_estimate" : 0.17755681818182,
+         "percent_max" : 11.1111111111111,
+         "percent_min" : 0,
+         "text" : "salt",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:e102",
+         "percent_estimate" : 0.0887784090909065,
+         "percent_max" : 10,
+         "percent_min" : 0,
+         "text" : "e102",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:e120",
+         "percent_estimate" : 0.0887784090909065,
+         "percent_max" : 9.09090909090909,
+         "percent_min" : 0,
+         "text" : "e120",
+         "vegan" : "no",
+         "vegetarian" : "no"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:non-vegetarian"
+   ],
+   "ingredients_from_or_that_may_be_from_palm_oil_n" : 0,
+   "ingredients_from_palm_oil_n" : 0,
+   "ingredients_from_palm_oil_tags" : [],
+   "ingredients_hierarchy" : [
+      "en:wheat-flour",
+      "en:cereal",
+      "en:flour",
+      "en:wheat",
+      "en:cereal-flour",
+      "en:sugar",
+      "en:egg",
+      "en:strawberry",
+      "en:fruit",
+      "en:berries",
+      "en:high-fructose-corn-syrup",
+      "en:glucose",
+      "en:fructose",
+      "en:corn-syrup",
+      "en:glucose-fructose-syrup",
+      "en:rapeseed-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:macadamia-nut",
+      "en:nut",
+      "en:tree-nut",
+      "en:milk-proteins",
+      "en:protein",
+      "en:animal-protein",
+      "en:salt",
+      "en:e102",
+      "en:e120"
+   ],
+   "ingredients_n" : 11,
+   "ingredients_n_tags" : [
+      "11",
+      "11-20"
+   ],
+   "ingredients_original_tags" : [
+      "en:wheat-flour",
+      "en:sugar",
+      "en:egg",
+      "en:strawberry",
+      "en:high-fructose-corn-syrup",
+      "en:rapeseed-oil",
+      "en:macadamia-nut",
+      "en:milk-proteins",
+      "en:salt",
+      "en:e102",
+      "en:e120"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:wheat-flour",
+      "en:cereal",
+      "en:flour",
+      "en:wheat",
+      "en:cereal-flour",
+      "en:sugar",
+      "en:egg",
+      "en:strawberry",
+      "en:fruit",
+      "en:berries",
+      "en:high-fructose-corn-syrup",
+      "en:glucose",
+      "en:fructose",
+      "en:corn-syrup",
+      "en:glucose-fructose-syrup",
+      "en:rapeseed-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:macadamia-nut",
+      "en:nut",
+      "en:tree-nut",
+      "en:milk-proteins",
+      "en:protein",
+      "en:animal-protein",
+      "en:salt",
+      "en:e102",
+      "en:e120"
+   ],
+   "ingredients_text" : "wheat flour (origin: UK), sugar (Paraguay), eggs, strawberries, high fructose corn syrup, rapeseed oil, macadamia nuts, milk proteins, salt, E102, E120",
+   "ingredients_that_may_be_from_palm_oil_n" : 0,
+   "ingredients_that_may_be_from_palm_oil_tags" : [],
+   "known_ingredients_n" : 27,
+   "labels_tags" : [
+      "en:organic",
+      "en:fair-trade"
+   ],
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "en",
+   "minerals_tags" : [],
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed",
+      "en:forest-footprint-computed",
+      "en:forest-footprint-a"
+   ],
+   "nova_group" : 4,
+   "nova_group_debug" : " -- ingredients/en:salt : 3 -- additives/en:e120 : 4",
+   "nova_groups" : "4",
+   "nova_groups_tags" : [
+      "en:4-ultra-processed-food-and-drink-products"
+   ],
+   "nucleotides_tags" : [],
+   "nutrient_levels" : {
+      "fat" : "moderate",
+      "salt" : "low",
+      "saturated-fat" : "moderate",
+      "sugars" : "high"
+   },
+   "nutrient_levels_tags" : [
+      "en:fat-in-moderate-quantity",
+      "en:saturated-fat-in-moderate-quantity",
+      "en:sugars-in-high-quantity",
+      "en:salt-in-low-quantity"
+   ],
+   "nutriments" : {
+      "energy_100g" : 800,
+      "fat_100g" : 12,
+      "fiber_100g" : 3,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nova-group" : 4,
+      "nova-group_100g" : 4,
+      "nova-group_serving" : 4,
+      "nutrition-score-fr" : 8,
+      "nutrition-score-fr_100g" : 8,
+      "proteins_100g" : 2,
+      "salt_100g" : 0.25,
+      "saturated-fat_100g" : 4,
+      "sodium_100g" : 0.1,
+      "sugars_100g" : 25
+   },
+   "nutriscore_data" : {
+      "energy" : 800,
+      "energy_points" : 2,
+      "energy_value" : 800,
+      "fiber" : 3,
+      "fiber_points" : 3,
+      "fiber_value" : 3,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "c",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 11,
+      "positive_points" : 3,
+      "proteins" : 2,
+      "proteins_points" : 1,
+      "proteins_value" : 2,
+      "saturated_fat" : 4,
+      "saturated_fat_points" : 3,
+      "saturated_fat_ratio" : 33.3333333333333,
+      "saturated_fat_ratio_points" : 4,
+      "saturated_fat_ratio_value" : 33.3,
+      "saturated_fat_value" : 4,
+      "score" : 8,
+      "sodium" : 100,
+      "sodium_points" : 1,
+      "sodium_value" : 100,
+      "sugars" : 25,
+      "sugars_points" : 5,
+      "sugars_value" : 25
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 8,
+   "nutriscore_score_opposite" : -8,
+   "nutrition_data_per" : "100g",
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "other_nutritional_substances_tags" : [],
+   "packaging_text" : "Cardboard box, film wrap",
+   "packagings" : [
+      {
+         "material" : "en:cardboard",
+         "shape" : "en:box"
+      },
+      {
+         "shape" : "en:film"
+      }
+   ],
+   "pnns_groups_1" : "unknown",
+   "pnns_groups_1_tags" : [
+      "unknown",
+      "missing-association"
+   ],
+   "pnns_groups_2" : "unknown",
+   "pnns_groups_2_tags" : [
+      "unknown",
+      "missing-association"
+   ],
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_from_user" : "(en) ",
+   "traces_hierarchy" : [],
+   "traces_tags" : [],
+   "unknown_ingredients_n" : 0,
+   "unknown_nutrients_tags" : [],
+   "vitamins_tags" : []
+}

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -76,30 +76,12 @@
          "attributes" : [
             {
                "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
-               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
                "match" : 100,
-               "name" : "Sulphur dioxide and sulphites",
+               "name" : "Gluten",
                "status" : "known",
-               "title" : "Does not contain: Sulphur dioxide and sulphites"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
-               "id" : "allergens_no_soybeans",
-               "match" : 100,
-               "name" : "Soybeans",
-               "status" : "known",
-               "title" : "Does not contain: Soybeans"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
-               "id" : "allergens_no_lupin",
-               "match" : 100,
-               "name" : "Lupin",
-               "status" : "known",
-               "title" : "Does not contain: Lupin"
+               "title" : "Does not contain: Gluten"
             },
             {
                "debug" : "11 ingredients (0 unknown)",
@@ -109,69 +91,6 @@
                "name" : "Milk",
                "status" : "known",
                "title" : "Does not contain: Milk"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Sesame seeds",
-               "status" : "known",
-               "title" : "Does not contain: Sesame seeds"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
-               "id" : "allergens_no_fish",
-               "match" : 100,
-               "name" : "Fish",
-               "status" : "known",
-               "title" : "Does not contain: Fish"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Oats",
-               "status" : "known",
-               "title" : "Does not contain: Oats"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "None",
-               "status" : "known",
-               "title" : "Does not contain: None"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
-               "id" : "allergens_no_crustaceans",
-               "match" : 100,
-               "name" : "Crustaceans",
-               "status" : "known",
-               "title" : "Does not contain: Crustaceans"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Celery",
-               "status" : "known",
-               "title" : "Does not contain: Celery"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Mustard",
-               "status" : "known",
-               "title" : "Does not contain: Mustard"
             },
             {
                "debug" : "11 ingredients (0 unknown)",
@@ -193,6 +112,78 @@
             },
             {
                "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Peanuts",
+               "status" : "known",
+               "title" : "Does not contain: Peanuts"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame_seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Sesame seeds",
+               "status" : "known",
+               "title" : "Does not contain: Sesame seeds"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soybeans",
+               "status" : "known",
+               "title" : "Does not contain: Soybeans"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Celery",
+               "status" : "known",
+               "title" : "Does not contain: Celery"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Mustard",
+               "status" : "known",
+               "title" : "Does not contain: Mustard"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Does not contain: Lupin"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Fish",
+               "status" : "known",
+               "title" : "Does not contain: Fish"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustaceans",
+               "status" : "known",
+               "title" : "Does not contain: Crustaceans"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
                "icon_url" : "https://server_domain/images/attributes/no-molluscs.svg",
                "id" : "allergens_no_molluscs",
                "match" : 100,
@@ -202,21 +193,12 @@
             },
             {
                "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur_dioxide_and_sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
-               "name" : "Gluten",
+               "name" : "Sulphur dioxide and sulphites",
                "status" : "known",
-               "title" : "Does not contain: Gluten"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Peanuts",
-               "status" : "known",
-               "title" : "Does not contain: Peanuts"
+               "title" : "Does not contain: Sulphur dioxide and sulphites"
             }
          ],
          "id" : "allergens",
@@ -687,7 +669,7 @@
       "en:forest-footprint-a"
    ],
    "nova_group" : 4,
-   "nova_group_debug" : " -- ingredients/en:sugar : 3 -- ingredients/en:high-fructose-corn-syrup : 4",
+   "nova_group_debug" : " -- ingredients/en:salt : 3 -- additives/en:e102 : 4",
    "nova_groups" : "4",
    "nova_groups_tags" : [
       "en:4-ultra-processed-food-and-drink-products"

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -25,7 +25,7 @@
             {
                "description" : "",
                "description_short" : "Average nutritional quality",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-c.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutriscore-c.svg",
                "id" : "nutriscore",
                "match" : 45,
                "name" : "Nutri-Score",
@@ -34,7 +34,7 @@
             },
             {
                "description_short" : "0.25 g / 100 g",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-low.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-low.svg",
                "id" : "low_salt",
                "match" : 83.3333333333333,
                "name" : "Salt",
@@ -43,7 +43,7 @@
             },
             {
                "description_short" : "12 g / 100 g",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-medium.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-medium.svg",
                "id" : "low_fat",
                "match" : 48.2352941176471,
                "name" : "Fat",
@@ -52,7 +52,7 @@
             },
             {
                "description_short" : "25 g / 100 g",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-high.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-high.svg",
                "id" : "low_sugars",
                "match" : 0,
                "name" : "Sugars",
@@ -61,7 +61,7 @@
             },
             {
                "description_short" : "4 g / 100 g",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-medium.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-medium.svg",
                "id" : "low_saturated_fat",
                "match" : 37.1428571428571,
                "name" : "Saturated fat",
@@ -76,133 +76,7 @@
          "attributes" : [
             {
                "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
-               "id" : "allergens_no_soybeans",
-               "match" : 100,
-               "name" : "Soybeans",
-               "status" : "known",
-               "title" : "Does not contain: Soybeans"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Peanuts",
-               "status" : "known",
-               "title" : "Does not contain: Peanuts"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Sesame seeds",
-               "status" : "known",
-               "title" : "Does not contain: Sesame seeds"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "None",
-               "status" : "known",
-               "title" : "Does not contain: None"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Nuts",
-               "status" : "known",
-               "title" : "Does not contain: Nuts"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Milk",
-               "status" : "known",
-               "title" : "Does not contain: Milk"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
-               "id" : "allergens_no_lupin",
-               "match" : 100,
-               "name" : "Lupin",
-               "status" : "known",
-               "title" : "Does not contain: Lupin"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
-               "id" : "allergens_no_molluscs",
-               "match" : 100,
-               "name" : "Molluscs",
-               "status" : "known",
-               "title" : "Does not contain: Molluscs"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
-               "id" : "allergens_no_fish",
-               "match" : 100,
-               "name" : "Fish",
-               "status" : "known",
-               "title" : "Does not contain: Fish"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
-               "id" : "allergens_no_crustaceans",
-               "match" : 100,
-               "name" : "Crustaceans",
-               "status" : "known",
-               "title" : "Does not contain: Crustaceans"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
-               "match" : 100,
-               "name" : "Gluten",
-               "status" : "known",
-               "title" : "Does not contain: Gluten"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Oats",
-               "status" : "known",
-               "title" : "Does not contain: Oats"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Mustard",
-               "status" : "known",
-               "title" : "Does not contain: Mustard"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Celery",
-               "status" : "known",
-               "title" : "Does not contain: Celery"
-            },
-            {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
                "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
                "name" : "Sulphur dioxide and sulphites",
@@ -211,12 +85,138 @@
             },
             {
                "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soybeans",
+               "status" : "known",
+               "title" : "Does not contain: Soybeans"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Does not contain: Lupin"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Milk",
+               "status" : "known",
+               "title" : "Does not contain: Milk"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Sesame seeds",
+               "status" : "known",
+               "title" : "Does not contain: Sesame seeds"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Fish",
+               "status" : "known",
+               "title" : "Does not contain: Fish"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Oats",
+               "status" : "known",
+               "title" : "Does not contain: Oats"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "None",
+               "status" : "known",
+               "title" : "Does not contain: None"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustaceans",
+               "status" : "known",
+               "title" : "Does not contain: Crustaceans"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Celery",
+               "status" : "known",
+               "title" : "Does not contain: Celery"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Mustard",
+               "status" : "known",
+               "title" : "Does not contain: Mustard"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
                "id" : "allergens_no_eggs",
                "match" : 100,
                "name" : "Eggs",
                "status" : "known",
                "title" : "Does not contain: Eggs"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Nuts",
+               "status" : "known",
+               "title" : "Does not contain: Nuts"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Molluscs",
+               "status" : "known",
+               "title" : "Does not contain: Molluscs"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Does not contain: Gluten"
+            },
+            {
+               "debug" : "11 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Peanuts",
+               "status" : "known",
+               "title" : "Does not contain: Peanuts"
             }
          ],
          "id" : "allergens",
@@ -226,7 +226,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/non-vegan.svg",
+               "icon_url" : "https://server_domain/images/attributes/non-vegan.svg",
                "id" : "vegan",
                "match" : 0,
                "name" : "Vegan",
@@ -234,7 +234,7 @@
                "title" : "Non-vegan"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/non-vegetarian.svg",
+               "icon_url" : "https://server_domain/images/attributes/non-vegetarian.svg",
                "id" : "vegetarian",
                "match" : 0,
                "name" : "Vegetarian",
@@ -242,7 +242,7 @@
                "title" : "Non-vegetarian"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/palm-oil-free.svg",
+               "icon_url" : "https://server_domain/images/attributes/palm-oil-free.svg",
                "id" : "palm_oil_free",
                "match" : 100,
                "name" : "Palm oil free",
@@ -258,7 +258,7 @@
             {
                "description" : "",
                "description_short" : "Ultra processed foods",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-4.svg",
+               "icon_url" : "https://server_domain/images/attributes/nova-group-4.svg",
                "id" : "nova",
                "match" : 0,
                "name" : "NOVA group",
@@ -272,7 +272,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/2-additives.svg",
+               "icon_url" : "https://server_domain/images/attributes/2-additives.svg",
                "id" : "additives",
                "match" : 60,
                "name" : "Additives",
@@ -288,7 +288,7 @@
             {
                "description" : "",
                "description_short" : "Low environmental impact",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-b.svg",
+               "icon_url" : "https://server_domain/images/attributes/ecoscore-b.svg",
                "id" : "ecoscore",
                "match" : 62,
                "name" : "Eco-Score",
@@ -298,7 +298,7 @@
             {
                "description" : "",
                "description_short" : "Almost no risk of deforestation",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-a.svg",
+               "icon_url" : "https://server_domain/images/attributes/forest-footprint-a.svg",
                "id" : "forest_footprint",
                "match" : 99.9292929292929,
                "name" : "Forest footprint",
@@ -314,7 +314,7 @@
             {
                "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
                "description_short" : "Promotes ecological sustainability and biodiversity.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic.svg",
+               "icon_url" : "https://server_domain/images/attributes/organic.svg",
                "id" : "labels_organic",
                "match" : 100,
                "name" : "Organic farming",
@@ -324,7 +324,7 @@
             {
                "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
                "description_short" : "Helps producers in developping countries.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade.svg",
+               "icon_url" : "https://server_domain/images/attributes/fair-trade.svg",
                "id" : "labels_fair_trade",
                "match" : 100,
                "name" : "Fair trade",
@@ -687,7 +687,7 @@
       "en:forest-footprint-a"
    ],
    "nova_group" : 4,
-   "nova_group_debug" : " -- ingredients/en:salt : 3 -- additives/en:e120 : 4",
+   "nova_group_debug" : " -- ingredients/en:sugar : 3 -- ingredients/en:high-fructose-corn-syrup : 4",
    "nova_groups" : "4",
    "nova_groups_tags" : [
       "en:4-ultra-processed-food-and-drink-products"

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -26,7 +26,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sel",
                "status" : "unknown",
                "title" : "Sel en quantité inconnue"
@@ -34,7 +34,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Matières grasses / Lipides",
                "status" : "unknown",
                "title" : "Matières grasses / Lipides en quantité inconnue"
@@ -42,7 +42,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sucres",
                "status" : "unknown",
                "title" : "Sucres en quantité inconnue"
@@ -50,7 +50,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Acides gras saturés",
                "status" : "unknown",
                "title" : "Acides gras saturés en quantité inconnue"
@@ -63,12 +63,57 @@
          "attributes" : [
             {
                "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
-               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
                "match" : 100,
-               "name" : "Anhydride sulfureux et sulfites",
+               "name" : "Gluten",
                "status" : "known",
-               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Milk"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Eggs"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Nuts"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Peanuts"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame_seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Sesame_seeds"
             },
             {
                "debug" : "1 ingredients (0 unknown)",
@@ -77,7 +122,25 @@
                "match" : 100,
                "name" : "Soja",
                "status" : "known",
-               "title" : "Ne contient pas : Soja"
+               "title" : "Ne contient pas : Soybeans"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Celery"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Mustard"
             },
             {
                "debug" : "1 ingredients (0 unknown)",
@@ -90,48 +153,12 @@
             },
             {
                "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
                "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
                "id" : "allergens_no_fish",
                "match" : 100,
                "name" : "Poisson",
                "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
+               "title" : "Ne contient pas : Fish"
             },
             {
                "debug" : "1 ingredients (0 unknown)",
@@ -140,43 +167,7 @@
                "match" : 100,
                "name" : "Crustacés",
                "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
-               "id" : "allergens_no_eggs",
-               "match" : 100,
-               "name" : "Œufs",
-               "status" : "known",
-               "title" : "Ne contient pas : Œufs"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
+               "title" : "Ne contient pas : Crustaceans"
             },
             {
                "debug" : "1 ingredients (0 unknown)",
@@ -185,25 +176,16 @@
                "match" : 100,
                "name" : "Mollusques",
                "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
+               "title" : "Ne contient pas : Molluscs"
             },
             {
                "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur_dioxide_and_sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
-               "name" : "Gluten",
+               "name" : "Anhydride sulfureux et sulfites",
                "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
+               "title" : "Ne contient pas : Sulphur_dioxide_and_sulphites"
             }
          ],
          "id" : "allergens",
@@ -238,7 +220,7 @@
             }
          ],
          "id" : "ingredients_analysis",
-         "name" : "Ingredients"
+         "name" : "Ingrédients"
       },
       {
          "attributes" : [
@@ -274,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Impact environnemental inconnu",
+               "description_short" : "Unknown environmental impact",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -256,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Unknown environmental impact",
+               "description_short" : "Impact environnemental inconnu",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -16,7 +16,7 @@
             {
                "description" : "",
                "description_short" : "Qualité nutritionnelle inconnue",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutriscore-unknown.svg",
                "id" : "nutriscore",
                "match" : 0,
                "name" : "Nutri-Score",
@@ -24,7 +24,7 @@
                "title" : "Nutri-Score non calculé"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sel",
@@ -32,7 +32,7 @@
                "title" : "Sel en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Matières grasses / Lipides",
@@ -40,7 +40,7 @@
                "title" : "Matières grasses / Lipides en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sucres",
@@ -48,7 +48,7 @@
                "title" : "Sucres en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Acides gras saturés",
@@ -63,133 +63,7 @@
          "attributes" : [
             {
                "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
-               "id" : "allergens_no_soybeans",
-               "match" : 100,
-               "name" : "Soja",
-               "status" : "known",
-               "title" : "Ne contient pas : Soja"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
-               "id" : "allergens_no_lupin",
-               "match" : 100,
-               "name" : "Lupin",
-               "status" : "known",
-               "title" : "Ne contient pas : Lupin"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
-               "id" : "allergens_no_molluscs",
-               "match" : 100,
-               "name" : "Mollusques",
-               "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
-               "id" : "allergens_no_fish",
-               "match" : 100,
-               "name" : "Poisson",
-               "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
-               "id" : "allergens_no_crustaceans",
-               "match" : 100,
-               "name" : "Crustacés",
-               "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
-               "match" : 100,
-               "name" : "Gluten",
-               "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
                "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
                "name" : "Anhydride sulfureux et sulfites",
@@ -198,12 +72,138 @@
             },
             {
                "debug" : "1 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
                "id" : "allergens_no_eggs",
                "match" : 100,
                "name" : "Œufs",
                "status" : "known",
                "title" : "Ne contient pas : Œufs"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
             }
          ],
          "id" : "allergens",
@@ -213,7 +213,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegan.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegan.svg",
                "id" : "vegan",
                "match" : 100,
                "name" : "Végétalien",
@@ -221,7 +221,7 @@
                "title" : "Végétalien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegetarian.svg",
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
@@ -229,7 +229,7 @@
                "title" : "Végétarien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/contains-palm-oil.svg",
+               "icon_url" : "https://server_domain/images/attributes/contains-palm-oil.svg",
                "id" : "palm_oil_free",
                "match" : 0,
                "name" : "Sans huile de palme",
@@ -245,7 +245,7 @@
             {
                "description" : "",
                "description_short" : "Degré de transformation des aliments inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nova-group-unknown.svg",
                "id" : "nova",
                "match" : 0,
                "name" : "Groupe NOVA",
@@ -259,7 +259,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "icon_url" : "https://server_domain/images/attributes/0-additives.svg",
                "id" : "additives",
                "match" : 100,
                "name" : "Additifs",
@@ -275,7 +275,7 @@
             {
                "description" : "",
                "description_short" : "Impact environnemental inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,
                "name" : "Éco-Score",
@@ -285,7 +285,7 @@
             {
                "description" : "",
                "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "icon_url" : "https://server_domain/images/attributes/forest-footprint-not-computed.svg",
                "id" : "forest_footprint",
                "match" : 0,
                "name" : "Empreinte forêt",
@@ -301,7 +301,7 @@
             {
                "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
                "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/organic-unknown.svg",
                "id" : "labels_organic",
                "name" : "Agriculture biologique",
                "status" : "unknown",
@@ -310,7 +310,7 @@
             {
                "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
                "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/fair-trade-unknown.svg",
                "id" : "labels_fair_trade",
                "name" : "Commerce équitable",
                "status" : "unknown",

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -1,0 +1,490 @@
+{
+   "additives_n" : 0,
+   "additives_old_n" : 0,
+   "additives_old_tags" : [],
+   "additives_original_tags" : [],
+   "additives_tags" : [],
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_from_user" : "(fr) ",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "amino_acids_tags" : [],
+   "attribute_groups_fr" : [
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Qualité nutritionnelle inconnue",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "id" : "nutriscore",
+               "match" : 0,
+               "name" : "Nutri-Score",
+               "status" : "unknown",
+               "title" : "Nutri-Score non calculé"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "id" : "low_salt",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sel",
+               "status" : "unknown",
+               "title" : "Sel en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "id" : "low_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Matières grasses / Lipides",
+               "status" : "unknown",
+               "title" : "Matières grasses / Lipides en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "id" : "low_sugars",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sucres",
+               "status" : "unknown",
+               "title" : "Sucres en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "id" : "low_saturated_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Acides gras saturés",
+               "status" : "unknown",
+               "title" : "Acides gras saturés en quantité inconnue"
+            }
+         ],
+         "id" : "nutritional_quality",
+         "name" : "Qualité nutritionnelle"
+      },
+      {
+         "attributes" : [
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "match" : 100,
+               "name" : "Anhydride sulfureux et sulfites",
+               "status" : "known",
+               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+            },
+            {
+               "debug" : "1 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Œufs"
+            }
+         ],
+         "id" : "allergens",
+         "name" : "Allergènes",
+         "warning" : "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegan.svg",
+               "id" : "vegan",
+               "match" : 100,
+               "name" : "Végétalien",
+               "status" : "known",
+               "title" : "Végétalien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "id" : "vegetarian",
+               "match" : 100,
+               "name" : "Végétarien",
+               "status" : "known",
+               "title" : "Végétarien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/contains-palm-oil.svg",
+               "id" : "palm_oil_free",
+               "match" : 0,
+               "name" : "Sans huile de palme",
+               "status" : "known",
+               "title" : "Huile de palme"
+            }
+         ],
+         "id" : "ingredients_analysis",
+         "name" : "Ingredients"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Degré de transformation des aliments inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "id" : "nova",
+               "match" : 0,
+               "name" : "Groupe NOVA",
+               "status" : "unknown",
+               "title" : "NOVA non calculé"
+            }
+         ],
+         "id" : "processing",
+         "name" : "Transformation des aliments"
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "id" : "additives",
+               "match" : 100,
+               "name" : "Additifs",
+               "status" : "known",
+               "title" : "Sans additives"
+            }
+         ],
+         "id" : "ingredients",
+         "name" : ""
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Impact environnemental inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "id" : "ecoscore",
+               "match" : 0,
+               "name" : "Éco-Score",
+               "status" : "unknown",
+               "title" : "Eco-Score non calculé"
+            },
+            {
+               "description" : "",
+               "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "id" : "forest_footprint",
+               "match" : 0,
+               "name" : "Empreinte forêt",
+               "status" : "known",
+               "title" : "Empreinte forêt non calculée"
+            }
+         ],
+         "id" : "environment",
+         "name" : "Environnement"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+               "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "id" : "labels_organic",
+               "name" : "Agriculture biologique",
+               "status" : "unknown",
+               "title" : "Information manquante : produit bio ?"
+            },
+            {
+               "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+               "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "id" : "labels_fair_trade",
+               "name" : "Commerce équitable",
+               "status" : "unknown",
+               "title" : "Information manquante : produit de commerce équitable ?"
+            }
+         ],
+         "id" : "labels",
+         "name" : "Labels"
+      }
+   ],
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-unknown",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score" : 0,
+            "transportation_value" : 0,
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "ingredient" : "en:palm-oil",
+            "value" : -10
+         }
+      },
+      "agribalyse" : {
+         "warning" : "missing_agribalyse_match"
+      },
+      "missing" : {
+         "categories" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_agribalyse_match_warning" : 1,
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "unknown",
+   "ecoscore_tags" : [
+      "unknown"
+   ],
+   "ingredients" : [
+      {
+         "from_palm_oil" : "yes",
+         "id" : "en:palm-kernel-fat",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "graisse de palmiste",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_from_or_that_may_be_from_palm_oil_n" : 1,
+   "ingredients_from_palm_oil_n" : 1,
+   "ingredients_from_palm_oil_tags" : [
+      "huile-de-palme"
+   ],
+   "ingredients_hierarchy" : [
+      "en:palm-kernel-fat",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:palm-kernel-oil-and-fat"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:palm-kernel-fat"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:palm-kernel-fat",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:palm-kernel-oil-and-fat"
+   ],
+   "ingredients_text" : "graisse de palmiste",
+   "ingredients_that_may_be_from_palm_oil_n" : 0,
+   "ingredients_that_may_be_from_palm_oil_tags" : [],
+   "known_ingredients_n" : 4,
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fr",
+   "minerals_tags" : [],
+   "misc_tags" : [
+      "en:nutriscore-not-computed",
+      "en:nutriscore-missing-category",
+      "en:ecoscore-not-computed"
+   ],
+   "nova_group_debug" : "no nova group when the product does not have a category",
+   "nova_group_tags" : [
+      "not-applicable"
+   ],
+   "nucleotides_tags" : [],
+   "nutrient_levels" : {},
+   "nutrient_levels_tags" : [],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "nutrition_grades_tags" : [
+      "unknown"
+   ],
+   "nutrition_score_debug" : "no score when the product does not have a category",
+   "other_nutritional_substances_tags" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
+   "pnns_groups_1" : "unknown",
+   "pnns_groups_1_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "pnns_groups_2" : "unknown",
+   "pnns_groups_2_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_from_user" : "(fr) ",
+   "traces_hierarchy" : [],
+   "traces_tags" : [],
+   "unknown_ingredients_n" : 0,
+   "unknown_nutrients_tags" : [],
+   "vitamins_tags" : []
+}

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -26,7 +26,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sel",
                "status" : "unknown",
                "title" : "Sel en quantité inconnue"
@@ -34,7 +34,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Matières grasses / Lipides",
                "status" : "unknown",
                "title" : "Matières grasses / Lipides en quantité inconnue"
@@ -42,7 +42,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sucres",
                "status" : "unknown",
                "title" : "Sucres en quantité inconnue"
@@ -50,7 +50,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Acides gras saturés",
                "status" : "unknown",
                "title" : "Acides gras saturés en quantité inconnue"
@@ -63,12 +63,57 @@
          "attributes" : [
             {
                "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
-               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
                "match" : 100,
-               "name" : "Anhydride sulfureux et sulfites",
+               "name" : "Gluten",
                "status" : "known",
-               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Milk"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Eggs"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Nuts"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Peanuts"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame_seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Sesame_seeds"
             },
             {
                "debug" : "4 ingredients (0 unknown)",
@@ -77,7 +122,25 @@
                "match" : 100,
                "name" : "Soja",
                "status" : "known",
-               "title" : "Ne contient pas : Soja"
+               "title" : "Ne contient pas : Soybeans"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Celery"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Mustard"
             },
             {
                "debug" : "4 ingredients (0 unknown)",
@@ -90,48 +153,12 @@
             },
             {
                "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
                "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
                "id" : "allergens_no_fish",
                "match" : 100,
                "name" : "Poisson",
                "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
+               "title" : "Ne contient pas : Fish"
             },
             {
                "debug" : "4 ingredients (0 unknown)",
@@ -140,43 +167,7 @@
                "match" : 100,
                "name" : "Crustacés",
                "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
-               "id" : "allergens_no_eggs",
-               "match" : 100,
-               "name" : "Œufs",
-               "status" : "known",
-               "title" : "Ne contient pas : Œufs"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
+               "title" : "Ne contient pas : Crustaceans"
             },
             {
                "debug" : "4 ingredients (0 unknown)",
@@ -185,25 +176,16 @@
                "match" : 100,
                "name" : "Mollusques",
                "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
+               "title" : "Ne contient pas : Molluscs"
             },
             {
                "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur_dioxide_and_sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
-               "name" : "Gluten",
+               "name" : "Anhydride sulfureux et sulfites",
                "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
+               "title" : "Ne contient pas : Sulphur_dioxide_and_sulphites"
             }
          ],
          "id" : "allergens",
@@ -238,7 +220,7 @@
             }
          ],
          "id" : "ingredients_analysis",
-         "name" : "Ingredients"
+         "name" : "Ingrédients"
       },
       {
          "attributes" : [
@@ -274,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Impact environnemental inconnu",
+               "description_short" : "Unknown environmental impact",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -16,7 +16,7 @@
             {
                "description" : "",
                "description_short" : "Qualité nutritionnelle inconnue",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutriscore-unknown.svg",
                "id" : "nutriscore",
                "match" : 0,
                "name" : "Nutri-Score",
@@ -24,7 +24,7 @@
                "title" : "Nutri-Score non calculé"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sel",
@@ -32,7 +32,7 @@
                "title" : "Sel en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Matières grasses / Lipides",
@@ -40,7 +40,7 @@
                "title" : "Matières grasses / Lipides en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sucres",
@@ -48,7 +48,7 @@
                "title" : "Sucres en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Acides gras saturés",
@@ -63,133 +63,7 @@
          "attributes" : [
             {
                "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
-               "id" : "allergens_no_soybeans",
-               "match" : 100,
-               "name" : "Soja",
-               "status" : "known",
-               "title" : "Ne contient pas : Soja"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
-               "id" : "allergens_no_lupin",
-               "match" : 100,
-               "name" : "Lupin",
-               "status" : "known",
-               "title" : "Ne contient pas : Lupin"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
-               "id" : "allergens_no_molluscs",
-               "match" : 100,
-               "name" : "Mollusques",
-               "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
-               "id" : "allergens_no_fish",
-               "match" : 100,
-               "name" : "Poisson",
-               "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
-               "id" : "allergens_no_crustaceans",
-               "match" : 100,
-               "name" : "Crustacés",
-               "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
-               "match" : 100,
-               "name" : "Gluten",
-               "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
                "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
                "name" : "Anhydride sulfureux et sulfites",
@@ -198,12 +72,138 @@
             },
             {
                "debug" : "4 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
                "id" : "allergens_no_eggs",
                "match" : 100,
                "name" : "Œufs",
                "status" : "known",
                "title" : "Ne contient pas : Œufs"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
             }
          ],
          "id" : "allergens",
@@ -213,7 +213,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/maybe-vegan.svg",
+               "icon_url" : "https://server_domain/images/attributes/maybe-vegan.svg",
                "id" : "vegan",
                "match" : 20,
                "name" : "Végétalien",
@@ -221,7 +221,7 @@
                "title" : "Peut-être végétalien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegetarian.svg",
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
@@ -229,7 +229,7 @@
                "title" : "Végétarien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/palm-oil-free.svg",
+               "icon_url" : "https://server_domain/images/attributes/palm-oil-free.svg",
                "id" : "palm_oil_free",
                "match" : 100,
                "name" : "Sans huile de palme",
@@ -245,7 +245,7 @@
             {
                "description" : "",
                "description_short" : "Degré de transformation des aliments inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nova-group-unknown.svg",
                "id" : "nova",
                "match" : 0,
                "name" : "Groupe NOVA",
@@ -259,7 +259,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "icon_url" : "https://server_domain/images/attributes/0-additives.svg",
                "id" : "additives",
                "match" : 100,
                "name" : "Additifs",
@@ -275,7 +275,7 @@
             {
                "description" : "",
                "description_short" : "Impact environnemental inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,
                "name" : "Éco-Score",
@@ -285,7 +285,7 @@
             {
                "description" : "",
                "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "icon_url" : "https://server_domain/images/attributes/forest-footprint-not-computed.svg",
                "id" : "forest_footprint",
                "match" : 0,
                "name" : "Empreinte forêt",
@@ -301,7 +301,7 @@
             {
                "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
                "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/organic-unknown.svg",
                "id" : "labels_organic",
                "name" : "Agriculture biologique",
                "status" : "unknown",
@@ -310,7 +310,7 @@
             {
                "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
                "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/fair-trade-unknown.svg",
                "id" : "labels_fair_trade",
                "name" : "Commerce équitable",
                "status" : "unknown",

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -256,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Unknown environmental impact",
+               "description_short" : "Impact environnemental inconnu",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -1,0 +1,514 @@
+{
+   "additives_n" : 0,
+   "additives_old_n" : 0,
+   "additives_old_tags" : [],
+   "additives_original_tags" : [],
+   "additives_tags" : [],
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_from_user" : "(fr) ",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "amino_acids_tags" : [],
+   "attribute_groups_fr" : [
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Qualité nutritionnelle inconnue",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "id" : "nutriscore",
+               "match" : 0,
+               "name" : "Nutri-Score",
+               "status" : "unknown",
+               "title" : "Nutri-Score non calculé"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "id" : "low_salt",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sel",
+               "status" : "unknown",
+               "title" : "Sel en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "id" : "low_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Matières grasses / Lipides",
+               "status" : "unknown",
+               "title" : "Matières grasses / Lipides en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "id" : "low_sugars",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sucres",
+               "status" : "unknown",
+               "title" : "Sucres en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "id" : "low_saturated_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Acides gras saturés",
+               "status" : "unknown",
+               "title" : "Acides gras saturés en quantité inconnue"
+            }
+         ],
+         "id" : "nutritional_quality",
+         "name" : "Qualité nutritionnelle"
+      },
+      {
+         "attributes" : [
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "match" : 100,
+               "name" : "Anhydride sulfureux et sulfites",
+               "status" : "known",
+               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+            },
+            {
+               "debug" : "4 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Œufs"
+            }
+         ],
+         "id" : "allergens",
+         "name" : "Allergènes",
+         "warning" : "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/maybe-vegan.svg",
+               "id" : "vegan",
+               "match" : 20,
+               "name" : "Végétalien",
+               "status" : "known",
+               "title" : "Peut-être végétalien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "id" : "vegetarian",
+               "match" : 100,
+               "name" : "Végétarien",
+               "status" : "known",
+               "title" : "Végétarien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/palm-oil-free.svg",
+               "id" : "palm_oil_free",
+               "match" : 100,
+               "name" : "Sans huile de palme",
+               "status" : "known",
+               "title" : "Sans huile de palme"
+            }
+         ],
+         "id" : "ingredients_analysis",
+         "name" : "Ingredients"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Degré de transformation des aliments inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "id" : "nova",
+               "match" : 0,
+               "name" : "Groupe NOVA",
+               "status" : "unknown",
+               "title" : "NOVA non calculé"
+            }
+         ],
+         "id" : "processing",
+         "name" : "Transformation des aliments"
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "id" : "additives",
+               "match" : 100,
+               "name" : "Additifs",
+               "status" : "known",
+               "title" : "Sans additives"
+            }
+         ],
+         "id" : "ingredients",
+         "name" : ""
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Impact environnemental inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "id" : "ecoscore",
+               "match" : 0,
+               "name" : "Éco-Score",
+               "status" : "unknown",
+               "title" : "Eco-Score non calculé"
+            },
+            {
+               "description" : "",
+               "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "id" : "forest_footprint",
+               "match" : 0,
+               "name" : "Empreinte forêt",
+               "status" : "known",
+               "title" : "Empreinte forêt non calculée"
+            }
+         ],
+         "id" : "environment",
+         "name" : "Environnement"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+               "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "id" : "labels_organic",
+               "name" : "Agriculture biologique",
+               "status" : "unknown",
+               "title" : "Information manquante : produit bio ?"
+            },
+            {
+               "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+               "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "id" : "labels_fair_trade",
+               "name" : "Commerce équitable",
+               "status" : "unknown",
+               "title" : "Information manquante : produit de commerce équitable ?"
+            }
+         ],
+         "id" : "labels",
+         "name" : "Labels"
+      }
+   ],
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-unknown",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score" : 0,
+            "transportation_value" : 0,
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "warning" : "missing_agribalyse_match"
+      },
+      "missing" : {
+         "categories" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_agribalyse_match_warning" : 1,
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "unknown",
+   "ecoscore_tags" : [
+      "unknown"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:water",
+         "percent_estimate" : 62.5,
+         "percent_max" : 100,
+         "percent_min" : 25,
+         "text" : "eau",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:flour",
+         "percent_estimate" : 18.75,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "farine",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "percent_estimate" : 9.375,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "sucre",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:chocolate",
+         "percent_estimate" : 9.375,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "text" : "chocolat",
+         "vegan" : "maybe",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:maybe-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_from_or_that_may_be_from_palm_oil_n" : 0,
+   "ingredients_from_palm_oil_n" : 0,
+   "ingredients_from_palm_oil_tags" : [],
+   "ingredients_hierarchy" : [
+      "en:water",
+      "en:flour",
+      "en:sugar",
+      "en:chocolate"
+   ],
+   "ingredients_n" : 4,
+   "ingredients_n_tags" : [
+      "4",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:water",
+      "en:flour",
+      "en:sugar",
+      "en:chocolate"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:water",
+      "en:flour",
+      "en:sugar",
+      "en:chocolate"
+   ],
+   "ingredients_text" : "eau, farine, sucre, chocolat",
+   "ingredients_that_may_be_from_palm_oil_n" : 0,
+   "ingredients_that_may_be_from_palm_oil_tags" : [],
+   "known_ingredients_n" : 4,
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fr",
+   "minerals_tags" : [],
+   "misc_tags" : [
+      "en:nutriscore-not-computed",
+      "en:nutriscore-missing-category",
+      "en:ecoscore-not-computed"
+   ],
+   "nova_group_debug" : "no nova group when the product does not have a category",
+   "nova_group_tags" : [
+      "not-applicable"
+   ],
+   "nucleotides_tags" : [],
+   "nutrient_levels" : {},
+   "nutrient_levels_tags" : [],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "nutrition_grades_tags" : [
+      "unknown"
+   ],
+   "nutrition_score_debug" : "no score when the product does not have a category",
+   "other_nutritional_substances_tags" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
+   "pnns_groups_1" : "unknown",
+   "pnns_groups_1_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "pnns_groups_2" : "unknown",
+   "pnns_groups_2_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_from_user" : "(fr) ",
+   "traces_hierarchy" : [],
+   "traces_tags" : [],
+   "unknown_ingredients_n" : 0,
+   "unknown_nutrients_tags" : [],
+   "vitamins_tags" : []
+}

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -16,7 +16,7 @@
             {
                "description" : "",
                "description_short" : "Qualité nutritionnelle inconnue",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutriscore-unknown.svg",
                "id" : "nutriscore",
                "match" : 0,
                "name" : "Nutri-Score",
@@ -24,7 +24,7 @@
                "title" : "Nutri-Score non calculé"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sel",
@@ -32,7 +32,7 @@
                "title" : "Sel en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Matières grasses / Lipides",
@@ -40,7 +40,7 @@
                "title" : "Matières grasses / Lipides en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sucres",
@@ -48,7 +48,7 @@
                "title" : "Sucres en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Acides gras saturés",
@@ -63,133 +63,7 @@
          "attributes" : [
             {
                "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
-               "id" : "allergens_no_soybeans",
-               "match" : 100,
-               "name" : "Soja",
-               "status" : "known",
-               "title" : "Ne contient pas : Soja"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
-               "id" : "allergens_no_lupin",
-               "match" : 100,
-               "name" : "Lupin",
-               "status" : "known",
-               "title" : "Ne contient pas : Lupin"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
-               "id" : "allergens_no_molluscs",
-               "match" : 100,
-               "name" : "Mollusques",
-               "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
-               "id" : "allergens_no_fish",
-               "match" : 100,
-               "name" : "Poisson",
-               "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
-               "id" : "allergens_no_crustaceans",
-               "match" : 100,
-               "name" : "Crustacés",
-               "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
-               "match" : 100,
-               "name" : "Gluten",
-               "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
                "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
                "name" : "Anhydride sulfureux et sulfites",
@@ -198,12 +72,138 @@
             },
             {
                "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
                "id" : "allergens_no_eggs",
                "match" : 100,
                "name" : "Œufs",
                "status" : "known",
                "title" : "Ne contient pas : Œufs"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
             }
          ],
          "id" : "allergens",
@@ -213,7 +213,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegan.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegan.svg",
                "id" : "vegan",
                "match" : 100,
                "name" : "Végétalien",
@@ -221,7 +221,7 @@
                "title" : "Végétalien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegetarian.svg",
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
@@ -229,7 +229,7 @@
                "title" : "Végétarien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/contains-palm-oil.svg",
+               "icon_url" : "https://server_domain/images/attributes/contains-palm-oil.svg",
                "id" : "palm_oil_free",
                "match" : 0,
                "name" : "Sans huile de palme",
@@ -245,7 +245,7 @@
             {
                "description" : "",
                "description_short" : "Degré de transformation des aliments inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nova-group-unknown.svg",
                "id" : "nova",
                "match" : 0,
                "name" : "Groupe NOVA",
@@ -259,7 +259,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "icon_url" : "https://server_domain/images/attributes/0-additives.svg",
                "id" : "additives",
                "match" : 100,
                "name" : "Additifs",
@@ -275,7 +275,7 @@
             {
                "description" : "",
                "description_short" : "Impact environnemental inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,
                "name" : "Éco-Score",
@@ -285,7 +285,7 @@
             {
                "description" : "",
                "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "icon_url" : "https://server_domain/images/attributes/forest-footprint-not-computed.svg",
                "id" : "forest_footprint",
                "match" : 0,
                "name" : "Empreinte forêt",
@@ -301,7 +301,7 @@
             {
                "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
                "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/organic-unknown.svg",
                "id" : "labels_organic",
                "name" : "Agriculture biologique",
                "status" : "unknown",
@@ -310,7 +310,7 @@
             {
                "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
                "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/fair-trade-unknown.svg",
                "id" : "labels_fair_trade",
                "name" : "Commerce équitable",
                "status" : "unknown",

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -256,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Unknown environmental impact",
+               "description_short" : "Impact environnemental inconnu",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -1,0 +1,506 @@
+{
+   "additives_n" : 0,
+   "additives_old_n" : 0,
+   "additives_old_tags" : [],
+   "additives_original_tags" : [],
+   "additives_tags" : [],
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_from_user" : "(fr) ",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "amino_acids_tags" : [],
+   "attribute_groups_fr" : [
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Qualité nutritionnelle inconnue",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "id" : "nutriscore",
+               "match" : 0,
+               "name" : "Nutri-Score",
+               "status" : "unknown",
+               "title" : "Nutri-Score non calculé"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "id" : "low_salt",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sel",
+               "status" : "unknown",
+               "title" : "Sel en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "id" : "low_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Matières grasses / Lipides",
+               "status" : "unknown",
+               "title" : "Matières grasses / Lipides en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "id" : "low_sugars",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sucres",
+               "status" : "unknown",
+               "title" : "Sucres en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "id" : "low_saturated_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Acides gras saturés",
+               "status" : "unknown",
+               "title" : "Acides gras saturés en quantité inconnue"
+            }
+         ],
+         "id" : "nutritional_quality",
+         "name" : "Qualité nutritionnelle"
+      },
+      {
+         "attributes" : [
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "match" : 100,
+               "name" : "Anhydride sulfureux et sulfites",
+               "status" : "known",
+               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Œufs"
+            }
+         ],
+         "id" : "allergens",
+         "name" : "Allergènes",
+         "warning" : "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegan.svg",
+               "id" : "vegan",
+               "match" : 100,
+               "name" : "Végétalien",
+               "status" : "known",
+               "title" : "Végétalien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "id" : "vegetarian",
+               "match" : 100,
+               "name" : "Végétarien",
+               "status" : "known",
+               "title" : "Végétarien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/contains-palm-oil.svg",
+               "id" : "palm_oil_free",
+               "match" : 0,
+               "name" : "Sans huile de palme",
+               "status" : "known",
+               "title" : "Huile de palme"
+            }
+         ],
+         "id" : "ingredients_analysis",
+         "name" : "Ingredients"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Degré de transformation des aliments inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "id" : "nova",
+               "match" : 0,
+               "name" : "Groupe NOVA",
+               "status" : "unknown",
+               "title" : "NOVA non calculé"
+            }
+         ],
+         "id" : "processing",
+         "name" : "Transformation des aliments"
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "id" : "additives",
+               "match" : 100,
+               "name" : "Additifs",
+               "status" : "known",
+               "title" : "Sans additives"
+            }
+         ],
+         "id" : "ingredients",
+         "name" : ""
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Impact environnemental inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "id" : "ecoscore",
+               "match" : 0,
+               "name" : "Éco-Score",
+               "status" : "unknown",
+               "title" : "Eco-Score non calculé"
+            },
+            {
+               "description" : "",
+               "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "id" : "forest_footprint",
+               "match" : 0,
+               "name" : "Empreinte forêt",
+               "status" : "known",
+               "title" : "Empreinte forêt non calculée"
+            }
+         ],
+         "id" : "environment",
+         "name" : "Environnement"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+               "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "id" : "labels_organic",
+               "name" : "Agriculture biologique",
+               "status" : "unknown",
+               "title" : "Information manquante : produit bio ?"
+            },
+            {
+               "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+               "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "id" : "labels_fair_trade",
+               "name" : "Commerce équitable",
+               "status" : "unknown",
+               "title" : "Information manquante : produit de commerce équitable ?"
+            }
+         ],
+         "id" : "labels",
+         "name" : "Labels"
+      }
+   ],
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-unknown",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score" : 0,
+            "transportation_value" : 0,
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "ingredient" : "en:palm-oil",
+            "value" : -10
+         }
+      },
+      "agribalyse" : {
+         "warning" : "missing_agribalyse_match"
+      },
+      "missing" : {
+         "categories" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_agribalyse_match_warning" : 1,
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "unknown",
+   "ecoscore_tags" : [
+      "unknown"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:potato",
+         "percent_estimate" : 75,
+         "percent_max" : 100,
+         "percent_min" : 50,
+         "text" : "pommes de terres",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "from_palm_oil" : "yes",
+         "id" : "en:palm-oil",
+         "percent_estimate" : 25,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "huile de palme",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_from_or_that_may_be_from_palm_oil_n" : 1,
+   "ingredients_from_palm_oil_n" : 1,
+   "ingredients_from_palm_oil_tags" : [
+      "huile-de-palme"
+   ],
+   "ingredients_hierarchy" : [
+      "en:potato",
+      "en:vegetable",
+      "en:root-vegetable",
+      "en:palm-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:palm-oil-and-fat"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:potato",
+      "en:palm-oil"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:potato",
+      "en:vegetable",
+      "en:root-vegetable",
+      "en:palm-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:palm-oil-and-fat"
+   ],
+   "ingredients_text" : "pommes de terres, huile de palme",
+   "ingredients_that_may_be_from_palm_oil_n" : 0,
+   "ingredients_that_may_be_from_palm_oil_tags" : [],
+   "known_ingredients_n" : 7,
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fr",
+   "minerals_tags" : [],
+   "misc_tags" : [
+      "en:nutriscore-not-computed",
+      "en:nutriscore-missing-category",
+      "en:ecoscore-not-computed"
+   ],
+   "nova_group_debug" : "no nova group when the product does not have a category",
+   "nova_group_tags" : [
+      "not-applicable"
+   ],
+   "nucleotides_tags" : [],
+   "nutrient_levels" : {},
+   "nutrient_levels_tags" : [],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "nutrition_grades_tags" : [
+      "unknown"
+   ],
+   "nutrition_score_debug" : "no score when the product does not have a category",
+   "other_nutritional_substances_tags" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
+   "pnns_groups_1" : "unknown",
+   "pnns_groups_1_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "pnns_groups_2" : "unknown",
+   "pnns_groups_2_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_from_user" : "(fr) ",
+   "traces_hierarchy" : [],
+   "traces_tags" : [],
+   "unknown_ingredients_n" : 0,
+   "unknown_nutrients_tags" : [],
+   "vitamins_tags" : []
+}

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -26,7 +26,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sel",
                "status" : "unknown",
                "title" : "Sel en quantité inconnue"
@@ -34,7 +34,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Matières grasses / Lipides",
                "status" : "unknown",
                "title" : "Matières grasses / Lipides en quantité inconnue"
@@ -42,7 +42,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sucres",
                "status" : "unknown",
                "title" : "Sucres en quantité inconnue"
@@ -50,7 +50,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Acides gras saturés",
                "status" : "unknown",
                "title" : "Acides gras saturés en quantité inconnue"
@@ -63,12 +63,57 @@
          "attributes" : [
             {
                "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
-               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
                "match" : 100,
-               "name" : "Anhydride sulfureux et sulfites",
+               "name" : "Gluten",
                "status" : "known",
-               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Milk"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Eggs"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Nuts"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Peanuts"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame_seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Sesame_seeds"
             },
             {
                "debug" : "2 ingredients (0 unknown)",
@@ -77,7 +122,25 @@
                "match" : 100,
                "name" : "Soja",
                "status" : "known",
-               "title" : "Ne contient pas : Soja"
+               "title" : "Ne contient pas : Soybeans"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Celery"
+            },
+            {
+               "debug" : "2 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Mustard"
             },
             {
                "debug" : "2 ingredients (0 unknown)",
@@ -90,48 +153,12 @@
             },
             {
                "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
                "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
                "id" : "allergens_no_fish",
                "match" : 100,
                "name" : "Poisson",
                "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
+               "title" : "Ne contient pas : Fish"
             },
             {
                "debug" : "2 ingredients (0 unknown)",
@@ -140,43 +167,7 @@
                "match" : 100,
                "name" : "Crustacés",
                "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
-               "id" : "allergens_no_eggs",
-               "match" : 100,
-               "name" : "Œufs",
-               "status" : "known",
-               "title" : "Ne contient pas : Œufs"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
+               "title" : "Ne contient pas : Crustaceans"
             },
             {
                "debug" : "2 ingredients (0 unknown)",
@@ -185,25 +176,16 @@
                "match" : 100,
                "name" : "Mollusques",
                "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
+               "title" : "Ne contient pas : Molluscs"
             },
             {
                "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur_dioxide_and_sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
-               "name" : "Gluten",
+               "name" : "Anhydride sulfureux et sulfites",
                "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "2 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
+               "title" : "Ne contient pas : Sulphur_dioxide_and_sulphites"
             }
          ],
          "id" : "allergens",
@@ -238,7 +220,7 @@
             }
          ],
          "id" : "ingredients_analysis",
-         "name" : "Ingredients"
+         "name" : "Ingrédients"
       },
       {
          "attributes" : [
@@ -274,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Impact environnemental inconnu",
+               "description_short" : "Unknown environmental impact",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -16,7 +16,7 @@
             {
                "description" : "",
                "description_short" : "Qualité nutritionnelle inconnue",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutriscore-unknown.svg",
                "id" : "nutriscore",
                "match" : 0,
                "name" : "Nutri-Score",
@@ -24,7 +24,7 @@
                "title" : "Nutri-Score non calculé"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sel",
@@ -32,7 +32,7 @@
                "title" : "Sel en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Matières grasses / Lipides",
@@ -40,7 +40,7 @@
                "title" : "Matières grasses / Lipides en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Sucres",
@@ -48,7 +48,7 @@
                "title" : "Sucres en quantité inconnue"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
                "missing" : "Faits nutritionnels manquants",
                "name" : "Acides gras saturés",
@@ -63,133 +63,7 @@
          "attributes" : [
             {
                "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
-               "id" : "allergens_no_soybeans",
-               "match" : 100,
-               "name" : "Soja",
-               "status" : "known",
-               "title" : "Ne contient pas : Soja"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
-               "id" : "allergens_no_lupin",
-               "match" : 100,
-               "name" : "Lupin",
-               "status" : "known",
-               "title" : "Ne contient pas : Lupin"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
-               "id" : "allergens_no_molluscs",
-               "match" : 100,
-               "name" : "Mollusques",
-               "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
-               "id" : "allergens_no_fish",
-               "match" : 100,
-               "name" : "Poisson",
-               "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
-               "id" : "allergens_no_crustaceans",
-               "match" : 100,
-               "name" : "Crustacés",
-               "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
-               "match" : 100,
-               "name" : "Gluten",
-               "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
                "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
                "name" : "Anhydride sulfureux et sulfites",
@@ -198,12 +72,138 @@
             },
             {
                "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "icon_url" : "https://server_domain/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
                "id" : "allergens_no_eggs",
                "match" : 100,
                "name" : "Œufs",
                "status" : "known",
                "title" : "Ne contient pas : Œufs"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
             }
          ],
          "id" : "allergens",
@@ -213,7 +213,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegan.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegan.svg",
                "id" : "vegan",
                "match" : 100,
                "name" : "Végétalien",
@@ -221,7 +221,7 @@
                "title" : "Végétalien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "icon_url" : "https://server_domain/images/attributes/vegetarian.svg",
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
@@ -229,7 +229,7 @@
                "title" : "Végétarien"
             },
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/may-contain-palm-oil.svg",
+               "icon_url" : "https://server_domain/images/attributes/may-contain-palm-oil.svg",
                "id" : "palm_oil_free",
                "match" : 20,
                "name" : "Sans huile de palme",
@@ -245,7 +245,7 @@
             {
                "description" : "",
                "description_short" : "Degré de transformation des aliments inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/nova-group-unknown.svg",
                "id" : "nova",
                "match" : 0,
                "name" : "Groupe NOVA",
@@ -259,7 +259,7 @@
       {
          "attributes" : [
             {
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "icon_url" : "https://server_domain/images/attributes/0-additives.svg",
                "id" : "additives",
                "match" : 100,
                "name" : "Additifs",
@@ -275,7 +275,7 @@
             {
                "description" : "",
                "description_short" : "Impact environnemental inconnu",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,
                "name" : "Éco-Score",
@@ -285,7 +285,7 @@
             {
                "description" : "",
                "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "icon_url" : "https://server_domain/images/attributes/forest-footprint-not-computed.svg",
                "id" : "forest_footprint",
                "match" : 0,
                "name" : "Empreinte forêt",
@@ -301,7 +301,7 @@
             {
                "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
                "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/organic-unknown.svg",
                "id" : "labels_organic",
                "name" : "Agriculture biologique",
                "status" : "unknown",
@@ -310,7 +310,7 @@
             {
                "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
                "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
-               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "icon_url" : "https://server_domain/images/attributes/fair-trade-unknown.svg",
                "id" : "labels_fair_trade",
                "name" : "Commerce équitable",
                "status" : "unknown",

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -26,7 +26,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-salt-unknown.svg",
                "id" : "low_salt",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sel",
                "status" : "unknown",
                "title" : "Sel en quantité inconnue"
@@ -34,7 +34,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-fat-unknown.svg",
                "id" : "low_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Matières grasses / Lipides",
                "status" : "unknown",
                "title" : "Matières grasses / Lipides en quantité inconnue"
@@ -42,7 +42,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-sugars-unknown.svg",
                "id" : "low_sugars",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Sucres",
                "status" : "unknown",
                "title" : "Sucres en quantité inconnue"
@@ -50,7 +50,7 @@
             {
                "icon_url" : "https://server_domain/images/attributes/nutrient-level-saturated-fat-unknown.svg",
                "id" : "low_saturated_fat",
-               "missing" : "Faits nutritionnels manquants",
+               "missing" : "Données nutritionnelles manquantes",
                "name" : "Acides gras saturés",
                "status" : "unknown",
                "title" : "Acides gras saturés en quantité inconnue"
@@ -63,12 +63,57 @@
          "attributes" : [
             {
                "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
-               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
                "match" : 100,
-               "name" : "Anhydride sulfureux et sulfites",
+               "name" : "Gluten",
                "status" : "known",
-               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Milk"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Eggs"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Nuts"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Peanuts"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-sesame_seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Sesame_seeds"
             },
             {
                "debug" : "3 ingredients (0 unknown)",
@@ -77,7 +122,25 @@
                "match" : 100,
                "name" : "Soja",
                "status" : "known",
-               "title" : "Ne contient pas : Soja"
+               "title" : "Ne contient pas : Soybeans"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Celery"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Mustard"
             },
             {
                "debug" : "3 ingredients (0 unknown)",
@@ -90,48 +153,12 @@
             },
             {
                "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-milk.svg",
-               "id" : "allergens_no_milk",
-               "match" : 100,
-               "name" : "Lait",
-               "status" : "known",
-               "title" : "Ne contient pas : Lait"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-sesame-seeds.svg",
-               "id" : "allergens_no_sesame_seeds",
-               "match" : 100,
-               "name" : "Graines de sésame",
-               "status" : "known",
-               "title" : "Ne contient pas : Graines de sésame"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
                "icon_url" : "https://server_domain/images/attributes/no-fish.svg",
                "id" : "allergens_no_fish",
                "match" : 100,
                "name" : "Poisson",
                "status" : "known",
-               "title" : "Ne contient pas : Poisson"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-oats.svg",
-               "id" : "allergens_no_oats",
-               "match" : 100,
-               "name" : "Avoine",
-               "status" : "known",
-               "title" : "Ne contient pas : Avoine"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-none.svg",
-               "id" : "allergens_no_none",
-               "match" : 100,
-               "name" : "Aucun",
-               "status" : "known",
-               "title" : "Ne contient pas : Aucun"
+               "title" : "Ne contient pas : Fish"
             },
             {
                "debug" : "3 ingredients (0 unknown)",
@@ -140,43 +167,7 @@
                "match" : 100,
                "name" : "Crustacés",
                "status" : "known",
-               "title" : "Ne contient pas : Crustacés"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-celery.svg",
-               "id" : "allergens_no_celery",
-               "match" : 100,
-               "name" : "Céleri",
-               "status" : "known",
-               "title" : "Ne contient pas : Céleri"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-mustard.svg",
-               "id" : "allergens_no_mustard",
-               "match" : 100,
-               "name" : "Moutarde",
-               "status" : "known",
-               "title" : "Ne contient pas : Moutarde"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-eggs.svg",
-               "id" : "allergens_no_eggs",
-               "match" : 100,
-               "name" : "Œufs",
-               "status" : "known",
-               "title" : "Ne contient pas : Œufs"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-nuts.svg",
-               "id" : "allergens_no_nuts",
-               "match" : 100,
-               "name" : "Fruits à coque",
-               "status" : "known",
-               "title" : "Ne contient pas : Fruits à coque"
+               "title" : "Ne contient pas : Crustaceans"
             },
             {
                "debug" : "3 ingredients (0 unknown)",
@@ -185,25 +176,16 @@
                "match" : 100,
                "name" : "Mollusques",
                "status" : "known",
-               "title" : "Ne contient pas : Mollusques"
+               "title" : "Ne contient pas : Molluscs"
             },
             {
                "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
-               "id" : "allergens_no_gluten",
+               "icon_url" : "https://server_domain/images/attributes/no-sulphur_dioxide_and_sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                "match" : 100,
-               "name" : "Gluten",
+               "name" : "Anhydride sulfureux et sulfites",
                "status" : "known",
-               "title" : "Ne contient pas : Gluten"
-            },
-            {
-               "debug" : "3 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-peanuts.svg",
-               "id" : "allergens_no_peanuts",
-               "match" : 100,
-               "name" : "Arachides",
-               "status" : "known",
-               "title" : "Ne contient pas : Arachides"
+               "title" : "Ne contient pas : Sulphur_dioxide_and_sulphites"
             }
          ],
          "id" : "allergens",
@@ -238,7 +220,7 @@
             }
          ],
          "id" : "ingredients_analysis",
-         "name" : "Ingredients"
+         "name" : "Ingrédients"
       },
       {
          "attributes" : [
@@ -274,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Impact environnemental inconnu",
+               "description_short" : "Unknown environmental impact",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -1,0 +1,515 @@
+{
+   "additives_n" : 0,
+   "additives_old_n" : 0,
+   "additives_old_tags" : [],
+   "additives_original_tags" : [],
+   "additives_tags" : [],
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_from_user" : "(fr) ",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "amino_acids_tags" : [],
+   "attribute_groups_fr" : [
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Qualité nutritionnelle inconnue",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutriscore-unknown.svg",
+               "id" : "nutriscore",
+               "match" : 0,
+               "name" : "Nutri-Score",
+               "status" : "unknown",
+               "title" : "Nutri-Score non calculé"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-salt-unknown.svg",
+               "id" : "low_salt",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sel",
+               "status" : "unknown",
+               "title" : "Sel en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-fat-unknown.svg",
+               "id" : "low_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Matières grasses / Lipides",
+               "status" : "unknown",
+               "title" : "Matières grasses / Lipides en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-sugars-unknown.svg",
+               "id" : "low_sugars",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Sucres",
+               "status" : "unknown",
+               "title" : "Sucres en quantité inconnue"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nutrient-level-saturated-fat-unknown.svg",
+               "id" : "low_saturated_fat",
+               "missing" : "Faits nutritionnels manquants",
+               "name" : "Acides gras saturés",
+               "status" : "unknown",
+               "title" : "Acides gras saturés en quantité inconnue"
+            }
+         ],
+         "id" : "nutritional_quality",
+         "name" : "Qualité nutritionnelle"
+      },
+      {
+         "attributes" : [
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-soybeans.svg",
+               "id" : "allergens_no_soybeans",
+               "match" : 100,
+               "name" : "Soja",
+               "status" : "known",
+               "title" : "Ne contient pas : Soja"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-peanuts.svg",
+               "id" : "allergens_no_peanuts",
+               "match" : 100,
+               "name" : "Arachides",
+               "status" : "known",
+               "title" : "Ne contient pas : Arachides"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sesame-seeds.svg",
+               "id" : "allergens_no_sesame_seeds",
+               "match" : 100,
+               "name" : "Graines de sésame",
+               "status" : "known",
+               "title" : "Ne contient pas : Graines de sésame"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-none.svg",
+               "id" : "allergens_no_none",
+               "match" : 100,
+               "name" : "Aucun",
+               "status" : "known",
+               "title" : "Ne contient pas : Aucun"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-nuts.svg",
+               "id" : "allergens_no_nuts",
+               "match" : 100,
+               "name" : "Fruits à coque",
+               "status" : "known",
+               "title" : "Ne contient pas : Fruits à coque"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-milk.svg",
+               "id" : "allergens_no_milk",
+               "match" : 100,
+               "name" : "Lait",
+               "status" : "known",
+               "title" : "Ne contient pas : Lait"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-lupin.svg",
+               "id" : "allergens_no_lupin",
+               "match" : 100,
+               "name" : "Lupin",
+               "status" : "known",
+               "title" : "Ne contient pas : Lupin"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-molluscs.svg",
+               "id" : "allergens_no_molluscs",
+               "match" : 100,
+               "name" : "Mollusques",
+               "status" : "known",
+               "title" : "Ne contient pas : Mollusques"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-fish.svg",
+               "id" : "allergens_no_fish",
+               "match" : 100,
+               "name" : "Poisson",
+               "status" : "known",
+               "title" : "Ne contient pas : Poisson"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-crustaceans.svg",
+               "id" : "allergens_no_crustaceans",
+               "match" : 100,
+               "name" : "Crustacés",
+               "status" : "known",
+               "title" : "Ne contient pas : Crustacés"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-gluten.svg",
+               "id" : "allergens_no_gluten",
+               "match" : 100,
+               "name" : "Gluten",
+               "status" : "known",
+               "title" : "Ne contient pas : Gluten"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-oats.svg",
+               "id" : "allergens_no_oats",
+               "match" : 100,
+               "name" : "Avoine",
+               "status" : "known",
+               "title" : "Ne contient pas : Avoine"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-mustard.svg",
+               "id" : "allergens_no_mustard",
+               "match" : 100,
+               "name" : "Moutarde",
+               "status" : "known",
+               "title" : "Ne contient pas : Moutarde"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-celery.svg",
+               "id" : "allergens_no_celery",
+               "match" : 100,
+               "name" : "Céleri",
+               "status" : "known",
+               "title" : "Ne contient pas : Céleri"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+               "id" : "allergens_no_sulphur_dioxide_and_sulphites",
+               "match" : 100,
+               "name" : "Anhydride sulfureux et sulfites",
+               "status" : "known",
+               "title" : "Ne contient pas : Anhydride sulfureux et sulfites"
+            },
+            {
+               "debug" : "3 ingredients (0 unknown)",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/no-eggs.svg",
+               "id" : "allergens_no_eggs",
+               "match" : 100,
+               "name" : "Œufs",
+               "status" : "known",
+               "title" : "Ne contient pas : Œufs"
+            }
+         ],
+         "id" : "allergens",
+         "name" : "Allergènes",
+         "warning" : "Il est toujours possible que les données sur les allergènes soient manquantes, incomplètes, incorrectes ou que la composition du produit ait changé. Si vous êtes allergique, vérifiez toujours les informations sur l'emballage réel du produit."
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegan.svg",
+               "id" : "vegan",
+               "match" : 100,
+               "name" : "Végétalien",
+               "status" : "known",
+               "title" : "Végétalien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/vegetarian.svg",
+               "id" : "vegetarian",
+               "match" : 100,
+               "name" : "Végétarien",
+               "status" : "known",
+               "title" : "Végétarien"
+            },
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/may-contain-palm-oil.svg",
+               "id" : "palm_oil_free",
+               "match" : 20,
+               "name" : "Sans huile de palme",
+               "status" : "known",
+               "title" : "Pourrait contenir de l'huile de palme"
+            }
+         ],
+         "id" : "ingredients_analysis",
+         "name" : "Ingredients"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Degré de transformation des aliments inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/nova-group-unknown.svg",
+               "id" : "nova",
+               "match" : 0,
+               "name" : "Groupe NOVA",
+               "status" : "unknown",
+               "title" : "NOVA non calculé"
+            }
+         ],
+         "id" : "processing",
+         "name" : "Transformation des aliments"
+      },
+      {
+         "attributes" : [
+            {
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/0-additives.svg",
+               "id" : "additives",
+               "match" : 100,
+               "name" : "Additifs",
+               "status" : "known",
+               "title" : "Sans additives"
+            }
+         ],
+         "id" : "ingredients",
+         "name" : ""
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "",
+               "description_short" : "Impact environnemental inconnu",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/ecoscore-unknown.svg",
+               "id" : "ecoscore",
+               "match" : 0,
+               "name" : "Éco-Score",
+               "status" : "unknown",
+               "title" : "Eco-Score non calculé"
+            },
+            {
+               "description" : "",
+               "description_short" : "Pour l'instant seulement pour les produits avec du poulet ou des oeufs",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/forest-footprint-not-computed.svg",
+               "id" : "forest_footprint",
+               "match" : 0,
+               "name" : "Empreinte forêt",
+               "status" : "known",
+               "title" : "Empreinte forêt non calculée"
+            }
+         ],
+         "id" : "environment",
+         "name" : "Environnement"
+      },
+      {
+         "attributes" : [
+            {
+               "description" : "L'agriculture biologique vise à protéger l'environnement et à conserver la biodiversité en prohibant ou limitant l'utilisation d'engrais synthétiques, de pesticides et d'additifs alimentaires.",
+               "description_short" : "Les produits bios encouragent la durabilité écologique et la biodiversité.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/organic-unknown.svg",
+               "id" : "labels_organic",
+               "name" : "Agriculture biologique",
+               "status" : "unknown",
+               "title" : "Information manquante : produit bio ?"
+            },
+            {
+               "description" : "Quand vous achetez des produits du commerce équitable, les producteurs dans les pays en développement sont payés un prix plus haut et plus équitable, ce qui les aide à atteindre des plus hauts standards sociaux et environnementaux et à les conserver.",
+               "description_short" : "Les produits du commerce équitable aident les producteurs des pays en voie de développement.",
+               "icon_url" : "https://static.openfoodfacts.dev/images/attributes/fair-trade-unknown.svg",
+               "id" : "labels_fair_trade",
+               "name" : "Commerce équitable",
+               "status" : "unknown",
+               "title" : "Information manquante : produit de commerce équitable ?"
+            }
+         ],
+         "id" : "labels",
+         "name" : "Labels"
+      }
+   ],
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-unknown",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score" : 0,
+            "transportation_value" : 0,
+            "value" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "warning" : "missing_agribalyse_match"
+      },
+      "missing" : {
+         "categories" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_agribalyse_match_warning" : 1,
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "unknown",
+   "ecoscore_tags" : [
+      "unknown"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:corn-flour",
+         "percent_estimate" : 66.6666666666667,
+         "percent_max" : 100,
+         "percent_min" : 33.3333333333333,
+         "text" : "farine de maïs",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "from_palm_oil" : "maybe",
+         "id" : "en:vegetable-oil",
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "huiles végétales",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:salt",
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "sel",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:may-contain-palm-oil",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_from_or_that_may_be_from_palm_oil_n" : 1,
+   "ingredients_from_palm_oil_n" : 0,
+   "ingredients_from_palm_oil_tags" : [],
+   "ingredients_hierarchy" : [
+      "en:corn-flour",
+      "en:cereal",
+      "en:flour",
+      "en:corn",
+      "en:vegetable-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:salt"
+   ],
+   "ingredients_n" : 3,
+   "ingredients_n_tags" : [
+      "3",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:corn-flour",
+      "en:vegetable-oil",
+      "en:salt"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:corn-flour",
+      "en:cereal",
+      "en:flour",
+      "en:corn",
+      "en:vegetable-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:salt"
+   ],
+   "ingredients_text" : "farine de maïs, huiles végétales, sel",
+   "ingredients_that_may_be_from_palm_oil_n" : 1,
+   "ingredients_that_may_be_from_palm_oil_tags" : [
+      "huile-vegetale"
+   ],
+   "known_ingredients_n" : 8,
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fr",
+   "minerals_tags" : [],
+   "misc_tags" : [
+      "en:nutriscore-not-computed",
+      "en:nutriscore-missing-category",
+      "en:ecoscore-not-computed"
+   ],
+   "nova_group_debug" : "no nova group when the product does not have a category",
+   "nova_group_tags" : [
+      "not-applicable"
+   ],
+   "nucleotides_tags" : [],
+   "nutrient_levels" : {},
+   "nutrient_levels_tags" : [],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "nutrition_grades_tags" : [
+      "unknown"
+   ],
+   "nutrition_score_debug" : "no score when the product does not have a category",
+   "other_nutritional_substances_tags" : [],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
+   "pnns_groups_1" : "unknown",
+   "pnns_groups_1_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "pnns_groups_2" : "unknown",
+   "pnns_groups_2_tags" : [
+      "unknown",
+      "missing-category"
+   ],
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_from_user" : "(fr) ",
+   "traces_hierarchy" : [],
+   "traces_tags" : [],
+   "unknown_ingredients_n" : 0,
+   "unknown_nutrients_tags" : [],
+   "vitamins_tags" : []
+}

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -256,7 +256,7 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Unknown environmental impact",
+               "description_short" : "Impact environnemental inconnu",
                "icon_url" : "https://server_domain/images/attributes/ecoscore-unknown.svg",
                "id" : "ecoscore",
                "match" : 0,


### PR DESCRIPTION
There is currently a mistmatch in the attributes_groups definition and the attributes returned on products for the palm_oil_free attribute, which makes it not work at all currently.

This fixes #5007

And it also introduce tests for attributes.