### PR TITLE
New Portuguese translations in packaging_materials.txt

### DIFF
--- a/taxonomies/packaging_materials.txt
+++ b/taxonomies/packaging_materials.txt
@@ -19,6 +19,7 @@ de:Kunststoff
 fr:Plastique
 hu:Műanyag
 it:Plastica
+pt:Plástico
 ru:Пластик
 wikidata:en:Q11474
 non_recyclable_and_non_biodegradable:en:maybe
@@ -60,7 +61,7 @@ hu:Újrahasznosított műanyag, Újrahasznosított műanyagból
 it:Plastica riciclata
 nl:Hergebruikt plastic
 nl_be:Hergebruikt plastic
-pt:Plástico reciclável
+pt:Plástico reciclado
 
 
 # Plastics:
@@ -93,30 +94,36 @@ hu:Újrahasznosított PET
 it:PET riciclato, Polietilene tereftalato riciclato
 nl:Hergebruikt PET
 nl_be:hergebruikt PET
+pt:rPET - Tereftalato de polietileno reciclado, PET reciclado, Tereftalato de polietileno reciclado
 
 <xx:PET
 en:Biobased PET
 de:Biobasiertes PET
 fr:PET biosourcé
+pt:Bioplástico PET
 
 <xx:PET
 en:Transparent PET
 de:Transparentes PET
 fr:PET transparent
+pt:PET transparente
 
 <xx:rPET
 en:Transparent rPET
 de:Transparentes rPET
 fr:rPET transparent, rPET transparente
+pt:rPET transparente
 
 <xx:PET
 en:Colored PET
 de:Gefärbtes PET
 fr:PET coloré, PET colorée
+pt:PET colorido
 
 <xx:PET
 en:Opaque PET
 fr:PET opaque
+pt:PET opaco
 
 <en:Plastic
 en:HDPE - High-density polyethylene, High-density polyethylene
@@ -127,12 +134,14 @@ hu:Nagy sűrűségű polietilén
 it:Polietilene ad alta densità
 nl:Hogedichtheidpolyetheen, HDPE, PE-HD
 nl_be:Hogedichtheidpolyetheen, HDPE, PE-HD 02
+pt:HDPE - Polietileno de alta densidade, Polietileno de alta densidade
 wikidata:en:Q2641430
 non_recyclable_and_non_biodegradable:en:no
 
 <xx:HDPE
 en:Biobased HDPE
 fr:PEHD biosourcé
+pt:Bioplástico PEHD
 
 <en:Plastic
 en:PVC - Polyvinyl chloride, Polyvinyl chloride
@@ -143,6 +152,7 @@ hu:Polivinil-klorid, polivinilklorid, polivinil klorid
 it:Cloruro di polivinile, polivinilcloruro
 nl:Polyvinylchloride, pvc, polychlooretheen
 nl_be:Polyvinylchloride, pvc, polychlooretheen
+pt:PVC - Policloreto de vinil, Policloreto de vinil
 ru:ПВХ, Поливинилхлорид
 wikidata:en:Q146368
 
@@ -155,6 +165,7 @@ hu:Kis sűrűségű polietilén
 it:Polietilene a bassa densità
 nl:lagedichtheidpolyetheen
 nl_be:lagedichtheidpolyetheen
+pt:LDPE - Polietileno de baixa densidade, Polietileno de baixa densidade
 wikidata:en:Q2033818
 non_recyclable_and_non_biodegradable:en:no
 
@@ -167,6 +178,7 @@ hu:Polipropilén
 it:Polipropilene, polipropene
 nl:Polypropeen, polypropyleen
 nl_be:Polypropeen, polypropyleen
+pt:PP - Polipropileno, Polipropileno
 ru:Полипропилен
 wikidata:en:Q146174
 non_recyclable_and_non_biodegradable:en:no
@@ -180,6 +192,7 @@ hu:Polisztirol
 it:Polistirene, polistirolo
 nl:Polystyreen
 nl_be:Polystyreen
+pt:PS - Poliestireno, Poliestireno
 ru:Полистирол
 wikidata:en:Q146243
 
@@ -192,6 +205,7 @@ hu:Minden más műanyag
 it:Altre plastiche
 nl:Andere plastics
 nl_be:Andere plastics
+pt:Outros plásticos, Todos os outros plásticos, outro plástico
 ru:Другие пластики, Другие пластмассы
 non_recyclable_and_non_biodegradable:en:yes
 
@@ -202,6 +216,7 @@ fr:Acrylonitrile butadiène styrène
 hu:Akrilnitril-butadién-sztirol, 09 ABS, ABS, ABS 09, ABS 9, 9 ABS
 nl:Acrylonitril-butadieen-styreen, ABS
 nl_be:Acrylonitril-butadieen-styreen, ABS
+pt:Acrilonitrila butadieno estireno, 09 ABS, ABS, ABS 09, ABS 9, 9 ABS
 
 <en:Plastic
 <en:Other plastics
@@ -209,6 +224,7 @@ en:PLA - Polylactic acid, Polylactic acid, PLA
 de:PLA - Polylactide, PLA, Polylactide
 xx:PLA
 fr:PLA - Acide polylactique, Acide polylactique
+pt:PLA - Ácido poliláctico, poliácido láctico
 wikidata:en:Q413769
 
 en:Lead–acid battery, 8 Lead, Lead 8
@@ -216,6 +232,7 @@ de:Bleibatterie, 8 Lead, 8-Lead
 hu:Ólom-sav akkumulátor, 8 Lead, Lead 8
 nl:Lood, Loodaccu
 nl_be:Lood, Loodaccu
+pt:Bateria de chumbo-ácido, 8 Lead, Lead 8
 wikidata:en:Q337724
 
 en:Alkaline battery, 19 Alkaline, 19
@@ -224,6 +241,7 @@ fr:Pile alcaline, batterie alcaline, accumulateur alcaline
 hu:Alkáli elem, 19 Alkaline, 19
 nl:Alkalinebatterij
 nl_be:Alkalinebatterij
+pt:Bateria alcalina, pilha alcalina, 19 Alkaline, 19
 wikidata:en:Q861345
 
 en:Nickel–cadmium battery, 10 NiCD
@@ -232,6 +250,7 @@ fr:Accumulateur nickel-cadmium, batterie nickel-cadmium
 hu:Nikkel-kadmium akkumulátor, 10 NiCD
 nl:Nikkel-cadmium-accu
 nl_be:Nikkel-cadmium-accu
+pt:Bateria de níquel cádmio, pilha de níquel cádmio, bateria de níquel-cádmio, pilha de níquel-cádmio
 wikidata:en:Q898377
 
 en:Nickel–metal hydride battery, 11 NiMH
@@ -240,6 +259,7 @@ fr:Accumulateur nickel-hydrure métallique, batterie nickel-hydrure métallique
 hu:Nikkel-fémhidrid akkumulátor,Nikkel-metál-hidrid akkumulátor, 11 NiMH
 nl:nikkel-metaalhydride-accu, NiMH-accu
 nl_be:nikkel-metaalhydride-accu, NiMH-accu
+pt:Bateria de níquel-hidreto metálico, bateria de hidreto metálico de níquel, pilha de níquel-hidreto metálico, pilha de hidreto metálico de níquel 
 wikidata:en:Q308567
 
 en:Lithium battery, 12 Li
@@ -248,6 +268,7 @@ fr:Accumulateur lithium, batterie lithium, batterie au lithium, accumulateur au 
 hu:Lítium akkumulátor, 12 Li, 12-Li
 nl:Lithium-ion-accu, Li-ion-accu
 nl_be:Lithium-ion-accu, Li-ion-accu
+pt:Bateria de lítio, pilha de lítio
 wikidata:en:Q899079
 
 en:Silver-oxide battery, 13 SO(Z)
@@ -255,6 +276,7 @@ de:Silberoxidbatterie, 13 SO(Z), 13-SO
 hu:Ezüst-oxid akkumulátor, Ezüst-oxid elem, 13 SO(Z), 13-SO
 nl:zilveroxide batterij
 nl_be:zilveroxide batterij
+pt:Bateria de óxido de prata, bateria prata-óxido, pilha de óxido de prata, pilha prata-óxido
 wikidata:en:Q900791
 
 en:Zinc–carbon battery, 14 CZ
@@ -262,6 +284,7 @@ de:Zink–Kohle-Batterie, 14 CZ, 14-CZ
 hu:Cink-szén akkumulátor, Szén-cink elem, 14 CZ
 nl:Zink-koolstofcel
 nl_be:Zink-koolstofcel
+pt:Bateria de zinco-carbono, pilha de zinco-carbono
 wikidata:en:Q28765
 
 en:Cardboard, 20 C PAP, 20 C PCB
@@ -271,17 +294,20 @@ hu:Hullámkarton, Hullámpapír kartondoboz, kartondoboz, 20 C PAP, 20 C PCB
 it:Cartone, cartone ondulato
 nl:Karton, Strokarton, Vouwkarton, Massiefkarton, Golfkarton, Turfkarton, Vormkarton
 nl_be:Karton, Strokarton, Vouwkarton, Massiefkarton, Golfkarton, Turfkarton, Vormkarton
+pt:Cartão, cartão ondulado, cartão canelado, cartonado, cartonada, papelão, papel grosso, 20 C PAP, 20 C PCB
 
 <en:Cardboard
 <en:Recycled material
 en:Recycled cardboard, 100% recycled cardboard
 de:Recycelter Karton, Recyclingkarton
 fr:Carton recyclé, carton recyclé 100%, carton 100% recyclé
+pt:Cartão reciclado, cartão ondulado reciclado, cartonado reciclado, cartonada reciclada, papelão reciclado, cartolina reciclada, papel grosso reciclado
 
 <en:Cardboard
 en:FSC cardboard
 de:FSC-Karton
 fr:Carton FSC
+pt:Cartão FSC
 
 en:Other paper, 21 PAP
 de:Sonstige Pappe, 21 PAP, 21-PAP
@@ -289,6 +315,7 @@ fr:Autres papiers, autre papier
 hu:Egyéb papír, más papír, 21 PAP, 21-PAP
 nl:Ander karton
 nl_be:Ander karton
+pt:Outro papel, outros papéis, 21 PAP
 
 en:Paper, 22 PAP, PAP 22
 de:Papier, 22 PAP, PAP 22
@@ -298,24 +325,29 @@ nl:Papier
 nl_be:Papier
 ru:Бумага
 ja:紙
+pt:Papel, 22 PAP, PAP 22
 wikidata:en:Q11472
 
 <en:paper
 en:Recycled paper, 100% recycled paper
 fr:Papier recyclé, papier recyclé 100%, papier 100% recyclé
+pt:Papel reciclado, 100% papel reciclado, papel 100% reciclado
 
 <en:paper
 en:FSC paper
 fr:Papier FSC
+pt:Papel FSC
 
 <en:Paper
 en:Kraft paper, kraft
 de:Kraftpapier
 fr:Papier kraft, kraft
+pt:Papel kraft, kraft
 
 en:Wax
 de:Wachs
 fr:Cire
+pt:Papel cera, papel de cera
 wikidata:en:Q124695
 
 en:Paperboard, 23 PBD, 23 PPB, PPB, PBD, PBD 23, PPB 23
@@ -323,6 +355,7 @@ de:Karton, 23 PBD, 23 PPB, PPB, PBD, PBD 23, PPB 23, 23-PBD
 fr:Papier cartonné
 hu:Kartonpapír, Karton, Papírkarton, 23 PBD, 23 PPB, PPB, PBD, PBD 23, PPB 23
 it:Cartoncino, PBD
+pt:Papel cartonado, 23 PBD, 23 PPB, PPB, PBD, PBD 23, PPB 23
 
 en:Metal, Metals
 fr:Métal, Métaux
@@ -338,6 +371,7 @@ en:Recyclable Metals
 de:Wiederverwertbare Metalle, Wiederverwertbares Metall
 hu:Újrahasznosított fémek
 it:Metalli riciclabili
+pt:Metais recicláveis
 
 <en:Metals
 en:Steel, 40 FE, Recycling Code 40, RC 40, 40, RC Steel
@@ -346,6 +380,7 @@ fr:Acier
 hu:Acél, 40 FE, RC 40, 40
 it:Acciaio
 nl:Staal
+pt:Aço, 40 FE, RC 40, 40, RC Steel
 ru:Сталь
 ja:スチール
 wikidata:en:Q11427
@@ -357,6 +392,7 @@ fr:Aluminium
 hu:Alumínium
 it:Alluminio
 nl:Aluminium
+pt:Alumínio
 ru:Алюминий
 ja:アルミ
 xx:41 ALU
@@ -366,12 +402,14 @@ wikidata:en:Q663
 en:Heavy aluminium, thick aluminium
 de:Schweres Aluminium, dickes Aluminium
 fr:Aluminium lourd, aluminium épais
+pt:Alumínio pesado, alumínio grosso, alumínio rígido
 
 # Thin sheets, small things that cannot be easily recycled
 <en:Aluminium
 en:Light aluminium, thin aluminium
 de:Leichtes Aluminium, dünnes Aluminium
 fr:Aluminium léger, aluminium fin
+pt:Alumínio leve, alumínio fino, alumínio maleável
 
 en:Wood, 50 FOR
 de:Holz, 50 FOR, 50-FOR
@@ -379,6 +417,7 @@ fr:Bois
 hu:Fa, 50 FOR
 it:Legno
 nl:Hout
+pt:Madeira, 50 FOR
 ru:Древесина
 wikidata:en:Q287
 
@@ -387,6 +426,7 @@ de:Kork, 51 FOR, 51-FOR
 fr:Liège
 hu:Parafa, 51 FOR, 51-FOR
 nl:Kurk
+pt:Cortiça, 51 FOR, 51-FOR
 ru:Пробка
 wikidata:en:Q49444
 
@@ -396,12 +436,14 @@ fr:Coton
 hu:Pamut, 60 COT
 it:Cotone
 nl:Katoen
+pt:Algodão, 60 COT
 ru:Хлопок
 wikidata:en:Q8231603
 
 en:Jute, 61 TEX
 de:Jute, 61 TEX, 61-TEX
 hu:Juta, 61 TEX, 61-TEX
+pt:Juta, 61 TEX, 61-TEX
 ru:Джутовое волокно
 wikidata:en:Q107211
 
@@ -410,29 +452,34 @@ de:Andere Textilien, 62, 63, 64, 65, 66, 67, 68, 69, 62 TEX, 63 TEX, 64 TEX, 65 
 fr:Autres textiles, autre textile
 hu:Egyéb textília, Más textilek, 62, 63, 64, 65, 66, 67, 68, 69, 62 TEX, 63 TEX, 64 TEX, 65 TEX, 66 TEX, 67 TEX, 68 TEX, 69 TEX
 nl:Ander textiel
+pt:Outros têxteis, 62, 63, 64, 65, 66, 67, 68, 69, 62 TEX, 63 TEX, 64 TEX, 65 TEX, 66 TEX, 67 TEX, 68 TEX, 69 TEX, 62-TEX, 63-TEX, 64-TEX, 65-TEX, 66-TEX, 67-TEX, 68-TEX, 69-TEX
 
 en:Glass
 de:Glas
 fr:Verre
 hu:Üveg
 it:Vetro
+pt:vidro
 wikidata:en:Q11469
 
 <en:Glass
 en:Mixed Glass Container/Multi-Part Container, 70 GLS
 hu:Vegyes üveg
+pt:Contentor de vidro misturado, 70 GLS
 
 <en:Glass
 en:Clear Glass, 71 GLS, 71-GLS
 de:Klarglas, 71 GLS, 71-GLS
 fr:Verre transparent
 hu:Fehér üveg
+pt:Vidro transparente, 71 GLS, 71-GLS
 
 <en:Glass
 en:Green Glass, 72 GLS, 72-GLS
 de:Grünglas, 72 GLS, 72-GLS
 fr:Verre vert
 hu:Zöld üveg
+pt:Vidro verde, 72 GLS, 72-GLS
 
 <en:Glass
 en:Dark Sort Glass, 73 GLS
@@ -453,6 +500,7 @@ en:Light Leaded Glass, 75 GLS
 en:Leaded Glass, 76 GLS, 76-GLS
 de:Bleiglas, 76 GLS, 76-GLS
 hu:Ólomüveg
+pt:Vidro de chumbo, 76 GLS, 76-GLS
 
 <en:Glass
 en:Copper Mixed/Copper Backed Glass, 77 GLS
@@ -466,6 +514,7 @@ en:Gold Mixed/Gold Backed Glass, 79 GLS
 en:Paper and plastic, Paper + Plastic, 81 PapPet
 fr:Papier et plastique
 hu:Papír és műanyag, 81 PapPet
+pt:Papel e plástico, Papel + plástico, 81 PapPet
 
 #en:Paper and cardboard / Plastic / Aluminium, 84 C/PAP, PapAl
 #hu:Papír és karton / Műanyag / Alumínium, 84 C/PAP, PapAl
@@ -473,10 +522,12 @@ hu:Papír és műanyag, 81 PapPet
 <en:Plastic
 en:Biodegradable plastic, Card-stock Laminate, 87
 hu:Lebomló műanyag, Laminált kartonpapír, 87
+pt:Plástico biodegradável, 87
 
 en:Tetra Pak, Tetrapak, Tetra Pack, Tetrapack, Standard Tetra Pak
 xx:Tetra Pak, Tetrapak, Tetra Pack, Tetrapack, Standard Tetra Pak
 fr:Tetra Pak, Tetra Pak Standard, Brique type Tetra Pak standard
+pt:Tetra Pak, Tetrapak, Tetra Pack, Tetrapack, Standard Tetra Pak
 
 en:Biobased Tetra Pak
 de:Biobasiertes Tetra Pak
@@ -485,9 +536,11 @@ fr:Tetra Pak biosourcé, Brique type Tetra Pak biosourcé
 en:Multilayer composite, multilayer, composite composite materials, polycoat
 fr:Composites multicouches, composites multi-couches, Composite Multicouches, composite multi-couches, multi-couches, multicouches
 non_recyclable_and_non_biodegradable:en:yes
+pt:Compósito de várias camadas, compósito multi-camada
 
 en:Ceramic
 de:Keramik
 fr:Céramique
+pt:Cerâmica
 wikidata:en:Q45621
 non_recyclable_and_non_biodegradable:en:yes


### PR DESCRIPTION
Added and fixed some Portuguese translations to packaging_materials.txt

**Description:**

Added and fixed some Portuguese translations about packaging materials since most of them didn't exist.

**Related issues and discussion:** #[ISSUE NUMBER]

Please someone just take a quick look to check if it's OK, just de code and not the translations since I'm a Portuguese native speaker. I've checked and rechecked to see if I've made some mistake like deleting other translations.
Practically it's the first time I use github and I don't understand most of it. I'm not a programmer. Sorry if I made some mistake. By the way, I didn't discuss this change first as seen in [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/master/CONTRIBUTING.md) because I don't have access to https://openfoodfacts.slack.com/ and most of things in contribution guidelines are beyond my knowledge.

Additional note: it seems "Wax" material should be "[Wax paper](https://en.wikipedia.org/wiki/Wax_paper)" and the wikidata changed to [Q297216](https://www.wikidata.org/wiki/Q297216):
en:Wax
de:Wachs
fr:Cire
pt:Papel cera, papel de cera
wikidata:en:Q124695