### PR TITLE
Make ingredients categories+types (e.g. oils (rapeseed, oil) -> rapeseed oil, olive oil) more generic

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2502,7 +2502,6 @@ sub normalize_a_of_b($$$) {
 	$b =~ s/^\s+//;
 
 	if ($lc eq "en") {
-
 		return $b . " " . $a;
 	}
 	elsif ($lc eq "es") {
@@ -2518,6 +2517,9 @@ sub normalize_a_of_b($$$) {
 			return $a . " de " . $b;
 		}
 	}
+	elsif ($lc eq "ru") {
+		return $b . " " . $a;		
+	}
 }
 
 
@@ -2531,13 +2533,19 @@ sub normalize_enumeration($$$) {
 	my $enumeration = shift;
 
 	$log->debug("normalize_enumeration", { type => $type, enumeration => $enumeration }) if $log->is_debug();
+	
+	# If there is a trailing space, save it and output it
+	my $trailing_space = "";
+	if ($enumeration =~ /\s+$/) {
+		$trailing_space = " ";
+	}
 
 	my $and = $Lang{_and_}{$lc};
 	#my $enumeration_separators = $obrackets . '|' . $cbrackets . '|\/| \/ | ' . $dashes . ' |' . $commas . ' |' . $commas. '|'  . $Lang{_and_}{$lc};
 
 	my @list = split(/$obrackets|$cbrackets|\/| \/ | $dashes |$commas |$commas|$and/i, $enumeration);
 
-	return join(", ", map { normalize_a_of_b($lc, $type, $_)} @list);
+	return join(", ", map { normalize_a_of_b($lc, $type, $_)} @list) . $trailing_space;
 }
 
 
@@ -3661,6 +3669,413 @@ sub replace_additive($$$) {
 }
 
 
+=head2 develop_ingredients_categories_and_types ( $product_lc, $text ) - turn "oil (sunflower, olive and palm)" into "sunflower oil, olive oil, palm oil"
+
+Some ingredients are specified by an ingredient "category" (e.g. "oil", "flavouring") and a "type" (e.g. "sunflower", "palm" or "strawberry", "vanilla").
+
+Sometimes, the category is mentioned only once for several types:
+"strawberry and vanilla flavourings", "vegetable oil (palm, sunflower)".
+
+This function lists each individual ingredient: 
+"oil (sunflower, olive and palm)" becomes "sunflower oil, olive oil, palm oil"
+
+=head3 Arguments
+
+=head4 Language
+
+=head4 Ingredients list text
+
+=head3 Return value
+
+=head4 Transformed ingredients list text
+
+=cut
+
+# simple plural (just an additional "s" at the end) will be added in the regexp
+my %ingredients_categories_and_types = (
+
+en =>
+[
+	# oils
+	[
+		# categories
+		[
+			"oil",
+			"vegetable oil",
+			"vegetal oil",
+		],
+		# types
+		[
+			"colza",
+			"olive",
+			"palm",
+			"rapeseed",
+			"sunflower",
+		],
+	],
+],
+
+
+fr =>
+[
+	# huiles
+	[
+		[
+			"huile",
+			"huile végétale",
+			"huiles végétales",
+			"matière grasse",
+			"matières grasses",
+			"matière grasse végétale",
+			"matières grasses végétales",
+			"graisse",
+			"graisse végétale",
+			"graisses végétales",
+		],
+		[
+			"arachide",
+			"avocat",
+			"chanvre",
+			"coco",
+			"colza",
+			"illipe",
+			"karité",
+			"lin",
+			"mangue",
+			"noisette",
+			"noix",
+			"noyaux de mangue",
+			"olive",
+			"olive extra",
+			"olive vierge",
+			"olive extra vierge",
+			"olive vierge extra",
+			"palme",
+			"palmiste",
+			"pépins de raisin",
+			"sal",
+			"sésame",
+			"soja",
+			"tournesol",
+			"tournesol oléique",
+		]
+	],
+		
+	[
+		[
+			"extrait",
+			"extrait naturel",
+		],
+		[
+			"café",
+			"chicorée",
+			"curcuma",
+			"houblon",
+			"levure",
+			"malt",
+			"muscade",
+			"poivre",
+			"poivre noir",
+			"romarin",
+			"thé",
+			"thé vert",
+			"thym",
+		]
+	],
+
+	[
+		[
+			"lécithine",
+		],
+		[
+			"colza",
+			"soja",
+			"soja sans ogm",
+			"tournesol",
+		]
+	],
+
+	[
+		[
+			"arôme naturel",
+			"arômes naturels",
+			"arôme artificiel",
+			"arômes artificiels",
+			"arômes naturels et artificiels",
+			"arômes",
+		],
+		[
+			"abricot",
+			"ail",
+			"amande",
+			"amande amère",
+			"agrumes",
+			"aneth",
+			"boeuf",
+			"cacao",
+			"cannelle",
+			"caramel",
+			"carotte",
+			"carthame",
+			"cassis",
+			"céleri",
+			"cerise",
+			"curcuma",
+			"cumin",
+			"citron",
+			"citron vert",
+			"crustacés",
+			"estragon",
+			"fenouil",
+			"figue",
+			"fraise",
+			"framboise",
+			"fromage de chèvre",
+			"fruit",
+			"fruit de la passion",
+			"fruits de la passion",
+			"fruits de mer",
+			"fumée",
+			"gentiane",
+			"herbes",
+			"jasmin",
+			"laurier",
+			"lime",
+			"limette",
+			"mangue",
+			"menthe",
+			"menthe crêpue",
+			"menthe poivrée",
+			"muscade",
+			"noix",
+			"noix de coco",
+			"oignon",
+			"olive",
+			"orange",
+			"orange amère",
+			"origan",
+			"pamplemousse",
+			"pamplemousse rose",
+			"pêche",
+			"piment",
+			"pistache",
+			"porc",
+			"pomme",
+			"poire",
+			"poivre",
+			"poisson",
+			"poulet",
+			"réglisse",
+			"romarin",
+			"rose",
+			"rhum",
+			"sauge",
+			"saumon",
+			"sureau",
+			"thé",
+			"thym",
+			"vanille",
+			"vanille de Madagascar",
+			"autres agrumes",
+		]
+	],
+
+	[
+		[
+			"carbonate",
+			"carbonates acides",
+			"chlorure",
+			"citrate",
+			"iodure",
+			"nitrate",
+			"diphosphate",
+			"diphosphate",
+			"phosphate",
+			"sélénite",
+			"sulfate",
+			"hydroxyde",
+			"sulphate",
+		],
+		[
+			"aluminium",
+			"ammonium",
+			"calcium",
+			"cuivre",
+			"fer",
+			"magnésium",
+			"manganèse",
+			"potassium",
+			"sodium",
+			"zinc",
+		]
+	],
+],
+
+ru =>
+[
+	# oils
+	[
+		# categories
+		[
+			"масло",
+			"масло растительное",
+		],
+		# types
+		[
+			"подсолнечное",
+			"соевое",
+		],
+	],
+],
+
+);
+
+# Symbols to indicate labels like organic, fairtrade etc.
+my @symbols = ('\*\*\*', '\*\*', '\*', '°°°', '°°', '°', '\(1\)', '\(2\)', '¹', '²');
+my $symbols_regexp = join('|', @symbols);
+
+sub develop_ingredients_categories_and_types ($$) {
+	
+	my $product_lc = shift;
+	my $text = shift;	
+	
+	if (defined $ingredients_categories_and_types{$product_lc}) {
+
+		foreach my $categories_and_types_ref (@{$ingredients_categories_and_types{$product_lc}}) {
+
+			my $category_regexp = "";
+			foreach my $category (@{$categories_and_types_ref->[0]}) {
+				$category_regexp .= '|' . $category . '|' . $category . 's';
+				my $unaccented_category = unac_string_perl($category);
+				if ($unaccented_category ne $category) {
+					$category_regexp .= '|' . $unaccented_category . '|' . $unaccented_category . 's';
+				}
+
+			}
+			$category_regexp =~ s/^\|//;
+
+			if ($product_lc eq "en") {
+				$category_regexp = '(?:organic |fair trade )*(?:' . $category_regexp . ')(?:' . $symbols_regexp . ')*';
+			}
+			elsif ($product_lc eq "fr") {
+				$category_regexp = '(?:' . $category_regexp . ')(?: bio| biologique| équitable|s|\s|' . $symbols_regexp . ')*';
+			}
+			else {
+				$category_regexp = '(?:' . $category_regexp . ')(?:' . $symbols_regexp . ')*';
+			}
+
+			my $type_regexp = "";
+			foreach my $type (@{$categories_and_types_ref->[1]}) {
+				$type_regexp .= '|' . $type . '|' . $type . 's';
+				my $unaccented_type = unac_string_perl($type);
+				if ($unaccented_type ne $type) {
+					$type_regexp .= '|' . $unaccented_type . '|' . $unaccented_type . 's';
+				}
+
+			}
+			$type_regexp =~ s/^\|//;
+
+			# arôme naturel de citron-citron vert et d'autres agrumes
+			# -> separate types
+			$text =~ s/($type_regexp)-($type_regexp)/$1, $2/g;
+			
+			my $and = ' - ';
+			if (defined $and{$product_lc}) {
+				$and = $and{$product_lc};
+			}			
+			my $of = ' - ';
+			if (defined $of{$product_lc}) {
+				$of = $of{$product_lc};
+			}
+			my $and_of = ' - ';
+			if (defined $and_of{$product_lc}) {
+				$and_of = $and_of{$product_lc};
+			}
+			my $and_or = ' - ';
+			if (defined $and_or{$product_lc}) {
+				$and_or = $and_or{$product_lc};
+			}	
+			
+			if (($product_lc eq "en") or ($product_lc eq "ru")) {
+
+				# vegetable oil (palm, sunflower and olive)
+				$text =~ s/($category_regexp)(?::|\(|\[| | $of )+((($type_regexp)($symbols_regexp|\s)*( |\/| \/ | - |,|, |$and|$of|$and_of|$and_or)+)+($type_regexp)($symbols_regexp|\s)*)\b(\s?(\)|\]))?/normalize_enumeration($product_lc,$1,$2)/ieg;
+				
+				# vegetable oil (palm)
+				$text =~ s/($category_regexp)\s?(?:\(|\[)\s?($type_regexp)\b(\s?(\)|\]))/normalize_enumeration($product_lc,$1,$2)/ieg;
+				# vegetable oil: palm
+				$text =~ s/($category_regexp)\s?(?::)\s?($type_regexp)(?=$separators|$)/normalize_enumeration($product_lc,$1,$2)/ieg;	
+			}
+			elsif ($product_lc eq "fr") {
+				# arôme naturel de pomme avec d'autres âromes
+				$text =~ s/ (ou|et|avec) (d')?autres /, /g;
+
+				$text =~ s/($category_regexp) et ($category_regexp)(?:$of)?($type_regexp)/normalize_fr_a_et_b_de_c($1, $2, $3)/ieg;
+				
+				# Huiles végétales de palme, de colza et de tournesol
+				# Carbonate de magnésium, fer élémentaire -> should not trigger carbonate de fer élémentaire. Bug #3838
+				# TODO 18/07/2020 remove when we have a better solution
+				$text =~ s/fer (é|e)l(é|e)mentaire/fer_élémentaire/ig;
+				$text =~ s/($category_regexp)(?::|\(|\[| | de | d')+((($type_regexp)($symbols_regexp|\s)*( |\/| \/ | - |,|, | et | de | et de | et d'| d')+)+($type_regexp)($symbols_regexp|\s)*)\b(\s?(\)|\]))?/normalize_enumeration($product_lc,$1,$2)/ieg;
+				$text =~ s/fer_élémentaire/fer élémentaire/ig;				
+
+				# huile végétale (colza)
+				$text =~ s/($category_regexp)\s?(?:\(|\[)\s?($type_regexp)\b(\s?(\)|\]))/normalize_enumeration($product_lc,$1,$2)/ieg;
+				# huile végétale : colza,
+				$text =~ s/($category_regexp)\s?(?::)\s?($type_regexp)(?=$separators|$)/normalize_enumeration($product_lc,$1,$2)/ieg;
+			}
+		}
+
+		# Some additives have "et" in their name: need to recombine them
+		
+		if ($product_lc eq "fr") {
+
+			# Sels de sodium et de potassium de complexes cupriques de chlorophyllines,
+		
+			my $info = <<INFO
+Complexe cuivrique des chlorophyllines avec sels de sodium et de potassium,
+oxyde et hydroxyde de fer rouge,
+oxyde et hydroxyde de fer jaune et rouge,
+Tartrate double de sodium et de potassium,
+Éthylènediaminetétraacétate de calcium et de disodium,
+Phosphate d'aluminium et de sodium,
+Diphosphate de potassium et de sodium,
+Tripoliphosphates de sodium et de potassium,
+Sels de sodium de potassium et de calcium d'acides gras,
+Mono- et diglycérides d'acides gras,
+Esters acétiques des mono- et diglycérides,
+Esters glycéroliques de l'acide acétique et d'acides gras,
+Esters glycéroliques de l'acide citrique et d'acides gras,
+Esters monoacétyltartriques et diacétyltartriques,
+Esters mixtes acétiques et tartriques des mono- et diglycérides d'acides gras,
+Esters lactyles d'acides gras du glycérol et du propane-1,
+Silicate double d'aluminium et de calcium,
+Silicate d'aluminium et calcium,
+Silicate d'aluminium et de calcium,
+Silicate double de calcium et d'aluminium,
+Glycine et son sel de sodium,
+Cire d'abeille blanche et jaune,
+Acide cyclamique et ses sels,
+Saccharine et ses sels,
+Acide glycyrrhizique et sels,
+Sels et esters de choline,
+Octénylesuccinate d'amidon et d'aluminium,
+INFO
+;
+
+			# Phosphate d'aluminium et de sodium --> E541. Should not be split.
+
+			$text =~ s/(di|tri|tripoli|)(phosphate|phosphates) d'aluminium,\s?(di|tri|tripoli)?(phosphate|phosphates) de sodium/$1phosphate d'aluminium et de sodium/ig;
+
+			# Sels de sodium et de potassium de complexes cupriques de chlorophyllines -> should not be split...
+			$text =~ s/(sel|sels) de sodium,\s?(sel|sels) de potassium/sels de sodium et de potassium/ig;
+		}
+	}
+	
+	return $text;
+}
+
+
 =head2 preparse_ingredients_text ($product_lc, $text) - normalize the ingredient list to make parsing easier
 
 This function transform the ingredients list in a more normalized list that is easier to parse.
@@ -3688,7 +4103,6 @@ It does the following:
 
 =cut
 
-
 sub preparse_ingredients_text($$) {
 
 	my $product_lc = shift;
@@ -3710,10 +4124,6 @@ sub preparse_ingredients_text($$) {
 
 	$prev_lc = $product_lc;
 	$prev_text = $text;
-
-	# Symbols to indicate labels like organic, fairtrade etc.
-	my @symbols = ('\*\*\*', '\*\*', '\*', '°°°', '°°', '°', '\(1\)', '\(2\)', '¹', '²');
-	my $symbols_regexp = join('|', @symbols);
 
 	if ((scalar keys %labels_regexps) == 0) {
 		init_labels_regexps();
@@ -3921,305 +4331,12 @@ sub preparse_ingredients_text($$) {
 
 		$text =~ s/dient\(s\)/dients/ig;
 		$text =~ s/\bissu(\(e\))?(\(s\))?/issu/ig;
-
-		# simple plural (just an additional "s" at the end) will be added in the regexp
-		my @prefixes_suffixes_list = (
-# huiles
-[[
-"huile",
-"huile végétale",
-"huiles végétales",
-"matière grasse",
-"matières grasses",
-"matière grasse végétale",
-"matières grasses végétales",
-"graisse",
-"graisse végétale",
-"graisses végétales",
-],
-[
-"arachide",
-"avocat",
-"chanvre",
-"coco",
-"colza",
-"illipe",
-"karité",
-"lin",
-"mangue",
-"noisette",
-"noix",
-"noyaux de mangue",
-"olive",
-"olive extra",
-"olive vierge",
-"olive extra vierge",
-"olive vierge extra",
-"palme",
-"palmiste",
-"pépins de raisin",
-"sal",
-"sésame",
-"soja",
-"tournesol",
-"tournesol oléique",
-]
-],
-
-
-[[
-"extrait",
-"extrait naturel",
-],
-[
-"café",
-"chicorée",
-"curcuma",
-"houblon",
-"levure",
-"malt",
-"muscade",
-"poivre",
-"poivre noir",
-"romarin",
-"thé",
-"thé vert",
-"thym",
-]
-],
-
-[[
-"lécithine",
-],
-[
-"colza",
-"soja",
-"soja sans ogm",
-"tournesol",
-]
-],
-
-[
-[
-"arôme naturel",
-"arômes naturels",
-"arôme artificiel",
-"arômes artificiels",
-"arômes naturels et artificiels",
-"arômes",
-],
-[
-"abricot",
-"ail",
-"amande",
-"amande amère",
-"agrumes",
-"aneth",
-"boeuf",
-"cacao",
-"cannelle",
-"caramel",
-"carotte",
-"carthame",
-"cassis",
-"céleri",
-"cerise",
-"curcuma",
-"cumin",
-"citron",
-"citron vert",
-"crustacés",
-"estragon",
-"fenouil",
-"figue",
-"fraise",
-"framboise",
-"fromage de chèvre",
-"fruit",
-"fruit de la passion",
-"fruits de la passion",
-"fruits de mer",
-"fumée",
-"gentiane",
-"herbes",
-"jasmin",
-"laurier",
-"lime",
-"limette",
-"mangue",
-"menthe",
-"menthe crêpue",
-"menthe poivrée",
-"muscade",
-"noix",
-"noix de coco",
-"oignon",
-"olive",
-"orange",
-"orange amère",
-"origan",
-"pamplemousse",
-"pamplemousse rose",
-"pêche",
-"piment",
-"pistache",
-"porc",
-"pomme",
-"poire",
-"poivre",
-"poisson",
-"poulet",
-"réglisse",
-"romarin",
-"rose",
-"rhum",
-"sauge",
-"saumon",
-"sureau",
-"thé",
-"thym",
-"vanille",
-"vanille de Madagascar",
-"autres agrumes",
-]
-],
-
-
-[
-[
-"carbonate",
-"carbonates acides",
-"chlorure",
-"citrate",
-"iodure",
-"nitrate",
-"diphosphate",
-"diphosphate",
-"phosphate",
-"sélénite",
-"sulfate",
-"hydroxyde",
-"sulphate",
-],
-[
-"aluminium",
-"ammonium",
-"calcium",
-"cuivre",
-"fer",
-"magnésium",
-"manganèse",
-"potassium",
-"sodium",
-"zinc",
-]
-],
-
-);
-
-		foreach my $prefixes_suffixes_ref (@prefixes_suffixes_list) {
-
-			my $prefixregexp = "";
-			foreach my $prefix (@{$prefixes_suffixes_ref->[0]}) {
-				$prefixregexp .= '|' . $prefix . '|' . $prefix . 's';
-				my $unaccented_prefix = unac_string_perl($prefix);
-				if ($unaccented_prefix ne $prefix) {
-					$prefixregexp .= '|' . $unaccented_prefix . '|' . $unaccented_prefix . 's';
-				}
-
-			}
-			$prefixregexp =~ s/^\|//;
-
-			$prefixregexp = '(' . $prefixregexp . ')( bio| biologique| équitable|s|\s|' . $symbols_regexp . ')*';
-
-			my $suffixregexp = "";
-			foreach my $suffix (@{$prefixes_suffixes_ref->[1]}) {
-				$suffixregexp .= '|' . $suffix . '|' . $suffix . 's';
-				my $unaccented_suffix = unac_string_perl($suffix);
-				if ($unaccented_suffix ne $suffix) {
-					$suffixregexp .= '|' . $unaccented_suffix . '|' . $unaccented_suffix . 's';
-				}
-
-			}
-			$suffixregexp =~ s/^\|//;
-
-			# arôme naturel de citron-citron vert et d'autres agrumes
-			# -> separate suffixes
-			$text =~ s/($suffixregexp)-($suffixregexp)/$1, $2/g;
-
-			# arôme naturel de pomme avec d'autres âromes
-			$text =~ s/ (ou|et|avec) (d')?autres /, /g;
-
-			$text =~ s/($prefixregexp) et ($prefixregexp) (de |d')?($suffixregexp)/normalize_fr_a_et_b_de_c($1, $4, $8)/ieg;
-
-			# old:
-
-			#$text =~ s/($prefixregexp) (\(|\[|de |d')?($suffixregexp) et (de |d')?($suffixregexp)(\)|\])?/normalize_fr_a_de_enumeration($1, $3, $5)/ieg;
-			#$text =~ s/($prefixregexp) (\(|\[|de |d')?($suffixregexp), (de |d')?($suffixregexp) et (de |d')?($suffixregexp)(\)|\])?/normalize_fr_a_de_enumeration($1, $3, $5, $7)/ieg;
-			#$text =~ s/($prefixregexp) (\(|\[|de |d')?($suffixregexp), (de |d')?($suffixregexp), (de |d')?($suffixregexp) et (de |d')?($suffixregexp)(\)|\])?/normalize_fr_a_de_enumeration($1, $3, $5, $7, $9)/ieg;
-			#$text =~ s/($prefixregexp) (\(|\[|de |d')?($suffixregexp), (de |d')?($suffixregexp), (de |d')?($suffixregexp), (de |d')?($suffixregexp) et (de |d')?($suffixregexp)(\)|\])?/normalize_fr_a_de_enumeration($1, $3, $5, $7, $9, $11)/ieg;
-
-			$text =~ s/($prefixregexp)\s?(:|\(|\[)\s?($suffixregexp)\b(\s?(\)|\]))/normalize_enumeration($product_lc,$1,$5)/ieg;
-
-			# Huiles végétales de palme, de colza et de tournesol
-			# Carbonate de magnésium, fer élémentaire -> should not trigger carbonate de fer élémentaire. Bug #3838
-			# TODO 18/07/2020 remove when we have a better solution
-			$text =~ s/fer (é|e)l(é|e)mentaire/fer_élémentaire/ig;
-			$text =~ s/($prefixregexp)(:|\(|\[| | de | d')+((($suffixregexp)($symbols_regexp|\s)*( |\/| \/ | - |,|, | et | de | et de | et d'| d')+)+($suffixregexp)($symbols_regexp|\s)*)\b(\s?(\)|\]))?/normalize_enumeration($product_lc,$1,$5)/ieg;
-			$text =~ s/fer_élémentaire/fer élémentaire/ig;
-		}
-
-		# Caramel ordinaire et curcumine
-		# $text =~ s/ et /, /ig;
-		# --> too dangerous, too many exceptions
-
-		# Some additives have "et" in their name: need to recombine them
-
-		# Sels de sodium et de potassium de complexes cupriques de chlorophyllines,
-		my $info = <<INFO
-		Complexe cuivrique des chlorophyllines avec sels de sodium et de potassium,
-		oxyde et hydroxyde de fer rouge,
-		oxyde et hydroxyde de fer jaune et rouge,
-		Tartrate double de sodium et de potassium,
-		Éthylènediaminetétraacétate de calcium et de disodium,
-		Phosphate d'aluminium et de sodium,
-		Diphosphate de potassium et de sodium,
-		Tripoliphosphates de sodium et de potassium,
-		Sels de sodium de potassium et de calcium d'acides gras,
-		Mono- et diglycérides d'acides gras,
-		Esters acétiques des mono- et diglycérides,
-		Esters glycéroliques de l'acide acétique et d'acides gras,
-		Esters glycéroliques de l'acide citrique et d'acides gras,
-		Esters monoacétyltartriques et diacétyltartriques,
-		Esters mixtes acétiques et tartriques des mono- et diglycérides d'acides gras,
-		Esters lactyles d'acides gras du glycérol et du propane-1,
-		Silicate double d'aluminium et de calcium,
-		Silicate d'aluminium et calcium,
-		Silicate d'aluminium et de calcium,
-		Silicate double de calcium et d'aluminium,
-		Glycine et son sel de sodium,
-		Cire d'abeille blanche et jaune,
-		Acide cyclamique et ses sels,
-		Saccharine et ses sels,
-		Acide glycyrrhizique et sels,
-		Sels et esters de choline,
-		Octénylesuccinate d'amidon et d'aluminium,
-INFO
-;
-
-
-		# Phosphate d'aluminium et de sodium --> E541. Should not be split.
-
-		$text =~ s/(di|tri|tripoli|)(phosphate|phosphates) d'aluminium,\s?(di|tri|tripoli)?(phosphate|phosphates) de sodium/$1phosphate d'aluminium et de sodium/ig;
-
-		# Sels de sodium et de potassium de complexes cupriques de chlorophyllines -> should not be split...
-		$text =~ s/(sel|sels) de sodium,\s?(sel|sels) de potassium/sels de sodium et de potassium/ig;
-
-		# vitamines A, B1, B2, B5, B6, B9, B12, C, D, H, PP et E
-		# vitamines (A, B1, B2, B5, B6, B9, B12, C, D, H, PP et E)
-
 	}
-
+	
+	$text = develop_ingredients_categories_and_types($product_lc, $text);
+	
+	# vitamines A, B1, B2, B5, B6, B9, B12, C, D, H, PP et E
+	# vitamines (A, B1, B2, B5, B6, B9, B12, C, D, H, PP et E)	
 
 	my @vitaminssuffixes = (
 "a", "rétinol",

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2491,6 +2491,7 @@ sub normalize_fr_a_de_enumeration {
 
 # English: oil, olive -> olive oil
 # French: huile, olive -> huile d'olive
+# Russian: масло растительное, пальмовое -> масло растительное оливковое
 
 sub normalize_a_of_b($$$) {
 
@@ -2518,7 +2519,7 @@ sub normalize_a_of_b($$$) {
 		}
 	}
 	elsif ($lc eq "ru") {
-		return $b . " " . $a;		
+		return $a . " " . $b;		
 	}
 }
 
@@ -3922,8 +3923,15 @@ ru =>
 		],
 		# types
 		[
-			"подсолнечное",
-			"соевое",
+			"Подсолнечное",
+			"Пальмовое",
+			"Рапсовое",
+			"Кокосовое",
+			"горчицы",
+			"Соевое",
+			"Пальмоядровое",
+			"Оливковое",
+			"пальм",
 		],
 	],
 ],

--- a/t/expected_test_results/ingredients/ru-russian-oil.json
+++ b/t/expected_test_results/ingredients/ru-russian-oil.json
@@ -1,0 +1,75 @@
+{
+   "ingredients" : [
+      {
+         "from_palm_oil" : "no",
+         "id" : "en:sunflower-oil",
+         "percent_estimate" : 66.6666666666667,
+         "percent_max" : 100,
+         "percent_min" : 33.3333333333333,
+         "text" : "масло растительное подсолнечное",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "from_palm_oil" : "no",
+         "id" : "en:soya-oil",
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "масло растительное соевое",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "from_palm_oil" : "yes",
+         "id" : "en:palm-oil",
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "Масло Пальмовое",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:sunflower-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:vegetable-oil",
+      "en:soya-oil",
+      "en:palm-oil",
+      "en:palm-oil-and-fat"
+   ],
+   "ingredients_n" : 3,
+   "ingredients_n_tags" : [
+      "3",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:sunflower-oil",
+      "en:soya-oil",
+      "en:palm-oil"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:sunflower-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:vegetable-oil",
+      "en:soya-oil",
+      "en:palm-oil",
+      "en:palm-oil-and-fat"
+   ],
+   "ingredients_text" : "масло растительное (подсолнечное, соевое), Масло (Пальмовое)",
+   "known_ingredients_n" : 7,
+   "lc" : "ru",
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "unknown_ingredients_n" : 0
+}

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -317,6 +317,15 @@ my @tests = (
 			ingredients_text => "huiles végétales non hydrogénées (huile de palme certifiée durable, huile de colza)",
 		},
 	],
+	
+	# Russian oil parsing
+	[
+		"ru-russian-oil",
+		{
+			lc => "ru",
+			ingredients_text => "масло растительное (подсолнечное, соевое), Масло (Пальмовое)",
+		},
+	],
 
 );
 

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -301,6 +301,21 @@ my @lists =(
 "Sel, sucre Commerce équitable, graisse de palme Bio, amidons Bio (maïs Bio, pomme de terre Bio ), oignon Bio : 8,9%, ail Bio, oignon grillé Bio : 1,4%, épices Bio et aromate Bio (livèche Bio : 0,4%, curcuma Bio, noix de muscade Bio ), carotte Bio : 0,5%. Traces éventuelles : céleri, Traces éventuelles : céréales contenant du gluten, Traces éventuelles : lait, Traces éventuelles : moutarde, Traces éventuelles : œuf, Traces éventuelles : soja."],
 	# Russian е character
 	["ru", "е322, Куркумины e100, е-1442, (е621)", "e322, куркумины e100, e1442, (e621)"],
+	
+	# New ingredients categories + types : generalized from French to other languages
+	["fr", "huiles végétales (palme, olive et tournesol)", "huiles végétales de palme, huiles végétales d'olive, huiles végétales de tournesol"],
+	["fr", "huile végétale : colza", "huile végétale de colza"],
+	["fr", "huile végétale : colza, fraises", "huile végétale de colza, fraises"],
+	["fr", "huile végétale : colza et tomates","huile végétale : colza et tomates"],
+	["en", "vegetable oil: sunflower", "sunflower vegetable oil"],
+	["en", "vegetable oil (palm)", "palm vegetable oil"],
+	["en", "vegetable oils (palm, olive)", "palm vegetable oils, olive vegetable oils"],
+	["en", "organic vegetable oils (sunflower, colza and rapeseed)","sunflower organic vegetable oils, colza organic vegetable oils, rapeseed organic vegetable oils"],
+	# used to have bad output: sunflower vegetable oils, colza vegetable oilsand strawberry
+	["en", "vegetable oils : sunflower, colza and strawberry","sunflower vegetable oils, colza vegetable oils and strawberry"],
+	# Russian oils (more tests needed)
+	["ru", "масло (Подсолнечное)", "Подсолнечное масло"],
+	["ru", "масло растительное (подсолнечное, соевое)","подсолнечное масло растительное, соевое масло растительное"],
 );
 
 foreach my $test_ref (@lists) {

--- a/t/ingredients_parsing.t
+++ b/t/ingredients_parsing.t
@@ -314,8 +314,9 @@ my @lists =(
 	# used to have bad output: sunflower vegetable oils, colza vegetable oilsand strawberry
 	["en", "vegetable oils : sunflower, colza and strawberry","sunflower vegetable oils, colza vegetable oils and strawberry"],
 	# Russian oils (more tests needed)
-	["ru", "масло (Подсолнечное)", "Подсолнечное масло"],
-	["ru", "масло растительное (подсолнечное, соевое)","подсолнечное масло растительное, соевое масло растительное"],
+	["ru", "масло (Подсолнечное)", "масло Подсолнечное"],
+	["ru", "Масло (подсолнечное)", "Масло подсолнечное"],
+	["ru", "масло растительное (подсолнечное, соевое)","масло растительное подсолнечное, масло растительное соевое"],
 );
 
 foreach my $test_ref (@lists) {

--- a/t/ingredients_tags.t
+++ b/t/ingredients_tags.t
@@ -146,6 +146,9 @@ my @tests = (
 	[ { lc => "ru", ingredients_text => "яблоко и / или малина"}, ["en:apple","en:raspberry"]],
 	[ { lc => "ru", ingredients_text => "бензоат натрия и сорбат калия"}, ["en:e211", "en:e202"]],
 	
+	# Russian oil
+	[ { lc => "ru", ingredients_text => "масло растительное (подсолнечное, соевое), Масло (Пальмовое)"}, ["en:sunflower-oil", "en:soya-oil", "en:palm-oil"]],
+	
 	
 );
 

--- a/taxonomies/ingredients.result.txt
+++ b/taxonomies/ingredients.result.txt
@@ -22,7 +22,6 @@ stopwords:nl:bevat, met, waarvan, bevatten, van, vervaardigd met, behandeld papi
 stopwords:nn:av
 stopwords:pl:w tym, zawiera, z
 stopwords:pt:do qual, dos quais,e
-stopwords:ru:состав, состав продукта, энергетическая ценность, калорийность, содержат, идентичный натуральному, g, ж, ул
 stopwords:sk:obsahuje
 stopwords:sl:vsebuje, sestavine
 stopwords:sv:av, från, med, innehåller, inklusive, bl a, bland annat, minimum, maximum, varav, certifierad, tillsatt, valio
@@ -2370,6 +2369,10 @@ wikidata:en: Q133948
 
 < en:Antioxidant
 en:natural antioxidant
+
+< en:Apple
+en:apple jam
+ru:повидло яблочное, яблочное повидло
 
 < en:Apple
 en:apple pieces
@@ -10800,7 +10803,7 @@ fr:Poudre de cacao brute
 
 < en:Cocoa powder
 en:skimmed cocoa powder
-ru:обезжиренный какаопорошок
+ru:обезжиренный какаопорошок, сухой обезжиренный остаток какао
 
 < en:Cocoa powder
 fr:poudre de cacao cru
@@ -14011,7 +14014,7 @@ ps:شيدې
 pt:Leite
 qu:Lichi, Pilli
 ro:Lapte
-ru:Молоко, нормализованное молоко, молоко нормализованное пастеризованное, молоко нормализованное по содержанию жира
+ru:Молоко, нормализованное молоко, молоко нормализованное, молоко нормализованное пастеризованное, молоко нормализованное по содержанию жира
 sa:क्षीरम्
 sd:کير
 sh:Mlijeko
@@ -15267,6 +15270,7 @@ sk:E101a, E101a food additive
 sl:E101a, E101a food additive
 sv:E101a, E101a food additive
 additives_classes:en: en:colour
+comment:en: E101a is the same as E101ii. All synonyms are under E101-ii-. Needs more cleanup
 e_number:en: 101a
 efsa_evaluation:en: Scientific Opinion on the re-evaluation of riboflavin -E 101i- and riboflavin-5'-phosphate sodium -E 101-ii-- as food additives.
 efsa_evaluation_date:en: 2013-10-22
@@ -19252,10 +19256,14 @@ vegetarian:en: yes
 
 en:E170, Calcium carbonates
 ca:E170, Carbonats de calci
+de:E170, Calciumcarbonate, Calciumcarbonat
 es:E170, Carbonatos de calcio
 fi:E170, Kalsiumkarbonaatit
 fr:E170, Carbonates de calcium
+hu:E170
+it:Carbonato di calcio
 nl:E170, Calciumcarbonaten
+comment:en: enter the synonyms in plural.
 
 < en:E170
 en:E170i, Calcium carbonate, CI Pigment White 18, Chalk
@@ -19269,7 +19277,7 @@ ca:E170i, Carbonat de calci
 cs:E170i, Uhličitan vápenatý, CI bílý pigment 18
 cy:E170i, calsiwm carbonad
 da:E170i, Calciumcarbonat, CI Pigment White 18
-de:E170i, Calciumcarbonat, Pigment White 18, Kalk
+de:E170i, Pigment White 18, Kalk
 el:E170i, Ανθρακικο ασβεστιο, Λευκό CI Pigment 18
 eo:E170i, kalcia karbonato
 es:E170i, Carbonato de calcio, CI Pigment White 18, Carbonato cálcico
@@ -19288,7 +19296,7 @@ hu:E170i, Kalcium-karbonát, CI Pigment White 18
 hy:E170i, Կալցիումի կարբոնատ
 id:E170i, calsium carbonat
 is:E170i, Kalsíumkarbónat
-it:E170i, Carbonato di calcio, CI pigmento bianco 18
+it:E170i, CI pigmento bianco 18
 ja:E170i, 炭酸カルシウム
 ko:E170i, 탄산 칼슘
 ky:E170i, Кальций карбонаты
@@ -22889,6 +22897,7 @@ es:E322, Lecitinas, Fosfátidos
 et:E322, Letsitiinid, Fosfatiidid
 fi:E322, Lesitiinit, Fosfatidit, Lesitiinejä, Fosfatidejä
 fr:E322, Lécithines, Phosphatidylcholine, Phosphatides, Phospholipides, Phospho lutéines
+he:E322, לציטינים, לציטין, פוספטידים, תרכובות שומניות
 hu:E322, Lecitinek, Foszfatidek
 it:E322, Lecitine, Fosfatidi
 lt:E322, Lecitinai, Fosfatidai
@@ -22926,7 +22935,7 @@ fa:E322i, لسیتین
 fi:E322i, Lesitiini, Lesitiiniä
 fr:E322i, Lécithine
 gl:E322i, Lecitina
-he:E322i, לציטין
+he:E322i
 hr:E322i, Lecitin
 hu:E322i, Lecitin
 hy:E322i, Լեցիտիններ
@@ -25335,6 +25344,7 @@ ro:E381, citrat feric de amoniu
 sk:E381, citran amónno-železitý
 sl:E381, železov amonijev citrat
 sv:E381, ferriammoniumcitrat
+comment:en: FERRIC AMMONIUM CITRATE is for the moment listed in both the additves and ingredients taxonomy.
 e_number:en: 381
 vegan:en: yes
 vegetarian:en: yes
@@ -25365,6 +25375,7 @@ sk:E383, glycerofosforečnan vápenatý
 sl:E383, kalcijev glicerofosfat
 sr:E383, Kalcijum glicerilfosfat
 sv:E383, kalciumglycerolfosfat
+comment:en: CALCIUM GLYCEROPHOSPHATE is for the moment listed in both the additves and ingredients taxonomy.
 description:en: CALCIUM GLYCERYLPHOSPHATE -or calcium glycerophosphate- is a mineral supplement for Calcium.
 e_number:en: 383
 vegan:en: yes
@@ -27521,6 +27532,7 @@ es:E441, Aceite de semillas de colza superglicerinado hidrogenado
 fi:E441, Superglyseroitu hydrattu rypsiöljy
 fr:E441, Huile de colza superglycérinée hydrogénée
 it:E441
+nl:E441
 e_number:en: 441
 
 en:E442, Ammonium phosphatides, Mixed ammonium salts of phosphorylated glycerides, Emulsifier YN, Ammonium phosphatide, E 442
@@ -29290,6 +29302,7 @@ et:E476, Ritsinoolhappe polüglütseroolestrid
 fi:E476, Polyglyserolipolyrisiinioleaatti, PGPR, Polyglyserolipolyrisiinioleaatteja
 fr:E476, Esters polyglycériques d'acides gras d'huile de ricin, Polyricinoléate de polyglycérol, Esters polyglycériques de l'acide ricinoléique interesterifié, PGPR, Esters polyglycéroliques de l'acide ricinoléique interesterifié, Esters polyglycériques d'acides gras polycondensés d'huile de ricin, Esters glycériques d'acides gras condensés d'huile de ricin
 ga:polairicineoláit pholaigliocróil
+he:E476, פוליגליצרול פוליריצינולאט, חומר מתחלב, PGPR
 hr:poliglicerol - poliricinoleat
 hu:E476, Poliglicerin-poliricinoleát
 it:E476, Poliricinoleato di poliglicerolo
@@ -29921,6 +29934,7 @@ es:E500, Carbonatos de sodio
 et:E500, E500 food additive
 fi:E500, natriumkarbonaatit
 fr:E500, Carbonates de sodium
+he:E500, קרבונטים של נתרן, נתרן קרבונט, נתרן ביקרבונט, נתרן מימן-קרבונט, נתרן ססקויקרבונט, נתרן פחמתי, סודיום קרבונטים, סודיום קרבונט, חומר מווסת חומציות, חומר התפחה
 hu:E500, nátrium-karbonátok
 it:E500, Carbonati di sodio
 lt:E500, E500 food additive
@@ -29974,10 +29988,10 @@ eo:E500i, natria karbonato
 es:E500i, Carbonato sódico, Carbonato de sodio, Sosa comercial
 et:E500i, Naatriumkarbonaat
 fa:E500i, سدیم کربنات
-fi:E500i, Naatriumkarbonaat, Sooda, Pesusooda, Kristalne sooda, Kaltsineeritud sooda, Natriumkarbonaattidekahydraatti, Natriumkarbonaatti, Natriitti, Kidesooda, Natriumkarbonaattimonohydraatti, Soodaa, Pesusoodaa, Natriumkarbonaattidekahydraattia, Natriumkarbonaattia, Natriittia, Kidesoodaa, Natriumkarbonaattimonohydraattia
+fi:E500i, Sooda, Pesusooda, Natriumkarbonaattidekahydraatti, Natriumkarbonaatti, Natriitti, Kidesooda, Natriumkarbonaattimonohydraatti, Soodaa, Pesusoodaa, Natriumkarbonaattidekahydraattia, Natriumkarbonaattia, Natriittia, Kidesoodaa, Natriumkarbonaattimonohydraattia
 fr:E500i, Carbonate de sodium, Carbonate de soude, Cristaux de soude
 gv:E500i, Carboanaayt sodjum
-he:E500i, נתרן פחמתי
+he:E500i
 hi:E500i, क्षारातु प्रांगारीय
 hr:E500i, Natrijev karbonat
 hu:E500i, Nátrium-karbonát, szóda, sziksó, mosószóda, kalcinált szóda
@@ -30026,7 +30040,7 @@ wikidata:en: Q190227
 en:E500ii, Sodium hydrogen carbonate, Sodium bicarbonate, sodium acid carbonate, Bicarbonate of soda, baking soda
 af:E500ii, Natriumbikarbonaat
 ar:E500ii, بيكربونات الصوديوم
-bg:E500ii, Натриев бикарбонат, Натриев хидроген карбонат, натриев кисел карбонат, сода бикарбонат
+bg:E500ii, Натриев хидроген карбонат, Натриев бикарбонат, натриев кисел карбонат, сода бикарбонат
 bn:E500ii, সোডিয়াম বাইকার্বনেট
 bs:E500ii, Natrij-hidrogenkarbonat
 ca:E500ii, hidrogencarbonat de sodi, bicarbonat sòdic
@@ -30140,7 +30154,7 @@ wikidata:en: Q2234978
 < en:E500ii
 ca:carbonat àcid de sodi i difosfat de disodi
 fr:diphosphate disodique et carbonate acide de sodium
-ru:сода, сода пищевая, гидрокарбонат натрия  разрыхлитель гидрокарбонат натрия
+ru:сода, сода пищевая, гидрокарбонат натрия, разрыхлитель гидрокарбонат натрия
 
 en:E501, Potassium carbonates, E-501
 bg:E501, E501 food additive
@@ -30167,6 +30181,7 @@ sk:E501, E501 food additive, uhličitany draselné
 sl:E501, E501 food additive
 sv:E501, Kaliumkarbonater
 additives_classes:en: en:stabilizer
+comment:en: Use plural for E501 and singular for E501i.
 e_number:en: 501
 mandatory_additive_class:en: en:acidity-regulator
 organic_eu:en: authorized
@@ -32921,6 +32936,7 @@ uk:Глюконат кальцію
 vi:canxi gluconat
 zh:葡萄糖酸钙
 additives_classes:en: en:sequestrant
+comment:en: CALCIUM GLUCONATE is for the moment listed in both the additves and ingredients taxonomy.
 e_number:en: 578
 mandatory_additive_class:en: en:acidity-regulator, en:firming-agent, en:sequestrant
 vegan:en: yes
@@ -34381,7 +34397,7 @@ ms:Vaseline
 mt:E905b, E905b food additive
 nb:E905b, hvit myk parafin, Vaselin
 nl:E905b, petroleum jelly, Vaseline
-nn:E905b, Петролатум, kvit mjuk parafin
+nn:E905b, kvit mjuk parafin
 pl:E905b, Wazelina
 ps:E905b, واسلين
 pt:E905b, vaselina, gelatina de petróleo
@@ -35012,6 +35028,7 @@ tr:E917, Potasyum iyodat
 uk:E917, Йодат калію
 vi:E917, Kali iodat
 zh:E917, 碘酸钾
+comment:en: POTASSIUM IODATE is for the moment listed in both the additves and ingredients taxonomy.
 e_number:en: 917
 mandatory_additive_class:en: en:flour-treatment-agent
 organic_eu:en: authorized
@@ -37710,6 +37727,7 @@ it:enzima coagulante
 nl:stremmingsenzymen, stollingsmiddel
 pl:Enzym koagulujący
 pt:coagulante
+ru:молокосвертывающий фермент
 sv:koagulerande enzym, mjölkkoagulerande enzym, mjölkkoagulerande ystenzym
 vegan:en: maybe
 vegetarian:en: maybe
@@ -38185,7 +38203,7 @@ vegetarian:en: no
 en:shortening
 fr:graisse alimentaire
 ja:ショートニング
-ru:жир кондитрерский, кондитрерский жир
+ru:жир кондитерский, кондитерский жир
 wikidata:en: Q1194601
 wikipedia:en: https://en.wikipedia.org/wiki/Shortening
 
@@ -39336,7 +39354,7 @@ en:butter flavouring
 de:butteraroma, butter-aroma
 fi:voiaromi
 fr:arôme de beurre
-ru:ароматизатор масла
+ru:ароматизатор масла, ароматизатор идентичный натуральному сливки
 sv:smörarom
 
 < en:Flavouring
@@ -39518,6 +39536,10 @@ sv:mangoarom
 < en:Flavouring
 en:meat flavour
 es:aroma de carne
+
+< en:Flavouring
+en:milk flavouring
+ru:ароматизатор молоко, ароматизатор топленое молоко
 
 < en:Flavouring
 en:mint flavouring
@@ -47001,7 +47023,10 @@ es:hierro reducido
 fr:fer réduit
 
 en:isomaltose
+de:Isomaltose
 es:isomaltosa
+fr:Isomaltose
+it:Isomaltosio
 wikipedia:en: https://en.wikipedia.org/wiki/Isomaltose
 
 < en:Jalapeno
@@ -47036,6 +47061,9 @@ de:grüne jalapenos
 fi:vihreä jalapeño, vihreä jalapeno, vihreät jalapenot
 fr:piment jalapeño vert
 sv:grön jalapeño
+
+en:jam
+ru:джем, повидло, варенье
 
 en:juice
 de:Saft
@@ -57711,7 +57739,7 @@ oc:Òli de palma
 pl:Olej palmowy
 pt:óleo de palma, óleo de palmeira, óleo vegetal de palma
 ro:Ulei de palmier, ulei vegetal de palmier
-ru:Пальмовое масло, масло пальмовое, пальмовое масло и его фракции
+ru:Пальмовое масло, масло пальмовое, пальмовое масло и его фракции, масло растительное пальмовое
 sk:Palmový olej
 sr:Палмино уље
 sv:Palmolja
@@ -71134,7 +71162,7 @@ ps:بوره
 pt:Açúcar
 qu:Asukar
 ro:Zahăr, zahar, zaharuri
-ru:Сахар, сахар песок
+ru:Сахар, сахар песок, сахара
 rw:Isukari
 sa:शर्करा
 sd:کنڊ
@@ -77196,7 +77224,7 @@ nb:soyaolje
 nl:sojaolie
 pl:olej sojowy
 pt:óleo de soja
-ru:Соевое масло, масло соевое
+ru:Соевое масло, масло соевое, масло растительное соевое
 sv:Sojaolja, sojaböns olja
 uk:Соєва олія
 zh:大豆油
@@ -77210,7 +77238,7 @@ en:sunflower oil, sunflower seed oil
 ar:زيت زهرة الشمس
 az:Günəbaxan yağı
 be:Сланечнікавы алей
-bg:Слънчогледово олио, слънчогледово масло
+bg:Слънчогледово олио, слънчогледово масло, масло слънчогледово
 ca:oli de gira-sol, oli vegetal de gira-sol, oli de girasol, oli vegetal de girasol
 cs:Slunečnicový olej
 da:solsikkeolie
@@ -77242,7 +77270,7 @@ nn:solsikkeolje
 pl:Olej słonecznikowy
 pt:óleo de girassol, óleo vegetal de girassol
 ro:ulei de floarea soarelui
-ru:подсолнечное масло, масло подсолнечное
+ru:подсолнечное масло, масло подсолнечное, масло растительное подсолнечное
 sa:सूर्यकान्तितैलम्
 sh:Suncokretovo ulje
 sk:Slnečnicový olej
@@ -77293,7 +77321,7 @@ fr:huile végétale raffinée
 
 < en:Vegetable oil and fat
 en:cocoa butter substitute
-ru:заменитель масла какао, заменитель какао масла
+ru:заменитель масла какао, заменитель какао масла, эквивалент масла какао, заменитель какао масла лауринового типа
 
 < en:Vegetable oil and fat
 en:non hydrogenated vegetable oil and fat

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -16983,7 +16983,7 @@ oc:Òli de palma
 pl:Olej palmowy
 pt:óleo de palma, óleo de palmeira, óleo vegetal de palma
 ro:Ulei de palmier, ulei vegetal de palmier
-ru:Пальмовое масло, масло пальмовое, пальмовое масло и его фракции
+ru:Пальмовое масло, масло пальмовое, пальмовое масло и его фракции, масло растительное пальмовое
 sk:Palmový olej
 sr:Палмино уље
 sv:Palmolja
@@ -17979,7 +17979,7 @@ nb:soyaolje
 nl:sojaolie
 pl:olej sojowy
 pt:óleo de soja
-ru:Соевое масло, масло соевое
+ru:Соевое масло, масло соевое, масло растительное соевое
 sv:Sojaolja, sojaböns olja
 uk:Соєва олія
 zh:大豆油
@@ -18279,7 +18279,7 @@ en:sunflower oil, sunflower seed oil
 ar:زيت زهرة الشمس
 az:Günəbaxan yağı
 be:Сланечнікавы алей
-bg:Слънчогледово олио, слънчогледово масло
+bg:Слънчогледово олио, слънчогледово масло, масло слънчогледово
 ca:oli de gira-sol, oli vegetal de gira-sol,oli de girasol, oli vegetal de girasol
 cs:Slunečnicový olej
 da:solsikkeolie
@@ -18311,7 +18311,7 @@ nn:solsikkeolje
 pl:Olej słonecznikowy
 pt:óleo de girassol, óleo vegetal de girassol
 ro:ulei de floarea soarelui, Ulei de floarea-soarelui
-ru:подсолнечное масло, масло подсолнечное
+ru:подсолнечное масло, масло подсолнечное, масло растительное подсолнечное
 sa:सूर्यकान्तितैलम्
 sh:Suncokretovo ulje
 sk:Slnečnicový olej


### PR DESCRIPTION
We have some ingredients parsing code for French to transform ingredients that are specified with a category + some types (e.g. vegetable oils (olive, palm and sunflower) to individual ingredients: olive vegetable oils, palm vegetable oils, sunflower vegetable oils.

This PR is to make this code more generic, so that it can be applied or adapted more easily to other languages.

I added a few examples for English and Russian (from @blazern : #5017 ).

We can add more categories and more types gradually (and more corresponding tests too).

We can also probably extend the system to more languages easily (e.g. Italian, Portuguese, Spanish). I'm not sure about the languages with compound words like Dutch, Finnish or German, but I'm guessing we can find a way.
