### PR TITLE
Fix update_all_products_from_dir.pl script for producers platform

### DIFF
--- a/scripts/update_all_products_from_dir_in_mongodb.pl
+++ b/scripts/update_all_products_from_dir_in_mongodb.pl
@@ -55,9 +55,9 @@ use Data::Dumper;
 use Getopt::Long;
 
 my @products = ();
+my $owner = undef;
 
-
-GetOptions ( 'products=s' => \@products);
+GetOptions ( 'products=s' => \@products, 'owner=s' => \$owner);
 @products = split(/,/,join(',',@products));
 
 my $d = 0;
@@ -94,7 +94,15 @@ sub find_products($$) {
 
 
 if (scalar $#products < 0) {
-	find_products("$data_root/products",'');
+	if ((defined $server_options{private_products}) and ($server_options{private_products})) {
+		if (not defined $owner) {
+			die("The owner must be specified on the producers platform");
+		}
+		find_products("$data_root/products/$owner",'');
+	}
+	else {
+		find_products("$data_root/products",'');
+	}
 }
 
 
@@ -113,7 +121,7 @@ my %codes = ();
 
 		#next if ($code ne "4072700318675");
 
-		my $product_id = product_id_for_owner(undef, $code);
+		my $product_id = product_id_for_owner($owner, $code);
 
 		my $path = product_path_from_id($product_id);
 


### PR DESCRIPTION
The script is used to load the .sto files in MongoDB. (e.g. if we want to retrieve deleted products)