### PR TITLE
Many small improvements for the producers platform

### DIFF
--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -131,8 +131,7 @@ if ($action eq "display") {
 		$template_data_ref->{allow_submit} = 1;
 	}
 	
-	$tt->process('export_products.tt.html', $template_data_ref, \$html) || ($html .= 'template error: ' . $tt->error());
-
+	process_template('export_products.tt.html', $template_data_ref, \$html) || ($html .= 'template error: ' . $tt->error());
 }
 
 elsif (($action eq "process") and $allow_submit) {
@@ -161,6 +160,12 @@ elsif (($action eq "process") and $allow_submit) {
 	
 	if ((defined param("only_export_products_with_changes")) and (param("only_export_products_with_changes"))) {
 		$args_ref->{query}{states_tags} = 'en:to-be-exported';
+	}
+	
+	if ($admin) {
+		if ((defined param("overwrite_owner")) and (param("overwrite_owner"))) {
+			$args_ref->{overwrite_owner} = 1;
+		}		
 	}
 	
 	# Create Minion tasks for export and import

--- a/lib/ProductOpener/GS1.pm
+++ b/lib/ProductOpener/GS1.pm
@@ -735,7 +735,7 @@ sub gs1_to_off ($$$) {
 	
 	# We should have a hash
 	if (ref($json_ref) ne "HASH") {
-		$log->error("gs1_to_off - json_ref is not a hash", { json_re => $json_ref, results_ref => $results_ref }) if $log->is_error();
+		$log->error("gs1_to_off - json_ref is not a hash", { gs1_to_off_ref => $gs1_to_off_ref, json_ref => $json_ref, results_ref => $results_ref }) if $log->is_error();
 		return;
 	}
 	

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -729,11 +729,6 @@ sub check_edit_owner($$) {
 		# Also edit the current user object so that we can display the current status directly on the form result page
 		delete $User{pro_moderator_owner};
 	}
-	elsif ($user_ref->{pro_moderator_owner} =~ /^org-/) {
-		my $orgid = $';
-		$User{pro_moderator_owner} = $user_ref->{pro_moderator_owner};
-		$log->debug("set pro_moderator_owner (org)", { orgid => $orgid, pro_moderator_owner => $User{pro_moderator_owner} }) if $log->is_debug();
-	}
 	elsif ($user_ref->{pro_moderator_owner} =~ /^user-/) {
 		my $userid = $';
 		# Add check that organization exists when we add org profiles
@@ -751,13 +746,22 @@ sub check_edit_owner($$) {
 		$User{pro_moderator_owner} = $user_ref->{pro_moderator_owner};
 		$log->debug("set pro_moderator_owner (all) see products from all owners", { pro_moderator_owner => $User{pro_moderator_owner} }) if $log->is_debug();
 	}
+	elsif ($user_ref->{pro_moderator_owner} =~ /^org-/) {
+		my $orgid = $';
+		$User{pro_moderator_owner} = $user_ref->{pro_moderator_owner};
+		$log->debug("set pro_moderator_owner (org)", { orgid => $orgid, pro_moderator_owner => $User{pro_moderator_owner} }) if $log->is_debug();
+	}
 	else {
-		push @{$errors_ref},$Lang{error_malformed_owner}{$lang};
-		$log->debug("error - malformed pro_moderator_owner", { pro_moderator_owner => $User{pro_moderator_owner} }) if $log->is_debug();
+		# if there is no user- or org- prefix, assume it is an org
+		my $orgid = $user_ref->{pro_moderator_owner};
+		$User{pro_moderator_owner} = "org-" . $orgid;
+		$user_ref->{pro_moderator_owner} = "org-" . $orgid;
+		$log->debug("set pro_moderator_owner (org)", { orgid => $orgid, pro_moderator_owner => $User{pro_moderator_owner} }) if $log->is_debug();
 	}
 
 	return;
 }
+
 
 sub init_user()
 {

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5394,3 +5394,12 @@ msgstr "The product does not exist yet on the public database"
 msgctxt "some_product_updates_have_not_been_published_on_the_public_database"
 msgid "Some product updates have not been published on the public database."
 msgstr "Some product updates have not been published on the public database."
+
+msgctxt "org_do_not_import_codeonline"
+msgid "Do not import CodeOnline data."
+msgstr "Do not import CodeOnline data."
+
+msgctxt "overwrite_owner"
+msgid "Overwrite products that have a different owner on the public platform. Otherwise, products with a different owner will be skipped."
+msgstr "Overwrite products that have a different owner on the public platform. Otherwise, products with a different owner will be skipped."
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5415,3 +5415,12 @@ msgctxt "some_product_updates_have_not_been_published_on_the_public_database"
 msgid "Some product updates have not been published on the public database."
 msgstr "Some product updates have not been published on the public database."
 
+msgctxt "org_do_not_import_codeonline"
+msgid "Do not import CodeOnline data."
+msgstr "Do not import CodeOnline data."
+
+msgctxt "overwrite_owner"
+msgid "Overwrite products that have a different owner on the public platform. Otherwise, products with a different owner will be skipped."
+msgstr "Overwrite products that have a different owner on the public platform. Otherwise, products with a different owner will be skipped."
+
+

--- a/templates/export_products.tt.html
+++ b/templates/export_products.tt.html
@@ -21,19 +21,28 @@
 		[% IF allow_submit %]
 
 			<label for="export_photos">
-				<input type="checkbox" name="export_photos" [% export_photos_value %]>
+				<input type="checkbox" id="export_photos" name="export_photos" [% export_photos_value %]>
 				[% lang('export_photos') %]
 			</label>
 
 			<label for="replace_selected_photos">
-				<input type="checkbox" name="replace_selected_photos" [% replace_selected_photos_value %]>	
+				<input type="checkbox" id="replace_selected_photos" name="replace_selected_photos" [% replace_selected_photos_value %]>	
 				[% lang('replace_selected_photos') %]
 			</label>
 
 			<label for="only_export_products_with_changes">
-				<input type="checkbox" name="only_export_products_with_changes" [% only_export_products_with_changes_value %]>	
+				<input type="checkbox" id="only_export_products_with_changes" name="only_export_products_with_changes" [% only_export_products_with_changes_value %]>	
 				[% lang('only_export_products_with_changes') %]
 			</label>
+			
+			[% IF admin %]
+			
+			<label for="overwrite_owner">
+				<input type="checkbox" id="overwrite_owner" name="overwrite_owner" [% overwrite_owner %]>	
+				[% lang('overwrite_owner') %]
+			</label>
+			
+			[% END %]
 		[% END %]
 			
 		<input type="submit" class="button small" value="[% lang('export_product_data_photos') %]">

--- a/templates/org_form.tt.html
+++ b/templates/org_form.tt.html
@@ -5,7 +5,7 @@
 [% IF action == 'display' %]
 
 	[% IF org_does_not_exist %]
-		<div class="panel" style="background-color:#ffdddd">The organization <b>[% orgid %]</b> does not exist yet. It will be created if you submit the form.</div>
+		<div class="panel" style="background-color:#ffdddd">The organization <strong>[% orgid %]</strong> does not exist yet. It will be created if you submit the form.</div>
 	[% END %]
 
     <!-- Start form -->

--- a/templates/org_form.tt.html
+++ b/templates/org_form.tt.html
@@ -4,6 +4,10 @@
 
 [% IF action == 'display' %]
 
+	[% IF org_does_not_exist %]
+		<div class="panel" style="background-color:#ffdddd">The organization <b>[% orgid %]</b> does not exist yet. It will be created if you submit the form.</div>
+	[% END %]
+
     <!-- Start form -->
     
     <p>[% lang('org_profile_description') %]</p>
@@ -52,7 +56,6 @@
 						<label for="[% field.field %]">
 							<input type="checkbox" id="[% field.field %]" name="[% field.field %]" [% IF field.value == 'on' %]checked="checked"[% END %] />
 							[% field.label %]
-							value: [% field.value %]
 						</label>
 					[% END %]
 					


### PR DESCRIPTION
- Org profiles have an extra checkbox for admins to disable CodeOnline imports
- Org profiles allow admins to input a list of GLNs. The GS1 org ids (GLN) are now stored in a hash (orgs_glns.sto), and they are used to force the match of a GLN to an org during Equadis / CodeOnline imports.
- Imports to the public platform now skip products that would result in an owner change
- The export form has an extra checkbox to allow overwriting owners
- When editing an org profile, admins can now create the org profile if it does not exist yet (and they are warned that they are editing an unknown org profile)
- The side column form for admins to switch to a specific org now defaults to organizations if the entered it does not start by user- or org-. i.e. it's possible to just input "nestle-france".