### PR TITLE
Script to generate Nutri-Score stats from scanbot.pl output

### DIFF
--- a/scripts/add_nutriscore_to_scanbot_csv.pl
+++ b/scripts/add_nutriscore_to_scanbot_csv.pl
@@ -1,0 +1,122 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2019 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# This script expects nginx access logs on STDIN
+# filtered by the app:
+# grep "Official Android App" nginx.access2.log | grep Scan > android_app.log
+
+use Modern::Perl '2017';
+use utf8;
+
+use CGI::Carp qw(fatalsToBrowser);
+
+use ProductOpener::Config qw/:all/;
+use ProductOpener::Store qw/:all/;
+use ProductOpener::Index qw/:all/;
+use ProductOpener::Display qw/:all/;
+use ProductOpener::Tags qw/:all/;
+use ProductOpener::Users qw/:all/;
+use ProductOpener::Images qw/:all/;
+use ProductOpener::Lang qw/:all/;
+use ProductOpener::Mail qw/:all/;
+use ProductOpener::Products qw/:all/;
+use ProductOpener::Food qw/:all/;
+use ProductOpener::Ingredients qw/:all/;
+use ProductOpener::Images qw/:all/;
+use ProductOpener::Data qw/:all/;
+
+use CGI qw/:cgi :form escapeHTML/;
+use URI::Escape::XS;
+use Storable qw/dclone/;
+use Encode;
+use JSON::PP;
+
+my %total = ();
+
+print join("\t", qw(code scans unique_scans found source found_status found_scans found_unique_scans nutriscore_status nutriscore_scans nutriscore_unique_scans)) . "\n";
+
+while (<STDIN>)
+{
+	$total{products}++;
+	chomp;
+	my ($code, $scans, $unique_scans, $found, $source) = split(/\t/);
+	
+	my $found_scans = 0;
+	my $found_unique_scans = 0;
+	my $found_status = 0;	
+	
+	my $nutriscore_scans = 0;
+	my $nutriscore_unique_scans = 0;
+	my $nutriscore_status = 0;
+
+	if ($found eq "FOUND") {
+		
+		$total{found_products}++;
+		$found_status = 1;
+		$found_scans = $scans;
+		$found_unique_scans = $unique_scans;
+		
+		my $product_ref = retrieve_product($code);
+		if ((defined $product_ref) and (defined $product_ref->{nutriscore_grade})
+		and ($product_ref->{nutriscore_grade} =~ /^[a-e]$/)) {
+			$nutriscore_scans = $scans;
+			$nutriscore_unique_scans = $unique_scans;
+			$nutriscore_status = 1;
+			$total{nutriscore_products}++;
+		}
+	}
+	
+	$total{scans} += $scans;
+	$total{unique_scans} += $unique_scans;
+	$total{found_scans} += $found_scans;
+	$total{found_unique_scans} += $found_unique_scans;	
+	$total{nutriscore_scans} += $nutriscore_scans;
+	$total{nutriscore_unique_scans} += $nutriscore_unique_scans;
+	
+	print join("\t", $code, $scans, $unique_scans, $found, $source, $found_status, $found_scans, $found_unique_scans, $nutriscore_status, $nutriscore_scans, $nutriscore_unique_scans) . "\n";
+}
+
+my $found_products_percent = sprintf("%.2f", 100 * $total{found_products} / $total{products});
+my $found_scans_percent = sprintf("%.2f", 100 * $total{found_scans} / $total{scans});
+my $found_unique_scans_percent = sprintf("%.2f", 100 * $total{found_unique_scans} / $total{unique_scans});
+
+my $nutriscore_products_percent = sprintf("%.2f", 100 * $total{nutriscore_products} / $total{products});
+my $nutriscore_scans_percent = sprintf("%.2f", 100 * $total{nutriscore_scans} / $total{scans});
+my $nutriscore_unique_scans_percent = sprintf("%.2f", 100 * $total{nutriscore_unique_scans} / $total{unique_scans});
+
+print STDERR <<TXT
+
+products: $total{products}
+scans: $total{scans}
+unique_scans: $total{unique_scans}
+
+found_products: $total{found_products} - $found_products_percent
+found_scans: $total{found_scans} - $found_scans_percent
+found_unique_scans: $total{found_unique_scans} - $found_unique_scans_percent
+
+nutriscore_products: $total{nutriscore_products} - $nutriscore_products_percent
+nutriscore_scans: $total{nutriscore_scans} - $nutriscore_scans_percent
+nutriscore_unique_scans: $total{nutriscore_unique_scans} - $nutriscore_unique_scans_percent
+
+TXT
+;
+


### PR DESCRIPTION
This scripts adds columns to the output of scanbot.pl about the % of products that have a Nutri-Score computed.

It's been done to process already existing outputs, but for the future, we should update scanbot.pl so that it adds those columns on the fly, that would be much easier.

The script also computes some stats and prints them on STDERR:

off1:/srv/off/scripts# ./add_nutriscore_to_scanbot_csv.pl < scanbot.2020_fr/scanbot_fr.products.csv > scanbot.2020_fr/scanbot_fr.products.nutriscore.csv 

products: 399339
scans: 4169276
unique_scans: 2627876

found_products: 220217 - 55.15
found_scans: 3840435 - 92.11
found_unique_scans: 2396592 - 91.20

nutriscore_products: 124560 - 31.19
nutriscore_scans: 3159908 - 75.79
nutriscore_unique_scans: 2006105 - 76.34
