### PR TITLE
Indicate source of data for CodeOnline and Equadis + dedicated pages

### DIFF
--- a/lang/fr/data_sources/database-codeonline.html
+++ b/lang/fr/data_sources/database-codeonline.html
@@ -1,0 +1,13 @@
+<h1>CodeOnline Food - GS1 France</h1>
+
+<p>Open Food Facts intègre les données de la plateforme CodeOnline Food de GS1 France.</p>
+
+<p>Les fabricants qui transmettent les données de leurs produits à CodeOnline peuvent accéder à ces données sur la <a href="https://fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a> d'Open Food Facts pour :</p>
+<ul>
+<li>pouvoir si besoin compléter les données (en particulier pour obtenir un calcul plus précis de l'Eco-Score en indiquant les origines des ingrédients et les composants de l'emballage) ou envoyer des photos supplémentaires</li>
+<li>obtenir des rapports sur la qualité des données et identifier les produits pour lesquelles certaines données semblent incorrectes</li>
+<li>obtenir des analyses des données de leurs produits, des opportunités d'amélioration (comme l'identification des produits qui peuvent obtenir une meilleure note Nutri-Score)
+</ul>
+
+<p>Source des données CodeOnline Food : GS1 France CodeOnline - Données originales téléchargées sur <a href="https://codeonline.fr/opendata ">codeonline.fr/opendata</a> - Mise à jour de Mars 2021.</p>
+

--- a/lang/fr/data_sources/database-equadis.html
+++ b/lang/fr/data_sources/database-equadis.html
@@ -1,0 +1,11 @@
+<h1>Intégration des données GDSN avec Equadis</h1>
+
+<p>Les fabricants peuvent envoyer automatiquement et en temps réel les données et photos de leurs produits sur Open Food Facts via la plateforme <a href="https://equadis.com/">Equadis</a>. L'envoi à Open Food Facts des données GDSN des produits est disponible sans surcoût à tous les clients d'Equadis.</p>
+
+<p>Les fabricants peuvent ensuite accéder à ces données sur la <a href="https://fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a> d'Open Food Facts pour :</p>
+<ul>
+<li>pouvoir si besoin compléter les données (en particulier pour obtenir un calcul plus précis de l'Eco-Score en indiquant les origines des ingrédients et les composants de l'emballage)</li>
+<li>obtenir des rapports sur la qualité des données et identifier les produits pour lesquelles certaines données semblent incorrectes</li>
+<li>obtenir des analyses des données de leurs produits, des opportunités d'amélioration (comme l'identification des produits qui peuvent obtenir une meilleure note Nutri-Score)
+</ul>
+

--- a/lib/ProductOpener/Export.pm
+++ b/lib/ProductOpener/Export.pm
@@ -371,6 +371,9 @@ sub export_csv($) {
 
 		my $added_images_urls = 0;
 		my $product_path = product_path($product_ref);
+		
+		# Add data sources from the sources field (useful for old imports for which we did not have some sources -> data_sources associations)
+		compute_data_sources($product_ref);
 
 		foreach my $field (@sorted_populated_fields) {
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1230,7 +1230,7 @@ sub compute_data_sources($) {
 	}
 
 
-	# Add a data source forapps
+	# Add a data source for apps
 
 	if (defined $product_ref->{editors_tags}) {
 		foreach my $editor (@{$product_ref->{editors_tags}}) {

--- a/templates/display_product.tt.html
+++ b/templates/display_product.tt.html
@@ -84,7 +84,7 @@
     </div>
 [% END %]
 
-<!-- photos and data sources -->
+<!-- owner -->
 [% IF owner %]
 	<p>
 		[% FILTER format(lang("sources_manufacturer")) %]<a href="/editor/[% owner %]">[% owner_org.name %]</a>[% END %]
@@ -398,6 +398,19 @@
 	[% END %]
 	</ul>
 [% END %]
+
+<!-- databases data sources -->
+<h2>[% lang('data_sources_p') FILTER ucfirst %]</h2>
+
+[% IF data_source_database_equadis %]
+	<p>[% data_source_database_equadis %]</p>
+[% ELSIF data_source_database_codeonline %]
+	<p>[% data_source_database_codeonline %]</p>
+	<p>[% data_source_database_note_about_the_producers_platform %]</p>
+[% ELSE %]
+<p>_</p>
+[% END %]
+
 
 <p class="details">
     [% lang('product_added') %] [% created_date %] [% lang('by') %] [% creator %]<br>


### PR DESCRIPTION
This will add a link at the bottom of product pages to indicate that some data comes from CodeOnline, or from Equadis. The link will lead to a page with a small text about each, plus the list of corresponding products. Essentially it's just 2 additional values to the /data-sources facet.