### PR TITLE
Allow imports of files that contain the URL of an image + its type in another column + small fixes for Carrefour import

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -694,7 +694,7 @@ $options{import_export_fields_groups} = [
 		]
 	],
 	[   "images",
-		[   "image_front_url", "image_ingredients_url", "image_nutrition_url", "image_packaging_url", "image_other_url"
+		[   "image_front_url", "image_ingredients_url", "image_nutrition_url", "image_packaging_url", "image_other_url", "image_other_type",
 		]
 	],
 ];
@@ -781,7 +781,7 @@ $options{import_export_fields_importance} = {
 	categories => "mandatory",
 	labels => "mandatory",
 	countries => "recommended",
-	obsolete => "mandatory",
+	obsolete => "recommended",
 	obsolete_since_date => "recommended",
 	
 	origins => "mandatory",

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -230,6 +230,10 @@ sub assign_nid_modifier_value_and_unit($$$$$) {
 	if ((not defined $unit) or ($unit eq "")) {
 		$unit = default_unit_for_nid($nid);
 	}
+	# if the nid is "energy" and we have a unit, set "energy-kj" or "energy-kcal"
+	elsif (($nid eq "energy") and (($unit eq "kj") or ($unit eq "kcal"))) {
+		$nid = "energy-" . $unit;
+	}
 
 	$value = convert_string_to_number($value);
 
@@ -241,7 +245,7 @@ sub assign_nid_modifier_value_and_unit($$$$$) {
 	}
 	$product_ref->{nutriments}{$nid . "_unit"} = $unit;
 	$product_ref->{nutriments}{$nid . "_value"} = $value;
-
+	
 	if (((uc($unit) eq 'IU') or (uc($unit) eq 'UI')) and (exists $Nutriments{$nid}) and ($Nutriments{$nid}{iu} > 0)) {
 		$value = $value * $Nutriments{$nid}{iu} ;
 		$unit = $Nutriments{$nid}{unit};
@@ -261,7 +265,7 @@ sub assign_nid_modifier_value_and_unit($$$$$) {
 	else {
 		$product_ref->{nutriments}{$nid} = unit_to_g($value, $unit) + 0;
 	}
-
+	
 	return;
 }
 
@@ -309,8 +313,6 @@ sub kcal_to_unit($$) {
 
 	(not defined $value) and return $value;
 	
-	print STDERR "value: $value - unit: $unit\n";
-
 	($unit eq 'kj') and return int($value * 4.184 + 0.5);
 
 	# return value without modification if it's already in kcal

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -1259,7 +1259,7 @@ EMAIL
 							# Assign energy-kj and energy-kcal values from energy field
 
 							if (($nid eq "energy") and ($imported_product_ref->{$nid . $type . $per . "_value_unit"} =~ /\b([0-9]+)(\s*)kJ/i)) {
-								if (not defined $imported_product_ref->{$nid . "-j" . $type . $per . "_value_unit"}) {
+								if (not defined $imported_product_ref->{$nid . "-kj" . $type . $per . "_value_unit"}) {
 									$imported_product_ref->{$nid . "-kj" . $type . $per . "_value_unit"} = $1 . " kJ";
 								}
 							}
@@ -1451,7 +1451,6 @@ EMAIL
 				}
 			}
 		}		
-
 
 		if ((defined $stats{products_info_added}{$code}) or (defined $stats{products_info_changed}{$code})) {
 			$stats{products_info_updated}{$code} = 1;
@@ -1664,6 +1663,13 @@ EMAIL
 			next if $field !~ /^image_((front|ingredients|nutrition|packaging|other)(_[a-z]{2})?)_url/;
 
 			my $imagefield = $1 . $'; # e.g. image_front_url_fr -> front_fr
+			
+					# If the imagefield is other, and we have a value for image_other_type, try to identify the imagefield
+					if (($imagefield eq "other") and (defined $imported_product_ref->{"image_other_type"}) and ($imported_product_ref->{"image_other_type"} ne "")) {
+						my $type_imagefield = get_imagefield_from_string($product_ref->{lc}, $imported_product_ref->{"image_other_type"});
+						$log->debug("imagefield is other, tried to guess it image_other_type", { imagefield => $imagefield, type_imagefield => $type_imagefield, image_other_type => $imported_product_ref->{"image_other_type"} }) if $log->is_debug();
+						$imagefield = $type_imagefield;
+					}			
 
 			$log->debug("image file", { field => $field, imagefield => $imagefield, field_value => $imported_product_ref->{$field} }) if $log->is_debug();
 			

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5414,3 +5414,13 @@ msgstr "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_
 msgctxt "data_source_database_equadis"
 msgid "The manufacturer %s uses %s to automatically transmit data and photos for its products."
 msgstr "The manufacturer %s uses %s to automatically transmit data and photos for its products."
+
+
+msgctxt "image_other_type"
+msgid "Type of the product photo"
+msgstr "Type of the product photo"
+
+# do not translate "front, ingredients, nutrition, packaging"
+msgctxt "image_other_type_description"
+msgid "If you use the same column on multiple lines to provide images URLs for a single product, you can use this field to indicate the type of the image: front, ingredients, nutrition or packaging."
+msgstr "If you use the same column on multiple lines to provide images URLs for a single product, you can use this field to indicate the type of the image: front, ingredients, nutrition or packaging."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5434,3 +5434,12 @@ msgstr "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_
 msgctxt "data_source_database_equadis"
 msgid "The manufacturer %s uses %s to automatically transmit data and photos for its products."
 msgstr "The manufacturer %s uses %s to automatically transmit data and photos for its products."
+
+msgctxt "image_other_type"
+msgid "Type of the product photo"
+msgstr "Type of the product photo"
+
+# do not translate "front, ingredients, nutrition, packaging"
+msgctxt "image_other_type_description"
+msgid "If you use the same column on multiple lines to provide images URLs for a single product, you can use this field to indicate the type of the image: front, ingredients, nutrition or packaging."
+msgstr "If you use the same column on multiple lines to provide images URLs for a single product, you can use this field to indicate the type of the image: front, ingredients, nutrition or packaging."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5286,5 +5286,11 @@ msgctxt "data_source_database_equadis"
 msgid "The manufacturer %s uses %s to automatically transmit data and photos for its products."
 msgstr "Le fabricant %s utilise %s pour transmettre automatiquement les photos et données de ses produits."
 
+msgctxt "image_other_type"
+msgid "Type of the product photo"
+msgstr "Type de la photo du produit"
 
-
+# do not translate "front, ingredients, nutrition, packaging"
+msgctxt "image_other_type_description"
+msgid "If you use the same column on multiple lines to provide images URLs for a single product, you can use this field to indicate the type of the image: front, ingredients, nutrition or packaging."
+msgstr "Si vous utilisez la même colonne sur plusieurs lignes pour fournir les URLs des images d'un même produit, vous pouvez utiliser ce champ pour indiquer le type de l'image : front, ingredients, nutrition or packaging."

--- a/scripts/convert_carrefour_data.pl
+++ b/scripts/convert_carrefour_data.pl
@@ -270,7 +270,8 @@ F=>undef,
 
 			["ProductCode", "producer_product_id"],
 
-			["nutrients.ENERKJ.[0].RoundValue", "nutriments.energy_kJ"],
+			["nutrients.ENERKJ.[0].RoundValue", "nutriments.energy-kj_kJ"],
+			["nutrients.ENERKC.[0].RoundValue", "nutriments.energy-kcal_kcal"],
 			["nutrients.FAT.[0].RoundValue", "nutriments.fat_g"],
 			["nutrients.FASAT.[0].RoundValue", "nutriments.saturated-fat_g"],
 			["nutrients.CHOAVL.[0].RoundValue", "nutriments.carbohydrates_g"],


### PR DESCRIPTION
This is to fix small issues with the Carrefour import, and to allow importing a CSV file that looks like this:

EAN | URL | ANGLE
-- | -- | --
8012666520305 | https://basephoto-cdn.carrefour.com/product_pictures/304155 | Front
3046300001085 | https://basephoto-cdn.carrefour.com/product_pictures/1028813 | 3/4
3046300001085 | https://basephoto-cdn.carrefour.com/product_pictures/1028814 | Front
3046300001085 | https://basephoto-cdn.carrefour.com/product_pictures/1028815 | Back
3046300001245 | https://basephoto-cdn.carrefour.com/product_pictures/1028816 | 3/4
3046300001245 | https://basephoto-cdn.carrefour.com/product_pictures/1028817 | Front

![image](https://user-images.githubusercontent.com/8158668/112612713-874c7f80-8e1f-11eb-8442-4bbc2df6d3b0.png)

