### PR TITLE
Translations for recycling_bins.txt

### DIFF
--- a/taxonomies/recycling_bins.txt
+++ b/taxonomies/recycling_bins.txt
@@ -1,14 +1,20 @@
 en:General waste
+pt:lixo indiferenciado, indiferenciado, indeferenciados, lixo, contentor de lixo, contentor do lixo, caixote de lixo, caixote do lixo, cesto de lixo, cesto do lixo, lixo doméstico, resíduos indiferenciados
 
 fr:Bac jaune
 
 en:Plastics container
 nl:PMD-bak, bak voor plastic flessn en flacons - metalen verpakkingen en drinkpakken
 
+#used in Portugal for packages in general (most of them plastic, metal and Tetra Pak) except glass, paper, cardboard, journals, books... but not mixed paper and other materials like Tetra Pak
+<en:Plastics container
+pt:coponto amarelo, contentor azul, contentor do plástico, contentor dos plásticos, contentor das embalagens, contentor de embalagens, contentor do plástico e metal, contentor dos plásticos e metais
+
 en:Glass container
 fr:Bac à verre, Cuboverre
 nl:Glasbak
 de:Glascontainer, Altglas
+pt:Ecoponto verde, contentor verde, contentor do vidro, contentor dos vidros, contentor de garrafas, contentor das garrafas
 geographic_synonyms:fr_FR:paris:Bac blanc
 geographic_synonyms:fr_NL:Bac vert
 
@@ -36,8 +42,12 @@ nl:Bruin glas, glasbak voor bruin glas
 en:Container for paper
 nl:Papierbak
 de:Altpapier, Papiercontainer
+pt:Ecoponto azul, contentor azul, contentor do papel, contentor dos papéis, contentor do cartão, contentor do cartão de papel, contentor do papel e cartão, contentor dos papéis e cartões
 
 nl:GFT-bak, Groente- Fruit- en tuinafval-bak
+
+en:Cooking oil
+pt:Ecoponto laranja, ecoponto de óleo, ecoponto do óleo de fritar, contentor de óleo, contentor do óleo de fritar
 
 fr:Consigné
 nl:Statiegeld


### PR DESCRIPTION
Adding Portuguese translations for recycling_bins.txt

Since is not possible to have pt-br translations as said in https://github.com/openfoodfacts/openfoodfacts-server/pull/5039#issuecomment-804919894, and I should add them to pt: I can't do that in this case because colors containers are different in Portugal and Brazil, (same color to different materials), and may be even in Angola, Mozambique and other Portuguese countries. For example:
-red container = plastics in Brazil; batteries in Portugal
-yellow container = metals in Brazil; plastics in Portugal
Any suggestion/solution?