### PR TITLE
 scripts updates for Carrefour import on pro platform

### DIFF
--- a/cron/import_carrefour.sh
+++ b/cron/import_carrefour.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+cp -a /home/sftp/carrefour/data/*xml /srv/off/imports/carrefour/data/
+
+cd /srv/off/imports/carrefour
+
+./mv_non_off_files.sh
+
+# Warning some Carrefour XML files are broken with 2 <TabNutXMLPF>.*</TabNutXMLPF>
+# fix them by removing the second one:
+cd data
+find . -name "*.xml" -type f -exec sed -i 's/<\/TabNutXMLPF><TabNutXMLPF>.*/<\/TabNutXMLPF>/g' {} \;
+
+unzip -o '/home/sftp/carrefour/data/*zip' -d /srv/off/imports/carrefour/images/
+
+cd /srv/off-pro/scripts
+
+export PERL5LIB=.
+
+./convert_carrefour_data_off1.sh
+
+./import_carrefour_pro_off1.sh
+
+./export_csv_file.pl --fields code,nutrition_grades_tags --query editors_tags=carrefour --separator ';' > /srv/off/html/data/exports/carrefour_nutriscore.csv
+
+./export_csv_file.pl --fields code,nutrition_grades_tags --separator ';' > /srv/off/html/data/exports/nutriscore.csv

--- a/cron/import_fleurymichon.sh
+++ b/cron/import_fleurymichon.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+cd /srv/off/imports/fleurymichon/images
+
+php ExportOpenFoodFacts.php
+
+nice ./delete_broken_image_files.pl download/*.png
+
+cp -a /home/sftp/fleurymichon/data/*.xml /srv/off/imports/fleurymichon/data/
+
+cd /srv/off/imports/fleurymichon/data
+
+latest_xml=$(ls -t *.xml | head -n 1)
+
+export PERL5LIB=.
+
+cd /srv/off/scripts
+
+echo $latest_xml
+
+nice ./import_fleurymichon.pl /srv/off/imports/fleurymichon/data/$latest_xml /srv/off/imports/fleurymichon/images/download
+

--- a/cron/import_systemeu.sh
+++ b/cron/import_systemeu.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+cp -a /home/sftp/systemeu/data/*csv /srv/off/imports/systemeu/data/
+cp -a /home/sftp/systemeu/data/*xlsx /srv/off/imports/systemeu/data/
+
+cd /srv/off/imports/systemeu
+
+unzip -j -u -o '/home/sftp/systemeu/data/*zip' -d /srv/off/imports/systemeu/images/
+
+cd /srv/off/imports/systemeu/images
+
+# systemeu zip includes files starting with ._ that are just metadata
+mv ._* ../tmp/
+
+# transparent png files support is broken in perlmagick on the production
+# server, mogrify them to jpg
+mogrify -format jpg *.png
+mv *.png ../images.png_converted_to_jpg/
+
+
+# cd /srv/off/scripts
+
+export PERL5LIB=.
+
+#./convert_systemeu_data_off1.sh
+
+#./import_systemeu_off1.sh
+

--- a/scripts/convert_carrefour_data.sh
+++ b/scripts/convert_carrefour_data.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-export PERL5LIB="../lib:${PERL5LIB}"
-./convert_carrefour_data.pl /data/off/carrefour/data /data/off/carrefour/Nomenclature_OpenFoodFacts.csv > carrefour.csv

--- a/scripts/convert_carrefour_data_off1.sh
+++ b/scripts/convert_carrefour_data_off1.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./convert_carrefour_data.pl /srv/off/imports/carrefour/data /srv/off/imports/carrefour/Nomenclature_OpenFoodFacts.csv > /srv/off/imports/carrefour/carrefour.csv

--- a/scripts/export_producers_platform_data_to_public_database.sh
+++ b/scripts/export_producers_platform_data_to_public_database.sh
@@ -21,3 +21,5 @@ export PERL5LIB="../lib:${PERL5LIB}"
 
 ./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-garofalo-france
 
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-carrefour
+

--- a/scripts/export_producers_platform_data_to_public_database.sh
+++ b/scripts/export_producers_platform_data_to_public_database.sh
@@ -21,5 +21,7 @@ export PERL5LIB="../lib:${PERL5LIB}"
 
 ./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-garofalo-france
 
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-brasseries-kronenbourg
+
 ./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-carrefour
 

--- a/scripts/import_carrefour.sh
+++ b/scripts/import_carrefour.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-export PERL5LIB="../lib:${PERL5LIB}"
-./import_csv_file.pl --csv_file /home/off/scripts/carrefour.csv --user_id carrefour --comment "Import Carrefour" --source_id "carrefour" --source_name "Carrefour" --source_url "https://www.carrefour.fr" --images_dir /data/off/carrefour/images --manufacturer --skip_products_without_info

--- a/scripts/import_carrefour_pro_off1.sh
+++ b/scripts/import_carrefour_pro_off1.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./import_csv_file.pl --csv_file /srv/off/imports/carrefour/carrefour.csv --user_id carrefour --comment "Import Carrefour" --source_id "carrefour" --source_name "Carrefour" --source_url "https://www.carrefour.fr" --manufacturer --org_id carrefour --define lc=fr 
+

--- a/scripts/import_carrefour_test.sh
+++ b/scripts/import_carrefour_test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-export PERL5LIB="../lib:${PERL5LIB}"
-./import_csv_file.pl --csv_file /home/off/scripts/carrefour_test.csv --user_id carrefour --comment "Import Carrefour" --source_id "carrefour" --source_name "Carrefour" --source_url "https://www.carrefour.fr" --images_dir /data/off/carrefour/images --manufacturer --test


### PR DESCRIPTION
Removing old scripts and adding new ones.

The main change is that instead of importing Carrefour data and photos directly to the public platform, they now go first to the pro platform.