### PR TITLE
Improve scanbot, store each product scans in scans.json files

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -58,6 +58,8 @@ requires 'Text::Fuzzy';
 requires 'Spreadsheet::CSV'; # deps: libspreadsheet-parseexcel-perl
 requires 'File::chmod::Recursive'; # deps: libfile-chmod-perl
 requires 'Devel::Size'; # deps: libdevel-size-perl
+requires 'JSON::Create';
+requires 'JSON::Parse';
 
 # Mojolicious/Minion
 requires 'Mojolicious::Lite';

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -34,6 +34,8 @@ BEGIN
 		&get_ascii_fileid
 		&store
 		&retrieve
+		&store_json
+		&retrieve_json
 		&unac_string_perl
 		&get_string_id_for_lang
 		&get_url_id_for_lang
@@ -50,6 +52,8 @@ use Encode::Punycode;
 use URI::Escape::XS;
 use Unicode::Normalize;
 use Log::Any qw($log);
+use JSON::Create qw(write_json);
+use JSON::Parse qw(read_json);
 
 # Text::Unaccent unac_string causes Apache core dumps with Apache 2.4 and mod_perl 2.0.9 on jessie
 
@@ -254,6 +258,31 @@ sub retrieve {
 	}
 	my $return = undef;
 	eval {$return = lock_retrieve($file);};
+
+	if ($@ ne '')
+	{
+		require Carp;
+		Carp::carp("cannot retrieve $file : $@");
+ 	}
+
+	return $return;
+}
+
+sub store_json {
+	my $file = shift @_;
+	my $ref = shift @_;
+
+	return write_json ($file, $ref);
+}
+
+sub retrieve_json {
+	my $file = shift @_;
+	# If the file does not exist, return undef.
+	if (! -e $file) {
+		return;
+	}
+	my $return = undef;
+	eval {$return = read_json($file);};
 
 	if ($@ ne '')
 	{

--- a/scripts/scanbot.pl
+++ b/scripts/scanbot.pl
@@ -56,11 +56,13 @@ use Getopt::Long;
 my $year;
 my $update_popularity;
 my $update_scans;
+my $add_countries;
 
 GetOptions (
 	'year=s' => \$year,
 	'update-popularity' => \$update_popularity,
 	'update-scans' => \$update_scans,
+	'add-countries' => \$add_countries,
 );
 
 if ((not defined $year) or not ((defined $update_popularity) or (defined $update_scans))) {
@@ -69,7 +71,7 @@ scanbot.pl processes nginx log files that have been filtered to keep only the OF
 
 Usage:
 
-scanbot.pl --year 2020 --update-popularity --update-scans < scans_log
+scanbot.pl --year 2020 --update-popularity --update-scans --add-countries < scans_log
 
 Options:
 	--update-popularity	Update the popularity_tags facet for each scanned products.
@@ -394,7 +396,7 @@ foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $c
 
 					# Do not add countries for products with a code beginning by 2
 					# (codes can be reused by different companies in different countries)
-					if (($code !~ /^(02|2)/) and (not exists $existing{$country})) {
+					if (($add_countries) and ($code !~ /^(02|2)/) and (not exists $existing{$country})) {
 						print "- adding $country to $product_ref->{countries}\n";
 						$product_ref->{countries} .= ", $country";
 						$bot .= "+$country ";

--- a/scripts/scanbot.pl
+++ b/scripts/scanbot.pl
@@ -43,18 +43,48 @@ use ProductOpener::Food qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Images qw/:all/;
 use ProductOpener::Data qw/:all/;
+use ProductOpener::GeoIP;
+
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;
 use Storable qw/dclone/;
 use Encode;
 use JSON::PP;
+use Getopt::Long;
 
-use ProductOpener::GeoIP;
+my $year;
+my $update_popularity;
+my $update_scans;
 
-my $year = $ARGV[0];
+GetOptions (
+	'year=s' => \$year,
+	'update-popularity' => \$update_popularity,
+	'update-scans' => \$update_scans,
+);
 
-defined $year or die("Need to pass year 2019 or 2020 etc. as first argument.");
+if ((not defined $year) or not ((defined $update_popularity) or (defined $update_scans))) {
+	print STDERR <<USAGE
+scanbot.pl processes nginx log files that have been filtered to keep only the OFF apps scans for a particular year.
+
+Usage:
+
+scanbot.pl --year 2020 --update-popularity --update-scans < scans_log
+
+Options:
+	--update-popularity	Update the popularity_tags facet for each scanned products.
+	--update-scans		Update the scans.sto file for each scanned product.
+	
+Products that are scanned but do not exist on OFF are not created,
+but they are taken into account to compute some values of the popularity facets (e.g. top-95-percent-scans).
+
+The --year parameter and at least one of --update-popularity or --update-scans is required.
+
+USAGE
+;
+	exit();
+}
+
 
 print STDERR "Running scanbot for year $year\n";
 
@@ -63,6 +93,10 @@ my %codes = ();
 my $j = 0;    # API calls (or scans if logs have been filtered to keep only scans)
 
 # 139.167.246.115 - - [02/Jan/2019:17:46:57 +0100] "GET /api/v0/product/123.json?f
+
+print STDERR "Loading scan logs\n";
+
+my %ips = ();
 
 while (<STDIN>)
 {
@@ -85,8 +119,16 @@ while (<STDIN>)
 
 		$codes{$code}{n}++;
 		$codes{$code}{ips}{$ip}++;
+		
+		$ips{$ip}++;
+		
+		($j % 1000) == 0 and print "Loading scan logs $j\n";
 	}
 }
+
+my $products = $j;
+
+print STDERR "Loaded scan logs: $j lines\n";
 
 my $changed_products = 0;
 my $added_countries = 0;
@@ -98,17 +140,107 @@ my $total_scans = 0;
 foreach my $code (keys %codes) {
 	$codes{$code}{u} = scalar keys %{$codes{$code}{ips}};
 	$total_scans += $codes{$code}{u};
+	
 }
+
+# Cache GeoIP results
+
+my %geoips = ();
+my $ips_n = scalar keys %ips;
+
+print STDERR "Computing GeoIPs for $ips_n ip addresses\n";
+
+$j = 0;
+
+foreach my $ip (keys %ips) {
+	$j++;
+	$geoips{$ip} = ProductOpener::GeoIP::get_country_code_for_ip($ip);
+	if (defined $geoips{$ip}) {
+		$geoips{$ip} = lc($geoips{$ip});
+	}
+	($j % 1000) == 0 and print "$j / $ips_n ips\n";
+}
+
+# Compute countries
+
+print STDERR "Computing countries for all products\n";
+
+my %countries_for_products = ();
+my %products_for_countries = ();
+
+my %countries_ranks_for_products = ();
+
+$j = 0;
+
+my $k = 0;
+my $i = 0;
+
+foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $codes{$a}{n} } keys %codes) {
+
+	next if $code eq "";
+	
+	$j++;
+	
+	$countries_for_products{$code} = { "world" => 0};
+
+	# too slow
+	# next if not defined retrieve_product($code);
+	my $product_id = $code;
+	my $path = product_path_from_id($product_id);
+	my $product_path = "$data_root/products/$path/product.sto";	
+	next if ! -e $product_path;
+	
+	$countries_ranks_for_products{$code} = {};
+
+	while (my ($ip, $v) = each %{$codes{$code}{ips}}) {
+	#foreach my $ip (keys %{$codes{$code}{ips}}) {
+		
+		$i++;
+		
+		my $country_code = $geoips{$ip};
+		
+		if ((defined $country_code) and ($country_code ne "")) {
+			$countries_for_products{$code}{$country_code}++;
+		}
+		
+		$countries_for_products{$code}{"world"}++;
+	}
+	
+	foreach my $country_code (keys %{$countries_for_products{$code}}) {
+		defined $products_for_countries{$country_code} or $products_for_countries{$country_code} = {};
+		$products_for_countries{$country_code}{$code} = $countries_for_products{$code}{$country_code};
+	}
+	
+	if (($j % 100) == 0) {
+		print "computing countries $j - $i ips \n";
+		$k = 0;
+		$i = 0;
+	}
+}
+
+print STDERR "Ranking products for all countries\n";
+
+foreach my $country_code (sort keys %products_for_countries) {
+	
+	my $rank = 0;
+	
+	foreach my $code (sort { $products_for_countries{$country_code}{$b} <=> $products_for_countries{$country_code}{$a} } keys %{$products_for_countries{$country_code}}) {
+	
+			$rank++;
+			$countries_ranks_for_products{$code}{$country_code} = $rank;
+	}
+}
+
+print STDERR "Ranked products for all countries\n";
+
+print STDERR "Process and update all products\n";
 
 # Log products scan counts
 
-open (my $PRODUCTS, ">:encoding(UTF-8)", "scanbot.products.csv") or die("Cannot create scanbot.products.csv: $!\n");
+open (my $PRODUCTS, ">:encoding(UTF-8)", "scanbot.$year.products.csv") or die("Cannot create scanbot.$year.products.csv: $!\n");
 open (my $LOG, ">:encoding(UTF-8)", "scanbot.log") or die("Cannot create scanbot.log: $!\n");
 
-
-my $rank             = 0;    # existing products scanned
 my $cumulative_scans = 0;    # cumulative total of scans so that we can compute which top products represent 95% of the scans
-my %rank_by_country  = ();
 
 my $i = 0;    # products scanned
 
@@ -123,18 +255,11 @@ foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $c
 
 	my $bot = '';
 
-	my %countries = ();
-	foreach my $ip (keys %{$codes{$code}{ips}}) {
-		my $countrycode = ProductOpener::GeoIP::get_country_code_for_ip($ip);
-		if ((defined $countrycode) and ($countrycode ne "")) {
-			$countrycode = lc($countrycode);
-			$countries{$countrycode}++;
-		}
-	}
-
 	print "$i\t$code\t$codes{$code}{n}\t" . $unique_scans_n . "\t";
 
 	$bot .= "product code $code scanned $scans_n times (from $unique_scans_n ips) - ";
+	
+	my %countries = %{$countries_for_products{$code}};	
 
 	foreach my $cc (sort { $countries{$b} <=> $countries{$a} } keys %countries) {
 		print "$cc:$countries{$cc} ";
@@ -155,185 +280,206 @@ foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $c
 	if ((defined $product_ref) and ($code ne '') and (defined $product_ref->{code}) and (defined $product_ref->{lc})) {
 
 		my $path = product_path($product_ref);
-
-		$found = "FOUND";
-
-		if ((defined $product_ref->{data_sources}) 
-			and ($product_ref->{data_sources} =~ /producer/i)) {
-			$source = "producers";
+		
+		# Update scans.sto
+		
+		if ($update_scans) {
+			
+			my $scans_ref = retrieve("$data_root/products/$path/scans.sto");
+			if (not defined $scans_ref) {
+				$scans_ref = {};
+			}
+			
+			$scans_ref->{$year} = {
+				scans_n => $scans_n + 0,
+				unique_scans_n => $unique_scans_n + 0,
+				unique_scans_n_by_country => $countries_for_products{$code},
+				unique_scans_rank_by_country => $countries_ranks_for_products{$code},
+			};
+			
+			store("$data_root/products/$path/scans.sto", $scans_ref);
 		}
+		
+		# Update popularity_tags + add countries
+		
+		if ($update_popularity) {
 
-		$lc = $product_ref->{lc};
+			$found = "FOUND";
 
-		$product_ref->{unique_scans_n} = $unique_scans_n + 0;
-		$product_ref->{scans_n} = $scans_n + 0;
+			if ((defined $product_ref->{data_sources}) 
+				and ($product_ref->{data_sources} =~ /producer/i)) {
+				$source = "producers";
+			}
 
-		$rank++;
+			$lc = $product_ref->{lc};
 
-		# compute the top products
+			$product_ref->{unique_scans_n} = $unique_scans_n + 0;
+			$product_ref->{scans_n} = $scans_n + 0;
 
-		if (defined $product_ref->{popularity_tags}) {
-			my @popularity_tags = @{$product_ref->{popularity_tags}};
-			$product_ref->{popularity_tags} = [];
-			foreach my $tag (@popularity_tags) {
-				if ($tag !~ /-$year/) {
-					push @{$product_ref->{popularity_tags}}, $tag;
+			my $rank = $countries_ranks_for_products{$code}{"world"};
+
+			# compute the top products
+
+			if (defined $product_ref->{popularity_tags}) {
+				my @popularity_tags = @{$product_ref->{popularity_tags}};
+				$product_ref->{popularity_tags} = [];
+				foreach my $tag (@popularity_tags) {
+					if ($tag !~ /-$year/) {
+						push @{$product_ref->{popularity_tags}}, $tag;
+					}
 				}
 			}
-		}
-		else {
-			$product_ref->{popularity_tags} = [];
-		}
-
-		foreach my $top (10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000) {
-
-			if ($rank <= $top) {
-				push @{$product_ref->{popularity_tags}}, "top-" . $top . "-scans-$year";
-			}
-		}
-
-		foreach my $min (5, 10) {
-			if ($unique_scans_n >= $min) {
-				push @{$product_ref->{popularity_tags}}, "at-least-" . $min . "-scans-$year";
-			}
-		}
-
-		$cumulative_scans += $codes{$code}{u};
-
-		foreach my $percent (90, 95) {
-			if ($cumulative_scans / $total_scans <= $percent / 100) {
-				push @{$product_ref->{popularity_tags}}, "top-" . $percent . "-percent-scans-$year";
-			}
 			else {
-				push @{$product_ref->{popularity_tags}}, "bottom-" . (100 - $percent) . "-percent-scans-$year";
+				$product_ref->{popularity_tags} = [];
 			}
-		}
-
-		# Add countries tags based on scans
-		my $field = 'countries';
-
-		my $current_countries = $product_ref->{$field};
-
-		my %existing = ();
-		foreach my $countryid (@{$product_ref->{countries_tags}}) {
-			$existing{$countryid} = 1;
-		}
-
-		$bot .= " current countries: $current_countries -- adding ";
-
-		my $top_country;
-
-		foreach my $cc (sort { $countries{$b} <=> $countries{$a} } keys %countries) {
-			print "$cc:$countries{$cc} ";
-
-			defined $rank_by_country{$cc} or $rank_by_country{$cc} = 0;
-			$rank_by_country{$cc}++;
 
 			foreach my $top (10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000) {
 
-				if ($rank_by_country{$cc} <= $top) {
-					push @{$product_ref->{popularity_tags}}, "top-" . $top . "-$cc-scans-$year";
+				if ($rank <= $top) {
+					push @{$product_ref->{popularity_tags}}, "top-" . $top . "-scans-$year";
 				}
 			}
 
-			if (not $top_country) {
-				push @{$product_ref->{popularity_tags}}, "top-country-" . $cc . "-scans-$year";
-				$top_country = $cc;
-			}
-
-			if ($countries{$cc} >= 5) {
-				my $country = canonicalize_taxonomy_tag('en', "countries", $cc);
-
-				# Do not add countries for products with a code beginning by 2
-				# (codes can be reused by different companies in different countries)
-				if (($code !~ /^(02|2)/) and (not exists $existing{$country})) {
-					print "- adding $country to $product_ref->{countries}\n";
-					$product_ref->{countries} .= ", $country";
-					$bot .= "+$country ";
-					$added_countries++;
-					$added_countries_list .= $country .',';
-				}
-
-				foreach my $min (5, 10) {
-					if ($countries{$cc} >= $min) {
-						push @{$product_ref->{popularity_tags}}, "at-least-" . $min . "-" . $cc . "-scans-$year";
-					}
-				}
-			}
-		}
-
-		if ($product_ref->{$field} ne $current_countries) {
-			$product_ref->{"countries_beforescanbot"} = $current_countries;
-			$changed_products++;
-
-			if ($product_ref->{$field} =~ /^, /) {
-				$product_ref->{$field} = $';
-			}
-
-			if (defined $taxonomy_fields{$field}) {
-				$product_ref->{$field . "_hierarchy" } = [ gen_tags_hierarchy_taxonomy($lc, $field, $product_ref->{$field}) ];
-				$product_ref->{$field . "_tags" } = [];
-				foreach my $tag (@{$product_ref->{$field . "_hierarchy" }}) {
-					push @{$product_ref->{$field . "_tags" }}, get_taxonomyid($lc, $tag);
+			foreach my $min (5, 10) {
+				if ($unique_scans_n >= $min) {
+					push @{$product_ref->{popularity_tags}}, "at-least-" . $min . "-scans-$year";
 				}
 			}
 
-			if (defined $hierarchy_fields{$field}) {
-				$product_ref->{$field . "_hierarchy" } = [ gen_tags_hierarchy($field, $product_ref->{$field}) ];
-				$product_ref->{$field . "_tags" } = [];
-				foreach my $tag (@{$product_ref->{$field . "_hierarchy" }}) {
-					if (get_fileid($tag) ne '') {
-						push @{$product_ref->{$field . "_tags" }}, get_fileid($tag);
-					}
-				}
-			}
+			$cumulative_scans += $codes{$code}{u};
 
-			my $comment = $bot;
-
-			if (0) {
-				# notify slack
-				#  payload={"text": "A very important thing has occurred! <https://alert-system.com/alerts/1234|Click here> for details!"}
-
-				# curl -X POST --data-urlencode 'payload={"channel": "#general", "username": "webhookbot", "text": "This is posted to #general and comes from a bot named webhookbot.", "icon_emoji": ":ghost:"}' https://openfoodfacts.slack.com/services/hooks/incoming-webhook?token=jMDE8Fzkz9qD7uC9Lq04fbZH
-
-				# my $data =  encode_json(\%response);
-
-				$bot .= " -- <https://world.openfoodfacts.org/product/$code>";
-
-				print "notifying slack: $bot\n";
-
-				require LWP::UserAgent;
-
-				my $ua = LWP::UserAgent->new;
-
-				my $server_endpoint = "https://openfoodfacts.slack.com/services/hooks/incoming-webhook?token=jMDE8Fzkz9qD7uC9Lq04fbZH";
-
-				# set custom HTTP request header fields
-				my $req = HTTP::Request->new(POST => $server_endpoint);
-				$req->header('content-type' => 'application/json');
-
-				# add POST data to HTTP request body
-				my $post_data = '{"channel": "#bots-alerts", "username": "scanbot", "text": "' . $bot . '", "icon_emoji": ":ghost:" }';
-				$req->content($post_data);
-
-				my $resp = $ua->request($req);
-				if ($resp->is_success) {
-					my $message = $resp->decoded_content;
-					print "Received reply: $message\n";
+			foreach my $percent (75, 80, 85, 90) {
+				if ($cumulative_scans / $total_scans <= $percent / 100) {
+					push @{$product_ref->{popularity_tags}}, "top-" . $percent . "-percent-scans-$year";
 				}
 				else {
-					print "HTTP POST error code: ", $resp->code, "\n";
-					print "HTTP POST error message: ", $resp->message, "\n";
+					push @{$product_ref->{popularity_tags}}, "bottom-" . (100 - $percent) . "-percent-scans-$year";
 				}
 			}
 
-			$User_id = 'scanbot';
-			store_product($product_ref, $comment);
-		}
-		else {
-			print "updating scan count for $code\n";
-			store("$data_root/products/$path/product.sto", $product_ref);
-			get_products_collection()->replace_one({"_id" => $product_ref->{_id}}, $product_ref, { upsert => 1 });
+			# Add countries tags based on scans
+			my $field = 'countries';
+
+			my $current_countries = $product_ref->{$field};
+
+			my %existing = ();
+			foreach my $countryid (@{$product_ref->{countries_tags}}) {
+				$existing{$countryid} = 1;
+			}
+
+			$bot .= " current countries: $current_countries -- adding ";
+
+			my $top_country;
+
+			foreach my $cc (sort { $countries{$b} <=> $countries{$a} } keys %countries) {
+				print "$cc:$countries{$cc} ";
+
+				foreach my $top (10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000) {
+
+					if ($countries_ranks_for_products{$code}{$cc} <= $top) {
+						push @{$product_ref->{popularity_tags}}, "top-" . $top . "-$cc-scans-$year";
+					}
+				}
+
+				if (not $top_country) {
+					push @{$product_ref->{popularity_tags}}, "top-country-" . $cc . "-scans-$year";
+					$top_country = $cc;
+				}
+
+				if ($countries{$cc} >= 5) {
+					my $country = canonicalize_taxonomy_tag('en', "countries", $cc);
+
+					# Do not add countries for products with a code beginning by 2
+					# (codes can be reused by different companies in different countries)
+					if (($code !~ /^(02|2)/) and (not exists $existing{$country})) {
+						print "- adding $country to $product_ref->{countries}\n";
+						$product_ref->{countries} .= ", $country";
+						$bot .= "+$country ";
+						$added_countries++;
+						$added_countries_list .= $country .',';
+					}
+
+					foreach my $min (5, 10) {
+						if ($countries{$cc} >= $min) {
+							push @{$product_ref->{popularity_tags}}, "at-least-" . $min . "-" . $cc . "-scans-$year";
+						}
+					}
+				}
+			}
+
+			if ($product_ref->{$field} ne $current_countries) {
+				$product_ref->{"countries_beforescanbot"} = $current_countries;
+				$changed_products++;
+
+				if ($product_ref->{$field} =~ /^, /) {
+					$product_ref->{$field} = $';
+				}
+
+				if (defined $taxonomy_fields{$field}) {
+					$product_ref->{$field . "_hierarchy" } = [ gen_tags_hierarchy_taxonomy($lc, $field, $product_ref->{$field}) ];
+					$product_ref->{$field . "_tags" } = [];
+					foreach my $tag (@{$product_ref->{$field . "_hierarchy" }}) {
+						push @{$product_ref->{$field . "_tags" }}, get_taxonomyid($lc, $tag);
+					}
+				}
+
+				if (defined $hierarchy_fields{$field}) {
+					$product_ref->{$field . "_hierarchy" } = [ gen_tags_hierarchy($field, $product_ref->{$field}) ];
+					$product_ref->{$field . "_tags" } = [];
+					foreach my $tag (@{$product_ref->{$field . "_hierarchy" }}) {
+						if (get_fileid($tag) ne '') {
+							push @{$product_ref->{$field . "_tags" }}, get_fileid($tag);
+						}
+					}
+				}
+
+				my $comment = $bot;
+
+				if (0) {
+					# notify slack
+					#  payload={"text": "A very important thing has occurred! <https://alert-system.com/alerts/1234|Click here> for details!"}
+
+					# curl -X POST --data-urlencode 'payload={"channel": "#general", "username": "webhookbot", "text": "This is posted to #general and comes from a bot named webhookbot.", "icon_emoji": ":ghost:"}' https://openfoodfacts.slack.com/services/hooks/incoming-webhook?token=jMDE8Fzkz9qD7uC9Lq04fbZH
+
+					# my $data =  encode_json(\%response);
+
+					$bot .= " -- <https://world.openfoodfacts.org/product/$code>";
+
+					print "notifying slack: $bot\n";
+
+					require LWP::UserAgent;
+
+					my $ua = LWP::UserAgent->new;
+
+					my $server_endpoint = "https://openfoodfacts.slack.com/services/hooks/incoming-webhook?token=jMDE8Fzkz9qD7uC9Lq04fbZH";
+
+					# set custom HTTP request header fields
+					my $req = HTTP::Request->new(POST => $server_endpoint);
+					$req->header('content-type' => 'application/json');
+
+					# add POST data to HTTP request body
+					my $post_data = '{"channel": "#bots-alerts", "username": "scanbot", "text": "' . $bot . '", "icon_emoji": ":ghost:" }';
+					$req->content($post_data);
+
+					my $resp = $ua->request($req);
+					if ($resp->is_success) {
+						my $message = $resp->decoded_content;
+						print "Received reply: $message\n";
+					}
+					else {
+						print "HTTP POST error code: ", $resp->code, "\n";
+						print "HTTP POST error message: ", $resp->message, "\n";
+					}
+				}
+
+				$User_id = 'scanbot';
+				store_product($product_ref, $comment);
+			}
+			else {
+				print "updating scan count for $code\n";
+				store("$data_root/products/$path/product.sto", $product_ref);
+				get_products_collection()->replace_one({"_id" => $product_ref->{_id}}, $product_ref, { upsert => 1 });
+			}
 		}
 	}
 

--- a/scripts/scanbot.pl
+++ b/scripts/scanbot.pl
@@ -73,7 +73,7 @@ scanbot.pl --year 2020 --update-popularity --update-scans < scans_log
 
 Options:
 	--update-popularity	Update the popularity_tags facet for each scanned products.
-	--update-scans		Update the scans.sto file for each scanned product.
+	--update-scans		Update the scans.json file for each scanned product.
 	
 Products that are scanned but do not exist on OFF are not created,
 but they are taken into account to compute some values of the popularity facets (e.g. top-95-percent-scans).
@@ -242,7 +242,7 @@ open (my $LOG, ">:encoding(UTF-8)", "scanbot.log") or die("Cannot create scanbot
 
 my $cumulative_scans = 0;    # cumulative total of scans so that we can compute which top products represent 95% of the scans
 
-my $i = 0;    # products scanned
+$i = 0;    # products scanned
 
 foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $codes{$a}{n} } keys %codes) {
 
@@ -281,11 +281,11 @@ foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $c
 
 		my $path = product_path($product_ref);
 		
-		# Update scans.sto
+		# Update scans.json
 		
 		if ($update_scans) {
 			
-			my $scans_ref = retrieve("$data_root/products/$path/scans.sto");
+			my $scans_ref = retrieve_json("$data_root/products/$path/scans.json");
 			if (not defined $scans_ref) {
 				$scans_ref = {};
 			}
@@ -297,7 +297,7 @@ foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $c
 				unique_scans_rank_by_country => $countries_ranks_for_products{$code},
 			};
 			
-			store("$data_root/products/$path/scans.sto", $scans_ref);
+			store_json("$data_root/products/$path/scans.json", $scans_ref);
 		}
 		
 		# Update popularity_tags + add countries
@@ -372,6 +372,9 @@ foreach my $code (sort { $codes{$b}{u} <=> $codes{$a}{u} || $codes{$b}{n} <=> $c
 			my $top_country;
 
 			foreach my $cc (sort { $countries{$b} <=> $countries{$a} } keys %countries) {
+				
+				next if $cc eq "world";
+				
 				print "$cc:$countries{$cc} ";
 
 				foreach my $top (10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000) {


### PR DESCRIPTION
We need scans data to be available for each product. While it would be cool to have data by year, months, days etc. (see #1501), it would be already be very useful to have it by year and by country.

This update to scanbot creates a new scans.sto file with aggregated scan data by year and country.

Example:
```

./sto_to_xml.pl /srv/off/products/800/227/001/4901/scans.sto 
/srv/off/products/800/227/001/4901/scans.sto$VAR1 = {
          '2020' => {
                      'unique_scans_n_by_country' => {
                                                       'world' => 4,
                                                       'fr' => 2,
                                                       'be' => 2
                                                     },
                      'unique_scans_n' => 4,
                      'scans_n' => 4,
                      'unique_scans_rank_by_country' => {
                                                          'fr' => 19,
                                                          'world' => 1,
                                                          'be' => 1
                                                        }
                    }
        };

```

It also changes the way we compute the top products per country, to make it more accurate. Currently the top lists of products per country are derived from the top list of product for the world, and if the product is sold in a country, it is added to the top list of each country. But that means that the most globally popular products always come first (especially for countries where we have few scans compared to others).

The new way really computes the top products for a country based on only the scans for that country.
