### PR TITLE
added German synonyms for yellow pepper and cumin

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -48006,7 +48006,7 @@ nl:paprika's
 <en:bell pepper
 en:yellow bell pepper, yellow pepper
 ca:pebrot groc
-de:gelbe Paprika
+de:gelbe Paprika, Paprika gelb
 es:pimiento amarillo, pimientos amarillos
 fi:keltainen paprika
 fr:poivron jaune, poivrons jaunes
@@ -52410,7 +52410,7 @@ en:cumin seeds, cumin
 ar:كمون
 ca:llavors de comí
 da:Spidskommen
-de:Kümmelkörnen, Kreuzkümmel, cumin
+de:Kümmelkörner, Kreuzkümmel, Cumin, Kumin
 es:comino, semillas de comino,Granos de comino
 fi:roomankumina, juustokumina, jeera, juustokuminansiemen
 fr:graines de cumin, cumin


### PR DESCRIPTION
**Description:**

I added German synonyms for 'yellow pepper' and 'cumin'. On-the-fly I fixed some misspellings in the other synonyms of these ingredients.
