### PR TITLE
Improvements for CodeOnline import

### DIFF
--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -110,29 +110,8 @@ if ($action eq 'process') {
 					$org_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));
 				}
 				
-				# List of GS1 GLNs
-				# Remove existing GLNs
-				my $glns_ref = retrieve("$data_root/orgs_glns.sto");
-				not defined $glns_ref and $glns_ref = {};
-				if (defined $org_ref->{list_of_gs1_gln}) {
-					foreach my $gln (split(/,| /, $org_ref->{list_of_gs1_gln})) {
-						$gln =~ s/\s//g;
-						if ($gln =~ /[0-9]+/) {
-							delete $glns_ref->{$gln};
-						}
-					}
-				}
-				# Add new GLNs
-				$org_ref->{list_of_gs1_gln} = remove_tags_and_quote(decode utf8=>param("list_of_gs1_gln"));
-				if (defined $org_ref->{list_of_gs1_gln}) {
-					foreach my $gln (split(/,| /, $org_ref->{list_of_gs1_gln})) {
-						$gln =~ s/\s//g;
-						if ($gln =~ /[0-9]+/) {
-							$glns_ref->{$gln} = $orgid;
-						}
-					}
-				}
-				store("$data_root/orgs_glns.sto", $glns_ref);
+				# Set the list of org GLNs
+				set_org_gs1_gln($org_ref, remove_tags_and_quote(decode utf8=>param("list_of_gs1_gln")));
 			}
 			
 			# Other fields

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -535,6 +535,8 @@ sub import_csv_file($) {
 						if (defined $imported_product_ref->{"sources_fields:org-gs1:partyName"}) {
 							$org_ref->{sources_field}{"org-gs1"}{"partyName"} = $imported_product_ref->{"sources_fields:org-gs1:partyName"};
 						}
+						set_org_gs1_gln($org_ref, $imported_product_ref->{"sources_fields:org-gs1:gln"});
+						$glns_ref = retrieve("$data_root/orgs_glns.sto");
 					}
 			
 					store_org($org_ref);

--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -865,6 +865,9 @@ sub clean_fields($) {
 				foreach my $brand (split(/,/, $product_ref->{brands})) {
 					$brand =~ s/^\s+//;
 					$brand =~ s/\s+$//;
+					# dashes/dots/spaces -> allow matching dashes/dot/spaces
+					# e.g. "bons.mayennais" matches "bons mayennais"
+					$brand =~ s/(\s|\.|-|_)/\(\\s|\\.|-|_\)/g;
 					$product_ref->{$field} =~ s/\s+$brand$//i;
 				}
 			}

--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -54,6 +54,7 @@ BEGIN
 		&add_user_to_org
 		&remove_user_from_org
 		&is_user_in_org_group
+		&set_org_gs1_gln
 
 		&org_name
 		&org_url
@@ -230,6 +231,57 @@ sub retrieve_or_create_org($$) {
 	}
 
 	return $org_ref;
+}
+
+
+=head2 set_org_gs1_gln ( $org_ref, $list_of_gs1_gln )
+
+If the org exists, the function returns the org object. Otherwise it creates a new org.
+
+=head3 Arguments
+
+=head4 $creator
+
+User id of the user creating the org (it can be the first user of the org,
+or an admin that creates an org by assigning an user to it).
+
+=head4 $org_id / $org_name
+
+Identifier for the org (without the "org-" prefix), or org name.
+
+=head3 Return values
+
+This function returns a hash ref for the org.
+
+=cut
+
+sub set_org_gs1_gln($$) {
+	
+	my $org_ref = shift;
+	my $list_of_gs1_gln = shift,
+	
+	# Remove existing GLNs
+	my $glns_ref = retrieve("$data_root/orgs_glns.sto");
+	not defined $glns_ref and $glns_ref = {};
+	if (defined $org_ref->{list_of_gs1_gln}) {
+		foreach my $gln (split(/,| /, $org_ref->{list_of_gs1_gln})) {
+			$gln =~ s/\s//g;
+			if ($gln =~ /[0-9]+/) {
+				delete $glns_ref->{$gln};
+			}
+		}
+	}
+	# Add new GLNs
+	$org_ref->{list_of_gs1_gln} = $list_of_gs1_gln;
+	if (defined $org_ref->{list_of_gs1_gln}) {
+		foreach my $gln (split(/,| /, $org_ref->{list_of_gs1_gln})) {
+			$gln =~ s/\s//g;
+			if ($gln =~ /[0-9]+/) {
+				$glns_ref->{$gln} = $org_ref->{org_id};
+			}
+		}
+	}
+	store("$data_root/orgs_glns.sto", $glns_ref);
 }
 
 

--- a/t/import.t
+++ b/t/import.t
@@ -188,6 +188,18 @@ foreach my $test_ref (@tests) {
 	{lc => "es", product_name_es => "Natillas de soja sabor vainilla", brands => "Carrefour, Carrefour bio"},
 ],
 
+# Brand with dots or other characters instead of spaces / dashes
+
+[
+	{lc => "fr", product_name_fr => "Petit brie bons.mayennais", brands => "Bons mayennais"},
+	{lc => "fr", product_name_fr => "Petit brie", brands => "Bons mayennais"},
+],
+
+[
+	{lc => "fr", product_name_fr => "Petit brie bonsxmayennais", brands => "Bons mayennais"},
+	{lc => "fr", product_name_fr => "Petit brie bonsxmayennais", brands => "Bons mayennais"},
+],
+
 	# combine serving_size, serving_size_value, serving_size_unit (e.g. US import)
 
 [


### PR DESCRIPTION
- remove "BONS.MAYENNAIS" from the product name when we have a "Bons Mayennais" brand. (done in a generic way)
- when an org is created through a GS1 import, we now assign the ownership of the GLN to it, so that we don't get multiple orgs for the same GLN because the import file contains multiple variations of the party name.