### PR TITLE
added adverse effect on children warning

### DIFF
--- a/taxonomies/labels.result.txt
+++ b/taxonomies/labels.result.txt
@@ -14979,6 +14979,9 @@ nl:Max Havelaar Frankrijk
 en:May contain eggshell, may contain egg shell
 es:Puede contener cáscara de huevo
 
+en:May have an adverse effect on activity and attention in children
+fr:Peut avoir des effets indésirables sur l'activité et l'attention chez les enfants, peut avoir des effets indésirables sur l'activité et l'attention des enfants, peuvent avoir des effets indésirables sur l'activité et l'attention chez les enfants, peuvent avoir des effets indésirables sur l'activité et l'attention des enfants
+
 en:Mediterranean International Wine and Spirit Challenge
 fr:Concours international de vin à Eilat
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -19078,3 +19078,8 @@ xx:Recicla amarillo
 
 es:Recicla azul
 xx:Recicla azul
+
+en:May have an adverse effect on activity and attention in children
+fr:Peut avoir des effets indésirables sur l'activité et l'attention chez les enfants, peut avoir des effets indésirables sur l'activité et l'attention des enfants, peuvent avoir des effets indésirables sur l'activité et l'attention chez les enfants, peuvent avoir des effets indésirables sur l'activité et l'attention des enfants
+
+


### PR DESCRIPTION
We have ~100 products with ingredients listing some food dyes that may have adverse effect on children. Adding it to the labels taxonomy will make ingredients analysis work for those products.

"eau, sucre, tartrazine. peut avoir des effets indésirables sur l’activité et l’attention chez les enfants"

e.g. https://fr.pro.openfoodfacts.dev/cgi/test_ingredients_analysis.pl?ingredients_text=eau%2C+sucre%2C+tartrazine.+peut+avoir+des+effets+ind%C3%A9sirables+sur+l%E2%80%99activit%C3%A9+et+l%E2%80%99attention+chez+les+enfants&type=add&action=process&submit=Envoyer