### PR TITLE
Added alcoholic beverage categories

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -1076,9 +1076,44 @@ pnns_group_2:en:Alcoholic beverages
 nova:en:3
 
 <en:Alcoholic beverages
+en:Premixed alcoholic beverages
+
+<en:Premixed alcoholic beverages
+en:Beer-based alcoholic beverages
+
+<en:Beer-based alcoholic beverages
+en:Shandy, Beer with lemonade
+fr:Panaché, Limonade et bière, Bières à la limonade
+it:Birra al limone
+agribalyse_food_code:en:5004
+ciqual_food_code:en:5004
+ciqual_food_name:en:Shandy (beer + lemonade)
+
+<en:Shandy
+en:Shandy with less than 1° of alcohol
+fr:Panaché à moins de 1° d'alcool
+agribalyse_food_code:en:5005
+ciqual_food_code:en:5005
+ciqual_food_name:en:Shandy, prepacked (<1° alcohol)
+ciqual_food_name:fr:Panaché préemballé (<1° alc.)
+
+<en:Premixed alcoholic beverages
+en:Rum-based alcoholic beverages
+
+<en:Premixed alcoholic beverages
+en:Vodka-based alcoholic beverages
+
+<en:Premixed alcoholic beverages
+en:Wine-based alcoholic beverages
+
+
+
+# description:en:A punch, Sangria traditionally consists of red wine and chopped fruit, often with other ingredients or spirits.
+
+<en:Wine-based alcoholic beverages
 en:Sangria
-es:Sangría
-fr:Sangria
+xx:Sangria
+wikipedia:en:https://en.wikipedia.org/wiki/Sangria
 agribalyse_food_code:en:1017
 ciqual_food_code:en:1017
 ciqual_food_name:en:Sangria
@@ -1111,22 +1146,6 @@ agribalyse_food_code:en:1026
 ciqual_food_code:en:1026
 ciqual_food_name:en:Sake or rice wine
 
-<en:Alcoholic beverages
-en:Shandy, Beer with lemonade
-fr:Panaché, Limonade et bière, Bières à la limonade
-it:Birra al limone
-agribalyse_food_code:en:5004
-ciqual_food_code:en:5004
-ciqual_food_name:en:Shandy (beer + lemonade)
-ciqual_food_name:fr:Panaché (limonade et bière)
-
-<en:Alcoholic beverages
-en:Shandy with less than 1° of alcohol
-fr:Panaché à moins de 1° d'alcool
-agribalyse_food_code:en:5005
-ciqual_food_code:en:5005
-ciqual_food_name:en:Shandy, prepacked (<1° alcohol)
-ciqual_food_name:fr:Panaché préemballé (<1° alc.)
 
 <en:Alcoholic beverages
 en:Beers

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -1088,6 +1088,7 @@ it:Birra al limone
 agribalyse_food_code:en:5004
 ciqual_food_code:en:5004
 ciqual_food_name:en:Shandy (beer + lemonade)
+ciqual_food_name:fr:Panaché (limonade et bière)
 
 <en:Shandy
 en:Shandy with less than 1° of alcohol


### PR DESCRIPTION
Purpose is to describe alcoholic beverages that have been mixed. These can be based on other liquors, like wine, beer, etc.

The idea is to have a place where we can pit the Bacardi Breezers, Smirnoff ice and other premixed (designer) drinks.

This category is not very well defined on Wikipedia, but is related to [Ready to Drink](https://en.wikipedia.org/wiki/Ready_to_drink), [Alcopop](https://en.wikipedia.org/wiki/Alcopop), [Wine cooler](https://en.wikipedia.org/wiki/Wine_cooler), etc.

There might be an overlap with flavoured drinks, like flavoured beers, vodka based beers, etc. 