### PR TITLE
Templatize emails for the producers platform

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -320,6 +320,9 @@ sub process_template($$$) {
 	$template_data_ref->{lc} = $lc;
 	$template_data_ref->{cc} = $cc;
 	$template_data_ref->{display_icon} = \&display_icon;
+	$template_data_ref->{time_t} = time();
+	$template_data_ref->{display_date_without_time} = \&display_date_without_time;
+	$template_data_ref->{display_date_ymd} = \&display_date_ymd;	
 	$template_data_ref->{display_date_tag} = \&display_date_tag;
 	$template_data_ref->{display_taxonomy_tag} = sub ($$) {
 		return display_taxonomy_tag($lc, $_[0], $_[1]);
@@ -1145,6 +1148,18 @@ sub display_date_without_time($) {
 	}
 
 }
+
+sub display_date_ymd() {
+	my $t = shift;
+	my $dt = _get_date($t);
+	if (defined $dt) {
+		return $dt->ymd;
+	}
+	else {
+		return;
+	}	
+}
+
 
 sub display_date_tag($) {
 

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -1,4 +1,4 @@
-﻿# This file is part of Product Opener.
+# This file is part of Product Opener.
 #
 # Product Opener
 # Copyright (C) 2011-2020 Association Open Food Facts
@@ -604,7 +604,7 @@ Nous disposons également d’une intégration automatisée via plusieurs systè
 
 Vous trouverez une présentation complète de la plateforme dans cette présentation :
 
-Guide plateforme - https://docs.google.com/presentation/d/e/2PACX-1vQiPrVqyVFxie7embgOIeCAWkfPALWOjfMOBQBvFBiNqxyUJUrgr_rt48WnWuvvJKo-UPtLx52xuV6M/pub?start=false&loop=false&delayms=3000&slide=id.g76aba96933_2_51
+Guide plateforme - https://docs.google.com/presentation/d/1222_dW0st0bPjwV0ViaeQqtqNp3ZozOpsqTs14yrL0Q/
 
 Je suis à votre disposition si vous avez des questions ou besoin d'aide sur ces divers points.
 
@@ -645,7 +645,10 @@ cc: $user_ref->{initial_cc}<br>
 
 <a href="https://world.pro.openfoodfacts.org/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-$user_ref->{requested_org_id}">Access the pro platform as organization $user_ref->{requested_org_id}</a><br>
 
+Il semble que mailto_body et mailto_subject tapent l'email de rattachement au lieu de l'email de relance. Il faudrait les 2 en vrai
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject&cc=producteurs\@openfoodfacts.org&body=$mailto_body">E-mail de relance</a>
+<br>
+<a href="mailto:$user_ref->{email}?subject=$mailto_subject&cc=producteurs\@openfoodfacts.org&body=$mailto_body">E-mail de rattachement</a>
 
 EMAIL
 ;
@@ -670,6 +673,7 @@ cc: $user_ref->{initial_cc}<br>
 
 <a href="https://world.pro.openfoodfacts.org/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-$user_ref->{requested_org_id}">Access the pro platform as organization $user_ref->{requested_org_id}</a><br>
 TODO: Add a specific mail telling that the account was linked
+# Curieusement l'email de rattachement est la ?
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject_org_request&cc=producteurs\@openfoodfacts.org&body=$mailto_body_org_request">E-mail de relance</a>
 
 EMAIL

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -651,6 +651,7 @@ Il semble que mailto_body et mailto_subject tapent l'email de rattachement au li
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject&cc=producteurs\@openfoodfacts.org&body=$mailto_body">E-mail de rattachement</a>
 <br>
 Here is the tabular data for the producer if they are not in the tracking spreadsheet yet.
+<br>Tracking spreadsheet: https://docs.google.com/spreadsheets/d/1Smx74TevmNlPyEqrcCtvN9uJIdUh-mC1cznLCQaV0V8/edit#gid=0
 <br>
 <table>
 <thead>
@@ -708,6 +709,7 @@ TODO: Add a specific mail telling that the account was linked
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject_org_request&cc=producteurs\@openfoodfacts.org&body=$mailto_body_org_request">E-mail de relance</a>
 <br>
 Here is the tabular data for the producer if they are not in the tracking spreadsheet yet.
+<br>Tracking spreadsheet: https://docs.google.com/spreadsheets/d/1Smx74TevmNlPyEqrcCtvN9uJIdUh-mC1cznLCQaV0V8/edit#gid=0
 <br>
 <table>
 <thead>

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -649,6 +649,37 @@ Il semble que mailto_body et mailto_subject tapent l'email de rattachement au li
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject&cc=producteurs\@openfoodfacts.org&body=$mailto_body">E-mail de relance</a>
 <br>
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject&cc=producteurs\@openfoodfacts.org&body=$mailto_body">E-mail de rattachement</a>
+<br>
+Here is the tabular data for the producer if they are not in the tracking spreadsheet yet.
+<br>
+<table>
+<thead>
+  <tr>
+    <th>Name</th>
+    <th>Status</th>
+    <th>Countries</th>
+    <th>OFF public user</th>
+    <th>-</th>
+    <th>Organization name</th>
+    <th>-</th>
+    <th>Converted</th>
+    <th>Email</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>$Org_id</td>
+    <td>Signed up to the platform on XX/XX/XXXX</td>
+    <td>$cc</td>
+    <td>$User{name}</td>
+    <td></td>
+    <td>$Org_id</td>
+    <td></td>
+    <td>Yes</td>
+    <td>$User{email}</td>
+  </tr>
+</tbody>
+</table>
 
 EMAIL
 ;
@@ -675,6 +706,37 @@ cc: $user_ref->{initial_cc}<br>
 TODO: Add a specific mail telling that the account was linked
 # Curieusement l'email de rattachement est la ?
 <a href="mailto:$user_ref->{email}?subject=$mailto_subject_org_request&cc=producteurs\@openfoodfacts.org&body=$mailto_body_org_request">E-mail de relance</a>
+<br>
+Here is the tabular data for the producer if they are not in the tracking spreadsheet yet.
+<br>
+<table>
+<thead>
+  <tr>
+    <th>Name</th>
+    <th>Status</th>
+    <th>Countries</th>
+    <th>OFF public user</th>
+    <th>-</th>
+    <th>Organization name</th>
+    <th>-</th>
+    <th>Converted</th>
+    <th>Email</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>$Org_id</td>
+    <td>Signed up to the platform on XX/XX/XXXX</td>
+    <td>$cc</td>
+    <td>$User{name}</td>
+    <td></td>
+    <td>$Org_id</td>
+    <td></td>
+    <td>Yes</td>
+    <td>$User{email}</td>
+  </tr>
+</tbody>
+</table>
 
 EMAIL
 ;

--- a/templates/emails/user_new_pro_account.tt.txt
+++ b/templates/emails/user_new_pro_account.tt.txt
@@ -1,0 +1,21 @@
+Subject: Aide pour importer vos produits sur Open Food Facts - [% user.org or user.requested_org %]
+
+Bonjour,
+
+J'ai remarqué que vous avez créé un compte sur la plate-forme producteur d'Open Food Facts  - https://fr.pro.openfoodfacts.org - mais que vous n'avez pas encore importé de produits.
+
+Cette plateforme totalement gratuite soutenue par Santé publique France vous permet d'importer vos produits dans Open Food Facts ainsi que les plus de 100 applications et services qui utilisent nos données.
+
+- Elle vous permet également de trouver des opportunités de reformulation pour améliorer le Nutri-Score de vos produits.
+- Il vous suffit d'importer tout tableau Excel dont vous disposez déjà, de vérifier et d’éventuellement ajuster la correspondance des colonnes pour importer l'ensemble de votre gamme.
+- Vous pouvez également glisser-déposer des images de vos produits (face avant, ingrédients, nutrition et éventuellement pack à plat, instruction de recyclage…)
+
+Nous disposons également d’une intégration automatisée via plusieurs systèmes de gestion de données.
+
+Vous trouverez une présentation complète de la plateforme dans cette présentation :
+
+Guide plateforme - https://docs.google.com/presentation/d/1222_dW0st0bPjwV0ViaeQqtqNp3ZozOpsqTs14yrL0Q/
+
+Je suis à votre disposition si vous avez des questions ou besoin d'aide sur ces divers points.
+
+Bien cordialement,

--- a/templates/emails/user_new_pro_account_admin_notification.tt.html
+++ b/templates/emails/user_new_pro_account_admin_notification.tt.html
@@ -1,0 +1,61 @@
+[% IF user.requested_org_id %]
+Subject: New pro account for existing org [% user.requested_org_id %] - [% user.userid %]
+[% ELSE %]
+Subject: New pro account for new org [% user.requested_org_id %] - [% user.userid %]
+[% END %]
+
+
+org_id: [% user.org_id or user.requested_org_id %]<br>
+org_name: [% user.org or user.requested_org %]<br>
+userid: [% user.userid %]<br>
+name: [% user.name %]<br>
+email: [% user.email %]<br>
+lc: [% user.initial_lc %]<br>
+cc: [% user.initial_cc %]<br>
+
+<a href="https://world.pro.openfoodfacts.org/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-[% user.requested_org_id %]">Access the pro platform as organization [% user.requested_org_id %]</a>
+<br>
+<br>
+<a href="mailto:[% user.email %]?subject=[% mail_subject_new_pro_account %]&cc=producteurs@openfoodfacts.org&body=[% mail_body_new_pro_account %]">E-mail de relance</a>
+<br>
+<br>
+
+[% IF user.requested_org_id %]
+<a href="mailto:[% user.email %]?subject=[% mail_subject_new_pro_account_org_request_validated %]&cc=producteurs@openfoodfacts.org&body=[% mail_body_new_pro_account_org_request_validated %]">E-mail de rattachement à l'organisation</a>
+<br>
+<br>
+[% END %]
+
+Here is the tabular data for the producer if they are not in the tracking spreadsheet yet.
+<br>
+<br>Tracking spreadsheet: https://docs.google.com/spreadsheets/d/1Smx74TevmNlPyEqrcCtvN9uJIdUh-mC1cznLCQaV0V8/edit#gid=0
+<br>
+<br>
+<table>
+<thead>
+  <tr>
+    <th>Name</th>
+    <th>Status</th>
+    <th>Countries</th>
+    <th>OFF public user</th>
+    <th>-</th>
+    <th>Organization name</th>
+    <th>-</th>
+    <th>Converted</th>
+    <th>Email</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>[% user.org_id or user.requested_org_id %]</td>
+    <td>Signed up to the platform on [% display_date_ymd(time_t) %]</td>
+    <td>$cc</td>
+    <td>[% user.name %]</td>
+    <td></td>
+    <td>[% user.org_id or user.requested_org_id %]</td>
+    <td></td>
+    <td>Yes</td>
+    <td>[% user.email %]</td>
+  </tr>
+</tbody>
+</table>

--- a/templates/emails/user_new_pro_account_org_request_validated.tt.txt
+++ b/templates/emails/user_new_pro_account_org_request_validated.tt.txt
@@ -1,0 +1,11 @@
+Subject: Vous avez été rattaché à l'organisation [% user.requested_org %]
+
+Bonjour,
+
+Nous venons de mettre à jour votre compte pour le rattacher à l'organisation [% user.requested_org %]. 
+
+Vous pouvez accéder à votre espace producteur depuis votre compte [% user.userid %] sur https://fr.pro.openfoodfacts.org
+
+Merci beaucoup pour votre démarche de transparence,
+
+Bien cordialement,


### PR DESCRIPTION
- added a new /templates/emails directory to store email templates (either in .txt or .html)
- email templates:

-- user_new_pro_account.tt.txt : mail template to email producers after a few days
-- user_new_pro_account_org_request_validated.tt.txt : mail template when we accept their request to join an org
-- user_new_pro_account_admin_notification.tt.html : HTML notification email sent to the producers platform admins, with 2 mailto: links that embed the first 2 emails

Fixes #5208 #5200 
Will help to do #5182


