### PR TITLE
new checkboxes to fix GS1 data issues

### DIFF
--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -106,7 +106,12 @@ if ($action eq 'process') {
 					$org_ref = create_org($User_id, $orgid);
 				}
 				
-				foreach my $field ("enable_manual_export_to_public_platform", "activate_automated_daily_export_to_public_platform", "do_not_import_codeonline") {
+				foreach my $field ("enable_manual_export_to_public_platform",
+					"activate_automated_daily_export_to_public_platform",
+					"do_not_import_codeonline",
+					"gs1_product_name_is_abbreviated",
+					"gs1_nutrients_are_unprepared",
+					) {
 					$org_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));
 				}
 				
@@ -187,7 +192,15 @@ if ($action eq 'display') {
 				{
 					field => "do_not_import_codeonline",
 					type => "checkbox",
-				},				
+				},
+				{
+					field => "gs1_product_name_is_abbreviated",
+					type => "checkbox",
+				},
+				{
+					field => "gs1_nutrients_are_unprepared",
+					type => "checkbox",
+				},	
 			]
 		};		
 	}

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5649,3 +5649,20 @@ msgstr "The Eco-Score was initially developped for France and it is being extend
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Eco-Score and more!"
 msgstr "Scan barcodes to get the Nutri-Score, the Eco-Score and more!"
+
+msgctxt "org_gs1_product_name_is_abbreviated"
+msgid "GS1 product names for this manufacturer are abbreviated."
+msgstr "GS1 product names for this manufacturer are abbreviated."
+
+msgctxt "org_gs1_nutrients_are_unprepared"
+msgid "GS1 prepared nutrients for this manufacturer are in fact for the product as sold."
+msgstr "GS1 prepared nutrients for this manufacturer are in fact for the product as sold."
+
+msgctxt "org_gs1_nutrients_are_unprepared_note"
+msgid "Check that the manufacturer does not make products that really have nutrients for the prepared product."
+msgstr "Check that the manufacturer does not make products that really have nutrients for the prepared product."
+
+msgctxt "org_gs1_product_name_is_abbreviated_description"
+msgid "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
+msgstr "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5667,3 +5667,19 @@ msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Eco-Score and more!"
 msgstr "Scan barcodes to get the Nutri-Score, the Eco-Score and more!"
 
+msgctxt "org_gs1_product_name_is_abbreviated"
+msgid "GS1 product names for this manufacturer are abbreviated."
+msgstr "GS1 product names for this manufacturer are abbreviated."
+
+msgctxt "org_gs1_nutrients_are_unprepared"
+msgid "GS1 prepared nutrients for this manufacturer are in fact for the product as sold."
+msgstr "GS1 prepared nutrients for this manufacturer are in fact for the product as sold."
+
+msgctxt "org_gs1_nutrients_are_unprepared_note"
+msgid "Check that the manufacturer does not make products that really have nutrients for the prepared product."
+msgstr "Check that the manufacturer does not make products that really have nutrients for the prepared product."
+
+msgctxt "org_gs1_product_name_is_abbreviated_description"
+msgid "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
+msgstr "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
+


### PR DESCRIPTION
We can't import GS1 data from producers as-is because it contains errors. This adds 2 checkboxes on the org edit form for admins to mark that an organization needs special processing of GS1 data:

- gs1_product_name_is_abbreviated : the product name field contains abbreviations (like the ones on receipts)
- gs1_nutrients_are_unprepared : the producer has entered nutrition data for the prepared product, but it's a product that is consumed as sold, without preparation

This just adds the checkboxes, the code to use them will come later.