### PR TITLE
Imports: do not overwrite product name with generic name

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4843,6 +4843,10 @@ sub search_and_display_products($$$$$) {
 		"code" => 1,
 		"product_name" => 1,
 		"product_name_$lc" => 1,
+		"generic_name" => 1,
+		"generic_name_$lc" => 1,
+		"abbreviated_product_name" => 1,
+		"abbreviated_product_name_$lc" => 1,		
 		"brands" => 1,
 		"images" => 1,
 		"quantity" => 1

--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -833,14 +833,6 @@ sub clean_fields($) {
 
 	$log->debug("clean_fields - start", {  }) if $log->is_debug();
 
-	foreach my $field (keys %{$product_ref}) {
-
-		# If we have generic_name but not product_name, also assign generic_name to product_name
-		if (($field =~ /^generic_name_(\w\w)$/) and (not defined $product_ref->{"product_name_" . $1})) {
-			$product_ref->{"product_name_" . $1} = $product_ref->{"generic_name_" . $1};
-		}
-	}
-
 	# Quantity in the product name?
 	assign_quantity_from_field($product_ref, "product_name_" . $product_ref->{lc});
 	

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -2177,6 +2177,12 @@ sub product_name_brand($) {
 	elsif ((defined $ref->{product_name}) and ($ref->{product_name} ne '')) {
 		$full_name = $ref->{product_name};
 	}
+	elsif ((defined $ref->{"generic_name_$lc"}) and ($ref->{"generic_name_$lc"} ne '')) {
+		$full_name = $ref->{"generic_name_$lc"};
+	}
+	elsif ((defined $ref->{generic_name}) and ($ref->{generic_name} ne '')) {
+		$full_name = $ref->{generic_name};
+	}	
 	elsif ((defined $ref->{"abbreviated_product_name_$lc"}) and ($ref->{"abbreviated_product_name_$lc"} ne '')) {
 		$full_name = $ref->{"abbreviated_product_name_$lc"};
 	}

--- a/t/import.t
+++ b/t/import.t
@@ -233,8 +233,7 @@ foreach my $test_ref (@tests) {
 	# Test unspecified values
 [
 	{ lc => "en", generic_name_en => "unspecified", labels => "non-specified", origins => "unknown", warning_en => "not specified" },
-	{ lc => "en", product_name_en => '-', generic_name_en => "-", labels => "", origins => "", warning_en => "-" },
-	# product_name_en is missing, so it is copied from generic_name_en
+	{ lc => "en", generic_name_en => "-", labels => "", origins => "", warning_en => "-" },
 ],
 
 [


### PR DESCRIPTION
For imports, when we had a generic name but not a product name, we used to copy the generic name to the product name (because in most cases the generic name was also the product name).

But with the current GS1 imports, it's very frequent that the product name is in fact an abbreviated product name, so I made an organization checkbox to assign the GS1 product name to the abbreviated product name. That means we don't have a product name for many products.

So this:
- remove the automatic generic name copy to product name when it does not exist
- changes the display of products to display the generic name when we don't have a product name