### PR TITLE
very small start of a refactoring for handling links of texts translations

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -91,6 +91,7 @@ BEGIN
 		&count_products
 		&add_params_to_query
 		
+		&url_for_text
 		&process_template
 
 		@search_series
@@ -297,7 +298,43 @@ $world_subdomain = format_subdomain('world');
 
 my $user_preferences;	# enables using user preferences to show a product summary and to rank and filter results
 
+
 =head1 FUNCTIONS
+
+
+=head2 url_for_text ( $textid )
+
+Return the localized URL for a text. (e.g. "data" points to /data in English and /donnees in French)
+
+=cut
+
+# Note: the following urls are currently hardcoded, but the idea is to build the mapping table
+# at startup from the available translated texts in the repository. (TODO)
+my %urls_for_texts = (
+	"ecoscore" => {
+		en => "eco-score-the-environmental-impact-of-food-products",
+		fr => "eco-score-l-impact-environnemental-des-produits-alimentaires",
+	},
+);
+
+sub url_for_text($) {
+	
+	my $textid = shift;
+	
+	if (not defined $urls_for_texts{$textid}) {
+		return "/" . $textid;
+	}
+	elsif (defined $urls_for_texts{$textid}{$lc}) {
+		return "/" . $urls_for_texts{$textid}{$lc};
+	}
+	elsif ($urls_for_texts{$textid}{en}) {
+		return "/" . $urls_for_texts{$textid}{en};
+	}
+	else {
+		return "/" . $textid;
+	}
+}
+
 
 =head2 process_template ( $template_filename , $template_data_ref , $result_content_ref )
 
@@ -324,6 +361,7 @@ sub process_template($$$) {
 	$template_data_ref->{display_date_without_time} = \&display_date_without_time;
 	$template_data_ref->{display_date_ymd} = \&display_date_ymd;	
 	$template_data_ref->{display_date_tag} = \&display_date_tag;
+	$template_data_ref->{url_for_text} = \&url_for_text;
 	$template_data_ref->{display_taxonomy_tag} = sub ($$) {
 		return display_taxonomy_tag($lc, $_[0], $_[1]);
 	};

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -313,7 +313,12 @@ Return the localized URL for a text. (e.g. "data" points to /data in English and
 my %urls_for_texts = (
 	"ecoscore" => {
 		en => "eco-score-the-environmental-impact-of-food-products",
+		de => "eco-score-die-umweltauswirkungen-von-lebensmitteln",
+		es => "eco-score-el-impacto-medioambiental-de-los-productos-alimenticios",
 		fr => "eco-score-l-impact-environnemental-des-produits-alimentaires",
+		it => "eco-score-impatto-ambientale-dei-prodotti-alimentari",
+		nl => "eco-score-de-milieu-impact-van-voedingsproducten",
+		pt => "eco-score-o-impacto-ambiental-dos-produtos-alimentares",
 	},
 );
 

--- a/templates/display_product.tt.html
+++ b/templates/display_product.tt.html
@@ -227,7 +227,7 @@
 
 [% IF ecoscore_grade %]
 	<h4>Eco-score
-		<a href="/ecoscore" title="[% lang('ecoscore_information') %]">[% display_icon('info') %]</a>
+		<a href="[% url_for_text("ecoscore") %]" title="[% lang('ecoscore_information') %]">[% display_icon('info') %]</a>
 	</h4>
 	
 	<p>[% lang("ecoscore_description") %]</p>
@@ -238,7 +238,7 @@
 		<p class="note">→ [% lang("ecoscore_warning_international") %]</p>
 	[% END %]
 	
-	<a href="/ecoscore" title="[% lang('ecoscore_information') %]">
+	<a href="[% url_for_text("ecoscore") %]" title="[% lang('ecoscore_information') %]">
 		<img src="/images/icons/ecoscore-[% ecoscore_grade_lc %].svg" alt="Eco-score [% ecoscore_grade %]" style="margin-bottom:1rem;max-width:100%">
 	</a>
 	<br>


### PR DESCRIPTION
This is to solve the issue of texts that have different urls in different languages, and how we can link to them easily. (see #1818)

This is just a start. It solves #5260, but with an hardcoded mapping structure.

The goal is to generate the mapping structure at startup, using the available translations in the texts directory (we could create a new one, and move texts gradually).
