### PR TITLE
Detect allergens using the ingredients taxonomy and ingredients analysis

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -5216,10 +5216,11 @@ sub replace_allergen_between_separators($$$$$$) {
 }
 
 
-
 =head2 detect_allergens_from_ingredients ( $product_ref )
 
-Detects allergens from the ingredients extracted from the ingredients text.
+Detects allergens from the ingredients extracted from the ingredients text,
+using the "allergens:en" property associated to some ingredients in the
+ingredients taxonomy.
 
 This functions needs to be run after the $product_ref->{ingredients} array
 is populated from the ingredients text.
@@ -5261,6 +5262,29 @@ sub detect_allergens_from_ingredients($) {
 	}	
 }
 
+
+=head2 detect_allergens_from_text ( $product_ref )
+
+This function:
+- combines all the ways we have to detect allergens in order to populate
+the allergens_tags and traces_tags fields.
+- creates the ingredients_text_with_allergens_[lc] fields with added
+HTML <span class="allergen"> tags
+
+Allergens are recognized in the following ways:
+
+1. using the list of ingredients that have been recognized through
+ingredients analysis, by looking at the allergens:en property in the
+ingredients taxonomy.
+This is done with the function detect_allergens_from_ingredients()
+
+2. when entered in ALL CAPS, or between underscores
+
+3. when matching exact entries o synonyms of the allergens taxonomy
+
+Allergens detected using 2. or 3. are marked with <span class="allergen">
+
+=cut
 
 sub detect_allergens_from_text($) {
 
@@ -5318,9 +5342,6 @@ sub detect_allergens_from_text($) {
 			$text =~ s/\&quot;/"/g;
 
 			# allergens between underscores
-
-			#print STDERR "current text 1: $text\n";
-
 			# _allergen_ + __allergen__ + ___allergen___
 
 			$text =~ s/\b___([^,;_\(\)\[\]]+?)___\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
@@ -5337,9 +5358,6 @@ sub detect_allergens_from_text($) {
 			}
 
 			# allergens between separators
-
-			# print STDERR "current text 2: $text\n";
-			# print STDERR "separators\n";
 
 			# positive look ahead for the separators so that we can properly match the next word
 			# match at least 3 characters so that we don't match the separator

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -5216,6 +5216,20 @@ sub replace_allergen_between_separators($$$$$$) {
 }
 
 
+
+=head2 detect_allergens_from_ingredients ( $product_ref )
+
+Detects allergens from the ingredients extracted from the ingredients text.
+
+This functions needs to be run after the $product_ref->{ingredients} array
+is populated from the ingredients text.
+
+It is called by detect_allergens_from_text().
+Allergens are added to $product_ref->{"allergens_from_ingredients"} which
+is then used by detect_allergens_from_text() to populate the allergens_tags field.
+
+=cut
+
 sub detect_allergens_from_ingredients($) {
 
 	my $product_ref = shift;

--- a/t/allergens_tags.t
+++ b/t/allergens_tags.t
@@ -18,9 +18,9 @@ use ProductOpener::Products qw/:all/;
 my @tests = (
 	[ { lc => "fr", ingredients_text => "lait demi-écrémé 67%" }, [ "en:milk", ] ],
 	[ { lc => "fr", ingredients_text => "Eau, gluten et dérivés" }, [ "en:gluten", ] ],
-	[ { lc => "fr", ingredients_text => "NOIX DE SAINT-JACQUES MARINÉES: blabla, do not match the title of the product" }, [ ] ],
+	[ { lc => "fr", ingredients_text => "NOIX DE SAINT-JACQUES MARINÉES: blabla, do not match the title of the product" }, [ "en:molluscs"] ],
 	[ { lc => "fr", ingredients_text => "NOIX DE SAINT-JACQUES sans corail (8.6 %), ingredients in lower case too, match the ingredient" }, [ "en:molluscs", ] ],
-	[ { lc => "fr", ingredients_text => "Noix de Saint-Jacques marinées (8.6 %), ingredients in lower case too, no match" }, [ ] ],
+	[ { lc => "fr", ingredients_text => "Noix de Saint-Jacques marinées (8.6 %), ingredients in lower case too, no match" }, [ "en:molluscs" ] ],
 	[ { lc => "fr", ingredients_text => "GRAINES DE SESAME grillées, ingredients in lower case too" }, [ "en:sesame-seeds", ] ],
 	[ { lc => "fr", ingredients_text => "FRUITS A COQUE 10%, ingredients in lower case too" }, [ "en:nuts", ] ],
 	[ { lc => "fr", ingredients_text => "FRUITS A COQUE - Something else, ingredients in lower case too" }, [ "en:nuts", ] ],
@@ -53,7 +53,7 @@ my @tests = (
 
 	[ { lc => "fr", ingredients_text => "Sucre. Fabriqué dans un atelier qui manipule du lait, de la moutarde et du céleri." }, [], ["en:celery", "en:milk", "en:mustard"] ],
 
-	[ { lc => "fr", ingredients_text => "amidon de blé. traces de _céleri_." }, [], ["en:celery"] ],
+	[ { lc => "fr", ingredients_text => "amidon de blé. traces de _céleri_." }, ["en:gluten"], ["en:celery"] ],
 	[ { lc => "fr", ingredients_text => "Traces éventuelles de : épeautre." }, [], ["en:gluten"] ],
 
 	[ { lc => "fr", ingredients_text => "Contient du _lait_." }, ["en:milk"], [] ],
@@ -69,7 +69,7 @@ my @tests = (
 	[ { lc => "fr", ingredients_text => "sucre, lécithine de soja, sel. Allergènes : voir les ingrédients en gras. Traces éventuelles de gluten et de fruits à coque."}, ['en:soybeans'], ['en:gluten', 'en:nuts' ] ],
 	
 	# Use the ingredients taxonomy to add allergens
-	[ { lc => "fr", ingredients_text => "semoule de blé dur, pousses de soja" }, [], ["en:gluten"] ],	
+	[ { lc => "fr", ingredients_text => "semoule de blé dur, pousses de soja" }, ["en:gluten"], [] ],	
 
 );
 

--- a/t/allergens_tags.t
+++ b/t/allergens_tags.t
@@ -67,6 +67,9 @@ my @tests = (
 	[ { lc => "de", ingredients_text => "Kann spuren von Erdnüssen" }, [], ["en:peanuts"] ],
 	[ { lc => "en", ingredients_text => "salt, egg, spice. allergen advice: for allergens including cereals containing gluten, see ingredients in bold. May contain traces of nuts."}, ['en:eggs'], ['en:nuts'] ],
 	[ { lc => "fr", ingredients_text => "sucre, lécithine de soja, sel. Allergènes : voir les ingrédients en gras. Traces éventuelles de gluten et de fruits à coque."}, ['en:soybeans'], ['en:gluten', 'en:nuts' ] ],
+	
+	# Use the ingredients taxonomy to add allergens
+	[ { lc => "fr", ingredients_text => "semoule de blé dur, pousses de soja" }, [], ["en:gluten"] ],	
 
 );
 
@@ -79,6 +82,7 @@ foreach my $test_ref (@tests) {
 	$product_ref->{"ingredients_text_" . $product_ref->{lc}} = $product_ref->{ingredients_text};
 
 	compute_languages($product_ref);
+	extract_ingredients_from_text($product_ref);
 	detect_allergens_from_text($product_ref);
 
 	is_deeply ($product_ref->{allergens_tags},

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -14,10 +14,14 @@
       "en:e120"
    ],
    "allergens" : "",
-   "allergens_from_ingredients" : "",
+   "allergens_from_ingredients" : "en:gluten",
    "allergens_from_user" : "(en) ",
-   "allergens_hierarchy" : [],
-   "allergens_tags" : [],
+   "allergens_hierarchy" : [
+      "en:gluten"
+   ],
+   "allergens_tags" : [
+      "en:gluten"
+   ],
    "amino_acids_tags" : [],
    "attribute_groups_en" : [
       {
@@ -75,13 +79,13 @@
       {
          "attributes" : [
             {
-               "debug" : "11 ingredients (0 unknown)",
-               "icon_url" : "https://server_domain/images/attributes/no-gluten.svg",
+               "debug" : "en:gluten in allergens",
+               "icon_url" : "https://server_domain/images/attributes/contains-gluten.svg",
                "id" : "allergens_no_gluten",
-               "match" : 100,
+               "match" : 0,
                "name" : "Gluten",
                "status" : "known",
-               "title" : "Does not contain: Gluten"
+               "title" : "Contains: Gluten"
             },
             {
                "debug" : "11 ingredients (0 unknown)",


### PR DESCRIPTION
We currently detect allergens using the allergens taxonomy. This adds detection through the ingredients taxonomy, so that we can catch more ingredients containing allergens. e.g. in the allergens taxonomy, we have some common ingredients containing gluten listed as synonyms of gluten, but we don't have all possible ingredients containing gluten (e.g. "durum wheat semolina").

On the other hand, thanks to the ingredients taxonomy, we know that "durum wheat semolina" is a child of "wheat", and that "wheat" has the "allergens:en: en:gluten" property.

Main issue: #3297

Will also fix: #5250