### PR TITLE
improve milk recognition, fix nutriscore issue

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -424,22 +424,20 @@ XML
 ;
 
 
-# Nutriscore: milk and drinkable yogurts are not considered beverages
-# list only categories that are under en:beverages
+# Nutriscore: categories that are never considered beverages for Nutri-Score computation
 $options{categories_not_considered_as_beverages_for_nutriscore} = [qw(
 	en:plant-milks
 	en:milks
-	en:dairy-drinks
 	en:meal-replacement
 	en:dairy-drinks-substitutes
 	en:chocolate-powders
 	en:soups
-	en:coffees
 	en:tea-bags
 	en:herbal-teas
 )];
 
-# exceptions
+# categories that are considered as beverages
+# unless they have 80% milk (which we will determine through ingredients analysis)
 $options{categories_considered_as_beverages_for_nutriscore} = [qw(
 	en:tea-based-beverages
 	en:iced-teas
@@ -457,7 +455,6 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:coffees
 	en:food-additives
 	en:herbal-teas
-	en:honeys
 	en:meal-replacements
 	en:salts
 	en:spices
@@ -465,7 +462,6 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:vinegars
 	en:pet-food
 	en:non-food-products
-
 )];
 
 # exceptions

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -4281,18 +4281,11 @@ sub is_beverage_for_nutrition_score($) {
 		}
 		
 		# dairy drinks need to have at least 80% of milk to be considered as food instead of beverages
-		if (has_tag($product_ref, "categories", "en:dairy-drinks")) {
+		my $milk_percent = estimate_milk_percent_from_ingredients($product_ref); 
 			
-			my $milk_percent = estimate_milk_percent_from_ingredients($product_ref); 
-			
-			if ($milk_percent < 80) {
-				$log->debug("in en:dairy-drinks category but milk < 80%", { milk_percent => $milk_percent }) if $log->is_debug();
-				$is_beverage = 1;
-			}
-			else {
-				$log->debug("in en:dairy-drinks category but milk >= 80%", { milk_percent => $milk_percent }) if $log->is_debug();
-				$is_beverage = 0;
-			}
+		if ($milk_percent >= 80) {
+			$log->debug("milk >= 80%", { milk_percent => $milk_percent }) if $log->is_debug();
+			$is_beverage = 0;
 		}
 	}
 

--- a/t/expected_test_results/nutriscore/beverage-with-80-percent-milk.json
+++ b/t/expected_test_results/nutriscore/beverage-with-80-percent-milk.json
@@ -1,0 +1,143 @@
+{
+   "categories" : "beverages",
+   "categories_hierarchy" : [
+      "en:beverages"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "categories_tags" : [
+      "en:beverages"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:fresh-milk",
+         "percent" : "80",
+         "percent_estimate" : "80",
+         "percent_max" : "80",
+         "percent_min" : "80",
+         "text" : "Fresh milk",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "percent_estimate" : 20,
+         "percent_max" : 20,
+         "percent_min" : 20,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:fresh-milk",
+      "en:dairy",
+      "en:milk",
+      "en:sugar"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:fresh-milk",
+      "en:sugar"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:fresh-milk",
+      "en:dairy",
+      "en:milk",
+      "en:sugar"
+   ],
+   "ingredients_text" : "Fresh milk 80%, sugar",
+   "known_ingredients_n" : 4,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 10,
+      "fiber_100g" : 2,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nutrition-score-fr" : 19,
+      "nutrition-score-fr_100g" : 19,
+      "proteins_100g" : 5,
+      "saturated-fat_100g" : 5,
+      "sodium_100g" : 0,
+      "sugars_100g" : 10
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 2,
+      "fiber_points" : 2,
+      "fiber_value" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "e",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 21,
+      "positive_points" : 2,
+      "proteins" : 5,
+      "proteins_points" : 3,
+      "proteins_value" : 5,
+      "saturated_fat" : 5,
+      "saturated_fat_points" : 4,
+      "saturated_fat_ratio" : 50,
+      "saturated_fat_ratio_points" : 7,
+      "saturated_fat_ratio_value" : 50,
+      "saturated_fat_value" : 5,
+      "score" : 19,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 10,
+      "sugars_points" : 7,
+      "sugars_value" : 10
+   },
+   "nutriscore_grade" : "e",
+   "nutriscore_score" : 19,
+   "nutriscore_score_opposite" : -19,
+   "nutrition_grade_fr" : "e",
+   "nutrition_grades" : "e",
+   "nutrition_grades_tags" : [
+      "e"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Sweetened beverages",
+   "pnns_groups_2_tags" : [
+      "sweetened-beverages",
+      "known"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/nutriscore/beverage-with-80-percent-milk.json
+++ b/t/expected_test_results/nutriscore/beverage-with-80-percent-milk.json
@@ -77,8 +77,8 @@
       "fat_100g" : 10,
       "fiber_100g" : 2,
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
-      "nutrition-score-fr" : 19,
-      "nutrition-score-fr_100g" : 19,
+      "nutrition-score-fr" : 14,
+      "nutrition-score-fr_100g" : 14,
       "proteins_100g" : 5,
       "saturated-fat_100g" : 5,
       "sodium_100g" : 0,
@@ -94,12 +94,12 @@
       "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
       "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
       "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
-      "grade" : "e",
-      "is_beverage" : 1,
+      "grade" : "d",
+      "is_beverage" : 0,
       "is_cheese" : 0,
       "is_fat" : 0,
       "is_water" : 0,
-      "negative_points" : 21,
+      "negative_points" : 16,
       "positive_points" : 2,
       "proteins" : 5,
       "proteins_points" : 3,
@@ -110,34 +110,34 @@
       "saturated_fat_ratio_points" : 7,
       "saturated_fat_ratio_value" : 50,
       "saturated_fat_value" : 5,
-      "score" : 19,
+      "score" : 14,
       "sodium" : 0,
       "sodium_points" : 0,
       "sodium_value" : 0,
       "sugars" : 10,
-      "sugars_points" : 7,
+      "sugars_points" : 2,
       "sugars_value" : 10
    },
-   "nutriscore_grade" : "e",
-   "nutriscore_score" : 19,
-   "nutriscore_score_opposite" : -19,
-   "nutrition_grade_fr" : "e",
-   "nutrition_grades" : "e",
+   "nutriscore_grade" : "d",
+   "nutriscore_score" : 14,
+   "nutriscore_score_opposite" : -14,
+   "nutrition_grade_fr" : "d",
+   "nutrition_grades" : "d",
    "nutrition_grades_tags" : [
-      "e"
+      "d"
    ],
-   "nutrition_score_beverage" : 1,
+   "nutrition_score_beverage" : 0,
    "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
    "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
-   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1" : "unknown",
    "pnns_groups_1_tags" : [
-      "beverages",
-      "known"
+      "unknown",
+      "missing-association"
    ],
-   "pnns_groups_2" : "Sweetened beverages",
+   "pnns_groups_2" : "unknown",
    "pnns_groups_2_tags" : [
-      "sweetened-beverages",
-      "known"
+      "unknown",
+      "missing-association"
    ],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/nutriscore/breakfast-cereals.json
+++ b/t/expected_test_results/nutriscore/breakfast-cereals.json
@@ -1,0 +1,106 @@
+{
+   "categories" : "breakfast cereals",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:cereals-and-potatoes",
+      "en:breakfasts",
+      "en:cereals-and-their-products",
+      "en:breakfast-cereals"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "32135",
+      "ciqual_food_code:en" : "32003"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-32135",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-32003",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-32135"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:cereals-and-potatoes",
+      "en:breakfasts",
+      "en:cereals-and-their-products",
+      "en:breakfast-cereals"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-no-fruits-vegetables-nuts",
+      "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 2450,
+      "fat_100g" : 100,
+      "fiber_100g" : 6.9,
+      "nutrition-score-fr" : 10,
+      "nutrition-score-fr_100g" : 10,
+      "proteins_100g" : 10.3,
+      "saturated-fat_100g" : 1.03,
+      "sodium_100g" : 0.221,
+      "sugars_100g" : 31
+   },
+   "nutriscore_data" : {
+      "energy" : 2450,
+      "energy_points" : 7,
+      "energy_value" : 2450,
+      "fiber" : 6.9,
+      "fiber_points" : 5,
+      "fiber_value" : 6.9,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "c",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 15,
+      "positive_points" : 5,
+      "proteins" : 10.3,
+      "proteins_points" : 5,
+      "proteins_value" : 10.3,
+      "saturated_fat" : 1.03,
+      "saturated_fat_points" : 0,
+      "saturated_fat_ratio" : 1.03,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 1,
+      "saturated_fat_value" : 1,
+      "score" : 10,
+      "sodium" : 221,
+      "sodium_points" : 2,
+      "sodium_value" : 221,
+      "sugars" : 31,
+      "sugars_points" : 6,
+      "sugars_value" : 31
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 10,
+   "nutriscore_score_opposite" : -10,
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_no_fruits_vegetables_nuts" : 1,
+   "pnns_groups_1" : "Cereals and potatoes",
+   "pnns_groups_1_tags" : [
+      "cereals-and-potatoes",
+      "known"
+   ],
+   "pnns_groups_2" : "Breakfast cereals",
+   "pnns_groups_2_tags" : [
+      "breakfast-cereals",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/colza-oil.json
+++ b/t/expected_test_results/nutriscore/colza-oil.json
@@ -1,0 +1,108 @@
+{
+   "categories" : "colza oils",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:vegetable-fats",
+      "en:vegetable-oils",
+      "en:rapeseed-oils"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_food_code:en" : "17130",
+      "ciqual_food_code:en" : "17130"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-17130",
+      "agribalyse-food-code-known",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-17130",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-17130"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:vegetable-fats",
+      "en:vegetable-oils",
+      "en:rapeseed-oils"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-from-category",
+      "en:nutrition-fruits-vegetables-nuts-from-category-en-rapeseed-oils",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3760,
+      "fat_100g" : 100,
+      "fiber_100g" : 0,
+      "nutrition-score-fr" : 5,
+      "nutrition-score-fr_100g" : 5,
+      "proteins_100g" : 0,
+      "saturated-fat_100g" : 7,
+      "sodium_100g" : 0,
+      "sugars_100g" : 0
+   },
+   "nutriscore_data" : {
+      "energy" : 3760,
+      "energy_points" : 10,
+      "energy_value" : 3760,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 100,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 5,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 100,
+      "grade" : "c",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 1,
+      "is_water" : 0,
+      "negative_points" : 10,
+      "positive_points" : 5,
+      "proteins" : 0,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : 7,
+      "saturated_fat_points" : 6,
+      "saturated_fat_ratio" : 7,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 7,
+      "saturated_fat_value" : 7,
+      "score" : 5,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 0,
+      "sugars_points" : 0,
+      "sugars_value" : 0
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 5,
+   "nutriscore_score_opposite" : -5,
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category" : "en:rapeseed-oils",
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category_value" : 100,
+   "pnns_groups_1" : "Fat and sauces",
+   "pnns_groups_1_tags" : [
+      "fat-and-sauces",
+      "known"
+   ],
+   "pnns_groups_2" : "Fats",
+   "pnns_groups_2_tags" : [
+      "fats",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/cookies.json
+++ b/t/expected_test_results/nutriscore/cookies.json
@@ -1,0 +1,100 @@
+{
+   "categories" : "cookies",
+   "categories_hierarchy" : [
+      "en:snacks",
+      "en:sweet-snacks",
+      "en:biscuits-and-cakes",
+      "en:biscuits"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "24000"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-24000",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-unknown",
+      "agribalyse-known",
+      "agribalyse-24000"
+   ],
+   "categories_tags" : [
+      "en:snacks",
+      "en:sweet-snacks",
+      "en:biscuits-and-cakes",
+      "en:biscuits"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-no-fruits-vegetables-nuts",
+      "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3460,
+      "fat_100g" : 90,
+      "fiber_100g" : 0,
+      "nutrition-score-fr" : 20,
+      "nutrition-score-fr_100g" : 20,
+      "proteins_100g" : 0,
+      "saturated-fat_100g" : 15,
+      "sodium_100g" : 0,
+      "sugars_100g" : 0
+   },
+   "nutriscore_data" : {
+      "energy" : 3460,
+      "energy_points" : 10,
+      "energy_value" : 3460,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "e",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 20,
+      "positive_points" : 0,
+      "proteins" : 0,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : 15,
+      "saturated_fat_points" : 10,
+      "saturated_fat_ratio" : 16.6666666666667,
+      "saturated_fat_ratio_points" : 2,
+      "saturated_fat_ratio_value" : 16.7,
+      "saturated_fat_value" : 15,
+      "score" : 20,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 0,
+      "sugars_points" : 0,
+      "sugars_value" : 0
+   },
+   "nutriscore_grade" : "e",
+   "nutriscore_score" : 20,
+   "nutriscore_score_opposite" : -20,
+   "nutrition_grade_fr" : "e",
+   "nutrition_grades" : "e",
+   "nutrition_grades_tags" : [
+      "e"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_no_fruits_vegetables_nuts" : 1,
+   "pnns_groups_1" : "Sugary snacks",
+   "pnns_groups_1_tags" : [
+      "sugary-snacks",
+      "known"
+   ],
+   "pnns_groups_2" : "Biscuits and cakes",
+   "pnns_groups_2_tags" : [
+      "biscuits-and-cakes",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/dairy-drink-with-80-percent-milk.json
+++ b/t/expected_test_results/nutriscore/dairy-drink-with-80-percent-milk.json
@@ -1,0 +1,147 @@
+{
+   "categories" : "dairy drinks",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:dairies",
+      "en:dairy-drinks"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:dairies",
+      "en:dairy-drinks"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:fresh-milk",
+         "percent" : "80",
+         "percent_estimate" : "80",
+         "percent_max" : "80",
+         "percent_min" : "80",
+         "text" : "Fresh milk",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "percent_estimate" : 20,
+         "percent_max" : 20,
+         "percent_min" : 20,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:fresh-milk",
+      "en:dairy",
+      "en:milk",
+      "en:sugar"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:fresh-milk",
+      "en:sugar"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:fresh-milk",
+      "en:dairy",
+      "en:milk",
+      "en:sugar"
+   ],
+   "ingredients_text" : "Fresh milk 80%, sugar",
+   "known_ingredients_n" : 4,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 10,
+      "fiber_100g" : 2,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nutrition-score-fr" : 14,
+      "nutrition-score-fr_100g" : 14,
+      "proteins_100g" : 5,
+      "saturated-fat_100g" : 5,
+      "sodium_100g" : 0,
+      "sugars_100g" : 10
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 2,
+      "fiber_points" : 2,
+      "fiber_value" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "d",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 16,
+      "positive_points" : 2,
+      "proteins" : 5,
+      "proteins_points" : 3,
+      "proteins_value" : 5,
+      "saturated_fat" : 5,
+      "saturated_fat_points" : 4,
+      "saturated_fat_ratio" : 50,
+      "saturated_fat_ratio_points" : 7,
+      "saturated_fat_ratio_value" : 50,
+      "saturated_fat_value" : 5,
+      "score" : 14,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 10,
+      "sugars_points" : 2,
+      "sugars_value" : 10
+   },
+   "nutriscore_grade" : "d",
+   "nutriscore_score" : 14,
+   "nutriscore_score_opposite" : -14,
+   "nutrition_grade_fr" : "d",
+   "nutrition_grades" : "d",
+   "nutrition_grades_tags" : [
+      "d"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "pnns_groups_1" : "Milk and dairy products",
+   "pnns_groups_1_tags" : [
+      "milk-and-dairy-products",
+      "known"
+   ],
+   "pnns_groups_2" : "Milk and yogurt",
+   "pnns_groups_2_tags" : [
+      "milk-and-yogurt",
+      "known"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/nutriscore/dairy-drink-with-less-than-80-percent-milk.json
+++ b/t/expected_test_results/nutriscore/dairy-drink-with-less-than-80-percent-milk.json
@@ -1,0 +1,144 @@
+{
+   "categories" : "dairy drinks",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:dairies",
+      "en:dairy-drinks"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:dairies",
+      "en:dairy-drinks"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:milk",
+         "percent_estimate" : 75,
+         "percent_max" : 100,
+         "percent_min" : 50,
+         "text" : "Milk",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "percent_estimate" : 25,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:milk",
+      "en:dairy",
+      "en:sugar"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:milk",
+      "en:sugar"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:milk",
+      "en:dairy",
+      "en:sugar"
+   ],
+   "ingredients_text" : "Milk, sugar",
+   "known_ingredients_n" : 3,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 10,
+      "fiber_100g" : 2,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nutrition-score-fr" : 19,
+      "nutrition-score-fr_100g" : 19,
+      "proteins_100g" : 5,
+      "saturated-fat_100g" : 5,
+      "sodium_100g" : 0,
+      "sugars_100g" : 10
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 2,
+      "fiber_points" : 2,
+      "fiber_value" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "e",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 21,
+      "positive_points" : 2,
+      "proteins" : 5,
+      "proteins_points" : 3,
+      "proteins_value" : 5,
+      "saturated_fat" : 5,
+      "saturated_fat_points" : 4,
+      "saturated_fat_ratio" : 50,
+      "saturated_fat_ratio_points" : 7,
+      "saturated_fat_ratio_value" : 50,
+      "saturated_fat_value" : 5,
+      "score" : 19,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 10,
+      "sugars_points" : 7,
+      "sugars_value" : 10
+   },
+   "nutriscore_grade" : "e",
+   "nutriscore_score" : 19,
+   "nutriscore_score_opposite" : -19,
+   "nutrition_grade_fr" : "e",
+   "nutrition_grades" : "e",
+   "nutrition_grades_tags" : [
+      "e"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Sweetened beverages",
+   "pnns_groups_2_tags" : [
+      "sweetened-beverages",
+      "known"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/nutriscore/dairy-drinks-without-milk.json
+++ b/t/expected_test_results/nutriscore/dairy-drinks-without-milk.json
@@ -1,0 +1,142 @@
+{
+   "categories" : "dairy drinks",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:dairies",
+      "en:dairy-drinks"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:dairies",
+      "en:dairy-drinks"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:water",
+         "percent_estimate" : 75,
+         "percent_max" : 100,
+         "percent_min" : 50,
+         "text" : "Water",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "percent_estimate" : 25,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:water",
+      "en:sugar"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:water",
+      "en:sugar"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:water",
+      "en:sugar"
+   ],
+   "ingredients_text" : "Water, sugar",
+   "known_ingredients_n" : 2,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 10,
+      "fiber_100g" : 2,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nutrition-score-fr" : 19,
+      "nutrition-score-fr_100g" : 19,
+      "proteins_100g" : 5,
+      "saturated-fat_100g" : 5,
+      "sodium_100g" : 0,
+      "sugars_100g" : 10
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 2,
+      "fiber_points" : 2,
+      "fiber_value" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "e",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 21,
+      "positive_points" : 2,
+      "proteins" : 5,
+      "proteins_points" : 3,
+      "proteins_value" : 5,
+      "saturated_fat" : 5,
+      "saturated_fat_points" : 4,
+      "saturated_fat_ratio" : 50,
+      "saturated_fat_ratio_points" : 7,
+      "saturated_fat_ratio_value" : 50,
+      "saturated_fat_value" : 5,
+      "score" : 19,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 10,
+      "sugars_points" : 7,
+      "sugars_value" : 10
+   },
+   "nutriscore_grade" : "e",
+   "nutriscore_score" : 19,
+   "nutriscore_score_opposite" : -19,
+   "nutrition_grade_fr" : "e",
+   "nutrition_grades" : "e",
+   "nutrition_grades_tags" : [
+      "e"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Sweetened beverages",
+   "pnns_groups_2_tags" : [
+      "sweetened-beverages",
+      "known"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/nutriscore/honey.json
+++ b/t/expected_test_results/nutriscore/honey.json
@@ -1,0 +1,142 @@
+{
+   "categories" : "honeys",
+   "categories_hierarchy" : [
+      "en:spreads",
+      "en:breakfasts",
+      "en:bee-products",
+      "en:farming-products",
+      "en:sweet-spreads",
+      "en:sweeteners",
+      "en:honeys"
+   ],
+   "categories_lc" : "fr",
+   "categories_properties" : {
+      "agribalyse_food_code:en" : "31008",
+      "ciqual_food_code:en" : "31008"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-31008",
+      "agribalyse-food-code-known",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-31008",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-31008"
+   ],
+   "categories_tags" : [
+      "en:spreads",
+      "en:breakfasts",
+      "en:bee-products",
+      "en:farming-products",
+      "en:sweet-spreads",
+      "en:sweeteners",
+      "en:honeys"
+   ],
+   "ingredients" : [
+      {
+         "id" : "fr:honey",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "honey"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "fr:honey"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "fr:honey"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "fr:honey"
+   ],
+   "ingredients_text" : "honey",
+   "known_ingredients_n" : 0,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 1370,
+      "fat_100g" : 8.4,
+      "fiber_100g" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nutrition-score-fr" : 14,
+      "nutrition-score-fr_100g" : 14,
+      "proteins_100g" : 0.3,
+      "saturated-fat_100g" : 0.04,
+      "sodium_100g" : 0.001,
+      "sugars_100g" : 69.5
+   },
+   "nutriscore_data" : {
+      "energy" : 1370,
+      "energy_points" : 4,
+      "energy_value" : 1370,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "d",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 14,
+      "positive_points" : 0,
+      "proteins" : 0.3,
+      "proteins_points" : 0,
+      "proteins_value" : 0.3,
+      "saturated_fat" : 0.04,
+      "saturated_fat_points" : 0,
+      "saturated_fat_ratio" : 0.476190476190476,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 0.5,
+      "saturated_fat_value" : 0,
+      "score" : 14,
+      "sodium" : 1,
+      "sodium_points" : 0,
+      "sodium_value" : 1,
+      "sugars" : 69.5,
+      "sugars_points" : 10,
+      "sugars_value" : 69.5
+   },
+   "nutriscore_grade" : "d",
+   "nutriscore_score" : 14,
+   "nutriscore_score_opposite" : -14,
+   "nutrition_grade_fr" : "d",
+   "nutrition_grades" : "d",
+   "nutrition_grades_tags" : [
+      "d"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "pnns_groups_1" : "Sugary snacks",
+   "pnns_groups_1_tags" : [
+      "sugary-snacks",
+      "known"
+   ],
+   "pnns_groups_2" : "Sweets",
+   "pnns_groups_2_tags" : [
+      "sweets",
+      "known"
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/t/expected_test_results/nutriscore/milk.json
+++ b/t/expected_test_results/nutriscore/milk.json
@@ -1,0 +1,134 @@
+{
+   "categories" : "milk",
+   "categories_hierarchy" : [
+      "en:dairies",
+      "en:milks"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "19041"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-19041",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-unknown",
+      "agribalyse-known",
+      "agribalyse-19041"
+   ],
+   "categories_tags" : [
+      "en:dairies",
+      "en:milks"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:milk",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Milk",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:milk",
+      "en:dairy"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:milk"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:milk",
+      "en:dairy"
+   ],
+   "ingredients_text" : "Milk",
+   "known_ingredients_n" : 2,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 10,
+      "fiber_100g" : 2,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "nutrition-score-fr" : 14,
+      "nutrition-score-fr_100g" : 14,
+      "proteins_100g" : 5,
+      "saturated-fat_100g" : 5,
+      "sodium_100g" : 0,
+      "sugars_100g" : 10
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 2,
+      "fiber_points" : 2,
+      "fiber_value" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "d",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 16,
+      "positive_points" : 2,
+      "proteins" : 5,
+      "proteins_points" : 3,
+      "proteins_value" : 5,
+      "saturated_fat" : 5,
+      "saturated_fat_points" : 4,
+      "saturated_fat_ratio" : 50,
+      "saturated_fat_ratio_points" : 7,
+      "saturated_fat_ratio_value" : 50,
+      "saturated_fat_value" : 5,
+      "score" : 14,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 10,
+      "sugars_points" : 2,
+      "sugars_value" : 10
+   },
+   "nutriscore_grade" : "d",
+   "nutriscore_score" : 14,
+   "nutriscore_score_opposite" : -14,
+   "nutrition_grade_fr" : "d",
+   "nutrition_grades" : "d",
+   "nutrition_grades_tags" : [
+      "d"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 0,
+   "pnns_groups_1" : "Milk and dairy products",
+   "pnns_groups_1_tags" : [
+      "milk-and-dairy-products",
+      "known"
+   ],
+   "pnns_groups_2" : "Milk and yogurt",
+   "pnns_groups_2_tags" : [
+      "milk-and-yogurt",
+      "known"
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/nutriscore/mushrooms.json
+++ b/t/expected_test_results/nutriscore/mushrooms.json
@@ -1,0 +1,140 @@
+{
+   "categories" : "meals",
+   "categories_hierarchy" : [
+      "en:meals"
+   ],
+   "categories_lc" : "fr",
+   "categories_properties" : {},
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+   ],
+   "categories_tags" : [
+      "en:meals"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:oyster-mushroom",
+         "origins" : "en:european-union",
+         "percent" : "69",
+         "percent_estimate" : "69",
+         "percent_max" : "69",
+         "percent_min" : "69",
+         "text" : "Pleurotes",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "fr:chapelure de mais",
+         "percent_estimate" : 31,
+         "percent_max" : 31,
+         "percent_min" : 31,
+         "text" : "chapelure de mais"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "en:oyster-mushroom",
+      "en:mushroom",
+      "fr:chapelure de mais"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:oyster-mushroom",
+      "fr:chapelure de mais"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:oyster-mushroom",
+      "en:mushroom",
+      "fr:chapelure-de-mais"
+   ],
+   "ingredients_text" : "Pleurotes* 69% (Origine UE), chapelure de mais",
+   "known_ingredients_n" : 2,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 667,
+      "fat_100g" : 8.4,
+      "fiber_100g" : 10.9,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 69,
+      "nutrition-score-fr" : -2,
+      "nutrition-score-fr_100g" : -2,
+      "proteins_100g" : 2.4,
+      "saturated-fat_100g" : 1.2,
+      "sodium_100g" : 0.4,
+      "sugars_100g" : 1.1
+   },
+   "nutriscore_data" : {
+      "energy" : 667,
+      "energy_points" : 1,
+      "energy_value" : 667,
+      "fiber" : 10.9,
+      "fiber_points" : 5,
+      "fiber_value" : 10.9,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 69,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 69,
+      "grade" : "a",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 6,
+      "positive_points" : 8,
+      "proteins" : 2.4,
+      "proteins_points" : 1,
+      "proteins_value" : 2.4,
+      "saturated_fat" : 1.2,
+      "saturated_fat_points" : 1,
+      "saturated_fat_ratio" : 14.2857142857143,
+      "saturated_fat_ratio_points" : 1,
+      "saturated_fat_ratio_value" : 14.3,
+      "saturated_fat_value" : 1.2,
+      "score" : -2,
+      "sodium" : 400,
+      "sodium_points" : 4,
+      "sodium_value" : 400,
+      "sugars" : 1.1,
+      "sugars_points" : 0,
+      "sugars_value" : 1.1
+   },
+   "nutriscore_grade" : "a",
+   "nutriscore_score" : -2,
+   "nutriscore_score_opposite" : 2,
+   "nutrition_grade_fr" : "a",
+   "nutrition_grades" : "a",
+   "nutrition_grades_tags" : [
+      "a"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 69,
+   "pnns_groups_1" : "Composite foods",
+   "pnns_groups_1_tags" : [
+      "composite-foods",
+      "known"
+   ],
+   "pnns_groups_2" : "One-dish meals",
+   "pnns_groups_2_tags" : [
+      "one-dish-meals",
+      "known"
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/t/expected_test_results/nutriscore/olive-oil.json
+++ b/t/expected_test_results/nutriscore/olive-oil.json
@@ -1,0 +1,110 @@
+{
+   "categories" : "olive oils",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:vegetable-fats",
+      "en:olive-tree-products",
+      "en:vegetable-oils",
+      "en:olive-oils"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "17270",
+      "ciqual_food_code:en" : "17001"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-17270",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-17001",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-17270"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:vegetable-fats",
+      "en:olive-tree-products",
+      "en:vegetable-oils",
+      "en:olive-oils"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-from-category",
+      "en:nutrition-fruits-vegetables-nuts-from-category-en-olive-oils",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3460,
+      "fat_100g" : 92,
+      "fiber_100g" : 0,
+      "nutrition-score-fr" : 6,
+      "nutrition-score-fr_100g" : 6,
+      "proteins_100g" : 0,
+      "saturated-fat_100g" : 14,
+      "sodium_100g" : 0,
+      "sugars_100g" : 0
+   },
+   "nutriscore_data" : {
+      "energy" : 3460,
+      "energy_points" : 10,
+      "energy_value" : 3460,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 100,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 5,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 100,
+      "grade" : "c",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 1,
+      "is_water" : 0,
+      "negative_points" : 11,
+      "positive_points" : 5,
+      "proteins" : 0,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : 14,
+      "saturated_fat_points" : 10,
+      "saturated_fat_ratio" : 15.2173913043478,
+      "saturated_fat_ratio_points" : 1,
+      "saturated_fat_ratio_value" : 15.2,
+      "saturated_fat_value" : 14,
+      "score" : 6,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 0,
+      "sugars_points" : 0,
+      "sugars_value" : 0
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 6,
+   "nutriscore_score_opposite" : -6,
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category" : "en:olive-oils",
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category_value" : 100,
+   "pnns_groups_1" : "Fat and sauces",
+   "pnns_groups_1_tags" : [
+      "fat-and-sauces",
+      "known"
+   ],
+   "pnns_groups_2" : "Fats",
+   "pnns_groups_2_tags" : [
+      "fats",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/sunflower-oil.json
+++ b/t/expected_test_results/nutriscore/sunflower-oil.json
@@ -1,0 +1,108 @@
+{
+   "categories" : "sunflower oils",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:vegetable-fats",
+      "en:vegetable-oils",
+      "en:sunflower-seeds-and-their-products",
+      "en:sunflower-oils"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_food_code:en" : "17440",
+      "ciqual_food_code:en" : "17440"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-17440",
+      "agribalyse-food-code-known",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-17440",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-17440"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:vegetable-fats",
+      "en:vegetable-oils",
+      "en:sunflower-seeds-and-their-products",
+      "en:sunflower-oils"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-no-fruits-vegetables-nuts",
+      "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 100,
+      "fiber_100g" : 0,
+      "nutrition-score-fr" : 11,
+      "nutrition-score-fr_100g" : 11,
+      "proteins_100g" : 0,
+      "saturated-fat_100g" : 10,
+      "sodium_100g" : 0,
+      "sugars_100g" : 0
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "d",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 1,
+      "is_water" : 0,
+      "negative_points" : 11,
+      "positive_points" : 0,
+      "proteins" : 0,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : 10,
+      "saturated_fat_points" : 9,
+      "saturated_fat_ratio" : 10,
+      "saturated_fat_ratio_points" : 1,
+      "saturated_fat_ratio_value" : 10,
+      "saturated_fat_value" : 10,
+      "score" : 11,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 0,
+      "sugars_points" : 0,
+      "sugars_value" : 0
+   },
+   "nutriscore_grade" : "d",
+   "nutriscore_score" : 11,
+   "nutriscore_score_opposite" : -11,
+   "nutrition_grade_fr" : "d",
+   "nutrition_grades" : "d",
+   "nutrition_grades_tags" : [
+      "d"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_no_fruits_vegetables_nuts" : 1,
+   "pnns_groups_1" : "Fat and sauces",
+   "pnns_groups_1_tags" : [
+      "fat-and-sauces",
+      "known"
+   ],
+   "pnns_groups_2" : "Fats",
+   "pnns_groups_2_tags" : [
+      "fats",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/walnut-oil.json
+++ b/t/expected_test_results/nutriscore/walnut-oil.json
@@ -1,0 +1,112 @@
+{
+   "categories" : "walnut oils",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:nuts-and-their-products",
+      "en:vegetable-fats",
+      "en:vegetable-oils",
+      "en:nut-oils",
+      "en:walnut-oils"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "17210",
+      "ciqual_food_code:en" : "17220"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-17210",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-17220",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-17210"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:plant-based-foods",
+      "en:fats",
+      "en:nuts-and-their-products",
+      "en:vegetable-fats",
+      "en:vegetable-oils",
+      "en:nut-oils",
+      "en:walnut-oils"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-from-category",
+      "en:nutrition-fruits-vegetables-nuts-from-category-en-walnut-oils",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 3378,
+      "fat_100g" : 100,
+      "fiber_100g" : 0,
+      "nutrition-score-fr" : 6,
+      "nutrition-score-fr_100g" : 6,
+      "proteins_100g" : 0,
+      "saturated-fat_100g" : 10,
+      "sodium_100g" : 0,
+      "sugars_100g" : 0
+   },
+   "nutriscore_data" : {
+      "energy" : 3378,
+      "energy_points" : 10,
+      "energy_value" : 3378,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 100,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 5,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 100,
+      "grade" : "c",
+      "is_beverage" : 0,
+      "is_cheese" : 0,
+      "is_fat" : 1,
+      "is_water" : 0,
+      "negative_points" : 11,
+      "positive_points" : 5,
+      "proteins" : 0,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : 10,
+      "saturated_fat_points" : 9,
+      "saturated_fat_ratio" : 10,
+      "saturated_fat_ratio_points" : 1,
+      "saturated_fat_ratio_value" : 10,
+      "saturated_fat_value" : 10,
+      "score" : 6,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 0,
+      "sugars_points" : 0,
+      "sugars_value" : 0
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 6,
+   "nutriscore_score_opposite" : -6,
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 0,
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category" : "en:walnut-oils",
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category_value" : 100,
+   "pnns_groups_1" : "Fat and sauces",
+   "pnns_groups_1_tags" : [
+      "fat-and-sauces",
+      "known"
+   ],
+   "pnns_groups_2" : "Fats",
+   "pnns_groups_2_tags" : [
+      "fats",
+      "known"
+   ]
+}

--- a/t/nutriscore.t
+++ b/t/nutriscore.t
@@ -3,55 +3,107 @@
 use strict;
 use warnings;
 
+use JSON;
+use Getopt::Long;
+
 use Test::More;
 use Test::Number::Delta relative => 1.001;
 use Log::Any::Adapter 'TAP';
 
+use ProductOpener::Config qw/:all/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Food qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Nutriscore qw/:all/;
 
+my $testdir = "nutriscore";
+
+my $usage = <<TXT
+
+The expected results of the tests are saved in $data_root/t/expected_test_results/$testdir
+
+To verify differences and update the expected test results, actual test results
+can be saved to a directory by passing --results [path of results directory]
+
+The directory will be created if it does not already exist.
+
+TXT
+;
+
+my $resultsdir;
+
+GetOptions ("results=s"   => \$resultsdir)
+  or die("Error in command line arguments.\n\n" . $usage);
+  
+if ((defined $resultsdir) and (! -e $resultsdir)) {
+	mkdir($resultsdir, 0755) or die("Could not create $resultsdir directory: $!\n");
+}
+
 init_emb_codes();
 
 my @tests = (
 
-[{ lc=>"en", categories=>"cookies", nutriments=>{energy_100g=>3460, fat_100g=>90, "saturated-fat_100g"=>15, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 20, "e"],
-[{ lc=>"en", categories=>"olive oils", nutriments=>{energy_100g=>3460, fat_100g=>92, "saturated-fat_100g"=>14, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 6, "c"],
-[{ lc=>"en", categories=>"colza oils", nutriments=>{energy_100g=>3760, fat_100g=>100, "saturated-fat_100g"=>7, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 5, "c"],
-[{ lc=>"en", categories=>"walnut oils", nutriments=>{energy_100g=>3378, fat_100g=>100, "saturated-fat_100g"=>10, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 6, "c"],
-[{ lc=>"en", categories=>"sunflower oils", nutriments=>{energy_100g=>3378, fat_100g=>100, "saturated-fat_100g"=>10, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}, 11, "d"],
+["cookies", { lc=>"en", categories=>"cookies", nutriments=>{energy_100g=>3460, fat_100g=>90, "saturated-fat_100g"=>15, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}],
+["olive-oil", { lc=>"en", categories=>"olive oils", nutriments=>{energy_100g=>3460, fat_100g=>92, "saturated-fat_100g"=>14, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}],
+["colza-oil", { lc=>"en", categories=>"colza oils", nutriments=>{energy_100g=>3760, fat_100g=>100, "saturated-fat_100g"=>7, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}],
+["walnut-oil", { lc=>"en", categories=>"walnut oils", nutriments=>{energy_100g=>3378, fat_100g=>100, "saturated-fat_100g"=>10, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}],
+["sunflower-oil", { lc=>"en", categories=>"sunflower oils", nutriments=>{energy_100g=>3378, fat_100g=>100, "saturated-fat_100g"=>10, sugars_100g=>0, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}],
 
 # saturated fat 1.03 should be rounded to 1.0 which is not strictly greater than 1.0
-[{ lc=>"en", categories=>"breakfast cereals", nutriments=>{energy_100g=>2450, fat_100g=>100, "saturated-fat_100g"=>1.03, sugars_100g=>31, sodium_100g=>0.221, fiber_100g=>6.9, proteins_100g=>10.3}}, 10, "c"],
+["breakfast-cereals", { lc=>"en", categories=>"breakfast cereals", nutriments=>{energy_100g=>2450, fat_100g=>100, "saturated-fat_100g"=>1.03, sugars_100g=>31, sodium_100g=>0.221, fiber_100g=>6.9, proteins_100g=>10.3}}],
 
 # dairy drink with milk >= 80% are considered food and not beverages
 
-[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
-	ingredients_text=>"Water, sugar"}, 19, "e"],
-[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
-	ingredients_text=>"Milk"}, 14, "d"],
-[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
-	ingredients_text=>"Fresh milk 80%, sugar"}, 14, "d"],
-[{ lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
-	ingredients_text=>"Milk, sugar"}, 19, "e"],
+["dairy-drinks-without-milk", { lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Water, sugar"}],
+["milk", { lc=>"en", categories=>"milk", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Milk"}],
+["dairy-drink-with-80-percent-milk", { lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Fresh milk 80%, sugar"}],
+["beverage-with-80-percent-milk", { lc=>"en", categories=>"beverages", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Fresh milk 80%, sugar"}],
+["dairy-drink-with-less-than-80-percent-milk", { lc=>"en", categories=>"dairy drinks", nutriments=>{energy_100g=>3378, fat_100g=>10, "saturated-fat_100g"=>5, sugars_100g=>10, sodium_100g=>0, fiber_100g=>2, proteins_100g=>5},
+	ingredients_text=>"Milk, sugar"}],
 	
 # mushrooms are counted as fruits/vegetables
-[{ lc=>"fr", categories=>"meals", nutriments=>{energy_100g=>667, fat_100g=>8.4, "saturated-fat_100g"=>1.2, sugars_100g=>1.1, sodium_100g=>0.4, fiber_100g=>10.9, proteins_100g=>2.4},
-	ingredients_text=>"Pleurotes* 69% (Origine UE), chapelure de mais"}, -2, "a"],
+["mushrooms", { lc=>"fr", categories=>"meals", nutriments=>{energy_100g=>667, fat_100g=>8.4, "saturated-fat_100g"=>1.2, sugars_100g=>1.1, sodium_100g=>0.4, fiber_100g=>10.9, proteins_100g=>2.4},
+	ingredients_text=>"Pleurotes* 69% (Origine UE), chapelure de mais"}],
 
 );
 
+
+my $json = JSON->new->allow_nonref->canonical;
+
 foreach my $test_ref (@tests) {
 
-	my $product_ref = $test_ref->[0];
+	my $testid = $test_ref->[0];
+	my $product_ref = $test_ref->[1];
+
 	compute_field_tags($product_ref, $product_ref->{lc}, "categories");
 	extract_ingredients_from_text($product_ref);
 	special_process_product($product_ref);
 	compute_nutrition_score($product_ref);
 
-	is($product_ref->{nutrition_grade_fr}, $test_ref->[2]);
-	is($product_ref->{nutriments}{"nutrition-score-fr"}, $test_ref->[1]) or diag explain $product_ref;
+	# Save the result
+	
+	if (defined $resultsdir) {
+		open (my $result, ">:encoding(UTF-8)", "$resultsdir/$testid.json") or die("Could not create $resultsdir/$testid.json: $!\n");
+		print $result $json->pretty->encode($product_ref);
+		close ($result);
+	}
+	
+	# Compare the result with the expected result
+	
+	if (open (my $expected_result, "<:encoding(UTF-8)", "$data_root/t/expected_test_results/$testdir/$testid.json")) {
+
+		local $/; #Enable 'slurp' mode
+		my $expected_product_ref = $json->decode(<$expected_result>);
+		is_deeply ($product_ref, $expected_product_ref) or diag explain $product_ref;
+	}
+	else {
+		fail("could not load expected_test_results/$testdir/$testid.json");
+		diag explain $product_ref;
+	}
 
 }
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -6460,6 +6460,10 @@ carbon_footprint_fr_foodges_ingredient:fr:Lait semi-écrémé, pasteurisé
 carbon_footprint_fr_foodges_value:fr:1.2
 
 <en:milk
+en:milk enriched with cream
+fr:lait enrichi de crème
+
+<en:milk
 en:sterilised milk
 ca:llet esterilitzada
 da:steriliseret mælk


### PR DESCRIPTION
This is to fix a nutriscore issue signaled on twitter for https://world.openfoodfacts.org/product/7610900251759/caffe-latte-double-zero-macchiato-emmi

Beverages that contain 80% of milk are considered food for the nutriscore. We rely on the ingredients analysis to determine if there is milk and how much there is in it.