### PR TITLE
Remove unneeded CSS style in user form

### DIFF
--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -1,3 +1,5 @@
+<!-- start templates/[% template.name %] -->
+
 [% IF product_changes_saved %]
     <div data-alert class="alert-box info">
         <span>lang('product_changes_saved')</span>
@@ -450,3 +452,5 @@
         [% lang('edit_product_page') %]
     </a>
 </div>
+
+<!-- end templates/[% template.name %] -->

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -32,10 +32,6 @@
 </script>
 
 <style>
-    .teams_section {
-        display: block;
-    }
-
     .pro_org_display {
         display: none;
     }


### PR DESCRIPTION
Removing an inactive style that was needed in the previous version of the form, where we had a table with rows.