### PR TITLE
included templates need to use component.name instead of template.name

### DIFF
--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -1,5 +1,5 @@
 
-<!-- start templates/[% template.name %] -->
+<!-- start templates/[% component.name %] -->
 
 [% IF (product_type == 'food') && (cc == 'fr') %]
 <div id="ecoscore_banner" class="row">
@@ -88,4 +88,4 @@
 </div>
 [% END %]
 
-<!-- end templates/[% template.name %] -->
+<!-- end templates/[% component.name %] -->

--- a/templates/web/common/includes/error_list.tt.html
+++ b/templates/web/common/includes/error_list.tt.html
@@ -1,4 +1,4 @@
-<!-- start templates/[% template.name %] -->
+<!-- start templates/[% component.name %] -->
 
 [% IF errors && errors.size %]
 <div data-alert class="alert-box alert">
@@ -11,4 +11,4 @@
 </div>
 [% END %]
 
-<!-- end templates/[% template.name %] -->
+<!-- end templates/[% component.name %] -->


### PR DESCRIPTION
related to https://github.com/openfoodfacts/openfoodfacts-server/pull/5297 and #5261 #5248 

we use to need [% component.name %] instead of [% template.name %] in order to have the name of included template, and not the page level template.

see http://www.template-toolkit.org/docs/manual/Variables.html#section_component

We should do the same for all included templates.