### PR TITLE
Docker config: add query_uri to backend redirect

### DIFF
--- a/docker/frontend-git/conf/nginx.conf
+++ b/docker/frontend-git/conf/nginx.conf
@@ -60,7 +60,7 @@ server {
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		set $backend backend;
-		proxy_pass http://$backend/cgi/display.pl?;
+		proxy_pass http://$backend/cgi/display.pl?$request_uri;
 	}
 
 	location /cgi/ {
@@ -120,7 +120,7 @@ server {
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		set $backend backend-pro;
-		proxy_pass http://$backend/cgi/display.pl?;
+		proxy_pass http://$backend/cgi/display.pl?$request_uri;
 	}
 
 	location /cgi/ {


### PR DESCRIPTION
I'm not sure why, but the query string was no longer appended to the proxy_pass directive. It's probably when I changed the config to use "backend" and "backend-pro". Adding query_uri seems to work.