### PR TITLE
Add authorized import sources for orgs for USDA and CodeOnline

### DIFF
--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -105,15 +105,19 @@ if ($action eq 'process') {
 				if (not defined $org_ref) {
 					$org_ref = create_org($User_id, $orgid);
 				}
+
+				my @admin_fields = ();
 				
-				foreach my $field ("enable_manual_export_to_public_platform",
+				push (@admin_fields, ("enable_manual_export_to_public_platform",
 					"activate_automated_daily_export_to_public_platform",
 					"do_not_import_codeonline",
 					"gs1_product_name_is_abbreviated",
 					"gs1_nutrients_are_unprepared",
-					) {
+				));
+				
+				foreach my $field (@admin_fields) {
 					$org_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));
-				}
+				}			
 				
 				# Set the list of org GLNs
 				set_org_gs1_gln($org_ref, remove_tags_and_quote(decode utf8=>param("list_of_gs1_gln")));
@@ -175,33 +179,49 @@ if ($action eq 'display') {
 	# Admin
 	
 	if ($admin) {
+
+		my $admin_fields_ref = [];
+
+		push (@$admin_fields_ref, (
+			{
+				field => "enable_manual_export_to_public_platform",
+				type => "checkbox",
+			},
+			{
+				field => "activate_automated_daily_export_to_public_platform",
+				type => "checkbox",
+			},
+		));
+
+		if (defined $options{import_sources}) {
+			foreach my $source_id (sort keys %{$options{import_sources}}) {
+				push (@$admin_fields_ref, 
+					{
+						field => "import_source_" . $source_id,
+						type => "checkbox",
+						label => sprintf(lang("import_source_string"), $options{import_sources}{$source_id}),
+					},
+				);
+			}
+		}
+
+		push (@$admin_fields_ref, (
+			{
+				field => "list_of_gs1_gln",
+			},
+			{
+				field => "gs1_product_name_is_abbreviated",
+				type => "checkbox",
+			},
+			{
+				field => "gs1_nutrients_are_unprepared",
+				type => "checkbox",
+			},	
+		));
+
 		push @{$template_data_ref->{sections}}, {
 			id => "admin",
-			fields => [
-				{
-					field => "enable_manual_export_to_public_platform",
-					type => "checkbox",
-				},
-				{
-					field => "activate_automated_daily_export_to_public_platform",
-					type => "checkbox",
-				},
-				{
-					field => "list_of_gs1_gln",
-				},
-				{
-					field => "do_not_import_codeonline",
-					type => "checkbox",
-				},
-				{
-					field => "gs1_product_name_is_abbreviated",
-					type => "checkbox",
-				},
-				{
-					field => "gs1_nutrients_are_unprepared",
-					type => "checkbox",
-				},	
-			]
+			fields => $admin_fields_ref,
 		};		
 	}
 	
@@ -281,8 +301,10 @@ if ($action eq 'display') {
 				$field_lang_id = "org_" . $field;
 			}
 			
-			# Label
-			$field_ref->{label} = lang($field_lang_id);
+			# Label if it has not been set already
+			if (not defined $field_ref->{label}) {
+				$field_ref->{label} = lang($field_lang_id);
+			}
 			
 			# Descriptions and notes for fields
 			if (lang($field_lang_id . "_description")) {

--- a/lib/ProductOpener/Export.pm
+++ b/lib/ProductOpener/Export.pm
@@ -150,7 +150,7 @@ fields will be exported.
 		fields => [qw(code ingredients_text_en additives_tags)] });
 
 
-=head4 include_images_files - optional - Export local file paths to images
+=head4 include_images_paths - optional - Export local file paths to images
 
 If defined and not null, specifies to export local file paths for selected images
 for front, ingredients and nutrition in all languages.

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -366,8 +366,21 @@ sub convert_file($$$$) {
 
 	foreach my $column (@{$headers_ref}) {
 
+		my $field;
+
+		# columns_fields_ref may contain unnormalized or normalized column names
+		# we will try to match both
+		my $columnid = get_string_id_for_lang("no_language", normalize_column_name($column));
+
 		if ((defined $columns_fields_ref->{$column}) and (defined $columns_fields_ref->{$column}{field})) {
-			my $field = $columns_fields_ref->{$column}{field};
+			$field = $columns_fields_ref->{$column}{field};
+		}
+		elsif ((defined $columns_fields_ref->{$columnid}) and (defined $columns_fields_ref->{$columnid}{field})) {
+			$field = $columns_fields_ref->{$columnid}{field};
+			$column = $columnid;
+		}
+
+		if (defined $field) {
 
 			# For columns mapped to a specific label, output labels:Label name as the column name
 			if ($field =~ /^(labels|categories)_specific$/) {
@@ -399,7 +412,7 @@ sub convert_file($$$$) {
 				}
 			}
 
-			$log->debug("convert_file", { column => $column, field => $field, col => $col }) if $log->is_debug();
+			$log->debug("convert_file - found matching column", { column => $column, field => $field, col => $col }) if $log->is_debug();
 
 			if (defined $seen_fields{$field}) {
 				$seen_fields{$field}++;
@@ -413,6 +426,9 @@ sub convert_file($$$$) {
 				push @headers, $field;
 				$headers_cols{$field} = $col;
 			}
+		}
+		else {
+			$log->debug("convert_file - no matching column", { column => $column }) if $log->is_debug();
 		}
 
 		$col++;

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -394,7 +394,15 @@ sub convert_file($$$$) {
 			}
 			# Source specific fields
 			elsif ($field eq "sources_fields_specific") {
-				$field = "sources_fields:" . $Owner_id . ":";
+				my $source_id;
+				if (defined $default_values_ref->{source_id}) {
+					# e.g. org-database-usda
+					$source_id = "org-" . $default_values_ref->{source_id};
+				}
+				elsif (defined $Owner_id) {
+					$source_id = $Owner_id;
+				}
+				$field = "sources_fields:" . $source_id . ":";
 				if (defined $columns_fields_ref->{$column}{tag}) {
 					$field .= $columns_fields_ref->{$column}{tag};
 				}

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5666,3 +5666,7 @@ msgctxt "org_gs1_product_name_is_abbreviated_description"
 msgid "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
 msgstr "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
 
+# do not remove %s, it will be replaced with the source name
+msgctxt "import_source_string"
+msgid "Import data from %s"
+msgstr "Import data from %s"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5683,3 +5683,9 @@ msgctxt "org_gs1_product_name_is_abbreviated_description"
 msgid "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
 msgstr "Some manufacturers have incorrect values for some fields in GS1. The features below can be used to fix some of them."
 
+# do not remove %s, it will be replaced with the source name
+msgctxt "import_source_string"
+msgid "Import data from %s"
+msgstr "Import data from %s"
+
+

--- a/scripts/convert_csv_file.pl
+++ b/scripts/convert_csv_file.pl
@@ -55,6 +55,7 @@ TXT
 my $csv_file;
 my $converted_csv_file;
 my $columns_fields_file;
+my $source_id;
 my %global_values = ();
 
 GetOptions (
@@ -62,14 +63,19 @@ GetOptions (
     "converted_csv_file=s" => \$converted_csv_file,
     "columns_fields_file=s" => \$columns_fields_file,
 	"define=s%" => \%global_values,
-
+	"source_id=s" => \$source_id,
 		)
   or die("Error in command line arguments:\n$\nusage");
+
+if (defined $source_id) {
+	$global_values{source_id} = $source_id;
+}
 
 print STDERR "convert_csv_file.pl
 - csv_file: $csv_file
 - converted_csv_file: $converted_csv_file
 - columns_fields_file: $columns_fields_file
+- source_id: $source_id
 - global fields values:
 ";
 

--- a/scripts/convert_csv_file.pl
+++ b/scripts/convert_csv_file.pl
@@ -1,0 +1,90 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2020 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use Modern::Perl '2017';
+use utf8;
+
+use ProductOpener::Config qw/:all/;
+use ProductOpener::Store qw/:all/;
+use ProductOpener::Producers qw/:all/;
+
+use URI::Escape::XS;
+use Storable qw/dclone/;
+use Encode;
+use JSON::PP;
+use Time::Local;
+use Data::Dumper;
+use Text::CSV;
+use Getopt::Long;
+
+use Log::Any::Adapter 'TAP', filter => "none";
+
+my $usage = <<TXT
+convert_csv_file.pl converts a CSV file with product data into a CSV file in the Product Opener format.
+
+Usage:
+
+convert_csv_file.pl --csv_file path_to_csv_file --images_dir path_to_directory_containing_images --user_id user_id --comment "Systeme U import"
+ --define lc=fr --define stores="Magasins U"
+
+--define	: allows to define field values that will be applied to all products.
+
+TXT
+;
+
+
+my $csv_file;
+my $converted_csv_file;
+my $columns_fields_file;
+my %global_values = ();
+
+GetOptions (
+	"csv_file=s" => \$csv_file,
+    "converted_csv_file=s" => \$converted_csv_file,
+    "columns_fields_file=s" => \$columns_fields_file,
+	"define=s%" => \%global_values,
+
+		)
+  or die("Error in command line arguments:\n$\nusage");
+
+print STDERR "convert_csv_file.pl
+- csv_file: $csv_file
+- converted_csv_file: $converted_csv_file
+- columns_fields_file: $columns_fields_file
+- global fields values:
+";
+
+foreach my $field (sort keys %global_values) {
+	print STDERR "-- $field: $global_values{$field}\n";
+}
+
+my $missing_arg = 0;
+if (not defined $csv_file) {
+	print STDERR "missing --csv_file parameter\n";
+	$missing_arg++;
+}
+if (not defined $converted_csv_file) {
+	print STDERR "missing --converted_csv_file parameter\n";
+	$missing_arg++;
+}
+
+convert_file(\%global_values, $csv_file, $columns_fields_file, $converted_csv_file);

--- a/scripts/convert_usda.sh
+++ b/scripts/convert_usda.sh
@@ -3,4 +3,4 @@
 # match the columns of the USDA file (converted and merged with the recipe-analyzer script)
 # sample script:
 
-./convert_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged.10.csv --columns_fields_file=/srv/off-pro/import_files/org-database-usda-stephane/all_columns_fields.sto --converted_csv_file /srv2/stephane/usda-202104/merged.10.converted.csv
+./convert_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged_joined_category.csv --columns_fields_file=/srv/off-pro/import_files/org-database-usda/all_columns_fields.sto --converted_csv_file /srv2/stephane/usda-202104/merged_joined_category.converted.csv --source_id database-usda

--- a/scripts/convert_usda.sh
+++ b/scripts/convert_usda.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# match the columns of the USDA file (converted and merged with the recipe-analyzer script)
+# sample script:
+
+./convert_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged.10.csv --columns_fields_file=/srv/off-pro/import_files/org-database-usda-stephane/all_columns_fields.sto --converted_csv_file /srv2/stephane/usda-202104/merged.10.converted.csv

--- a/scripts/convert_usda_small.sh
+++ b/scripts/convert_usda_small.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# match the columns of the USDA file (converted and merged with the recipe-analyzer script)
+# sample script:
+
+./convert_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged_joined_category.100.csv --columns_fields_file=/srv/off-pro/import_files/org-database-usda/all_columns_fields.sto --converted_csv_file /srv2/stephane/usda-202104/merged_joined_category.100.converted.csv --source_id database-usda

--- a/scripts/import_csv_file.pl
+++ b/scripts/import_csv_file.pl
@@ -72,6 +72,7 @@ import_csv_file.pl --csv_file path_to_csv_file --images_dir path_to_directory_co
 --skip_products_without_info
 --skip_existing_values
 --only_select_not_existing_images
+--use_brand_owner_as_org_name
 TXT
 ;
 
@@ -98,6 +99,7 @@ my $skip_if_not_code;
 my $skip_products_without_info = 0;
 my $skip_existing_values = 0;
 my $only_select_not_existing_images = 0;
+my $use_brand_owner_as_org_name = 0;
 my $user_id;
 my $org_id;
 my $owner_id;
@@ -126,6 +128,7 @@ GetOptions (
 	"skip_products_without_info" => \$skip_products_without_info,
 	"skip_existing_values" => \$skip_existing_values,
 	"only_select_not_existing_images" => \$only_select_not_existing_images,
+	"use_brand_owner_as_org_name" => \$use_brand_owner_as_org_name,
 		)
   or die("Error in command line arguments:\n$\nusage");
 
@@ -136,6 +139,7 @@ print STDERR "import_csv_file.pl
 - csv_file: $csv_file
 - images_dir: $images_dir
 - skip_products_without_images: $skip_products_without_images
+- use_brand_owner_as_org_name: $use_brand_owner_as_org_name
 - comment: $comment
 - source_id: $source_id
 - source_name: $source_name
@@ -216,6 +220,7 @@ my $stats_ref = import_csv_file( {
 	skip_products_without_info => $skip_products_without_info,
 	skip_existing_values => $skip_existing_values,
 	only_select_not_existing_images => $only_select_not_existing_images,
+	use_brand_owner_as_org_name => $use_brand_owner_as_org_name,
 });
 
 print STDERR "\n\nstats:\n\n";

--- a/scripts/import_usda.sh
+++ b/scripts/import_usda.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./import_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged.10.csv --user_id database-usda-import --comment "USDA Branded Foods 2021-04 import" --source_id "database-usda" --source_name "database-usda" --manufacturer --org_id database-usda-stephane --define lc=en --define countries=us --source_url "https://fdc.nal.usda.gov/"
+

--- a/scripts/import_usda.sh
+++ b/scripts/import_usda.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-./import_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged.10.csv --user_id database-usda-import --comment "USDA Branded Foods 2021-04 import" --source_id "database-usda" --source_name "database-usda" --manufacturer --org_id database-usda-stephane --define lc=en --define countries=us --source_url "https://fdc.nal.usda.gov/"
+./import_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged.10.csv --user_id database-usda-import --comment "USDA Branded Foods 2021-04 import" --source_id "database-usda" --source_name "database-usda" --manufacturer --use_brand_owner_as_org_name --define lc=en --define countries=us --source_url "https://fdc.nal.usda.gov/"
 

--- a/scripts/import_usda_small.sh
+++ b/scripts/import_usda_small.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./import_csv_file.pl --csv_file /srv2/stephane/usda-202104/merged_joined_category.100.converted.csv --user_id database-usda-import --comment "USDA Branded Foods 2021-04 import" --source_id "database-usda" --source_name "database-usda" --manufacturer --use_brand_owner_as_org_name --define lc=en --define countries=us --source_url "https://fdc.nal.usda.gov/"
+


### PR DESCRIPTION
I closed https://github.com/openfoodfacts/openfoodfacts-server/pull/5302 and opened this new PR as I changed a lot of things on the branch.

This implements the mechanism described in #5304 

It will be used for both CodeOnline and USDA imports.