### PR TITLE
Added new subheading "Running minion jobs"

### DIFF
--- a/installation/Developer-guide.md
+++ b/installation/Developer-guide.md
@@ -68,11 +68,14 @@ mkdir directory-name
 
 ### Running minion jobs
 
+[Minion](https://docs.mojolicious.org/Minion) is a high-performance job queue for Perl. [Minion](https://docs.mojolicious.org/Minion) is used in [openfoodfacts-server](https://github.com/openfoodfacts/openfoodfacts-server) for time-consuming import and export tasks. These tasks are processed and queued using the minion jobs queue. Therefore, are called minion jobs.
+
 Go to `/opt/product-opener/scripts` and run
 
 ```
 ./minion_producers.pl minion job
 ```
+
 The above command will show the status of minion jobs. Run the following command to launch the minion jobs.
 
 ```

--- a/installation/Developer-guide.md
+++ b/installation/Developer-guide.md
@@ -73,9 +73,8 @@ Go to `/opt/product-opener/scripts` and run
 ```
 ./minion_producers.pl minion job
 ```
-The above command will show the status of minion jobs.
+The above command will show the status of minion jobs. Run the following command to launch the minion jobs.
 
-Run the following command to launch the minion jobs.
 ```
 ./minion_producers.pl minion worker -m production -q pro.openfoodfacts.org
 ```

--- a/installation/Developer-guide.md
+++ b/installation/Developer-guide.md
@@ -66,6 +66,20 @@ Navigate to your specific directory using `cd` command and run
 mkdir directory-name
 ```
 
+### Running minion jobs
+
+Go to `/opt/product-opener/scripts` and run
+
+```
+./minion_producers.pl minion job
+```
+The above command will show the status of minion jobs.
+
+Run the following command to launch the minion jobs.
+```
+./minion_producers.pl minion worker -m production -q pro.openfoodfacts.org
+```
+
 ### Exiting from bash terminal
 
 Use `exit` to exit from the bash terminal.


### PR DESCRIPTION
Updated the developer guide to add the new subheading "Running minion jobs" under the heading "Running Docker in bash".