### PR TITLE
Protect data provided by some organizations, 

### DIFF
--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -67,7 +67,7 @@ my $org_ref = retrieve_org($orgid);
 if (not defined $org_ref) {
 	$log->debug("org does not exist", { orgid => $orgid }) if $log->is_debug();
 	
-	if ($admin) {
+	if ($admin or $User{pro_moderator}) {
 		$template_data_ref->{org_does_not_exist} = 1;
 	}
 	else {
@@ -77,7 +77,7 @@ if (not defined $org_ref) {
 
 # Does the user have permission to edit the org profile?
 
-if (not (is_user_in_org_group($org_ref, $User_id, "admins") or $admin)) {
+if (not (is_user_in_org_group($org_ref, $User_id, "admins") or $admin or $User{pro_moderator})) {
 	$log->debug("user does not have permission to edit org", { orgid => $orgid, org_admins => $org_ref->{admins}, User_id => $User_id }) if $log->is_debug();
 	display_error($Lang{error_no_permission}{$lang}, 403);
 }
@@ -99,7 +99,7 @@ if ($action eq 'process') {
 			
 			# Administrator fields
 			
-			if ($admin) {
+			if ($admin or $User{pro_moderator}) {
 				
 				# If the org does not exist yet, create it
 				if (not defined $org_ref) {
@@ -110,6 +110,7 @@ if ($action eq 'process') {
 				
 				push (@admin_fields, ("enable_manual_export_to_public_platform",
 					"activate_automated_daily_export_to_public_platform",
+					"protect_data",
 					"do_not_import_codeonline",
 					"gs1_product_name_is_abbreviated",
 					"gs1_nutrients_are_unprepared",
@@ -178,7 +179,7 @@ if ($action eq 'display') {
 	
 	# Admin
 	
-	if ($admin) {
+	if ($admin or $User{pro_moderator}) {
 
 		my $admin_fields_ref = [];
 
@@ -191,6 +192,10 @@ if ($action eq 'display') {
 				field => "activate_automated_daily_export_to_public_platform",
 				type => "checkbox",
 			},
+			{
+				field => "protect_data",
+				type => "checkbox",
+			},			
 		));
 
 		if (defined $options{import_sources}) {

--- a/cgi/product_image_crop.pl
+++ b/cgi/product_image_crop.pl
@@ -73,7 +73,19 @@ if (not defined $code) {
 
 my $product_ref = retrieve_product($product_id);
 
-if ((defined $product_ref) and (has_tag($product_ref,"data_sources","producers")) and (defined $product_ref->{images}) and (defined $product_ref->{images}{$id})
+
+# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
+# when the corresponding organization has the protect_data checkbox checked
+my $protected_data = 0;
+if ((defined $product_ref->{owner}) and ($product_ref->{owner} =~ /^org-(.+)$/)) {
+	my $org_id = $1;
+	my $org_ref = retrieve_org($org_id);
+	if ((defined $org_ref) and ($org_ref->{protect_data})) {
+		$protected_data = 1;
+	}
+}
+
+if ((defined $product_ref) and ($protected_data) and (defined $product_ref->{images}) and (defined $product_ref->{images}{$id})
 	and (referer() !~ /\/cgi\/product.pl/)) {
 	$log->debug("do not select image: data_sources contains producers and referer is not the web product edit form", { code => $code, id => $id, referer => referer() }) if $log->is_debug();;
 }

--- a/cgi/product_image_crop.pl
+++ b/cgi/product_image_crop.pl
@@ -76,14 +76,7 @@ my $product_ref = retrieve_product($product_id);
 
 # Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
 # when the corresponding organization has the protect_data checkbox checked
-my $protected_data = 0;
-if ((defined $product_ref->{owner}) and ($product_ref->{owner} =~ /^org-(.+)$/)) {
-	my $org_id = $1;
-	my $org_ref = retrieve_org($org_id);
-	if ((defined $org_ref) and ($org_ref->{protect_data})) {
-		$protected_data = 1;
-	}
-}
+my $protected_data = product_data_is_protected($product_ref);
 
 if ((defined $product_ref) and ($protected_data) and (defined $product_ref->{images}) and (defined $product_ref->{images}{$id})
 	and (referer() !~ /\/cgi\/product.pl/)) {

--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -277,14 +277,7 @@ else {
 
 	# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
 	# when the corresponding organization has the protect_data checkbox checked
-	my $protected_data = 0;
-	if ((defined $product_ref->{owner}) and ($product_ref->{owner} =~ /^org-(.+)$/)) {
-		my $org_id = $1;
-		my $org_ref = retrieve_org($org_id);
-		if ((defined $org_ref) and ($org_ref->{protect_data})) {
-			$protected_data = 1;
-		}
-	}
+	my $protected_data = product_data_is_protected($product_ref);
 
 	foreach my $field (@app_fields, 'nutrition_data_per', 'serving_size', 'traces', 'ingredients_text', 'packaging_text', 'lang') {
 

--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -275,10 +275,18 @@ else {
 		}
 	}
 
+	# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
+	# when the corresponding organization has the protect_data checkbox checked
+	my $protected_data = 0;
+	if ((defined $product_ref->{owner}) and ($product_ref->{owner} =~ /^org-(.+)$/)) {
+		my $org_id = $1;
+		my $org_ref = retrieve_org($org_id);
+		if ((defined $org_ref) and ($org_ref->{protect_data})) {
+			$protected_data = 1;
+		}
+	}
+
 	foreach my $field (@app_fields, 'nutrition_data_per', 'serving_size', 'traces', 'ingredients_text', 'packaging_text', 'lang') {
-
-
-
 
 		# 11/6/2018 --> force add_brands and add_countries for yuka / kiliweb
 		if ((defined $User_id) and ($User_id eq 'kiliweb')
@@ -303,7 +311,7 @@ else {
 		elsif (defined param($field)) {
 
 			# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
-			if ((has_tag($product_ref,"data_sources","producers")) and (defined $product_ref->{$field}) and ($product_ref->{$field} ne "")) {
+			if (($protected_data) and (defined $product_ref->{$field}) and ($product_ref->{$field} ne "")) {
 				$log->debug("producer data already exists for field, skip empty value", { field => $field, code => $code, existing_value => $product_ref->{$field} }) if $log->is_debug();
 
 			}
@@ -342,7 +350,7 @@ else {
 				if (defined param($field_lc)) {
 
 					# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
-					if ((has_tag($product_ref,"data_sources","producers")) and (defined $product_ref->{$field_lc}) and ($product_ref->{$field_lc} ne "")) {
+					if (($protected_data) and (defined $product_ref->{$field_lc}) and ($product_ref->{$field_lc} ne "")) {
 						$log->debug("producer data already exists for field, skip empty value", { field_lc => $field_lc, code => $code, existing_value => $product_ref->{$field_lc} }) if $log->is_debug();
 					}
 					else {
@@ -390,7 +398,7 @@ else {
 	# Nutrition data
 
 	# Do not allow nutrition edits through API for data provided by producers
-	if ((has_tag($product_ref,"data_sources","producers")) and (defined $product_ref->{"nutriments"})) {
+	if (($protected_data) and (defined $product_ref->{"nutriments"})) {
 		print STDERR "product_jqm_multilingual.pm - code: $code - nutrition data provided by producer exists, skip nutrients\n";
 	}
 	else {

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -673,6 +673,16 @@ sub import_csv_file($) {
 			}
 		}
 
+		# add data_source "Producers"
+		if (($Org_id !~ /^app-/) and ( $Org_id !~ /^database-/ ) and ($Org_id !~ /^label-/)) {
+			if (defined $imported_product_ref->{data_sources}) {
+				$imported_product_ref->{data_sources} .= ", Producers, Producer - " . $Org_id;
+			}
+			else {
+				$imported_product_ref->{data_sources} = "Producers, Producer - " . $Org_id;
+			}
+		}
+
 		if (not defined $imported_product_ref->{lc})  {
 			$log->error("Error - missing language code lc in csv file or global field values", { i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_error();
 			next;

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -104,6 +104,7 @@ BEGIN
 		&add_back_field_values_removed_by_user
 
 		&process_product_edit_rules
+		&product_data_is_protected
 
 		&make_sure_numbers_are_stored_as_numbers
 		&change_product_server_or_code
@@ -120,6 +121,7 @@ use vars @EXPORT_OK ;
 use ProductOpener::Store qw/:all/;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Users qw/:all/;
+use ProductOpener::Orgs qw/:all/;
 use ProductOpener::Lang qw/:all/;
 use ProductOpener::Food qw/:all/;
 use ProductOpener::Tags qw/:all/;
@@ -2819,6 +2821,41 @@ sub add_user_teams ($) {
 	}
 
 	return;
+}
+
+
+=head2 product_data_is_protected ( $product_ref )
+
+Checks if the product data should be protected from edits.
+e.g. official producer data that should not be changed by anonymous users through the API
+
+Product data is protected if it has an owner and if the corresponding organization has
+the "protect data" checkbox checked.
+
+=head3 Parameters
+
+=head4 $product_ref
+
+=head3 Return values
+
+- 1 if the data is protected
+- 0 if the data is not protected
+
+=cut
+
+sub product_data_is_protected($) {
+
+	my $product_ref = shift;
+
+	my $protected_data = 0;
+	if ((defined $product_ref->{owner}) and ($product_ref->{owner} =~ /^org-(.+)$/)) {
+		my $org_id = $1;
+		my $org_ref = retrieve_org($org_id);
+		if ((defined $org_ref) and ($org_ref->{protect_data})) {
+			$protected_data = 1;
+		}
+	}
+	return $protected_data;
 }
 
 1;

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5670,3 +5670,11 @@ msgstr "Some manufacturers have incorrect values for some fields in GS1. The fea
 msgctxt "import_source_string"
 msgid "Import data from %s"
 msgstr "Import data from %s"
+
+msgctxt "org_protect_data"
+msgid "Protect the data that is provided by the organization."
+msgstr "Protect the data that is provided by the organization."
+
+msgctxt "org_protect_data_note"
+msgid "Removing or changing the provided data will be possible only by experimented contributors on the web site."
+msgstr "Removing or changing the provided data will be possible only by experimented contributors on the web site."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5688,4 +5688,10 @@ msgctxt "import_source_string"
 msgid "Import data from %s"
 msgstr "Import data from %s"
 
+msgctxt "org_protect_data"
+msgid "Protect the data that is provided by the organization."
+msgstr "Protect the data that is provided by the organization."
 
+msgctxt "org_protect_data_note"
+msgid "Removing or changing the provided data will be possible only by experimented contributors on the web site."
+msgstr "Removing or changing the provided data will be possible only by experimented contributors on the web site."


### PR DESCRIPTION
fixes #5325

Instead of protecting by default all "producer" data, we now require a manual activation of the protection, as a lot of producer data comes from 3rd parties like CodeOnline or the USDA and might be outdated or of not so good quality.