### PR TITLE
Use Eco-Score for France in fact instead of Eco-Score missing transportation bonus

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -606,12 +606,17 @@ sub compute_ecoscore($) {
 				$log->debug("compute_ecoscore - final score and grade", { score => $product_ref->{"score" . $suffix}, grade => $product_ref->{"grade" . $suffix}}) if $log->is_debug();				
 			}
 			
-			# The following values correspond to the Eco-Score without a transportation adjustment
+			# The following values correspond to the Eco-Score for France.
 			# at run-time, they may be changed to the values for a specific country
 			# after localize_ecoscore() is called
+
+			# The ecoscore_tags used for the /ecoscore facet and the ecoscore_score used for sorting by Eco-Score
+			# can only have 1 value. 
+			# Unfortunately there is a MongoDB index limit and we cannot create a different set of field
+			# for each country.
 			
-			$product_ref->{"ecoscore_score"} = $product_ref->{ecoscore_data}{"score"};
-			$product_ref->{"ecoscore_grade"} = $product_ref->{ecoscore_data}{"grade"};
+			$product_ref->{"ecoscore_score"} = $product_ref->{ecoscore_data}{"score_fr"};
+			$product_ref->{"ecoscore_grade"} = $product_ref->{ecoscore_data}{"grade_fr"};
 			$product_ref->{"ecoscore_tags"} = [$product_ref->{ecoscore_grade}];			
 			
 			if ($missing_data_warning) {

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -468,10 +468,10 @@
       "score_nl" : 61,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 56,
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 62,
    "ecoscore_tags" : [
-      "c"
+      "b"
    ],
    "forest_footprint_data" : {
       "footprint_per_kg" : 0.00176767676767677,

--- a/t/expected_test_results/ecoscore/carrots-plastic.json
+++ b/t/expected_test_results/ecoscore/carrots-plastic.json
@@ -49,8 +49,8 @@
             "non_recyclable_and_non_biodegradable_materials" : 1,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:plastic",
                   "non_recyclable_and_non_biodegradable" : "maybe",
                   "shape" : "en:tray"
@@ -81,7 +81,7 @@
          "ef_distribution" : "0.0091483656",
          "ef_packaging" : "0",
          "ef_processing" : "0",
-         "ef_total" : 0.070883164,
+         "ef_total" : "0.070883164",
          "ef_transportation" : "0.013259629",
          "is_beverage" : 0,
          "name_en" : "Carrot, raw",
@@ -111,7 +111,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "b",
-   "ecoscore_score" : 108,
+   "ecoscore_score" : 123,
    "ecoscore_tags" : [
       "b"
    ],

--- a/t/expected_test_results/ecoscore/carrots.json
+++ b/t/expected_test_results/ecoscore/carrots.json
@@ -49,7 +49,7 @@
             "packagings" : [
                {
                   "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 0,
+                  "ecoscore_shape_ratio" : "0",
                   "material" : "en:unknown",
                   "shape" : "en:bulk"
                }
@@ -80,7 +80,7 @@
          "ef_distribution" : "0.0091483656",
          "ef_packaging" : "0",
          "ef_processing" : "0",
-         "ef_total" : 0.070883164,
+         "ef_total" : "0.070883164",
          "ef_transportation" : "0.013259629",
          "is_beverage" : 0,
          "name_en" : "Carrot, raw",
@@ -114,7 +114,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "a",
-   "ecoscore_score" : 118,
+   "ecoscore_score" : 123,
    "ecoscore_tags" : [
       "a"
    ],

--- a/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
@@ -48,24 +48,24 @@
             "non_recyclable_and_non_biodegradable_materials" : 0,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 81,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "81",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:glass",
                   "number" : "1",
                   "recycling" : "en:recycle",
                   "shape" : "en:pot"
                },
                {
-                  "ecoscore_material_score" : 76,
-                  "ecoscore_shape_ratio" : 0.2,
+                  "ecoscore_material_score" : "76",
+                  "ecoscore_shape_ratio" : "0.2",
                   "material" : "en:steel",
                   "number" : "1",
                   "recycling" : "en:recycle",
                   "shape" : "en:lid"
                },
                {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 0.1,
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "0.1",
                   "material" : "en:plastic",
                   "non_recyclable_and_non_biodegradable" : "maybe",
                   "number" : "1",
@@ -98,7 +98,7 @@
          "ef_distribution" : "0.0091483656",
          "ef_packaging" : "0",
          "ef_processing" : "0",
-         "ef_total" : 0.070883164,
+         "ef_total" : "0.070883164",
          "ef_transportation" : "0.013259629",
          "is_beverage" : 0,
          "name_en" : "Carrot, raw",
@@ -128,27 +128,27 @@
       "status" : "known"
    },
    "ecoscore_grade" : "a",
-   "ecoscore_score" : 110,
+   "ecoscore_score" : 123,
    "ecoscore_tags" : [
       "a"
    ],
    "ingredients" : [
       {
          "id" : "en:aubergine",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "Aubergine",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
          "id" : "en:potato",
-         "percent" : 39,
-         "percent_estimate" : 39,
-         "percent_max" : 39,
-         "percent_min" : 39,
+         "percent" : "39",
+         "percent_estimate" : "39",
+         "percent_max" : "39",
+         "percent_min" : "39",
          "text" : "Pomme de terre",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -156,10 +156,10 @@
       {
          "from_palm_oil" : "no",
          "id" : "en:colza-oil",
-         "percent" : 1,
+         "percent" : "1",
          "percent_estimate" : 1,
-         "percent_max" : 1,
-         "percent_min" : 1,
+         "percent_max" : "1",
+         "percent_min" : "1",
          "text" : "Huile de colza",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
@@ -48,24 +48,24 @@
             "non_recyclable_and_non_biodegradable_materials" : 0,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 81,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "81",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:glass",
                   "number" : "1",
                   "recycling" : "en:recycle",
                   "shape" : "en:pot"
                },
                {
-                  "ecoscore_material_score" : 76,
-                  "ecoscore_shape_ratio" : 0.2,
+                  "ecoscore_material_score" : "76",
+                  "ecoscore_shape_ratio" : "0.2",
                   "material" : "en:steel",
                   "number" : "1",
                   "recycling" : "en:recycle",
                   "shape" : "en:lid"
                },
                {
-                  "ecoscore_material_score" : 21,
-                  "ecoscore_shape_ratio" : 0.1,
+                  "ecoscore_material_score" : "21",
+                  "ecoscore_shape_ratio" : "0.1",
                   "material" : "en:pp-polypropylene",
                   "non_recyclable_and_non_biodegradable" : "no",
                   "number" : "1",
@@ -98,7 +98,7 @@
          "ef_distribution" : "0.0091483656",
          "ef_packaging" : "0",
          "ef_processing" : "0",
-         "ef_total" : 0.070883164,
+         "ef_total" : "0.070883164",
          "ef_transportation" : "0.013259629",
          "is_beverage" : 0,
          "name_en" : "Carrot, raw",
@@ -128,27 +128,27 @@
       "status" : "known"
    },
    "ecoscore_grade" : "a",
-   "ecoscore_score" : 110,
+   "ecoscore_score" : 123,
    "ecoscore_tags" : [
       "a"
    ],
    "ingredients" : [
       {
          "id" : "en:aubergine",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "Aubergine",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
          "id" : "en:potato",
-         "percent" : 39,
-         "percent_estimate" : 39,
-         "percent_max" : 39,
-         "percent_min" : 39,
+         "percent" : "39",
+         "percent_estimate" : "39",
+         "percent_max" : "39",
+         "percent_min" : "39",
          "text" : "Pomme de terre",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -156,10 +156,10 @@
       {
          "from_palm_oil" : "no",
          "id" : "en:colza-oil",
-         "percent" : 1,
+         "percent" : "1",
          "percent_estimate" : 1,
-         "percent_max" : 1,
-         "percent_min" : 1,
+         "percent_max" : "1",
+         "percent_min" : "1",
          "text" : "Huile de colza",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.009194265200000001",
          "ef_packaging" : "0.015478282000000001",
          "ef_processing" : "0.01151692",
-         "ef_total" : 0.33526651,
+         "ef_total" : "0.33526651",
          "ef_transportation" : "0.018090858",
          "is_beverage" : 0,
          "name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
@@ -119,10 +119,10 @@
       "score_nl" : 56,
       "status" : "known"
    },
-   "ecoscore_grade" : "b",
-   "ecoscore_score" : 61,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 56,
    "ecoscore_tags" : [
-      "b"
+      "c"
    ],
    "labels_tags" : [
       "en:roundtable-on-sustainable-palm-oil"

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.009194265200000001",
          "ef_packaging" : "0.015478282000000001",
          "ef_processing" : "0.01151692",
-         "ef_total" : 0.33526651,
+         "ef_total" : "0.33526651",
          "ef_transportation" : "0.018090858",
          "is_beverage" : 0,
          "name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
@@ -119,10 +119,10 @@
       "score_nl" : 56,
       "status" : "known"
    },
-   "ecoscore_grade" : "b",
-   "ecoscore_score" : 61,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 56,
    "ecoscore_tags" : [
-      "b"
+      "c"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.0096880018",
          "ef_packaging" : "0.015478282000000001",
          "ef_processing" : "0.055903738",
-         "ef_total" : 1.1514725,
+         "ef_total" : "1.1514725",
          "ef_transportation" : "0.013733529",
          "is_beverage" : 0,
          "name_en" : "Butter, 82% fat, unsalted",
@@ -120,7 +120,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "e",
-   "ecoscore_score" : 17,
+   "ecoscore_score" : 12,
    "ecoscore_tags" : [
       "e"
    ],

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.009194265200000001",
          "ef_packaging" : "0.015478282000000001",
          "ef_processing" : "0.01151692",
-         "ef_total" : 0.33526651,
+         "ef_total" : "0.33526651",
          "ef_transportation" : "0.018090858",
          "is_beverage" : 0,
          "name_en" : "Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted, rich in omega 3",
@@ -119,10 +119,10 @@
       "score_nl" : 56,
       "status" : "known"
    },
-   "ecoscore_grade" : "b",
-   "ecoscore_score" : 61,
+   "ecoscore_grade" : "c",
+   "ecoscore_score" : 56,
    "ecoscore_tags" : [
-      "b"
+      "c"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -84,7 +84,7 @@
          "ef_distribution" : "0.0096880018",
          "ef_packaging" : "0.015478282000000001",
          "ef_processing" : "0.055903738",
-         "ef_total" : 1.1514725,
+         "ef_total" : "1.1514725",
          "ef_transportation" : "0.013733529",
          "is_beverage" : 0,
          "name_en" : "Butter, 82% fat, unsalted",
@@ -120,7 +120,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 32,
+   "ecoscore_score" : 27,
    "ecoscore_tags" : [
       "d"
    ],

--- a/t/expected_test_results/ecoscore/milk.json
+++ b/t/expected_test_results/ecoscore/milk.json
@@ -48,8 +48,8 @@
             "non_recyclable_and_non_biodegradable_materials" : 0,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 50,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "50",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:pet-polyethylene-terephthalate",
                   "material_shape" : "en:pet-polyethylene-terephthalate.en:bottle",
                   "non_recyclable_and_non_biodegradable" : "no",
@@ -57,8 +57,8 @@
                   "shape" : "en:bottle"
                },
                {
-                  "ecoscore_material_score" : 50,
-                  "ecoscore_shape_ratio" : 0.1,
+                  "ecoscore_material_score" : "50",
+                  "ecoscore_shape_ratio" : "0.1",
                   "material" : "en:hdpe-high-density-polyethylene",
                   "material_shape" : "en:hdpe-high-density-polyethylene.en:bottle-cap",
                   "non_recyclable_and_non_biodegradable" : "no",
@@ -91,7 +91,7 @@
          "ef_distribution" : "0.004287772",
          "ef_packaging" : "0.014723027999999999",
          "ef_processing" : "0.0014905525",
-         "ef_total" : 0.13351659,
+         "ef_total" : "0.13351659",
          "ef_transportation" : "0.0079906595",
          "is_beverage" : 1,
          "name_en" : "Milk, semi-skimmed, UHT",
@@ -121,7 +121,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "b",
-   "ecoscore_score" : 63,
+   "ecoscore_score" : 79,
    "ecoscore_tags" : [
       "b"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -89,7 +89,7 @@
          "ef_distribution" : "0.0091648653",
          "ef_packaging" : "0.056809478",
          "ef_processing" : "0.041272627",
-         "ef_total" : 0.55246032,
+         "ef_total" : "0.55246032",
          "ef_transportation" : "0.02822842",
          "is_beverage" : 0,
          "name_en" : "Jam, strawberry",
@@ -124,17 +124,17 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 40,
+   "ecoscore_score" : 54,
    "ecoscore_tags" : [
       "c"
    ],
    "ingredients" : [
       {
          "id" : "en:apricot",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -142,10 +142,10 @@
       {
          "id" : "en:cane-sugar",
          "origins" : "en:martinique",
-         "percent" : 30,
-         "percent_estimate" : 30,
-         "percent_max" : 30,
-         "percent_min" : 30,
+         "percent" : "30",
+         "percent_estimate" : "30",
+         "percent_max" : "30",
+         "percent_min" : "30",
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -84,7 +84,7 @@
          "ef_distribution" : "0.0091648653",
          "ef_packaging" : "0.056809478",
          "ef_processing" : "0.041272627",
-         "ef_total" : 0.55246032,
+         "ef_total" : "0.55246032",
          "ef_transportation" : "0.02822842",
          "is_beverage" : 0,
          "name_en" : "Jam, strawberry",
@@ -119,17 +119,17 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 40,
+   "ecoscore_score" : 56,
    "ecoscore_tags" : [
       "c"
    ],
    "ingredients" : [
       {
          "id" : "en:apricot",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -137,10 +137,10 @@
       {
          "id" : "en:cane-sugar",
          "origins" : "en:martinique",
-         "percent" : 30,
-         "percent_estimate" : 30,
-         "percent_max" : 30,
-         "percent_min" : 30,
+         "percent" : "30",
+         "percent_estimate" : "30",
+         "percent_max" : "30",
+         "percent_min" : "30",
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -116,10 +116,10 @@
       "score_nl" : 39,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 44,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 39,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "ingredients" : [
       {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -116,10 +116,10 @@
       "score_nl" : 39,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 44,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 39,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "ingredients" : [
       {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -81,7 +81,7 @@
          "ef_distribution" : "0.0091648653",
          "ef_packaging" : "0.056809478",
          "ef_processing" : "0.041272627",
-         "ef_total" : 0.55246032,
+         "ef_total" : "0.55246032",
          "ef_transportation" : "0.02822842",
          "is_beverage" : 0,
          "name_en" : "Jam, strawberry",
@@ -116,28 +116,28 @@
       "score_nl" : 35,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 40,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 35,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "ingredients" : [
       {
          "id" : "en:apricot",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
          "id" : "en:cane-sugar",
-         "percent" : 30,
-         "percent_estimate" : 30,
-         "percent_max" : 30,
-         "percent_min" : 30,
+         "percent" : "30",
+         "percent_estimate" : "30",
+         "percent_max" : "30",
+         "percent_min" : "30",
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -84,7 +84,7 @@
          "ef_distribution" : "0.0091648653",
          "ef_packaging" : "0.056809478",
          "ef_processing" : "0.041272627",
-         "ef_total" : 0.55246032,
+         "ef_total" : "0.55246032",
          "ef_transportation" : "0.02822842",
          "is_beverage" : 0,
          "name_en" : "Jam, strawberry",
@@ -119,7 +119,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 40,
+   "ecoscore_score" : 50,
    "ecoscore_tags" : [
       "c"
    ],
@@ -127,20 +127,20 @@
       {
          "id" : "en:apricot",
          "origins" : "en:france",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
       },
       {
          "id" : "en:cane-sugar",
-         "percent" : 30,
-         "percent_estimate" : 30,
-         "percent_max" : 30,
-         "percent_min" : 30,
+         "percent" : "30",
+         "percent_estimate" : "30",
+         "percent_max" : "30",
+         "percent_min" : "30",
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -100,7 +100,7 @@
          "ef_distribution" : "0.0091648653",
          "ef_packaging" : "0.056809478",
          "ef_processing" : "0.041272627",
-         "ef_total" : 0.55246032,
+         "ef_total" : "0.55246032",
          "ef_transportation" : "0.02822842",
          "is_beverage" : 0,
          "name_en" : "Jam, strawberry",
@@ -135,7 +135,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 40,
+   "ecoscore_score" : 52,
    "ecoscore_tags" : [
       "c"
    ],
@@ -143,10 +143,10 @@
       {
          "id" : "en:apricot",
          "origins" : "en:france,en:spain",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -154,10 +154,10 @@
       {
          "id" : "en:cane-sugar",
          "origins" : "en:martinique,en:guadeloupe,en:dominican-republic",
-         "percent" : 30,
-         "percent_estimate" : 30,
-         "percent_max" : 30,
-         "percent_min" : 30,
+         "percent" : "30",
+         "percent_estimate" : "30",
+         "percent_max" : "30",
+         "percent_min" : "30",
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -88,7 +88,7 @@
          "ef_distribution" : "0.0091648653",
          "ef_packaging" : "0.056809478",
          "ef_processing" : "0.041272627",
-         "ef_total" : 0.55246032,
+         "ef_total" : "0.55246032",
          "ef_transportation" : "0.02822842",
          "is_beverage" : 0,
          "name_en" : "Jam, strawberry",
@@ -123,7 +123,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 40,
+   "ecoscore_score" : 55,
    "ecoscore_tags" : [
       "c"
    ],
@@ -131,10 +131,10 @@
       {
          "id" : "en:apricot",
          "origins" : "en:france",
-         "percent" : 60,
-         "percent_estimate" : 60,
-         "percent_max" : 60,
-         "percent_min" : 60,
+         "percent" : "60",
+         "percent_estimate" : "60",
+         "percent_max" : "60",
+         "percent_min" : "60",
          "text" : "apricots",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -142,10 +142,10 @@
       {
          "id" : "en:cane-sugar",
          "origins" : "en:martinique",
-         "percent" : 30,
-         "percent_estimate" : 30,
-         "percent_max" : 30,
-         "percent_min" : 30,
+         "percent" : "30",
+         "percent_estimate" : "30",
+         "percent_max" : "30",
+         "percent_min" : "30",
          "text" : "cane sugar",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -116,10 +116,10 @@
       "score_nl" : 39,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 44,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 39,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "ingredients" : [
       {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -114,10 +114,10 @@
       "score_nl" : 39,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 44,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 39,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "ingredients" : [
       {

--- a/t/expected_test_results/ecoscore/packaging-en-bulk.json
+++ b/t/expected_test_results/ecoscore/packaging-en-bulk.json
@@ -51,7 +51,7 @@
             "packagings" : [
                {
                   "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 0,
+                  "ecoscore_shape_ratio" : "0",
                   "material" : "en:unknown",
                   "shape" : "en:bulk"
                }
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.0088128735",
          "ef_packaging" : "0.014792145999999999",
          "ef_processing" : "0.0056288216",
-         "ef_total" : 0.14687612,
+         "ef_total" : "0.14687612",
          "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
          "name_en" : "Mixed fruits juice, orange based, multivitamin",
@@ -120,7 +120,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 51,
+   "ecoscore_score" : 46,
    "ecoscore_tags" : [
       "c"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -50,23 +50,23 @@
             "non_recyclable_and_non_biodegradable_materials" : 0,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 92,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "92",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:cardboard",
                   "number" : "1",
                   "shape" : "en:box"
                },
                {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 0.1,
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "0.1",
                   "material" : "en:plastic",
                   "non_recyclable_and_non_biodegradable" : "maybe",
                   "number" : "1",
                   "shape" : "en:film"
                },
                {
-                  "ecoscore_material_score" : 76,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "76",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:steel",
                   "number" : "6",
                   "quantity" : "33cl",
@@ -101,7 +101,7 @@
          "ef_distribution" : "0.0088128735",
          "ef_packaging" : "0.014792145999999999",
          "ef_processing" : "0.0056288216",
-         "ef_total" : 0.14687612,
+         "ef_total" : "0.14687612",
          "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
          "name_en" : "Mixed fruits juice, orange based, multivitamin",
@@ -137,7 +137,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 47,
+   "ecoscore_score" : 42,
    "ecoscore_tags" : [
       "c"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -50,8 +50,8 @@
             "non_recyclable_and_non_biodegradable_materials" : 0,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 50,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "50",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:pet-polyethylene-terephthalate",
                   "material_shape" : "en:pet-polyethylene-terephthalate.en:bottle",
                   "non_recyclable_and_non_biodegradable" : "no",
@@ -84,7 +84,7 @@
          "ef_distribution" : "0.0088128735",
          "ef_packaging" : "0.014792145999999999",
          "ef_processing" : "0.0056288216",
-         "ef_total" : 0.14687612,
+         "ef_total" : "0.14687612",
          "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
          "name_en" : "Mixed fruits juice, orange based, multivitamin",
@@ -120,7 +120,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 46,
+   "ecoscore_score" : 41,
    "ecoscore_tags" : [
       "c"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -50,8 +50,8 @@
             "non_recyclable_and_non_biodegradable_materials" : 1,
             "packagings" : [
                {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:plastic",
                   "non_recyclable_and_non_biodegradable" : "maybe",
                   "shape" : "en:bottle"
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.0088128735",
          "ef_packaging" : "0.014792145999999999",
          "ef_processing" : "0.0056288216",
-         "ef_total" : 0.14687612,
+         "ef_total" : "0.14687612",
          "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
          "name_en" : "Mixed fruits juice, orange based, multivitamin",
@@ -118,10 +118,10 @@
       "score_nl" : 36,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 41,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 36,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -51,7 +51,7 @@
             "packagings" : [
                {
                   "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:unknown",
                   "shape" : "en:bottle"
                }
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.0088128735",
          "ef_packaging" : "0.014792145999999999",
          "ef_processing" : "0.0056288216",
-         "ef_total" : 0.14687612,
+         "ef_total" : "0.14687612",
          "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
          "name_en" : "Mixed fruits juice, orange based, multivitamin",
@@ -119,10 +119,10 @@
       "score_nl" : 36,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 41,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 36,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -51,7 +51,7 @@
             "packagings" : [
                {
                   "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
+                  "ecoscore_shape_ratio" : "1",
                   "material" : "en:unknown",
                   "shape" : "en:can"
                }
@@ -83,7 +83,7 @@
          "ef_distribution" : "0.0088128735",
          "ef_packaging" : "0.014792145999999999",
          "ef_processing" : "0.0056288216",
-         "ef_total" : 0.14687612,
+         "ef_total" : "0.14687612",
          "ef_transportation" : "0.029304117999999997",
          "is_beverage" : 1,
          "name_en" : "Mixed fruits juice, orange based, multivitamin",
@@ -119,10 +119,10 @@
       "score_nl" : 36,
       "status" : "known"
    },
-   "ecoscore_grade" : "c",
-   "ecoscore_score" : 41,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 36,
    "ecoscore_tags" : [
-      "c"
+      "d"
    ],
    "lc" : "en",
    "misc_tags" : [

--- a/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
+++ b/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
@@ -49,7 +49,7 @@
             "packagings" : [
                {
                   "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 0,
+                  "ecoscore_shape_ratio" : "0",
                   "material" : "en:unknown",
                   "shape" : "en:bulk"
                }
@@ -80,7 +80,7 @@
          "ef_distribution" : "0.011840366",
          "ef_packaging" : "0.023412096",
          "ef_processing" : "0.10705326",
-         "ef_total" : 1.1111394,
+         "ef_total" : "1.1111394",
          "ef_transportation" : "0.02444929",
          "is_beverage" : 0,
          "name_en" : "Chicken, breast, without skin, cooked",
@@ -114,7 +114,7 @@
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 48,
+   "ecoscore_score" : 53,
    "ecoscore_tags" : [
       "c"
    ],


### PR DESCRIPTION
The "transportation less" Eco-Score grade and score we have today in the ecoscore_tags and ecoscore_grade fields is not meaningful, and far from the actual Eco-Score for any country.

It is better to use the Eco-Score for France instead, as there will be much less differences. We can try to find a better system later. Unfortunately we are constrained by the number of possible indexes in MongoDB (64) so we can't index all the Eco-Score values for all countries.