### PR TITLE
Ecoscore changes for unknown packaging and fresh fruits and vegetables

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -1217,8 +1217,8 @@ sub compute_ecoscore_packaging_adjustment($) {
 	$packaging_score = 100 - $packaging_score;
 	
 	my $value = round($packaging_score / 10 - 10);
-	if ($value < -10) {
-		$value = -10;
+	if ($value < -15) {
+		$value = -15;
 	}
 
 	$product_ref->{ecoscore_data}{adjustments}{packaging} = {

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -492,7 +492,7 @@ sub compute_ecoscore($) {
 	
 	# Special case for waters and sodas: disable the Eco-Score
 	
-	my @categories_without_ecoscore = ("en:waters", "en:sodas", "en:energy-drinks");
+	my @categories_without_ecoscore = ("en:waters", "en:sodas", "en:energy-drinks", "en:fresh-vegetables", "en:fresh-fruits");
 	my $category_without_ecoscore;
 	
 	foreach my $category (@categories_without_ecoscore) {

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -261,6 +261,15 @@ my @tests = (
 			packaging_text=>"1 cardboard box, 1 plastic film wrap, 6 33cl steel beverage cans"
 		}
 	],
+
+	[
+		'packaging-en-multiple-over-maximum-malus',
+		{
+			lc => "en",
+			categories_tags=>["en:biscuits"],
+			packaging_text=>"1 plastic box, 1 plastic film wrap, 12 individual plastic bags"
+		}
+	],	
 	
 	[
 		'packaging-en-unspecified-material-bottle',

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -416,6 +416,28 @@ my @tests = (
 			packaging_text => "1 bouteille en plastique PET, 1 bouchon PEHD",
 			ingredients_text => "Water",
 		},
+	],
+
+	# Fresh fruits and vegetables should not have an Eco-Score (at least until we handle seasonality)
+
+	[
+		'fresh-vegetable',
+		{
+			lc => "en",
+			categories_tags=>["en:fresh-vegetables", "en:fresh-tomatoes", "en:tomatoes"],
+			packaging_text => "1 plastic film",
+			ingredients_text => "Tomatoes",
+		},
+	],
+
+	[
+		'frozen-vegetable',
+		{
+			lc => "en",
+			categories_tags=>["en:frozen-vegetables", "en:frozen-carrots", "en:carrots"],
+			packaging_text => "1 plastic film",
+			ingredients_text => "Carrots",
+		},
 	],	
 
 );

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -288,6 +288,24 @@ my @tests = (
 			packaging_text=>"can"
 		}
 	],
+
+	[
+		'packaging-unspecified',
+		{
+			lc => "en",
+			categories_tags=>["en:milks"],
+		}
+	],
+
+	[
+		'packaging-unspecified-no-a-eco-score',
+		{
+			lc => "en",
+			categories_tags=>["en:speculoos"],
+			ingredients_text=>"Wheat (France)",
+			labels_tags=>["fr:ab-agriculture-biologique"],
+		}
+	],		
 	
 	# Sodas: no Eco-Score
 	

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -301,7 +301,7 @@ my @tests = (
 		'packaging-unspecified-no-a-eco-score',
 		{
 			lc => "en",
-			categories_tags=>["en:speculoos"],
+			categories_tags=>["en:baguettes"],
 			ingredients_text=>"Wheat (France)",
 			labels_tags=>["fr:ab-agriculture-biologique"],
 		}

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -357,17 +357,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -469,12 +459,7 @@
    ],
    "nutrition_score_debug" : "no score when the product does not have a category",
    "other_nutritional_substances_tags" : [],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "pnns_groups_1" : "unknown",
    "pnns_groups_1_tags" : [
       "unknown",

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -357,17 +357,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -493,12 +483,7 @@
    ],
    "nutrition_score_debug" : "no score when the product does not have a category",
    "other_nutritional_substances_tags" : [],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "pnns_groups_1" : "unknown",
    "pnns_groups_1_tags" : [
       "unknown",

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -357,17 +357,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -485,12 +475,7 @@
    ],
    "nutrition_score_debug" : "no score when the product does not have a category",
    "other_nutritional_substances_tags" : [],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "pnns_groups_1" : "unknown",
    "pnns_groups_1_tags" : [
       "unknown",

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -357,17 +357,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -494,12 +484,7 @@
    ],
    "nutrition_score_debug" : "no score when the product does not have a category",
    "other_nutritional_substances_tags" : [],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "pnns_groups_1" : "unknown",
    "pnns_groups_1_tags" : [
       "unknown",

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -44,17 +44,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -85,10 +75,5 @@
    "misc_tags" : [
       "en:ecoscore-not-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/fresh-vegetable.json
+++ b/t/expected_test_results/ecoscore/fresh-vegetable.json
@@ -1,0 +1,68 @@
+{
+   "categories_tags" : [
+      "en:fresh-vegetables",
+      "en:fresh-tomatoes",
+      "en:tomatoes"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {},
+      "ecoscore_not_applicable_for_category" : "en:fresh-vegetables",
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "not-applicable",
+   "ecoscore_tags" : [
+      "not-applicable"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:tomato",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Tomatoes",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:tomato",
+      "en:vegetable"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:tomato"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:tomato",
+      "en:vegetable"
+   ],
+   "ingredients_text" : "Tomatoes",
+   "known_ingredients_n" : 2,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-not-applicable",
+      "en:ecoscore-not-computed"
+   ],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 100
+   },
+   "packaging_text" : "1 plastic film",
+   "packagings" : [
+      {
+         "material" : "en:plastic",
+         "number" : "1",
+         "shape" : "en:film"
+      }
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/ecoscore/frozen-vegetable.json
+++ b/t/expected_test_results/ecoscore/frozen-vegetable.json
@@ -1,0 +1,179 @@
+{
+   "categories_tags" : [
+      "en:frozen-vegetables",
+      "en:frozen-carrots",
+      "en:carrots"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 0,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "0.1",
+                  "material" : "en:plastic",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "number" : "1",
+                  "shape" : "en:film"
+               }
+            ],
+            "score" : 90,
+            "value" : -1
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_food_code" : "20009",
+         "co2_agriculture" : "0.087677241",
+         "co2_consumption" : "0.099564814",
+         "co2_distribution" : "0.029228063",
+         "co2_packaging" : "0",
+         "co2_processing" : "0",
+         "co2_total" : "0.38690672",
+         "co2_transportation" : "0.1704366",
+         "code" : "20009",
+         "dqr" : "2.15",
+         "ef_agriculture" : "0.044256253",
+         "ef_consumption" : "0.0042189169",
+         "ef_distribution" : "0.0091483656",
+         "ef_packaging" : "0",
+         "ef_processing" : "0",
+         "ef_total" : "0.070883164",
+         "ef_transportation" : "0.013259629",
+         "is_beverage" : 0,
+         "name_en" : "Carrot, raw",
+         "name_fr" : "Carotte, crue",
+         "score" : 98
+      },
+      "grade" : "a",
+      "grade_be" : "a",
+      "grade_ch" : "a",
+      "grade_de" : "a",
+      "grade_es" : "a",
+      "grade_fr" : "a",
+      "grade_ie" : "a",
+      "grade_it" : "a",
+      "grade_lu" : "a",
+      "grade_nl" : "a",
+      "missing" : {
+         "labels" : 1,
+         "origins" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 97,
+      "score_be" : 92,
+      "score_ch" : 92,
+      "score_de" : 92,
+      "score_es" : 92,
+      "score_fr" : 92,
+      "score_ie" : 92,
+      "score_it" : 92,
+      "score_lu" : 92,
+      "score_nl" : 92,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "a",
+   "ecoscore_score" : 92,
+   "ecoscore_tags" : [
+      "a"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:carrot",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Carrots",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:carrot",
+      "en:vegetable",
+      "en:root-vegetable"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:carrot"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:carrot",
+      "en:vegetable",
+      "en:root-vegetable"
+   ],
+   "ingredients_text" : "Carrots",
+   "known_ingredients_n" : 3,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 100
+   },
+   "packaging_text" : "1 plastic film",
+   "packagings" : [
+      {
+         "material" : "en:plastic",
+         "number" : "1",
+         "shape" : "en:film"
+      }
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -90,7 +80,7 @@
          "name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
          "score" : 71
       },
-      "grade" : "b",
+      "grade" : "c",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -107,20 +97,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 61,
-      "score_be" : 56,
-      "score_ch" : 56,
-      "score_de" : 56,
-      "score_es" : 56,
-      "score_fr" : 56,
-      "score_ie" : 56,
-      "score_it" : 56,
-      "score_lu" : 56,
-      "score_nl" : 56,
+      "score" : 56,
+      "score_be" : 51,
+      "score_ch" : 51,
+      "score_de" : 51,
+      "score_es" : 51,
+      "score_fr" : 51,
+      "score_ie" : 51,
+      "score_it" : 51,
+      "score_lu" : 51,
+      "score_nl" : 51,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56,
+   "ecoscore_score" : 51,
    "ecoscore_tags" : [
       "c"
    ],
@@ -132,10 +122,5 @@
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -90,7 +80,7 @@
          "name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
          "score" : 71
       },
-      "grade" : "b",
+      "grade" : "c",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -107,20 +97,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 61,
-      "score_be" : 56,
-      "score_ch" : 56,
-      "score_de" : 56,
-      "score_es" : 56,
-      "score_fr" : 56,
-      "score_ie" : 56,
-      "score_it" : 56,
-      "score_lu" : 56,
-      "score_nl" : 56,
+      "score" : 56,
+      "score_be" : 51,
+      "score_ch" : 51,
+      "score_de" : 51,
+      "score_es" : 51,
+      "score_fr" : 51,
+      "score_ie" : 51,
+      "score_it" : 51,
+      "score_lu" : 51,
+      "score_nl" : 51,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56,
+   "ecoscore_score" : 51,
    "ecoscore_tags" : [
       "c"
    ],
@@ -129,10 +119,5 @@
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -107,20 +97,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 17,
-      "score_be" : 12,
-      "score_ch" : 12,
-      "score_de" : 12,
-      "score_es" : 12,
-      "score_fr" : 12,
-      "score_ie" : 12,
-      "score_it" : 12,
-      "score_lu" : 12,
-      "score_nl" : 12,
+      "score" : 12,
+      "score_be" : 7,
+      "score_ch" : 7,
+      "score_de" : 7,
+      "score_es" : 7,
+      "score_fr" : 7,
+      "score_ie" : 7,
+      "score_it" : 7,
+      "score_lu" : 7,
+      "score_nl" : 7,
       "status" : "known"
    },
    "ecoscore_grade" : "e",
-   "ecoscore_score" : 12,
+   "ecoscore_score" : 7,
    "ecoscore_tags" : [
       "e"
    ],
@@ -129,10 +119,5 @@
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -90,7 +80,7 @@
          "name_fr" : "Matière grasse végétale (type margarine) à 50-63% MG, allégée, doux, riche en oméga 3",
          "score" : 71
       },
-      "grade" : "b",
+      "grade" : "c",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -107,20 +97,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 61,
-      "score_be" : 56,
-      "score_ch" : 56,
-      "score_de" : 56,
-      "score_es" : 56,
-      "score_fr" : 56,
-      "score_ie" : 56,
-      "score_it" : 56,
-      "score_lu" : 56,
-      "score_nl" : 56,
+      "score" : 56,
+      "score_be" : 51,
+      "score_ch" : 51,
+      "score_de" : 51,
+      "score_es" : 51,
+      "score_fr" : 51,
+      "score_ie" : 51,
+      "score_it" : 51,
+      "score_lu" : 51,
+      "score_nl" : 51,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56,
+   "ecoscore_score" : 51,
    "ecoscore_tags" : [
       "c"
    ],
@@ -129,10 +119,5 @@
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -107,20 +97,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 32,
-      "score_be" : 27,
-      "score_ch" : 27,
-      "score_de" : 27,
-      "score_es" : 27,
-      "score_fr" : 27,
-      "score_ie" : 27,
-      "score_it" : 27,
-      "score_lu" : 27,
-      "score_nl" : 27,
+      "score" : 27,
+      "score_be" : 22,
+      "score_ch" : 22,
+      "score_de" : 22,
+      "score_es" : 22,
+      "score_fr" : 22,
+      "score_ie" : 22,
+      "score_it" : 22,
+      "score_lu" : 22,
+      "score_nl" : 22,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 27,
+   "ecoscore_score" : 22,
    "ecoscore_tags" : [
       "d"
    ],
@@ -132,10 +122,5 @@
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -55,17 +55,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -96,7 +86,7 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 50
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -111,20 +101,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 40,
-      "score_be" : 54,
-      "score_ch" : 50,
-      "score_de" : 51,
-      "score_es" : 47,
-      "score_fr" : 54,
-      "score_ie" : 49,
-      "score_it" : 48,
-      "score_lu" : 53,
-      "score_nl" : 53,
+      "score" : 35,
+      "score_be" : 49,
+      "score_ch" : 45,
+      "score_de" : 46,
+      "score_es" : 42,
+      "score_fr" : 49,
+      "score_ie" : 44,
+      "score_it" : 43,
+      "score_lu" : 48,
+      "score_nl" : 48,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 54,
+   "ecoscore_score" : 49,
    "ecoscore_tags" : [
       "c"
    ],
@@ -207,11 +197,6 @@
       "en:dordogne",
       "en:belgium"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -50,17 +50,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -91,7 +81,7 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 50
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -106,20 +96,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 40,
-      "score_be" : 54,
-      "score_ch" : 51,
-      "score_de" : 51,
-      "score_es" : 49,
-      "score_fr" : 56,
-      "score_ie" : 50,
-      "score_it" : 49,
-      "score_lu" : 53,
-      "score_nl" : 53,
+      "score" : 35,
+      "score_be" : 49,
+      "score_ch" : 46,
+      "score_de" : 46,
+      "score_es" : 44,
+      "score_fr" : 51,
+      "score_ie" : 45,
+      "score_it" : 44,
+      "score_lu" : 48,
+      "score_nl" : 48,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 56,
+   "ecoscore_score" : 51,
    "ecoscore_tags" : [
       "c"
    ],
@@ -200,11 +190,6 @@
    "origins_tags" : [
       "en:france"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -88,7 +78,7 @@
          "name_fr" : "Camembert, sans précision",
          "score" : 54
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "d",
       "grade_ch" : "d",
       "grade_de" : "d",
@@ -104,20 +94,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 44,
-      "score_be" : 39,
-      "score_ch" : 39,
-      "score_de" : 39,
-      "score_es" : 39,
-      "score_fr" : 39,
-      "score_ie" : 39,
-      "score_it" : 39,
-      "score_lu" : 39,
-      "score_nl" : 39,
+      "score" : 39,
+      "score_be" : 34,
+      "score_ch" : 34,
+      "score_de" : 34,
+      "score_es" : 34,
+      "score_fr" : 34,
+      "score_ie" : 34,
+      "score_it" : 34,
+      "score_lu" : 34,
+      "score_nl" : 34,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 39,
+   "ecoscore_score" : 34,
    "ecoscore_tags" : [
       "d"
    ],
@@ -238,11 +228,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -88,7 +78,7 @@
          "name_fr" : "Camembert, sans précision",
          "score" : 54
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "d",
       "grade_ch" : "d",
       "grade_de" : "d",
@@ -104,20 +94,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 44,
-      "score_be" : 39,
-      "score_ch" : 39,
-      "score_de" : 39,
-      "score_es" : 39,
-      "score_fr" : 39,
-      "score_ie" : 39,
-      "score_it" : 39,
-      "score_lu" : 39,
-      "score_nl" : 39,
+      "score" : 39,
+      "score_be" : 34,
+      "score_ch" : 34,
+      "score_de" : 34,
+      "score_es" : 34,
+      "score_fr" : 34,
+      "score_ie" : 34,
+      "score_it" : 34,
+      "score_lu" : 34,
+      "score_nl" : 34,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 39,
+   "ecoscore_score" : 34,
    "ecoscore_tags" : [
       "d"
    ],
@@ -200,11 +190,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -88,7 +78,7 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 50
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "d",
       "grade_ch" : "d",
       "grade_de" : "d",
@@ -104,20 +94,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 40,
-      "score_be" : 35,
-      "score_ch" : 35,
-      "score_de" : 35,
-      "score_es" : 35,
-      "score_fr" : 35,
-      "score_ie" : 35,
-      "score_it" : 35,
-      "score_lu" : 35,
-      "score_nl" : 35,
+      "score" : 35,
+      "score_be" : 30,
+      "score_ch" : 30,
+      "score_de" : 30,
+      "score_es" : 30,
+      "score_fr" : 30,
+      "score_ie" : 30,
+      "score_it" : 30,
+      "score_lu" : 30,
+      "score_nl" : 30,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 35,
+   "ecoscore_score" : 30,
    "ecoscore_tags" : [
       "d"
    ],
@@ -194,11 +184,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -50,17 +50,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -91,11 +81,11 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 50
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
-      "grade_es" : "c",
+      "grade_es" : "d",
       "grade_fr" : "c",
       "grade_ie" : "c",
       "grade_it" : "c",
@@ -106,20 +96,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 40,
-      "score_be" : 49,
-      "score_ch" : 47,
-      "score_de" : 46,
-      "score_es" : 44,
-      "score_fr" : 50,
-      "score_ie" : 45,
-      "score_it" : 45,
-      "score_lu" : 48,
-      "score_nl" : 48,
+      "score" : 35,
+      "score_be" : 44,
+      "score_ch" : 42,
+      "score_de" : 41,
+      "score_es" : 39,
+      "score_fr" : 45,
+      "score_ie" : 40,
+      "score_it" : 40,
+      "score_lu" : 43,
+      "score_nl" : 43,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 50,
+   "ecoscore_score" : 45,
    "ecoscore_tags" : [
       "c"
    ],
@@ -197,11 +187,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -66,17 +66,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -107,7 +97,7 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 50
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -122,20 +112,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 40,
-      "score_be" : 49,
-      "score_ch" : 47,
-      "score_de" : 49,
-      "score_es" : 50,
-      "score_fr" : 52,
-      "score_ie" : 47,
-      "score_it" : 46,
-      "score_lu" : 48,
-      "score_nl" : 48,
+      "score" : 35,
+      "score_be" : 44,
+      "score_ch" : 42,
+      "score_de" : 44,
+      "score_es" : 45,
+      "score_fr" : 47,
+      "score_ie" : 42,
+      "score_it" : 41,
+      "score_lu" : 43,
+      "score_nl" : 43,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 52,
+   "ecoscore_score" : 47,
    "ecoscore_tags" : [
       "c"
    ],
@@ -214,11 +204,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -54,17 +54,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -95,7 +85,7 @@
          "name_fr" : "Confiture de fraise (extra ou classique)",
          "score" : 50
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "c",
       "grade_ch" : "c",
       "grade_de" : "c",
@@ -110,20 +100,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 40,
-      "score_be" : 53,
-      "score_ch" : 51,
-      "score_de" : 51,
-      "score_es" : 49,
-      "score_fr" : 55,
-      "score_ie" : 49,
-      "score_it" : 50,
-      "score_lu" : 53,
-      "score_nl" : 52,
+      "score" : 35,
+      "score_be" : 48,
+      "score_ch" : 46,
+      "score_de" : 46,
+      "score_es" : 44,
+      "score_fr" : 50,
+      "score_ie" : 44,
+      "score_it" : 45,
+      "score_lu" : 48,
+      "score_nl" : 47,
       "status" : "known"
    },
    "ecoscore_grade" : "c",
-   "ecoscore_score" : 55,
+   "ecoscore_score" : 50,
    "ecoscore_tags" : [
       "c"
    ],
@@ -203,11 +193,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 70
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -88,7 +78,7 @@
          "name_fr" : "Camembert, sans précision",
          "score" : 54
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "d",
       "grade_ch" : "d",
       "grade_de" : "d",
@@ -104,20 +94,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 44,
-      "score_be" : 39,
-      "score_ch" : 39,
-      "score_de" : 39,
-      "score_es" : 39,
-      "score_fr" : 39,
-      "score_ie" : 39,
-      "score_it" : 39,
-      "score_lu" : 39,
-      "score_nl" : 39,
+      "score" : 39,
+      "score_be" : 34,
+      "score_ch" : 34,
+      "score_de" : 34,
+      "score_es" : 34,
+      "score_fr" : 34,
+      "score_ie" : 34,
+      "score_it" : 34,
+      "score_lu" : 34,
+      "score_nl" : 34,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 39,
+   "ecoscore_score" : 34,
    "ecoscore_tags" : [
       "d"
    ],
@@ -165,11 +155,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -46,17 +46,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -87,7 +77,7 @@
          "name_fr" : "Camembert, sans précision",
          "score" : 54
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "d",
       "grade_ch" : "d",
       "grade_de" : "d",
@@ -102,20 +92,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 44,
-      "score_be" : 39,
-      "score_ch" : 39,
-      "score_de" : 39,
-      "score_es" : 39,
-      "score_fr" : 39,
-      "score_ie" : 39,
-      "score_it" : 39,
-      "score_lu" : 39,
-      "score_nl" : 39,
+      "score" : 39,
+      "score_be" : 34,
+      "score_ch" : 34,
+      "score_de" : 34,
+      "score_es" : 34,
+      "score_fr" : 34,
+      "score_ie" : 34,
+      "score_it" : 34,
+      "score_lu" : 34,
+      "score_nl" : 34,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 39,
+   "ecoscore_score" : 34,
    "ecoscore_tags" : [
       "d"
    ],
@@ -165,11 +155,6 @@
    "origins_tags" : [
       "en:unspecified"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
@@ -1,0 +1,165 @@
+{
+   "categories_tags" : [
+      "en:biscuits"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 2,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "1",
+                  "material" : "en:plastic",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "number" : "1",
+                  "shape" : "en:box"
+               },
+               {
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "0.1",
+                  "material" : "en:plastic",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "number" : "1",
+                  "shape" : "en:film"
+               },
+               {
+                  "ecoscore_material_score" : "0",
+                  "ecoscore_shape_ratio" : "1",
+                  "material" : "en:plastic",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "number" : "12",
+                  "shape" : "en:bag"
+               }
+            ],
+            "score" : -110,
+            "value" : -15
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "24000",
+         "co2_agriculture" : "3.8424243",
+         "co2_consumption" : "0",
+         "co2_distribution" : "0.029120657",
+         "co2_packaging" : "0.10869536",
+         "co2_processing" : "0.32913764",
+         "co2_total" : "4.4447267",
+         "co2_transportation" : "0.135384",
+         "code" : "24000",
+         "dqr" : "2.14",
+         "ef_agriculture" : "0.36061353999999995",
+         "ef_consumption" : "0",
+         "ef_distribution" : "0.0098990521",
+         "ef_packaging" : "0.016471127999999998",
+         "ef_processing" : "0.051325736000000004",
+         "ef_total" : "0.44895118",
+         "ef_transportation" : "0.010645482000000001",
+         "is_beverage" : 0,
+         "name_en" : "Biscuit (cookie)",
+         "name_fr" : "Biscuit sec, sans précision",
+         "score" : 58
+      },
+      "grade" : "c",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
+         "origins" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 43,
+      "score_be" : 38,
+      "score_ch" : 38,
+      "score_de" : 38,
+      "score_es" : 38,
+      "score_fr" : 38,
+      "score_ie" : 38,
+      "score_it" : 38,
+      "score_lu" : 38,
+      "score_nl" : 38,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 38,
+   "ecoscore_tags" : [
+      "d"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packaging_text" : "1 plastic box, 1 plastic film wrap, 12 individual plastic bags",
+   "packagings" : [
+      {
+         "material" : "en:plastic",
+         "number" : "1",
+         "shape" : "en:box"
+      },
+      {
+         "material" : "en:plastic",
+         "number" : "1",
+         "shape" : "en:film"
+      },
+      {
+         "material" : "en:plastic",
+         "number" : "12",
+         "shape" : "en:bag"
+      }
+   ]
+}

--- a/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
@@ -1,0 +1,176 @@
+{
+   "categories_tags" : [
+      "en:speculoos"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:france",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 93,
+            "epi_value" : 4,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 85,
+            "transportation_score_ch" : 69,
+            "transportation_score_de" : 61,
+            "transportation_score_es" : 37,
+            "transportation_score_fr" : 100,
+            "transportation_score_ie" : 47,
+            "transportation_score_it" : 47,
+            "transportation_score_lu" : 82,
+            "transportation_score_nl" : 77,
+            "transportation_value_be" : 13,
+            "transportation_value_ch" : 10,
+            "transportation_value_de" : 9,
+            "transportation_value_es" : 6,
+            "transportation_value_fr" : 15,
+            "transportation_value_ie" : 7,
+            "transportation_value_it" : 7,
+            "transportation_value_lu" : 12,
+            "transportation_value_nl" : 12,
+            "value_be" : 17,
+            "value_ch" : 14,
+            "value_de" : 13,
+            "value_es" : 10,
+            "value_fr" : 19,
+            "value_ie" : 11,
+            "value_it" : 11,
+            "value_lu" : 16,
+            "value_nl" : 16
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "label" : "fr:ab-agriculture-biologique",
+            "value" : 15
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_food_code" : "24009",
+         "co2_agriculture" : "4.5649571",
+         "co2_consumption" : "0",
+         "co2_distribution" : "0.029120657",
+         "co2_packaging" : "0.10868914",
+         "co2_processing" : "0.30914227",
+         "co2_total" : "5.1404703",
+         "co2_transportation" : "0.12860414",
+         "code" : "24009",
+         "dqr" : "2.14",
+         "ef_agriculture" : "0.42279176",
+         "ef_consumption" : "0",
+         "ef_distribution" : "0.0098990521",
+         "ef_packaging" : "0.016470524",
+         "ef_processing" : "0.050097131",
+         "ef_total" : "0.50926159",
+         "ef_transportation" : "0.010007618999999999",
+         "is_beverage" : 0,
+         "name_en" : "Speculoos biscuit",
+         "name_fr" : "Spéculoos",
+         "score" : 53
+      },
+      "grade" : "c",
+      "grade_be" : "b",
+      "grade_ch" : "b",
+      "grade_de" : "b",
+      "grade_es" : "b",
+      "grade_fr" : "b",
+      "grade_ie" : "b",
+      "grade_it" : "b",
+      "grade_lu" : "b",
+      "grade_nl" : "b",
+      "missing" : {
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 58,
+      "score_be" : 75,
+      "score_ch" : 72,
+      "score_de" : 71,
+      "score_es" : 68,
+      "score_fr" : 77,
+      "score_ie" : 69,
+      "score_it" : 69,
+      "score_lu" : 74,
+      "score_nl" : 74,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "b",
+   "ecoscore_score" : 77,
+   "ecoscore_tags" : [
+      "b"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:wheat",
+         "origins" : "en:france",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Wheat",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:wheat",
+      "en:cereal"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:wheat"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:wheat",
+      "en:cereal"
+   ],
+   "ingredients_text" : "Wheat (France)",
+   "known_ingredients_n" : 2,
+   "labels_tags" : [
+      "fr:ab-agriculture-biologique"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
@@ -1,7 +1,8 @@
 {
    "categories_tags" : [
-      "en:speculoos"
+      "en:baguettes"
    ],
+   "downgraded" : "non_recyclable_and_non_biodegradable_materials",
    "ecoscore_data" : {
       "adjustments" : {
          "origins_of_ingredients" : {
@@ -46,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -66,29 +57,29 @@
          "threatened_species" : {}
       },
       "agribalyse" : {
-         "agribalyse_food_code" : "24009",
-         "co2_agriculture" : "4.5649571",
+         "agribalyse_food_code" : "7001",
+         "co2_agriculture" : "0.27683119",
          "co2_consumption" : "0",
-         "co2_distribution" : "0.029120657",
-         "co2_packaging" : "0.10868914",
-         "co2_processing" : "0.30914227",
-         "co2_total" : "5.1404703",
-         "co2_transportation" : "0.12860414",
-         "code" : "24009",
-         "dqr" : "2.14",
-         "ef_agriculture" : "0.42279176",
+         "co2_distribution" : "0.0064852108",
+         "co2_packaging" : "0.096327546",
+         "co2_processing" : "0.15668205",
+         "co2_total" : "0.66956768",
+         "co2_transportation" : "0.13323488",
+         "code" : "7001",
+         "dqr" : "1.95",
+         "ef_agriculture" : "0.060092513",
          "ef_consumption" : "0",
-         "ef_distribution" : "0.0098990521",
-         "ef_packaging" : "0.016470524",
-         "ef_processing" : "0.050097131",
-         "ef_total" : "0.50926159",
-         "ef_transportation" : "0.010007618999999999",
+         "ef_distribution" : "0.0014414118",
+         "ef_packaging" : "0.020603751",
+         "ef_processing" : "0.035781102999999995",
+         "ef_total" : "0.12836245",
+         "ef_transportation" : "0.010443509",
          "is_beverage" : 0,
-         "name_en" : "Speculoos biscuit",
-         "name_fr" : "Spéculoos",
-         "score" : 53
+         "name_en" : "Bread, French bread, baguette",
+         "name_fr" : "Pain, baguette, courante",
+         "score" : 95
       },
-      "grade" : "c",
+      "grade" : "b",
       "grade_be" : "b",
       "grade_ch" : "b",
       "grade_de" : "b",
@@ -102,20 +93,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 58,
-      "score_be" : 75,
-      "score_ch" : 72,
-      "score_de" : 71,
-      "score_es" : 68,
-      "score_fr" : 77,
-      "score_ie" : 69,
-      "score_it" : 69,
-      "score_lu" : 74,
-      "score_nl" : 74,
+      "score" : 95,
+      "score_be" : 112,
+      "score_ch" : 109,
+      "score_de" : 108,
+      "score_es" : 105,
+      "score_fr" : 114,
+      "score_ie" : 106,
+      "score_it" : 106,
+      "score_lu" : 111,
+      "score_nl" : 111,
       "status" : "known"
    },
    "ecoscore_grade" : "b",
-   "ecoscore_score" : 77,
+   "ecoscore_score" : 114,
    "ecoscore_tags" : [
       "b"
    ],
@@ -166,11 +157,6 @@
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
    },
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ],
+   "packagings" : [],
    "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/ecoscore/packaging-unspecified.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -90,7 +80,7 @@
          "name_fr" : "Lait demi-écrémé, UHT",
          "score" : 54
       },
-      "grade" : "c",
+      "grade" : "d",
       "grade_be" : "d",
       "grade_ch" : "d",
       "grade_de" : "d",
@@ -107,20 +97,20 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 44,
-      "score_be" : 39,
-      "score_ch" : 39,
-      "score_de" : 39,
-      "score_es" : 39,
-      "score_fr" : 39,
-      "score_ie" : 39,
-      "score_it" : 39,
-      "score_lu" : 39,
-      "score_nl" : 39,
+      "score" : 39,
+      "score_be" : 34,
+      "score_ch" : 34,
+      "score_de" : 34,
+      "score_es" : 34,
+      "score_fr" : 34,
+      "score_ie" : 34,
+      "score_it" : 34,
+      "score_lu" : 34,
+      "score_nl" : 34,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 39,
+   "ecoscore_score" : 34,
    "ecoscore_tags" : [
       "d"
    ],
@@ -129,10 +119,5 @@
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }

--- a/t/expected_test_results/ecoscore/packaging-unspecified.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified.json
@@ -1,0 +1,138 @@
+{
+   "categories_tags" : [
+      "en:milks"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : 0,
+                  "ecoscore_shape_ratio" : 1,
+                  "material" : "en:unknown",
+                  "non_recyclable_and_non_biodegradable" : "maybe",
+                  "shape" : "en:unknown"
+               }
+            ],
+            "score" : 0,
+            "value" : -10,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "19041",
+         "co2_agriculture" : "1.1888463",
+         "co2_consumption" : "0",
+         "co2_distribution" : "0.012078628",
+         "co2_packaging" : "0.17188731",
+         "co2_processing" : "0.01061493",
+         "co2_total" : "1.4865868",
+         "co2_transportation" : "0.10315961",
+         "code" : "19041",
+         "dqr" : "2.47",
+         "ef_agriculture" : "0.10502456",
+         "ef_consumption" : "0",
+         "ef_distribution" : "0.004287772",
+         "ef_packaging" : "0.014723027999999999",
+         "ef_processing" : "0.0014905525",
+         "ef_total" : "0.13351659",
+         "ef_transportation" : "0.0079906595",
+         "is_beverage" : 1,
+         "name_en" : "Milk, semi-skimmed, UHT",
+         "name_fr" : "Lait demi-écrémé, UHT",
+         "score" : 54
+      },
+      "grade" : "c",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 44,
+      "score_be" : 39,
+      "score_ch" : 39,
+      "score_de" : 39,
+      "score_es" : 39,
+      "score_fr" : 39,
+      "score_ie" : 39,
+      "score_it" : 39,
+      "score_lu" : 39,
+      "score_nl" : 39,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 39,
+   "ecoscore_tags" : [
+      "d"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : [
+      {
+         "material" : "en:unknown",
+         "shape" : "en:unknown"
+      }
+   ]
+}

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -47,17 +47,7 @@
          },
          "packaging" : {
             "non_recyclable_and_non_biodegradable_materials" : 1,
-            "packagings" : [
-               {
-                  "ecoscore_material_score" : 0,
-                  "ecoscore_shape_ratio" : 1,
-                  "material" : "en:unknown",
-                  "non_recyclable_and_non_biodegradable" : "maybe",
-                  "shape" : "en:unknown"
-               }
-            ],
-            "score" : 0,
-            "value" : -10,
+            "value" : -15,
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
@@ -88,10 +78,5 @@
    "misc_tags" : [
       "en:ecoscore-not-computed"
    ],
-   "packagings" : [
-      {
-         "material" : "en:unknown",
-         "shape" : "en:unknown"
-      }
-   ]
+   "packagings" : []
 }


### PR DESCRIPTION
Some fixes / changes related to recent changes in the Eco-Score formula:

1.  we do not compute an Eco-Score for fresh fruits and vegetables. This is temporary, to avoid showing a A Eco-Score for out of season vegetables and fruits. Ultimately the formula will take the seasonality into account and we can compute the Eco-Score again for those.
2. when we don't have packaging information, we now give a -15 malus (the maximum) instead of considering 1 unknown packaging component of unknown material (which gave a -10 malus).

