### PR TITLE
Changed Agribalyse category proxy for Eco-Score foie gras

### DIFF
--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -438,6 +438,17 @@ my @tests = (
 			packaging_text => "1 plastic film",
 			ingredients_text => "Carrots",
 		},
+	],
+
+	# Foie gras should not use the "Duck, liver, raw" Agribalyse category which has a very small impact (modeled after chicken liver)
+	[
+		'foie-gras',
+		{
+			lc => "fr",
+			categories_tags=>["en:foies-gras"],
+			packaging_text => "1 pot en verre, 1 couvercle en acier",
+			ingredients_text => "Foie gras de canard",
+		},
 	],	
 
 );

--- a/t/expected_test_results/ecoscore/foie-gras.json
+++ b/t/expected_test_results/ecoscore/foie-gras.json
@@ -1,0 +1,190 @@
+{
+   "categories_tags" : [
+      "en:foies-gras"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 0,
+            "packagings" : [
+               {
+                  "ecoscore_material_score" : "81",
+                  "ecoscore_shape_ratio" : "1",
+                  "material" : "en:glass",
+                  "number" : "1",
+                  "shape" : "en:pot"
+               },
+               {
+                  "ecoscore_material_score" : "76",
+                  "ecoscore_shape_ratio" : "0.2",
+                  "material" : "en:steel",
+                  "number" : "1",
+                  "shape" : "en:lid"
+               }
+            ],
+            "score" : 76.2,
+            "value" : -2
+         },
+         "production_system" : {
+            "warning" : "no_label"
+         },
+         "threatened_species" : {}
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "8110",
+         "co2_agriculture" : "5.1140984",
+         "co2_consumption" : "0.16733102",
+         "co2_distribution" : "0.038356389",
+         "co2_packaging" : "0.3631791",
+         "co2_processing" : "1.6807444",
+         "co2_total" : "7.7453518",
+         "co2_transportation" : "0.38166236",
+         "code" : "8110",
+         "dqr" : "2.51",
+         "ef_agriculture" : "0.93044509",
+         "ef_consumption" : "0.038521225",
+         "ef_distribution" : "0.011223332",
+         "ef_packaging" : "0.022303626",
+         "ef_processing" : "0.14486322",
+         "ef_total" : "1.1775702000000001",
+         "ef_transportation" : "0.030204191999999998",
+         "is_beverage" : 0,
+         "name_en" : "Preserved duck",
+         "name_fr" : "Confit de canard",
+         "score" : 27
+      },
+      "grade" : "d",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "missing" : {
+         "labels" : 1,
+         "origins" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 25,
+      "score_be" : 20,
+      "score_ch" : 20,
+      "score_de" : 20,
+      "score_es" : 20,
+      "score_fr" : 20,
+      "score_ie" : 20,
+      "score_it" : 20,
+      "score_lu" : 20,
+      "score_nl" : 20,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 20,
+   "ecoscore_tags" : [
+      "d"
+   ],
+   "ingredients" : [
+      {
+         "id" : "en:duck-foie-gras",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Foie gras de canard",
+         "vegan" : "no",
+         "vegetarian" : "no"
+      }
+   ],
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:non-vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:duck-foie-gras",
+      "en:poultry",
+      "en:duck",
+      "en:duck-liver"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:duck-foie-gras"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:duck-foie-gras",
+      "en:poultry",
+      "en:duck",
+      "en:duck-liver"
+   ],
+   "ingredients_text" : "Foie gras de canard",
+   "known_ingredients_n" : 4,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0
+   },
+   "packaging_text" : "1 pot en verre, 1 couvercle en acier",
+   "packagings" : [
+      {
+         "material" : "en:glass",
+         "number" : "1",
+         "shape" : "en:pot"
+      },
+      {
+         "material" : "en:steel",
+         "number" : "1",
+         "shape" : "en:lid"
+      }
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/taxonomies/categories.result.txt
+++ b/taxonomies/categories.result.txt
@@ -5457,6 +5457,10 @@ en:Fresh blackcurrants
 fr:Cassis frais
 season_in_country_fr:en: 6‚7,8
 
+< en:Block of foie gras
+fr:Bloc de foie gras avec morceaux
+nl:Foie de gras blokken met stukjes
+
 < en:Blonde lentils
 < en:Cooked vegetables
 en:Cooked blond lentils
@@ -22736,9 +22740,9 @@ fr:Foies gras, Foie gras
 he:כבד אווז
 it:Foie gras
 nl:Foie gras
-agribalyse_proxy_food_code:en: 40120
-agribalyse_proxy_food_name:en: Liver, goose, raw
-agribalyse_proxy_food_name:fr: Foie, oie, cru
+agribalyse_proxy_food_code:en: 8110
+agribalyse_proxy_food_name:en: Preserved duck
+agribalyse_proxy_food_name:fr: Confit de canard
 pnns_group_2:en: Salty and fatty products
 wikidata:en: Q34807
 
@@ -24459,7 +24463,12 @@ ciqual_food_name:en: Focaccia, filled
 ciqual_food_name:fr: Focaccia, garnie
 
 < en:Foies gras
-en:Foies gras from ducks, fat liver from ducks, Block of foie gras
+en:Block of foie gras
+fr:Bloc de foie gras
+nl:Foie gras blokken
+
+< en:Foies gras
+en:Foies gras from ducks, fat liver from ducks, Block of duck foie gras
 ca:Foie-gras d'ànec, Foie de fetge d'ànec
 de:Gänseleber, Gänseleberpastete, Fettleber von der Ente
 es:Foies gras de patos
@@ -24496,10 +24505,6 @@ fi:kokonaiset rasvamaksat
 fr:Foies gras entiers
 it:Foie gras intero
 nl:Hele foie gras
-
-< en:Foies gras
-fr:Bloc de foie gras
-nl:Foie gras blokken
 
 < en:Foies gras
 fr:Foies gras cuits, foies gras cuit, foie gras cuit
@@ -78442,10 +78447,6 @@ instanceof:fr: AOP
 fr:Blaye-Côtes-de-Bordeaux blanc
 country:en: France
 instanceof:fr: AOP
-
-< fr:Bloc de foie gras
-fr:Bloc de foie gras avec morceaux
-nl:Foie de gras blokken met stukjes
 
 < fr:Boudins
 en:Brown puddings

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -83577,9 +83577,10 @@ it:Foie gras
 nl:Foie gras
 wikidata:en:Q34807
 pnns_group_2:en:Salty and fatty products
-agribalyse_proxy_food_code:en:40120
-agribalyse_proxy_food_name:en:Liver, goose, raw
-agribalyse_proxy_food_name:fr:Foie, oie, cru
+agribalyse_proxy_food_code:en:8110
+agribalyse_proxy_food_name:en:Preserved duck
+agribalyse_proxy_food_name:fr:Confit de canard
+# Note the Agribalyse category 40121 "Liver, duck, raw" has a value that corresponds to chicken liver, it is not a good proxy for foie gras.
 
 <en:goose meat
 en:Goose liver, goose liver
@@ -83590,6 +83591,7 @@ ciqual_food_name:en:Liver, goose, raw
 ciqual_food_name:fr:Foie, oie, cru
 
 <en:Foies gras
+en:Block of foie gras
 fr:Bloc de foie gras
 nl:Foie gras blokken
 
@@ -83612,7 +83614,7 @@ fr:Foies gras cuits, foies gras cuit, foie gras cuit
 nl:Gekookte foie gras
 
 <en:Foies gras
-en:Foies gras from ducks, fat liver from ducks, Block of foie gras
+en:Foies gras from ducks, fat liver from ducks, Block of duck foie gras
 ca:Foie-gras d'ànec, Foie de fetge d'ànec
 de:Gänseleber, Gänseleberpastete, Fettleber von der Ente
 es:Foies gras de patos


### PR DESCRIPTION
We now use a more realistic proxy for foie gras.