### PR TITLE
Re-architecturing the Open Food Facts Perl modules and functions

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -152,6 +152,7 @@ use ProductOpener::Nutriscore qw(:all);
 use ProductOpener::Ecoscore qw(:all);
 use ProductOpener::Attributes qw(:all);
 use ProductOpener::Orgs qw(:all);
+use ProductOpener::Web qw(:all);
 
 use Cache::Memcached::Fast;
 use Encode;
@@ -7057,18 +7058,6 @@ sub display_bottom_block($)
 	}
 
 	return;
-}
-
-
-sub display_blocks($)
-{
-	my $request_ref = shift;
-
-	my $html = '';
-	my $template_data_ref_blocks->{blocks} = $request_ref->{blocks_ref};
-
-	process_template('web/common/includes/display_blocks.tt.html', $template_data_ref_blocks, \$html) || return "template error: " . $tt->error();
-	return $html;
 }
 
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -122,7 +122,7 @@ BEGIN
 		$nutriment_table
 
 		%file_timestamps
-		
+
 		$show_ecoscore
 		$attributes_options_ref
 

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -28,6 +28,10 @@ use Exporter qw(import);
 
 use ProductOpener::Display qw/:all/;
 
+
+use Template;
+
+
 BEGIN
 {
 	use vars       qw(@ISA @EXPORT_OK %EXPORT_TAGS);
@@ -49,3 +53,5 @@ sub display_blocks($)
 	process_template('web/common/includes/display_blocks.tt.html', $template_data_ref_blocks, \$html) || return "template error: " . $tt->error();
 	return $html;
 }
+
+1;

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -18,6 +18,20 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=head1 NAME
+
+ProductOpener::Web - contains display functions for the website.
+
+=head1 SYNOPSIS
+
+C<ProductOpener::Web> consists of functions used only in OpenFoodFacts website for different tasks.
+
+=head1 DESCRIPTION
+
+The module implements the functions that are being used by the OpenFoodFacts website.
+This module consists of different fucntions for displaying the different parts of home page, creating and saving products, etc
+
+=cut
 
 package ProductOpener::Web;
 
@@ -39,6 +53,15 @@ BEGIN
 }
 
 use vars @EXPORT_OK;
+
+
+=head1 FUNCTIONS
+
+=head2 display_blocks( $request_ref )
+
+The sidebar of home page consists of blocks. It displays some of those blocks in the sidebar.
+
+=cut
 
 sub display_blocks($)
 {

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -27,10 +27,7 @@ use utf8;
 use Exporter qw(import);
 
 use ProductOpener::Display qw/:all/;
-
-
 use Template;
-
 
 BEGIN
 {

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -1,0 +1,40 @@
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2020 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+package ProductOpener::Web;
+
+
+use Modern::Perl '2017';
+use utf8;
+use Exporter qw(import);
+
+use ProductOpener::Display qw/:all/;
+
+sub display_blocks($)
+{
+	my $request_ref = shift;
+
+	my $html = '';
+	my $template_data_ref_blocks->{blocks} = $request_ref->{blocks_ref};
+
+	process_template('web/common/includes/display_blocks.tt.html', $template_data_ref_blocks, \$html) || return "template error: " . $tt->error();
+	return $html;
+}

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -28,6 +28,17 @@ use Exporter qw(import);
 
 use ProductOpener::Display qw/:all/;
 
+BEGIN
+{
+	use vars       qw(@ISA @EXPORT_OK %EXPORT_TAGS);
+	@EXPORT_OK = qw(
+		&display_blocks
+		);
+	%EXPORT_TAGS = (all => [@EXPORT_OK]);
+}
+
+use vars @EXPORT_OK;
+
 sub display_blocks($)
 {
 	my $request_ref = shift;

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -29,7 +29,7 @@ C<ProductOpener::Web> consists of functions used only in OpenFoodFacts website f
 =head1 DESCRIPTION
 
 The module implements the functions that are being used by the OpenFoodFacts website.
-This module consists of different fucntions for displaying the different parts of home page, creating and saving products, etc
+This module consists of different functions for displaying the different parts of home page, creating and saving products, etc
 
 =cut
 

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2020 Association Open Food Facts
+# Copyright (C) 2011-2021 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #


### PR DESCRIPTION
"Re-architecturing the Open Food Facts Perl modules and functions, possibly making some of them more generic and publishing them on CPAN."
Specifically, `Display.pm` is way too big, and it's very difficult to understand what all the functions do. Trying to move the functions from `Display.pm` to new files like `Web.pm`, `Api.pm`, etc

Related to : https://github.com/openfoodfacts/openfoodfacts-server/issues/5205