### PR TITLE
Fix goose foie gras Eco-Score property

### DIFF
--- a/taxonomies/categories.result.txt
+++ b/taxonomies/categories.result.txt
@@ -5029,6 +5029,9 @@ nl:Biscuits met zoetstoffen
 < en:Biscuits
 fr:Biscuits roses de Reims
 
+< en:Biscuits
+it:Paste di meliga
+
 en:Biscuits and cakes
 bg:Бисквити и сладкиши
 ca:Galetes i pastissos
@@ -6655,6 +6658,10 @@ en:Porridge
 de:Haferbrei, Porridge, Haferschleim
 fi:Puuro
 fr:Porridge
+
+< en:Breakfast cereals
+en:Wheat bran sticks
+fr:Bâtonnets de son de blé
 
 < en:Breakfast cereals filled with chocolate
 < en:Breakfast cereals fortified with vitamins and chemical elements
@@ -24488,9 +24495,6 @@ fi:Hanhenmaksapateet
 fr:Foies gras d'oies, Foie gras d'oies
 it:Foie gras di oca
 nl:Ganzen foie gras
-agribalyse_proxy_food_code:en: 40120
-agribalyse_proxy_food_name:en: Liver, goose, raw
-agribalyse_proxy_food_name:fr: Foie, oie, cru
 
 < en:Foies gras
 en:Foies gras pâtés
@@ -27710,14 +27714,6 @@ agribalyse_food_code:en: 20121
 ciqual_food_code:en: 20121
 ciqual_food_name:en: Spinach, frozen, cooked
 ciqual_food_name:fr: Épinard, surgelé, cuit
-
-< en:Frozen spinachs
-en:Frozen spinach
-fr:Épinards surgelés
-agribalyse_food_code:en: 20083
-ciqual_food_code:en: 20083
-ciqual_food_name:en: Spinach, frozen, raw
-ciqual_food_name:fr: Épinard, surgelé, cru
 
 < en:Frozen spinachs
 en:Frozen spinach leaves
@@ -61517,7 +61513,7 @@ ciqual_food_name:fr: Épinard, appertisé, égoutté
 
 < en:Frozen vegetables
 < en:Spinachs
-en:Frozen spinachs
+en:Frozen spinachs, Frozen spinach
 de:Gefrorene Spinate
 es:Espinacas congeladas
 fi:pakastetut pinaatit
@@ -61525,9 +61521,10 @@ fr:Épinards surgelés
 it:Spinaci surgelati
 nl:Diepvriesspinazies
 pl:Szpinak mrożony
-agribalyse_proxy_food_code:en: 20121
-agribalyse_proxy_food_name:en: Spinach, frozen, cooked
-agribalyse_proxy_food_name:fr: Épinard, surgelé, cuit
+agribalyse_food_code:en: 20083
+ciqual_food_code:en: 20083
+ciqual_food_name:en: Spinach, frozen, raw
+ciqual_food_name:fr: Épinard, surgelé, cru
 
 < en:Spinachs
 en:Spinach with cream sauce

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -83679,9 +83679,6 @@ fi:Hanhenmaksapateet
 fr:Foies gras d'oies, Foie gras d'oies
 it:Foie gras di oca
 nl:Ganzen foie gras
-agribalyse_proxy_food_code:en:40120
-agribalyse_proxy_food_name:en:Liver, goose, raw
-agribalyse_proxy_food_name:fr:Foie, oie, cru
 
 <en:Foies gras
 fr:Foies gras mi-cuits, foies gras mi-cuit, foie gras mi-cuit


### PR DESCRIPTION
delete the wrong agribalyse association, so that we get the good association from the parent "foies gras"