### PR TITLE
Moved the function display_my_block() to Web.pm

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6890,48 +6890,7 @@ sub display_login_register($)
 	return;
 }
 
-sub display_my_block($)
-{
-	my $blocks_ref = shift;
 
-	if (defined $User_id) {
-
-		my $content = '';
-		my $template_data_ref_block = {};
-
-		$template_data_ref_block->{org_name} = $Org{name};
-		$template_data_ref_block->{server_options_private_products} = $server_options{private_products};
-
-		if ((defined $server_options{private_products}) and ($server_options{private_products})) {
-
-			my $pro_moderator_message;
-
-			if (defined $User{pro_moderator_owner}) {
-				$pro_moderator_message = sprintf(lang("pro_moderator_owner_set"), $User{pro_moderator_owner});
-			}
-			else {
-				$pro_moderator_message = lang("pro_moderator_owner_not_set");
-			}
-
-			$template_data_ref_block->{pro_moderator_message} = $pro_moderator_message;
-			$template_data_ref_block->{user_pro_moderator} = $User{pro_moderator}; #can be removed after changes in Display.pm get merged
-		}
-		else {
-			$template_data_ref_block->{edited_products_url} = canonicalize_tag_link("editors", get_string_id_for_lang("no_language",$User_id));
-			$template_data_ref_block->{created_products_to_be_completed_url} = canonicalize_tag_link("users", get_string_id_for_lang("no_language",$User_id)) . canonicalize_taxonomy_tag_link($lc,"states", "en:to-be-completed")
-		}
-
-		process_template('web/common/includes/display_my_block.tt.html', $template_data_ref_block, \$content) || ($content .= 'template error: ' . $tt->error());
-
-		push @{$blocks_ref}, {
-			'title'=> lang("hello") . ' ' . $User{name},
-			'content'=>$content,
-			'id'=>'my_block',
-		};
-	}
-
-	return;
-}
 
 
 

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -41,14 +41,37 @@ use utf8;
 use Exporter qw(import);
 
 use ProductOpener::Display qw/:all/;
+use ProductOpener::Store qw(:all);
+use ProductOpener::Config qw(:all);
+use ProductOpener::Tags qw(:all);
+use ProductOpener::TagsEntries qw(:all);
+use ProductOpener::Users qw(:all);
+use ProductOpener::Index qw(:all);
+use ProductOpener::Lang qw(:all);
+use ProductOpener::Images qw(:all);
+use ProductOpener::Food qw(:all);
+use ProductOpener::Ingredients qw(:all);
+use ProductOpener::Products qw(:all);
+use ProductOpener::Missions qw(:all);
+use ProductOpener::MissionsConfig qw(:all);
+use ProductOpener::URL qw(:all);
+use ProductOpener::Data qw(:all);
+use ProductOpener::Text qw(:all);
+use ProductOpener::Nutriscore qw(:all);
+use ProductOpener::Ecoscore qw(:all);
+use ProductOpener::Attributes qw(:all);
+use ProductOpener::Orgs qw(:all);
+
 use Template;
+use Log::Log4perl;
 
 BEGIN
 {
 	use vars       qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
 		&display_blocks
-		);
+		&display_my_block
+		); #the fucntions which are called outside this file
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
 
@@ -72,6 +95,57 @@ sub display_blocks($)
 
 	process_template('web/common/includes/display_blocks.tt.html', $template_data_ref_blocks, \$html) || return "template error: " . $tt->error();
 	return $html;
+}
+
+=head1 FUNCTIONS
+
+=head2 display_my_block ( $request_ref )
+
+The sidebar of home page consists of blocks. This function is used to to display one block.
+
+=cut
+
+sub display_my_block($)
+{
+	my $blocks_ref = shift;
+
+	if (defined $User_id) {
+
+		my $content = '';
+		my $template_data_ref_block = {};
+
+		$template_data_ref_block->{org_name} = $Org{name};
+		$template_data_ref_block->{server_options_private_products} = $server_options{private_products};
+
+		if ((defined $server_options{private_products}) and ($server_options{private_products})) {
+
+			my $pro_moderator_message;
+
+			if (defined $User{pro_moderator_owner}) {
+				$pro_moderator_message = sprintf(lang("pro_moderator_owner_set"), $User{pro_moderator_owner});
+			}
+			else {
+				$pro_moderator_message = lang("pro_moderator_owner_not_set");
+			}
+
+			$template_data_ref_block->{pro_moderator_message} = $pro_moderator_message;
+			$template_data_ref_block->{user_pro_moderator} = $User{pro_moderator}; #can be removed after changes in Display.pm get merged
+		}
+		else {
+			$template_data_ref_block->{edited_products_url} = canonicalize_tag_link("editors", get_string_id_for_lang("no_language",$User_id));
+			$template_data_ref_block->{created_products_to_be_completed_url} = canonicalize_tag_link("users", get_string_id_for_lang("no_language",$User_id)) . canonicalize_taxonomy_tag_link($lc,"states", "en:to-be-completed")
+		}
+
+		process_template('web/common/includes/display_my_block.tt.html', $template_data_ref_block, \$content) || ($content .= 'template error: ' . $tt->error());
+
+		push @{$blocks_ref}, {
+			'title'=> lang("hello") . ' ' . $User{name},
+			'content'=>$content,
+			'id'=>'my_block',
+		};
+	}
+
+	return;
 }
 
 1;

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -40,27 +40,14 @@ use Modern::Perl '2017';
 use utf8;
 use Exporter qw(import);
 
-use ProductOpener::Display qw/:all/;
 use ProductOpener::Store qw(:all);
+use ProductOpener::Display qw/:all/;
 use ProductOpener::Config qw(:all);
 use ProductOpener::Tags qw(:all);
-use ProductOpener::TagsEntries qw(:all);
 use ProductOpener::Users qw(:all);
-use ProductOpener::Index qw(:all);
-use ProductOpener::Lang qw(:all);
-use ProductOpener::Images qw(:all);
-use ProductOpener::Food qw(:all);
-use ProductOpener::Ingredients qw(:all);
-use ProductOpener::Products qw(:all);
-use ProductOpener::Missions qw(:all);
-use ProductOpener::MissionsConfig qw(:all);
-use ProductOpener::URL qw(:all);
-use ProductOpener::Data qw(:all);
-use ProductOpener::Text qw(:all);
-use ProductOpener::Nutriscore qw(:all);
-use ProductOpener::Ecoscore qw(:all);
-use ProductOpener::Attributes qw(:all);
 use ProductOpener::Orgs qw(:all);
+use ProductOpener::Lang qw(:all);
+
 
 use Template;
 use Log::Log4perl;

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -101,7 +101,7 @@ sub display_blocks($)
 
 =head2 display_my_block ( $request_ref )
 
-The sidebar of home page consists of blocks. This function is used to to display one block.
+The sidebar of home page consists of blocks. This function is used to to display one block with information and links related to the logged in user.
 
 =cut
 

--- a/templates/web/common/includes/display_my_block.tt.html
+++ b/templates/web/common/includes/display_my_block.tt.html
@@ -46,7 +46,7 @@
     <ul class="side-nav" style="padding-top:0">
         <li><a href="[% edited_products_url %]">[% lang("products_you_edited") %]</a></li>
         <li><a href="[% created_products_to_be_completed_url %]">[% lang("incomplete_products_you_added") %]</a></li>
-    </ul>    
+    </ul>
 [% END %]
 
 <form method="post" action="/cgi/session.pl">


### PR DESCRIPTION
**Description:** 

"Re-architecturing the Open Food Facts Perl modules and functions, possibly making some of them more generic and publishing them on CPAN."
Specifically, `Display.pm` is way too big, and it's very difficult to understand what all the functions do. Trying to move the functions from `Display.pm` to new files like `Web.pm`, `Api.pm`, etc

Moved the function display_my_block() from `Dispaly.pm` to `Web.pm`.

**Related to :** https://github.com/openfoodfacts/openfoodfacts-server/issues/5205