### PR TITLE
Moved display_login_register() to Web.pm

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -90,7 +90,7 @@ BEGIN
 
 		&count_products
 		&add_params_to_query
-		
+
 		&url_for_text
 		&process_template
 
@@ -6866,28 +6866,6 @@ sub search_and_map_products($$$) {
 	process_template('web/pages/products_map/map_of_products.tt.html', $map_template_data_ref, \$html) || ($html .= 'template error: ' . $tt->error());
 
 	return $html;
-}
-
-
-
-sub display_login_register($)
-{
-	my $blocks_ref = shift;
-
-	if (not defined $User_id) {
-
-		my $content = '';
-		my $template_data_ref_login = {};
-
-		process_template('web/common/includes/display_login_register.tt.html', $template_data_ref_login, \$content) || ($content .= 'template error: ' . $tt->error());
-
-		push @{$blocks_ref}, {
-			'title'=>lang("login_register_title"),
-			'content'=>$content,
-		};
-	}
-
-	return;
 }
 
 sub display_my_block($)

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -41,12 +41,35 @@ use utf8;
 use Exporter qw(import);
 
 use ProductOpener::Display qw/:all/;
+use ProductOpener::Store qw(:all);
+use ProductOpener::Config qw(:all);
+use ProductOpener::Tags qw(:all);
+use ProductOpener::TagsEntries qw(:all);
+use ProductOpener::Users qw(:all);
+use ProductOpener::Index qw(:all);
+use ProductOpener::Lang qw(:all);
+use ProductOpener::Images qw(:all);
+use ProductOpener::Food qw(:all);
+use ProductOpener::Ingredients qw(:all);
+use ProductOpener::Products qw(:all);
+use ProductOpener::Missions qw(:all);
+use ProductOpener::MissionsConfig qw(:all);
+use ProductOpener::URL qw(:all);
+use ProductOpener::Data qw(:all);
+use ProductOpener::Text qw(:all);
+use ProductOpener::Nutriscore qw(:all);
+use ProductOpener::Ecoscore qw(:all);
+use ProductOpener::Attributes qw(:all);
+use ProductOpener::Orgs qw(:all);
+
 use Template;
+use Log::Log4perl;
 
 BEGIN
 {
 	use vars       qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
+		&display_login_register
 		&display_blocks
 		);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
@@ -72,6 +95,35 @@ sub display_blocks($)
 
 	process_template('web/common/includes/display_blocks.tt.html', $template_data_ref_blocks, \$html) || return "template error: " . $tt->error();
 	return $html;
+}
+
+
+=head1 FUNCTIONS
+
+=head2 display_login_register( $blocks_ref )
+
+This function displays the sign in block in the sidebar.
+
+=cut
+
+sub display_login_register($)
+{
+	my $blocks_ref = shift;
+
+	if (not defined $User_id) {
+
+		my $content = '';
+		my $template_data_ref_login = {};
+
+		process_template('web/common/includes/display_login_register.tt.html', $template_data_ref_login, \$content) || ($content .= 'template error: ' . $tt->error());
+
+		push @{$blocks_ref}, {
+			'title'=>lang("login_register_title"),
+			'content'=>$content,
+		};
+	}
+
+	return;
 }
 
 1;


### PR DESCRIPTION
**Description:**

"Re-architecturing the Open Food Facts Perl modules and functions, possibly making some of them more generic and publishing them on CPAN."
Specifically, `Display.pm` is way too big, and it's very difficult to understand what all the functions do. Trying to move the functions from `Display.pm` to new files like `Web.pm`, `Api.pm`, etc

Moved the function `display_login_register()` from `Dispaly.pm` to `Web.pm`.

**Related to:** #5205

**Note:** This PR might arise merge conflicts with https://github.com/openfoodfacts/openfoodfacts-server/pull/5435 but I'll solve them. 