### PR TITLE
Initial attempt at mapping CIQUAL categories to ingredients

### DIFF
--- a/t/expected_test_results/ingredients/fr-starred-label.json
+++ b/t/expected_test_results/ingredients/fr-starred-label.json
@@ -1,7 +1,7 @@
 {
    "ingredients" : [
       {
-         "id" : "en:cocoa",
+         "id" : "en:cocoa-paste",
          "labels" : "en:fair-trade, en:organic",
          "origins" : "en:madagascar",
          "percent" : "75",
@@ -39,8 +39,8 @@
       "en:vegetarian"
    ],
    "ingredients_hierarchy" : [
-      "en:cocoa",
       "en:cocoa-paste",
+      "en:cocoa",
       "en:cane-sugar",
       "en:sugar",
       "en:cocoa-butter"
@@ -58,12 +58,13 @@
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
       "en:cocoa-paste",
+      "en:cocoa",
       "en:cane-sugar",
       "en:sugar",
       "en:cocoa-butter"
    ],
    "ingredients_text" : "pâte de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce équitable et de l'agriculture biologique (100% du poids total).",
-   "known_ingredients_n" : 4,
+   "known_ingredients_n" : 5,
    "lc" : "fr",
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0

--- a/t/expected_test_results/ingredients/fr-starred-label.json
+++ b/t/expected_test_results/ingredients/fr-starred-label.json
@@ -58,7 +58,6 @@
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
       "en:cocoa-paste",
-      "en:cocoa",
       "en:cane-sugar",
       "en:sugar",
       "en:cocoa-butter"

--- a/t/expected_test_results/ingredients/fr-starred-label.json
+++ b/t/expected_test_results/ingredients/fr-starred-label.json
@@ -64,7 +64,7 @@
       "en:cocoa-butter"
    ],
    "ingredients_text" : "pâte de cacao* de Madagascar 75%, sucre de canne*, beurre de cacao*. * issus du commerce équitable et de l'agriculture biologique (100% du poids total).",
-   "known_ingredients_n" : 5,
+   "known_ingredients_n" : 4,
    "lc" : "fr",
    "nutriments" : {
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0

--- a/t/expected_test_results/ingredients/fr-starred-label.json
+++ b/t/expected_test_results/ingredients/fr-starred-label.json
@@ -1,7 +1,7 @@
 {
    "ingredients" : [
       {
-         "id" : "en:cocoa-paste",
+         "id" : "en:cocoa",
          "labels" : "en:fair-trade, en:organic",
          "origins" : "en:madagascar",
          "percent" : "75",

--- a/t/expected_test_results/ingredients/fr-starred-label.json
+++ b/t/expected_test_results/ingredients/fr-starred-label.json
@@ -39,8 +39,8 @@
       "en:vegetarian"
    ],
    "ingredients_hierarchy" : [
-      "en:cocoa-paste",
       "en:cocoa",
+      "en:cocoa-paste",
       "en:cane-sugar",
       "en:sugar",
       "en:cocoa-butter"

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -735,9 +735,9 @@ my @tests = (
 				'text' => "haselnüsse"
 			},
 			{
-				'id' => 'en:toasted-hazelnut',
-				'processing' => 'en:chopped',
-				'text' => "geröstete haselnuss"
+				'id' => 'en:hazelnut',
+				'processing' => 'en:chopped, en:toasted',
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:almond',

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -902,7 +902,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:salted',
-				'text' => "haselnuss"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:hazelnut',
@@ -912,7 +912,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:salted',
-				'text' => 'haselnüsse'
+				'text' => 'haselnuss'
 			},
 			{
 				'id' => 'en:shallot',

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -392,7 +392,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'de:gegart',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:almond',
@@ -433,7 +433,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => "en:oiled",
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			}
 		]
 	],
@@ -472,7 +472,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:puffed',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:passion-fruit',
@@ -536,7 +536,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'de:geschwefelt',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:passion-fruit',
@@ -604,7 +604,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:halved',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:almond',
@@ -625,7 +625,7 @@ my @tests = (
 			},
 			{	'id'         => 'en:hazelnut',
 				'processing' => 'en:concentrated',
-				'text'       => "haseln\x{fc}sse"
+				'text'       => "haselnüsse"
 			},
 			{	'id'         => 'en:almond',
 				'processing' => 'en:concentrated',
@@ -679,7 +679,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'de:zerkleinert',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:almond',
@@ -714,7 +714,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'de:feinst-zerkleinert',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:fig',
@@ -732,7 +732,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:toasted, en:chopped',
-				'text' => "haselnuss"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:hazelnut',
@@ -769,7 +769,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'de:fein-gemahlen',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:spinach',
@@ -809,7 +809,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:dried',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:spinach',
@@ -902,17 +902,17 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:salted',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnuss"
 			},
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:salted',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:salted',
-				'text' => 'haselnuss'
+				'text' => 'haselnüsse'
 			},
 			{
 				'id' => 'en:shallot',
@@ -1093,7 +1093,7 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'de:handgeschnitten',
-				'text' => "haseln\x{fc}sse"
+				'text' => "haselnüsse"
 			}
 		]
 	],

--- a/t/ingredients_processing.t
+++ b/t/ingredients_processing.t
@@ -732,12 +732,12 @@ my @tests = (
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:toasted, en:chopped',
-				'text' => "haselnüsse"
+				'text' => "haselnuss"
 			},
 			{
 				'id' => 'en:hazelnut',
 				'processing' => 'en:chopped, en:toasted',
-				'text' => "haselnüsse"
+				'text' => "haselnuss"
 			},
 			{
 				'id' => 'en:almond',

--- a/t/tags.t
+++ b/t/tags.t
@@ -346,17 +346,27 @@ is_deeply($product_ref->{brands_tags},
 
 my @tags = ();
 
+# ingredients taxonomy (@2021-09-03):
+# en:salt is at top-level (4)?
+# en:orange is child of en:fruit AND en:citrus-fruit (3)
+# en:citrus-fruit is child of en:fruit (2) and (3)
+# en:fruit is at top-level (4)
+# en:fruit-juice is child of en:fruit (3)
+# en:orange-juice is child of en:orange AND en:fruit-juice (2)
+# en:concentrated-orange-juice is child of en:orange-juice (1)
+# en:sugar is at the top-level (4)?
+
 @tags = gen_tags_hierarchy_taxonomy("en", "ingredients", "en:concentrated-orange-juice, en:sugar, en:salt, en:orange");
 
 is_deeply (\@tags, [
-	'en:fruit',
-	'en:citrus-fruit',
-	'en:fruit-juice',
-	'en:salt',
-	'en:sugar',
-	'en:orange',
-	'en:orange-juice',
-	'en:concentrated-orange-juice'
+	'en:fruit', 
+	'en:sugar', 
+	'en:citrus-fruit', 
+	'en:fruit-juice', 
+	'en:salt', 
+	'en:orange', 
+	'en:orange-juice', 
+	'en:concentrated-orange-juice' 
 ]
 ) or diag explain(\@tags);
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10484,6 +10484,22 @@ fr:Fromage blanc
 hu:cottage sajt, cottage cheese
 wikidata:en:Q15080546
 
+#category/faiselles
+<en:cheese
+en:faiselle
+ar:فايسيل
+el:Φεσέλ
+ko:페셀
+xx:faisselle
+description:en:Faisselle is a non-protected French cheese made of raw milk from cows, goats, or sheep.
+description:es:Faisselle è un generico nome francese per un formaggio fresco a base di latte crudo.
+description:fr:La faisselle est une appellation générique française désignant du fromage frais au lait cru.
+description:nl:Faisselle is een naam die gebruikt wordt voor een Franse kaas, een fromage blanc.
+ciqual_food_code:en:19641
+ciqual_food_name:en:Drained soft fresh cheese, around 6% fat
+ciqual_food_name:fr:Faisselle, 6% MG environ
+
+
 # category/feta
 <en:cheese
 en:feta, feta cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -5196,19 +5196,9 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_acidophilus
 
 <en:Lactobacillus
 en:Lactobacillus bulgaricus, L. bulgaricus, Lactobacillus delbrueckii subsp. bulgaricus, L. delbrueckii subsp. bulgaricus
-cs:Lactobacillus bulgaricus, L. bulgaricus
-da:Lactobacillus bulgaricus, L. bulgaricus
-de:Lactobacillus bulgaricus, L. bulgaricus
-es:Lactobacillus bulgaricus, L. bulgaricus, lactobacilus delbrueckii sp Bulgaricus, Lactobacillus delbrueckii subspecies bulgaricus
-fi:lactobacillus bulgaricus, l. bulgaricus
-fr:Lactobacillus bulgaricus, l. bulgaricus, L bulgaricus, bulgaricus
-hu:Lactobacillus bulgaricus, L. bulgaricus
-it:Lactobacillus bulgaricus, L. bulgaricus
-nb:Lactobacillus bulgaricus, L. bulgaricus
-nl:Lactobacillus bulgaricus, L. bulgaricus
-pl:Lactobacillus bulgaricus, L. bulgaricus
-pt:Lactobacillus bulgaricus, L. bulgaricus
-sv:Lactobacillus bulgaricus, L. bulgaricus
+es:lactobacilus delbrueckii sp Bulgaricus, Lactobacillus delbrueckii subspecies bulgaricus
+fr:L bulgaricus, bulgaricus
+xx:Lactobacillus bulgaricus, L. bulgaricus
 wikidata:en:Q47455075
 wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_delbrueckii_subsp._bulgaricus
 # ingredient/Lactobacillus-bulgaricus has 157 products in 13 languages @2019-07-08
@@ -5330,52 +5320,25 @@ wikidata:en:Q597078
 
 <en:Lactobacillus
 en:Lactobacillus rhamnosus
-bg:Lactobacillus rhamnosus
-ca:Lactobacillus rhamnosus
-da:Lactobacillus rhamnosus
-de:Lactobacillus rhamnosus
-es:Lactobacillus rhamnosus
-fi:Lactobacillus rhamnosus
-fr:Lactobacillus rhamnosus
-hu:Lactobacillus rhamnosus
-it:Lactobacillus rhamnosus
 ja:ラクトバチルスラムノーザス
 ko:락토바실러스
-nl:Lactobacillus rhamnosus
-pl:Lactobacillus rhamnosus
-ro:Lactobacillus rhamnosus
-ru:Lactobacillus Rhamnosus
-uk:Lactobacillus rhamnosus
-# ast:Lactobacillus rhamnosus
+xx:Lactobacillus rhamnosus
 wikidata:en:Q1607640
 wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_rhamnosus
 
 <en:Lactobacillus rhamnosus
 en:Lactobacillus rhamnosus GG
-de:Lactobacillus rhamnosus GG
-fi:Lactobacillus rhamnosus GG
+xx:Lactobacillus rhamnosus GG
 # ingredient/fi:Lactobacillus-rhamnosus-GG has 1 product in 2 languages @2020-06-08
 
 # description:en:BACILLUS COAGULANS is a lactic acid-forming bacterial species. B. coagulans is often marketed as Lactobacillus sporogenes or a 'sporeforming lactic acid bacterium' probiotic, but this is an outdated name due to taxonomic changes in 1939.
 
 <en:lactic ferments
 en:Bacillus coagulans
-bg:Bacillus coagulans
-ca:Bacillus coagulans
-de:Bacillus coagulans, Lactobacillus sporogenes
-es:Bacillus coagulans
-eu:Bacillus coagulans
-fi:bacillus coagulans, lactobacillus sporogenes
-fr:Bacillus coagulans
-hu:Bacillus coagulans
-it:Bacillus coagulans
-la:Bacillus coagulans
-nl:Bacillus coagulans
-pt:Bacillus coagulans
-ro:Bacillus coagulans
-uk:Bacillus coagulans
+de:Lactobacillus sporogenes
+fi:lactobacillus sporogenes
+xx:Bacillus coagulans
 zh:芽孢乳酸菌
-# ast:Bacillus coagulans
 # zh-tw:凝結桿菌
 wikidata:en:Q2603895
 wikipedia:en:https://en.wikipedia.org/wiki/Bacillus_coagulans
@@ -8104,11 +8067,23 @@ fr:yaourt britannique
 <en:low fat yogurt
 fr:yaourt britannique à faible teneur en matières grasses
 
+#comment:en:There is a lot of discussion on this subject https://en.wikipedia.org/wiki/Talk:Strained_yogurt. Many marketing issues, so lets just follow what is found as ingredients and not merge them.
 <en:yogurt
 en:greek yogurt
 de:griechischer Joghurt
 es:yogur griego, yogurt griego
 fr:yaourt grec
+nl:Griekse yoghurt
+sk:Grécky jogurt
+wikidate:en:none
+# 395 in 5 @2021-08-25
+
+<en:greek yogurt
+en:Yogurt Greek-style from ewe's milk
+fr:Yaourt à la grecque au lait de brebis
+ciqual_food_code:en:19550
+ciqual_food_name:en:Yogurt, Greek-style, ewe's milk
+ciqual_food_name:fr:Yaourt à la grecque, au lait de brebis
 
 
 # no products in OFF

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10538,14 +10538,34 @@ ciqual_food_code:en:12061
 ciqual_food_name:en:Feta cheese, from ewe's milk
 ciqual_food_name:fr:Feta de brebis
 
+#category/fontina
 <en:cheese
 en:fontina, fontina cheese
-de:Fontina g.U.
-es:fontina, queso fontina
-fr:Fontine, Fontina AOP, Fontine DOP
-it:Fontina, Fontina DOP
+ar:فونتينا
+de:Fontina
+es:queso fontina
+fr:Fontine, 
+ja:フォンティーナ
+ko:폰티나
+ru:Фонтина
+uk:Фонтіна
+xx:Fontina
+zh:芳提娜芝士
 wikidata:en:Q534043
 wikipedia:en:https://en.wikipedia.org/wiki/Fontina
+description:en:Fontina is a cow's milk cheese, produced worldwide.
+
+<en:fontina
+en:fontina AOP
+de:Fontina g.U.
+fr:Fontine DOP
+xx:Fontina AOP
+description:de:Fontina AOP ist ein norditalienischer Käse mit geschützter Herkunftsbezeichnung.
+description:en:Fontina AOP is an cow's milk cheese, produced in the Aosta Valley.
+description:es:La Fontina AOP es un queso italiano con denominación de origen.
+description:fr:La fontine AOP est un fromage italien AOP, à base de lait de vache à texture demi-dure, produit de la Vallée d'Aoste.
+description:it:La fontina AOP è un formaggio a denominazione di origine protetta (DOP) Valdostano.
+description:nl:Fontina AOP is een beetje zachte, strogele kaas met een licht zoete, nootachtige smaak uit noordwest Italië.
 
 <en:fontina
 en:fontal, fontal cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -9825,17 +9825,91 @@ description:nl:De Beaufort AOP is een Franse kaas die in Savoie geproduceerd wor
 # ingredient/en:beaufort has 50 products in 2 languages @2021-08-14
 
 
-# description:en:Brie is a soft cow's-milk cheese named after Brie, the French region from which it originated (roughly corresponding to the modern département of Seine-et-Marne). It is pale in color with a slight grayish tinge under a rind of white mould.
-
+#category/bries
 <en:cheese
 en:Brie, brie cheese
-de:Brie
+ar:بري
+be:Бры
+bg:бри
+bn:ব্রাই
+ca:formatge Brie
+cv:Бри
+el:Μπρι
+eo:Brio
 es:queso brie
-fr:Brie
+et:Brie juust
+fa:پنیر بری
+he:ברי
+hi:ब्राई
+hy:բրի
+ka:ბრი
+ko:브리
+lt:Bri
+ro:Brânză de Brie
+ru:бри
+th:บรี
+uk:Брі
+xx:Brie
+zh:布利乾酪
 wikidata:en:Q193411
 wikipedia:en:https://en.wikipedia.org/wiki/Brie
+description:de:Brie ist die Bezeichnung für einen ursprünglich aus der gleichnamigen Region in Frankreich stammenden Weichkäse mit weißem Edelschimmel.
+description:en:Brie is a soft cow's-milk cheese named after Brie, the French region from which it originated. It is pale in color with a slight grayish tinge under a rind of white mould.
+description:es:El brie es un queso de pasta blanda elaborado con leche cruda de vaca.
+description:fr:Les bries sont une famille de fromages à pâte molle à croûte fleurie, originaire de la région française de Brie.
+description:it:Il Brie è un formaggio francese vaccino a pasta molle e crosta fiorita che prende il nome da Brie, la regione della Francia in cui è prodotto.
+description:nl:Brie is een Franse witschimmelkaas.
+description:nn:Brie er en fransk ost fra Brie-regionen sør for Paris.
+description:pt:Os chamados brie são uma família de queijos de pasta mole e crosta branca, originários da região de Brie, na França.
+# 85 in 3 @ 2021-08-25
 
+<en:Brie
+en:Brie cheese from cow's milk
+fr:Brie sans précision
+ciqual_food_code:en:12020
+ciqual_food_name:en:Brie cheese, from cow's milk
+ciqual_food_name:fr:Brie, sans précision
 
+#category/brie-de-meaux-cheeses
+<en:Brie
+en:Brie de Meaux
+fr:Brie de Meaux AOP
+ja:ブリー・ド・モー
+ko:브리 드 모
+th:บรีเดอโม
+xx:Brie de Meaux
+zh:莫城布里
+wikidata:en:Q749378
+wikipedia:en:https://en.wikipedia.org/wiki/Brie_de_Meaux
+description:en:Brie de Meaux is an unpasteurized brie, manufactured in the town of Meaux in the Brie region of northern France since the 8th century.
+description:es:Brie de Meaux es un queso francés con denominación de origen protegida elaborado alrededor de la ciudad de Meaux, en la región de Brie.
+description:fr:Le brie de Meaux est un fromage au lait cru avec une AOC depuis 1980. Son appellation vient de la région de la Brie et de la commune de Meaux en France.
+description:nl:Brie de Meaux AOP is een Franse traditionele, rauwmelkse witte korstkaas van koemelk met het AOC- en AOP-keur.
+
+<en:Brie de Meaux
+en:Brie de Meaux cheese from cow's milk
+fr:Brie de Meaux
+ciqual_food_code:en:12021
+ciqual_food_name:en:Brie de Meaux cheese, from cow's milk
+ciqual_food_name:fr:Brie de Meaux
+
+#category/brie-de-melun
+<en:Brie
+en:Brie de Melun
+xx:Brie de Melun
+zh:默倫布里
+wikidata:en:Q545994
+description:en:Brie de Melun is a brie made with unpasteurized milk.
+description:es:Brie de Melun es un queso francés con denominación de origen protegida. Se trata de un queso brie elaborado alrededor de la ciudad de Melun en la región de la Brie.
+description:fr:Brie de Melun est une appellation d'origine désignant un fromage au lait cru de la plaine de Melun.
+description:nl:Brie de Melun AOP is een Franse traditionele, rauwmelkse witte korstkaas van koemelk met het AOC- en AOP-keur.
+
+<en:Brie de Melun
+en:Brie de Melun cheese from cow's milk
+fr:Brie de Melun
+ciqual_food_code:en:12022
+ciqual_food_name:en:Brie de Melun cheese, from cow's milk
+ciqual_food_name:fr:Brie de Melun
 
 <en:cheese
 en:camembert, camembert cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -69429,30 +69429,48 @@ ciqual_food_code:en:10045
 ciqual_food_name:en:Scallop, without coral, raw
 ciqual_food_name:fr:Coquille Saint-Jacques, noix, crue
 
+
 # en:description:Argopecten irradians, formerly classified as Aequipecten irradians, common names Atlantic bay scallop or bay scallop, is an edible species of saltwater clam, a scallop
 
 <en:scallop
-en:Atlantic bay scallop, bay scallop, Argopecten irradians
-de:Jakobsmuscheln der atlantischen Küste, Argopecten irradians
-fa:گوش‌ماهی خلیج, Argopecten irradians
-fr:Pétoncle, pétoncles, Argopecten irradians
-is:Flóaskel, Argopecten irradians
+en:Atlantic bay scallop, bay scallop
+de:Jakobsmuscheln der atlantischen Küste
+fa:گوش‌ماهی خلیج
+fr:Pétoncle, pétoncles
+is:Flóaskel
 la:Argopecten irradians
-zh:海湾扇贝, Argopecten irradians
+zh:海湾扇贝
 wikipedia:en:https://en.wikipedia.org/wiki/Argopecten_irradians
 wikidata:en:Q3018372
 # ingredient/fr:Argopecten-irradians has 10 products @2019-01-13
 
 
 <en:scallop
-en:Atlantic calico scallop, Argopecten Gibbus
-de:Atlantische Kattunmuschel, Argopecten Gibbus
-fr:Pétoncle calicot, Argopecten Gibbus
+en:Atlantic calico scallop
+de:Atlantische Kattunmuschels
+fr:Pétoncle calicot
 la:Argopecten Gibbus
-sr:Ostrea gibba, Argopecten Gibbus
+sr:Ostrea gibba
 wikidata:en:Q3017111
 wikipedia:en:https://en.wikipedia.org/wiki/Argopecten_gibbus
 # ingredient/fr:Argopecten-Gibbus has 1 product @2019-01-12
+
+<en:scallop
+en:American sea scallop, Canadian sea scallop
+fr:Pecten d'Amérique, Peigne du Canada, pétoncle géant, peigne hauturier
+la:Placopecten magellanicus
+description:en:Placopecten magellanicus, common names Atlantic deep-sea scallop, deep sea scallop, North Atlantic sea scallop, American sea scallop, Atlantic sea scallop, or sea scallop, is a commercially important pectinid bivalve mollusk native to the northwest Atlantic Ocean.
+wikipedia:en:https://en.wikipedia.org/wiki/Placopecten_magellanicus
+description:fr:Le pétoncle géant1 (ou peigne hauturier) est un pectinidé comestible, qui vit dans l'Atlantique Nord-Ouest, de Terre-Neuve à la Caroline du Nord.
+description:nl:Placopecten magellanicus is een tweekleppigensoort uit de familie van de Pectinidae.
+description:sv:Placopecten magellanicus är en musselart.
+
+<en:American sea scallop
+en:Raw American sea scallop without coral, Raw Canadian sea scallop without coral
+fr:Pecten d'Amérique avec noix cru, Peigne du Canada avec noix cru
+ciqual_food_code:en:10048
+ciqual_food_name:en:American or Canadian sea scallop, without coral, raw
+ciqual_food_name:fr:Pecten d'Amérique ou Peigne du canada, noix, crue
 
 
 <en:scallop
@@ -69467,67 +69485,65 @@ wikidata:en:Q13444410
 # description:en:Pecten maximus, common names the great scallop, king scallop, St James shell or escallop, is a northeast Atlantic species of scallop, an edible saltwater clam, a marine bivalve mollusc in the family Pectinidae.
 
 <en:scallop
-en:great scallop, king scallop, St James shell, escallop, Pecten maximus
-ar:أسقلوب, Pecten maximus
-br:Krogenn-Sant-Jakez, Pecten maximus
-ca:petxina de pelegrí de l'Atlàntic, Pecten maximus
-da:stor kammusling, Pecten maximus
-de:Große Pilgermuschel, Pecten maximus
-es:Venera, Pecten maximus
-eu:Erromes-maskor handi, Pecten maximus
-fa:گوش‌ماهی شاه, Pecten maximus
-fi:isokampasimpukka, Pecten maximus
-fr:Pecten maximus
-ga:Muirín, Pecten maximus
-gd:Slige-chreachainn, Pecten maximus
-gl:Vieira, Pecten maximus
-id:Simping, Pecten maximus
-io:Petonklo, Pecten maximus
-is:Risadiskur, Pecten maximus
+en:great scallop, king scallop, St James shell, escallop
+ar:أسقلوب
+br:Krogenn-Sant-Jakez
+ca:petxina de pelegrí de l'Atlàntic
+da:stor kammusling
+de:Große Pilgermuschel
+es:Venera
+eu:Erromes-maskor handi
+fa:گوش‌ماهی شاه
+fi:isokampasimpukka
+ga:Muirín
+gd:Slige-chreachainn
+gl:Vieira
+id:Simping
+io:Petonklo
+is:Risadiskur
 la:Pecten maximus
-nl:grote mantel, Pecten maximus
-pl:Przegrzebek zwyczajny, Pecten maximus
-pt:Vieira, Pecten maximus
-sv:Pilgrimsmussla, Pecten maximus
-# de-ch:Jakobsmuschel, Pecten maximus
-# el:Χτένι, Pecten maximus
-# pt-br:Vieira, Pecten maximus
+nl:grote mantel
+pl:Przegrzebek zwyczajny
+pt:Vieira
+sv:Pilgrimsmussla
+# de-ch:Jakobsmuschel
+# el:Χτένι
+# pt-br:Vieira
 wikidata:en:Q1249634
 wikipedia:en:https://en.wikipedia.org/wiki/Pecten_maximus
 # ingredient/fr:noix-de-Saint-Jacques has 216 products @2019-01-12
 # ingredient/fr:Pecten-maximus has 25 products @2019-01-12
 
 <en:scallop
-en:Patagonian scallop, Zygochlamys patagonica
-de:Kammmuschel, Zygochlamys patagonica
-fi:patagoniankampasimpukka, Zygochlamys patagonica
-fr:Pétoncle de Patagonie, Zygochlamys patagonica
+en:Patagonian scallop
+de:Kammmuschel
+fi:patagoniankampasimpukka
+fr:Pétoncle de Patagonie
 la:Zygochlamys patagonica, Chlamys zygopatagonica
 # ingredient/fr:Zygochlamys-patagonica has 87 products @2019-01-12
 
 
 <en:scallop
-en:noble scallop, Chlamys nobilis
-de:Feine Kammmuschel, Chlamys nobilis
-fr:Chlamys nobilis
-ja:ヒオウギガイ, Chlamys nobilis
+en:noble scallop
+de:Feine Kammmuschel
+ja:ヒオウギガイ
 la:Chlamys nobilis, Mimachlamys nobilis
-vi:Sò điệp, Chlamys nobilis
-zh:华贵栉孔扇贝, Chlamys nobilis
-# zh-hans:华贵栉孔扇贝, Chlamys nobilis
-# zh-hant:高貴海扇蛤, Chlamys nobilis
-# zh-hk:高貴海扇蛤, Chlamys nobilis
-# zh-tw:高貴海扇蛤, Chlamys nobilis
+vi:Sò điệp
+zh:华贵栉孔扇贝
+# zh-hans:华贵栉孔扇贝
+# zh-hant:高貴海扇蛤
+# zh-hk:高貴海扇蛤
+# zh-tw:高貴海扇蛤
 # ingredient/fr:Chlamys-nobilis has 20 products in french @2019-01-13
 
 
 # Argopecten purpuratus, common names the "Peruvian scallop", is an edible species of saltwater clam, a scallop
 
 <en:scallop
-en:Peruvian scallop, Argopecten purpuratus
-de:Peruanische Jakobsmuscheln, Argopecten purpuratus
-es:ostión del norte, concha de abanico, Argopecten purpuratus
-fr:Pétoncle chilien, Argopecten purpuratus
+en:Peruvian scallop
+de:Peruanische Jakobsmuscheln
+es:ostión del norte, concha de abanico
+fr:Pétoncle chilien
 la:Argopecten purpuratus
 wikidata:en:Q3412062
 wikipedia:en:https://en.wikipedia.org/wiki/Argopecten_purpuratus
@@ -69537,19 +69553,19 @@ wikipedia:en:https://en.wikipedia.org/wiki/Argopecten_purpuratus
 # en:description:The queen scallop (Chlamys opercularis) is a medium-sized species of scallop, an edible marine bivalve mollusk in the family Pectinidae, the scallops.
 
 <en:scallop
-en:queen scallop, Chlamys opercularis
-ca:xelet, Chlamys opercularis
-de:Kleine Pilgermuschel, Chlamys opercularis
+en:queen scallop
+ca:xelet
+de:Kleine Pilgermuschel
 es:volandeira
-fi:kuningatarkampasimpukka, Chlamys opercularis
-fr:Pétoncle blanc, Vanneau, peigne, Chlamys opercularis
-gl:Volandeira, Chlamys opercularis
-it:Canestrello, Chlamys opercularis
-ja:クイーンホタテ, Chlamys opercularis
+fi:kuningatarkampasimpukka
+fr:Pétoncle blanc, Vanneau, peigne
+gl:Volandeira
+it:Canestrello
+ja:クイーンホタテ
 la:Chlamys opercularis, Aequipecten opercularis
-nl:Wijde mantel, Chlamys opercularis
-sr:Ostrea elegans, Chlamys opercularis
-zh:女王扇貝, Chlamys opercularis
+nl:Wijde mantel
+sr:Ostrea elegans
+zh:女王扇貝
 wikidata:en:Q1746507
 wikipedia:en:https://en.wikipedia.org/wiki/Queen_scallop
 # ingredient/fr:Chlamys-opercularis has 81 products @2019-01-12
@@ -69557,18 +69573,18 @@ wikipedia:en:https://en.wikipedia.org/wiki/Queen_scallop
 # en:description:Argopecten gibbus (Atlantic calico scallop) is a species of medium-sized edible marine bivalve mollusk in the family Pectinidae, the scallops
 
 <en:scallop
-en:speckled Scallop, Argopecten irradians concentricus
-de:Gefleckte Jakobsmuschel, Argopecten irradians concentricus
-fr:Pétoncle moucheté, Argopecten irradians concentricus
+en:speckled Scallop
+de:Gefleckte Jakobsmuschel
+fr:Pétoncle moucheté
 la:Argopecten irradians concentricus, Argopecten circularis
 wikidata:en:Q30749478
 # ingredient/fr:Argopecten-circularis has 10 products in french @2019-01-13
 
 
 <en:scallop
-en:white scallop, Chlamys albida
-de:Weiße Jakobsmuschel, Chlamys albida
-fr:Pétoncle blanc, Chlamys albida
+en:white scallop
+de:Weiße Jakobsmuschel
+fr:Pétoncle blanc
 la:Chlamys albida, Chlamys albidus
 wikipedia:nl:https://nl.wikipedia.org/wiki/Chlamys_albida
 wikidata:en:Q3802698

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -9746,6 +9746,7 @@ wikidata:en:Q27972032
 # Specific named cheeses start here
 
 <en:cow cheese
+<en:cheese
 en:Abondance,Abondance cheese from cow's milk
 ar:أبوندانس
 eo:fromaĝo de Abundeco
@@ -11890,6 +11891,30 @@ description:es:El bleu d’Auvergne es un queso azul francés AOP fabricado en l
 description:fr:Bleu d’Auvergne est un fromage français AOP de lait de vache, à pâte persillée, du Massif central. 
 description:it:Il bleu d'Auvergne (blu d'Alvernia) è un formaggio di latte vaccino a pasta erborinata prodotto nel Massiccio Centrale, in Francia.
 description:nl:De bleu d'Auvergne is een AOP blauwschimmelkaas op basis van koeienmelk uit de Auvergne.
+
+#category/fourme-d-ambert-cheese-from-cow-s-milk
+<en:cow cheese
+<en:blue cheese
+en:fourme d'ambert
+ar:فورم دامبيرت
+hy:Ֆուրմ-դ'Ամբեր
+ja:フルム・ダンベール
+ko:푸름 당베르
+oc:Forma d'Embèrt
+ru:Фурм-д’Амбер
+uk:Фурм д'Амбер
+xx:fourme d'ambert
+zh:昂贝尔奶酪
+wikidata:en:Q1245530
+wikipedia:en:https://en.wikipedia.org/wiki/Fourme_d%27Ambert
+ciqual_food_code:en:12522
+ciqual_food_name:en:Fourme d'Ambert cheese, from cow's milk
+ciqual_food_name:fr:Fourme d'Ambert
+description:de:Fourme d’Ambert ist eine französische AOC Edelschimmelkäsesorte aus der Auvergne.
+description:en:Fourme d'Ambert is a semi-hard French AOC blue cheese, made from raw cow's milk from the Auvergne region of France.
+description:es:El Fourme d’Ambert es un queso francés, de leche de vaca de pasta entreverada de verde, de la región de Auvernia.
+description:fr:La fourme d'Ambert est un fromage français, à base de lait de vache, à pâte persillée, non cuite et non pressée, à croûte sèche et fleurie, créé à l'origine dans les environs d'Ambert.
+description:nl:De Fourme d’Ambert is een Franse koemelkkaas met Penicillum Roqueforti schimmels, afkomstig uit Saint-Just in het bergachtige gebied van de Puy-de-Dôme.
 
 # <en:compound
 <en:cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11027,6 +11027,32 @@ ca:mozzarella ratllada
 es:mozzarella rallada
 
 <en:cheese
+en:Ossau-Iraty
+ar:اوساو يراتى
+ca:Ossau-Irati
+el:Οσό-Ιρατί
+eu:Ossau-Irati
+ja:オッソー・イラティ
+ko:오소이라티
+oc:Aussau-Irati
+ru:Оссо-Ирати
+uk:Оссо-Іраті
+xx:Ossau-Iraty
+zh:伊拉堤芝士
+wikidata:en:Q520598
+wikipedia:en:https://en.wikipedia.org/wiki/Ossau-Iraty
+ciqual_food_code:en:12119
+ciqual_food_name:en:Ossau-Iraty cheese, from ewe's milk
+ciqual_food_name:fr:Ossau-Iraty
+description:de:Ossau-Iraty ist ein französischer Schnittkäse aus Schafmilch mit geschützter Ursprungsbezeichnung.
+description:en:Ossau-Iraty is an Occitan-Basque cheese made from sheep milk.
+description:es:El Ossau-Iraty es un queso francés del País Vasco francés y del Bearne, que se produce en un territorio bien delimitado, en el departamento de los Pirineos Atlánticos y en una pequeña parte del departamento de los Altos Pirineos.
+description:fr:Ossau-iraty est l'appellation d'origine d'un fromage français de lait de brebis à pâte pressée non cuite fabriqué dans le Pays basque français et le Béarn.
+description:it:L'ossau-iraty è un formaggio francese prodotto dal latte di pecora a pasta semidura non cotta, nel dipartimento dei Pirenei Atlantici e in qualche comune degli Alti Pirenei.
+description:nl:De Ossau-Iraty is een Franse kaas, een halfharde kaas afkomstig uit Frans-Baskenland en het hogergelegen deel van Béarn.
+description:oc:L'Aussau-Irati es un fromatge de Bearn e de Bascoat. 
+
+<en:cheese
 en:parmesan, parmigiano reggiano, Parmesan cheese, parmigiano reggiano cheese, Parmesan cheese from cow's milk
 af:Parmesaan
 ar:بارميجيانو ريجيانو
@@ -70780,17 +70806,21 @@ comment:en:The term shrimp is used to refer to some decapod crustaceans, althoug
 wikidata:en:Q1517781
 wikipedia:en:https://en.wikipedia.org/wiki/Shrimp
 # ingredient/fr:crevette has 840 products in 7 languages @2019-01-06
+
+<en:shrimp
+en:raw shrimp
 ciqual_food_code:en:10021
 ciqual_food_name:en:Shrimp or prawn, raw
 ciqual_food_name:fr:Crevette, crue
 
+<en:shrimp
 en:cooked shrimp, cooked prawn
 fr:Crevette cuite
 ciqual_food_code:en:10007
 ciqual_food_name:en:Shrimp or prawn, cooked
 ciqual_food_name:fr:Crevette, cuite
 
-<en:prawn
+<en:shrimp
 en:red prawn
 de:Blassrote Tiefseegarnele, Gamba Roja
 es:gamba roja

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -50339,7 +50339,7 @@ et:tšilli, tšillipipar
 eu:Pipermin
 fa:فلفل تند
 fi:chili, chilipippuri, chilipaprika
-fr:chili, piment du chili
+fr:chili, piment du chili, piment
 gl:Chile
 gn:Ky'ỹi
 gu:મરચું

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -65744,6 +65744,119 @@ ciqual_food_name:en:European perch, raw
 ciqual_food_name:fr:Perche, crue
 
 
+<en:fish
+en:European seabass
+ar:شبص أوروبي
+az:Lavrak
+bg:морски вълк
+br:Draeneg
+bs:Lubin
+ca:llobarro
+co:Ragnola
+cs:mořčák evropský
+cy:Draenogyn Mor
+da:Havbars
+de:Europäischer Wolfsbarsch
+el:Λαβράκι
+eo:Labrako
+es:Llobarro
+eu:Lupi
+fa:ماهی خاردار اروپایی
+fi:Meribassi
+fr:bar commun
+ga:Doingean mara
+gl:Robaliza
+he:לברק
+hr:Lubin
+hu:farkassügér
+io:Barsho
+is:Evrópskur hafbarri
+it:spigola
+ja:ヨーロピアンシーバス
+ka:ლავრაკი
+kg:Kilondo
+ky:Лаврак
+la:Dicentrarchus Labrax
+lt:Paprastasis vilkešeris
+nl:Europese zeebaars
+nn:havabbor
+pl:Labraks
+pt:robalo
+ro:biban de mare european
+ru:Лаврак
+sk:Okúň branzino
+sl:Brancin
+sv:Havsabborre
+tr:Bayağı levrek
+uk:Лаврак
+zh:	歐洲鱸
+wikidata:en:Q217129
+wikipedia:en:https://en.wikipedia.org/wiki/European_bass
+description:de:Der Europäische Wolfsbarsch oder auch Seebarsch (Dicentrarchus labrax) ist ein Fisch aus der Familie der Wolfsbarsche.
+description:en:The European bass (Dicentrarchus labrax) is a primarily ocean-going fish native to the waters off Europe's western and southern and Africa's northern coasts.
+description:es:La lubina, lobina, róbalo, robalo5 o robaliza (Dicentrarchus labrax) es una especie de pez perciforme de la familia Moronidae.
+description:fr:Le bar commun ou bar européen (Dicentrarchus labrax), surnommé loup ou perche de mer, est une espèce de poissons principalement marins qui entrent parfois en eau saumâtre et en eau douce, appartenant à la famille des moronidés.
+description:it:Dicentrarchus labrax nota comunemente come spigola (nell'Italia peninsulare e insulare) o branzino (prevalentemente nell'Italia settentrionale), è un pesce osseo marino e d'acqua salmastra della famiglia Moronidae.
+description:nl:De Europese zeebaars of zeebaars (Dicentrarchus labrax) is een straalvinnige vis uit de familie van Moronidae.
+description:pt:Dicentrarchus labrax é uma espécie de peixe da família Moronidae de tons acinzentados. Vulgarmente conhecido em Portugal por robalo e robalete, é muito apreciado na culinária portuguesa e de outros países europeus.
+
+<en:European seabass
+en:Raw wild European seabass
+fr:Bar commun cru sauvage
+ciqual_food_code:en:26205
+ciqual_food_name:en:Mediterranean bass, raw, wild
+ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, sauvage
+
+<en:European seabass
+en:Raw farmed Mediterranean bass
+fr:Bar commun cru d'élevage
+ciqual_food_code:en:26206
+ciqual_food_name:en:Mediterranean bass, raw, farmed
+ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, élevage
+
+<en:fish
+en:striped bass
+az:Zolaqlı lavrak
+bg:раиран костур
+ca:llobarro atlàntic ratllat
+cs:mořčák pruhovaný
+de:Felsenbarsch
+fa:خارماهی نواری
+fi:Juovabassi
+fr:Bar rayé
+he:בס מנומר
+hu:csíkos sügér
+it:v
+ja:ストライプドバス
+ko:줄농어
+ky:Таргыл лаврак
+nl:Gestreepte zeebaars
+nn:Stripet havabbor
+pl:Skalnik prążkowany
+pt:robalo riscado
+ru:Полосатый лаврак
+sv:Strimmig havsabborre
+uk:Окунь смугастий
+vi:Cá vược sọc
+zh:銀花鱸魚
+wikidata:en:Q842647
+wikipedia:en:https://en.wikipedia.org/wiki/Striped_bass
+description:de:Morone saxatilis, gelegentlich als Felsenbarsch bezeichnet, ist ein Fisch aus der Familie der Wolfsbarsche.
+description:en:The striped bass (Morone saxatilis), also called the Atlantic striped bass, striper, linesider, rock or rockfish, is an anadromous perciform fish of the family Moronidae found primarily along the Atlantic coast of North America.
+description:es:La lubina rayada atlántica (Morone saxatilis) es un pez anádromo que se encuentra a lo largo de la costa atlántica de América del Norte.
+description:fr:Le bar rayé ou bar d'Amérique (Morone saxatilis) est une espèce de poissons anadromes de la famille des Moronidés.
+description:it:Morone saxatilis, comunemente noto come persico spigola, è un pesce osseo marino e d'acqua dolce della famiglia dei Moronidae.
+description:nl:De gestreepte zeebaars (Morone saxatilis) is een straalvinnige vis uit de familie van Moronidae.
+description:pt:O robalo riscado (Morone saxatilis) é um peixe anádromo encontrado ao longo da Costa Atlântica da América do Norte
+
+<en:striped bass
+en:Raw striped bass
+fr:Bar rayé cru, Bar d'Amérique cru
+ciqual_food_code:en:26001
+ciqual_food_name:en:American bass, raw
+ciqual_food_name:fr:Bar rayé ou bar d'Amérique cru
+
+
 ###################################################################################################
 #
 #                                Plaice
@@ -66236,7 +66349,6 @@ fr:clupea harengus pêché en Atlantique Nord
 
 # en:description:Jack mackerels or saurels are marine fish in the genus Trachurus of the family Carangidae.
 
-<en:fish
 <en:oily fish
 en:jack mackerels
 ar:طرخورة
@@ -67857,15 +67969,15 @@ en:Mediterranean bass
 fr:Loup de Méditerranée
 
 <en:Mediterranean bass
-en:Raw wild mediterranean bass
-fr:Bar commun cru sauvage, Loup de Méditerranée cru sauvage
+en:Raw wild Mediterranean bass
+fr:Loup de Méditerranée cru sauvage
 ciqual_food_code:en:26205
 ciqual_food_name:en:Mediterranean bass, raw, wild
 ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, sauvage
 
-<Mediterranean bass
+<en:Mediterranean bass
 en:Raw farmed Mediterranean bass
-fr:Bar commun cru d'élevage, Loup de Méditerranée cru d'élevage
+fr:Loup de Méditerranée cru d'élevage
 ciqual_food_code:en:26206
 ciqual_food_name:en:Mediterranean bass, raw, farmed
 ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, élevage
@@ -70171,21 +70283,21 @@ sv:krabbextrakt
 # Cancer pagurus, commonly known as the edible crab or brown crab, is a species of crab found in the North Sea, North Atlantic Ocean
 
 <en:crab
-en:edible crab, brown crab, Cancer pagurus
-bg:ядивни раци, Cancer pagurus
-cs:krab německý, Cancer pagurus
-de:Taschenkrebs, Cancer pagurus
-es:Buey de mar, Cancer pagurus
-fi:Isotaskurapu, Cancer pagurus
-fr:Crabe dormeur, Dormeur, Poupard, Poupart, Tourteau, Crabe-de-lune, Poing-clos, Clos-poing, Ouvet, Cancer pagurus
-hu:Nagy tarisznyarák, Cancer pagurus
+en:edible crab, brown crab
+bg:ядивни раци
+cs:krab německý
+de:Taschenkrebs
+es:Buey de mar
+fi:Isotaskurapu
+fr:Crabe dormeur, Dormeur, Poupard, Poupart, Tourteau, Crabe-de-lune, Poing-clos, Clos-poing, Ouvet
+hu:Nagy tarisznyarák
 la:Cancer pagurus
-nl:Noordzeekrab, Cancer pagurus
-nn:taskekrabbe, Cancer pagurus
-pt:Caranguejola, Cancer pagurus
-ru:Большой сухопутный краб, Cancer pagurus
-sk:Krab piesočný, Cancer pagurus
-sv:Krabbtaska, Cancer pagurus
+nl:Noordzeekrab
+nn:taskekrabbe
+pt:Caranguejola
+ru:Большой сухопутный краб
+sk:Krab piesočný
+sv:Krabbtaska
 # ingredient/fr:tourteau has 13 products @2019-01-14
 wikidata:en:Q752188
 wikipedia:en:https://en.wikipedia.org/wiki/Cancer_pagurus

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -67972,7 +67972,7 @@ en:nile tilapia
 la:Oreochromis niloticus
 
 
-
+# <en:saltwater fish
 <en:fish
 en:tuna
 af:Tuna
@@ -68206,6 +68206,9 @@ sv:Gulfenad tonfisk
 # ceb:Carao
 wikidata:en:Q269781
 wikipedia:en:https://en.wikipedia.org/wiki/Yellowfin_tuna
+ciqual_food_code:en:26064
+ciqual_food_name:en:Yellowfin tuna, raw
+ciqual_food_name:fr:Thon albacore ou thon jaune, cru
 # ingredient/fr:thon-albacore has 172 products in 2 languages 2019-01-02
 # ingredient/fr:Thunnus-albacares has 58 products @2019-01-02
 # THON albacore (Thunnus albacares)

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11485,51 +11485,38 @@ ciqual_food_name:en:Provolone cheese, from cow's milk
 ciqual_food_name:fr:Provolone
 
 
-# description:en:RACLETTE is a semi-hard cow's milk cheese that is usually fashioned into a wheel of about 6 kg.
 
+<en:cow cheese
 <en:cheese
 en:Raclette
 ar:راكليتي
 be:Раклет
 ca:formatge de raclet
-cs:Raclette
-de:Raclette
 eo:Rakledo
-es:raclette
-fi:Raclette
-fr:Raclette
 he:רקלט
-hu:Raclette, Raclette sajt
+hu:Raclette sajt
 hy:Ռակլետ
-id:Raclette
-it:Raclette
 ja:ラクレット
-la:Raclette
-lb:Raclette
-ms:Raclette
-nb:Raclette
-nl:Raclette
-oc:Raclette
-pl:Raclette
-pt:Raclette
 ru:Раклет
 sh:Raklet
-sk:Raclette
 sr:Raklet
-sw:Raclette
-tr:Raclette
 uk:Раклет
+xx:raclette
 zh:拉可雷特芝士
-# en-ca:Raclette
-# en-gb:Raclette
-# gsw:Raclette
 # yue:烘焗瑞士芝士
 # zh-cn:拉可雷特芝士
 # zh-hans:拉可雷特芝士
 # zh-hant:拉可雷特芝士
-wikidata:en:Q20748
+wikidata:en:Q57827645
 wikipedia:en:https://en.wikipedia.org/wiki/Raclette
-# fr:raclette has 47 products in 4 languages @2018-10-27
+ciqual_food_code:en:12749
+ciqual_food_name:en:Raclette cheese, from cow's milk
+ciqual_food_name:fr:Raclette (fromage)
+description:de:Raclette ist der Name eines Kuhmilchkäses.
+description:en:RACLETTE is a semi-hard cow's milk cheese.
+description:es:El raclette es un queso semicurado de origen suizo proveniente del cantón del Valais. 
+description:fr:Le raclette est un fromage à base de lait cru de vache, à pâte pressée non cuite d'origine du canton du Valais en Suisse.
+# 84 in 4 @2021-08-31
 
 #category/reblochon
 <en:cow cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10468,31 +10468,21 @@ fr:Fromage blanc
 hu:cottage sajt, cottage cheese
 wikidata:en:Q15080546
 
-
+# category/feta
 <en:cheese
 en:feta, feta cheese
-af:Feta
 ar:فيتا
 az:Brınza
 be:Фета
 bg:Бяло саламурено сирене
-ca:feta
-cs:feta
-cy:feta
-da:Feta
-de:Feta, Feta-Käse
+de:Feta-Käse
 el:Φέτα, Τυρί φέτα
 eo:Feta-fromaĝo
 es:Sirene, queso feta
-et:Feta
-eu:Feta
 fa:پنیر فتا
-fi:Feta
-fr:feta, fromage feta
-gl:Feta
+fr:fromage feta
 he:פטה
-hr:Feta
-hu:feta, fetasajt, feta sajt
+hu:fetasajt, feta sajt
 hy:Ֆեթա
 id:Keju Sirene
 is:Fetaostur
@@ -10501,31 +10491,28 @@ ja:フェタチーズ
 kn:ಫ಼ೆಟಾ ಚೀಸ್
 ko:페타
 la:Pheta
-lt:Feta
-lv:Feta
 mk:Бело сирење
-nb:feta
-nl:Feta
 pl:Ser szopski
 pt:Sirene
 ru:Фета
-sc:Feta
-sk:feta
 sr:фета
-sv:Fetaost, feta
-tl:Feta
+sv:Fetaost
 tr:Beyaz peynir
 uk:Фета
-vi:Feta
+xx:feta
 zh:菲達芝士
 # be-tarask:Фэта
-# gsw:Feta
-# sco:feta
 # yue:菲達芝士
 wikidata:en:Q182760
 wikipedia:en:https://en.wikipedia.org/wiki/Feta
-# fr:feta has 49 products in 3 languages @2018-10-28
-description:en:FETA is a brined curd white cheese made in Greece from sheep's milk or from a mixture of sheep and goat's milk.
+# 775 in 7 @2021-08-30
+description:de:Der Feta ist ein Salzlakenkäse.
+description:en:FETA is a greek brined curd white cheese from sheep's milk or from a mixture of sheep and goat's milk.
+description:es:Feta es un queso clásico de Grecia, fundamentado en la cuajada del queso que se cura en salmuera.
+description:fr:Feta désigne un fromage caillé en saumure originaire de Grèce.
+description:it:La feta è un formaggio tradizionale greco, a pasta semidura ma friabile, bianchissimo e piuttosto salato.
+description:nl:Feta is een Griekse kaas gemaakt van schapenmelk, eventueel aangevuld met geitenmelk.
+description:pt:Feta é um queijo coalhado típico da Grécia, feito tradicionalmente com leite de ovelha e de cabra. 
 ciqual_food_code:en:12061
 ciqual_food_name:en:Feta cheese, from ewe's milk
 ciqual_food_name:fr:Feta de brebis
@@ -11104,92 +11091,68 @@ de:Pepper Jack, Pepper-Jack-Käse
 
 # description:en:MOZZARELLA is a traditionally southern Italian spun paste dairy made with Italian buffalo's milk by the pasta filata method.
 
+#category/mozzarella
 <en:cheese
 en:mozzarella, mozzarella cheese
-af:Mozzarella
 ar:موتزاريلا
-az:Mozzarella
 be:Мацарэла
 bg:Моцарела
 bn:মজারেলা পনির
 bo:མོ་ཟ་རེལ་ལ།
-br:mozzarella
 bs:mocarela
-ca:mozzarella, formatge mozzarella
-cs:mozzarella, sýr mozzarella
+ca:formatge mozzarella
+cs:sýr mozzarella
 cv:Моцарелла
 cy:Mosarela
-da:mozzarella, mozzarella ost
-de:Mozzarella
+da:mozzarella ost
 el:Μοτσαρέλα, τυρι Μοτσαρέλλα
 eo:Mocarelo
-es:mozzarella, queso mozzarella,queso mozarella
-et:mozzarella
-eu:mozzarella
+es:queso mozzarella, queso mozarella
 fa:موزارلا
-fi:mozzarella, mozzarellajuustoa, mozzarella-juusto
-fr:mozzarella, fromage mozzarella
-fy:mozzarella
-gl:Mozzarella
+fi:mozzarellajuustoa, mozzarella-juusto
+fr:fromage mozzarella
 he:מוצרלה
 hi:मोत्ज़ारेला
 hr:mocarela
-hu:mozzarella
 hy:Մոցարելա
-id:Mozzarella
-is:Mozzarella
-it:mozzarella, formaggio mozzarella
+it:formaggio mozzarella
 ja:モッツァレッラ
-jv:Mozzarella
 ka:მოცარელა
 kk:Моцарелла
 kn:ಮೋಟ್ಸರೆಲ್ಲಾ ಚೀಸ್
 ko:모차렐라
-ku:Mozzarella
-la:Mozzarella
-lb:Mozzarella
-li:Mozzarella
-ln:Mozzarella
 lt:Mocarela
 lv:mocarella
 mk:Моцарела
 mr:मोजारेला
-ms:Mozzarella
-mt:Mozzarella
-nb:mozzarella
-nl:mozzarella
-nn:mozzarella
-oc:Mozzarella
 or:ମୋଜ୍ଜରେଲା
 pa:ਮੋਜ਼ਾਰੇਲਾ
-pl:mozzarella, ser mozzarella
-pt:mozarela, mozzarella, queijo mozzarella
-ro:mozzarella
+pl:ser mozzarella
+pt:mozarela, queijo mozzarella
 ru:моцарелла
 sh:Mocarela
-sk:mozzarella, syr mozzarella
+sk:syr mozzarella
 sl:Mocarela
 sq:mocarela
 sr:моцарела
-sv:mozzarella, mozzarellaost, mozzarella-ost
+sv:mozzarellaost, mozzarella-ost
 th:มอซซาเรลลา
-tr:Mozzarella
 uk:Моцарела
 ur:موزاریلا
-vi:Mozzarella
+xx:Mozzarella
 zh:莫薩里拉乾酪
 # arz:موتزاريلا
-# ast:Mozzarella
 # nap:Muzzarella
 # pnb:موزاریلا
 # roa-tara:muzzarelle
-# scn:Mozzarella
-# sco:mozzarella
 # yue:水牛芝士
 # zh-hans:莫薩里拉乾酪
 # zh-hant:莫札瑞拉起司
 wikidata:en:Q14088
 wikipedia:en:https://en.wikipedia.org/wiki/Mozzarella
+ciqual_food_code:en:19590
+ciqual_food_name:en:Mozzarella cheese, from cow's milk
+ciqual_food_name:fr:Mozzarella au lait de vache
 # fr:mozzarella has 1057 products in 15 languages @2018-10-28
 
 <en:mozzarella

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11377,6 +11377,26 @@ nl:pecorino romano, pecorino romano kaas
 # fr:pecorino-romano has 30 products in 1 language @2018-10-27
 # fr:pecorino-romano-aop has 10 product in 1 language @2018-10-27
 
+#category/pont-l-eveque
+<en:cheese
+en:pont l'evêque
+ar:پونت ليڤيكو
+ja:ポン・レヴェック
+ko:퐁레베크
+ru:Пон-л’Эвек
+uk:Пон-л'Евек
+xx:pont l'evêque
+zh:龐特伊維克芝士
+wikidata:Q1233145
+wikipedia:en:wiki/Pont-l%27Évêque_cheese
+description:de:Der Pont-l’Évêque ist ein französischer Käse aus der Normandie, der aus roher oder pasteurisierter Kuhmilch hergestellt wird. 
+description:en:Pont-l'Évêque is an uncooked, unpressed cow's-milk cheese, originally manufactured in the area around the commune of Pont-l'Évêque, in the Calvados département of Normandy.
+description:es:El pont-l'évêque es un queso francés a base de leche de vaca fabricado en Normandía.
+description:fr:Le pont-l’évêque est un fromage français de lait de vache produit et affiné sur le territoire de l'ancienne Normandie historique.
+description:it:Pont-l'Évêque è un formaggio francese di latte vaccino, a pasta molle e crosta lavata, prodotto sul territorio dell'antica Normandia storica.
+description:nl:De Pont-l'Évêque is een Franse kaas van het type rood-bacterie- of gewassen-korst-kaas afkomstig uit Normandië.
+description:pt:O Pont-l'évêque é um queijo francês à base de leite de vaca da região da Normandia.
+
 # Romano cheese is a term used in the United States and Canada for a class of hard, salty cheeses suitable primarily for grating similar to Pecorino Romano, from which the name is derived
 
 <en:cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -9912,6 +9912,7 @@ ciqual_food_code:en:12022
 ciqual_food_name:en:Brie de Melun cheese, from cow's milk
 ciqual_food_name:fr:Brie de Melun
 
+#category/camemberts
 <en:cheese
 en:camembert, camembert cheese
 ar:كامامبير
@@ -9948,10 +9949,17 @@ zh:卡芒贝尔奶酪
 # zh-tw:卡芒貝爾乾酪
 wikidata:en:Q131480
 wikipedia:en:https://en.wikipedia.org/wiki/Camembert
-# ingredient/fr:camembert has 23 products @2019-02-17
-carbon_footprint_fr_foodges_ingredient:fr:Fromage à pâte molle (type camembert)
-carbon_footprint_fr_foodges_value:fr:4.3
-description:en:CAMEMBERT is a moist, soft, creamy, surface-ripened cow's milk cheese.
+# 113 in 8 @2020-08-29
+ciqual_food_code:en:12001
+ciqual_food_name:en:Camembert cheese, from cow's milk
+ciqual_food_name:fr:Camembert, sans précision
+description:de:Camembert ist ein französischer Weißschimmelkäse.
+description:en:CAMEMBERT is a moist, soft, creamy, surface-ripened cow's milk cheese from Normandy, France.
+description:es:El Camembert de Normandía es un queso de leche de vaca producido en la región francesa de Normandía.
+description:fr:Camembert est une appellation générique qui désigne généralement un fromage à pâte molle et à croûte fleurie.
+description:it:Il camembert è un formaggio francese a pasta molle e crosta fiorita prodotto in Normandia.
+description:nl:Camembert is een Franse witte schimmelkaas, die van koemelk wordt gemaakt en Penicillium camemberti. 
+description:pt:Camembert ou camember é uma variedade de queijo de pasta mole, originária da região da Normandia, França
 
 <en:camembert
 fr:camembert au lait pasteurisé

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -51002,7 +51002,7 @@ fr:tomates semi-séchées marinées, tomates semi-déshydratées et marinées
 #process:en: en:dried
 #process:en: en:dehydrated
 <en:tomato
-en:dried tomatoes
+en:dried tomatoes, Dried tomato
 #da:tørret tomat
 #de:getrocknete Tomaten
 #es:tomate deshidratado
@@ -51014,6 +51014,9 @@ ja:ドライトマト
 #nn:tørket tomat
 #ro:roșii uscate
 #sv:torkad tomat
+ciqual_food_code:en:20189
+ciqual_food_name:en:Tomato, dried
+ciqual_food_name:fr:Tomate, séchée
 # ingredient/fr:tomate-séchée has 423 products in 9 languages @2018-12-26
 
 #process:en: en:sundried
@@ -51034,11 +51037,6 @@ description:fr:Les tomates séchées sont un aliment déshydraté traditionnel, 
 # ingredient/fr:tomates-sechees-au-soleil has 281 products in 1 language @2020-05-21
 
 <en:sundried tomatoes
-en:Dried tomato, Dried tomatoes, Sun-Dried tomato, Sun-Dried tomatoes
-fr:Tomate séchée, Tomates séchées
-ciqual_food_code:en:20189
-ciqual_food_name:en:Tomato, dried
-ciqual_food_name:fr:Tomate, séchée
 
 #<en:sundried tomatoes
 #en:Dried tomato in oil, Dried tomatoes in oil, Sun-Dried tomato in oil, Sun-Dried tomatoes in oil
@@ -52151,9 +52149,9 @@ de:grüne Erbsen
 es:guisantes verdes
 fi:vihreät herneet
 fr:Petits pois
-it:Piselli
+it:Piselli verde
 ja:グリーンピース
-nl:erwten
+nl:groene erwten
 sv:gröna ärtor
 th:ถั่ว ลันเตา
 vegan:en:yes
@@ -53413,8 +53411,10 @@ nutriscore_fruits_vegetables_nuts:en:yes
 ###################################################################################################
 # Almonds
 
+#comment:en:do NOT add the state of the almond, i.e. peeled, crushed, etc. This is detected in the processing taxonomy
+
 <en:tree nut
-en:almond, almonds, peeled Almond, unpeeled almond, blanched almond
+en:almond, almonds
 am:አልመንድ
 ar:لوز
 bg:бадеми
@@ -53428,7 +53428,7 @@ es:almendra, almendras
 et:Mandel, mandlid, mandleid
 eu:Arbendol
 fi:manteli, mantelit, mantelia
-fr:amande, amandes, Amande mondée, amande émondée, amande blanchie
+fr:amande, amandes
 fy:Mangel
 ga:almóinní
 gl:Améndoa

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11389,6 +11389,9 @@ xx:pont l'evêque
 zh:龐特伊維克芝士
 wikidata:Q1233145
 wikipedia:en:wiki/Pont-l%27Évêque_cheese
+ciqual_food_code:en:12042
+ciqual_food_name:en:Pont l'Evêque cheese, from cow's milk
+ciqual_food_name:fr:Pont l'Évêque
 description:de:Der Pont-l’Évêque ist ein französischer Käse aus der Normandie, der aus roher oder pasteurisierter Kuhmilch hergestellt wird. 
 description:en:Pont-l'Évêque is an uncooked, unpressed cow's-milk cheese, originally manufactured in the area around the commune of Pont-l'Évêque, in the Calvados département of Normandy.
 description:es:El pont-l'évêque es un queso francés a base de leche de vaca fabricado en Normandía.
@@ -11675,6 +11678,23 @@ description:en:Salers is a French semi-hard com milk cheese originating from Sal
 description:es:El salers es un queso francés propio del departamento de Cantal, en la región volcánica de los montes de Auvernia.
 description:fr:Le salers est un fromage au lait cru de vache à pâte pressée non cuite français du département du Cantal.
 description:nl:De Salers is een harde koemelk Franse kaas, geproduceerd in de Cantal, in de Haute-Auvergne.
+
+#category/saint-marcellin
+<en:cheese
+en:Saint Marcellin
+ar:ساينت مارسيلين
+fr:Saint Marcellin IGP
+xx:Saint-Marcellin, Saint Marcellin
+zh:圣马尔瑟兰
+wikidata:en:Q510126
+ciqual_food_code:en:12049
+ciqual_food_name:en:Saint-Marcellin cheese, from cow's milk
+ciqual_food_name:fr:Saint-Marcellin
+description:de:Der Saint-Marcellin ist ein französischer Käse aus der Dauphiné, der aus roher oder pasteurisierter Milch von Hausziegen oder Kühen hergestellt wird.
+description:en:Saint-Marcellin is a soft French cheese made from cow's milk, produced in the former Dauphiné province.
+description:es:El Saint-Marcellin es un queso francés del Delfinado, a base de leche de vaca, con pasta blanda y corteza fermentada.
+description:fr:Le saint-marcellin est un fromage AOP français, à base de lait de vache, à pâte molle à croûte fleurie, du Dauphiné.
+description:nl:De Saint-Marcellin is een klein Frans kaasje, afkomstig uit het dorp Saint-Marcellin in de Dauphiné.
 
 # description:en:Stilton is an English cheese, produced in two varieties: Blue, which has had Penicillium roqueforti added to generate a characteristic smell and taste, and White, which has not.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -9994,6 +9994,12 @@ ciqual_food_code:en:12723
 ciqual_food_name:en:Cantal, Salers or Laguiole cheese, from cow's milk
 ciqual_food_name:fr:Cantal, Salers ou Laguiole
 
+<en:cheese
+en:Chaource cheese
+fr:Chaource
+ciqual_food_code:en:12028
+ciqual_food_name:en:Chaource cheese, from cow's milk
+ciqual_food_name:fr:Chaource
 
 <en:cheese
 en:cheddar, cheddar cheese, Cheddar cheese from cow's milk
@@ -10882,12 +10888,6 @@ ciqual_food_code:en:12030
 ciqual_food_name:en:Maroilles ""fermier"" cheese
 ciqual_food_name:fr:Maroilles fermier
 
-<en:cheese
-en:Chaource cheese
-fr:Chaource
-ciqual_food_code:en:12028
-ciqual_food_name:en:Chaource cheese, from cow's milk
-ciqual_food_name:fr:Chaource
 
 # MASCARPONE is an Italian cream cheese coagulated by the addition of certain acidic substances such as lemon juice, vinegar, citric acid or acetic acid.
 
@@ -11165,6 +11165,31 @@ description:fr:Ossau-iraty est l'appellation d'origine d'un fromage français de
 description:it:L'ossau-iraty è un formaggio francese prodotto dal latte di pecora a pasta semidura non cotta, nel dipartimento dei Pirenei Atlantici e in qualche comune degli Alti Pirenei.
 description:nl:De Ossau-Iraty is een Franse kaas, een halfharde kaas afkomstig uit Frans-Baskenland en het hogergelegen deel van Béarn.
 description:oc:L'Aussau-Irati es un fromatge de Bearn e de Bascoat. 
+
+#category/munsters
+<en:cheese
+en:munster
+ar:مونستير
+be:Мюнстэр
+cv:Мюнстер
+id:Keju Munster
+ja:マンステール
+ko:묑스테르
+ru:Мюнстер
+th:เมิงสแตร์ชีส
+uk:Мюнстер
+xx:munster
+zh:芒斯特芝士
+wikidata:en:Q765540
+ciqual_food_code:en:12039
+ciqual_food_name:en:Munster cheese, from cow's milk
+ciqual_food_name:fr:Munster
+description:de:Munster oder Munster-Géromé ist ein französischer Weichkäse aus den Hochvogesen und traditionell besonders aus dem elsässischen Münstertal (Vallée de Munster).
+description:en:Munster, Munster-géromé, or Minschterkaas, is a strong-smelling soft cheese with a subtle taste, made mainly from milk first produced in the Vosges.
+description:fr:Le munster et le munster-géromé constituent une appellation d'origine désignant un fromage de lait de vache de l'Est de la France.
+description:es:El munster es un queso francés del este de Francia beneficiario de una AOC.
+description:nl:De Munster is een Franse kaas, afkomstig uit de Vogezen.
+description:pt:O munster ou munster-géromé é um queijo francês do Leste, das regiões da Alsácia.
 
 #category/neufchatel-cheese-from-cow-s-milk
 <en:cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -65800,19 +65800,20 @@ description:it:Dicentrarchus labrax nota comunemente come spigola (nell'Italia p
 description:nl:De Europese zeebaars of zeebaars (Dicentrarchus labrax) is een straalvinnige vis uit de familie van Moronidae.
 description:pt:Dicentrarchus labrax é uma espécie de peixe da família Moronidae de tons acinzentados. Vulgarmente conhecido em Portugal por robalo e robalete, é muito apreciado na culinária portuguesa e de outros países europeus.
 
+
 <en:European seabass
+en:Raw European seabass
+fr:Bar commun cru, Loup cru
+ciqual_food_code:en:26072
+ciqual_food_name:en:European bass, raw
+ciqual_food_name:fr:Bar commun ou loup, cru, sans précision
+
+<en:Raw European seabass
 en:Raw wild European seabass
 fr:Bar commun cru sauvage
 ciqual_food_code:en:26205
 ciqual_food_name:en:Mediterranean bass, raw, wild
 ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, sauvage
-
-<en:European seabass
-en:Raw farmed Mediterranean bass
-fr:Bar commun cru d'élevage
-ciqual_food_code:en:26206
-ciqual_food_name:en:Mediterranean bass, raw, farmed
-ciqual_food_name:fr:Bar commun ou loup (Méditerranée), cru, élevage
 
 <en:fish
 en:striped bass
@@ -67720,6 +67721,23 @@ it:Filetti di sgombro occhione
 fr:filets de maquereaux cuits au court-bouillon
 # ingredient/fr:filets-de-maquereaux-cuits-au-court-bouillon has 33 products in french @2018-12-30
 # structure:outer:role:compound, eg Filets de maquereaux cuits au court-bouillon (filets de maquereaux 55%, sel, épices et aromates)
+
+#comment:en:We need more products to figure out how the generic name bream is divided over specific species.
+<en:fish
+en:freshwater bream, bream
+de:brasse
+fr:brème
+wikidata:en:Q17767599
+wikipedia:en:https://en.wikipedia.org/wiki/Bream
+description:en:Bream are species of freshwater and marine fish belonging to a variety of genera.
+description:fr:Brème est un nom vernaculaire féminin, ambigu en français car il peut désigner différentes espèces de poissons d'eau douce
+
+<en:freshwater bream
+en:Raw freshwater bream
+fr:Brème cru
+ciqual_food_code:en:26170
+ciqual_food_name:en:Freshwater bream, raw
+ciqual_food_name:fr:Brème, cru
 
 
 #description:en:Molva est un genre de poissons appelés lingues, élingues ou juliennes.

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11916,6 +11916,26 @@ description:es:El Fourme d’Ambert es un queso francés, de leche de vaca de pa
 description:fr:La fourme d'Ambert est un fromage français, à base de lait de vache, à pâte persillée, non cuite et non pressée, à croûte sèche et fleurie, créé à l'origine dans les environs d'Ambert.
 description:nl:De Fourme d’Ambert is een Franse koemelkkaas met Penicillum Roqueforti schimmels, afkomstig uit Saint-Just in het bergachtige gebied van de Puy-de-Dôme.
 
+<en:blue cheese
+en:bleu de gex
+ar:بليو د جيكس
+az:Blyö de Jeks
+hy:Բլյո դը Ժեքս
+ru:Блё де Жекс
+uk:Бле-де-Жекс
+xx:bleu de gex, Bleu du Haut-Jura, Bleu de septmoncel
+zh:布勒·德·吉克斯芝士
+wikidata:en:Q1231078
+wikipedia:en:https://en.wikipedia.org/wiki/Bleu_de_Gex
+ciqual_food_code:en:12526
+ciqual_food_name:en:Gex blue cheese, or Jura blue cheese or Septmoncel blue cheese, from cow's milk.
+ciqual_food_name:fr:Bleu de Gex ou Fromage bleu du Haut-jura ou Bleu de septmoncel (AOC)
+description:de:Der Bleu de Gex, auch Bleu de Septmoncel oder Bleu du Haut Jura genannt, ist ein französischer Blauschimmelkäse.
+description:en:Bleu de Gex (also Bleu du Haut-Jura or Bleu de Septmoncel) is a creamy, semi-soft blue cheese made from unpasteurized milk in the Jura region of France.
+description:es:El bleu de Gex es un queso francés de las mesetas del Alto Jura.
+description:fr:Le bleu de Gex Haut-Jura ou bleu de Septmoncel est un fromage au lait de vache à pâte persillée produit dans les plateaux du Haut-Jura.
+description:nl:De Bleu de Gex AOP is een Franse kaas, geproduceerd in de streek Haut Jura.
+
 # <en:compound
 <en:cheese
 fr:base aromatisante fromage

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -78241,16 +78241,17 @@ wikidata:en:Q19573669
 
 fr:génoise, genoise
 
-# description:en:A CROUTON is a piece of sautéed or rebaked bread, often cubed and seasoned, that is used to add texture and flavor to salads as an accompaniment to soups and stews, or eaten as a snack food.
 
 # <en:compound
 # mainIngredient:en:wheat
 # <en:Breads
+#category/croutons
 en:crouton, croutons
 af:Crouton
 be:грэнкі
 bg:крутон
 ca:crostó
+cs:kruton
 da:crouton, croutoner
 de:Croûton, Croutons
 el:κρουτόν
@@ -78278,8 +78279,16 @@ zh:麵包丁
 likely_allergens:en: en:gluten
 wikidata:en:Q1197400
 wikipedia:en:https://en.wikipedia.org/wiki/Crouton
-# ingredient/fr:croûtons has 107 products in 5 languages @2019-04-21
-# category/croutons has 166 products @2019-05-19
+ciqual_food_code:en:7430
+ciqual_food_name:en:Croutons
+ciqual_food_name:fr:Croûtons
+description:de:Croûtons sind kleine Würfel von geröstetem oder in Fett gebratenem Brot.
+description:en:A CROUTON is a piece of sautéed or rebaked bread, often cubed and seasoned, that is used to add texture and flavor to salads as an accompaniment to soups and stews, or eaten as a snack food.
+description:es:Los croûtons son pequeñas porciones de pan tostado o ligeramente frito o salteado en aceite o mantequilla.
+description:fr:Un croûton est un petit morceau de pain sec de forme variée, parfois assaisonné, doré au beurre, frit à l'huile ou séché au four, et qui sert de garniture à certains plats.
+description:nl:Een crouton is de Franse benaming voor een stukje geroosterd brood.
+description:pt:Croûton é um pequeno pedaço de pão, frito ou assado com óleo, azeite ou manteiga, utilizado para acompanhar sopas ou saladas.
+# 311 products in 9 @2021-09-02
 # usage:en:croutons (wheat flour, vegetable fat, edible salt, maltodextrin, grape sugar, onions, herbs, yeast extract, dehydrated garlic, flavoring, yeast, spice extract)
 
 de:Reisextrudat

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -66072,9 +66072,35 @@ wikipedia:en:https://en.wikipedia.org/wiki/Argentine_hake
 # ingredient/fr:Merluccius-hubbsi has 3 products in french @2018-12-31
 # structure:inner:role:synonym, eg Filet de merlu blanc (Merluccius hubbsi)
 
+<en:fish
+en:grouper
+ca:Epinefelí
+de:Zackenbarsche
+fi:meriahvenet
+fr:mérou
+ga:Garúpach
+nl:tandbaars
+ru:Груперы
+wikipedia:en:Q5559352
+wikipedia:en:https://en.wikipedia.org/wiki/Grouper
+description:de:Die Zackenbarsche (Epinephelidae) sind eine Familie kleiner bis sehr großer Meeresfische aus der Ordnung der Barschartigen.
+description:en:Groupers are fish of any of a number of genera in the subfamily Epinephelinae of the family Serranidae, in the order Perciformes.
+description:es:Los meros o chernas son un grupo de unos veinte géneros de la subfamilia Epinephelinae de peces perciformes.
+description:fr:Le terme de mérou est un nom vernaculaire qui désigne en français plusieurs espèces de poissons de la famille des Serranidae, voire celle des Polyprionidae.
+description:it:La sottofamiglia Epinephelinae (famiglia Serranidae) comprende numerose specie di pesci d'acqua salata, comunemente indicati come cernie.
+description:nl:Tandbaarzen (Epinephelinae) vormen een onderfamilie van de familie van zaagbaarzen (Serranidae), in de orde van baarsachtigen.
+description:pt:Garoupa, cherne, mero, marelaço, galinha-do-mar ou piracuca são nomes vulgares de várias espécies de peixes da subfamília Epinephelinae, família Serranidae, ordem dos Perciformes.
+
+<en:grouper
+en:Raw grouper
+fr:Mérou cru
+ciqual_food_code:en:26178
+ciqual_food_name:en:Grouper, raw
+ciqual_food_name:fr:Mérou, cru
+
+
 # description:en:HALIBUT is a common name principally applied to the two flatfish in the genus Hippoglossus from the family of right-eye flounders. Halibut are often boiled, deep-fried or grilled while fresh.
 
-<en:fish
 <en:white fish
 en:halibut
 da:helleflynder
@@ -74332,6 +74358,12 @@ it:Uovo fresco pastorizzato
 fr:œufs frais de poules élevées en plein air, oeufs frais de poules élevées en plein air
 # ingredient/fr:œufs-frais-de-poules-élevées-en-plein-air has 44 products in french @2018-12-18
 
+<en:egg
+en:liquid egg
+de:Flüssigei, flüssiges Ei
+es:huevo liquido
+fr:Œuf liquide
+
 # description:en:EGG WHITE is the clear liquid (also called the albumen or the glair/glaire) contained within an egg.
 
 <en:egg
@@ -74584,17 +74616,12 @@ ciqual_food_code:en:22002
 ciqual_food_name:en:Egg yolk, raw
 ciqual_food_name:fr:Oeuf, jaune (jaune d'oeuf), cru
 
+<en:egg yolk
 en:Cooked egg yolk
 fr:jaune d'oeuf cuit
 ciqual_food_code:en:22009
 ciqual_food_name:en:Egg yolk, cooked
 ciqual_food_name:fr:Oeuf, jaune (jaune d'oeuf), cuit
-
-<en:egg
-en:liquid egg
-de:Flüssigei, flüssiges Ei
-es:huevo liquido
-fr:Œuf liquide
 
 <en:egg yolk
 en:free range egg yolk

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11452,6 +11452,26 @@ ciqual_food_code:en:12500
 ciqual_food_name:en:Roquefort cheese, from ewe's milk
 ciqual_food_name:fr:Roquefort
 
+#<en:cow cheese
+#category/salers-cheese
+<en:cheese,
+en:Salers, Salers cheese
+ar:ساليرس
+de:Salers-Käse
+ja:サレール
+jv:Kéju salers
+oc:Salèrn
+ru:Салер
+tr:Salers peyniri
+xx:Salers
+ciqual_food_code:en:12725
+ciqual_food_name:en:Salers cheese, from cow's milk
+ciqual_food_name:fr:Salers
+description:de:Der Salers ist eine althergebrachte AOP-Rohmilchkäsesorte aus der Gegend um die Gemeinde Salers in der Auvergne in Frankreich.
+description:en:Salers is a French semi-hard com milk cheese originating from Salers, located in the volcanic region in the Cantal mountains of Massif Central, central France.
+description:es:El salers es un queso francés propio del departamento de Cantal, en la región volcánica de los montes de Auvernia.
+description:fr:Le salers est un fromage au lait cru de vache à pâte pressée non cuite français du département du Cantal.
+description:nl:De Salers is een harde koemelk Franse kaas, geproduceerd in de Cantal, in de Haute-Auvergne.
 
 # description:en:Stilton is an English cheese, produced in two varieties: Blue, which has had Penicillium roqueforti added to generate a characteristic smell and taste, and White, which has not.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -54503,15 +54503,13 @@ es:horchata de chufa
 #
 ###################################################################################################
 
+#comment:en:these are nuts that grow in trees, in contrast to peanuts that grow in the earth.
 <en:nut
 en:tree nut, treenuts, tree nuts
-de:Nüsse
+de:Baumnüsse
 es:nueces de árboles
-fr:Fruit à coque
-ja:ナッツ
 nb:trenøtt, trenøtter
-nl:noten
-pl:Migdały
+nl:boomnoten
 allergens:en: en:nuts
 
 ###################################################################################################
@@ -68887,8 +68885,8 @@ ciqual_food_name:en:Rainbow trout, raw, farmed
 ciqual_food_name:fr:Truite arc en ciel, crue, élevage
 
 <en:rainbow trout
-en:salmon trout
-fr:Truite saumonée
+en:raw salmon trout
+fr:Truite saumonée cru
 ciqual_food_code:en:27021
 ciqual_food_name:en:Salmon trout, raw
 ciqual_food_name:fr:Truite saumonée, crue
@@ -69004,8 +69002,8 @@ ciqual_food_name:en:Surmullet or red mullet, raw
 ciqual_food_name:fr:Rouget-barbet de roche, cru
 
 <en:tub gurnard
-en:Tub gurnard
-fr:Grondin perlon
+en:raw tub gurnard
+fr:Grondin perlon cru
 ciqual_food_code:en:26219
 ciqual_food_name:en:Tub gurnard, raw
 ciqual_food_name:fr:Grondin perlon, cru
@@ -74812,7 +74810,7 @@ eo:boligita ovo
 es:huevo cocido
 eu:Arrautza egosi
 fi:Keitetty muna
-fr:œuf dur, œufs durs, oeuf dur, oeufs durs, œuf à la coque
+fr:œuf dur, œufs durs, oeuf dur, oeufs durs
 gl:Ovo duro
 he:ביצה מבושלת
 hi:उबले हुए अंडे
@@ -74842,7 +74840,7 @@ description:fr:Un œuf dur est une préparation de l'œuf qui permet de consomme
 
 <en:boiled egg
 en:soft-boiled egg
-fr:oeuf à la coque
+fr:oeuf à la coque, œuf à la coque
 ciqual_food_code:en:22014
 ciqual_food_name:en:Egg, soft-boiled
 ciqual_food_name:fr:Oeuf, à la coque
@@ -78957,7 +78955,7 @@ ciqual_food_code:en:11001
 ciqual_food_name:en:Broth, stock or bouillon, beef, dehydrated
 ciqual_food_name:fr:Bouillon de boeuf, déshydraté
 
-<en:beef broth, beef stock
+<en:beef broth
 en:dehydrated beef stock, dehydrated beef bouillon
 fr:Bouillon de boeuf déshydraté
 ciqual_food_code:en:11001

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -73478,11 +73478,18 @@ description:pt:O pepino é o fruto do pepineiro (Cucumis sativus), que se come g
 # 6546 products in 22 @2021-09-02
 
 <en:cucumber
-en:raw cucumber pulp and peel raw
+en:raw cucumber pulp and peel
 fr:Concombre pulpe et peau cru
 ciqual_food_code:en:20019
 ciqual_food_name:en:Cucumber, pulp and peel, raw
 ciqual_food_name:fr:Concombre, pulpe et peau, cru
+
+<en:cucumber
+en:raw Cucumber pulp 
+fr:Concombre pulpe cru
+ciqual_food_code:en:20210
+ciqual_food_name:en:Cucumber, pulp, raw
+ciqual_food_name:fr:Concombre, pulpe, cru
 
 
 # description:en:A GHERKIN is a variety of cucumber
@@ -80884,8 +80891,7 @@ nl:sambal oelek
 description:en:Raw chili paste (bright red, thin and sharp tasting). Can be used as the base for making other sambals or as an ingredient for other cuisines.
 
 
-# description:en:BÉARNAISE SAUCE is a sauce made of clarified butter emulsified in egg yolks and white wine vinegar and flavored with herbs.
-
+#category/bearnaise-sauce
 <en:sauce
 en:béarnaise sauce
 be:беарнскі соус
@@ -80919,7 +80925,20 @@ tr:béarnaise sosu
 # zh_yue:賓利士汁
 wikidata:en:Q58265
 wikipedia:en:https://en.wikipedia.org/wiki/B%C3%A9arnaise_sauce
-# ingredient/fr:sauce-bearnaise has 6 products in 1 language @2020-05-24
+description:de:Sauce béarnaise oder Béarner Sauce ist warme aufgeschlagene Buttersauce.
+description:en:BÉARNAISE SAUCE is a sauce made of clarified butter emulsified in egg yolks and white wine vinegar and flavored with herbs.
+description:es:La salsa bearnesa es una salsa emulsionada a base de mantequilla y yema de huevo, condimentada con estragón y chalotas, con perifollo, cocinado en vino y vinagre para hacer un glaseado.
+description:fr:La sauce béarnaise, ou la béarnaise, est une sauce émulsifiée chaude à base de beurre clarifié, de jaune d'œuf, d'échalote, d'estragon et de cerfeuil, servie pour relever les viandes.
+description:it:La salsa bernese o salsa bearnaise o semplicemente la bernese, è una salsa di condimento.
+description:nl:Bearnaisesaus is een saus gemaakt van opgeklopte boter en eigeel met toevoeging van een gastrique, bestaande uit wijn, azijn, dragon, mignonettes, kervel, bouquet garni en sjalotten.
+# 9 in 1 language @2021-09-02
+
+<en:béarnaise sauce
+en:prepacked Bearnaise sauce 
+fr:Sauce béarnaise
+ciqual_food_code:en:11102
+ciqual_food_name:en:Bearnaise sauce, prepacked
+ciqual_food_name:fr:Sauce béarnaise, préemballée
 
 
 #category:en:Pestos

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11799,19 +11799,97 @@ fr:Vacherin fribourgeois AOP
 de:Vacherin fribourgeois AOP
 ja:ヴァシュラン・フリブール
 ko:바슈랭 프리부르주아
-nl:Vacherin fribourgeois AOP
+xx:Vacherin fribourgeois AOP
 wikidata:en:Q677647
 wikipedia:fr:https://fr.wikipedia.org/wiki/Vacherin_fribourgeois
 # fr:Vacherin-fribourgeois-AOP has 2 products in 3 languages @2018-10-27
 
-
-# <en:compound
+#category/blue-veined-cheeses
 <en:cheese
-fr:bleu
+en:blue cheese
+af:Bloukaas
+ar:جبنة زرقاء
+be:Блакітныя сыры
+ca:formatge blau
+cs:Sýr s modrou plísní
+da:blåskimmelost
 de:Blauschimmelkäse
-fi:sinihomejuusto
-# ingredient/fr:bleu has 47 products in french @2019-02-16
+el:Μπλε τυρί
+eo:blua fromaĝo
+es:queso azul
+et:Sinihallitusjuust
+eu:Gazta urdin
+fa:پنیر آبی
+fi:sinihomejuusto, homejuusto
+fr:fromage à pâte persillée, bleu
+gl:Queixo azul
+he:גבינה כחולה
+hy:կապույտ պանիրներ
+ia:Caseo blau
+is:Gráðostur
+it:formaggio a pasta erborinata
+ja:ブルーチーズ
+jv:Kèju biru
+ko:블루 치즈
+lo:ເນີຍແຂງຟ້າແກ່
+mk:сино сирење
+nb:blåmuggost
+nl:Blauwschimmelkaas
+nn:blåmuggost
+pl:Niebieski ser
+pt:queijo azul
+ro:Brânză cu mucegai
+ru:Голубые сыры
+sr:бупави сир
+sv:Blågrön mögelost
+th:บลูชีส
+tt:зәңгәр сыр
+uk:Блакитні сири
+vi:Pho mát xanh
+zh:藍乾酪
+wikidata:en:Q746471
+wikipedia:en:https://en.wikipedia.org/wiki/Blue_cheese
+description:de:Blauschimmelkäse ist Schimmelkäse, bei dessen Herstellung blau bis grünlich erscheinende Edelschimmelpilze wie Penicillium roqueforti und Penicillium glaucum eingesetzt werden.
+description:en:Blue cheese or bleu cheese is cheese made with cultures of the mold Penicillium, giving it spots or veins of the mold throughout the cheese, which can vary in color through various shades of blue and green.
+description:es:El queso azul es una clasificación general de los quesos de leche de vaca, de oveja y de cabra que tienen en su pasta cultivos de Penicillium añadidos al producto final y que proporcionan un color entre el azul y el gris-verdoso característico debido a los mohos.
+description:fr:Les fromages à pâte persillée ou à pâte à moisissure interne ou encore bleus1 sont des appellations appliquées à des fromages dont le caillé est ensemencé de penicillium.
+#description:it:L'erborinatura è una tecnica di lavorazione casearia che consente lo sviluppo di muffe nella pasta del formaggio con la conseguente comparsa di caratteristiche striature e chiazze blu-verdi.
+description:nl:Blauwschimmelkaas, ook wel blauwaderkaas genoemd, is een type schimmelkaas met een blauwe schimmel (Penicillium roqueforti) als opvallendste kenmerk.
+description:pt:Os queijos azuis têm uma produção mais elaborada, resultando assim numa massa macia e quebradiça, permeada por veios azulados que dão uma característica peculiar que dá nome a esse tipo de queijo.
+
+<en:blue cheese
+en:Blue cheese from cow's milk
+fr:Fromage bleu au lait de vache
+ciqual_food_code:en:12520
+ciqual_food_name:en:Blue cheese, from cow's milk
+ciqual_food_name:fr:Fromage bleu au lait de vache
+# ingredient/fr:bleu has 84 products in french @2021-08-28
 # bleu (lait de vache entier pasteurisé, présure végétale, ferments lactiques, sel)
+
+#category/auvergne-blue-cheese-from-cow-s-milk
+<en:blue cheese
+en:bleu d'auvergne
+ar:بلو دوفيرن
+ca:blau d'Alvèrnia
+eo:Aŭvernja blua fromaĝo
+ja:ブルー・ドーヴェルニュ
+ko:블뢰 도베르뉴
+oc:Blau d'Auvèrnhe
+ru:Блё д'Овернь
+uk:Блю де Овернь
+xx:bleu d'auvergne
+zh:布勒·德·奧福格芝士
+wikidata:en:Q883954
+wikipedia:en:https://en.wikipedia.org/wiki/Bleu_d%27Auvergne
+ciqual_food_code:en:12521
+ciqual_food_name:en:Auvergne blue cheese, from cow's milk
+ciqual_food_name:fr:Fromage bleu d'Auvergne
+description:de:Der Bleu d’Auvergne ist ein französischer AOP Blauschimmelkäse, der aus roher und pasteurisierter Kuhmilch hergestellt wird.
+description:en:Bleu d'Auvergne is a French AOP blue cheese, made from cow's milk, named for its place of origin in the Auvergne region of south-central France.
+description:es:El bleu d’Auvergne es un queso azul francés AOP fabricado en la región de Auvernia, hecho a base de leche de vaca, de pasta prensada cruda.
+description:fr:Bleu d’Auvergne est un fromage français AOP de lait de vache, à pâte persillée, du Massif central. 
+description:it:Il bleu d'Auvergne (blu d'Alvernia) è un formaggio di latte vaccino a pasta erborinata prodotto nel Massiccio Centrale, in Francia.
+description:nl:De bleu d'Auvergne is een AOP blauwschimmelkaas op basis van koeienmelk uit de Auvergne.
 
 # <en:compound
 <en:cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -54140,7 +54140,6 @@ de:Ölsamen
 <en:seed
 fr:graines grillées
 
-
 <en:seed
 <en:alfalfa
 en:alfalfa seeds
@@ -54156,12 +54155,12 @@ ciqual_food_code:en:15032
 ciqual_food_name:en:Alphalfa seeds, raw
 ciqual_food_name:fr:Luzerne, graine
 
-<en:alfalfa
+<en:alfalfa seeds
 en:sprouted alfalfa seeds, germinated alfalfa
 fr:Graines de Luzerne germées
 
-<en:sprouted alfalfa
-en:Raw sprouted alfalfa seeds
+<en:sprouted alfalfa seeds
+en:raw sprouted alfalfa seeds
 ciqual_food_code:en:15029
 ciqual_food_name:en:Alfalfa seeds, sprouted, raw
 ciqual_food_name:fr:Luzerne, graine germée
@@ -78116,7 +78115,7 @@ wikidata:en:Q96362190
 # ingredient/beef-broth has 1786 products in 10 languages @2021-08-19
 
 <en:beef broth, beef stock
-en:dehydrated broth stock, dehydrated beef bouillon
+en:dehydrated beef stock, dehydrated beef bouillon
 fr:Bouillon de boeuf déshydraté
 ciqual_food_code:en:11001
 ciqual_food_name:en:Broth, stock or bouillon, beef, dehydrated

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11696,6 +11696,43 @@ ciqual_food_code:en:12500
 ciqual_food_name:en:Roquefort cheese, from ewe's milk
 ciqual_food_name:fr:Roquefort
 
+#category/saint-nectaire
+<en:cheese
+en:saint nectaire
+ar:ساينت نيكتاير
+hy:Սեն Նեկտեր
+ja:サン＝ネクテール
+oc:Sant Nectàrie
+ru:Сен-Нектер
+uk:Сен-Нектер
+xx:saint nectaire, Saint-Nectaire AOC
+zh:圣内克泰尔
+wikidata:en:Q548309
+ciqual_food_code:en:12752
+ciqual_food_name:en:Saint-Nectaire cheese, from cow's milk
+ciqual_food_name:fr:Saint-Nectaire, sans précision
+description:de:Der Saint-Nectaire ist ein französischer AOC Kuhmilchkäse, benannt nach der Gemeinde Saint-Nectaire im Zentrum der Auvergne, Frankreich.
+description:en:Saint-Nectaire is a French AOC cheese made in the Auvergne region of central France.
+description:es:El saint-nectaire es un queso francés AOC de la región de los montes Dore de Auvernia.
+description:fr:Saint-nectaire est un fromage français AOC de lait de vache fabriqué dans la micro-région des Monts Dore.
+description:nl:De Saint-Nectaire is een Franse AOC kaas die geproduceerd wordt in Auvergne-Rhône-Alpes.
+description:pt:Saint-nectaire é um queijo de leite de vaca francês AOC feito na micro região de Monts Dore.
+
+#<en:saint nectaire
+#en:Saint-Nectaire cheese from cow's milk milk collected in an unique farm
+#fr:Saint-Nectaire fermier
+#ciqual_food_code:en:12751
+#ciqual_food_name:en:Saint-Nectaire cheese, from cow's milk, milk collected in an unique farm
+#ciqual_food_name:fr:Saint-Nectaire, fermier
+
+#<en:saint nectaire
+#en:Saint-Nectaire cheese from cow's milk milks collected in many farms
+#fr:Saint-Nectaire laitier
+#ciqual_food_code:en:12748
+#ciqual_food_name:en:Saint-Nectaire cheese, from cow's milk, milks collected in many farms
+#ciqual_food_name:fr:Saint-Nectaire, laitier
+
+
 #<en:cow cheese
 #category/salers-cheese
 <en:cheese,

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11511,34 +11511,31 @@ wikidata:en:Q20748
 wikipedia:en:https://en.wikipedia.org/wiki/Raclette
 # fr:raclette has 47 products in 4 languages @2018-10-27
 
-
-# description:en:Reblochon is a soft washed-rind and smear-ripened French cheese made in the Alpine region of Savoy from raw cow's milk.
-
+#category/reblochon
+<en:cow cheese
 <en:cheese
 en:reblochon
-ca:reblochon
-da:reblochon
-de:Reblochon
-es:reblochon
-fi:reblochon
-fr:reblochon, fromage reblochon
-hu:reblochon, reblochon sajt
-id:reblochon
-it:reblochon
+ar:ريبلوتشون
+fr:fromage reblochon
+he:רבלושון
+hu:reblochon sajt
 ko:르블로숑
-la:reblochon
-nb:reblochon
-nl:reblochon
-oc:reblochon
-ro:reblochon
 ru:реблошон
-sv:reblochon
 uk:Реблошон
+xx:reblochon
 zh:瑞布羅申芝士
-# frp:reblochon
 # yue:雷布洛芝士
 wikidata:en:Q543805
 wikipedia:en:https://en.wikipedia.org/wiki/Reblochon
+ciqual_food_code:en:12045
+ciqual_food_name:en:Reblochon cheese, from cow's milk
+ciqual_food_name:fr:Reblochon
+description:de:Reblochon ist ein feinwürziger AOC Kuhmilch-Käse aus der französischen Region Hochsavoyen und Savoyen.
+description:en:Reblochon is a soft washed-rind and smear-ripened French cheese made in the Alpine region of Savoy from raw cow's milk.
+description:es:El reblochon es un queso francés AOC,a base de leche de vaca de raza Abondance, Tarine y Montbéliarde, de la Alta Saboya.
+description:fr:Reblochon, ou reblochon de Savoie, est un fromage français AOC au lait cru et entier de vache à pâte pressée non cuite et croûte lavée, produit principalement en Haute-Savoie.
+reblochon:it:Il Reblochon o Reblochon di Savoia è un formaggio francese a pasta pressata da latte crudo di vacca.
+reblochon:nl:De reblochon is een Franse gewassenkorstkaas, geproduceerd in Haute-Savoie, Frankrijk.
 # ingredient/fr:reblochon has 64 products @2018-12-27
 
 <en:reblochon
@@ -11939,6 +11936,23 @@ description:fr:La fourme d'Ambert est un fromage français, à base de lait de v
 description:nl:De Fourme d’Ambert is een Franse koemelkkaas met Penicillum Roqueforti schimmels, afkomstig uit Saint-Just in het bergachtige gebied van de Puy-de-Dôme.
 
 <en:blue cheese
+en:bleu de Bresse
+ar:بليو د بريس
+he:ברס בלו
+ja:ブレス・ブルー
+ru:Бресс Блё
+xx:bleu de Bresse, Bresse Bleu
+zh:布勒·德·布瑞塞芝士
+wikidata:en:Q883933
+wikipedia:en:https://en.wikipedia.org/wiki/Bleu_de_Bresse
+description:de:Der Bleu de Bresse, auch Bresse Bleu genannt, ist ein französischer Blauschimmelkäse aus der Bresse in Ostfrankreich.
+description:en:Bleu de Bresse is a blue cheese made from whole milk.
+description:es:El Bleu de Bresse es un queso azul de leche entera que fue elaborado primero en la zona de Bresse.
+description:fr:Bresse Bleu (Bleu de Bresse) est un fromage au lait de vache pasteurisé, à pâte persillée produit en Bresse.
+description:nl:De Bleu de Bresse ofwel Bresse Bleu is een Franse kaas, een zachte kaas met een blauwschimmel.
+
+<en:blue cheese
+<en:cow cheese
 en:bleu de gex
 ar:بليو د جيكس
 az:Blyö de Jeks

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -73831,6 +73831,7 @@ es:fumé de perdiz
 
 # description:en:EGGS are laid by female animals of many different species, including birds, reptiles, amphibians, mammals, and fish, and have been eaten by humans for thousands of years.
 
+#category/eggs
 en:egg, eggs
 af:eier
 ak:Kosua
@@ -73948,6 +73949,15 @@ allergens:en: en:eggs
 # ingredient/egg has 15441 products in 24 languages @2018-12-19
 carbon_footprint_fr_foodges_ingredient:fr:Oeuf, moyenne nationale
 carbon_footprint_fr_foodges_value:fr:2.6
+description:en:EGGS are laid by female animals of many different species, including birds, reptiles, amphibians, mammals, and fish. This ingredient comprises mainly chicken eggs.
+
+<en:egg
+en:Raw egg
+fr:Oeuf cru
+ciqual_food_code:en:22000
+ciqual_food_name:en:Egg, raw
+ciqual_food_name:fr:Oeuf, cru
+
 
 <en:flavour
 en:egg flavour
@@ -74721,6 +74731,7 @@ en:egg derivatives
 de:aus Ei, enthält Hühnerei
 es:derivado del huevo,derivado de huevo
 
+#category/duck-eggs
 <en:egg
 en:duck egg
 de:Enteneier
@@ -74733,7 +74744,15 @@ ru:яйцо утки
 zh:鴨蛋
 # yue:鴨蛋
 wikidata:en:Q11173928
-# ingredient/duck-egg has 7 products @2018-12-17
+# ingredient/duck-egg 9 products @2021-08-22
+
+<en:duck egg
+en:Raw duck egg
+fr:Oeuf de cane cru
+ciqual_food_code:en:22060
+ciqual_food_name:en:Duck egg, raw
+ciqual_food_name:fr:Oeuf de cane, cru
+
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -34005,9 +34005,9 @@ fi:vihreä soijapapu
 fr:soja vert
 
 #process:en: en:paste
-#<en:soya bean
-#en:soya bean paste
-#de:Sojabohnenpaste
+<en:soya bean
+en:soya bean paste
+de:Sojabohnenpaste
 
 #process:en:en:flakes
 #<en:soya bean
@@ -37200,11 +37200,11 @@ ciqual_food_code:en:13118
 ciqual_food_name:en:Peach, dried
 ciqual_food_name:fr:Pêche, sèche
 
-#process:en:paste
-#<en:peach
-#en:peach paste
-#fi:persikkatahna
-#sv:persikopasta
+process:en:paste
+<en:peach
+en:peach paste
+fi:persikkatahna
+sv:persikopasta
 # ingredient/en:peach-paste has 2 product in 2 language @2021-08-19
 
 #compound
@@ -40870,12 +40870,12 @@ it:Datteri Medjool
 
 #process:en: en:paste
 #process:en: en:pureed
-#<en:date
-#en:date paste
-#de:pürierte Datteln
-#fr:pâte de datte
-#nl:dadelpuree
-#sv:dadelpuré
+<en:date
+en:date paste
+de:pürierte Datteln
+fr:pâte de datte
+nl:dadelpuree
+sv:dadelpuré
 
 <en:date
 en:Dried date pulp and peel
@@ -49837,12 +49837,12 @@ es:chiles tabasco
 
 #process:en: en:pureed
 #process:en: en:paste
-#<en:chili pepper
-#en:chili puree, chilli puree
-#de:Chilipaste, Chilipüree
-#fi:chilipyree, chilisose
-#fr:purée de piments
-#it:purea di peperoncino
+<en:chili pepper
+en:chili puree, chilli puree
+de:Chilipaste, Chilipüree
+fi:chilipyree, chilisose
+fr:purée de piments
+it:purea di peperoncino
 # ingredient/fr:purée-de-piments has 136 products in 4 languages @2019-04-15
 # usage:fr:purée de piments (piments, sel)
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -53548,10 +53548,17 @@ sv:mandelpulver
 
 <en:almond
 en:almond paste
-de:Marzipan, Mandelmasse
+de:Mandelmasse
 es:pasta de almendra
 fr:Pâte d'amandes, pâte d'amande
 pt:Pasta de amêndoa
+
+<en:almond paste
+en:prepacked Almond paste
+fr:Pâte d'amande préemballée
+ciqual_food_code:en:15201
+ciqual_food_name:en:Almond paste or marzipan, prepacked
+ciqual_food_name:fr:Pâte d'amande, préemballée
 
 <en:almond
 en:almond flour
@@ -78492,8 +78499,8 @@ wikipedia:en:https://en.wikipedia.org/wiki/Fondant_icing
 # usage:fr:Fondant (sucre, sirop de glucose, eau)
 
 
-# description:en:MARZIPAN is a confection consisting primarily of sugar or honey and almond meal (ground almonds), sometimes augmented with almond oil or extract.
 
+#category/marzipan
 # mainIngredient:en:sugar
 en:marzipan
 ar:مرصبان
@@ -78556,7 +78563,21 @@ zh:杏仁膏
 # zh-tw:杏仁膏
 wikidata:en:Q106252
 wikipedia:en:https://en.wikipedia.org/wiki/Marzipan
-# ingredient/fr:massepain has 27 products in 4 languages @2019-02-12
+description:de:Marzipan ist eine Süßware aus gemahlenen Mandeln, Zucker und – je nach Herkunft – beigefügten Aromastoffen. 
+description:en:MARZIPAN is a confection consisting primarily of sugar or honey and almond meal (ground almonds), sometimes augmented with almond oil or extract.
+description:es:El mazapán es un dulce cuyos ingredientes principales son almendras, azúcar y huevo.
+description:fr:Le massepain est une pâte confectionnée à base d'amandes mondées et finement moulues, mélangées à du blanc d'œuf et du sucre.
+description:it:Il marzapane è una preparazione dolciaria più o meno consistente, è costituita da pasta di mandorle suddivisa tra albume d'uovo e zucchero.
+description:nl:Marsepein is een deegachtig mengsel van gemalen amandelen en suiker.
+description:pt:Marzipã, marzipan ou maçapão é um doce, preparado a partir de uma pasta feita de amêndoas moídas, açúcar e claras de ovos
+# 84 in 11 @2021-09-01
+
+<en:marzipan
+en:prepacked marzipan
+fr:massepain préemballée
+ciqual_food_code:en:15201
+ciqual_food_name:en:Almond paste or marzipan, prepacked
+ciqual_food_name:fr:Pâte d'amande, préemballée
 
 # description:en:PERSIPAN is a material used in confectionery. It is similar to marzipan but apricot or peach kernels are used instead of almonds. Persipan consists of 60% sugar and 40% ground kernels.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10773,7 +10773,27 @@ fr:fromage lancashire, fromage lancashire au lait pasteurisé
 wikidata:en:Q1244290
 wikipedia:en:https://en.wikipedia.org/wiki/Lancashire_cheese
 
-
+#category/livarot
+<en:cheese
+en:livarot
+ar:ليڤاروت
+fr:livarot de Normandie AOP
+ja:リヴァロ
+ko:리바로
+os:Ливаро
+ru:Ливаро
+uk:Ліваро
+xx:livarot
+zh:里伐羅特芝士
+wikidata:en:Q1144668
+ciqual_food_code:en:12037
+ciqual_food_name:en:Livarot cheese, from cow's milk
+ciqual_food_name:fr:Livarot
+description:de:Der Livarot ist ein französischer Käse aus der Normandie, der aus roher oder pasteurisierter Kuhmilch hergestellt wird.
+description:en:Livarot is a French cheese of the Normandy region, originating in the commune of Livarot.
+description:es:El livarot es un queso francés fabricado en la región de Normandía, originario de la comuna de Livarot.
+description:fr:Le livarot est un fromage français de Normandie, originaire de la commune de Livarot.
+description:nl:Livarot is een halfzachte magere Franse kaas bereid uit koemelk, uit de streek Normandië. 
 
 <en:cheese
 en:maasdam, maasdam cheese
@@ -10843,6 +10863,9 @@ description:es:Maroilles es un queso de leche de vaca, elaborado en las regiones
 description:fr:Le maroilles ou marolles est une appellation d'origine désignant un fromage dont la production et la transformation s'effectuent dans la Thiérache française.
 description:it:Il Maroilles o Marolles è un formaggio francese di latte vaccino, a pasta molle e a crosta lavata, prodotto in Avesnois nei dipartimenti dell'Aisne e del Nord.
 description:nl:De maroilles of marolles is een Franse kaas van het type gewassenkorstkaas. 
+ciqual_food_code:en:12036
+ciqual_food_name:en:Maroilles cheese, from cow's milk
+ciqual_food_name:fr:Maroilles, sans précision
 # 63 in french @202108-27
 
 <en:Maroilles

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -17568,6 +17568,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Cooking_oil
 
 
 # nova:en:hydrogenated-oil
+# process:en en:hydrogenated
 <en:oil
 en:hydrogenated oil
 de:gehärtetes öl
@@ -17588,10 +17589,13 @@ da:stegeolie
 de:Frittieröl
 es:aceite para freír
 fi:paistoöljy, friteerausöljy
-fr:Huile de friture
+fr:Huile de friture, Huile pour friture
 hu:sütőolaj
 nl:bakvet
-
+ciqual_food_code:en:16128
+ciqual_food_name:en:Frying oil
+ciqual_food_name:fr:Huile pour friture, sans précision
+# 69 in 4 @2021-08-22
 
 # description:en:FAT is one of the three main macronutrients, along with the other two:carbohydrate and protein. Fats molecules consist of primarily carbon and hydrogen atoms, thus they are all hydrocarbon molecules.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -44589,6 +44589,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Crudités
 
 # description:en:The globe  ARTICHOKE  (Cynara cardunculus var. scolymus), also known as French artichoke and green artichoke in the USA, is a variety of a species of thistle cultivated as a food. Leaves are often removed one at a time, and the fleshy base eaten, with hollandaise, vinegar, butter, mayonnaise, aioli, lemon juice, or other sauces. The fibrous upper part of each leaf is usually discarded. The heart is eaten when the inedible choke has been peeled away from the base and discarded. The thin leaves covering the choke are also edible.
 
+#category/artichokes
 <en:vegetable
 en:artichoke
 ar:خرشوف
@@ -44648,6 +44649,13 @@ wikidata:en:Q23041430
 wikipedia:en:https://en.wikipedia.org/wiki/Artichoke
 carbon_footprint_fr_foodges_ingredient:fr:Artichauts
 carbon_footprint_fr_foodges_value:fr:2.5
+description:de:Die Artischocke (Cynara cardunculus subsp. scolymus (L.) Hegi, Syn.: Cynara scolymus L.) ist eine distelartige, kräftige Kulturpflanze aus der Familie der Korbblütler. Die Sortengruppe der Artischocken wird wegen ihrer essbaren knospigen Blütenstände angebaut und als Blütengemüse verzehrt.
+description:en:The globe ARTICHOKE (Cynara cardunculus var. scolymus), also known as French artichoke and green artichoke in the USA, is a variety of a species of thistle cultivated as a food. Leaves are often removed one at a time, and the fleshy base eaten, with hollandaise, vinegar, butter, mayonnaise, aioli, lemon juice, or other sauces. The fibrous upper part of each leaf is usually discarded. The heart is eaten when the inedible choke has been peeled away from the base and discarded. The thin leaves covering the choke are also edible.
+description:es:Cynara scolymus, la alcachofera, alcachofa, alcacil o alcaucil,1​ entre otros numerosos nombres vernáculos, es una planta herbácea del género Cynara en la familia Asteraceae; es cultivada desde la antigüedad como alimento en climas templados.
+description:fr:L’artichaut (Cynara cardunculus var. scolymus (L.) Benth.) est une plante de la famille des Astéracées. On désigne sous le nom d'artichaut à la fois la plante entière et sa partie comestible. Les têtes d'artichaut sont consommées soit crues soit cuites.
+description:it:Il carciofo (Cynara cardunculus subsp. scolymus) è una pianta angiosperma dicotiledone della famiglia Asteraceae coltivata in Italia e in altri Paesi per uso alimentare.
+description:nl:De artisjok (Cynara scolymus) is een plant uit de composietenfamilie. De vlezige schutbladeren van het gesloten bloemhoofdje worden als groente gegeten.
+description:pt:Uma alcachofra (Cynara cardunculus subsp. scolymus) é uma planta com até um metro de altura, da família das compostas.
 
 <en:artichoke
 en:raw globe artichoke
@@ -44656,7 +44664,7 @@ ciqual_food_code:en:20052
 ciqual_food_name:en:Artichoke, globe, raw
 ciqual_food_name:fr:Artichaut, cru
 
-
+#category/artichoke-hearts
 <en:artichoke
 en:Artichoke heart, artichoke bottom
 de:Artischockenherzen
@@ -44669,6 +44677,7 @@ description:en:The heart is eaten when the inedible choke has been peeled away f
 #wikidata:en:none
 # ingredient/Artichoke-heart 448 in 6 languages @2021-08-22
 
+#category/frozen-artichoke-bottom
 <en:Artichoke heart
 en:Frozen raw artichoke bottom
 fr:Fond d'artichaut cru surgelé

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10561,60 +10561,36 @@ es:fontal
 fr:fontal, fromage fontal
 wikidata:en:Q3076339
 
-# description:en:GORGONZOLA is a veined Italian blue cheese, made from unskimmed cow's milk.
-
+<en:cow cheese
 <en:cheese
 en:gorgonzola, gorgonzola cheese
-af:Gorgonzola
 ar:جبنة غورغونزولا
 be:Гаргандзола
 bg:Горгондзола
 bo:གོར་གོན་ཟོ་ལ།
-ca:gorgonzola
-cs:gorgonzola
 cv:Горгонзола
-da:Gorgonzola
-de:Gorgonzola
 el:Γκοργκοντζόλα
-eo:Gorgonzolo
-es:Gorgonzolo
-et:Gorgonzola, Gorgonzola juust
-eu:Gorgonzola
+et:Gorgonzola juust
 fa:گورگونتزولا
-fi:gorgonzola, gorgonzolajuusto
-fr:gorgonzola, fromage gorgonzola, gorgonzola AOP, fromage gorgonzola AOP
-gl:Gorgonzola
+fi:gorgonzolajuusto
+fr:fromage gorgonzola, gorgonzola AOP, fromage gorgonzola AOP
 he:גורגונזולה
-hr:Gorgonzola
-hu:Gorgonzola
 hy:Գորգոնձոլա
-id:Gorgonzola
-it:gorgonzola, formaggio gorgonzola
+it:formaggio gorgonzola
 ja:ゴルゴンゾーラ
 ko:고르곤졸라
-la:Gorgonzola
 mk:Горгонѕола
-nb:gorgonzola
-nl:gorgonzola
-pl:gorgonzola
-pt:gorgonzola
 ro:Brânză Gorgonzola
 ru:Горгондзола
 sd:گارگونزولا
 sl:Gorgonzola
 sr:горгонзола
-sv:Gorgonzola
-tr:Gorgonzola
 uk:Ґорґонцола
+xx:gorgonzola
 zh:古岡左拉芝士
 # eml:Gurgunzöla
-# en-ca:Gorgonzola
-# en-gb:Gorgonzola
 # lmo:Gorgonzoeula
-# pt-br:gorgonzola
-# sco:gorgonzola
 # sr-ec:горгонзола
-# sr-el:Gorgonzola
 # yue:哥根蘇拿芝士
 # zh-cn:古冈左拉干酪
 # zh-hans:古冈左拉芝士
@@ -10624,7 +10600,16 @@ zh:古岡左拉芝士
 # zh-tw:古岡左拉起司
 wikidata:en:Q209044
 wikipedia:en:https://en.wikipedia.org/wiki/Gorgonzola
-# ingredient/fr:gorgonzola has 108 products in french @2018-12-13
+description:de:Gorgonzola ist ein norditalienischer Blauschimmelkäse geschützter Ursprungsbezeichnung und besteht aus Kuhmilch, Lab und Salz, die mit einer Edelpilzkultur versetzt werden.
+description:en:GORGONZOLA is a veined Italian blue cheese, made from unskimmed cow's milk.
+description:es:El gorgonzola es un queso italiano de mesa, de pasta cremosa y untuosa, hecho con leche entera pasteurizada de vaca.
+description:fr:Le gorgonzola est l'appellation d'origine d'un fromage traditionnel à base de lait de vache, à pâte persillée, fabriqué dans les régions de Lombardie et du Piémont.
+description:it:Il gorgonzola è un formaggio erborinato, prodotto in Italia dal latte intero di vacca.
+description:nl:Gorgonzola is blauwschimmelkaas van volle koemelk uit het noorden van Italië.
+ciqual_food_code:en:12524
+ciqual_food_name:en:Gorgonzola cheese, from cow's milk
+ciqual_food_name:fr:Gorgonzola
+# 354 in 10 @2021-09-01
 
 
 <en:cheese
@@ -11514,7 +11499,7 @@ ciqual_food_name:en:Raclette cheese, from cow's milk
 ciqual_food_name:fr:Raclette (fromage)
 description:de:Raclette ist der Name eines Kuhmilchkäses.
 description:en:RACLETTE is a semi-hard cow's milk cheese.
-description:es:El raclette es un queso semicurado de origen suizo proveniente del cantón del Valais. 
+description:es:El raclette es un queso semicurado de origen suizo proveniente del cantón del Valais.
 description:fr:Le raclette est un fromage à base de lait cru de vache, à pâte pressée non cuite d'origine du canton du Valais en Suisse.
 # 84 in 4 @2021-08-31
 
@@ -45076,8 +45061,6 @@ wikidata:en:Q2142465
 wikipedia:en:https://en.wikipedia.org/wiki/Crudités
 # ingredient/fr:crudités has 74 products in french @2019-03-29
 
-
-# description:en:The globe  ARTICHOKE  (Cynara cardunculus var. scolymus), also known as French artichoke and green artichoke in the USA, is a variety of a species of thistle cultivated as a food. Leaves are often removed one at a time, and the fleshy base eaten, with hollandaise, vinegar, butter, mayonnaise, aioli, lemon juice, or other sauces. The fibrous upper part of each leaf is usually discarded. The heart is eaten when the inedible choke has been peeled away from the base and discarded. The thin leaves covering the choke are also edible.
 
 #category/artichokes
 <en:vegetable

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -54004,23 +54004,27 @@ ciqual_food_name:fr:Noisette
 <en:hazelnut
 fr:noisettes avec peau
 
+#processing:en: en:toasted
 <en:hazelnut
-en:toasted hazelnut
-ca:avellanes torrades
-de:geröstete Haselnüsse, Haselnüsse geröstet
-es:avellanas tostadas
-fi:paahdettu hasselpähkinä
-fr:noisettes grillées, noisettes torréfiées
-it:nocciole tostate
-nl:gebrande hazelnoot
-sv:rostade hasselnötter
-openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-grillées
-# 100 in 5 languages products @2018-10-07
+en:toasted hazelnuts
+#ca:avellanes torrades
+#de:geröstete Haselnüsse, Haselnüsse geröstet
+#es:avellanas tostadas
+#fi:paahdettu hasselpähkinä
+#fr:noisettes grillées, noisettes torréfiées
+#it:nocciole tostate
+#nl:gebrande hazelnoot
+#sv:rostade hasselnötter
+ciqual_food_code:en:15033
+ciqual_food_name:en:Hazelnut, grilled
+ciqual_food_name:fr:Noisette grillée
+# 495 in 10 @2021-09-01
 
 <en:hazelnut
 fr:noisettes décortiquées
 de:Haselnusskerne
 it:nocciole sgusciate
+ru:ядро ореха фундука 
 openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-décortiquées
 # 42 products in 4 languages @2018-10-07
 
@@ -54037,17 +54041,16 @@ nl:hele gegrilde hazelnoten
 openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-entières-torréfiées
 # 15 products in 1 language @2018-10-007
 
+#processing:en: en:chopped
 <en:hazelnut
 en:chopped hazelnuts
-de:Gehackte Haselnüsse
-es:avellanas troceados
-fi:pilkottu hasselpähkinä, pilkotut hasselpähkinät
-fr:noisettes hachées
-it:nocciole tritate
-nl:gehakte hazelnoot, gehakte hazelnoten
-#in processing de:gehackte Haselnüsse
-openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-hachées
-# 44 products @2018-10-07
+#de:Gehackte Haselnüsse
+#es:avellanas troceados
+#fi:pilkottu hasselpähkinä, pilkotut hasselpähkinät
+#fr:noisettes hachées
+#it:nocciole tritate
+#nl:gehakte hazelnoot, gehakte hazelnoten
+# 221 products in 7 @2021-09-01
 
 #<en:chopped hazelnuts
 #en:chopped toasted hazelnuts
@@ -54063,18 +54066,16 @@ pl:siekane i prażone orzeszki ziemne
 openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-hachées-grillées
 # 55 products in 3 languages @2018-10-07
 
+#processing:en: en:ground
 <en:hazelnut
 en:ground hazelnuts
-de:gemahlene Haselnüsse, Haselnüsse gemahlen
-es:avellanas molidas
-fi:hasselpähkinäjauhe, jauhetut hasselpähkinät
-fr:noisettes moulues, noisettes broyées
-it:nocciole macinate
-nl:gemalen hazelnoten
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-moulues
-# 76 products @2018-10-07
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:noisettes-broyées
-# 28 products in 3 languages @2018-10-07
+#de:gemahlene Haselnüsse, Haselnüsse gemahlen
+#es:avellanas molidas
+#fi:hasselpähkinäjauhe, jauhetut hasselpähkinät
+#fr:noisettes moulues, noisettes broyées
+#it:nocciole macinate
+#nl:gemalen hazelnoten
+# 275 in 17 @2021-09-01
 
 <en:hazelnut
 fr:éclats de noisettes

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -44648,21 +44648,33 @@ wikidata:en:Q23041430
 wikipedia:en:https://en.wikipedia.org/wiki/Artichoke
 carbon_footprint_fr_foodges_ingredient:fr:Artichauts
 carbon_footprint_fr_foodges_value:fr:2.5
+
+<en:artichoke
+en:raw globe artichoke
+fr:artichaut cru
 ciqual_food_code:en:20052
 ciqual_food_name:en:Artichoke, globe, raw
 ciqual_food_name:fr:Artichaut, cru
 
-# description:en:The heart is eaten when the inedible choke has been peeled away from the base and discarded.
 
 <en:artichoke
-en:Artichoke hearts
+en:Artichoke heart, artichoke bottom
 de:Artischockenherzen
 es:Corazones de alcachofa
 fi:artisokansydämet
 fr:cœurs d'artichauts, coeurs d'artichauts, Fonds d'artichaut
 it:Cuori di carciofo
 nl:artisjokharten
-# ingredient/fr:coeurs-d’artichauts has 52 products in 6 languages @2019-04-03
+description:en:The heart is eaten when the inedible choke has been peeled away from the base and discarded.
+#wikidata:en:none
+# ingredient/Artichoke-heart 448 in 6 languages @2021-08-22
+
+<en:Artichoke heart
+en:Frozen raw artichoke bottom
+fr:Fond d'artichaut cru surgelé
+ciqual_food_code:en:20232
+ciqual_food_name:en:Artichoke base, frozen, raw
+ciqual_food_name:fr:Artichaut, fond, surgelé, cru
 
 
 # Asparagus, or garden asparagus, folk name sparrow grass, scientific name Asparagus officinalis

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11143,6 +11143,30 @@ description:it:L'ossau-iraty è un formaggio francese prodotto dal latte di peco
 description:nl:De Ossau-Iraty is een Franse kaas, een halfharde kaas afkomstig uit Frans-Baskenland en het hogergelegen deel van Béarn.
 description:oc:L'Aussau-Irati es un fromatge de Bearn e de Bascoat. 
 
+#category/neufchatel-cheese-from-cow-s-milk
+<en:cheese
+en:neufchâtel
+ar:نيوفتشيتيل
+be:Нёшатэль
+cv:Невшатель
+hy:Նյոշատել
+id:Keju Neufchâtel
+ja:ヌシャテル
+ko:뇌샤텔
+ru:Нёшатель
+uk:Ньошатель
+xx:neufchâtel
+zh:紐沙特起司
+wikidata:en:Q1241190
+ciqual_food_code:en:12031
+ciqual_food_name:en:Neufchâtel cheese, from cow's milk
+ciqual_food_name:fr:Neufchâtel
+description:de:Der Neufchâtel ist ein französischer Käse der Normandie, der ausschließlich und im Original aus roher Kuhmilch hergestellt wird.
+description:en:Neufchâtel is a soft, slightly crumbly, mold-ripened cheese made in the Neufchâtel-en-Bray, French region of Normandy.
+description:es:El neufchâtel es un queso francés fabricado en pays de Bray.
+description:fr:Le neufchâtel est un fromage français fabriqué dans le pays de Bray.
+description:nl:De Neufchâtel is een Franse kaas uit het Pays de Bray in Normandië.
+
 <en:cheese
 en:parmesan, parmigiano reggiano, Parmesan cheese, parmigiano reggiano cheese, Parmesan cheese from cow's milk
 af:Parmesaan

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -17743,8 +17743,8 @@ ja:片栗粉
 ko:감자 녹말
 lt:bulvių krakmolas
 ms:Kanji kentang
-nb:potetstivelse, Potetmel
-nl:aardappelzetmeel, Aardappelmeel
+nb:potetstivelse
+nl:aardappelzetmeel
 nn:Potetmjøl
 pl:skrobia ziemniaczana, Mąka ziemniaczana
 pt:fecula de batata

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -18629,6 +18629,13 @@ wikipedia:en:https://en.wikipedia.org/wiki/Vegetable_oil
 <en:vegetable oil
 fr:huile végétale raffinée
 
+<en:vegetable oil
+en:vegetable oil blend
+fr:mélanges des huiles végétales
+ciqual_food_code:en:17700
+ciqual_food_name:en:Combined oil (blended vegetable oils)
+ciqual_food_name:fr:Huile combinée (mélange d'huiles)
+
 <en:vegetable oil and fat
 en:vegetable fat, vegetal fat, vegetable fats
 bg:растителна мазнина
@@ -28106,6 +28113,23 @@ nl:amaranthmeel, amarant gemalen
 <en:wholemeal flour
 en:whole grain amaranth flour
 de:Amaranthvollkornmehl, Amaranth-Vollkornmehl
+
+#category/chestnut-flours
+<en:flour
+en:chestnut flour
+de:Kastanienmehl
+eo:kaŝtana faruno
+es:harina de castaña
+fr:farine de châtaigne
+it:farina di castagne
+nl:kastanjemeel
+ciqual_food_code:en:9570
+ciqual_food_name:en:Chestnut flour
+ciqual_food_name:fr:Farine de châtaigne
+wikidata:en:Q3066928
+description:de:Maronenmehl wird aus getrockneten und geschälten Kastanien hergestellt und meist mehrfach gemahlen.
+description:en:Chestnuts can be dried and milled into flour, which can then be used to prepare breads, cakes, pies, pancakes, pastas, polenta, or used as thickener for stews, soups, and sauces.
+# 7 in 3 @2021-09-02
 
 # Is this the same as tapioca starch?
 
@@ -81350,9 +81374,4 @@ es:momordic
 fr:momordique, margose
 it:momordic
 
-<en:flour
-en:chestnut flour
-es:harina de castaña
-fr:farine de châtaigne
-it:farina di castagne
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -7103,11 +7103,54 @@ es:leche de vaca desnatada pasterizada
 
 ################################# GOAT MILKS ###################################
 
-# description:en:RAW GOAT MILK - milk produced by female goats before any treatment
+#category/goat-milks
+<en:milk
+en:goat milk, goat's milk, goats milk, goats' milk
+ca:llet de cabra
+cs:kozí mléko
+da:Gedemælk
+de:Ziegenmilch
+el:κατσικίσιο γάλα
+eo:kaprina lakto
+es:leche de cabra
+et:Kitsepiim
+eu:ahuntz esne
+fi:vuohenmaito
+fr:lait de chèvre
+he:חלב עיזים
+hu:kecsketej
+hy:այծի կաթ
+id:Susu kambing
+it:latte di capra, latte caprino
+ja:ヤギ乳
+jv:Susu wedhus
+kk:Ешкі сүті
+ko:염소젖
+lt:Ožkos pienas
+mk:козјо млеко
+nb:geitemelk
+nl:geitenmelk
+pl:Kozie mleko, mleko kozie
+pt:leite de cabra
+ro:lapte de capră, lapte de capra
+ru:Козье молоко
+sk:kozie mlieko
+sr:козје млеко
+sv:getmjölk
+vi:sữa dê
+wikidata:en:Q1418287
+description:de:Ziegenmilch ist die Milch von Hausziegen.
+description:en:Goat milk is the milk of domestic goats.
+description:es:La leche de cabra es el subproducto de la operación de ordeñe que se hace los mamíferos del género Capra.
+description:fr:Le lait de chèvre est le lait que produit la femelle de la Chèvre domestique.
+description:it:Il latte caprino è il tipo di latte generato dalle capre.
+description:nb:Geitemelk er melk fra geit (Capra aegagrus hircus).
+description:pl:Geitenmelk is de melk die gevormd wordt in de uier van een geit. 
+# 1.797 in 16 @2021-08-25
 
-<en:goat's milk
-<en:raw milk
-en:raw goat's milk
+
+<en:goat milk
+en:raw goat milk
 ca:llet crua de cabra, llet de cabra crua
 de:Ziegen-Rohmilch, Ziegenrohmilch, unpasteurisierte Ziegenmilch
 es:leche cruda de cabra, leche de cabra cruda
@@ -7115,27 +7158,8 @@ fi:vuohen raakamaito, raaka vuohenmaito
 fr:lait cru de chèvre, lait de chèvre cru
 hu:nyers kecsketej
 
-# description:en:GOATS MILK - goat milk that probably has been treated (pasteurisation)
-
-<en:milk
-en:goat's milk, goat milk, goats milk, goats' milk
-ca:llet de cabra
-da:Gedemælk
-de:Ziegenmilch
-es:leche de cabra
-fi:vuohenmaito
-fr:lait de chèvre
-hu:kecsketej
-it:latte di capra, latte caprino
-nl:geitenmelk
-pl:Kozie mleko
-ro:lapte de capră, lapte de capra
-ru:Козье молоко
-sv:getmjölk
-wikidata:en:Q1418287
-
-<en:goat's milk
-en:whole goat's milk, whole goat milk
+<en:goat milk
+en:whole goat milk, whole goat milk
 ca:llet sencera de cabra, llet de cabra sencera
 de:Ziegenvollmilch, Ziegen-Vollmilch
 es:leche entera de cabra, leche de cabra entera
@@ -7143,9 +7167,17 @@ fi:vuohen täysmaito
 fr:lait entier de chèvre
 hu:teljes kecsketej
 nl:volle geitemelk
+# 95 in 3 @2021-08-25
+
+<en:whole goat milk
+en:plain yogurt goat's milk around 5% fat
+fr:Yaourt au lait de chèvre nature 5% MG environ
+ciqual_food_code:en:19556
+ciqual_food_name:en:Yogurt, goat's milk, plain, around 5% fat
+ciqual_food_name:fr:Yaourt au lait de chèvre, nature, 5% MG environ
 
 <en:goat's milk
-en:semi-skimmed goat's milk
+en:semi-skimmed goat milk
 ca:llet de cabra parcialment desnatada, llet de cabra semidestada, llet parcialment desnatada de cabra, llet semidesnatada de cabra
 de:teilentrahmte Ziegenmilch
 es:leche de cabra parcialmente desnatada, leche de cabra semidesnatada, leche parcialmente desnatada de cabra, leche semidesnatada de cabra
@@ -7153,8 +7185,8 @@ fi:vuohen kevytmaito
 fr:lait de chevre demi-écrémé
 hu:zsírszegény kecsketej
 
-<en:goat's milk
-en:skimmed goat's milk, skimmed goat milk
+<en:goat milk
+en:skimmed goat milk, skimmed goat milk
 ca:llet de cabra descremada, llet de cabra desnatada, llet desnatada de cabra, llet descremada de cabra
 de:entrahmte Ziegenmilch
 es:leche de cabra descremada, leche de cabra desnatada, leche desnatada de cabra, leche descremada de cabra
@@ -7164,7 +7196,7 @@ hu:sovány kecsketej
 
 # description:en:GOATS MILK - raw goat milk that has been treated (pasteurisation)
 
-<en:goat's milk
+<en:goat milk
 en:pasteurised goat milk, pasteurized goat milk, pasteurised goatmilk
 ca:llet de cabra pasteuritzada, llet pasteuritzada de cabra
 de:pasteurisierte Ziegenmilch
@@ -73895,6 +73927,14 @@ wikipedia:en:https://en.wikipedia.org/wiki/Turkey_as_food
 # ingredient/fr:viande-de-dinde has 1257 products in 7 languages @2019-04-18
 carbon_footprint_fr_foodges_ingredient:fr:Cuisse de dinde
 carbon_footprint_fr_foodges_value:fr:6.6
+
+<en:turkey meat
+en:raw turkey meat 
+fr:viande de dinde sans peau crue
+ciqual_food_code:en:36301
+ciqual_food_name:en:Turkey, meat, raw
+ciqual_food_name:fr:Dinde, viande, crue
+
 
 <en:turkey meat
 de:Putenfleisch

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11115,7 +11115,7 @@ he:מוצרלה
 hi:मोत्ज़ारेला
 hr:mocarela
 hy:Մոցարելա
-it:formaggio mozzarella
+it:formaggio mozzarella, formaggi di mozzarella
 ja:モッツァレッラ
 ka:მოცარელა
 kk:Моцарелла
@@ -11125,6 +11125,8 @@ lt:Mocarela
 lv:mocarella
 mk:Моцарела
 mr:मोजारेला
+nl:mozzarella kaas
+nn:mozzarella ost
 or:ମୋଜ୍ଜରେଲା
 pa:ਮੋਜ਼ਾਰੇਲਾ
 pl:ser mozzarella
@@ -11153,19 +11155,28 @@ wikipedia:en:https://en.wikipedia.org/wiki/Mozzarella
 ciqual_food_code:en:19590
 ciqual_food_name:en:Mozzarella cheese, from cow's milk
 ciqual_food_name:fr:Mozzarella au lait de vache
-# fr:mozzarella has 1057 products in 15 languages @2018-10-28
+description:de:Mozzarella ist ein ursprünglich italienischer Filata-Käse aus der Milch des Wasserbüffels oder des Hausrinds oder einem Gemisch beider Milcharten.
+description:en:Mozzarella is a traditionally southern Italian cheese made from Italian buffalo's milk by the pasta filata method.
+description:es:La mozzarella es un tipo de queso originario de la cocina italiana.
+description:fr:La mozzarella est un fromage à pâte filée d'origine italienne à base de lait de vache ou de bufflonne.
+description:it:La mozzarella è un latticino a pasta filata originario dell'Italia meridionale e prodotta da secoli anche in Italia centrale.
+description:nl:Mozzarella is een verzamelnaam voor twee soorten verse kaas: mozzarella di bufala vervaardigd uit de melk van de waterbuffel en mozzarella vervaardigd uit koemelk.
+description:pt:A mozarela ou muçarela é uma variedade de queijo de massa filada com origem na comuna (município) de Aversa, Italia.
+# 4663 in 15 languages @2021-08-30
 
-<en:mozzarella
-en:firmed mozzarella
-de:schnittfester mozzarella
-fr:Mozzarella affinée
-nl:Geharde mozzarella
-sv:skivbar mozzarella
+#processing:en: en:firmed
+#<en:mozzarella
+#en:firmed mozzarella
+#de:schnittfester mozzarella
+#fr:Mozzarella affinée
+#nl:Geharde mozzarella
+#sv:skivbar mozzarella
 
-<en:mozzarella
-fr:mozzarella râpée
-ca:mozzarella ratllada
-es:mozzarella rallada
+#processing:en en:grated
+#<en:mozzarella
+#fr:mozzarella râpée
+#ca:mozzarella ratllada
+#es:mozzarella rallada
 
 
 #category/munsters

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -25256,7 +25256,6 @@ likely_allergens:en: en:gluten
 ##################################################################################
 
 <en:cereal
-<en:barley
 en:barley
 am:ገብስ
 an:hordio
@@ -54150,7 +54149,7 @@ wikidata:en:Q104245598
 
 <en:alfalfa seeds
 en:raw alfalfa seeds
-fr:Graines de Luzerne
+fr:Graines de Luzerne cru
 ciqual_food_code:en:15032
 ciqual_food_name:en:Alphalfa seeds, raw
 ciqual_food_name:fr:Luzerne, graine
@@ -54334,11 +54333,6 @@ openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:cumin-moulu
 #fr:cumin en poudre
 #es:comino en polvo
 
-<en:seed
-en:linseed seeds, linseeds
-de:Leinsamen
-es:semillas de linaza, linaza
-fr:Graines de lin
 
 <en:seed
 <en:melon
@@ -54541,15 +54535,13 @@ it:lino
 # ingredient/fr:lin has 239 products in 6 languages @2018-12-06
 
 
-# It is possible to derive oil from flax seed
-
 <en:seed
-en:flax seed, flax seeds, flaxseed, linseed
+en:flax seed, flax seeds, flaxseed, linseed, linseed seeds
 bg:Ленено семе
 cs:Len setý
 da:Hørfrø
 de:Leinsamen, Leinsaat
-es:semillas de lino
+es:semillas de lino, semillas de linaza, linaza
 et:Linaseemned, linaseeme
 fa:تخم کتان
 fi:pellavansiemen, pellavansiemenet, pellavansiemeniä
@@ -54631,7 +54623,7 @@ et:Pipar
 fi:pippuri
 fr:poivre, poivres
 gl:Pementa
-he:פלפל
+# he:פלפל overlap with bell pepper
 ht:Pwav
 hu:Bors
 is:pipar
@@ -54839,18 +54831,6 @@ sv:svartpepparextrakt
 en:black and green pepper,green and black pepper
 fi:musta- ja viherpippuri
 
-###################################################################################################
-#
-#                                Pink pepper
-#
-###################################################################################################
-
-<en:pepper
-en:pink pepper,rose pepper
-de:Rosa Pfeffer, Rosa Beeren, rosa Pfefferbeeren
-es:pimienta rosa
-fr:poivre rose
-pt:pimenta rosa
 
 
 ###################################################################################################
@@ -55537,7 +55517,7 @@ ml:കരിഞ്ചീരകം
 mr:शहाजिरे
 ms:Jintan
 my:ကရဝေး
-nb:spisskum, spisskummen, karve
+nb:karve
 nl:karwij, karwijzaad
 nn:Karve
 pa:زيره
@@ -56952,19 +56932,26 @@ fr:moutarde forte
 <en:mustard
 fr:moutarde à l'ancienne
 
+###################################################################################################
+#
+#                                Pink pepper
+#
+###################################################################################################
 
-<en:spice
-en:pink peppercorn, pink berries
+<en:pepper
+en:pink peppercorn, pink berries, pink pepper, rose pepper
 da:rosépeber
-de:Rosa Beeren
+de:Rosa Pfeffer, Rosa Beeren, rosa Pfefferbeeren
+es:pimienta rosa
 fa:فلفل صورتی
 fi:roseepippuri, rosépippuri, perunroseepippuri, ruusupippuri
-fr:baies roses, baies
+fr:baies roses, baies, poivre rose
 it:pepe rosa
 ja:ピンクペッパー
 la:Granum piperis roseum
 ml:പിങ്ക് പെപ്പർകോൺ
 nl:roze bessen
+pt:pimenta rosa
 ru:Розовый перец
 sv:Rosépeppar
 uk:Рожевий перець
@@ -60021,7 +60008,8 @@ sv:panax ginseng rotextrakt
 #                                Liquorice
 #
 ###################################################################################################
-# description:en:LIQUORICE or licorice is the root of Glycyrrhiza glabra from which a sweet flavour can be extracted.
+# description:en:LIQUORICE or licorice is the root of Glycyrrhiza glabra from which a sweet flavour can be extracted. 
+# comment:en:This refers to the root not the candy
 
 <en:plant
 en:liquorice, licorice
@@ -60036,7 +60024,7 @@ ca:regalèssia
 cs:lékořice lysá
 cy:Gwylys
 da:lakrids, Glat Lakrids
-de:Lakritz, Sussholz, Süßholz, Echtes Süßholz, Süßholzwurzel, Süßholzwurzeln
+de:Lakritz, Sussholz, Süßholz, Echtes Süßholz
 dv:ވޭމުއި
 el:Γλυκόριζα
 eo:Vera glicirizo
@@ -60824,14 +60812,6 @@ fr:Plantain lancéolé
 la:Plantago lanceolata
 wikipedia:en:https://en.wikipedia.org/wiki/Plantago_lanceolata
 
-<en:plant
-en:hibiscus
-de:Hibiskus
-es:hibisco
-fr:Hibiscus
-it:Ibisco
-nl:hibiscus
-wikipedia:en:https://en.wikipedia.org/wiki/Hibiscus
 
 ###################################################################################################
 #
@@ -60931,7 +60911,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Rose_water
 # Roselle (Hibiscus sabdariffa) is a species of Hibiscus used for the production of bast fibre and as an inon, in which it may be known as carcade.
 
 <en:plant
-en:roselle flower, hibiscus flower, hibiscus flowers
+en:roselle flower, hibiscus flower, hibiscus flowers, hibiscus
 ar:كركديه
 as:টেঙামৰা
 az:Məkkə çayı
@@ -60941,14 +60921,14 @@ cs:ibišek súdánský
 da:hibiskusblomst
 de:Karkadeblüten, Roselle, Hibiskus, Hibiskusblüten
 eo:Sabdarifo
-es:Flor Roselle
+es:Flor Roselle, hibisco
 fa:روزل
 fi:teehibiskus, hibiskus, hibiskuksen kukka
 fr:fleurs de carcadé, fleurs d'hibiscus, hibiscus
 gu:અંબાડી
 hu:rozella
 id:Rosela
-it:flori di carcadè
+it:flori di carcadè, Ibisco
 ja:ローゼル
 jv:Rosela
 ko:로젤
@@ -60959,7 +60939,7 @@ mr:अंबाडी
 ms:Asam belanda
 my:ချဉ်ပေါင်
 nb:hibiskusblomst
-nl:hibiscusbloem, roselle
+nl:hibiscusbloem, roselle, hibiscus
 pl:Ketmia szczawiowa
 pt:Vinagreira
 ru:Розелла
@@ -61167,7 +61147,7 @@ es:azafrán
 et:Safran
 eu:Azafrai
 fa:زعفران
-fi:Sahrami
+# fi:Sahrami part of E164
 fr:safran
 ga:Cróch
 gl:Azafrán
@@ -61198,7 +61178,7 @@ pa:ਕੇਸਰ
 pl:Zastosowanie szafranu
 ps:ګنګو
 pt:açafrão
-ro:șofran
+# ro:șofran part of E164
 ru:шафран
 sa:केसरम्
 sc:Zafferano
@@ -61767,7 +61747,7 @@ wikidata:en:Q11587820
 
 <en:green tea
 en:green tea leaf, green tea leaves
-de:Grüntee
+de:Grüntee blätter
 es:hojas de té verde
 
 <en:green tea
@@ -62531,7 +62511,7 @@ eu:Itsas belar
 fa:جلبک دریایی
 fi:Merilevä
 fo:Tari
-fr:algue marine, varech
+fr:algue marine
 ga:Feamainn
 gd:Feamainn ghropach
 he:אצה
@@ -62677,16 +62657,16 @@ es:Palmaria palmata, duse, dillisk
 fr:Palmaria palmata
 la:Palmaria palmata
 
-
-<en:seaweed
+# is part of e407a in additives taxonomy
+#<en:seaweed
 #<en:e407a
-en:processed euchema algae
-de:verarbeitete euchema algae
-fr:algues euchema transformées
-it:alghe euchema lavorate
-nl:Verwerkt Eucheuma-wier
-description:en:Eucheuma, commonly known as gusô, is a seaweed algae that may be brown, red, or green in color.
-wikipedia:en:https://en.wikipedia.org/wiki/Eucheuma
+#en:processed euchema algae
+#de:verarbeitete euchema algae
+#fr:algues euchema transformées
+#it:alghe euchema lavorate
+#nl:Verwerkt Eucheuma-wier
+#description:en:Eucheuma, commonly known as gusô, is a seaweed algae that may be brown, red, or green in color.
+#wikipedia:en:https://en.wikipedia.org/wiki/Eucheuma
 # ingredient/fr:algues-euchema-transformées has 147 products in 4 languages @2019-02-22
 
 
@@ -63304,7 +63284,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Cantharellus_cibarius
 <en:golden chanterelle
 en:cantharellus cibarius
 de:Echter Pfifferling (cantharellus cibarius)
-es:Cantharellus cibarius, rebozuelo, anacate, chantarela
+es:Cantharellus cibarius, rebozuelo, anacate
 fr:Cantharellus cibarius, Girolle, Girole, Chanterelle
 la:cantharellus cibarius
 
@@ -68370,7 +68350,7 @@ fr:chair de brochet
 
 <en:fish
 en:Pollack
-fr:lieu, Lieu jaune
+fr:Lieu jaune
 ciqual_food_code:en:26129
 ciqual_food_name:en:Pollack, raw
 ciqual_food_name:fr:Lieu jaune ou colin, cru
@@ -68501,7 +68481,7 @@ fi:äyriäisuute
 en:mollusc, molluscs, mollusks, mollusk
 af:Weekdiere
 am:ዛጎል ለበስ
-ar:رخويات ,محار, بلح البحر
+ar:رخويات , بلح البحر
 az:Molyusklar
 ba:Моллюскылар
 be:малюскі
@@ -69824,7 +69804,7 @@ es:sucedáneo de tinta de calamar
 
 <en:mollusc
 en:clam, clams
-ar:محار ملزمي
+ar: ملزمي
 ca:cloïssa
 de:Venusmuscheln
 el:Αχιβάδα

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -18969,20 +18969,24 @@ es:aceite orujo de oliva
 it:Olio di sansa di oliva
 wikipedia:en:https://en.wikipedia.org/wiki/Olive_pomace_oil
 
+#comment:en:Beware of a confusion between the generic name (rapeseed oil) and more specific oil varieties: colza oil and canola oil. Not all languages distinguish between the two. Probably where rapeseed is given, colza is meant. The difference between the two oils is important due to different levels of erucic acid. It seems that only the oils with a low erucic acid percentage are fit for humans. So th enaming difference between rapeseed, colza and canola might just be a language issue.
+
 <en:vegetable oil and fat
 en:rapeseed oil, rapeseed fat, rapeseed oil and fat
 cs:řepkový olej, olej řepkový
 da:rapsolie
 de:Rapsöl, Rapsol
+eo:rapoleo
 es:aceite de nabina, aceite vegetal de nabina
 et:rapsiõli, rapsiseemneõli, rüpsiõli
 fi:rapsiöljy, rapsirasva, rapsiöljy ja -rasva
-fr:Huile de colza ou de navette
+fr:Huile de navette
 he:שמן לפתית
 hr:repičino ulje
 hu:repceolaj, repcemagolaj, repcemagolajak, repcemagzsír, repce étolaj
 is:repjuolía
 ja:菜種油
+ko:유채유
 lt:rapsų aliejus
 lv:rapšu eļļa, rapšu ella
 nb:rapsolje
@@ -18992,9 +18996,16 @@ pl:olej roślinny rzepakowy
 ro:ulei de rapiță, ulei vegetal de rapiță, ulei de rapita
 ru:Рапсовое масло
 sk:repkový olej
+sq:repičino ulje
 sv:Rapsolja, Rapsfett
 from_palm_oil:en:no
-# Polish does not differentiate between colza and canola oil TODO
+wikipedia:en:Q1922338
+description:de:Rapsöl oder Rüböl (auch Rübsenöl, Kolzaöl und Kohlsaatöl genannt) ist ein pflanzliches Öl, welches aus den Samen vom Raps (Brassica napus), gewonnen wird.
+description:en:Rapeseed (Brassica napus), also known as rape, or oilseed rape, is a bright-yellow flowering member of the family Brassicaceae, cultivated mainly for its oil-rich seed, which naturally contains appreciable amounts of erucic acid. Rapeseed is the third-largest source of vegetable oil and the second-largest source of protein meal in the world.
+# 62.151 in 35 @2021-08-23
+
+<en:rapeseed oil
+en:british rapeseed oil
 
 <en:rapeseed oil
 en:canola oil
@@ -19010,51 +19021,20 @@ sv:rybsolja, rypsolja
 wikipedia:en:https://en.wikipedia.org/wiki/Canola_oil
 from_palm_oil:en:no
 nutriscore_fruits_vegetables_nuts:en:yes
+description:en:Canola oil, or canola for short, originally known as low erucic acid rapeseed, is a vegetable oil derived from a variety of rapeseed that is low in erucic acid, as opposed to colza oil.
+description:es:El aceite de colza (aceite de nabina o de canola) es el extracto de la semilla de la colza, usado sobre todo en el norte de Europa como condimento y para el alumbrado.
+description:pt:Canola é um cultivo criado para ter baixo teor de ácido erúcico. O termo canola (Brassica napus L., Brassica rapa L., e Brassica juncea) se refere a variedades de plantas de três espécies da família das crucíferas, pertencentes ao gênero Brassica, que produzem um óleo comestível.
 
-#fi:rypsiöljy, rypsiöljyä
-
-<en:rapeseed oil
-en:colza oil
-bg:рапично олио
-ca:Oli de colza
-de:Kolzaöl
-el:κραμβέλαιο
-es:aceite de colza
-fr:huile de colza, huile végétale de colza, huile colza, graisses végétales de colza, graisses vegetales de colza, colza
-it:olio di colza, olio vegetale di colza
-nb:rapsolje
-nl:koolzaadolie, plantaardige koolzaadolie
-pl:Olej rzepakowy
-pt:óleo de colza
-wikipedia:en:https://en.wikipedia.org/wiki/Colza_oil
-wikidata:en:Q697248
-carbon_footprint_fr_foodges_ingredient:fr:Huile de colza
-carbon_footprint_fr_foodges_value:fr:2.2
-from_palm_oil:en:no
-nutriscore_fruits_vegetables_nuts:en:yes
-ciqual_food_code:en:17130
-ciqual_food_name:en:Rapeseed oil
-ciqual_food_name:fr:Huile de colza
-
-
-<en:rapeseed oil
+<en:canola oil
 en:low erucic acid rapeseed oil
 de:eurucasäurearmes Rapsöl, LEAR
 
-<en:rapeseed oil
-en:british rapeseed oil
-
-# Canola oil, or canola for short, originally known as low erucic acid rapeseed, is a vegetable oil derived from a variety of rapeseed that is low in erucic acid, as opposed to colza oil.
-# The confusion between colza and rapeseed is also present in the wikipedia translations. It seems to be a us/eu difference.
-
-#da:Rapsolie
-#pl:Olej rzepakowy
-
-<en:canola oil
-en:fully hydrogenated canola oil
-de:ganz gehärtetes Canola-Öl, vollständig hydriertes Canola-Öl
-fi:kokonaan kovetettu rypsiöljy
-sv:fullhärdad rypsolja
+#process:en: en:fully hydrogenated
+#<en:canola oil
+#en:fully hydrogenated canola oil
+#de:ganz gehärtetes Canola-Öl, vollständig hydriertes Canola-Öl
+#fi:kokonaan kovetettu rypsiöljy
+#sv:fullhärdad rypsolja
 # ingredient/fi:kokonaan-kovetettu-rypsiöljy has 4 products in 1 language @2020-06-08
 
 <en:canola oil
@@ -19069,7 +19049,30 @@ sv:rypsoljeberedning
 # mainIngredient:en:canola oil
 # ingredient/fi:rypsiöljyvalmiste has 2 products in 1 language @2020-06-08
 
-# Colza oil or colza is a non-drying oil obtained from the seeds of rapeseed (Brassica napus subsp. napus). Note that this a single rapeseed variety
+<en:rapeseed oil
+en:colza oil
+bg:рапично олио
+ca:Oli de colza
+de:Kolzaöl, Kohlsaatöl
+el:κραμβέλαιο
+es:aceite de colza
+fr:huile de colza, huile végétale de colza, huile colza, graisses végétales de colza, graisses vegetales de colza, colza
+it:olio di colza, olio vegetale di colza
+nl:koolzaadolie, plantaardige koolzaadolie
+pt:óleo de colza
+wikipedia:en:https://en.wikipedia.org/wiki/Colza_oil
+wikidata:en:Q697248
+carbon_footprint_fr_foodges_ingredient:fr:Huile de colza
+carbon_footprint_fr_foodges_value:fr:2.2
+from_palm_oil:en:no
+nutriscore_fruits_vegetables_nuts:en:yes
+ciqual_food_code:en:17130
+ciqual_food_name:en:Rapeseed oil
+ciqual_food_name:fr:Huile de colza
+description:en:Colza oil or colza is a non-drying oil obtained from the seeds of rapeseed (Brassica napus subsp. napus).
+description:fr:L'huile de colza, appelée huile de canola au Canada, est une huile végétale que l'on obtient par trituration de graines de colza.
+description:it:L'olio di colza è un olio vegetale alimentare prodotto dai semi della colza (Brassica napus, Brassica rapa, Brassica juncea) e da cultivar o varietà mutanti sviluppate appositamente per modificarne la distribuzione di acidi grassi.
+description:nl:Koolzaadolie is een plantaardige olie die gewonnen wordt uit de zaden van koolzaad (Brassica napus).
 
 <en:colza oil
 en:organic colza oil
@@ -19081,23 +19084,26 @@ hu:bio repceolaj
 nl:olie van biologisch koolzaad
 # ingredient/nl:olie-van-biologisch-koolzaad has 1 product @2019-05-24
 
-<en:colza oil
-en:hydrogenated colza oil
-de:Gehärtetes Rapsöl
+process:en: en:hydrogenated
+#<en:colza oil
+#en:hydrogenated colza oil
+#de:Gehärtetes Rapsöl
 es:aceite hidrogenado de colza
-fi:kovetettu rapsiöljy
-fr:Huile de colza hydrogénée
-sv:hårdat rapsolja
+#fi:kovetettu rapsiöljy
+#fr:Huile de colza hydrogénée
+#sv:hårdat rapsolja
 
-<en:hydrogenated colza oil
-fr:huile de colza totalement hydrogénée, huiles végétales de colza totalement hydrogénée
-fi:kokonaan kovetettu rapsiöljy
-nb:fullherdet rapsolje
-sv:fullhärdad rapsolja
+#process:en: en:fully hydrogenated
+#<en:hydrogenated colza oil
+#fr:huile de colza totalement hydrogénée, huiles végétales de colza totalement hydrogénée
+#fi:kokonaan kovetettu rapsiöljy
+#nb:fullherdet rapsolje
+#sv:fullhärdad rapsolja
 # ingredient/fr:huile-de-colza-totalement-hydrogenee has 41 products in 4 languages @2020-06-10
 
-<en:colza oil
-fr:huile de colza non hydrogénée
+#process:en: en:non-hydrogenated
+#<en:colza oil
+#fr:huile de colza non hydrogénée
 
 <en:colza oil
 fr:huile de colza raffinée
@@ -19112,11 +19118,12 @@ de:Mono- und Diglyceride von Raps
 hu:repce mono- és digliceridjei
 # ingredient/fr:monodiglycérides-de-colza has 16 products in 2 languages @2019-02-18
 
-<en:rapeseed oil
-en:non-hydrogenated rapeseed oil
-de:ungehärtetes Rapsöl
-fi:kovettamaton rapsiöljy
-sv:ohärdad rapsolja
+#process:en: en:non-hydrogenated
+#<en:rapeseed oil
+#en:non-hydrogenated rapeseed oil
+#de:ungehärtetes Rapsöl
+#fi:kovettamaton rapsiöljy
+#sv:ohärdad rapsolja
 # ingredient/en:non-hydrogenated-rapeseed-oil has 4 products in 4 languages @2020-06-08
 
 <en:palm oil and fat

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -73946,7 +73946,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Egg_as_food
 vegetarian:en:yes
 vegan:en:no
 allergens:en: en:eggs
-# ingredient/egg has 15441 products in 24 languages @2018-12-19
+# ingredient/egg 71.383 in 41 @2021-08-22
 carbon_footprint_fr_foodges_ingredient:fr:Oeuf, moyenne nationale
 carbon_footprint_fr_foodges_value:fr:2.6
 description:en:EGGS are laid by female animals of many different species, including birds, reptiles, amphibians, mammals, and fish. This ingredient comprises mainly chicken eggs.
@@ -74007,7 +74007,9 @@ ja:スイス産卵
 nl:eieren uit Zwitserland, zwitserse eieren
 # 2@2109-05-31
 
-# category:en:en:Boiled eggs
+#comment:en:this should be split in boiled as process and the result hard/soft
+# category:en: en:Boiled eggs
+#process:en: en:cooked
 <en:egg
 en:boiled egg
 ar:بيض مسلوق
@@ -74038,19 +74040,30 @@ vi:Trứng luộc
 zh:水煮蛋
 # yue:烚蛋
 wikidata:en:Q1062531
-# ingredient/fr:oeuf-dur has 149 products @2018-12-18
+wikipedia:en:https://en.wikipedia.org/wiki/Boiled_egg
+description:de:Als gekochtes Ei, teils auch als Frühstücksei, wird ein Ei (üblicherweise ein Hühnerei) bezeichnet, das in seiner Schale in kochendem Wasser oder unter Dampf, etwa in einem Eierkocher, gegart wurde.
+description:en:Boiled eggs are eggs, typically from a chicken, cooked with their shells unbroken, usually by immersion in boiling water.
+description:es:El huevo duro, también llamado huevo cocido o huevo sancochado, es un huevo —por lo general de gallina— hervido, usualmente en una salmuera o agua hirviendo.
+description:fr:Un œuf dur est une préparation de l'œuf qui permet de consommer sous forme solide le jaune et le blanc.
+# ingredient/boiled-egg 255 in 5 @2021-08-22
+
+<en:boiled egg
+en:soft-boiled egg
+fr:oeuf à la coque
 ciqual_food_code:en:22014
 ciqual_food_name:en:Egg, soft-boiled
 ciqual_food_name:fr:Oeuf, à la coque
+description:fr:Un œuf à la coque est un œuf entier cuit dans sa coquille, de telle sorte que le blanc soit peu coagulé encore souple et le jaune coulant.
 
 <en:boiled egg
 fr:quartiers d'œufs durs
 nl:gekookt ei kwarten
 
-<en:egg
-fr:œuf pasteurisé, œufs pasteurisés, oeuf pasteurisé, oeufs pasteurisés
-de:Eier pasteurisiert
-it:uova pastorizzate
+#process:en: en:pasteurised
+#<en:egg
+#fr:œuf pasteurisé, œufs pasteurisés, oeuf pasteurisé, oeufs pasteurisés
+#de:Eier pasteurisiert
+#it:uova pastorizzate
 # ingredient/fr:oeuf-pasteurisé has 57 products in 4 languages @2018-12-18
 
 <en:egg
@@ -74157,14 +74170,16 @@ nl:scharreleieren, scharrelei, scharrel-ei
 <en:barn eggs
 nl:scharrel ei poeder
 
-<en:egg
-en:pasteurized liquid egg
-de:pasteurisiertes Flüssigei
-es:huevo líquido pasteurizado
-fr:œuf liquide pasteurisé, oeuf liquide pasteurisé
-nl:gepasteuriseerd vloeibaar ei
+#process:en: en:pasteurised
+#<en:egg
+#en:pasteurized liquid egg
+#de:pasteurisiertes Flüssigei
+#es:huevo líquido pasteurizado
+#fr:œuf liquide pasteurisé, oeuf liquide pasteurisé
+#nl:gepasteuriseerd vloeibaar ei
 # ingredient/fr:oeuf-liquide-pasteurisé has 50 products in 2 languages @2018-12-18
 
+#process:en: en:powdered
 <en:egg
 en:egg powder, powdered egg
 da:æggepulver

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -69537,17 +69537,27 @@ zh:华贵栉孔扇贝
 # ingredient/fr:Chlamys-nobilis has 20 products in french @2019-01-13
 
 
-# Argopecten purpuratus, common names the "Peruvian scallop", is an edible species of saltwater clam, a scallop
-
 <en:scallop
 en:Peruvian scallop
 de:Peruanische Jakobsmuscheln
 es:ostión del norte, concha de abanico
-fr:Pétoncle chilien
+fr:Pétoncle chilien, Pétoncle du Pérou, Peigne du Pérou
 la:Argopecten purpuratus
 wikidata:en:Q3412062
 wikipedia:en:https://en.wikipedia.org/wiki/Argopecten_purpuratus
+#description:en:Argopecten purpuratus, common names the "Peruvian scallop", is an edible species of saltwater clam, a scallop.
+description:es:Argopecten purpuratus es una especie de molusco bivalvo de la familia Pectinidae que se distribuye por las costas del Océano Pacífico de Perú y Chile.
+description:fr:Le pétoncle chilien (Argopecten purpuratus) est un bivalve de la famille des pectinidés habitant les côtes pacifiques de l'Amérique du Sud, du Pérou au Chili.
+description:it:Argopecten purpuratus è un mollusco appartenente alla famiglia Pectinidae a cui appartengono anche le capesante.
+description:nl:Argopecten purpuratus is een tweekleppigensoort uit de familie van de Pectinidae.
 # ingredient/fr:Argopecten-purpuratus has 68 products @2019-01-12
+
+<en:Peruvian scallop
+en:Raw Peruvian scallop without coral
+fr:Pétoncle du Pérou avec noix crue, Peigne du Pérou avec noix cru
+ciqual_food_code:en:10049
+ciqual_food_name:en:Peru sea scallop, without coral, raw
+ciqual_food_name:fr:Pétoncle ou Peigne du Pérou, noix, crue
 
 
 # en:description:The queen scallop (Chlamys opercularis) is a medium-sized species of scallop, an edible marine bivalve mollusk in the family Pectinidae, the scallops.

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -73424,8 +73424,8 @@ fi:kasvisteroliesteri, kasvisteroliesterit
 fr:ester de stérol végétal, esters de stérol végétal
 # ingredient/fr:esters-de-sterol-vegetal has 29 products in 3 languages @2020-12-21
 
-# description:en:CUCUMBER (Cucumis sativus) is a widely cultivated plant in the gourd family, Cucurbitaceae. In general cultivation, cucumbers are classified into three main cultivar groups:"slicing", "pickling", and "burpless". In a 100-gram serving, raw cucumber (with peel) is 95% water, provides 67 kilojoules (16 kilocalories) and supplies low content of essential nutrients, as it is notable only for vitamin K at 16% of the Daily Value.
 
+#category/cucumbers
 <en:vegetable
 en:cucumber, cucumbers
 ar:الخيار
@@ -73468,7 +73468,21 @@ carbon_footprint_fr_foodges_ingredient:fr:Concombre
 carbon_footprint_fr_foodges_value:fr:1.7
 carbon_footprint_fr_foodges_ingredient:fr:Concombre serre chauffée
 carbon_footprint_fr_foodges_value:fr:2.4
-# ingredient/fr:concombre has 549 products in 6 languages @2019-05-15
+description:de:Die Gurke (Cucumis sativus), auch als Kukumer und Gartengurke bezeichnet, ist eine Art der Gattung Gurken (Cucumis) aus der Familie der Kürbisgewächse. Die Salatgurken werden vorwiegend frisch als Salat verzehrt. 
+description:en:CUCUMBER (Cucumis sativus) is a widely cultivated plant in the gourd family, Cucurbitaceae.
+description:es:Cucumis sativus, conocido popularmente como pepino, es una planta anual de la familia de las cucurbitáceas. Es un ingrediente típico en las ensaladas mediterráneas y su variante encurtida, el pepinillo, un popular aperitivo.
+description:fr:Le concombre (Cucumis sativus) est une plante potagère herbacée, rampante, de la même famille que la calebasse africaine, le melon ou la courge (famille des Cucurbitacées).
+description:it:Il cetriolo (Cucumis sativus) è un ortaggio appartenente alla famiglia delle Cucurbitaceae.
+description:nl:De komkommer is een eenjarige plant uit de komkommerfamilie, waarvan de gelijknamige vrucht in Nederland en België vooral rauw als salade wordt gegeten.
+description:pt:O pepino é o fruto do pepineiro (Cucumis sativus), que se come geralmente em forma de salada.
+# 6546 products in 22 @2021-09-02
+
+<en:cucumber
+en:raw cucumber pulp and peel raw
+fr:Concombre pulpe et peau cru
+ciqual_food_code:en:20019
+ciqual_food_name:en:Cucumber, pulp and peel, raw
+ciqual_food_name:fr:Concombre, pulpe et peau, cru
 
 
 # description:en:A GHERKIN is a variety of cucumber

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -30172,7 +30172,7 @@ ko:흑설탕
 ml:ബ്രൗൺ ഷുഗർ
 ms:Gula perang
 nb:brunt sukker
-nl:basterdsuiker, bruine suiker
+nl:basterdsuiker
 pl:Brązowy cukier
 pt:açúcar mascavo
 ru:Коричневый сахар
@@ -30535,14 +30535,14 @@ hu:finomítatlan nádcukor
 it:zucchero di canna grezzo
 ja:黒糖
 nb:rårørsukker
-nl:Ongeraffineerde rietsuiker, ruwe rietsuiker
+nl:Ongeraffineerde rietsuiker
 pl:Cukier trzcinowy nierafinowany
 sv:rårörsocker
 
-<en:cane sugar
+<en:unrefined cane sugar
 en:whole cane sugar
 de:Vollrohrzucker
-es:azucar de caña integral,azucar integral de caña
+es:azucar de caña integral, azucar integral de caña
 fr:sucre de canne complet, suc de canne intégral, sucre de canne intégral, sucre complet de canne
 nl:ruwe rietsuiker
 
@@ -33022,7 +33022,7 @@ bg:обеэмаслено какао на прах
 ca:cacau desgreixat en pols
 cs:Kakaový prášek se sníženým obsahem tuku
 da:fedtfattigt kakaopulver, fedtreduceret kakaopulver, skummet kakaopulver
-de:fettarmes Kakaopulver, Kakaopulver stark entölt, mageres Kakaopulver, fettreduziertes Kakaopulver, Magerkakaopulver, Kakaopulver mit reduziertem Fettgehalt
+de:fettarmes Kakaopulver, Kakaopulver stark entölt, fettreduziertes Kakaopulver, Kakaopulver mit reduziertem Fettgehalt
 es:cacao magro en polvo, cacao desgrasado en polvo, cacao en polvo desgrasado, cacao en polvo reducido en grasa, cacao deshidratado rebajado en grasa
 et:lahja kakaopulber, vähendatud rasvasisaldusega kakaopulber
 fi:vähärasvainen kaakaojauhe, vähärasvaista kaakaojauhetta
@@ -45005,11 +45005,6 @@ de:Gemüse in verschiedener Größe
 es:verduras en proporción variable, hortalizas en proporción variable
 fr:légumes en proportions variables, légumes en proportion variable
 
-<en:vegetable
-en:mixed vegetables
-de:gemischtes Gemüse, Gemüsemischung
-es:mezclas vegetales
-ru:овощи
 
 <en:vegetable
 de:Gemüsepulver
@@ -45017,6 +45012,7 @@ fr:légumes en poudre
 
 <en:vegetable
 fr:légumes frais
+nl:verse groenten
 
 
 <en:vegetable
@@ -45032,11 +45028,12 @@ fi:vihannesuute
 
 # <en:compound
 <en:vegetable
-en:vegetable blend, vegetable mix
-de:Gemüsemischung
-es:mezcla de vegetales, mix de vegetales, blend de vegetales
+en:vegetable blend, vegetable mix, mixed vegetables
+de:Gemüsemischung, gemischtes Gemüse
+es:mezcla de vegetales, mix de vegetales, blend de vegetales, mezclas vegetales
 fi:vihannessekoitus, kasvissekoitus
 fr:mélange de légumes
+ru:овощи
 sv:grönsaksmix
 # usage:en:vegetable blend (carrot, onion, parsley)
 
@@ -50337,12 +50334,12 @@ da:Chili, chilipeber
 de:Peperoni, chilischoten, Pfefferoni, Chili, Piment
 el:Τσίλι
 eo:Kapsiketo
-es:guindilla, ají, chile, pimenton picante,pimiento picante
+es:guindilla, ají, chile, pimenton picante, pimiento picante
 et:tšilli, tšillipipar
 eu:Pipermin
 fa:فلفل تند
 fi:chili, chilipippuri, chilipaprika
-fr:chili, piment du chili, piment, piments
+fr:chili, piment du chili
 gl:Chile
 gn:Ky'ỹi
 gu:મરચું

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10821,33 +10821,43 @@ ca:formatge maasdam ratllat
 es:queso maasdam rallado
 nl:geraspte Maasdam
 
-# Maroilles is a cow's-milk cheese made in the regions of Picardy and Nord-Pas-de-Calais in northern France.
 
+#category/maroilles
 <en:cheese
 en:Maroilles
-br:Maroilles
-ca:maroilles
-de:Maroilles
-es:Maroilles
-fr:maroilles
-hu:Maroilles
-id:Maroilles
-it:Maroilles
+fr:maroilles AOP
 ja:マロリーズ
 ko:마루아유
-la:Maroilles
-nl:Maroilles
-oc:Maroilles
-ro:Maroilles
 ru:Марой
 uk:Марой
 wa:Marwale
+xx:Maroilles
 zh:瑪瑞里斯芝士
 # zh-hans:玛瑞里斯芝士
 # zh-hant:瑪瑞里斯芝士
 wikidata:en:Q734978
 wikipedia:en:https://en.wikipedia.org/wiki/Maroilles_cheese
-# ingredient/fr:maroilles has 41 products in french @2018-12-28
+description:de:Der Maroilles ist ein französischer Käse aus roher oder pasteurisierter Kuhmilch. 
+description:en:Maroilles is a cow's-milk cheese made in the regions of Picardy and Nord-Pas-de-Calais in northern France.
+description:es:Maroilles es un queso de leche de vaca, elaborado en las regiones de Picardía y Norte-Paso de Calais en el norte de Francia.
+description:fr:Le maroilles ou marolles est une appellation d'origine désignant un fromage dont la production et la transformation s'effectuent dans la Thiérache française.
+description:it:Il Maroilles o Marolles è un formaggio francese di latte vaccino, a pasta molle e a crosta lavata, prodotto in Avesnois nei dipartimenti dell'Aisne e del Nord.
+description:nl:De maroilles of marolles is een Franse kaas van het type gewassenkorstkaas. 
+# 63 in french @202108-27
+
+<en:Maroilles
+en:industrial Maroille
+fr:Maroilles laitier
+ciqual_food_code:en:12029
+ciqual_food_name:en:Maroilles ""laitier"" cheese
+ciqual_food_name:fr:Maroilles laitier
+
+<en:Maroilles
+en:farmers Maroilles
+fr:Maroilles fermier
+ciqual_food_code:en:12030
+ciqual_food_name:en:Maroilles ""fermier"" cheese
+ciqual_food_name:fr:Maroilles fermier
 
 <en:cheese
 en:Chaource cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -68020,11 +68020,22 @@ zh:鮪魚, 吞拿魚
 # scn:Tunnu
 # wuu:金枪鱼属
 # xmf:თინუსი
+wikidata:en:Q2346039
 wikipedia:en:https://en.wikipedia.org/wiki/Tuna
 # ingredient/tuna has 1347 products in 10 languages @2019-01-02
 carbon_footprint_fr_foodges_ingredient:fr:Thon en boîte
 carbon_footprint_fr_foodges_value:fr:4
-description:en:A tuna (also called tunny) is a saltwater fish that belongs to the tribe Thunnini, a subgrouping of the Scombridae (mackerel) family.
+ciqual_food_code:en:26053
+ciqual_food_name:en:Tuna, raw
+ciqual_food_name:fr:Thon, cru
+description:de:Thunfische bezeichnen eine Gattung großer Raubfische, die in allen tropischen, subtropischen und gemäßigten Meeren vorkommt. Sie gehören zu den wichtigsten Speisefischen.
+description:en:A tuna is a saltwater fish that belongs to the tribe Thunnini, a subgrouping of the Scombridae family.
+description:es:El grupo Thunnus es un género de peces óseos marinos con menos de diez especies incluidas en él.
+description:fr:Thunnus est un genre de poissons de la famille des Scombridés1. Les espèces de ce genre sont communément appelés « thons ».
+description:it:Thunnus è un genere della famiglia Scombridae che raggruppa otto specie di grandi pesci pelagici predatori, conosciuti comunemente come tonni.
+description:nl:Tonijnen zijn enkele soorten oceaanvissen uit de familie van makrelen (Scombridae).
+description:pt:Os atuns (género Thunnus) são um dos grupos de espécies de peixes mais importantes do ponto de vista pesqueiro.
+# 2838 @2021-09-02
 
 <en:tuna
 fr:filets de thon
@@ -68205,11 +68216,11 @@ la:Thunnus obesus
 wikidata:en:Q1122241
 wikipedia:en:https://en.wikipedia.org/wiki/Bigeye_tuna
 
-# thon-au-naturel is a compound ingredient
 
+#compound
 <en:tuna
 fr:thon au naturel
-# ingredient/fr:thon-au-naturel has 30 products in french @2019-01-02
+# ingredient/fr:thon-au-naturel 53 in french @202109-02
 # thon au naturel (thon albacore, eau, sel)
 
 <en:fish

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -9962,6 +9962,7 @@ description:nl:Camembert is een Franse witte schimmelkaas, die van koemelk wordt
 description:pt:Camembert ou camember é uma variedade de queijo de pasta mole, originária da região da Normandia, França
 
 <en:camembert
+en:camembert from pasteurised milk
 fr:camembert au lait pasteurisé
 ca:camembert de llet pasteuritzada
 es:camembert de leche pasteurizada
@@ -11800,25 +11801,38 @@ wikipedia:en:https://en.wikipedia.org/wiki/Tilsit_cheese
 # fr:tilsit has 1 product in 3 languages @2018-10-27
 
 
-# description:en:TOMME, occasionally spelled Tome, is a type of cheese, and is a generic name given to a class of cheese produced mainly in the French Alps and in Switzerland.
-
 <en:cheese
 en:tomme
 br:toma
-ca:Tomme
-de:Tomme
-es:Tomme
-fi:tomme
-fr:tomme
 he:טום
-hu:Tomme, tomme sajt
-la:Toma
+hu:tomme sajt
+ja:Tommé
 ru:Том
-sw:Tomme
-tr:Tomme
+xx:Tomme
 wikidata:en:Q2164539
 wikipedia:en:https://en.wikipedia.org/wiki/Tomme
-# fr:tomme has 13 products in 1 language @2018-10-27
+ciqual_food_code:en:12758
+ciqual_food_name:en:Tomme cheese, from cow's milk
+ciqual_food_name:fr:Tomme ou tome de vache
+description:de:Tomme ist eine Sammelbezeichnung zahlreicher Weichkäsesorten, die üblicherweise aus Frankreich, der Schweiz und Italien kommen.
+description:en:TOMME, occasionally spelled Tome, is a class of cheese produced mainly in the French Alps and in Switzerland.
+description:fr:La tomme ou tome est un fromage de montagne, existant en de multiples variétés.
+description:it:La tomme es un queso francés de montaña.
+# 34 in 4 @2020-08-29
+
+<en:tomme
+en:tomme de Savoie, tomme de Savoie IGP
+xx:tomme de Savoie, tomme de Savoie IGP
+wikidata:en:Q1247472
+wikipedia:en:https://en.wikipedia.org/wiki/Tomme_de_Savoie
+ciqual_food_code:en:12759
+ciqual_food_name:en:Tomme cheese, from mountain or Savoy
+ciqual_food_name:fr:Tomme ou tome de montagne ou de Savoie
+description:de:Der Tomme de Savoie ist ein französischer Käse aus nicht pasteurisierter Kuhmilch. 
+description:en:Tomme de Savoie is an upland variety of Tomme cheese, specifically, one from Savoy in the French Alps.
+description:es:Tomme de Savoie es un queso francés con indicación geográfica protegida.
+description:fr:Tomme de Savoie est un fromage AOC produit en France dans la région alpine de Savoie.
+description:nl:Tomme de Savoie is een halfharde kaas gemaakt in Savoie door gespecialiseerde kaasmakers.
 
 # description:en:Le VACHERIN FRIBOURGEOIS est un fromage suisse du canton de Fribourg.
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -11088,8 +11088,25 @@ en:pepper jack, pepper jack cheese
 de:Pepper Jack, Pepper-Jack-Käse
 # ingredient/en:pepper-jack has 5 products in 1 language @2020-06-08
 
+#category/morbier
+<en:cheese
+en:morbier, morbier AOP
+ja:モルビエ
+ko:모르비에
+ru:Морбье
+uk:Морб'є
+xx:morbier, morbier AOP
+zh:莫爾比耶乾酪
+wikidata:en:Q177727
+ciqual_food_code:en:12743
+ciqual_food_name:en:Morbier cheese, from cow's milk
+ciqual_food_name:fr:Morbier
+description:de:Morbier ist ein französischer AOP Käse aus Kuhmilch.
+description:en:Morbier is an AOP semi-soft cows' milk cheese of France.
+description:es:Morbier es un queso francés con AOC, proveniente del Franco-Condado.
+description:fr:Morbier est un fromage de lait cru de vache AOP, fabriqué dans le massif du Jura en France
+description:nl:Morbier is een halfharde Franse kaas met gewassen korst gemaakt in de Jura.
 
-# description:en:MOZZARELLA is a traditionally southern Italian spun paste dairy made with Italian buffalo's milk by the pasta filata method.
 
 #category/mozzarella
 <en:cheese

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -10779,6 +10779,25 @@ fr:fromage lancashire, fromage lancashire au lait pasteurisé
 wikidata:en:Q1244290
 wikipedia:en:https://en.wikipedia.org/wiki/Lancashire_cheese
 
+#category/langres
+<en:cheese
+en:langres
+ar:لانجريس تشيس
+ru:Лангр
+tr:Langres peyniri
+uk:Лангр
+xx:langres
+zh:朗格勒奶酪
+ciqual_food_code:en:12040
+ciqual_food_name:en:Langres cheese, from cow's milk
+ciqual_food_name:fr:Langres
+wikidata:en:Q1240158
+description:de:Langres ist ein französischer Weichkäse aus Kuhmilch mit Rotkultur aus dem Plateau von Langres. 
+description:en:Langres is a French cheese from the plateau of Langres in the region of Champagne-Ardenne.
+description:es:Langres es un queso francés de la meseta de Langres en la región de Champaña-Ardenas.
+description:fr:Le langres est un fromage français de la région Grand Est, bénéficiant d'une AOC depuis 1991.
+description:nl:De langres is een Franse gewassenkorstkaas gemaakt van volle koemelk kaas afkomstig uit de plaats met dezelfde naam.
+
 #category/livarot
 <en:cheese
 en:livarot
@@ -11140,31 +11159,6 @@ fr:mozzarella râpée
 ca:mozzarella ratllada
 es:mozzarella rallada
 
-<en:cheese
-en:Ossau-Iraty
-ar:اوساو يراتى
-ca:Ossau-Irati
-el:Οσό-Ιρατί
-eu:Ossau-Irati
-ja:オッソー・イラティ
-ko:오소이라티
-oc:Aussau-Irati
-ru:Оссо-Ирати
-uk:Оссо-Іраті
-xx:Ossau-Iraty
-zh:伊拉堤芝士
-wikidata:en:Q520598
-wikipedia:en:https://en.wikipedia.org/wiki/Ossau-Iraty
-ciqual_food_code:en:12119
-ciqual_food_name:en:Ossau-Iraty cheese, from ewe's milk
-ciqual_food_name:fr:Ossau-Iraty
-description:de:Ossau-Iraty ist ein französischer Schnittkäse aus Schafmilch mit geschützter Ursprungsbezeichnung.
-description:en:Ossau-Iraty is an Occitan-Basque cheese made from sheep milk.
-description:es:El Ossau-Iraty es un queso francés del País Vasco francés y del Bearne, que se produce en un territorio bien delimitado, en el departamento de los Pirineos Atlánticos y en una pequeña parte del departamento de los Altos Pirineos.
-description:fr:Ossau-iraty est l'appellation d'origine d'un fromage français de lait de brebis à pâte pressée non cuite fabriqué dans le Pays basque français et le Béarn.
-description:it:L'ossau-iraty è un formaggio francese prodotto dal latte di pecora a pasta semidura non cotta, nel dipartimento dei Pirenei Atlantici e in qualche comune degli Alti Pirenei.
-description:nl:De Ossau-Iraty is een Franse kaas, een halfharde kaas afkomstig uit Frans-Baskenland en het hogergelegen deel van Béarn.
-description:oc:L'Aussau-Irati es un fromatge de Bearn e de Bascoat. 
 
 #category/munsters
 <en:cheese
@@ -11214,6 +11208,32 @@ description:en:Neufchâtel is a soft, slightly crumbly, mold-ripened cheese made
 description:es:El neufchâtel es un queso francés fabricado en pays de Bray.
 description:fr:Le neufchâtel est un fromage français fabriqué dans le pays de Bray.
 description:nl:De Neufchâtel is een Franse kaas uit het Pays de Bray in Normandië.
+
+<en:cheese
+en:Ossau-Iraty
+ar:اوساو يراتى
+ca:Ossau-Irati
+el:Οσό-Ιρατί
+eu:Ossau-Irati
+ja:オッソー・イラティ
+ko:오소이라티
+oc:Aussau-Irati
+ru:Оссо-Ирати
+uk:Оссо-Іраті
+xx:Ossau-Iraty
+zh:伊拉堤芝士
+wikidata:en:Q520598
+wikipedia:en:https://en.wikipedia.org/wiki/Ossau-Iraty
+ciqual_food_code:en:12119
+ciqual_food_name:en:Ossau-Iraty cheese, from ewe's milk
+ciqual_food_name:fr:Ossau-Iraty
+description:de:Ossau-Iraty ist ein französischer Schnittkäse aus Schafmilch mit geschützter Ursprungsbezeichnung.
+description:en:Ossau-Iraty is an Occitan-Basque cheese made from sheep milk.
+description:es:El Ossau-Iraty es un queso francés del País Vasco francés y del Bearne, que se produce en un territorio bien delimitado, en el departamento de los Pirineos Atlánticos y en una pequeña parte del departamento de los Altos Pirineos.
+description:fr:Ossau-iraty est l'appellation d'origine d'un fromage français de lait de brebis à pâte pressée non cuite fabriqué dans le Pays basque français et le Béarn.
+description:it:L'ossau-iraty è un formaggio francese prodotto dal latte di pecora a pasta semidura non cotta, nel dipartimento dei Pirenei Atlantici e in qualche comune degli Alti Pirenei.
+description:nl:De Ossau-Iraty is een Franse kaas, een halfharde kaas afkomstig uit Frans-Baskenland en het hogergelegen deel van Béarn.
+description:oc:L'Aussau-Irati es un fromatge de Bearn e de Bascoat. 
 
 <en:cheese
 en:parmesan, parmigiano reggiano, Parmesan cheese, parmigiano reggiano cheese, Parmesan cheese from cow's milk

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -660,6 +660,15 @@ de:sprühgetrocknet, sprühgetrocknete, sprühgetrockneter, sprühgetrocknetes
 en:cured
 pt:curado, curada, curados, curadas
 
+#maybe this must be split in firmed and cuttable
+en:firmed
+da:skærefast
+de:schnittfester
+el:σκληρή
+fr:affinée
+nl:Geharde
+sv:skivbar
+
 #note that this must only contain the ingredient, not any sugary additions
 en:syrup, molasses
 bg:от фурми

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -525,6 +525,10 @@ es:solidos de jugo
 
 en:juice crystals
 
+# e.g. soaked beans
+en:soaked
+fr:trempé, trempée, trempés, trempées
+
 #######################################################################
 #
 #                H U M I D I T Y   P R O C E S S E S
@@ -1356,12 +1360,14 @@ hu:termesztett
 #we would need corresponding code changes so that NOVA 4 ingredient processing are used when computing NOVA groups.
 
 en:non-hydrogenated
-de:ungehärtet
+de:ungehärtet, ungehärtetes
 es:no hidrogenada
+fi:kovettamaton
 fr:non hydrogénée
 it:non idrogenato
 nl:niet gehydrogeneerde
 pt:nâo hidrogenada
+sv:ohärdad
 
 #en:hydrolysed, hydrolized
 #fr:Hydrolisé, hydrolisée
@@ -1370,8 +1376,11 @@ pt:nâo hidrogenada
 en:hydrogenated
 de:Gehärtetes
 es:hidrogenado
-fi:kovetettu
+fi:kovetettu, hydrogenoitu
 fr:hydrogénée
+hu:hidrogénezett
+it:idrogenato
+nl:Gehydrogeneerde
 sv:hårdat
 
 #<en:hydrogenated
@@ -1381,7 +1390,3 @@ fr:totalement hydrogénée
 fi:kokonaan kovetettu
 nb:fullherdet
 sv:fullhärdad
-
-# e.g. soaked beans
-en:soaked
-fr:trempé, trempée, trempés, trempées

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -563,11 +563,12 @@ de:200fach konzentriertes
 
 #en:not from concentrate
 
-en:paste
-de:paste
-fi:tahna
-fr:pâte de
-sv:pasta
+# there is a problem with en:cocoa paste
+#en:paste
+#de:paste
+#fi:tahna
+#fr:pâte de
+#sv:pasta
 
 de:eingekochter
 nl:ingekookt

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -381,7 +381,7 @@ pt:descascado, descascada, descascados, descascadas, sem casca, sem cascas
 # en:description:With the outermost layer or skin removed
 en:peeled, hulled
 da:afskallede
-de:geschälte
+# de:geschälte is a separate entry
 es:sin piel, repelada, repelado, repeladas, repelados, descascarrillado, descascarrillada, descascarrillados, descascarrilladas, descascarilladas
 fi:kuoritut
 fr:pelé, pelée, pelés, pelées, dépelliculé, dépelliculées

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -135,7 +135,7 @@ pt:laminado, laminada, laminados, laminadas, em lâminas, em lâmina, em rodela,
 en:chopped
 da:hakket, hakkede
 de:gehackt, gehackte, gehackter, gehacktes
-es:picada, picado, picadas, picados, trocitos, trocitas, troceados
+es:picada, picado, picadas, picados, trocitos, trocitas, troceado, troceada, troceados, troceadas
 fi:pilkottu, pilkotut
 fr:hâché, hâchée, hâchés, hâchées, hachées
 hu:apróra vágott, aprított, aprítva, apróra vágva
@@ -161,7 +161,7 @@ fi:kuutioitu, kuutioidut
 fr:en dés, en cubes, en julienne, cubes de, dés de, cubes d', dès d'
 hu:kockázott, kockázva, kockára vágva, kockára vágott
 nl:blokjes, in blokjes, blokje
-es:troceado, troceada,troceados, troceadas
+es:en cubitos
 sv:tärnad
 
 en:minced
@@ -954,7 +954,6 @@ nb:ristet, ristede
 nl:geroosterd, geroosterde
 pt:tostado, tostada, tostados, tostadas, torrado, torrada, torrados, torradas
 sl:praženi
-sv:rostade
 
 en:untoasted
 nl:ongeroosterd, ongebrand, ongebrande

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -161,7 +161,7 @@ fi:kuutioitu, kuutioidut
 fr:en dés, en cubes, en julienne, cubes de, dés de, cubes d', dès d'
 hu:kockázott, kockázva, kockára vágva, kockára vágott
 nl:blokjes, in blokjes, blokje
-es:en cubitos
+es:en cubitos, encuadritos
 sv:tärnad
 
 en:minced

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -293,6 +293,9 @@ de:halbiert, halbierte, halbierter, halbiertes, halbe
 pt:metade, metades
 # de:false-positives:Halbbitterschokolade, halbfettstufe, halbgetrocknete, halbfester, halberstädter, halbbitter, Halbrahm
 
+fr:quartiers
+nl:kwarten
+
 en:pieces
 af:stukkies
 de:stücke, stücken, stückchen, gestückelt, stück
@@ -843,15 +846,18 @@ fr:blanchi, blanchie, blanchis, blanchies
 hu:blansírozott
 nl:geblancheerd
 
-en:cooked
+en:cooked, boiled
 de:gekocht, gekochte, gekochter, gekochtes
 es:cocido, cocida, cocidos,cocidas
 fi:paistettu, keitetty, kypsennetty, kypsennetyt
 fr:cuit, cuite, cuits, cuites, cuit au naturel, cuite au naturel, cuits au naturel, cuites au naturel, cuisiné, cuisinée, cuisinés, cuisinées
 hu:főtt, főzött
+id:rebus
 it:cotto, cotta, cotti, cotte, cotto al naturale, cotta al naturale, cotti al naturale, cotte al naturale, cucinato, cucinata, cucinati, cucinate
+ms:rebus
 nl:gekookt, gekookte
 pt:cozido, cozida, cozidos, cozidas
+ro:fiert
 sv:kokt, kokta
 
 #<en:cooked

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -135,7 +135,7 @@ pt:laminado, laminada, laminados, laminadas, em lâminas, em lâmina, em rodela,
 en:chopped
 da:hakket, hakkede
 de:gehackt, gehackte, gehackter, gehacktes
-es:picada, picado, picadas, picados,trocitos,trocitas
+es:picada, picado, picadas, picados, trocitos, trocitas, troceados
 fi:pilkottu, pilkotut
 fr:hâché, hâchée, hâchés, hâchées, hachées
 hu:apróra vágott, aprított, aprítva, apróra vágva
@@ -222,6 +222,7 @@ sv:granulat
 
 # en:description:To reduce to smaller pieces by crushing with lateral motion.
 en:ground
+cs:mleté
 da:formalede
 de:gemahlen, gemahlene, gemahlener, gemahlenes
 es:molido, molidos, molida, molidas
@@ -231,6 +232,8 @@ hu:őrölt, őrölve, darált, darálva
 is:muldar
 nl:gemalen
 pt:moído, moída, moídos, moídas
+ru:дробленое
+sl:mleti
 sv:mald, malda, malen
 # nl:parse:gemalen_$
 # en:wiktionary:grind
@@ -936,9 +939,11 @@ sv:rostat, rostade
 #<en:roasted
 en:dry roasted
 
+#comment:en:In the actual translations on products, there is not always a difference between toasted and roasted
+
 # en:description:To lightly cook by browning via direct exposure to a fire or other heat source.
 en:toasted
-ca:torrat,torrats,torrada,torrades
+ca:torrat, torrats, torrada, torrades
 de:geröstet, geröstete, geröstetes, gerösteter, getoastet, getoastete, getoasteter, getoastetes
 es:tostado, tostada, tostados, tostadas
 fi:paahdettu, paahdetut
@@ -948,6 +953,8 @@ it:tostato, tostati, tostate
 nb:ristet, ristede
 nl:geroosterd, geroosterde
 pt:tostado, tostada, tostados, tostadas, torrado, torrada, torrados, torradas
+sl:praženi
+sv:rostade
 
 en:untoasted
 nl:ongeroosterd, ongebrand, ongebrande

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1367,6 +1367,21 @@ pt:nâo hidrogenada
 #fr:Hydrolisé, hydrolisée
 #nl:gehydrolyseerd, gehydrolyseerde
 
+en:hydrogenated
+de:Gehärtetes
+es:hidrogenado
+fi:kovetettu
+fr:hydrogénée
+sv:hårdat
+
+#<en:hydrogenated
+en:fully hydrogenated
+de::ganz gehärtetes, vollständig hydriertes
+fr:totalement hydrogénée
+fi:kokonaan kovetettu
+nb:fullherdet
+sv:fullhärdad
+
 # e.g. soaked beans
 en:soaked
 fr:trempé, trempée, trempés, trempées


### PR DESCRIPTION
### What
Initial attempt at mapping CIQUAL categories to ingredients.

### Why
- Agribalyse categories being CIQUAL categories, this should pave the way for refined computations.
- We should also be able to recompute approximate nutritional values from the nutritional values of each ingredient, multiplied by the CIQUAL nutritional values.

### Part of
- https://github.com/openfoodfacts/offf/issues/14