### PR TITLE
add icon for additives without overexposure risk

### DIFF
--- a/html/images/misc/additives-efsa-evaluation-overexposure-risk-icon-no.svg
+++ b/html/images/misc/additives-efsa-evaluation-overexposure-risk-icon-no.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="90"
+   height="90"
+   id="svg5283"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="additives-efsa-evaluation-overexposure-risk-icon-no.svg">
+  <defs
+     id="defs5299" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2488"
+     inkscape:window-height="1376"
+     id="namedview5297"
+     showgrid="false"
+     inkscape:zoom="2.1995155"
+     inkscape:cx="46.584566"
+     inkscape:cy="45.351703"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5283"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5285">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>vegetarianmark.net</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     ry="12.38329"
+     rx="12.38329"
+     y="1.3825e-06"
+     x="-90"
+     height="90"
+     width="90"
+     id="rect980"
+     style="fill:#00aa00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.154791;stroke-opacity:1"
+     transform="scale(-1,1)" />
+  <path
+     sodipodi:nodetypes="ccccccc"
+     inkscape:connector-curvature="0"
+     id="path968"
+     d="m 44.794597,7.3811632 c 3.733175,-0.0135 7.458335,0.3465167 11.119791,1.0748832 C 66.761622,10.627463 76.721761,15.965612 84.53613,23.795878 L 65.236652,43.09536 H 24.760746 L 5.463873,23.798478 C 15.894909,13.351696 30.031905,7.4506632 44.794597,7.3811632 Z"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke-width:0.147243" />
+  <path
+     style="fill:#000000;stroke:none;stroke-width:0.166666px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 38.332032,39.999997 18.332034,19.999999 28.332033,39.999997 Z"
+     id="path976"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+</svg>


### PR DESCRIPTION
fixes #5457 

![image](https://user-images.githubusercontent.com/8158668/129008356-d23de8b9-c311-4c8a-9034-32403bedce13.png)
