### PR TITLE
Add issue templates to support the scrum methodology

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,16 @@
+---
+name: Epic
+about: Template for epics. Epics group several user stories together into a main piece
+  of added value.
+title: ''
+labels: "♞ epic"
+assignees: ''
+
+---
+
+### Who for
+
+### What
+
+### Why
+

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,27 @@
+---
+name: Story
+about: Template for user stories. User stories represent a single increment towards
+  the product goal and/or an epic.
+title: ''
+labels: '📝 story'
+assignees: ''
+
+---
+
+Epic: #
+
+### Description
+<e.g. When tapping on the search box, Carla sees suggestions based on her search history to speed up the search process>
+
+### Acceptance criteria
+
+### What would a demo look like
+
+### Notes
+* 
+* 
+
+### Tasks
+- [ ] Task 1
+- [ ] Task 1
+- [ ] Task 1

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,11 @@
+---
+name: Task
+about: Template for tasks. Tasks are a small unit of work, usually resulting of breaking
+  down a user story or other bigger items of a sprint backlog.
+title: ''
+labels: '✔ task'
+assignees: ''
+
+---
+
+Story: #


### PR DESCRIPTION
**Description:**

Add issue templates to support the scrum methodology. The immediate need is the fellowship with Google but other groups collaborating in this way can benefit from them too, of course.

These are exact copies of the default templates located in the .github repository, https://github.com/openfoodfacts/.github/tree/main/.github/ISSUE_TEMPLATE. They need to be replicated here because this repository already has a .github/ISSUE_TEMPLATE directory, which overrides completely the one in the organisation's default repository entirely. (documentation ref: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#about-default-community-health-files)

**Alternative considered:**

The alternative would be to create a shared template for bugs and feature requests, and remove the .github/ISSUE_TEMPLATE directory from this repo. Happy to abandon this PR and do that instead. However, currently the bug and feature request templates in some repositories diverge slightly already. Examples
This repo: https://github.com/openfoodfacts/openfoodfacts-server/tree/main/.github/ISSUE_TEMPLATE
smooth-app repo: https://github.com/openfoodfacts/smooth-app/tree/develop/.github/ISSUE_TEMPLATE

So overall replicating the files seems like the easier option in the short term, without disrupting anything else or having to re-think things. The one-single-default-template-with-only-few-exceptions approach sounds more maintainable in the long run but would take some decision making for all affected repositories.