### PR TITLE
Fixed display_field()

### DIFF
--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -280,6 +280,8 @@ sub display_field($$) {
 
 		$template_data_ref_field->{to_do_status} = $to_do_status;
 		$template_data_ref_field->{done_status} = $done_status;
+		process_template('web/common/includes/display_field_states.tt.html', $template_data_ref_field, \$html) || return "template error: " . $tt->error();
+
 
 	}
 	elsif (defined $taxonomy_fields{$field}) {
@@ -323,6 +325,7 @@ sub display_field($$) {
 
 		$template_data_ref_field->{lang_field} = $lang_field;
 		$template_data_ref_field->{value} = $value;
+		process_template('web/common/includes/display_field.tt.html', $template_data_ref_field, \$html) || return "template error: " . $tt->error();
 
 		if ($field eq 'brands') {
 			my $brand = $value;
@@ -341,7 +344,6 @@ sub display_field($$) {
 		}
 	}
 
-	process_template('web/common/includes/display_field.tt.html', $template_data_ref_field, \$html) || return "template error: " . $tt->error();
 
 	return $html;
 }

--- a/templates/web/common/includes/display_field.tt.html
+++ b/templates/web/common/includes/display_field.tt.html
@@ -1,22 +1,12 @@
 <!-- start templates/[% template.name %] -->
 
-[% IF field == 'states' %]
-    [% IF to_do_status != "" %]
-        <p><span class="field">[% lang("to_do_status") %]: </span>[% to_do_status %]</p>
-    [% END %]
-    [% IF done_status != "" %]
-    <p><span class="field">[% lang("done_status") %]: </span>[% done_status %]</p>
-    [% END %]
-
-[% ELSE %]
-
-    [% IF value_check.defined && value_check!= '' %]
+[% IF value_check.defined && value_check != '' %]
+    [% IF field != 'states' %]
         <p>
             <span class="field">[% lang_field %]: </span>
             [% value %]
         </p>
     [% END %]
-
 [% END %]
 
 <!-- end templates/[% template.name %] -->

--- a/templates/web/common/includes/display_field_states.tt.html
+++ b/templates/web/common/includes/display_field_states.tt.html
@@ -1,0 +1,14 @@
+<!-- start templates/[% template.name %] -->
+
+[% IF field == 'states' %]
+
+    [% IF to_do_status != "" %]
+        <p><span class="field">[% lang("to_do_status") %]: </span>[% to_do_status %]</p>
+    [% END %]
+    [% IF done_status != "" %]
+    <p><span class="field">[% lang("done_status") %]: </span>[% done_status %]</p>
+    [% END %]
+
+[% END %]
+
+<!-- end templates/[% template.name %] -->


### PR DESCRIPTION
**Description:**
The template file for the function `display_field()` was being called for the empty fields as well. Split the template file into two and moved the `process_template()` statement inside the if conditions so they are only being called where necessary. 