### PR TITLE
Moved display_data_quality_description() to Web.pm

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7447,34 +7447,6 @@ JS
 	return $img;
 }
 
-
-=head2 display_data_quality_description( PRODUCT_REF, TAGID )
-
-Display an explanation of the data quality warning or error,
-using specific product data related to the warning.
-
-=cut
-
-sub display_data_quality_description($$) {
-
-	my $product_ref = shift;
-	my $tagid = shift;
-
-	my $html = "";
-	my $template_data_ref_quality = {};
-
-	$template_data_ref_quality->{tagid} = $tagid;
-	$template_data_ref_quality->{product_ref_nutriscore_score} = $product_ref->{nutriscore_score};
-	$template_data_ref_quality->{product_ref_nutriscore_score_producer} = $product_ref->{nutriscore_score_producer};
-	$template_data_ref_quality->{product_ref_nutriscore_grade_producer} = uc($product_ref->{nutriscore_grade_producer});
-	$template_data_ref_quality->{product_ref_nutriscore_grade} = uc($product_ref->{nutriscore_grade});
-
-	process_template('web/common/includes/display_data_quality_description.tt.html', $template_data_ref_quality, \$html) || return "template error: " . $tt->error();
-
-	return $html;
-}
-
-
 =head2 display_possible_improvement_description( PRODUCT_REF, TAGID )
 
 Display an explanation of the possible improvement, using the improvement

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -62,6 +62,7 @@ BEGIN
 		&display_my_block
 		&display_product_search_or_add
 		&display_field
+		&display_data_quality_description
 		); #the fucntions which are called outside this file
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -342,6 +343,33 @@ sub display_field($$) {
 	}
 
 	process_template('web/common/includes/display_field.tt.html', $template_data_ref_field, \$html) || return "template error: " . $tt->error();
+
+	return $html;
+}
+
+=head1 FUNCTIONS
+
+=head2 display_data_quality_description( $product_ref, $tagid )
+
+Display an explanation of the data quality warning or error, using specific product data related to the warning.
+
+=cut
+
+sub display_data_quality_description($$) {
+
+	my $product_ref = shift;
+	my $tagid = shift;
+
+	my $html = "";
+	my $template_data_ref_quality = {};
+
+	$template_data_ref_quality->{tagid} = $tagid;
+	$template_data_ref_quality->{product_ref_nutriscore_score} = $product_ref->{nutriscore_score};
+	$template_data_ref_quality->{product_ref_nutriscore_score_producer} = $product_ref->{nutriscore_score_producer};
+	$template_data_ref_quality->{product_ref_nutriscore_grade_producer} = uc($product_ref->{nutriscore_grade_producer});
+	$template_data_ref_quality->{product_ref_nutriscore_grade} = uc($product_ref->{nutriscore_grade});
+
+	process_template('web/common/includes/display_data_quality_description.tt.html', $template_data_ref_quality, \$html) || return "template error: " . $tt->error();
 
 	return $html;
 }


### PR DESCRIPTION
**Description:** 

"Re-architecturing the Open Food Facts Perl modules and functions, possibly making some of them more generic and publishing them on CPAN."
Specifically, `Display.pm` is way too big, and it's very difficult to understand what all the functions do. Trying to move the functions from `Display.pm` to new files like `Web.pm`, `Api.pm`, etc

Moved the function `display_data_quality_description()` from `Display.pm` to `Web.pm`.

**Related to:** #5205