### PR TITLE
docs: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# review when someone opens a pull request.
+# For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
+
+*       @openfoodfacts/openfoodfacts-server


### PR DESCRIPTION
This would allow GitHub to automatically assign reviewers to PRs, see: https://help.github.com/en/articles/about-code-owners

We could use more fine-grained assignments, so that ie. taxonomy changes are always assigned to another specific team or person, but I'm not sure we need it rigth now.