### PR TITLE
Enable cloud vision key, fixes #5562

### DIFF
--- a/docker/backend-dev/conf/Config.pm
+++ b/docker/backend-dev/conf/Config.pm
@@ -44,6 +44,8 @@ BEGIN
 		$facebook_app_id
 		$facebook_app_secret
 
+		$google_cloud_vision_api_key
+
 		$robotoff_url
 
 		$mongodb
@@ -231,6 +233,8 @@ $geolite2_path = $ProductOpener::Config2::geolite2_path;
 
 $facebook_app_id = $ProductOpener::Config2::facebook_app_id;
 $facebook_app_secret = $ProductOpener::Config2::facebook_app_secret;
+
+$google_cloud_vision_api_key = $ProductOpener::Config2::google_cloud_vision_api_key;
 
 $robotoff_url = $ProductOpener::Config2::robotoff_url;
 %server_options = %ProductOpener::Config2::server_options;

--- a/docker/backend-dev/conf/Config2.pm
+++ b/docker/backend-dev/conf/Config2.pm
@@ -38,9 +38,10 @@ BEGIN
 		$mongodb_timeout_ms
 		$memd_servers
 		$facebook_app_id
-	    $facebook_app_secret
+		$facebook_app_secret
 		$robotoff_url
 		%server_options
+		$google_cloud_vision_api_key
 	);
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -66,6 +67,8 @@ $memd_servers = [ "memcached:11211" ];
 $facebook_app_id = "";
 $facebook_app_secret = "";
 
+$google_cloud_vision_api_key = "";
+
 # Set this to your instance of https://github.com/openfoodfacts/robotoff/ to
 # enable an in-site robotoff-asker in the product page
 $robotoff_url = '';
@@ -75,4 +78,5 @@ $robotoff_url = '';
         export_servers => { public => "off", experiment => "off-exp" },
 		minion_backend => { Pg => 'postgresql://productopener:productopener@postgres/minion' },
 );
+
 1;


### PR DESCRIPTION
This enables using Google Cloud Vision. through docker dev environment. The key must be added in docker/backend-dev/conf/Config2.pm