### PR TITLE
moving-dependabot-to-daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,19 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
   
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "weekly"
+        interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/docker/backend"
     schedule:
-        interval: "weekly"
+        interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/docker/frontend"
     schedule:
-        interval: "weekly"
+        interval: "daily"


### PR DESCRIPTION
moving dependabot to daily with the idea that -as a result- the flow of PRs to merge will be more evenly distributed through time
