### PR TITLE
Add API to set extended_ecoscore_data field, create corresponding tags

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -212,8 +212,12 @@ else {
 	my @app_fields = qw(product_name generic_name quantity packaging brands categories labels origins manufacturing_places emb_codes link expiration_date purchase_places stores countries  );
 
 	# admin field to set a creator
-	if (($User_id eq 'stephane') or ($User_id eq 'teolemon')) {
+	if ($admin) {
 		push @app_fields, "creator";
+	}
+
+	if ($admin or ($User_id eq "ecoscore-impact-estimator")) {
+		push @app_fields, ("ecoscore_extended_data", "ecoscore_extended_data_version");
 	}
 
 	# generate a list of potential languages for language specific fields
@@ -322,6 +326,12 @@ else {
 						$product_ref->{lc} = $value;
 					}				
 					
+				}
+				elsif ($field eq "ecoscore_extended_data") {
+					# we expect a JSON value
+					if (defined param($field)) {
+						$product_ref->{$field} = decode_json(param($field));
+					}
 				}
 				else {
 					$product_ref->{$field} = remove_tags_and_quote(decode utf8=>param($field));

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -68,6 +68,7 @@ BEGIN
 use vars @EXPORT_OK ;
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::Store qw/:all/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Packaging qw/:all/;
 
@@ -577,7 +578,26 @@ sub compute_ecoscore($) {
 	
 	$product_ref->{ecoscore_data} = {
 		adjustments => {},
-	};		
+	};
+
+	# Check if we have extended ecoscore_data from the impact estimator
+	# Remove any misc "en:ecoscore-extended-data-version-[..]" tags
+	if (defined $product_ref->{misc_tags}) {
+		foreach my $tag (@{$product_ref->{misc_tags}}) {
+			if ($tag =~ /^en:ecoscore-extended-data/ ) {
+				remove_tag($product_ref,"misc", $tag);
+			}
+		}
+	}
+	if (defined $product_ref->{ecoscore_extended_data}) {
+		add_tag($product_ref,"misc","en:ecoscore-extended-data-computed");
+		if (defined $product_ref->{ecoscore_extended_data_version}) {
+			add_tag($product_ref,"misc","en:ecoscore-extended-data-version-" . get_string_id_for_lang("no_language", $product_ref->{ecoscore_extended_data_version}));
+		}
+	}
+	else {
+		add_tag($product_ref,"misc","en:ecoscore-extended-data-not-computed");
+	}
 	
 	# Special case for waters and sodas: disable the Eco-Score
 	

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -708,6 +708,7 @@
       "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
       "en:nutrition-all-nutriscore-values-known",
       "en:nutriscore-computed",
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed",
       "en:forest-footprint-computed",

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -439,6 +439,7 @@
    "misc_tags" : [
       "en:nutriscore-not-computed",
       "en:nutriscore-missing-category",
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-computed"
    ],
    "nova_group_debug" : "no nova group when the product does not have a category",

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -463,6 +463,7 @@
    "misc_tags" : [
       "en:nutriscore-not-computed",
       "en:nutriscore-missing-category",
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-computed"
    ],
    "nova_group_debug" : "no nova group when the product does not have a category",

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -455,6 +455,7 @@
    "misc_tags" : [
       "en:nutriscore-not-computed",
       "en:nutriscore-missing-category",
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-computed"
    ],
    "nova_group_debug" : "no nova group when the product does not have a category",

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -464,6 +464,7 @@
    "misc_tags" : [
       "en:nutriscore-not-computed",
       "en:nutriscore-missing-category",
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-computed"
    ],
    "nova_group_debug" : "no nova group when the product does not have a category",

--- a/t/expected_test_results/ecoscore/carrots-plastic.json
+++ b/t/expected_test_results/ecoscore/carrots-plastic.json
@@ -163,6 +163,7 @@
    ],
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/carrots.json
+++ b/t/expected_test_results/ecoscore/carrots.json
@@ -166,6 +166,7 @@
    ],
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/category-without-ecoscore-sodas.json
+++ b/t/expected_test_results/ecoscore/category-without-ecoscore-sodas.json
@@ -58,6 +58,7 @@
    "known_ingredients_n" : 2,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-applicable",
       "en:ecoscore-not-computed"
    ],

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -76,6 +76,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/energy-drink.json
+++ b/t/expected_test_results/ecoscore/energy-drink.json
@@ -44,6 +44,7 @@
    "known_ingredients_n" : 0,
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-applicable",
       "en:ecoscore-not-computed"
    ],

--- a/t/expected_test_results/ecoscore/foie-gras.json
+++ b/t/expected_test_results/ecoscore/foie-gras.json
@@ -172,6 +172,7 @@
    "known_ingredients_n" : 4,
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/fresh-vegetable.json
+++ b/t/expected_test_results/ecoscore/fresh-vegetable.json
@@ -50,6 +50,7 @@
    "known_ingredients_n" : 2,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-applicable",
       "en:ecoscore-not-computed"
    ],

--- a/t/expected_test_results/ecoscore/frozen-vegetable.json
+++ b/t/expected_test_results/ecoscore/frozen-vegetable.json
@@ -166,6 +166,7 @@
    "known_ingredients_n" : 3,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
@@ -213,6 +213,7 @@
    ],
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
@@ -213,6 +213,7 @@
    ],
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -124,6 +124,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -121,6 +121,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -121,6 +121,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -121,6 +121,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -124,6 +124,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/milk.json
+++ b/t/expected_test_results/ecoscore/milk.json
@@ -171,6 +171,7 @@
    ],
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -191,6 +191,7 @@
    "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -186,6 +186,7 @@
    "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -227,6 +227,7 @@
    "known_ingredients_n" : 8,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -189,6 +189,7 @@
    "known_ingredients_n" : 5,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -183,6 +183,7 @@
    "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -186,6 +186,7 @@
    "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -203,6 +203,7 @@
    "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -192,6 +192,7 @@
    "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -154,6 +154,7 @@
    "known_ingredients_n" : 2,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -151,6 +151,7 @@
    "known_ingredients_n" : 2,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-bulk.json
+++ b/t/expected_test_results/ecoscore/packaging-en-bulk.json
@@ -131,6 +131,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
@@ -146,6 +146,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -148,6 +148,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -131,6 +131,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -130,6 +130,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -131,6 +131,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -131,6 +131,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
@@ -156,6 +156,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/packaging-unspecified.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified.json
@@ -121,6 +121,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
+++ b/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
@@ -164,6 +164,7 @@
    ],
    "lc" : "fr",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/uk-milk.json
+++ b/t/expected_test_results/ecoscore/uk-milk.json
@@ -171,6 +171,7 @@
    "known_ingredients_n" : 2,
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
       "en:ecoscore-computed"
    ],

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -79,6 +79,7 @@
    ],
    "lc" : "en",
    "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-not-computed"
    ],
    "packagings" : []


### PR DESCRIPTION
- See #5584 for all the details about the API.

- Fixes #5584.