### PR TITLE
Use JSON template to generate Eco-Score Agribalyse LCA knowledge panel 

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -365,6 +365,8 @@ sub process_template($$$) {
 
 	$template_data_ref->{producers_platform_url} = $producers_platform_url;
 	$template_data_ref->{server_domain} = $server_domain;
+	$template_data_ref->{static_subdomain} = $static_subdomain;
+	$template_data_ref->{images_subdomain} = $images_subdomain;
 	(not defined $template_data_ref->{user_id}) and $template_data_ref->{user_id} = $User_id;
 	(not defined $template_data_ref->{org_id}) and $template_data_ref->{org_id} = $Org_id;
 
@@ -4705,7 +4707,7 @@ sub customize_response_for_product($$) {
 		}
 		# Knowledge panels in the $lc language
 		elsif ($field eq "knowledge_panels") {
-			compute_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
+			create_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
 			$customized_product_ref->{$field} = $product_ref->{"knowledge_panels_" . $lc};
 		}
 

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -1,0 +1,58 @@
+{
+    "parent_panel_id": "ecoscore",
+    "type" : "score",
+    "level" :"info",
+    "topics": [
+        "environment"
+    ],
+    "title": "Environmental impact on average for products of the same category",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "summary",
+                "html": `
+                    <p>Agribalyse category: 
+                    <a href=\"https://www.ecoscore_data.agribalyse.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]\">[% panel.agribalyse_category_name %]</a>
+                    </p>
+                    <ul>
+                        <li>
+                            [% lang('ecoscore_pef_environmental_score') %][% sep %]: [% product.ecoscore_data.agribalyse.ef_total FILTER format("%.2f"); %]
+                            [% lang('ecoscore_lower_the_score_lower_the_impact') %]
+                        </li>
+                        <li>
+                            [% lang('ecoscore_incl_climate_change_impact') %][% sep %]: [% product.ecoscore_data.agribalyse.co2_total FILTER format("%.2f"); %]
+                            [% lang('ecoscore_kg_co2_eq_kg_product') %]
+                        </li>
+                    </ul>
+                    `
+            }
+        },
+        {
+            "element_type": "table",
+            "element": {
+                "table_id": "ecoscore_lca_impacts_by_stages",
+                "table_type": "percents",
+                "title": "Details of the impacts by stages of the life cycle",
+                "headers": [
+                    "Steps",
+                    "Impact"
+                ],
+                "rows": [
+                    [% FOREACH step IN ["agriculture", "processing", "packaging", "transportation", "distribution", "consumption"] %]
+                    {
+                        "id": "[% step %]",
+                        "icon_url": "[% static_subdomain %]/images/icons/dist/[% step %].svg",
+                        "values": [
+                            "[% lang("ecoscore_$step") %]",
+                            [% ef_step = "ef_$step" %]
+                            "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %]"
+                        ],
+                        "percent": [% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) %]
+                    },
+                    [% END %]
+                ]
+            }
+        }
+    ]
+}

--- a/templates/api/knowledge-panels/ecoscore/ecoscore.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/ecoscore.tt.json
@@ -1,0 +1,33 @@
+{
+    "parent_panel_id": "root",
+    "type": "score",
+    "level": "info",
+    "grade": "[% grade %]",
+    "topics": [
+        "environment"
+    ],
+    "icon_url": "[% static_subdomain %]/images/attributes/ecoscore-[% panel.grade %].svg",
+    "title": "[% panel.title %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "h1",
+                "html": "Average impact of products of the [% panel.agribalyse_category_name %] category: [% panel.agribalyse_grade FILTER upper %] (Score: [% panel.agribalyse_score %]/100)"
+            }
+        },
+        {
+            "element_type": "panel",
+            "element": {
+                "panel_id": "ecoscore_agribalyse",
+            }
+        },
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "h1",
+                "html": "Impact for this product: [% panel.grade FILTER upper %] (Score: [% panel.score %]/100)"
+            }
+        },           
+    ]
+}

--- a/templates/api/knowledge-panels/ecoscore/ecoscore_unknown.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/ecoscore_unknown.tt.json
@@ -1,0 +1,20 @@
+{
+    "parent_panel_id": "root",
+    "type": "score",
+    "level": "info",
+    "grade": "unknown",
+    "topics": [
+        "environment"
+    ],
+    "icon_url": "[% static_subdomain %]/images/attributes/ecoscore-unknown.svg",
+    "title": "[% lang($lc, "attribute_ecoscore_unknown_title") %] - [% lang($target_lc, "attribute_ecoscore_unknown_description_short") %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "summary",
+                "html": "We could not compute the Eco-Score of this product as it is missing some data, could you help complete it?"
+            }
+        },       
+    ]
+}


### PR DESCRIPTION
### What
This is an implementation of the Eco-Score Agribalyse sub panel with LCA impacts for the different steps. (see #5541 )

I tried a different approach for this one: instead of using Perl code to generate the expected structure for the panel, the Perl code just passes the necessary data to a template that generates JSON for the structure.

It's a bit more tricky than templates to generate HTML code, but it works.

The goal is to have a better separation between model/data and display logic and form, and to allow non programmers to change, reorder etc. the panels just by changing the templates.

### Part of
- #2938