### PR TITLE
Disable translation upload

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -21,7 +21,7 @@ jobs:
     - name: crowdin action
       uses: crowdin/github-action@1.3.3
       with:
-        upload_translations: true # default is false
+        upload_translations: false # default is false
         # Use this option to upload translations for a single specified language
         download_translations: true
         # Upload sources to Crowdin


### PR DESCRIPTION
I believe we don't need to reupload translations everytime. Not only does it slow down the process, but it recontaminates translations from the old source code translations.
