### PR TITLE
add placeholder panels for ecoscore adjustments #5541

### DIFF
--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -367,6 +367,29 @@ sub create_ecoscore_panel($$$) {
 
         # TODO: add panels for the different bonuses and maluses
 
+        foreach my $adjustment ("production_system", "origins_of_ingredients", "threatened_species", "packaging") {
+
+            if (not defined $product_ref->{ecoscore_data}{adjustments}{$adjustment}{value}) {
+                $grade = "unknown";
+            }
+            elsif ($product_ref->{ecoscore_data}{adjustments}{$adjustment}{value} < 0) {
+                $grade = "minus";
+            }
+            else {
+                $grade = "plus";
+            }
+
+            $title = lang("ecoscore_" . $adjustment);
+
+            $panel_data_ref = {
+                "grade" => $grade,
+                "title" => $title,
+            };            
+
+            create_panel_from_json_template("ecoscore_" . $adjustment, "api/knowledge-panels/ecoscore/" . $adjustment . ".tt.json",
+                $panel_data_ref, $product_ref, $target_lc, $target_cc);
+        }
+
 	}
 	else {
         my $panel_data_ref = {};

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5534,7 +5534,7 @@ msgctxt "ecoscore_additional_bonuses_and_maluses"
 msgid "Additional bonuses and maluses"
 msgstr "Additional bonuses and maluses"
 
-msgctxt "ecoscore_production_mode"
+msgctxt "ecoscore_production_system"
 msgid "Production mode"
 msgstr "Production mode"
 
@@ -5546,9 +5546,9 @@ msgctxt "ecoscore_please_add_the_labels"
 msgid "If this product has a label characterizing the production system (organic, fair trade, Label Rouge, Bleu Blanc Coeur etc.), you can modify the product sheet to add it."
 msgstr "If this product has a label characterizing the production system (organic, fair trade, Label Rouge, Bleu Blanc Coeur etc.), you can modify the product sheet to add it."
 
-msgctxt "ecoscore_origin_of_ingredients"
-msgid "Origin of ingredients"
-msgstr "Origin of ingredients"
+msgctxt "ecoscore_origins_of_ingredients"
+msgid "Origins of ingredients"
+msgstr "Origins of ingredients"
 
 msgctxt "ecoscore_ingredients_not_indicated"
 msgid "The origins of the ingredients of this product are not indicated."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5678,3 +5678,19 @@ msgstr "Protect the data that is provided by the organization."
 msgctxt "org_protect_data_note"
 msgid "Removing or changing the provided data will be possible only by experimented contributors on the web site."
 msgstr "Removing or changing the provided data will be possible only by experimented contributors on the web site."
+
+msgctxt "ecoscore_packaging_impact_high"
+msgid "This product's packaging has an high impact on the environment."
+msgstr "This product's packaging has an high impact on the environment."
+
+msgctxt "ecoscore_packaging_impact_medium"
+msgid "This product's packaging has an average impact on the environment."
+msgstr "This product's packaging has an average impact on the environment."
+
+msgctxt "ecoscore_packaging_impact_low"
+msgid "This product's packaging has a low impact on the environment."
+msgstr "This product's packaging has a low impact on the environment."
+
+msgctxt "ecoscore_packaging_missing_information"
+msgid "The information about this product's packaging is missing."
+msgstr "The information about this product's packaging is missing."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5694,3 +5694,12 @@ msgstr "This product's packaging has a low impact on the environment."
 msgctxt "ecoscore_packaging_missing_information"
 msgid "The information about this product's packaging is missing."
 msgstr "The information about this product's packaging is missing."
+
+# medium as in "medium impact"
+msgctxt "medium"
+msgid "medium"
+msgstr "medium"
+
+msgctxt "impact"
+msgid "impact"
+msgstr "impact"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5695,3 +5695,19 @@ msgstr "Protect the data that is provided by the organization."
 msgctxt "org_protect_data_note"
 msgid "Removing or changing the provided data will be possible only by experimented contributors on the web site."
 msgstr "Removing or changing the provided data will be possible only by experimented contributors on the web site."
+
+msgctxt "ecoscore_packaging_impact_high"
+msgid "This product's packaging has an high impact on the environment."
+msgstr "This product's packaging has an high impact on the environment."
+
+msgctxt "ecoscore_packaging_impact_medium"
+msgid "This product's packaging has an average impact on the environment."
+msgstr "This product's packaging has an average impact on the environment."
+
+msgctxt "ecoscore_packaging_impact_low"
+msgid "This product's packaging has a low impact on the environment."
+msgstr "This product's packaging has a low impact on the environment."
+
+msgctxt "ecoscore_packaging_missing_information"
+msgid "The information about this product's packaging is missing."
+msgstr "The information about this product's packaging is missing."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5711,3 +5711,12 @@ msgstr "This product's packaging has a low impact on the environment."
 msgctxt "ecoscore_packaging_missing_information"
 msgid "The information about this product's packaging is missing."
 msgstr "The information about this product's packaging is missing."
+
+# medium as in "medium impact"
+msgctxt "medium"
+msgid "medium"
+msgstr "medium"
+
+msgctxt "impact"
+msgid "impact"
+msgstr "impact"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5555,7 +5555,7 @@ msgctxt "ecoscore_additional_bonuses_and_maluses"
 msgid "Additional bonuses and maluses"
 msgstr "Additional bonuses and maluses"
 
-msgctxt "ecoscore_production_mode"
+msgctxt "ecoscore_production_system"
 msgid "Production mode"
 msgstr "Production mode"
 
@@ -5567,9 +5567,9 @@ msgctxt "ecoscore_please_add_the_labels"
 msgid "If this product has a label characterizing the production system (organic, fair trade, Label Rouge, Bleu Blanc Coeur etc.), you can modify the product sheet to add it."
 msgstr "If this product has a label characterizing the production system (organic, fair trade, Label Rouge, Bleu Blanc Coeur etc.), you can modify the product sheet to add it."
 
-msgctxt "ecoscore_origin_of_ingredients"
-msgid "Origin of ingredients"
-msgstr "Origin of ingredients"
+msgctxt "ecoscore_origins_of_ingredients"
+msgid "Origins of ingredients"
+msgstr "Origins of ingredients"
 
 msgctxt "ecoscore_ingredients_not_indicated"
 msgid "The origins of the ingredients of this product are not indicated."

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -2,6 +2,7 @@
     "parent_panel_id": "ecoscore",
     "type" : "score",
     "level" :"info",
+    "grade": "[% panel.agribalyse_grade %]",
     "topics": [
         "environment"
     ],

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -45,9 +45,13 @@
                         "id": "[% step %]",
                         "icon_url": "[% static_subdomain %]/images/icons/dist/[% step %].svg",
                         "values": [
-                            "[% lang("ecoscore_$step") %]",
-                            [% ef_step = "ef_$step" %]
-                            "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %]"
+                            {
+                                "text": "[% lang("ecoscore_$step") %]"
+                            },
+                            {
+                                [% ef_step = "ef_$step" %]
+                                "text": "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %]"
+                            }
                         ],
                         "percent": [% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) %]
                     },

--- a/templates/api/knowledge-panels/ecoscore/ecoscore.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/ecoscore.tt.json
@@ -28,6 +28,14 @@
                 "text_type": "h1",
                 "html": "Impact for this product: [% panel.grade FILTER upper %] (Score: [% panel.score %]/100)"
             }
-        },           
+        },
+        [% FOREACH adjustment IN ["production_system", "origins_of_ingredients", "threatened_species", "packaging"] %]
+        {
+            "element_type": "panel",
+            "element": {
+                "panel_id": "ecoscore_[% adjustment %]",
+            }
+        },
+        [% END %]
     ]
 }

--- a/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
@@ -1,0 +1,21 @@
+{
+    "parent_panel_id": "ecoscore",
+    "type" : "score",
+    "level" :"info",
+    "grade": "[% panel.grade %]",
+    "topics": [
+        "environment"
+    ],
+    "title": "[% panel.title %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "summary",
+                "html": `
+                    <p>[give more details here]</p> 
+                    `
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -25,5 +25,51 @@
                     `
             }
         },
+        [% IF product.ecoscore_data.adjustments.packaging.packagings && product.ecoscore_data.adjustments.packaging.packagings.size %]
+        {
+            "element_type": "table",
+            "element": {
+                "table_id": "ecoscore_packaging_components",
+                "table_type": "table",
+                "title": "[% lang('packaging_parts') %]",
+                "headers": [
+                    "[% lang('packaging_shape') %]",
+                    "[% lang('packaging_material') %]",
+                    "[% lang('packaging_recycling') %]",
+                    "[% lang('packaging_impact') %]"
+                ],
+                "rows": [
+                    [% FOREACH packaging IN product.ecoscore_data.adjustments.packaging.packagings %]
+                    [% score = packaging.ecoscore_material_score * packaging.ecoscore_shape_ratio %]
+                    {
+                        "values": [
+                            {
+                                "text": "[% IF packaging.number %][% packaging.number %] [% END %][% display_taxonomy_tag('packaging_shapes',packaging.shape) %][% IF packaging.quantity %] ([% packaging.quantity %])[% END %]"
+                            },
+                            {
+                                "text": "[% display_taxonomy_tag('packaging_materials',packaging.material) %]"
+                            },
+                            {
+                                "text": "[% display_taxonomy_tag('packaging_recycling',packaging.recycling) %]"
+                            },
+                            {
+                            [% IF score >= 75 %]
+                                "text": "[% lang('low') FILTER ucfirst %]",
+                                "color": "green"
+                            [% ELSIF score <= 25 %]
+                                "text": "[% lang('high') FILTER ucfirst %]",
+                                "color": "red"
+                            [% ELSE %]
+                                "text": "[% lang('medium') FILTER ucfirst %]",
+                                "color": "orange"
+                            [% END %]
+                            }
+                        ]
+                    },
+                    [% END %]
+                ]
+            }
+        }
+        [% END %]         
     ]
 }

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -1,0 +1,21 @@
+{
+    "parent_panel_id": "ecoscore",
+    "type" : "score",
+    "level" :"info",
+    "grade": "[% panel.grade %]",
+    "topics": [
+        "environment"
+    ],
+    "title": "[% panel.title %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "summary",
+                "html": `
+                    <p>[give more details here]</p> 
+                    `
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -2,11 +2,19 @@
     "parent_panel_id": "ecoscore",
     "type" : "score",
     "level" :"info",
-    "grade": "[% panel.grade %]",
     "topics": [
         "environment"
     ],
-    "title": "[% panel.title %]",
+    [% IF product.ecoscore_data.adjustments.packaging.value <= -15 %]
+    "grade": "minus",
+    "title": "[% lang('ecoscore_packaging_impact_high') %]",
+    [% ELSIF product.ecoscore_data.adjustments.packaging.value <= -5 %]
+    "grade": "neutral",
+    "title": "[% lang('ecoscore_packaging_impact_medium') %]",    
+    [% ELSE %]
+    "grade": "plus",
+    "title": "[% lang('ecoscore_packaging_impact_low') %]",      
+    [% END %]
     "elements": [
         {
             "element_type": "text",

--- a/templates/api/knowledge-panels/ecoscore/production_system.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/production_system.tt.json
@@ -1,0 +1,21 @@
+{
+    "parent_panel_id": "ecoscore",
+    "type" : "score",
+    "level" :"info",
+    "grade": "[% panel.grade %]",
+    "topics": [
+        "environment"
+    ],
+    "title": "[% panel.title %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "summary",
+                "html": `
+                    <p>[give more details here]</p> 
+                    `
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/ecoscore/threatened_species.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/threatened_species.tt.json
@@ -1,0 +1,21 @@
+{
+    "parent_panel_id": "ecoscore",
+    "type" : "score",
+    "level" :"info",
+    "grade": "[% panel.grade %]",
+    "topics": [
+        "environment"
+    ],
+    "title": "[% panel.title %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "summary",
+                "html": `
+                    <p>[give more details here]</p> 
+                    `
+            }
+        },
+    ]
+}

--- a/templates/web/pages/product/includes/ecoscore_details.tt.html
+++ b/templates/web/pages/product/includes/ecoscore_details.tt.html
@@ -118,7 +118,7 @@
 	
 	<div class="small-12 large-6 columns">
 		 <div class="panel ecoscore_panel" id="ecoscore_panel_production_system" data-equalizer-watch="ecoscore1">
-	<h4>[% display_icon('agriculture') %] [% lang('ecoscore_production_mode') %]</h4>
+	<h4>[% display_icon('agriculture') %] [% lang('ecoscore_production_system') %]</h4>
 	
 	[% IF adjustments.production_system.value %]
 		<p><strong>[% display_taxonomy_tag("labels",adjustments.production_system.label) %][% sep %]: +[% adjustments.production_system.value %]</strong></p>
@@ -138,7 +138,7 @@
 	
 	<div class="small-12 large-6 columns">	
 		 <div class="panel ecoscore_panel" id="ecoscore_panel_origins" data-equalizer-watch="ecoscore1">
-	<h4>[% display_icon('public') %] [% lang('ecoscore_origin_of_ingredients') %]</h4>
+	<h4>[% display_icon('public') %] [% lang('ecoscore_origins_of_ingredients') %]</h4>
 	
 	[% IF adjustments.origins_of_ingredients.aggregated_origins %]
 		<ul>

--- a/templates/web/pages/product/includes/ecoscore_details_simple_html.tt.html
+++ b/templates/web/pages/product/includes/ecoscore_details_simple_html.tt.html
@@ -61,7 +61,7 @@
 	<h3>[% lang('ecoscore_additional_bonuses_and_maluses') %]</h3>
 	
 
-	<h4>🚜 [% lang('ecoscore_production_mode') %]</h4>
+	<h4>🚜 [% lang('ecoscore_production_system') %]</h4>
 	
 	[% IF adjustments.production_system.value %]
 		<p><strong>[% display_taxonomy_tag("labels",adjustments.production_system.label) %] : +[% adjustments.production_system.value %]</strong></p>
@@ -78,7 +78,7 @@
 		
 	[% END %]
 
-	<h4>🌎 [% lang('ecoscore_origin_of_ingredients') %]</h4>
+	<h4>🌎 [% lang('ecoscore_origins_of_ingredients') %]</h4>
 	
 	[% IF adjustments.origins_of_ingredients.aggregated_origins %]
 		<ul>


### PR DESCRIPTION
This PR creates mostly empty sub-panels for the Eco-Score adjusments (maluses and bonuses for packaging, production mode, origins of ingredients and threatened species).

This is so that we have the right structure in place, we can create the actual panels one by one in other PRs.