### PR TITLE
github-linguist: Treat .csv.<number> files as CSV, not Roff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,8 @@
 # Template::Toolkit
 # =================
 *.tt linguist-language=HTML
+
+# Do not treat .csv.<number> files as Roff programming language files
+# ===================================================================
+*.csv.[0-9] linguist-language=CSV
+*.csv.[0-9][0-9] linguist-language=CSV


### PR DESCRIPTION
## What is this PR about?
GitHub incorrectly shows that the Roff programming language is used in this project.
![image](https://user-images.githubusercontent.com/17103865/132227683-35928be4-9b89-4420-bfca-56252a0dcb4a.png)

This happens, because [files fulfilling `*.csv.<number>` pattern in this repo](https://github.com/search?q=repo%3Aopenfoodfacts%2Fopenfoodfacts-server+language%3ARoff&type=Code&l=Roff) are classified by [github-linguist](https://github.com/github/linguist) as Roff programming language files:
https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5126-L5157 

## Fix
This PR fixes the classification of the `*.csv.<number>` files.
After the fix they are classified as CSV files, not Roff files and the fix is done by overriding github-linguist defaults in .gitattributes.
Final effect: Roff language is no more detected in the project.

## Testing the change
Running github-linguist on `openfoodfacts-server` **before** .gitattributes update:
```
85.46%  50826505   HTML
8.24%   4900579    Roff
5.73%   3406423    Perl
0.26%   155273     JavaScript
0.11%   65295      SCSS
0.10%   59496      Shell
0.05%   27509      Python
0.03%   15522      CSS
0.02%   11814      Dockerfile
0.00%   1899       XSLT
0.00%   278        Batchfile
```

Running github-linguist on `openfoodfacts-server` **after** .gitattributes update (Roff is not detected anymore):
```
93.14%  50826505   HTML
6.24%   3406423    Perl
0.28%   155273     JavaScript
0.12%   65295      SCSS
0.11%   59496      Shell
0.05%   27509      Python
0.03%   15522      CSS
0.02%   11814      Dockerfile
0.00%   1899       XSLT
0.00%   278        Batchfile
```