### PR TITLE
Display knowledge panels on the web

### DIFF
--- a/icons/consumption.svg
+++ b/icons/consumption.svg
@@ -1,0 +1,1 @@
+cooking-pan.svg

--- a/icons/distribution.svg
+++ b/icons/distribution.svg
@@ -1,0 +1,1 @@
+cart.svg

--- a/icons/transportation.svg
+++ b/icons/transportation.svg
@@ -1,0 +1,1 @@
+truck.svg

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -270,7 +270,8 @@ $tt = Template->new(
 		STAT_TTL     => 60,                              # cache templates in memory for 1 min before checking if the source changed
 		COMPILE_EXT  => '.ttc',                          # compile templates to Perl code for much faster reload
 		COMPILE_DIR  => $data_root . '/tmp/templates',
-		ENCODING     => 'UTF-8'
+		ENCODING     => 'UTF-8',
+		RECURSION    => 1,	# Needed for the knowledge panels that contain subpanels
 	}
 );
 
@@ -8194,6 +8195,13 @@ HTML
 		$template_data_ref->{ecoscore_score} = $product_ref->{ecoscore_data}{"score"};
 		$template_data_ref->{ecoscore_data} = $product_ref->{ecoscore_data};
 		$template_data_ref->{ecoscore_calculation_details} = display_ecoscore_calculation_details($cc, $product_ref->{ecoscore_data});
+
+		# Knowledge panels are in development, they can be activated with the "panels" parameter
+		# for debugging and demonstration purposes
+		if (param('panels')) {
+			create_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
+			$template_data_ref->{ecoscore_panel} = display_knowledge_panel($product_ref->{"knowledge_panels_" . $lc}, "ecoscore");
+		}
 	}
 
 	# Forest footprint

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -369,20 +369,22 @@ sub create_ecoscore_panel($$$) {
 
         foreach my $adjustment ("production_system", "origins_of_ingredients", "threatened_species", "packaging") {
 
+            my $plus_or_minus;
+
             if (not defined $product_ref->{ecoscore_data}{adjustments}{$adjustment}{value}) {
-                $grade = "unknown";
+                $plus_or_minus = "unknown";
             }
             elsif ($product_ref->{ecoscore_data}{adjustments}{$adjustment}{value} < 0) {
-                $grade = "minus";
+                $plus_or_minus = "minus";
             }
             else {
-                $grade = "plus";
+                $plus_or_minus = "plus";
             }
 
             $title = lang("ecoscore_" . $adjustment);
 
             $panel_data_ref = {
-                "grade" => $grade,
+                "plus_or_minus" => $plus_or_minus,
                 "title" => $title,
             };            
 

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -64,6 +64,7 @@ BEGIN
 		&display_field
 		&display_data_quality_issues_and_improvement_opportunities
 		&display_data_quality_description
+		&display_knowledge_panel
 		); #the fucntions which are called outside this file
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -411,6 +412,28 @@ sub display_data_quality_description($$) {
 
 	process_template('web/common/includes/display_data_quality_description.tt.html', $template_data_ref_quality, \$html) || return "template error: " . $tt->error();
 
+	return $html;
+}
+
+
+=head2 display_knowledge_panel( $panels_ref, $panel_id )
+
+
+=cut
+
+sub display_knowledge_panel($$) {
+
+	my $panels_ref = shift;
+	my $panel_id = shift;
+
+	my $html = '';
+
+	my $template_data_ref = {
+		panels => $panels_ref,
+		panel_id => $panel_id,
+	};
+
+	process_template('web/panels/panel.tt.html', $template_data_ref, \$html) || return "template error: " . $tt->error();
 	return $html;
 }
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5486,6 +5486,7 @@ msgctxt "ecoscore_impact_detail_by_stages"
 msgid "Details of the impacts by stages of the life cycle"
 msgstr "Details of the impacts by stages of the life cycle"
 
+# stage meaning step
 msgctxt "ecoscore_stage"
 msgid "Stage"
 msgstr "Stage"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5505,6 +5505,7 @@ msgctxt "ecoscore_impact_detail_by_stages"
 msgid "Details of the impacts by stages of the life cycle"
 msgstr "Details of the impacts by stages of the life cycle"
 
+# stage meaning step
 msgctxt "ecoscore_stage"
 msgid "Stage"
 msgstr "Stage"
@@ -5716,7 +5717,3 @@ msgstr "The information about this product's packaging is missing."
 msgctxt "medium"
 msgid "medium"
 msgstr "medium"
-
-msgctxt "impact"
-msgid "impact"
-msgstr "impact"

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -34,26 +34,30 @@
             "element": {
                 "table_id": "ecoscore_lca_impacts_by_stages",
                 "table_type": "percents",
-                "title": "Details of the impacts by stages of the life cycle",
+                "title": "[% lang('ecoscore_impact_detail_by_stages') %]",
                 "headers": [
-                    "Steps",
-                    "Impact"
+                    {
+                        "text": "[% lang('ecoscore_stage') %]",
+                    },
+                    {
+                        "text": "[% lang('ecoscore_impact') %]",
+                    }
                 ],
                 "rows": [
                     [% FOREACH step IN ["agriculture", "processing", "packaging", "transportation", "distribution", "consumption"] %]
                     {
                         "id": "[% step %]",
-                        "icon_url": "[% static_subdomain %]/images/icons/dist/[% step %].svg",
                         "values": [
                             {
+                                "icon_url": "[% static_subdomain %]/images/icons/dist/[% step %].svg",
                                 "text": "[% lang("ecoscore_$step") %]"
                             },
                             {
                                 [% ef_step = "ef_$step" %]
-                                "text": "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %]"
+                                "text": "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %]",
+                                "percent": [% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) %]
                             }
                         ],
-                        "percent": [% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) %]
                     },
                     [% END %]
                 ]

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -6,13 +6,13 @@
         "environment"
     ],
     [% IF product.ecoscore_data.adjustments.packaging.value <= -15 %]
-    "grade": "minus",
+    "plus_or_minus": "minus",
     "title": "[% lang('ecoscore_packaging_impact_high') %]",
     [% ELSIF product.ecoscore_data.adjustments.packaging.value <= -5 %]
-    "grade": "neutral",
+    "plus_or_minus": "neutral",
     "title": "[% lang('ecoscore_packaging_impact_medium') %]",    
     [% ELSE %]
-    "grade": "plus",
+    "plus_or_minus": "plus",
     "title": "[% lang('ecoscore_packaging_impact_low') %]",      
     [% END %]
     "elements": [
@@ -33,10 +33,10 @@
                 "table_type": "table",
                 "title": "[% lang('packaging_parts') %]",
                 "headers": [
-                    "[% lang('packaging_shape') %]",
-                    "[% lang('packaging_material') %]",
-                    "[% lang('packaging_recycling') %]",
-                    "[% lang('packaging_impact') %]"
+                    { "text": "[% lang('packaging_shape') %]"},
+                    { "text": "[% lang('packaging_material') %]"},
+                    { "text": "[% lang('packaging_recycling') %]"},
+                    { "text": "[% lang('ecoscore_impact') %]"}
                 ],
                 "rows": [
                     [% FOREACH packaging IN product.ecoscore_data.adjustments.packaging.packagings %]

--- a/templates/web/common/includes/display_field.tt.html
+++ b/templates/web/common/includes/display_field.tt.html
@@ -1,8 +1,8 @@
-
 <!-- start templates/[% template.name %] -->
+
 <p id="field_[% field %]">
     <span class="field">[% name %][% sep %]: </span>
     <span class="field_value" id="field_[% field %]_value">[% value %]</span>
 </p>
-<!-- end templates/[% template.name %] -->
 
+<!-- end templates/[% template.name %] -->

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -7,7 +7,7 @@
     <title>[% title %]</title>
     [% meta_description %]
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta property="fb:app_id" content="[% fb_config %]">
+	<meta property="fb:app_id" content="[% fb_config %]">
     <meta property="og:type" content="[% og_type %]">
     <meta property="og:title" content="[% canon_title %]">
     <meta property="og:url" content="[% canon_url %]">
@@ -27,8 +27,6 @@
     </style>
     [% google_analytics %]
 </head>
-
-
 <body[% bodyabout %] class="[% page_type %]_page">
 <nav class="top-bar" data-topbar id="top-bar">
 	<ul class="title-area">
@@ -72,9 +70,9 @@
         </form>
       </li>
       <li class="show-for-large-only"><a href="/cgi/search.pl" title="[% lang('advanced_search') %]">[% display_icon('add') %]</a></li>
-      <li class="show-for-xlarge-up"><a href="/cgi/search.pl">[% display_icon('add') %] [% lang('advanced_search') %]</a></li>
+      <li class="show-for-xlarge-up"><a href="/cgi/search.pl">[% display_icon('add') %] [% lang('advanced_search') %]</span></a></li>
       <li class="show-for-large-only"><a href="/cgi/search.pl?graph=1" title="[% lang('graphs_and_maps') %]">[% display_icon('bar_chart') %]</a></li>
-      <li class="show-for-xlarge-up"><a href="/cgi/search.pl?graph=1">[% display_icon('bar_chart') %] [% lang('graphs_and_maps') %]</a></li>
+      <li class="show-for-xlarge-up"><a href="/cgi/search.pl?graph=1">[% display_icon('bar_chart') %] [% lang('graphs_and_maps') %]</span></a></li>
       [% IF !(server_options_producers_platform) %]
         <li class="show-for-large-up divider"></li>
         <li><a href="[% lang('menu_discover_link') %]">[% lang('menu_discover') %]</a></li>
@@ -147,13 +145,13 @@
 		[% END %]
 		
 		<!-- main row - comment used to remove left column and center content on some pages -->
-		<div id="main_content" class="row full-width" style="max-width: 100% !important;" data-equalizer>
-			<div id="side_content" class="xxlarge-2 xlarge-2 large-3 medium-4 columns hide-for-small" style="background-color:#fafafa;padding-top:1rem;" data-equalizer-watch>
+		<div class="row full-width" style="max-width: 100% !important;" data-equalizer>
+			<div class="xxlarge-2 xlarge-2 large-3 medium-4 columns hide-for-small" style="background-color:#fafafa;padding-top:1rem;" data-equalizer-watch>
 				<div class="sidebar">
 					<div style="text-align:center">
 						<a href="/"><img id="logo" src="/images/misc/[% lang('logo') %]" srcset="/images/misc/[% lang('logo2x') %] 2x" width="178" height="150" alt="[% lang('logo_site_name') %]" style="margin-bottom:0.5rem"></a>
 					</div>
-          <p id="tagline">[% tagline %]</p>
+					[% tagline %]
 					<form action="/cgi/search.pl" class="hide-for-large-up">
 						<div class="row collapse">
 							<div class="small-9 columns">
@@ -296,6 +294,21 @@
 	"sameAs" : [ "[% lang("facebook_page") %]", "https://twitter.com/[% twitter_account %]"]
 }
 </script>
+
+<script
+  type="text/javascript"
+  src="https://crowdin.com/js/crowdjet/crowdjet.js">
+</script>
+<div
+  id="crowdjet-container"
+  data-project-id="243092"
+  style="bottom: 90px; right: 20px;">
+</div>
+<div
+  id="crowdjet-expand-container"
+  style="bottom: 10px; right: 20px;">
+</div>
+
 </body>
 </html>
 

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -227,6 +227,12 @@
 	<h2 id="environmental_impact">[% lang('environmental_impact') %]</h2>
 [% END %]
 
+[% IF ecoscore_panel %]
+<p>Eco-Score knowledge panel (in development):</p>
+        [% ecoscore_panel %]
+<p>End of Eco-Score panel</p>
+[% END %]
+
 [% IF ecoscore_grade %]
 	<h4>Eco-score
 		<a href="[% url_for_text("ecoscore") %]" title="[% lang('ecoscore_information') %]">[% display_icon('info') %]</a>

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -56,7 +56,7 @@
                             [% FOREACH value IN row.item('values') %]
                                 <td>
                                     [% IF value.icon_url %]
-                                        <span class="icon"><img src="[% value.icon_url %]"></span>
+                                        <span class="icon"><img src="[% value.icon_url %]" alt="icon"></span>
                                     [% END %]
                                     [% IF value.percent.defined %]
                                         <div style="width:200px;float:left;margin-right:1rem;" class="show-for-large-up">

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -1,0 +1,80 @@
+[% panel = panels.$panel_id %]
+<!-- start templates/[% template.name %] - panel_id: [% panel_id %] -->
+<div class="panel[% IF panel.parent_panel_id == 'root' %] callout[% END %]" id="[% panel_id %]">
+    <div class="panel_title">
+        <h3>
+            [% IF panel.plus_or_minus %]
+                [% IF panel.plus_or_minus == "plus" %]
+                    <span class="icon" style="color:green">
+                        [% display_icon("check") %]
+                    </span>
+                [% ELSIF panel.plus_or_minus == "minus" %]
+                    <span class="icon" style="color:red">
+                        [% display_icon("cancel") %]
+                    </span>
+                [% ELSIF panel.plus_or_minus == "neutral" %]
+                    <span class="icon" style="color:grey">
+                        [% display_icon("check") %]
+                    </span>
+                [% ELSIF panel.plus_or_minus == "unknown" %]
+                    <span class="icon" style="color:grey">
+                        [% display_icon("help") %]
+                    </span>
+                [% END %]
+            [% END %]
+            [% panel.title %]
+        </h3>
+    </div>
+
+    [% FOREACH element_ref IN panel.elements %]
+        [% element_type = element_ref.element_type %]
+        [% element = element_ref.element %]
+        [% IF element_type == "panel" %]
+            [% INCLUDE web/panels/panel.tt.html panel_id = element.panel_id %]
+        [% ELSE %]
+        
+            [% IF element_type == "text" %]
+                [% IF element.text_type == "h1" %]<h4>[% END %]
+                    [% element.html %]
+                [% IF element.text_type == "h1" %]</h4>[% END %]
+
+            [% ELSIF element_type == "table" %]
+                <table[% IF element.table_id %] id="[% element.table_id %]"[% END %]>
+                    <caption style="text-align:left">[% element.title %]</caption>
+                    <thead>
+                        <tr>
+                            [% FOREACH header IN element.headers %]
+                            <th scope="col">
+                                [% header.text %]
+                            </th>
+                            [% END %]
+                        </tr>
+                    </thead>
+                    <tbody>
+                        [% FOREACH row IN element.rows %]
+                        <tr[% IF row.id %] id="[% row.id %]"[% END %]>
+                            [% FOREACH value IN row.item('values') %]
+                                <td>
+                                    [% IF value.icon_url %]
+                                        <span class="icon"><img src="[% value.icon_url %]"></span>
+                                    [% END %]
+                                    [% IF value.percent.defined %]
+                                        <div style="width:200px;float:left;margin-right:1rem;" class="show-for-large-up">
+                                            <div class="agribalyse_impact_bar_full">
+                                                <div class="agribalyse_impact_bar" style="width:[% round(2 * value.percent)%]px;background-color:#ffbb88;height:1.2rem;"></div>
+                                            </div>
+                                        </div>	
+                                    [% END %]                                                                          
+                                    [% value.text %]
+                                </td>                          
+                            [% END %]
+                        </tr>
+                        [% END %]
+                    </tbody>
+                </table>
+            [% END %]            
+
+        [% END %]
+    [% END %]
+</div>
+<!-- end templates/[% template.name %] - panel_id: [% panel_id %] -->


### PR DESCRIPTION
- See #5633

This PR:
- shows the Eco-Score panel next to the Eco-Score on product page when ?panels=1 is added to the URL.
- implements some basic functions to display panels and subpanels (currently just the text and table elements)

At this point, it is mostly for demo and development purposes, but the goal is to eventually replace the current Eco-Score + Eco-Score details display with the Eco-Score knowledge panel.

This is just a sample implementation to display the panels structure and data, the actual implementation of how we display panels on the web might be very different (e.g. using accordions, dropdowns, or modals to display panels and subpanels).