### PR TITLE
Disable deploy on main branch (temporarily)

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -2,8 +2,7 @@ name: Container Image Deployment CI
 
 on:
   push:
-    branches: 
-      - main
+    branches:
       - deploy-*
     tags: 
       - v*.*.*


### PR DESCRIPTION
Can be re-enabled once `restructure-docker` branch is merged (https://github.com/openfoodfacts/openfoodfacts-server/pull/5544)