### PR TITLE
Display note for Nutri-Score of teas and herbal teas bags

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -426,8 +426,6 @@ $options{categories_not_considered_as_beverages_for_nutriscore} = [qw(
 	en:dairy-drinks-substitutes
 	en:chocolate-powders
 	en:soups
-	en:tea-bags
-	en:herbal-teas
 )];
 
 # categories that are considered as beverages
@@ -438,6 +436,10 @@ $options{categories_considered_as_beverages_for_nutriscore} = [qw(
 	en:herbal-tea-beverages
 	en:coffee-beverages
 	en:coffee-drinks
+
+	en:coffees
+	en:herbal-teas
+	en:teas		
 )];
 
 $options{categories_exempted_from_nutriscore} = [qw(
@@ -446,9 +448,7 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:baby-foods
 	en:baby-milks
 	en:chewing-gum
-	en:coffees
 	en:food-additives
-	en:herbal-teas
 	en:meal-replacements
 	en:salts
 	en:spices
@@ -457,6 +457,13 @@ $options{categories_exempted_from_nutriscore} = [qw(
 	en:pet-food
 	en:non-food-products
 )];
+
+#	Coffees, teas and herbal teas can have a Nutri-Score if they have
+#	a nutrition facts table
+#
+#	en:coffees
+#	en:herbal-teas
+#	en:teas	
 
 # exceptions
 $options{categories_not_exempted_from_nutriscore} = [qw(

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8938,19 +8938,6 @@ sub display_nutrient_levels($) {
 	}
 
 
-
-	# do not compute a score for coffee, tea etc.
-	if (   ( has_tag( $product_ref, "categories", "en:alcoholic-beverages" ) )
-		or ( has_tag( $product_ref, "categories", "en:coffees" ) )
-		or ( has_tag( $product_ref, "categories", "en:teas" ) )
-		or ( has_tag( $product_ref, "categories", "en:teas" ) )
-		or ( has_tag( $product_ref, "categories", "fr:levure" ) )
-		or ( has_tag( $product_ref, "categories", "fr:levures" ) ) )
-	{
-
-			return "";
-	}
-
 	my $html_nutrition_grade = '';
 	my $html_nutrient_levels = '';
 
@@ -8966,6 +8953,16 @@ sub display_nutrient_levels($) {
 
 		# Do not display a warning for water
 		if (not (has_tag($product_ref, "categories", "en:spring-waters"))) {
+
+			# Warning for tea and herbal tea in bags: state that the Nutri-Score applies
+			# only when reconstituted with water only (no milk, no sugar)
+			if ((has_tag($product_ref, "categories", "en:tea-bags"))
+				or (has_tag($product_ref, "categories", "en:herbal-teas-in-tea-bags"))
+				# many tea bags are only under "en:teas", but there are also many tea beverages under "en:teas"
+				or ((has_tag($product_ref, "categories", "en:tea-bags")) and not (has_tag($product_ref, "categories", "en:tea-based-beverages")))
+				) {
+				$warning .= "<p>" . lang("nutrition_grade_fr_tea_bags_note") . "</p>";
+			}
 
 			# Combined message when we miss both fruits and fiber
 			if ((defined $product_ref->{nutrition_score_warning_no_fiber}) and ($product_ref->{nutrition_score_warning_no_fiber} == 1)

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8959,7 +8959,7 @@ sub display_nutrient_levels($) {
 			if ((has_tag($product_ref, "categories", "en:tea-bags"))
 				or (has_tag($product_ref, "categories", "en:herbal-teas-in-tea-bags"))
 				# many tea bags are only under "en:teas", but there are also many tea beverages under "en:teas"
-				or ((has_tag($product_ref, "categories", "en:tea-bags")) and not (has_tag($product_ref, "categories", "en:tea-based-beverages")))
+				or ((has_tag($product_ref, "categories", "en:teas")) and not (has_tag($product_ref, "categories", "en:tea-based-beverages")))
 				) {
 				$warning .= "<p>" . lang("nutrition_grade_fr_tea_bags_note") . "</p>";
 			}

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5704,3 +5704,7 @@ msgstr "medium"
 msgctxt "impact"
 msgid "impact"
 msgstr "impact"
+
+msgctxt "nutrition_grade_fr_tea_bags_note"
+msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5717,3 +5717,7 @@ msgstr "The information about this product's packaging is missing."
 msgctxt "medium"
 msgid "medium"
 msgstr "medium"
+
+msgctxt "nutrition_grade_fr_tea_bags_note"
+msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5520,3 +5520,6 @@ msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Eco-Score and more!"
 msgstr "Scannez les codes-barres pour obtenir le Nutri-Score, l'Eco-Score et plus !"
 
+msgctxt "nutrition_grade_fr_tea_bags_note"
+msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+msgstr "Note: le Nutri-Score des thés et tisanes correspond au produit préparé avec seulement de l'eau, sans sucre ni lait."


### PR DESCRIPTION
fixes #5644

This is to make it clear that the Nutri-Score of tea bags apply to the prepared product with water only.

![image](https://user-images.githubusercontent.com/8158668/132851998-909299e3-5fd8-4e62-aa11-7c43d1a73e62.png)
