### PR TITLE
i18n: Make 'X g / 100 g' translatable

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -1,7 +1,7 @@
 # This file is part of Product Opener.
 #
 # Product Opener
-# Copyright (C) 2011-2020 Association Open Food Facts
+# Copyright (C) 2011-2021 Association Open Food Facts
 # Contact: contact@openfoodfacts.org
 # Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
 #
@@ -1122,7 +1122,7 @@ sub compute_attribute_nutrient_level($$$$) {
 			if ($target_lc ne "data") {
 				$attribute_ref->{title} = sprintf(lang_in_other_lc($target_lc, "nutrient_in_quantity"), $Nutriments{$nid}{$target_lc} ,
 					lang_in_other_lc($target_lc, $product_ref->{nutrient_levels}{$nid} . "_quantity"));
-				$attribute_ref->{description_short} = (sprintf("%.2e", $product_ref->{nutriments}{$nid . $prepared . "_100g"}) + 0.0) . " g / 100 g";
+				$attribute_ref->{description_short} = sprintf lang_in_other_lc($target_lc, 'g_per_100g'), ($product_ref->{nutriments}{$nid . $prepared . '_100g'} + 0.0);
 			}
 		}
 	}

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -1122,7 +1122,10 @@ sub compute_attribute_nutrient_level($$$$) {
 			if ($target_lc ne "data") {
 				$attribute_ref->{title} = sprintf(lang_in_other_lc($target_lc, "nutrient_in_quantity"), $Nutriments{$nid}{$target_lc} ,
 					lang_in_other_lc($target_lc, $product_ref->{nutrient_levels}{$nid} . "_quantity"));
-				$attribute_ref->{description_short} = sprintf lang_in_other_lc($target_lc, 'g_per_100g'), ($product_ref->{nutriments}{$nid . $prepared . '_100g'} + 0.0);
+				$attribute_ref->{description_short} = sprintf(
+					lang_in_other_lc($target_lc, 'g_per_100g'),
+					(sprintf('%.2e', $product_ref->{nutriments}{$nid . $prepared . '_100g'}) + 0.0)
+				);
 			}
 		}
 	}

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5710,5 +5710,5 @@ msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product 
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 
 msgctxt "g_per_100g"
-msgid "%.2f g / 100 g"
-msgstr "%.2f g / 100 g"
+msgid "%s g / 100 g"
+msgstr "%s g / 100 g"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5708,3 +5708,7 @@ msgstr "impact"
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+
+msgctxt "g_per_100g"
+msgid "%.2f g / 100 g"
+msgstr "%.2f g / 100 g"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5723,5 +5723,5 @@ msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product 
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 
 msgctxt "g_per_100g"
-msgid "%.2f g / 100 g"
-msgstr "%.2f g / 100 g"
+msgid "%s g / 100 g"
+msgstr "%s g / 100 g"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5721,3 +5721,7 @@ msgstr "medium"
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+
+msgctxt "g_per_100g"
+msgid "%.2f g / 100 g"
+msgstr "%.2f g / 100 g"


### PR DESCRIPTION
**Description:** Introduces a new translation key `g_per_100g`, which can be used to translate the text `'%.2f g / 100 g'` into other languages. This is useful if a language uses other formatting, ie. RTL languages (as opposed to LTR languages).

- **Related issues and discussion:** #5640 
