### PR TITLE
fix: Move selected packaging photos to new main language

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -346,7 +346,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 				# Selected photos
 
-				foreach my $imageid ("front", "ingredients", "nutrition") {
+				foreach my $imageid ("front", "ingredients", "nutrition", "packaging") {
 
 					my $from_imageid = $imageid . "_" . $from_lc;
 					my $to_imageid = $imageid . "_" . $product_lc;


### PR DESCRIPTION
**Description:** In addition to front, ingredients, and nutrition, also copy the selected packaging image when changing a product's main language.
**Related issues and discussion:** Fixes #5657 
