### PR TITLE
Improvements for Eco-Score knowledge panels #5541

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -1407,6 +1407,20 @@ sub localize_ecoscore ($$) {
 			
 			$product_ref->{ecoscore_data}{adjustments}{origins_of_ingredients}{"transportation_value"}
 			= $product_ref->{ecoscore_data}{adjustments}{origins_of_ingredients}{"transportation_value_" . $cc};
+
+			# For each origin, we also add its score (EPI + transporation to country of request)
+			# so that clients can show which ingredients contributes the most to the origins of ingredients bonus / malus
+
+			if (defined $product_ref->{ecoscore_data}{adjustments}{origins_of_ingredients}{aggregated_origins}) {
+			
+				foreach my $origin_ref (@{$product_ref->{ecoscore_data}{adjustments}{origins_of_ingredients}{aggregated_origins}}) {
+		
+					my $origin_id = $origin_ref->{origin};
+					$origin_ref->{epi_score} = $ecoscore_data{origins}{$origin_id}{epi_score};
+					$origin_ref->{transportation_score} = $ecoscore_data{origins}{$origin_id}{"transportation_score_" . $cc};
+				}
+			}
+
 		}
 	}		
 	

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -163,6 +163,23 @@ sub create_knowledge_panels($$$$) {
 }
 
 
+=head2 convert_multiline_string_to_singleline($line)
+
+Helper function to allow to enter multiline strings in JSON templates.
+The function converts the multiline string into a single line string.
+
+=cut
+
+sub convert_multiline_string_to_singleline($) {
+    my $line = shift;
+    $line =~ s/\n/\\n/sg;
+    # Escape quotes unless they have been escaped already
+    # negative look behind to not convert \" to \\"
+    $line =~ s/(?<!\\)"/\\"/g;
+    return '"' . $line . '"';
+}
+
+
 =head2 create_panel_from_json_template ( $panel_id, $panel_template, $panel_data_ref, $product_ref, $target_lc, $target_cc )
 
 Creates a knowledge panel from a JSON template.
@@ -243,15 +260,6 @@ sub create_panel_from_json_template ($$$$$$) {
         # e.g. when we want to generate HTML
 
         # Also escape quotes " to \"
-
-        sub convert_multiline_string_to_singleline($) {
-            my $line = shift;
-            $line =~ s/\n/\\n/sg;
-            # Escape quotes unless they have been escaped already
-            # negative look behind to not convert \" to \\"
-            $line =~ s/(?<!\\)"/\\"/g;
-            return '"' . $line . '"';
-        }
 
         $panel_json =~ s/\`([^\`]*)\`/convert_multiline_string_to_singleline($1)/seg;
 

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -227,9 +227,14 @@ sub create_panel_from_json_template ($$$$$$) {
         # In the template, we use multiline strings for readability
         # e.g. when we want to generate HTML
 
+        # Also escape quotes " to \"
+
         sub convert_multiline_string_to_singleline($) {
             my $line = shift;
             $line =~ s/\n/\\n/sg;
+            # Escape quotes unless they have been escaped already
+            # negative look behind to not convert \" to \\"
+            $line =~ s/(?<!\\)"/\\"/g;
             return '"' . $line . '"';
         }
 
@@ -365,31 +370,15 @@ sub create_ecoscore_panel($$$) {
         create_panel_from_json_template("ecoscore_agribalyse", "api/knowledge-panels/ecoscore/agribalyse.tt.json",
             $panel_data_ref, $product_ref, $target_lc, $target_cc);
 
-        # TODO: add panels for the different bonuses and maluses
+        # Add panels for the different bonuses and maluses
 
         foreach my $adjustment ("production_system", "origins_of_ingredients", "threatened_species", "packaging") {
 
-            my $plus_or_minus;
-
-            if (not defined $product_ref->{ecoscore_data}{adjustments}{$adjustment}{value}) {
-                $plus_or_minus = "unknown";
-            }
-            elsif ($product_ref->{ecoscore_data}{adjustments}{$adjustment}{value} < 0) {
-                $plus_or_minus = "minus";
-            }
-            else {
-                $plus_or_minus = "plus";
-            }
-
-            $title = lang("ecoscore_" . $adjustment);
-
-            $panel_data_ref = {
-                "plus_or_minus" => $plus_or_minus,
-                "title" => $title,
+            my $adjustment_panel_data_ref = {
             };            
 
             create_panel_from_json_template("ecoscore_" . $adjustment, "api/knowledge-panels/ecoscore/" . $adjustment . ".tt.json",
-                $panel_data_ref, $product_ref, $target_lc, $target_cc);
+                $adjustment_panel_data_ref, $product_ref, $target_lc, $target_cc);
         }
 
 	}

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -169,6 +169,16 @@ Creates a knowledge panel from a JSON template.
 The template is passed both the full product data + optional panel specific data.
 The template is thus responsible for all the display logic (what to display and how to display it).
 
+Some special features that are not included in the JSON format are supported:
+
+1. Multiline strings can be included using backticks ` at the start and end of the multinine strings.
+- The multiline strings will be converted to a single string.
+- Quotes " are automatically escaped unless they are already escaped
+
+2. Comments can be included by starting a line with //
+- Comments will be removed in the resulting JSON, they are only intended to make the source template easier to understand.
+
+
 =head3 Arguments
 
 =head4 panel id $panel_id
@@ -222,6 +232,11 @@ sub create_panel_from_json_template ($$$$$$) {
     else {
 
         # Turn the JSON to valid JSON
+
+        # Remove comment lines starting with //
+        # comments are not allowed in JSON, but they can be useful to have in the templates source
+        # /m modifier: ^ and $ match the start and end of each line
+        $panel_json =~ s/^(\s*)\/\/(.*)$//mg;
 
         # Convert multilines strings between backticks `` into single line strings
         # In the template, we use multiline strings for readability

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5696,6 +5696,22 @@ msgctxt "ecoscore_packaging_missing_information"
 msgid "The information about this product's packaging is missing."
 msgstr "The information about this product's packaging is missing."
 
+msgctxt "ecoscore_origins_of_ingredients_impact_high"
+msgid "Transportation and origins of ingredients have a high impact."
+msgstr "Transportation and origins of ingredients have a high impact."
+
+msgctxt "ecoscore_origins_of_ingredients_impact_medium"
+msgid "Transportation and origins of ingredients have a medium impact."
+msgstr "Transportation and origins of ingredients have a medium impact."
+
+msgctxt "ecoscore_origins_of_ingredients_impact_low"
+msgid "Transportation and origins of ingredients have a low impact."
+msgstr "Transportation and origins of ingredients have a low impact."
+
+msgctxt "ecoscore_origins_of_ingredients_missing_information"
+msgid "The information about this product's origins of ingredients is missing."
+msgstr "The information about this product's origins of ingredients is missing."
+
 # medium as in "medium impact"
 msgctxt "medium"
 msgid "medium"
@@ -5708,7 +5724,3 @@ msgstr "impact"
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-
-msgctxt "g_per_100g"
-msgid "%s g / 100 g"
-msgstr "%s g / 100 g"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5728,3 +5728,7 @@ msgstr "impact"
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+
+msgctxt "g_per_100g"
+msgid "%s g / 100 g"
+msgstr "%s g / 100 g"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5712,6 +5712,10 @@ msgctxt "ecoscore_origins_of_ingredients_missing_information"
 msgid "The information about this product's origins of ingredients is missing."
 msgstr "The information about this product's origins of ingredients is missing."
 
+msgctxt "percent_of_ingredients"
+msgid "% of ingredients"
+msgstr "% of ingredients"
+
 # medium as in "medium impact"
 msgctxt "medium"
 msgid "medium"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5733,7 +5733,6 @@ msgctxt "percent_of_ingredients"
 msgid "% of ingredients"
 msgstr "% of ingredients"
 
-
 # medium as in "medium impact"
 msgctxt "medium"
 msgid "medium"
@@ -5742,3 +5741,7 @@ msgstr "medium"
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
+
+msgctxt "g_per_100g"
+msgid "%s g / 100 g"
+msgstr "%s g / 100 g"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5713,6 +5713,22 @@ msgctxt "ecoscore_packaging_missing_information"
 msgid "The information about this product's packaging is missing."
 msgstr "The information about this product's packaging is missing."
 
+msgctxt "ecoscore_origins_of_ingredients_impact_high"
+msgid "Transportation and origins of ingredients have a high impact."
+msgstr "Transportation and origins of ingredients have a high impact."
+
+msgctxt "ecoscore_origins_of_ingredients_impact_medium"
+msgid "Transportation and origins of ingredients have a medium impact."
+msgstr "Transportation and origins of ingredients have a medium impact."
+
+msgctxt "ecoscore_origins_of_ingredients_impact_low"
+msgid "Transportation and origins of ingredients have a low impact."
+msgstr "Transportation and origins of ingredients have a low impact."
+
+msgctxt "ecoscore_origins_of_ingredients_missing_information"
+msgid "The information about this product's origins of ingredients is missing."
+msgstr "The information about this product's origins of ingredients is missing."
+
 # medium as in "medium impact"
 msgctxt "medium"
 msgid "medium"
@@ -5721,7 +5737,3 @@ msgstr "medium"
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-
-msgctxt "g_per_100g"
-msgid "%s g / 100 g"
-msgstr "%s g / 100 g"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5729,6 +5729,11 @@ msgctxt "ecoscore_origins_of_ingredients_missing_information"
 msgid "The information about this product's origins of ingredients is missing."
 msgstr "The information about this product's origins of ingredients is missing."
 
+msgctxt "percent_of_ingredients"
+msgid "% of ingredients"
+msgstr "% of ingredients"
+
+
 # medium as in "medium impact"
 msgctxt "medium"
 msgid "medium"

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -402,6 +402,10 @@ h4 > .icon {
   &.green {
     background-color: #47a647;
   }
+
+  &.grey {
+    background-color: #444444;
+  }
 }
 
 .red {
@@ -414,6 +418,10 @@ h4 > .icon {
 
 .green {
   color: #47a647;
+}
+
+.grey {
+  color: #444444;
 }
 
 .percent_bar {

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -371,6 +371,10 @@ details.recent {
   height:1em;
 }
 
+h3 > .icon {
+  font-size:24px;
+}
+
 h4 > .icon {
   font-size:24px;
 }
@@ -399,6 +403,36 @@ h4 > .icon {
     background-color: #47a647;
   }
 }
+
+.red {
+  color: #ec5656;
+}
+
+.orange {
+  color: #f9904c;
+}
+
+.green {
+  color: #47a647;
+}
+
+.percent_bar {
+  background-color:#88bbff;
+}
+
+.percent_bar.red {
+  background-color: #ec5656;
+}
+
+.percent_bar.orange {
+  background-color: #f9904c;
+}
+
+.percent_bar.green {
+  background-color: #47a647;
+}
+
+
 
 a[aria-controls="idOfLeftMenu"] {
 

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -32,7 +32,7 @@
         {
             "element_type": "table",
             "element": {
-                "table_id": "ecoscore_lca_impacts_by_stages",
+                "id": "ecoscore_lca_impacts_by_stages_table",
                 "table_type": "percents",
                 "title": "[% lang('ecoscore_impact_detail_by_stages') %]",
                 "headers": [
@@ -41,6 +41,7 @@
                     },
                     {
                         "text": "[% lang('ecoscore_impact') %]",
+                        "type": "percent",
                     }
                 ],
                 "rows": [

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -35,9 +35,10 @@
                 "id": "ecoscore_lca_impacts_by_stages_table",
                 "table_type": "percents",
                 "title": "[% lang('ecoscore_impact_detail_by_stages') %]",
-                "headers": [
+                "columns": [
                     {
                         "text": "[% lang('ecoscore_stage') %]",
+                        "type": "text",
                     },
                     {
                         "text": "[% lang('ecoscore_impact') %]",

--- a/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/agribalyse.tt.json
@@ -54,7 +54,7 @@
                             },
                             {
                                 [% ef_step = "ef_$step" %]
-                                "text": "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %]",
+                                "text": "[% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) FILTER format('%.1f'); %] %",
                                 "percent": [% (100 * product.ecoscore_data.agribalyse.$ef_step / product.ecoscore_data.agribalyse.ef_total) %]
                             }
                         ],

--- a/templates/api/knowledge-panels/ecoscore/ecoscore_unknown.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/ecoscore_unknown.tt.json
@@ -7,7 +7,7 @@
         "environment"
     ],
     "icon_url": "[% static_subdomain %]/images/attributes/ecoscore-unknown.svg",
-    "title": "[% lang($lc, "attribute_ecoscore_unknown_title") %] - [% lang($target_lc, "attribute_ecoscore_unknown_description_short") %]",
+    "title": "[% lang("attribute_ecoscore_unknown_title") %] - [% lang("attribute_ecoscore_unknown_description_short") %]",
     "elements": [
         {
             "element_type": "text",

--- a/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
@@ -2,20 +2,87 @@
     "parent_panel_id": "ecoscore",
     "type" : "score",
     "level" :"info",
-    "grade": "[% panel.grade %]",
     "topics": [
         "environment"
     ],
-    "title": "[% panel.title %]",
+[% IF adjustments.origins_of_ingredients.warning == "origins_are_100_percent_unknown" %]
+    "plus_or_minus": "unknown",
+    "title": "[% lang('ecoscore_ingredients_not_indicated') %]",
     "elements": [
         {
             "element_type": "text",
             "element": {
-                "text_type": "summary",
+                "text_type": "warning",
                 "html": `
-                    <p>[give more details here]</p> 
+                [% lang('ecoscore_please_add_the_ingredients') %]<br><br>
+                [% lang('ecoscore_platform_prompt_ecoscore_modal') %]
                     `
             }
+        }, 
+[% ELSE %]
+    [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 0 %]
+    "plus_or_minus": "minus",
+    "title": "[% lang('ecoscore_origins_of_ingredients_impact_high') %]",
+    [% ELSIF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 15 %]
+    "plus_or_minus": "neutral",
+    "title": "[% lang('ecoscore_origins_of_ingredients_impact_medium') %]",    
+    [% ELSE %]
+    "plus_or_minus": "plus",
+    "title": "[% lang('ecoscore_origins_of_ingredients_impact_low') %]",      
+    [% END %]
+    "elements": [
+        {
+            "element_type": "table",
+            "element": {
+                "table_id": "ecoscore_origins_of_ingredients",
+                "table_type": "percents",
+                "title": "[% lang('ecoscore_origins_of_ingredients') %]",
+                "headers": [
+                    { "text": "[% lang('origin') %]"},
+                    { "text": "%"},
+                    {
+                        "text": "[% lang('ecoscore_impact') %]",
+                    }
+                ],
+                "rows": [
+                    [% FOREACH origin IN product.ecoscore_data.adjustments.origins_of_ingredients.aggregated_origins %]
+                    {
+                        "values": [
+                            {
+                                "text": "[% display_taxonomy_tag("origins",origin.origin) %]",
+                            },
+                            {
+                                "text": "[% round(origin.percent) %] %",
+                                "percent": [% round(origin.percent) %],
+                                // EPI bonus goes from -5 to 5 with the formula bonus = epi_score / 10 - 5
+                                // Transportation bonus goes from 0 to 15 with the formula bonus = transportation_score * 0.15
+                                [% SET score = origin.epi_score / 10 - 5 + origin.transportation_score * 0.15 %]
+                                [% IF score >= 15 %]
+                                    "percent_color": "green"
+                                [% ELSIF score <= 0 %]
+                                    "percent_color": "red"
+                                [% ELSE %]
+                                    "percent_color": "orange"
+                                [% END %]                                
+                            },
+                            {
+                                [% IF score >= 15 %]
+                                    "text": "[% lang('low') FILTER ucfirst %]",
+                                    "color": "green"
+                                [% ELSIF score <= 0 %]
+                                    "text": "[% lang('high') FILTER ucfirst %]",
+                                    "color": "red"
+                                [% ELSE %]
+                                    "text": "[% lang('medium') FILTER ucfirst %]",
+                                    "color": "orange"
+                                [% END %]
+                            }
+                            ]
+                    },
+                    [% END %]
+                ]
+            }
         },
+[% END %]
     ]
 }

--- a/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
@@ -39,7 +39,7 @@
                 "title": "[% lang('ecoscore_origins_of_ingredients') %]",
                 "headers": [
                     { "text": "[% lang('origin') %]"},
-                    { "text": "%"},
+                    { "text": "[% lang('percent_of_ingredients') %]"},
                     {
                         "text": "[% lang('ecoscore_impact') %]",
                     }

--- a/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
@@ -6,7 +6,7 @@
         "environment"
     ],
 [% IF adjustments.origins_of_ingredients.warning == "origins_are_100_percent_unknown" %]
-    "plus_or_minus": "unknown",
+    "evaluation": "unknown",
     "title": "[% lang('ecoscore_ingredients_not_indicated') %]",
     "elements": [
         {
@@ -21,25 +21,30 @@
         }, 
 [% ELSE %]
     [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 0 %]
-    "plus_or_minus": "minus",
+    "evaluation": "bad",
     "title": "[% lang('ecoscore_origins_of_ingredients_impact_high') %]",
     [% ELSIF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 15 %]
-    "plus_or_minus": "neutral",
+    "evaluation": "neutral",
     "title": "[% lang('ecoscore_origins_of_ingredients_impact_medium') %]",    
     [% ELSE %]
-    "plus_or_minus": "plus",
+    "evaluation": "good",
     "title": "[% lang('ecoscore_origins_of_ingredients_impact_low') %]",      
     [% END %]
     "elements": [
         {
             "element_type": "table",
             "element": {
-                "table_id": "ecoscore_origins_of_ingredients",
+                "id": "ecoscore_origins_of_ingredients_table",
                 "table_type": "percents",
                 "title": "[% lang('ecoscore_origins_of_ingredients') %]",
                 "headers": [
-                    { "text": "[% lang('origin') %]"},
-                    { "text": "[% lang('percent_of_ingredients') %]"},
+                    {
+                        "text": "[% lang('origin') %]"
+                    },
+                    {
+                        "text": "[% lang('percent_of_ingredients') %]",
+                        "type": "percent",
+                    },
                     {
                         "text": "[% lang('ecoscore_impact') %]",
                     }
@@ -58,23 +63,23 @@
                                 // Transportation bonus goes from 0 to 15 with the formula bonus = transportation_score * 0.15
                                 [% SET score = origin.epi_score / 10 - 5 + origin.transportation_score * 0.15 %]
                                 [% IF score >= 15 %]
-                                    "percent_color": "green"
+                                    "evaluation": "good",
                                 [% ELSIF score <= 0 %]
-                                    "percent_color": "red"
+                                    "evaluation": "bad",
                                 [% ELSE %]
-                                    "percent_color": "orange"
+                                    "evaluation": "neutral",
                                 [% END %]                                
                             },
                             {
                                 [% IF score >= 15 %]
                                     "text": "[% lang('low') FILTER ucfirst %]",
-                                    "color": "green"
+                                    "evaluation": "good",
                                 [% ELSIF score <= 0 %]
                                     "text": "[% lang('high') FILTER ucfirst %]",
-                                    "color": "red"
+                                    "evaluation": "bad",
                                 [% ELSE %]
                                     "text": "[% lang('medium') FILTER ucfirst %]",
-                                    "color": "orange"
+                                    "evaluation": "neutral",
                                 [% END %]
                             }
                             ]

--- a/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/origins_of_ingredients.tt.json
@@ -37,9 +37,10 @@
                 "id": "ecoscore_origins_of_ingredients_table",
                 "table_type": "percents",
                 "title": "[% lang('ecoscore_origins_of_ingredients') %]",
-                "headers": [
+                "columns": [
                     {
-                        "text": "[% lang('origin') %]"
+                        "text": "[% lang('origin') %]",
+                        "type": "text",
                     },
                     {
                         "text": "[% lang('percent_of_ingredients') %]",
@@ -47,6 +48,7 @@
                     },
                     {
                         "text": "[% lang('ecoscore_impact') %]",
+                        "type": "text",
                     }
                 ],
                 "rows": [

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -6,7 +6,7 @@
         "environment"
     ],
 [% IF not (product.ecoscore_data.adjustments.packaging.packagings && product.ecoscore_data.adjustments.packaging.packagings.size) %]
-    "plus_or_minus": "unknown",
+    "evaluation": "unknown",
     "title": "[% lang('ecoscore_packaging_missing_information') %]",
     "elements": [
         {
@@ -20,13 +20,13 @@
         }, 
 [% ELSE %]
     [% IF product.ecoscore_data.adjustments.packaging.value <= -15 %]
-    "plus_or_minus": "minus",
+    "evaluation": "bad",
     "title": "[% lang('ecoscore_packaging_impact_high') %]",
     [% ELSIF product.ecoscore_data.adjustments.packaging.value <= -5 %]
-    "plus_or_minus": "neutral",
+    "evaluation": "neutral",
     "title": "[% lang('ecoscore_packaging_impact_medium') %]",    
     [% ELSE %]
-    "plus_or_minus": "plus",
+    "evaluation": "good",
     "title": "[% lang('ecoscore_packaging_impact_low') %]",      
     [% END %]
     "elements": [
@@ -44,7 +44,7 @@
                 ],
                 "rows": [
                     [% FOREACH packaging IN product.ecoscore_data.adjustments.packaging.packagings %]
-                    [% score = packaging.ecoscore_material_score * packaging.ecoscore_shape_ratio %]
+                    [% score = packaging.ecoscore_material_score %]
                     {
                         "values": [
                             {
@@ -54,18 +54,23 @@
                                 "text": "[% display_taxonomy_tag('packaging_materials',packaging.material) %]"
                             },
                             {
-                                "text": "[% display_taxonomy_tag('packaging_recycling',packaging.recycling) %]"
+                                "text": "[% display_taxonomy_tag('packaging_recycling',packaging.recycling) %]",
+                                [% IF packaging.recycling == "en:recycle" %]
+                                    "evaluation": "good",
+                                [% ELSIF packaging.recycling == "en:discard" %]
+                                    "evaluation": "bad",
+                                [% END %]
                             },
                             {
                             [% IF score >= 75 %]
                                 "text": "[% lang('low') FILTER ucfirst %]",
-                                "color": "green"
+                                "evaluation": "good",
                             [% ELSIF score <= 25 %]
                                 "text": "[% lang('high') FILTER ucfirst %]",
-                                "color": "red"
+                                "evaluation": "bad",
                             [% ELSE %]
                                 "text": "[% lang('medium') FILTER ucfirst %]",
-                                "color": "orange"
+                                "evaluation": "neutral",
                             [% END %]
                             }
                         ]

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -5,6 +5,20 @@
     "topics": [
         "environment"
     ],
+[% IF not (product.ecoscore_data.adjustments.packaging.packagings && product.ecoscore_data.adjustments.packaging.packagings.size) %]
+    "plus_or_minus": "unknown",
+    "title": "[% lang('ecoscore_packaging_missing_information') %]",
+    "elements": [
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "warning",
+                "html": `
+                    [% lang('ecoscore_no_packaging_information') %]
+                    `
+            }
+        }, 
+[% ELSE %]
     [% IF product.ecoscore_data.adjustments.packaging.value <= -15 %]
     "plus_or_minus": "minus",
     "title": "[% lang('ecoscore_packaging_impact_high') %]",
@@ -16,16 +30,6 @@
     "title": "[% lang('ecoscore_packaging_impact_low') %]",      
     [% END %]
     "elements": [
-        {
-            "element_type": "text",
-            "element": {
-                "text_type": "summary",
-                "html": `
-                    <p>[give more details here]</p> 
-                    `
-            }
-        },
-        [% IF product.ecoscore_data.adjustments.packaging.packagings && product.ecoscore_data.adjustments.packaging.packagings.size %]
         {
             "element_type": "table",
             "element": {
@@ -69,7 +73,31 @@
                     [% END %]
                 ]
             }
-        }
-        [% END %]         
+        },
+        [% IF product.ecoscore_data.adjustments.packaging.warning %]
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "warning",
+                "html": `
+                    [% lang('ecoscore_unprecise_packaging_information') %]
+                    `
+            }
+        },         
+        [% END %]
+[% END %]           
+        [% IF product.ecoscore_data.adjustments.packaging.warning %]
+        {
+            "element_type": "text",
+            "element": {
+                "text_type": "warning",
+                "html": `
+                [% lang('ecoscore_edit_for_more_precise_ecoscore') %]
+                <br><br>
+                [% lang('ecoscore_platform_prompt_ecoscore_modal') %]
+                    `
+            }
+        },
+        [% END %]
     ]
 }

--- a/templates/api/knowledge-panels/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/packaging.tt.json
@@ -36,11 +36,23 @@
                 "table_id": "ecoscore_packaging_components",
                 "table_type": "table",
                 "title": "[% lang('packaging_parts') %]",
-                "headers": [
-                    { "text": "[% lang('packaging_shape') %]"},
-                    { "text": "[% lang('packaging_material') %]"},
-                    { "text": "[% lang('packaging_recycling') %]"},
-                    { "text": "[% lang('ecoscore_impact') %]"}
+                "columns": [
+                    {
+                        "text": "[% lang('packaging_shape') %]",
+                        "type": "text",
+                    },
+                    { 
+                        "text": "[% lang('packaging_material') %]",
+                        "type": "text",
+                    },
+                    { 
+                        "text": "[% lang('packaging_recycling') %]",
+                        "type": "text",
+                    },
+                    { 
+                        "text": "[% lang('ecoscore_impact') %]",
+                        "type": "text",
+                    }
                 ],
                 "rows": [
                     [% FOREACH packaging IN product.ecoscore_data.adjustments.packaging.packagings %]

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -3,20 +3,20 @@
 <div class="panel[% IF panel.parent_panel_id == 'root' %] callout[% END %]" id="[% panel_id %]">
     <div class="panel_title">
         <h3>
-            [% IF panel.plus_or_minus %]
-                [% IF panel.plus_or_minus == "plus" %]
+            [% IF panel.evaluation %]
+                [% IF panel.evaluation == "good" %]
                     <span class="icon" style="color:green">
                         [% display_icon("check") %]
                     </span>
-                [% ELSIF panel.plus_or_minus == "minus" %]
+                [% ELSIF panel.evaluation == "bad" %]
                     <span class="icon" style="color:red">
                         [% display_icon("cancel") %]
                     </span>
-                [% ELSIF panel.plus_or_minus == "neutral" %]
+                [% ELSIF panel.evaluation == "neutral" %]
                     <span class="icon" style="color:grey">
                         [% display_icon("check") %]
                     </span>
-                [% ELSIF panel.plus_or_minus == "unknown" %]
+                [% ELSIF panel.evaluation == "unknown" %]
                     <span class="icon" style="color:grey">
                         [% display_icon("help") %]
                     </span>
@@ -61,12 +61,24 @@
                                     [% IF value.percent.defined %]
                                         <div style="width:200px;float:left;margin-right:1rem;" class="show-for-large-up">
                                             <div class="agribalyse_impact_bar_full">
-                                                <div class="percent_bar[% IF value.percent_color.defined %] [% value.percent_color %][% END %]" style="width:[% round(2 * value.percent)%]px;height:1.2rem;"></div>
+                                                <div class="percent_bar
+                                                    [% IF value.evaluation == 'good' %] green
+                                                    [% ELSIF value.evaluation == 'neutral' %] orange
+                                                    [% ELSIF value.evaluation == 'bad' %] red
+                                                    [% ELSIF value.evaluation == 'unknown' %] grey
+                                                    [% END %]
+                                                    "
+                                                    style="width:[% round(2 * value.percent)%]px;height:1.2rem;"></div>
+                                                </div>
                                             </div>
-                                        </div>	
-                                    [% END %]
-                                    [% IF value.color.defined %]
-                                        <span class="[% value.color %]">[% value.text %]</span>
+                                        </div>
+                                        [% value.text %]
+                                    [% ELSIF value.evaluation.defined %]
+                                        <span class="[% IF value.evaluation == 'good' %] green
+                                        [% ELSIF value.evaluation == 'neutral' %] orange
+                                        [% ELSIF value.evaluation == 'bad' %] red
+                                        [% ELSIF value.evaluation == 'unknown' %] grey
+                                        [% END %]">[% value.text %]</span>
                                     [% ELSE %]
                                         [% value.text %]
                                     [% END %]

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -43,9 +43,9 @@
                     <caption style="text-align:left">[% element.title %]</caption>
                     <thead>
                         <tr>
-                            [% FOREACH header IN element.headers %]
+                            [% FOREACH column IN element.columns %]
                             <th scope="col">
-                                [% header.text %]
+                                [% column.text %]
                             </th>
                             [% END %]
                         </tr>

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -61,11 +61,15 @@
                                     [% IF value.percent.defined %]
                                         <div style="width:200px;float:left;margin-right:1rem;" class="show-for-large-up">
                                             <div class="agribalyse_impact_bar_full">
-                                                <div class="agribalyse_impact_bar" style="width:[% round(2 * value.percent)%]px;background-color:#ffbb88;height:1.2rem;"></div>
+                                                <div class="percent_bar[% IF value.percent_color.defined %] [% value.percent_color %][% END %]" style="width:[% round(2 * value.percent)%]px;height:1.2rem;"></div>
                                             </div>
                                         </div>	
-                                    [% END %]                                                                          
-                                    [% value.text %]
+                                    [% END %]
+                                    [% IF value.color.defined %]
+                                        <span class="[% value.color %]">[% value.text %]</span>
+                                    [% ELSE %]
+                                        [% value.text %]
+                                    [% END %]
                                 </td>                          
                             [% END %]
                         </tr>


### PR DESCRIPTION
Improvements to the Eco-Score panels.

- Enhance the backticks feature to escape quotes in JSON templates
- Allow comments in the JSON templates
- Move the logic to decide if an adjustment is a plus or minus directly in the template for each adjustment.
- Add some warnings when packaging info is missing.
- Added origins of ingredients table
- Support for colored percent bars