### PR TITLE
Fix daily MongoDB task + add refresh_products_tags.js cron

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -27,8 +27,8 @@ jobs:
 
   dev-db-sync:
     runs-on: ubuntu-latest
-    environment: off-net
-    concurrency: off-net
+    environment: mongo-dev
+    concurrency: mongo-dev
     steps:
     - name: Sync prod db data to dev MongoDB
       uses: appleboy/ssh-action@master
@@ -44,3 +44,22 @@ jobs:
           cd openfoodfacts-server/
           make import_prod_data
           make restart_db
+
+  refresh-products-tags:
+    runs-on: ubuntu-latest
+    environment: mongo-dev
+    concurrency: mongo-dev
+    steps:
+    - name: Refresh MongoDB products_tags collection
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_host: ${{ secrets.PROXY_HOST }}
+        proxy_username: ${{ secrets.USERNAME }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        script_stop: false
+        script: |
+          cd openfoodfacts-server/
+          make refresh_product_tags

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,3 +43,4 @@ jobs:
         script: |
           cd openfoodfacts-server/
           make import_prod_data
+          make restart_db

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,11 @@ import_prod_data:
 	${DOCKER_COMPOSE} exec -T mongodb /bin/sh -c "cd /data/db && tar -xzvf openfoodfacts-mongodbdump.tar.gz && mongorestore --batchSize=1 && rm openfoodfacts-mongodbdump.tar.gz"
 	rm openfoodfacts-mongodbdump.tar.gz
 
+refresh_product_tags:
+	@echo "🥫 Refreshing products tags (update MongoDB products_tags collection) …"
+	docker cp scripts/refresh_products_tags.js po_mongodb_1:/data/db
+	${DOCKER_COMPOSE} exec -T mongodb /bin/sh -c "mongo off /data/db/refresh_products_tags.js"
+
 #------------#
 # Production #
 #------------#

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ restart:
 	@echo "🥫 Restarting frontend & backend containers …"
 	${DOCKER_COMPOSE} restart backend frontend
 
+restart_db:
+	@echo: "🥫 Restarting MongoDB database …"
+	${DOCKER_COMPOSE} restart mongodb
+
 status:
 	@echo "🥫 Getting container status …"
 	${DOCKER_COMPOSE} ps
@@ -94,12 +98,12 @@ import_sample_data:
 import_prod_data:
 	@echo "🥫 Importing production data (~2M products) into MongoDB …"
 	@echo "🥫 This might take up to 10 mn, so feel free to grab a coffee!"
-	echo "🥫 Downloading the full MongoDB dump …"
+	echo "🥫 Downloading full MongoDB dump from production …"
 	wget https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz
 	echo "🥫 Copying the dump to MongoDB container …"
 	docker cp openfoodfacts-mongodbdump.tar.gz po_mongodb_1:/data/db
 	echo "🥫 Restoring the MongoDB dump …"
-	${DOCKER_COMPOSE} exec mongodb /bin/sh -c "cd /data/db && tar -xzvf openfoodfacts-mongodbdump.tar.gz && mongorestore"
+	${DOCKER_COMPOSE} exec -T mongodb /bin/sh -c "cd /data/db && tar -xzvf openfoodfacts-mongodbdump.tar.gz && mongorestore --batchSize=1 && rm openfoodfacts-mongodbdump.tar.gz"
 	rm openfoodfacts-mongodbdump.tar.gz
 
 #------------#

--- a/docker/mongodb.yml
+++ b/docker/mongodb.yml
@@ -1,11 +1,13 @@
 version: "3.7"
 services:
   mongodb:
+    restart: always
     image: mongo:4.4
     volumes:
-      - dbdata:/var/lib/mongodb
+      - dbdata:/data/db
     ports:
       - 27017:27017
 volumes:
   dbdata:
     external: true
+  

--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -1,4 +1,13 @@
 ﻿version: "3.7"
+services:
+  memcached:
+    restart: always
+  postgres:
+    restart: always
+  backend:
+    restart: always
+  frontend:
+    restart: always
 volumes:
   icons_dist:
     external: true


### PR DESCRIPTION
This makes sure that the `mongorestore` command will not go OOM. 

Proxmox VM size has been increased from 4GB to 16GB since the process takes at least 14GB of RAM to run. Disk space has also been increased by ~60GB.

Also: 
- [x] fix for the data directory mount for MongoDB, and set restart policy to always for all deployments (advised for prod deployments).
- [x] add cron for `refresh_products_tags.js` script that creates the MongoDB collection `products_tags`