### PR TITLE
Fix incron job

### DIFF
--- a/conf/incron.conf
+++ b/conf/incron.conf
@@ -1,1 +1,1 @@
-/mnt/podata/new_images IN_CREATE /opt/product-opener/scripts/process_new_image_off.sh $@/$# /opt/product-opener
+/mnt/podata/new_images IN_CREATE /opt/product-opener/scripts/process_new_image_off.sh $@/$# /opt/product-opener >> /mnt/podata/logs/incrond.log


### PR DESCRIPTION
Summary:

- Running incrond -n was working (I could symlink an image into /opt/product-opener/new_images and it was processed properly)
- Running incrond starts it as a service, and nothing was triggered when I symlinked

The incrontab conf we were using was:
`/mnt/podata/new_images IN_CREATE /opt/product-opener/scripts/process_new_image_off.sh $@/$# /opt/product-opener`

I wanted to figure out what was going on so I redirect the output to a log file:

`/mnt/podata/new_images IN_CREATE /opt/product-opener/scripts/process_new_image_off.sh $@/$# /opt/product-opener > /mnt/podata/logs/test.log`

and to my surprise after doing this the incron job is working ...

What was going on actually is that incrond tries to write to `/var/log/syslog` (there is no way to change this in `/etc/incrond.conf` ...) but this file doesn't exist in Docker since syslog is disabled, so it probably errors out while trying to write it's own log ...