### PR TITLE
make svgmin remove width/height and keep/add viewBox

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,14 @@ function icons() {
       svgmin({
       plugins: [
         {
+          name: "removeViewBox",
+          active: false
+        },
+        {
+          name: "removeDimensions",
+          active: true,
+        },
+        {
           name: "addClassesToSVGElement",
           active: true,
           params: { className: "icon" }


### PR DESCRIPTION
If svg icons have the width and height attributes set, instead of the viewBox attribute, it makes it harder to display them at different sizes using CSS styles.

e.g. with viewBox:

icons are resized to 18px through CSS
![image](https://user-images.githubusercontent.com/8158668/133807124-bd44a28b-3e68-4cc1-a61d-3b64b56e3562.png)

with with and height set to 24 px:
icons are not resized 

![image](https://user-images.githubusercontent.com/8158668/133807262-d196582e-612a-49b7-8cf8-996276aebc93.png)
