### PR TITLE
Make labels cumulative for Eco-Score production system adjustment + Sustainable fishing method label

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -890,6 +890,9 @@ $product_ref->{ecoscore_data}{missing} hash with:
 This function tests the presence of specific labels and categories that should not be renamed.
 They are listed in the t/ecoscore.t test file so that the test fail if they are renamed.
 
+The labels are listed in the Eco-Score documentation:
+https://docs.score-environnemental.com/methodologie/produit/label
+
 =cut
 
 my @production_system_labels = (
@@ -899,6 +902,8 @@ my @production_system_labels = (
 	
 	["fr:ab-agriculture-biologique", 15],
 	["en:eu-organic", 15],
+	# Eco-Score documentation: "Techniques de pêche durables : ligne et hameçon, pêche à la canne, casier, pêche à pied."
+	["en:sustainable-fishing-method", 15],
 	
 	["fr:haute-valeur-environnementale", 10],
 	["en:utz-certified", 10],
@@ -915,7 +920,7 @@ sub compute_ecoscore_production_system_adjustment($) {
 
 	my $product_ref = shift;
 	
-	$product_ref->{ecoscore_data}{adjustments}{production_system} = {};
+	$product_ref->{ecoscore_data}{adjustments}{production_system} = { value => 0, labels => []};
 		
 	foreach my $label_ref (@production_system_labels) {
 		
@@ -927,16 +932,30 @@ sub compute_ecoscore_production_system_adjustment($) {
 				or (has_tag($product_ref, "categories", "en:beef"))
 				or (has_tag($product_ref, "categories", "en:veal-meat"))
 				or (has_tag($product_ref, "categories", "en:lamb-meat")))) {
-					
-			$product_ref->{ecoscore_data}{adjustments}{production_system}{value} = $value;
-			$product_ref->{ecoscore_data}{adjustments}{production_system}{label} = $label;
 			
-			last;
+			push @{$product_ref->{ecoscore_data}{adjustments}{production_system}{labels}}, $label;
+
+			# Don't count the points for en:eu-organic if we already have fr:ab-agriculture-biologique
+			# and for ASC if we already have MSC
+			if (
+				(($label ne "en:eu-organic") or not (has_tag($product_ref, "labels", "fr:ab-agriculture-biologique")))
+				and
+				(($label ne "en:sustainable-seafood-msc") or not (has_tag($product_ref, "labels", "en:sustainable-fishing-method") ))
+				and
+				(($label ne "en:responsible-aquaculture-asc")
+					or not (has_tag($product_ref, "labels", "en:sustainable-seafood-msc") or has_tag($product_ref, "labels", "en:sustainable-fishing-method") ))
+			) {
+				$product_ref->{ecoscore_data}{adjustments}{production_system}{value} += $value;
+			}
 		}
+
+		if ($product_ref->{ecoscore_data}{adjustments}{production_system}{value} > 20) {
+			$product_ref->{ecoscore_data}{adjustments}{production_system}{value} = 20;
+		}		
 	}
 	
 	# No labels warning
-	if (not defined $product_ref->{ecoscore_data}{adjustments}{production_system}{label}) {
+	if ($product_ref->{ecoscore_data}{adjustments}{production_system}{value} == 0) {
 		$product_ref->{ecoscore_data}{adjustments}{production_system}{warning} = "no_label";
 		defined $product_ref->{ecoscore_data}{missing} or $product_ref->{ecoscore_data}{missing} = {};
 		$product_ref->{ecoscore_data}{missing}{labels} = 1;

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5709,8 +5709,8 @@ msgid "Transportation and origins of ingredients have a low impact."
 msgstr "Transportation and origins of ingredients have a low impact."
 
 msgctxt "ecoscore_origins_of_ingredients_missing_information"
-msgid "The information about this product's origins of ingredients is missing."
-msgstr "The information about this product's origins of ingredients is missing."
+msgid "Missing information about the origins of ingredients"
+msgstr "Missing information about the origins of ingredients"
 
 msgctxt "percent_of_ingredients"
 msgid "% of ingredients"
@@ -5721,10 +5721,6 @@ msgctxt "medium"
 msgid "medium"
 msgstr "medium"
 
-msgctxt "impact"
-msgid "impact"
-msgstr "impact"
-
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
 msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
@@ -5732,3 +5728,15 @@ msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
 msgstr "%s g / 100 g"
+
+msgctxt "ecoscore_production_system_labels_with_environmental_benefits"
+msgid "Production mode with environmental benefits"
+msgstr "Production mode with environmental benefits"
+
+msgctxt "ecoscore_production_system_labels_with_environmental_benefits_high"
+msgid "Production mode with high environmental benefits"
+msgstr "Production mode with high environmental benefits"
+
+msgctxt "ecoscore_production_system_labels_with_environmental_benefits_very_high"
+msgid "Production mode with very high environmental benefits"
+msgstr "Production mode with very high environmental benefits"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5726,8 +5726,8 @@ msgid "Transportation and origins of ingredients have a low impact."
 msgstr "Transportation and origins of ingredients have a low impact."
 
 msgctxt "ecoscore_origins_of_ingredients_missing_information"
-msgid "The information about this product's origins of ingredients is missing."
-msgstr "The information about this product's origins of ingredients is missing."
+msgid "Missing information about the origins of ingredients"
+msgstr "Missing information about the origins of ingredients"
 
 msgctxt "percent_of_ingredients"
 msgid "% of ingredients"
@@ -5745,3 +5745,15 @@ msgstr "Note: the Nutri-Score of teas and herbal teas corresponds to the product
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
 msgstr "%s g / 100 g"
+
+msgctxt "ecoscore_production_system_labels_with_environmental_benefits"
+msgid "Production mode with environmental benefits"
+msgstr "Production mode with environmental benefits"
+
+msgctxt "ecoscore_production_system_labels_with_environmental_benefits_high"
+msgid "Production mode with high environmental benefits"
+msgstr "Production mode with high environmental benefits"
+
+msgctxt "ecoscore_production_system_labels_with_environmental_benefits_very_high"
+msgid "Production mode with very high environmental benefits"
+msgstr "Production mode with very high environmental benefits"

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -118,6 +118,29 @@ my @tests = (
 			packaging_text => "Cardboard box, film wrap",
 		}
 	],
+
+	# Nutri-Score attribute, with a match score computed from the nutriscore score
+	# https://github.com/openfoodfacts/openfoodfacts-server/issues/5636
+	[
+		'en-nutriscore',
+		{
+			lc => "en",
+			categories => "biscuits",
+			categories_tags => ["en:biscuits"],
+			nutrition_data_per => "100g",
+			ingredients_text => "100% fruits",
+			nutriments => {
+				"energy_100g" => 2591,
+				"fat_100g" => 50,
+				"saturated-fat_100g" => 9.7,
+				"sugars_100g" => 5.1,
+				"salt_100g" => 0,
+				"sodium_100g" => 0,
+				"proteins_100g" => 29,
+				"fiber_100g" => 5.5,
+			},
+		}
+	],	
 );
 
 foreach my $test_ref (@tests) {

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -35,6 +35,7 @@ labels => [
 	
 	"fr:ab-agriculture-biologique",
 	"en:eu-organic",
+	#"en:sustainable-fishing-method",
 	
 	"fr:haute-valeur-environnementale",
 	"en:utz-certified",
@@ -114,6 +115,31 @@ my @tests = (
 			lc => "en",
 			categories_tags=>["en:butters"],
 			labels_tags=>["fr:ab-agriculture-biologique"],
+		}
+	],
+	# Labels can have cumulative points, except some labels that can't be cumulated (e.g. MSC + ASC, or AB Bio + EU Organic)
+	[
+		'label-ab-hve',
+		{
+			lc => "en",
+			categories_tags=>["en:butters"],
+			labels_tags=>["fr:ab-agriculture-biologique", "fr:haute-valeur-environnementale"],
+		}
+	],
+	[
+		'label-msc-asc',
+		{
+			lc => "en",
+			categories_tags=>["en:butters"],
+			labels_tags=>["en:sustainable-seafood-msc", "en:responsible-aquaculture-asc"],
+		}
+	],	
+	[
+		'label-ab-hve-msc-asc',
+		{
+			lc => "en",
+			categories_tags=>["en:butters"],
+			labels_tags=>["fr:ab-agriculture-biologique", "fr:haute-valeur-environnementale", "en:sustainable-seafood-msc", "en:responsible-aquaculture-asc"],
 		}
 	],
 	[

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -411,6 +411,8 @@
             "warning" : "unspecified_material"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}
@@ -621,7 +623,7 @@
       "en:egg",
       "en:strawberry",
       "en:fruit",
-	  "en:berries",
+      "en:berries",
       "en:high-fructose-corn-syrup",
       "en:glucose",
       "en:fructose",
@@ -669,7 +671,7 @@
       "en:egg",
       "en:strawberry",
       "en:fruit",
-	  "en:berries",
+      "en:berries",
       "en:high-fructose-corn-syrup",
       "en:glucose",
       "en:fructose",

--- a/t/expected_test_results/attributes/en-nutriscore.json
+++ b/t/expected_test_results/attributes/en-nutriscore.json
@@ -370,6 +370,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -358,6 +358,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -358,6 +358,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -358,6 +358,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -358,6 +358,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/carrots-plastic.json
+++ b/t/expected_test_results/ecoscore/carrots-plastic.json
@@ -63,7 +63,9 @@
             "value" : -10
          },
          "production_system" : {
-            "label" : "en:demeter",
+            "labels" : [
+               "en:demeter"
+            ],
             "value" : 20
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/carrots.json
+++ b/t/expected_test_results/ecoscore/carrots.json
@@ -62,7 +62,9 @@
             "warning" : "unspecified_material"
          },
          "production_system" : {
-            "label" : "en:demeter",
+            "labels" : [
+               "en:demeter"
+            ],
             "value" : 20
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/empty-product.json
+++ b/t/expected_test_results/ecoscore/empty-product.json
@@ -51,6 +51,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/foie-gras.json
+++ b/t/expected_test_results/ecoscore/foie-gras.json
@@ -70,6 +70,8 @@
             "value" : -2
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/frozen-vegetable.json
+++ b/t/expected_test_results/ecoscore/frozen-vegetable.json
@@ -66,6 +66,8 @@
             "value" : -1
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
@@ -80,7 +80,9 @@
             "value" : -3
          },
          "production_system" : {
-            "label" : "en:eu-organic",
+            "labels" : [
+               "en:eu-organic"
+            ],
             "value" : 15
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
@@ -80,7 +80,9 @@
             "value" : -3
          },
          "production_system" : {
-            "label" : "en:eu-organic",
+            "labels" : [
+               "en:eu-organic"
+            ],
             "value" : 15
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/label-ab-hve-msc-asc.json
+++ b/t/expected_test_results/ecoscore/label-ab-hve-msc-asc.json
@@ -54,8 +54,13 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
-            "label" : "fr:ab-agriculture-biologique",
-            "value" : 15
+            "labels" : [
+               "fr:ab-agriculture-biologique",
+               "fr:haute-valeur-environnementale",
+               "en:sustainable-seafood-msc",
+               "en:responsible-aquaculture-asc"
+            ],
+            "value" : 20
          },
          "threatened_species" : {
             "warning" : "ingredients_missing"
@@ -101,21 +106,21 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 27,
-      "score_be" : 22,
-      "score_ch" : 22,
-      "score_de" : 22,
-      "score_es" : 22,
-      "score_fr" : 22,
-      "score_ie" : 22,
-      "score_it" : 22,
-      "score_lu" : 22,
-      "score_nl" : 22,
-      "score_uk" : 22,
+      "score" : 32,
+      "score_be" : 27,
+      "score_ch" : 27,
+      "score_de" : 27,
+      "score_es" : 27,
+      "score_fr" : 27,
+      "score_ie" : 27,
+      "score_it" : 27,
+      "score_lu" : 27,
+      "score_nl" : 27,
+      "score_uk" : 27,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 22,
+   "ecoscore_score" : 27,
    "ecoscore_tags" : [
       "d"
    ],

--- a/t/expected_test_results/ecoscore/label-ab-hve-msc-asc.json
+++ b/t/expected_test_results/ecoscore/label-ab-hve-msc-asc.json
@@ -1,0 +1,135 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_score_uk" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "transportation_value_uk" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "value_uk" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "value" : -15,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "label" : "fr:ab-agriculture-biologique",
+            "value" : 15
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "16400",
+         "co2_agriculture" : "14.494556",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.031874285",
+         "co2_packaging" : "0.20585948",
+         "co2_processing" : "0.57399261",
+         "co2_total" : "15.49101",
+         "co2_transportation" : "0.1800882",
+         "code" : "16400",
+         "dqr" : "2.69",
+         "ef_agriculture" : "1.0542554",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0096880018",
+         "ef_packaging" : "0.015478282000000001",
+         "ef_processing" : "0.055903738",
+         "ef_total" : "1.1514725",
+         "ef_transportation" : "0.013733529",
+         "is_beverage" : 0,
+         "name_en" : "Butter, 82% fat, unsalted",
+         "name_fr" : "Beurre à 82% MG, doux",
+         "score" : 27
+      },
+      "grade" : "d",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "grade_uk" : "d",
+      "missing" : {
+         "ingredients" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 27,
+      "score_be" : 22,
+      "score_ch" : 22,
+      "score_de" : 22,
+      "score_es" : 22,
+      "score_fr" : 22,
+      "score_ie" : 22,
+      "score_it" : 22,
+      "score_lu" : 22,
+      "score_nl" : 22,
+      "score_uk" : 22,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 22,
+   "ecoscore_tags" : [
+      "d"
+   ],
+   "labels_tags" : [
+      "fr:ab-agriculture-biologique",
+      "fr:haute-valeur-environnementale",
+      "en:sustainable-seafood-msc",
+      "en:responsible-aquaculture-asc"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/ecoscore/label-ab-hve.json
+++ b/t/expected_test_results/ecoscore/label-ab-hve.json
@@ -54,8 +54,11 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
-            "label" : "fr:ab-agriculture-biologique",
-            "value" : 15
+            "labels" : [
+               "fr:ab-agriculture-biologique",
+               "fr:haute-valeur-environnementale"
+            ],
+            "value" : 20
          },
          "threatened_species" : {
             "warning" : "ingredients_missing"
@@ -101,21 +104,21 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 27,
-      "score_be" : 22,
-      "score_ch" : 22,
-      "score_de" : 22,
-      "score_es" : 22,
-      "score_fr" : 22,
-      "score_ie" : 22,
-      "score_it" : 22,
-      "score_lu" : 22,
-      "score_nl" : 22,
-      "score_uk" : 22,
+      "score" : 32,
+      "score_be" : 27,
+      "score_ch" : 27,
+      "score_de" : 27,
+      "score_es" : 27,
+      "score_fr" : 27,
+      "score_ie" : 27,
+      "score_it" : 27,
+      "score_lu" : 27,
+      "score_nl" : 27,
+      "score_uk" : 27,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 22,
+   "ecoscore_score" : 27,
    "ecoscore_tags" : [
       "d"
    ],

--- a/t/expected_test_results/ecoscore/label-ab-hve.json
+++ b/t/expected_test_results/ecoscore/label-ab-hve.json
@@ -1,0 +1,133 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_score_uk" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "transportation_value_uk" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "value_uk" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "value" : -15,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "label" : "fr:ab-agriculture-biologique",
+            "value" : 15
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "16400",
+         "co2_agriculture" : "14.494556",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.031874285",
+         "co2_packaging" : "0.20585948",
+         "co2_processing" : "0.57399261",
+         "co2_total" : "15.49101",
+         "co2_transportation" : "0.1800882",
+         "code" : "16400",
+         "dqr" : "2.69",
+         "ef_agriculture" : "1.0542554",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0096880018",
+         "ef_packaging" : "0.015478282000000001",
+         "ef_processing" : "0.055903738",
+         "ef_total" : "1.1514725",
+         "ef_transportation" : "0.013733529",
+         "is_beverage" : 0,
+         "name_en" : "Butter, 82% fat, unsalted",
+         "name_fr" : "Beurre à 82% MG, doux",
+         "score" : 27
+      },
+      "grade" : "d",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "grade_uk" : "d",
+      "missing" : {
+         "ingredients" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 27,
+      "score_be" : 22,
+      "score_ch" : 22,
+      "score_de" : 22,
+      "score_es" : 22,
+      "score_fr" : 22,
+      "score_ie" : 22,
+      "score_it" : 22,
+      "score_lu" : 22,
+      "score_nl" : 22,
+      "score_uk" : 22,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 22,
+   "ecoscore_tags" : [
+      "d"
+   ],
+   "labels_tags" : [
+      "fr:ab-agriculture-biologique",
+      "fr:haute-valeur-environnementale"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/ecoscore/label-fr-peche-a-la-ligne.json
+++ b/t/expected_test_results/ecoscore/label-fr-peche-a-la-ligne.json
@@ -1,0 +1,132 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_score_uk" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "transportation_value_uk" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "value_uk" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "value" : -15,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "labels" : [],
+            "value" : 0,
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "16400",
+         "co2_agriculture" : "14.494556",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.031874285",
+         "co2_packaging" : "0.20585948",
+         "co2_processing" : "0.57399261",
+         "co2_total" : "15.49101",
+         "co2_transportation" : "0.1800882",
+         "code" : "16400",
+         "dqr" : "2.69",
+         "ef_agriculture" : "1.0542554",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0096880018",
+         "ef_packaging" : "0.015478282000000001",
+         "ef_processing" : "0.055903738",
+         "ef_total" : "1.1514725",
+         "ef_transportation" : "0.013733529",
+         "is_beverage" : 0,
+         "name_en" : "Butter, 82% fat, unsalted",
+         "name_fr" : "Beurre à 82% MG, doux",
+         "score" : 27
+      },
+      "grade" : "e",
+      "grade_be" : "e",
+      "grade_ch" : "e",
+      "grade_de" : "e",
+      "grade_es" : "e",
+      "grade_fr" : "e",
+      "grade_ie" : "e",
+      "grade_it" : "e",
+      "grade_lu" : "e",
+      "grade_nl" : "e",
+      "grade_uk" : "e",
+      "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 12,
+      "score_be" : 7,
+      "score_ch" : 7,
+      "score_de" : 7,
+      "score_es" : 7,
+      "score_fr" : 7,
+      "score_ie" : 7,
+      "score_it" : 7,
+      "score_lu" : 7,
+      "score_nl" : 7,
+      "score_uk" : 7,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "e",
+   "ecoscore_score" : 7,
+   "ecoscore_tags" : [
+      "e"
+   ],
+   "labels" : "Pêché à la ligne",
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/ecoscore/label-fr-peche-a-la-ligne.json
+++ b/t/expected_test_results/ecoscore/label-fr-peche-a-la-ligne.json
@@ -54,9 +54,10 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
-            "labels" : [],
-            "value" : 0,
-            "warning" : "no_label"
+            "labels" : [
+               "en:sustainable-fishing-method"
+            ],
+            "value" : 15
          },
          "threatened_species" : {
             "warning" : "ingredients_missing"
@@ -85,43 +86,53 @@
          "name_fr" : "Beurre à 82% MG, doux",
          "score" : 27
       },
-      "grade" : "e",
-      "grade_be" : "e",
-      "grade_ch" : "e",
-      "grade_de" : "e",
-      "grade_es" : "e",
-      "grade_fr" : "e",
-      "grade_ie" : "e",
-      "grade_it" : "e",
-      "grade_lu" : "e",
-      "grade_nl" : "e",
-      "grade_uk" : "e",
+      "grade" : "d",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "grade_uk" : "d",
       "missing" : {
          "ingredients" : 1,
-         "labels" : 1,
          "origins" : 1,
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 12,
-      "score_be" : 7,
-      "score_ch" : 7,
-      "score_de" : 7,
-      "score_es" : 7,
-      "score_fr" : 7,
-      "score_ie" : 7,
-      "score_it" : 7,
-      "score_lu" : 7,
-      "score_nl" : 7,
-      "score_uk" : 7,
+      "score" : 27,
+      "score_be" : 22,
+      "score_ch" : 22,
+      "score_de" : 22,
+      "score_es" : 22,
+      "score_fr" : 22,
+      "score_ie" : 22,
+      "score_it" : 22,
+      "score_lu" : 22,
+      "score_nl" : 22,
+      "score_uk" : 22,
       "status" : "known"
    },
-   "ecoscore_grade" : "e",
-   "ecoscore_score" : 7,
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 22,
    "ecoscore_tags" : [
-      "e"
+      "d"
    ],
    "labels" : "Pêché à la ligne",
+   "labels_hierarchy" : [
+      "en:sustainable-fishing",
+      "en:sustainable-fishing-method",
+      "en:angled-fish"
+   ],
+   "labels_lc" : "fr",
+   "labels_tags" : [
+      "en:sustainable-fishing",
+      "en:sustainable-fishing-method",
+      "en:angled-fish"
+   ],
    "lc" : "fr",
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",

--- a/t/expected_test_results/ecoscore/label-msc-asc.json
+++ b/t/expected_test_results/ecoscore/label-msc-asc.json
@@ -54,7 +54,10 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
-            "label" : "en:sustainable-seafood-msc",
+            "labels" : [
+               "en:sustainable-seafood-msc",
+               "en:responsible-aquaculture-asc"
+            ],
             "value" : 10
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/label-msc-asc.json
+++ b/t/expected_test_results/ecoscore/label-msc-asc.json
@@ -1,0 +1,133 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_score_uk" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "transportation_value_uk" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "value_uk" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "value" : -15,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "label" : "en:sustainable-seafood-msc",
+            "value" : 10
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "16400",
+         "co2_agriculture" : "14.494556",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.031874285",
+         "co2_packaging" : "0.20585948",
+         "co2_processing" : "0.57399261",
+         "co2_total" : "15.49101",
+         "co2_transportation" : "0.1800882",
+         "code" : "16400",
+         "dqr" : "2.69",
+         "ef_agriculture" : "1.0542554",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0096880018",
+         "ef_packaging" : "0.015478282000000001",
+         "ef_processing" : "0.055903738",
+         "ef_total" : "1.1514725",
+         "ef_transportation" : "0.013733529",
+         "is_beverage" : 0,
+         "name_en" : "Butter, 82% fat, unsalted",
+         "name_fr" : "Beurre à 82% MG, doux",
+         "score" : 27
+      },
+      "grade" : "d",
+      "grade_be" : "e",
+      "grade_ch" : "e",
+      "grade_de" : "e",
+      "grade_es" : "e",
+      "grade_fr" : "e",
+      "grade_ie" : "e",
+      "grade_it" : "e",
+      "grade_lu" : "e",
+      "grade_nl" : "e",
+      "grade_uk" : "e",
+      "missing" : {
+         "ingredients" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 22,
+      "score_be" : 17,
+      "score_ch" : 17,
+      "score_de" : 17,
+      "score_es" : 17,
+      "score_fr" : 17,
+      "score_ie" : 17,
+      "score_it" : 17,
+      "score_lu" : 17,
+      "score_nl" : 17,
+      "score_uk" : 17,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "e",
+   "ecoscore_score" : 17,
+   "ecoscore_tags" : [
+      "e"
+   ],
+   "labels_tags" : [
+      "en:sustainable-seafood-msc",
+      "en:responsible-aquaculture-asc"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/ecoscore/label-msc-sustainable-fishing-method.json
+++ b/t/expected_test_results/ecoscore/label-msc-sustainable-fishing-method.json
@@ -58,7 +58,7 @@
                "en:sustainable-fishing-method",
                "en:sustainable-seafood-msc"
             ],
-            "value" : 20
+            "value" : 15
          },
          "threatened_species" : {
             "warning" : "ingredients_missing"
@@ -104,21 +104,21 @@
          "packagings" : 1
       },
       "missing_data_warning" : 1,
-      "score" : 32,
-      "score_be" : 27,
-      "score_ch" : 27,
-      "score_de" : 27,
-      "score_es" : 27,
-      "score_fr" : 27,
-      "score_ie" : 27,
-      "score_it" : 27,
-      "score_lu" : 27,
-      "score_nl" : 27,
-      "score_uk" : 27,
+      "score" : 27,
+      "score_be" : 22,
+      "score_ch" : 22,
+      "score_de" : 22,
+      "score_es" : 22,
+      "score_fr" : 22,
+      "score_ie" : 22,
+      "score_it" : 22,
+      "score_lu" : 22,
+      "score_nl" : 22,
+      "score_uk" : 22,
       "status" : "known"
    },
    "ecoscore_grade" : "d",
-   "ecoscore_score" : 27,
+   "ecoscore_score" : 22,
    "ecoscore_tags" : [
       "d"
    ],

--- a/t/expected_test_results/ecoscore/label-msc-sustainable-fishing-method.json
+++ b/t/expected_test_results/ecoscore/label-msc-sustainable-fishing-method.json
@@ -1,0 +1,136 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_score_uk" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "transportation_value_uk" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "value_uk" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "value" : -15,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "labels" : [
+               "en:sustainable-fishing-method",
+               "en:sustainable-seafood-msc"
+            ],
+            "value" : 20
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "16400",
+         "co2_agriculture" : "14.494556",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.031874285",
+         "co2_packaging" : "0.20585948",
+         "co2_processing" : "0.57399261",
+         "co2_total" : "15.49101",
+         "co2_transportation" : "0.1800882",
+         "code" : "16400",
+         "dqr" : "2.69",
+         "ef_agriculture" : "1.0542554",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0096880018",
+         "ef_packaging" : "0.015478282000000001",
+         "ef_processing" : "0.055903738",
+         "ef_total" : "1.1514725",
+         "ef_transportation" : "0.013733529",
+         "is_beverage" : 0,
+         "name_en" : "Butter, 82% fat, unsalted",
+         "name_fr" : "Beurre à 82% MG, doux",
+         "score" : 27
+      },
+      "grade" : "d",
+      "grade_be" : "d",
+      "grade_ch" : "d",
+      "grade_de" : "d",
+      "grade_es" : "d",
+      "grade_fr" : "d",
+      "grade_ie" : "d",
+      "grade_it" : "d",
+      "grade_lu" : "d",
+      "grade_nl" : "d",
+      "grade_uk" : "d",
+      "missing" : {
+         "ingredients" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 32,
+      "score_be" : 27,
+      "score_ch" : 27,
+      "score_de" : 27,
+      "score_es" : 27,
+      "score_fr" : 27,
+      "score_ie" : 27,
+      "score_it" : 27,
+      "score_lu" : 27,
+      "score_nl" : 27,
+      "score_uk" : 27,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "d",
+   "ecoscore_score" : 27,
+   "ecoscore_tags" : [
+      "d"
+   ],
+   "labels_tags" : [
+      "en:sustainable-seafood-msc",
+      "en:sustainable-fishing-method"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -54,7 +54,9 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
-            "label" : "fr:ab-agriculture-biologique",
+            "labels" : [
+               "fr:ab-agriculture-biologique"
+            ],
             "value" : 15
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/label-sustainable-fishing.json
+++ b/t/expected_test_results/ecoscore/label-sustainable-fishing.json
@@ -1,0 +1,132 @@
+{
+   "categories_tags" : [
+      "en:butters"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {
+         "origins_of_ingredients" : {
+            "aggregated_origins" : [
+               {
+                  "origin" : "en:unknown",
+                  "percent" : 100
+               }
+            ],
+            "epi_score" : 0,
+            "epi_value" : -5,
+            "origins_from_origins_field" : [
+               "en:unknown"
+            ],
+            "transportation_score_be" : 0,
+            "transportation_score_ch" : 0,
+            "transportation_score_de" : 0,
+            "transportation_score_es" : 0,
+            "transportation_score_fr" : 0,
+            "transportation_score_ie" : 0,
+            "transportation_score_it" : 0,
+            "transportation_score_lu" : 0,
+            "transportation_score_nl" : 0,
+            "transportation_score_uk" : 0,
+            "transportation_value_be" : 0,
+            "transportation_value_ch" : 0,
+            "transportation_value_de" : 0,
+            "transportation_value_es" : 0,
+            "transportation_value_fr" : 0,
+            "transportation_value_ie" : 0,
+            "transportation_value_it" : 0,
+            "transportation_value_lu" : 0,
+            "transportation_value_nl" : 0,
+            "transportation_value_uk" : 0,
+            "value_be" : -5,
+            "value_ch" : -5,
+            "value_de" : -5,
+            "value_es" : -5,
+            "value_fr" : -5,
+            "value_ie" : -5,
+            "value_it" : -5,
+            "value_lu" : -5,
+            "value_nl" : -5,
+            "value_uk" : -5,
+            "warning" : "origins_are_100_percent_unknown"
+         },
+         "packaging" : {
+            "non_recyclable_and_non_biodegradable_materials" : 1,
+            "value" : -15,
+            "warning" : "packaging_data_missing"
+         },
+         "production_system" : {
+            "labels" : [],
+            "value" : 0,
+            "warning" : "no_label"
+         },
+         "threatened_species" : {
+            "warning" : "ingredients_missing"
+         }
+      },
+      "agribalyse" : {
+         "agribalyse_proxy_food_code" : "16400",
+         "co2_agriculture" : "14.494556",
+         "co2_consumption" : "0.0047993021",
+         "co2_distribution" : "0.031874285",
+         "co2_packaging" : "0.20585948",
+         "co2_processing" : "0.57399261",
+         "co2_total" : "15.49101",
+         "co2_transportation" : "0.1800882",
+         "code" : "16400",
+         "dqr" : "2.69",
+         "ef_agriculture" : "1.0542554",
+         "ef_consumption" : "0.0024293397",
+         "ef_distribution" : "0.0096880018",
+         "ef_packaging" : "0.015478282000000001",
+         "ef_processing" : "0.055903738",
+         "ef_total" : "1.1514725",
+         "ef_transportation" : "0.013733529",
+         "is_beverage" : 0,
+         "name_en" : "Butter, 82% fat, unsalted",
+         "name_fr" : "Beurre à 82% MG, doux",
+         "score" : 27
+      },
+      "grade" : "e",
+      "grade_be" : "e",
+      "grade_ch" : "e",
+      "grade_de" : "e",
+      "grade_es" : "e",
+      "grade_fr" : "e",
+      "grade_ie" : "e",
+      "grade_it" : "e",
+      "grade_lu" : "e",
+      "grade_nl" : "e",
+      "grade_uk" : "e",
+      "missing" : {
+         "ingredients" : 1,
+         "labels" : 1,
+         "origins" : 1,
+         "packagings" : 1
+      },
+      "missing_data_warning" : 1,
+      "score" : 12,
+      "score_be" : 7,
+      "score_ch" : 7,
+      "score_de" : 7,
+      "score_es" : 7,
+      "score_fr" : 7,
+      "score_ie" : 7,
+      "score_it" : 7,
+      "score_lu" : 7,
+      "score_nl" : 7,
+      "score_uk" : 7,
+      "status" : "known"
+   },
+   "ecoscore_grade" : "e",
+   "ecoscore_score" : 7,
+   "ecoscore_tags" : [
+      "e"
+   ],
+   "labels" : "Sustainable fishing",
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-missing-data-warning",
+      "en:ecoscore-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/ecoscore/label-sustainable-fishing.json
+++ b/t/expected_test_results/ecoscore/label-sustainable-fishing.json
@@ -122,6 +122,13 @@
       "e"
    ],
    "labels" : "Sustainable fishing",
+   "labels_hierarchy" : [
+      "en:sustainable-fishing"
+   ],
+   "labels_lc" : "fr",
+   "labels_tags" : [
+      "en:sustainable-fishing"
+   ],
    "lc" : "en",
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",

--- a/t/expected_test_results/ecoscore/milk.json
+++ b/t/expected_test_results/ecoscore/milk.json
@@ -73,7 +73,9 @@
             "value" : -6
          },
          "production_system" : {
-            "label" : "en:eu-organic",
+            "labels" : [
+               "en:eu-organic"
+            ],
             "value" : 15
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -62,6 +62,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -57,6 +57,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -57,6 +57,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -73,6 +73,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -61,6 +61,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -53,6 +53,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/packaging-en-bulk.json
+++ b/t/expected_test_results/ecoscore/packaging-en-bulk.json
@@ -64,6 +64,8 @@
             "warning" : "unspecified_material"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
@@ -80,6 +80,8 @@
             "value" : -15
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -82,6 +82,8 @@
             "value" : -4
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -65,6 +65,8 @@
             "value" : -5
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -64,6 +64,8 @@
             "value" : -10
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -64,6 +64,8 @@
             "warning" : "unspecified_material"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -64,6 +64,8 @@
             "warning" : "unspecified_material"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
@@ -54,7 +54,9 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
-            "label" : "fr:ab-agriculture-biologique",
+            "labels" : [
+               "fr:ab-agriculture-biologique"
+            ],
             "value" : 15
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/packaging-unspecified.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
+++ b/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
@@ -62,7 +62,9 @@
             "warning" : "unspecified_material"
          },
          "production_system" : {
-            "label" : "en:demeter",
+            "labels" : [
+               "en:demeter"
+            ],
             "value" : 20
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/uk-milk.json
+++ b/t/expected_test_results/ecoscore/uk-milk.json
@@ -73,6 +73,8 @@
             "value" : -6
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {}

--- a/t/expected_test_results/ecoscore/unknown-category.json
+++ b/t/expected_test_results/ecoscore/unknown-category.json
@@ -54,6 +54,8 @@
             "warning" : "packaging_data_missing"
          },
          "production_system" : {
+            "labels" : [],
+            "value" : 0,
             "warning" : "no_label"
          },
          "threatened_species" : {

--- a/taxonomies/labels.result.txt
+++ b/taxonomies/labels.result.txt
@@ -165,7 +165,7 @@ xx:Haltungsform 4
 
 de:Migros "Aus der Region", "Aus der Region"
 fr:Migros "De la région", "De la région"
-origins:en: en:Switzerland
+origins:en: en:switzerland
 
 de:Nach traditioneller Art, Hausmacher Art
 fr:À l'ancienne
@@ -244,13 +244,6 @@ nl:2016 Voedingslabel experiment
 
 en:Agri Natura, AgriNatura
 
-en:Angled fish
-ca:Pescat amb canya
-de:Geangelter Fisch
-fi:koukulla pyydystettyä kalaa
-fr:Pêché à la ligne, Pêchés à la ligne, Pêché à la ligne à main, Pêchés à la ligne à main, Pêché à la ligne et hameçon, Pêchés à la ligne et hameçon, Pêché à la ligne et hameçons, Pêchés à la ligne et hameçons, Pêché à la canne, Pêchés à la canne, Pêche de ligne, Pêche de lignes, Pêchée à la ligne, Pêchées à la ligne
-label_categories:en: en:Fishing method
-
 en:Apples from France
 de:Äpfel aus Frankreich
 es:Manzanas de Francia
@@ -283,7 +276,7 @@ it:Prodotto in Australia
 nl:Geproduceerd in Australië
 country:en: Australia
 label_categories:en: en:Geographic label
-origins:en: en:Australia
+origins:en: en:australia
 wikidata:en: Q17000991
 
 en:Authentic Trappist Product
@@ -862,6 +855,29 @@ en:EAC
 it:EAC
 xx:EAC
 wikidata:en: Q18407253
+
+en:Eco-Score
+xx:Eco-Score
+
+< en:Eco-Score
+en:Eco-Score A
+xx:Eco-Score A
+
+< en:Eco-Score
+en:Eco-Score B
+xx:Eco-Score B
+
+< en:Eco-Score
+en:Eco-Score C
+xx:Eco-Score C
+
+< en:Eco-Score
+en:Eco-Score D
+xx:Eco-Score D
+
+< en:Eco-Score
+en:Eco-Score E
+xx:Eco-Score E
 
 en:Egg laid in France
 ca:Ous posats a França
@@ -14129,14 +14145,6 @@ fr:Muslim Conseil International, MCI
 < en:Halal
 fr:Société Française de Contrôle de Viande Halal, SFCVH, S-f-c-v-h
 
-en:Hand fishing
-ca:Pescat manualment
-de:Handfischen
-fi:Käsin kalastettu
-fr:Pêché à la main, Pêchés à la main, Pêchée à la main, Pêchées à la main
-he:דיג ידני
-label_categories:en: en:Fishing method
-
 en:Harvested in France
 ca:Veremat a França
 de:In Frankreich geerntet
@@ -14148,36 +14156,46 @@ origins:en: en:france
 
 en:Health Star Rating, Health Star Rating System, HSR
 it:Health Star Rating, Health Star Rating System, HSR
+xx:Health Star Rating, Health Star Rating System, HSR
 countries_where_sold:en: en:Australia
 label_categories:en: en:Nutrition Grades
 wikidata:en: Q85846088
 
 < en:Health Star Rating
 en:Health Star Rating 1
+xx:Health Star Rating 1
 
 < en:Health Star Rating
 en:Health Star Rating 1.5
+xx:Health Star Rating 1.5
 
 < en:Health Star Rating
 en:Health Star Rating 2
+xx:Health Star Rating 2
 
 < en:Health Star Rating
 en:Health Star Rating 2.5
+xx:Health Star Rating 2.5
 
 < en:Health Star Rating
 en:Health Star Rating 3
+xx:Health Star Rating 3
 
 < en:Health Star Rating
 en:Health Star Rating 3.5
+xx:Health Star Rating 3.5
 
 < en:Health Star Rating
 en:Health Star Rating 4
+xx:Health Star Rating 4
 
 < en:Health Star Rating
 en:Health Star Rating 4.5
+xx:Health Star Rating 4.5
 
 < en:Health Star Rating
 en:Health Star Rating 5
+xx:Health Star Rating 5
 
 < en:Hens raised without antibiotics
 en:Hens raised without antibiotics during the laying phase
@@ -14944,7 +14962,7 @@ it:Prodotto nell'EU, Prodotto nell'Unione europea
 nl:Geproduceerd in de EU
 pl:Wyprodukowano w UE
 pt:Feito na UE, feito na União Europeia
-origins:en: en:European Union
+origins:en: en:european-union
 
 < en:Max Havelaar
 en:Max Havelaar Belgium
@@ -16688,7 +16706,7 @@ en:raised in Ireland
 de:aufgezogen in Irland, aufgewachsen in Irland
 fi:kasvatettu Irlannissa
 fr:élevé en Irlande, élevés en Irlande, élevée en Irlande, élevées en Irlande
-origins:en: en:Ireland
+origins:en: en:ireland
 
 en:raised in Norway
 ca:Criat a Noruega
@@ -16697,14 +16715,14 @@ es:Criado en Noruega
 fi:Kasvatettu Norjassa
 fr:élevé en Norvège, élevés en Norvège, élevée en Norvège, élevées en Norvège
 it:Cresciuto in Norvegia
-origins:en: en:Norway
+origins:en: en:norway
 
 en:raised in Scotland
 de:In Schottland aufgewachsen
 fi:Kasvatettu Skotlannissa
 fr:élevé en Ecosse, élevés en Ecosse, élevée en Ecosse, élevées en Ecosse
 it:Cresciuto in Scozia, Allevato in Scozia
-origins:en: en:Scotland, en:United Kingdom
+origins:en: en:scotland,en:united-kingdom
 
 en:Real California Cheese
 country:en: United States
@@ -17519,7 +17537,7 @@ nl:UTZ Gecertificeerd
 auth_url:en: https://utz.org
 wikidata:en: Q2305872
 
-en:Sustainable fishery, Sustainable fishing, Sustainable Seafood
+en:Sustainable fishing, Sustainable Seafood, Sustainable fishery
 ca:Piscifactoria sostenible, Pesca sostenible, Marisc sostenible
 de:Nachhaltige Fischerei
 es:Pesca sostenible
@@ -17532,7 +17550,11 @@ nl:Duurzame visserij
 pl:Zrównoważone rybołówstwo
 label_categories:en: en:Fishing labels
 
-< en:Sustainable fishery
+< en:Sustainable fishing
+en:Sustainable fishing method, sustainable fishing technique
+fr:Méthode de pêche durable, Technique de pêche durable, Mode de pêche durable, Méthodes de pêche durables, techniques de pêche durables, modes de pêche durables
+
+< en:Sustainable fishing
 en:Sustainable Seafood MSC, sustainable food msc
 ca:Marisc sostenible MSC, MSC, Consell per la Protecció Marina
 de:Zertifizierte nachhaltige Fischerei MSC, MSC zertifiziert
@@ -17545,6 +17567,32 @@ xx:MSC, Marine Stewardship Council
 auth_url:en: https://www.msc.org
 label_categories:en: en:Fishing labels
 wikidata:en: Q1891246
+
+< en:Sustainable fishing method
+en:Angled fish
+ca:Pescat amb canya
+de:Geangelter Fisch
+fi:koukulla pyydystettyä kalaa
+fr:Pêché à la ligne, Pêchés à la ligne, Pêché à la ligne à main, Pêchés à la ligne à main, Pêché à la ligne et hameçon, Pêchés à la ligne et hameçon, Pêché à la ligne et hameçons, Pêchés à la ligne et hameçons, Pêché à la canne, Pêchés à la canne, Pêche de ligne, Pêche de lignes, Pêchée à la ligne, Pêchées à la ligne
+label_categories:en: en:Fishing method
+
+< en:Sustainable fishing method
+en:Hand fishing
+ca:Pescat manualment
+de:Handfischen
+fi:Käsin kalastettu
+fr:Pêché à la main, Pêchés à la main, Pêchée à la main, Pêchées à la main
+he:דיג ידני
+label_categories:en: en:Fishing method
+
+< en:Sustainable fishing method
+en:Trap Fishing
+de:Angeln mit Fallen
+fi:sulkukalastettu
+fr:Pêché au casier, Pêchés au casier, Pêché aux casiers, Pêchés aux casiers, Pêchée au casier, Pêchées aux casiers
+hu:csapdás halászat, csapdahalászat
+label_categories:en: en:Fishing method
+wikidata:en: Q2941001
 
 en:Sustainable Palm Oil
 ca:Oli de Palma Sostenible
@@ -17570,11 +17618,11 @@ wikidata:en: Q686421
 
 en:Swiss AOC, CH AOC, AOC CH
 fr:AOC Suisse, AOC CH, CH AOC
-origins:en: en:Switzerland
+origins:en: en:switzerland
 
 en:Swiss PGI, CH PGI, PGI CH
 fr:IGP Suisse, IGP CH, CH IGP
-origins:en: en:Switzerland
+origins:en: en:switzerland
 
 en:TerraSuisse
 fr:TerraSuisse
@@ -17598,15 +17646,15 @@ ca:Etiqueta de qualitat de salsa de peix Thai
 
 < en:Thai quality label
 en:Thailand Diversity & Refinement
-origins:en: en:Thailand
+origins:en: en:thailand
 
 en:The Balkan International Wine Competition
-categories:en: en:Wines
+categories:en: en:wines
 
 en:The International Wine & Spirit Competition
 
 en:Thessaloniki International Wine Competition
-categories:en: en:Wines
+categories:en: en:wines
 
 en:Tooth-health related labels
 de:Labels zur Zahngesundheit
@@ -17627,14 +17675,6 @@ it:Lavorato in Francia
 pt:Transformado na França
 label_categories:en: en:Geographic label
 manufacturing_places:en: en:france
-
-en:Trap Fishing
-de:Angeln mit Fallen
-fi:sulkukalastettu
-fr:Pêché au casier, Pêchés au casier, Pêché aux casiers, Pêchés aux casiers, Pêchée au casier, Pêchées aux casiers
-hu:csapdás halászat, csapdahalászat
-label_categories:en: en:Fishing method
-wikidata:en: Q2941001
 
 en:Trawl fishing
 ca:Pesca d'arrossegament
@@ -18037,7 +18077,7 @@ pt:Concurso Mundial de Vinhos
 label_categories:en: en:Wines
 
 en:Wine Women Awards à l'Hôtel Bristol à Paris
-categories:en: en:Wines
+categories:en: en:wines
 
 en:Winner of the "consumer rights and quality of service" (Russia)
 fi:Kuluttajien oikeuksien ja palvelun laadun voittaja (Venäjä)
@@ -18402,7 +18442,7 @@ fr:Concours des vins de Mâcon
 label_categories:en: en:Wines
 
 fr:Concours des vins de Piolenc
-categories:en: en:Wines
+categories:en: en:wines
 
 fr:Concours des vins du Grand Delta à Avignon
 label_categories:en: en:Wines
@@ -18449,7 +18489,7 @@ fr:Concours International des Vins de Montagne d'Aoste
 label_categories:en: en:Wines
 
 fr:Concours International des Vins de Terroir de Brignoles
-categories:en: en:Wines
+categories:en: en:wines
 
 fr:Concours International des Vins et Spiritueux VINUS
 es:Vino, Nutricion y Salud
@@ -18527,12 +18567,12 @@ wikidata:en: Q3149493
 
 fr:Indication géographique protégée de la République populaire de Chine, IGPRPC
 zh:中国地理标志
-origins:en: en:China
+origins:en: en:china
 wikidata:en: Q3150362
 
 fr:La Lorraine notre signature
 label_categories:en: en:Geographic label
-origins:en: en:france, fr:Lorraine
+origins:en: en:france,en:lorraine
 
 fr:Label Rouge
 xx:Label Rouge
@@ -18839,7 +18879,7 @@ origins:en: en:france
 
 fr:Saveurs en Or
 label_categories:en: en:Geographic label
-origins:en: en:france, fr:Hauts-de-France
+origins:en: en:france,fr:Hauts-de-France
 wikidata:en: Q3474531
 
 fr:Savourez l'Alsace
@@ -18850,7 +18890,7 @@ origins:en: en:france
 fr:Sélections Mondiales des Vins Canada à Québec
 
 fr:Soja Français, Soja de France, Filière Soja Français
-ingredients:en: en:soy
+ingredients:en: en:soya
 label_categories:en: en:Soy
 origins:en: en:france
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -16710,6 +16710,13 @@ it:Sicurezza dei Delfini
 nl:dolfijnvriendelijk
 label_categories:en: en:Fishing labels
 
+# Should not be automatically triggered by the MSC label
+# as we need to differentiate MSC fisheries from more environmentaly friendly fishing methods for the Eco-Score
+# From the Eco-Score documentation: "Techniques de pêche durables : ligne et hameçon, pêche à la canne, casier, pêche à pied. Ces méthodes sont sélectives et sans impact sur les fonds marins et l'habitat."
+<en:Sustainable fishing
+en:Sustainable fishing method, sustainable fishing technique
+fr:Méthode de pêche durable, Technique de pêche durable, Mode de pêche durable, Méthodes de pêche durables, techniques de pêche durables, modes de pêche durables
+
 en:Trawl fishing
 ca:Pesca d'arrossegament
 de:Schleppnetzfischerei
@@ -16730,6 +16737,7 @@ ru:сейнерная рыбалка
 wikidata:en:Q600580
 label_categories:en: en:Fishing method
 
+<en:Sustainable fishing method
 en:Angled fish
 ca:Pescat amb canya
 de:Geangelter Fisch
@@ -16737,6 +16745,7 @@ fi:koukulla pyydystettyä kalaa
 fr:Pêché à la ligne, Pêchés à la ligne, Pêché à la ligne à main, Pêchés à la ligne à main, Pêché à la ligne et hameçon, Pêchés à la ligne et hameçon, Pêché à la ligne et hameçons, Pêchés à la ligne et hameçons, Pêché à la canne, Pêchés à la canne, Pêche de ligne, Pêche de lignes, Pêchée à la ligne, Pêchées à la ligne
 label_categories:en: en:Fishing method
 
+<en:Sustainable fishing method
 en:Trap Fishing
 de:Angeln mit Fallen
 fi:sulkukalastettu
@@ -16784,6 +16793,7 @@ de:Lift Netz Fischerei
 fr:Pêché au filet soulevé, Pêchés au filet soulevé, Pêché aux filets soulevés, Pêchés aux filets soulevés, Pêchée au filet soulevé, Pêchées au filet soulevé
 label_categories:en: en:Fishing method
 
+<en:Sustainable fishing method
 en:Hand fishing
 ca:Pescat manualment
 de:Handfischen
@@ -16826,7 +16836,7 @@ zh:鸬鹚捕鱼
 wikidata:en:Q1784476
 label_categories:en: en:Fishing method
 
-en:Sustainable fishery, Sustainable fishing, Sustainable Seafood
+en:Sustainable fishing, Sustainable Seafood, Sustainable fishery
 ca:Piscifactoria sostenible, Pesca sostenible, Marisc sostenible
 de:Nachhaltige Fischerei
 es:Pesca sostenible

--- a/templates/api/knowledge-panels/ecoscore/ecoscore.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/ecoscore.tt.json
@@ -60,19 +60,14 @@
             }
         },
         [% FOREACH adjustment IN ["production_system", "origins_of_ingredients", "threatened_species", "packaging"] %]
-        {
-            "element_type": "panel",
-            "panel_element": {
-                "panel_id": "ecoscore_[% adjustment %]",
-            }
-        },
-        [% END %]
-        {
-            "element_type": "text",
-            "text_element": {
-                "type": "warning",
-                "html": `<p>[% lang("ecoscore_description") %]</p>`,
-            }
-        },        
+            [% IF (adjustment == "origins_of_ingredients") or (adjustment == "packaging") or (product.ecoscore_data.adjustments.$adjustment.value > 0) %]
+                {
+                    "element_type": "panel",
+                    "panel_element": {
+                        "panel_id": "ecoscore_[% adjustment %]",
+                    }
+                },
+            [% END %]
+        [% END %]       
     ]
 }

--- a/templates/api/knowledge-panels/ecoscore/production_system.tt.json
+++ b/templates/api/knowledge-panels/ecoscore/production_system.tt.json
@@ -6,14 +6,26 @@
         "environment"
     ],
     "title": "[% panel.title %]",
+    "evaluation": "good",
+    [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value >= 20 %]
+    "title": "[% lang('ecoscore_production_system_labels_with_environmental_benefits_very_high') %]",
+    [% ELSIF product.ecoscore_data.adjustments.origins_of_ingredients.value >= 15 %]
+    "title": "[% lang('ecoscore_production_system_labels_with_environmental_benefits_high') %]",    
+    [% ELSE %]
+    "title": "[% lang('ecoscore_production_system_labels_with_environmental_benefits') %]",      
+    [% END %]    
     "elements": [
         {
             "element_type": "text",
             "text_element": {
                 "text_type": "summary",
                 "html": `
-                    <p>[give more details here]</p> 
-                    `
+                <ul>
+                [% FOREACH label IN product.ecoscore_data.adjustments.production_system.labels %]
+                    <li>[% display_taxonomy_tag("labels",label) %]</li>
+                [% END %]
+                </ul>
+                `
             }
         },
     ]

--- a/templates/web/pages/product/includes/ecoscore_details.tt.html
+++ b/templates/web/pages/product/includes/ecoscore_details.tt.html
@@ -120,17 +120,24 @@
 		 <div class="panel ecoscore_panel" id="ecoscore_panel_production_system" data-equalizer-watch="ecoscore1">
 	<h4>[% display_icon('agriculture') %] [% lang('ecoscore_production_system') %]</h4>
 	
-	[% IF adjustments.production_system.value %]
-		<p><strong>[% display_taxonomy_tag("labels",adjustments.production_system.label) %][% sep %]: +[% adjustments.production_system.value %]</strong></p>
+	[% IF adjustments.production_system.value > 0 %]
+		
+		<ul>
+		[% FOREACH label IN adjustments.production_system.labels %]
+			<li>[% display_taxonomy_tag("labels",label) %]</li>
+		[% END %]
+		</ul>
+	
+		<p><strong>[% lang('ecoscore_production_system') %][% sep %]: +[% adjustments.production_system.value %]</strong></p>
 	[% ELSE %]
 		<p>[% lang('ecoscore_no_labels_taken_into_account') %]</p>
 		
-	[% IF adjustments.production_system.warning %]
-		<div class="panel warning">
-			[% lang('ecoscore_please_add_the_labels') %]<br><br>
-			[% lang('ecoscore_platform_prompt_ecoscore_modal') %]
-		</div>
-	[% END %]		
+		[% IF adjustments.production_system.warning %]
+			<div class="panel warning">
+				[% lang('ecoscore_please_add_the_labels') %]<br><br>
+				[% lang('ecoscore_platform_prompt_ecoscore_modal') %]
+			</div>
+		[% END %]		
 		
 	[% END %]
 	</div>

--- a/templates/web/pages/product/includes/ecoscore_details_simple_html.tt.html
+++ b/templates/web/pages/product/includes/ecoscore_details_simple_html.tt.html
@@ -63,18 +63,24 @@
 
 	<h4>🚜 [% lang('ecoscore_production_system') %]</h4>
 	
-	[% IF adjustments.production_system.value %]
-		<p><strong>[% display_taxonomy_tag("labels",adjustments.production_system.label) %] : +[% adjustments.production_system.value %]</strong></p>
+	[% IF adjustments.production_system.value > 0 %]
+		<ul>
+		[% FOREACH label IN adjustments.production_system.labels %]
+			<li>[% display_taxonomy_tag("labels",label) %]</li>
+		[% END %]
+		</ul>
+	
+		<p><strong>[% lang('ecoscore_production_system') %][% sep %]: +[% adjustments.production_system.value %]</strong></p>
 	[% ELSE %]
 		<p>[% lang('ecoscore_no_labels_taken_into_account') %]</p>
 		
-	[% IF adjustments.production_system.warning %]
-		<div class="panel warning">
-      <!--If this product has a label characterizing the production system (organic, fair trade, Label Rouge, Bleu Blanc Coeur etc.), you can modify the product sheet to add it.-->
-			[% lang('ecoscore_please_add_the_labels') %]<br><br>
-			[% lang('ecoscore_platform_prompt_ecoscore_modal') %]
-		</div>
-	[% END %]		
+		[% IF adjustments.production_system.warning %]
+			<div class="panel warning">
+		<!--If this product has a label characterizing the production system (organic, fair trade, Label Rouge, Bleu Blanc Coeur etc.), you can modify the product sheet to add it.-->
+				[% lang('ecoscore_please_add_the_labels') %]<br><br>
+				[% lang('ecoscore_platform_prompt_ecoscore_modal') %]
+			</div>
+		[% END %]		
 		
 	[% END %]
 


### PR DESCRIPTION
The production system adjustment has changed, labels can now be cumulative (e.g. organic + fair trade): https://docs.score-environnemental.com/methodologie/produit/label

"En cas de cumul des labels, les points associés s'additionnent dans la limite de 20 points, sauf pour les labels ASC/MSC qui ne peuvent se cumuler entre eux."

This change is to reflect that. Also added some tests for it.

There's also a new bonus for sustainable fishing methods that is higher (15) than MSC (10).

