### PR TITLE
fix: change local domain to openfoodfacts.localhost

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ COMPOSE_FILE=docker-compose.yml;docker/dev.yml
 
 TAG=latest
 PRODUCERS_PLATFORM=0
-PRODUCT_OPENER_DOMAIN=productopener.localhost
+PRODUCT_OPENER_DOMAIN=openfoodfacts.localhost
 PRODUCT_OPENER_PORT=80
 PRODUCT_OPENER_FLAVOR=openfoodfacts
 POSTGRES_USER=productopener

--- a/installation/dev-environment-quick-start-guide.md
+++ b/installation/dev-environment-quick-start-guide.md
@@ -105,13 +105,13 @@ The command will run 2 subcommands:
 
 **Hosts file:**
 
-Since the default `PRODUCT_OPENER_DOMAIN` in the `.env` file is set to `productopener.localhost`, add the following to your hosts file (Windows: `C:\Windows\System32\drivers\etc\hosts`; Linux/MacOSX: `/etc/hosts`):
+Since the default `PRODUCT_OPENER_DOMAIN` in the `.env` file is set to `openfoodfacts.localhost`, add the following to your hosts file (Windows: `C:\Windows\System32\drivers\etc\hosts`; Linux/MacOSX: `/etc/hosts`):
 
 ```text
-127.0.0.1 world.productopener.localhost fr.productopener.localhost static.productopener.localhost ssl-api.productopener.localhost fr-en.productopener.localhost
+127.0.0.1 world.openfoodfacts.localhost fr.openfoodfacts.localhost static.openfoodfacts.localhost ssl-api.openfoodfacts.localhost fr-en.openfoodfacts.localhost
 ```
 
-### You're done ! Check http://productopener.localhost/ !
+### You're done ! Check http://openfoodfacts.localhost/ !
 
 ## 5. Starting, stopping, restarting Docker containers, and more...
 


### PR DESCRIPTION
Change `productopener.localhost` to `openfoodfacts.localhost` to guarantee operability between local installations of Robotoff and Product Opener (Robotoff need them to run on the same domain otherwise requests are rejected..)