### PR TITLE
fix: producers emails - fixes #5712

### DIFF
--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -595,12 +595,15 @@ sub process_user_form($$) {
 				
 		my $mail = '';
 		process_template("emails/user_new_pro_account.tt.txt", $template_data_ref, \$mail);
-		if ($mail =~ /^\s*Subject:\s*(.*)\n/i) {
+		if ($mail =~ /^\s*Subject:\s*(.*)\n/im) {
 			my $subject = $1;
 			my $body = $';
 			$body =~ s/^\n+//;
 			$template_data_ref->{mail_subject_new_pro_account} = URI::Escape::XS::encodeURIComponent($subject);
 			$template_data_ref->{mail_body_new_pro_account} = URI::Escape::XS::encodeURIComponent($body);
+		}
+		else {
+			send_email_to_producers_admin("Error - broken template: emails/user_new_pro_account.tt.txt", "Missing Subject line:\n\n" . $mail);
 		}
 
 		if (defined $requested_org_ref) {
@@ -608,13 +611,16 @@ sub process_user_form($$) {
 			
 			$mail = '';
 			process_template("emails/user_new_pro_account_org_request_validated.tt.txt", $template_data_ref, \$mail);
-			if ($mail =~ /^\s*Subject:\s*(.*)\n/i) {
+			if ($mail =~ /^\s*Subject:\s*(.*)\n/im) {
 				my $subject = $1;
 				my $body = $';
 				$body =~ s/^\n+//;
 				$template_data_ref->{mail_subject_new_pro_account_org_request_validated} = URI::Escape::XS::encodeURIComponent($subject);
 				$template_data_ref->{mail_body_new_pro_account_org_request_validated} = URI::Escape::XS::encodeURIComponent($body);
-			}		
+			}
+			else {
+				send_email_to_producers_admin("Error - broken template: emails/user_new_pro_account_org_request_validated.tt.txt", "Missing Subject line:\n\n" . $mail);
+			}
 		}
 		else {
 			# The requested org does not exist, create it
@@ -633,12 +639,15 @@ sub process_user_form($$) {
 		
 		$mail = '';
 		process_template("emails/user_new_pro_account_admin_notification.tt.html", $template_data_ref, \$mail);
-		if ($mail =~ /^\s*Subject:\s*(.*)\n/i) {
+		if ($mail =~ /^\s*Subject:\s*(.*)\n/im) {
 			my $subject = $1;
 			my $body = $';
 			$body =~ s/^\n+//;
 			
 			send_email_to_producers_admin($subject, $body);
+		}
+		else {
+			send_email_to_producers_admin("Error - broken template: emails/user_new_pro_account_admin_notification.tt.html", "Missing Subject line:\n\n" . $mail);
 		}
 	}
 

--- a/templates/emails/user_new_pro_account_admin_notification.tt.html
+++ b/templates/emails/user_new_pro_account_admin_notification.tt.html
@@ -1,11 +1,10 @@
-<!-- start templates/[% template.name %] -->
-
 [% IF user.requested_org_id %]
 Subject: New pro account for existing org [% user.requested_org_id %] - [% user.userid %]
 [% ELSE %]
 Subject: New pro account for new org [% user.org_id %] - [% user.userid %]
 [% END %]
 
+<!-- start templates/[% template.name %] -->
 
 org_id: [% user.org_id or user.requested_org_id %]<br>
 org_name: [% user.org or user.requested_org %]<br>
@@ -63,3 +62,4 @@ Here is the tabular data for the producer if they are not in the tracking spread
 </table>
 
 <!-- end templates/[% template.name %] -->
+


### PR DESCRIPTION
The template for the email was broken (it expected Subject: something as the first line) and a HTML comment was added before.

Made the logic more resilient and we now send a warning email if the template is broken.

- fixes #5712

### Part of 
- #5730 
- #5521 