### PR TITLE
Map GS1 provenanceStatement to origin field, add it to product edit form

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -283,7 +283,7 @@ else {
 	# when the corresponding organization has the protect_data checkbox checked
 	my $protected_data = product_data_is_protected($product_ref);
 
-	foreach my $field (@app_fields, 'nutrition_data_per', 'serving_size', 'traces', 'ingredients_text', 'packaging_text', 'lang') {
+	foreach my $field (@app_fields, 'nutrition_data_per', 'serving_size', 'traces', 'ingredients_text', 'origin', 'packaging_text', 'lang') {
 
 		# 11/6/2018 --> force add_brands and add_countries for yuka / kiliweb
 		if ((defined $User_id) and ($User_id eq 'kiliweb')

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -282,7 +282,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	$product_ref->{"debug_param_sorted_langs"} = \@param_sorted_langs;
 
-	foreach my $field ('product_name', 'generic_name', @fields, 'nutrition_data_per', 'nutrition_data_prepared_per', 'serving_size', 'allergens', 'traces', 'ingredients_text', 'packaging_text', 'lang') {
+	foreach my $field ('product_name', 'generic_name', @fields, 'nutrition_data_per', 'nutrition_data_prepared_per', 'serving_size', 'allergens', 'traces', 'ingredients_text', 'origin', 'packaging_text', 'lang') {
 
 		if (defined $language_fields{$field}) {
 			foreach my $display_lc (@param_sorted_langs) {
@@ -754,7 +754,6 @@ sub display_input_field($$$) {
 	my $fieldtype = $field;
 	my $display_lc = $lc;
 	my @field_notes;
-	my $examples = '';
 
 	my $template_data_ref_field = {};
 
@@ -817,14 +816,13 @@ sub display_input_field($$$) {
 
 	if (defined $Lang{$fieldtype . "_example"}{$lang}) {
 
-		$examples = $Lang{example}{$lang};
+		my $examples = $Lang{example}{$lang};
 		if ($Lang{$fieldtype . "_example"}{$lang} =~ /,/) {
 			$examples = $Lang{examples}{$lang};
 		}
+		$template_data_ref_field->{examples} = $examples;
+		$template_data_ref_field->{field_type_examples} = $Lang{$fieldtype . "_example"}{$lang};
 	}
-
-	$template_data_ref_field->{examples} = $examples;
-	$template_data_ref_field->{field_type_examples} = $Lang{$fieldtype . "_example"}{$lang};
 
 	process_template('web/pages/product_edit/display_input_field.tt.html', $template_data_ref_field, \$html_field) or $html_field = "<p>" . $tt->error() . "</p>";
 
@@ -1092,7 +1090,7 @@ sub display_input_tabs($$$$$) {
 	}
 
 	$template_data_ref_display->{display_fields_arr} = \@display_fields_arr;
-	my @ingredients_fields = ("ingredients_image", "ingredients_text");
+	my @ingredients_fields = ("ingredients_image", "ingredients_text", "origin");
 
 	my $checked = '';
 	my $tablestyle = 'display: table;';

--- a/lib/ProductOpener/GS1.pm
+++ b/lib/ProductOpener/GS1.pm
@@ -570,6 +570,20 @@ my %gs1_to_off = (
 										],
 									},
 								],
+
+								["place_of_item_activity:placeOfItemActivityModule", {
+										fields => [
+											["placeOfProductActivity", {
+													fields => [
+														# provenanceStatement is a free text field, which can contain manufacturing places
+														# and/or origins of ingredients and related statements, in different languages
+														["provenanceStatement", "origin"],
+													],
+												},
+											],
+										],
+									},
+								],								
 								
 								["referenced_file_detail_information:referencedFileDetailInformationModule", {
 										fields => [

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -3147,7 +3147,15 @@ msgid "Recipe idea"
 msgstr ""
 
 msgctxt "origin"
-msgid "Origin"
+msgid "Origin of the product and/or its ingredients"
+msgstr ""
+
+msgctxt "origin_note"
+msgid "Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients"
+msgstr ""
+
+msgctxt "origin_example"
+msgid "Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand."
 msgstr ""
 
 msgctxt "customer_service"
@@ -5756,3 +5764,4 @@ msgstr "Production mode with high environmental benefits"
 msgctxt "ecoscore_production_system_labels_with_environmental_benefits_very_high"
 msgid "Production mode with very high environmental benefits"
 msgstr "Production mode with very high environmental benefits"
+

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -3185,8 +3185,16 @@ msgid "Recipe idea"
 msgstr "Recipe idea"
 
 msgctxt "origin"
-msgid "Origin"
-msgstr "Origin"
+msgid "Origin of the product and/or its ingredients"
+msgstr "Origin of the product and/or its ingredients"
+
+msgctxt "origin_note"
+msgid "Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients"
+msgstr "Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients"
+
+msgctxt "origin_example"
+msgid "Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand."
+msgstr "Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand."
 
 msgctxt "customer_service"
 msgid "Customer service"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -3028,8 +3028,16 @@ msgid "Recipe idea"
 msgstr "Idée recette"
 
 msgctxt "origin"
-msgid "Origin"
-msgstr "Origine"
+msgid "Origin of the product and/or its ingredients"
+msgstr "Origine du produit et/ou de ses ingrédients"
+
+msgctxt "origin_note"
+msgid "Packaging mentions that indicate the manufacturing place and/or the origins of the ingredients"
+msgstr "Mentions de l'emballage qui indiquent le lieu de fabrication et/ou les origines des ingrédients"
+
+msgctxt "origin_example"
+msgid "Made in France. Tomatoes from Italy. Origin of the rice: India, Thailand."
+msgstr "Fabriqué en France. Tomates d'Italie. Origine du riz: Inde, Thaïlande."
 
 msgctxt "customer_service"
 msgid "Customer service"

--- a/t/expected_test_results/import_gs1/equadis_brasseries_kronenbourg_tourtel.off.json
+++ b/t/expected_test_results/import_gs1/equadis_brasseries_kronenbourg_tourtel.off.json
@@ -25,6 +25,7 @@
    "net_weight" : "0.275 kg",
    "nutriscore_grade_producer" : "D",
    "org_name" : "BRASSERIES KRONENBOURG",
+   "origin_fr" : "67210 Obernai France",
    "packaging" : "Bouteille",
    "product_name_fr" : "TOURTEL - 27,5CL TTCITR BIO FR-BIO-01 - 0.00 DEGRE ALCOOL",
    "proteins_100g_unit" : "g",

--- a/t/expected_test_results/import_gs1/equadis_nestle_france_ricore.off.json
+++ b/t/expected_test_results/import_gs1/equadis_nestle_france_ricore.off.json
@@ -39,6 +39,7 @@
    "net_weight" : "400 g",
    "nutriscore_grade_producer" : "D",
    "org_name" : "NESTLE FRANCE (DIV CHOC,CUL,BI,INF)",
+   "origin_fr" : "Fabriqué en France. Café Origine non-UE. Chicorée Origine UE et Non-UE. Lait origine France. La majorité de notre chicorée vient du Nord de la France.",
    "packaging" : "Canette",
    "preparation_fr" : "4 cuillères + 200 ml d'eau frémissante.",
    "producer_version_id" : "44041392",

--- a/templates/web/pages/product_edit/display_input_field.tt.html
+++ b/templates/web/pages/product_edit/display_input_field.tt.html
@@ -20,7 +20,9 @@
     [% END %]
 [% END %]
 
-<p class="example">[% examples %][% field_type_examples %]</p>
+[% IF field_type_examples.defined %]
+    <p class="example">[% examples %] [% field_type_examples %]</p>
+[% END %]
 
 <!-- end templates/[% template.name %] -->
 


### PR DESCRIPTION
Related to #5713

We already have a "origin" language field, used for some imports like Carrefour, to store strings like "Made in Germany with almonds from Turkey". There is a similar field provenanceStatement in GS1 data, so we can map it to our "origin" field.

The field is now also displayed and editable in the product edit form, so contributors can also type it in and/or copy/paste it from the ingredients OCR.