### PR TITLE
fix: add nginx_status section to run the nginx_exporter correctly

### DIFF
--- a/conf/apache.conf
+++ b/conf/apache.conf
@@ -45,8 +45,8 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
 
 ExtendedStatus On
 <Location /server-status>
-    SetHandler server-status
-    Require all granted
+  SetHandler server-status
+  Require ip 172.30.0.0/16
 </Location>
 
 <Location /cgi>

--- a/conf/apache.conf
+++ b/conf/apache.conf
@@ -46,6 +46,7 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
 ExtendedStatus On
 <Location /server-status>
   SetHandler server-status
+  Require ip 127.0.0.1
   Require ip 172.30.0.0/16
 </Location>
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -107,6 +107,11 @@ server {
 		proxy_pass http://$backend/cgi/display.pl?$request_uri;
 	}
 
+	location /nginx_status {
+		stub_status;
+		allow all;
+	}
+
 	location /cgi/ {
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -111,7 +111,7 @@ server {
 		stub_status;
 		allow 127.0.0.1; 	   # localhost
 		allow 172.30.0.0/16;   # docker IP range
-        deny all;              # deny all other hosts 
+    	deny all;              # deny all other hosts 
 	}
 
 	location /cgi/ {
@@ -179,7 +179,7 @@ server {
 		stub_status;
 		allow 127.0.0.1; 	   # localhost
 		allow 172.30.0.0/16;   # docker IP range
-        deny all;              # deny all other hosts 
+    	deny all;              # deny all other hosts 
 	}
 
 	location /cgi/ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -111,7 +111,7 @@ server {
 		stub_status;
 		allow 127.0.0.1; 	   # localhost
 		allow 172.30.0.0/16;   # docker IP range
-    	deny all;              # deny all other hosts 
+		deny all;              # deny all other hosts 
 	}
 
 	location /cgi/ {
@@ -179,7 +179,7 @@ server {
 		stub_status;
 		allow 127.0.0.1; 	   # localhost
 		allow 172.30.0.0/16;   # docker IP range
-    	deny all;              # deny all other hosts 
+		deny all;              # deny all other hosts 
 	}
 
 	location /cgi/ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -109,7 +109,9 @@ server {
 
 	location /nginx_status {
 		stub_status;
-		allow all;
+		allow 127.0.0.1; 	   # localhost
+		allow 172.30.0.0/16;   # docker IP range
+        deny all;              # deny all other hosts 
 	}
 
 	location /cgi/ {
@@ -171,6 +173,13 @@ server {
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		set $backend backend;
 		proxy_pass http://$backend/cgi/display.pl?$request_uri;
+	}
+
+	location /nginx_status {
+		stub_status;
+		allow 127.0.0.1; 	   # localhost
+		allow 172.30.0.0/16;   # docker IP range
+        deny all;              # deny all other hosts 
 	}
 
 	location /cgi/ {

--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -27,3 +27,10 @@ volumes:
     external: true
   product_images:
     external: true
+
+networks:
+  webnet:
+    driver: bridge
+    ipam:
+      config:
+      - subnet: 172.30.0.0/16


### PR DESCRIPTION
Deployment of `nginx_exporter` failed because `/nginx_status` endpoint (healthcheck) was not added to NGINX config.