### PR TITLE
Remove ingredients related fields when ingredients are empty

### DIFF
--- a/t/expected_test_results/recipes/nectars.missing-ingredients.json
+++ b/t/expected_test_results/recipes/nectars.missing-ingredients.json
@@ -1,14 +1,5 @@
 {
-   "ingredients" : [],
-   "ingredients_hierarchy" : [],
-   "ingredients_original_tags" : [],
-   "ingredients_percent_analysis" : 1,
-   "ingredients_tags" : [],
    "ingredients_text" : "",
-   "ingredients_with_specified_percent_n" : 0,
-   "ingredients_with_specified_percent_sum" : 0,
-   "ingredients_with_unspecified_percent_n" : 0,
-   "ingredients_with_unspecified_percent_sum" : 0,
    "lc" : "en",
    "recipe" : null
 }


### PR DESCRIPTION
This is to remove some fields for products that have an empty ingredient list, as those fields don't make sense for them.
e.g. the number of unknown ingredients is 0.