### PR TITLE
fix: url for public product link on pro platform

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7686,7 +7686,7 @@ CSS
 
 	# On the producers platform, show a link to the public platform
 	if ($server_options{producers_platform}) {
-		my $public_product_url = "https:\/\/$cc.${server_domain}" . $request_ref->{canon_url};
+		my $public_product_url = $formatted_subdomain . product_url($product_ref);
 		$public_product_url =~ s/\.pro\./\./;
 		$template_data_ref->{public_product_url} = $public_product_url;
 	}


### PR DESCRIPTION
fixes #5771