### PR TITLE
feat: new taxonomy API

### DIFF
--- a/cgi/display.pl
+++ b/cgi/display.pl
@@ -92,6 +92,9 @@ if ((defined $request{api}) and (defined $request{api_method})) {
 		# /api/v0/attribute_groups or /api/v0/attribute_groups_[language code]
 		display_attribute_groups_api(\%request, $2);
 	}
+	elsif (param("api_method") eq "taxonomy") {
+		display_taxonomy_api(\%request);
+	}	
 	else {
 		# /api/v0/product/[code] or a local name like /api/v0/produit/[code] so that we can easily add /api/v0/ to any product url
 		display_product_api(\%request);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -822,8 +822,8 @@ sub analyze_request($)
 		$request_ref->{search} = 1;
 	}
 
-	# /tags API endpoint
-	# e.g. /api/v2/tags?type=categories&tags=en:fruits,en:vegetables&fields=name,description,parents,children&lc=en,fr&include_children=1
+	# /taxonomy API endpoint
+	# e.g. /api/v2/taxonomy?type=categories&tags=en:fruits,en:vegetables&fields=name,description,parents,children,vegan:en,inherited:vegetarian:en&lc=en,fr&include_children=1
 	elsif ($components[0] eq "taxonomy") {
 		$request_ref->{taxonomy} = 1;
 	}	

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -82,6 +82,7 @@ BEGIN
 		&search_and_map_products
 		&display_recent_changes
 		&add_tag_prefix_to_link
+		&display_taxonomy_api
 
 		&display_ingredient_analysis
 		&display_ingredients_analysis_details
@@ -563,6 +564,9 @@ sub init()
 			@lcs = ($lc);
 		}
 	}
+	else {
+		@lcs = ($lc);
+	}
 	# change the subdomain if we have overrides so that links to product pages are properly constructed
 	if ($cc_lc_overrides) {
 		$subdomain = $cc;
@@ -817,7 +821,13 @@ sub analyze_request($)
 	elsif ($components[0] eq "search") {
 		$request_ref->{search} = 1;
 	}
-	
+
+	# /tags API endpoint
+	# e.g. /api/v2/tags?type=categories&tags=en:fruits,en:vegetables&fields=name,description,parents,children&lc=en,fr&include_children=1
+	elsif ($components[0] eq "taxonomy") {
+		$request_ref->{taxonomy} = 1;
+	}	
+
 	# /products endpoint (e.g. /products/8024884500403+3263855093192 )
 	# assign the codes to the code parameter
 	elsif ($components[0] eq "products") {
@@ -9944,7 +9954,7 @@ sub display_preferences_api($$)
 }
 
 
-=head2 display_attribute_groups_api ( $target_lc )
+=head2 display_attribute_groups_api ( $request_ref, $target_lc )
 
 Return a JSON structure with all available attribute groups and attributes,
 with strings (names, descriptions etc.) in a specific language,
@@ -9996,8 +10006,49 @@ sub display_attribute_groups_api($$)
 }
 
 
-sub display_product_api($)
-{
+=head2 display_taxonomy_api ( $request_ref )
+
+Generate an extract of a taxonomy for specific tags, fields and languages,
+and return it as a JSON object.
+
+Accessed through the /api/v2/taxonomy API
+
+e.g. https://world.openfoodfacts.org/api/v2/taxonomy?type=labels&tags=en:organic,en:fair-trade&fields=name,description,children&include_children=1&lc=en,fr
+
+=head3 Arguments
+
+=head4 request object reference $request_ref
+
+=cut
+
+sub display_taxonomy_api($) {
+
+	my $request_ref = shift;
+
+	my $tagtype = param('type');
+	my $tags = param('tags');
+	my @tags = split(/,/, $tags);
+
+	my $options_ref = {};
+
+	foreach my $field (qw(fields include_children include_parents)) {
+		if (defined param($field)) {
+			$options_ref->{$field} = param($field);
+		}
+	}
+
+	my $taxonomy_ref = generate_tags_taxonomy_extract($tagtype, \@tags, $options_ref, \@lcs);
+
+	$request_ref->{structured_response} = $taxonomy_ref;
+
+	display_structured_response($request_ref);
+	
+	return;
+}
+
+
+sub display_product_api($) {
+
 	my $request_ref = shift;
 
 	my $code = normalize_code($request_ref->{code});

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1814,7 +1814,7 @@ sub generate_tags_taxonomy_extract ($$$$) {
 
 		if (defined $properties{$tagtype}{$tagid}) {
 
-			foreach my $prop_lc (sort keys %{$properties{$tagtype}{$tagid}}) {
+			foreach my $prop_lc (keys %{$properties{$tagtype}{$tagid}}) {
 				
 				if ($prop_lc =~ /^(.*):(\w\w)$/) {
 					my $prop = $1;


### PR DESCRIPTION
Fixes #5785 

This is a new API to get an extract of a taxonomy for specific tags, specific fields/properties, in specific languages.

example: https://world.openfoodfacts.dev/api/v2/taxonomy?type=labels&tags=en:organic,en:fair-trade&fields=name,description,children&include_children=1&lc=en,fr