### PR TITLE
fix: rename type to tagtype in taxonomy API

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10056,7 +10056,7 @@ sub display_taxonomy_api($) {
 
 	my $request_ref = shift;
 
-	my $tagtype = param('type');
+	my $tagtype = param('tagtype');
 	my $tags = param('tags');
 	my @tags = split(/,/, $tags);
 


### PR DESCRIPTION
This is to make field names more consistent with what we are using in the backend and what has been used in libraries.

Discussion on https://github.com/openfoodfacts/openfoodfacts-dart/issues/263