### PR TITLE
fix: remove external volumes for ones that need re-creation

### DIFF
--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -9,14 +9,6 @@ services:
   frontend:
     restart: always
 volumes:
-  icons_dist:
-    external: true
-  js_dist:
-    external: true
-  css_dist: 
-    external: true
-  node_modules:
-    external: true
   html_data:
     external: true
   users:


### PR DESCRIPTION
This makes only the volumes we mount from the FS as `external: true`. Others need to be re-created on every deployment, to update dist/ folders correctly.

Fixes #5845 