### PR TITLE
add missing strings to be translated in common.pot

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5816,3 +5816,14 @@ msgctxt "health_card_title"
 msgid "Nutrition and health"
 msgstr "Nutrition and health"
 
+msgctxt "contains_palm_oil"
+msgid "Contains palm oil"
+msgstr "Contains palm oil"
+
+msgctxt "contains_palm_oil_subtitle"
+msgid "Drives deforestation and threatens species such as the orangutan"
+msgstr "Drives deforestation and threatens species such as the orangutan"
+
+msgctxt "contains_palm_oil_description"
+msgid "Tropical forests in Asia, Africa and Latin America are destroyed to create and expand oil palm tree plantations. The deforestation contributes to climate change, and it endangers species such as the orangutan, the pigmy elephant and the Sumatran rhino."
+msgstr "Tropical forests in Asia, Africa and Latin America are destroyed to create and expand oil palm tree plantations. The deforestation contributes to climate change, and it endangers species such as the orangutan, the pigmy elephant and the Sumatran rhino."


### PR DESCRIPTION
I added some strings to en.po and forgot to add them in common.pot