### PR TITLE
fix: Remove empty POT-Creation-Date in hu.po

### DIFF
--- a/po/tags/hu.po
+++ b/po/tags/hu.po
@@ -1,7 +1,6 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: openfoodfacts\n"
-"POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-04-06 11:14+0200\n"
 "Last-Translator: Báthory Péter <bathory86p@gmail.com>\n"
 "Language-Team: Hungarian\n"


### PR DESCRIPTION
This removes the following warnings that are printed at the start of Product Opener and every script:

```
Use of uninitialized value $kind in string eq at /opt/product-opener/lib/ProductOpener/I18N.pm line 138.
Use of uninitialized value $kind in string eq at /opt/product-opener/lib/ProductOpener/I18N.pm line 139.
warning: malformed tag from .po file: __POT-Creation-Date
```
