### PR TITLE
feat: add include_root_entries option to taxonomy API, fixes #6039

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10092,7 +10092,7 @@ sub display_taxonomy_api($) {
 
 	my $options_ref = {};
 
-	foreach my $field (qw(fields include_children include_parents)) {
+	foreach my $field (qw(fields include_children include_parents include_root_entries)) {
 		if (defined param($field)) {
 			$options_ref->{$field} = param($field);
 		}


### PR DESCRIPTION
Requested by @gspencergoog for the category picker in the Flutter app.

e.g. https://world.openfoodfacts.dev/api/v2/taxonomy?tagtype=packaging_materials&tags=en:plastic&include_root_entries=1

For categories: https://world.openfoodfacts.dev/api/v2/taxonomy?tagtype=categories&include_root_entries=1

Note: we have many entries without parents that probably should have one.