### PR TITLE
Change vegan and vegetarian statuses of Glycerol

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -9694,8 +9694,8 @@ sl:E375, E375 food additive
 sv:E375, E375 food additive
 mandatory_additive_class:en: en:colour-retention-agent
 e_number:en:375
-vegan:en:yes
-vegetarian:en:yes
+vegan:en:maybe
+vegetarian:en:maybe
 
 en:E380, Triammonium citrate
 bg:E380, Триамониев цитрат
@@ -10947,9 +10947,8 @@ e_number:en:422
 wikidata:en:Q132501
 additives_classes:en: en:humectant, en:thickener
 organic_eu:en:authorized
-vegan:en:yes
-vegetarian:en:yes
-description:en:GLYCEROL can be used by all religious groups, vegans and vegetarians. The term carbohydrate alcohol is a chemical definition; glycerol does not contain alcohol (ethanol).
+vegan:en:maybe
+vegetarian:en:maybe
 
 en:E424, Curdlan
 bg:E424, E424 food additive


### PR DESCRIPTION
Hello!

Glycerol is not always vegan and vegetarian.
Source: https://www.veganfirst.com/article/qa-is-glycerin-vegan
Same with E472: https://doublecheckvegan.com/ingredients/e472b/