### PR TITLE
Update languages.result.txt

### DIFF
--- a/taxonomies/languages.result.txt
+++ b/taxonomies/languages.result.txt
@@ -1,3 +1,10 @@
+# NOTE: 1. Just translate the name of the language, for example, in "Abkhaz language" translate only "Abkhaz"
+#          because if the resulting translation is "Língua abcázia" (example in Portuguese) when you are editing a product
+#          in Open Food Facts website and you press the key "A" in the field using this translation, it will jump right
+#          to the language translation beginning with "A" and not "Língua abcázia" because this one begins with "L".
+#       2. Only the first string until "," is shown. So if there is need to show the name of the language in other language variation
+#          use "/", for example "Color / colour", "Pastó / afegão" or "Tcheco / checo". Try to keep short and only use very common names, 
+#          the first one should be the one with more speakers using it, and not the one technically more correct.
 
 
 en:Abkhaz, Abkhaz language, Abkhazian, ab, abk
@@ -53,7 +60,7 @@ oc:Abkhaz
 os:Абхазаг æвзаг
 pa:ਆਬਖ਼ਾਜ਼ ਭਾਸ਼ਾ
 pl:Język abchaski
-pt:Língua abecásia
+pt:Abcázio
 ro:Limba abhază
 ru:абхазский язык
 rw:Icyabukaziyani
@@ -114,7 +121,7 @@ nb:Afar
 nl:Afar
 nn:Afar
 pl:Język afar
-pt:Língua afar
+pt:Afar
 ru:Афарский язык
 sh:Afarski jezik
 sk:Afarčina
@@ -194,7 +201,7 @@ nn:Afrikaans
 oc:Afrikaans
 pa:ਆਫ਼੍ਰੀਕਾਂਸ ਭਾਸ਼ਾ
 pl:język afrikaans
-pt:língua africâner, africâner
+pt:Africâner
 qu:Afrikans simi
 ro:limba afrikaans
 ru:африкаанс, бурский язык
@@ -261,7 +268,7 @@ nl:Akan
 nn:Akan
 oc:Àkan
 pl:Język akan
-pt:Língua akan
+pt:Acã, Akan
 qu:Akan simi
 ru:акан, аканский язык
 sv:Akan
@@ -339,7 +346,7 @@ nn:Albansk
 oc:Albanés
 pa:ਅਲਬੇਨਿਆਈ ਬੋਲੀ
 pl:język albański
-pt:Língua albanesa
+pt:Albanês
 qu:Albanya simi
 ro:Limba albaneză
 ru:албанский язык
@@ -428,7 +435,7 @@ nl:Amhaars
 nn:Amharisk
 pa:ਅਮਹਾਰੀ ਭਾਸ਼ਾ
 pl:Język amharski
-pt:Língua amárica
+pt:Amárico
 qu:Amhara simi
 ro:limba amharică
 ru:амхарский язык
@@ -547,7 +554,7 @@ os:Араббаг æвзаг
 pa:ਅਰਬੀ ਭਾਸ਼ਾ
 pl:język arabski
 ps:عربي
-pt:língua árabe, árabe, idioma árabe, linguagem árabe
+pt:Árabe
 qu:Arabya simi
 ro:limba arabă
 ru:арабский язык
@@ -635,7 +642,7 @@ nl:Aragonees
 nn:Aragonesisk
 oc:Aragonés
 pl:Język aragoński
-pt:Língua aragonesa
+pt:Aragonês
 ro:Limba aragoneză
 ru:арагонский язык
 rw:Icyaragoneze
@@ -719,7 +726,7 @@ oc:armèni
 os:Сомихаг æвзаг
 pa:ਆਰਮੇਨੀਆਈ ਭਾਸ਼ਾ
 pl:język ormiański
-pt:língua arménia
+pt:Armênio / arménio
 qu:Arminya simi
 ro:limba armeană
 ru:армянский язык, армянский
@@ -803,7 +810,7 @@ nn:assamesisk
 or:ଅସମୀୟା ଭାଷା
 pa:ਆਸਾਮੀ ਭਾਸ਼ਾ
 pl:język asamski
-pt:língua assamesa
+pt:Assamês
 qu:Asam simi
 ro:Limba assameză
 ru:ассамский язык
@@ -869,7 +876,7 @@ oc:Àvar
 os:Солиаг æвзаг
 pa:ਅਵਾਰ ਭਾਸ਼ਾ
 pl:Język awarski
-pt:Língua avar
+pt:Avar
 ru:аварский язык
 sl:Avarščina
 sv:Avariska
@@ -932,7 +939,7 @@ nl:Avestisch
 os:Авестæйы æвзаг
 pa:ਅਵੇਸਤਨ ਭਾਸ਼ਾ
 pl:Język awestyjski
-pt:Língua avéstica
+pt:Avéstico
 ro:Limba avestică
 ru:Авестийский язык
 sh:Avestanski jezik
@@ -1003,7 +1010,7 @@ nv:Aymara bizaad, Aimara bizaad
 oc:Aymara
 os:Аймараг æвзаг
 pl:Język ajmara
-pt:Língua aimará
+pt:Aimará
 qu:Aymara simi, Aymar aru, Aymar shimi, Aymar simi
 ro:limba aimara, Limba aymara
 ru:аймара, Язык Аймара, Аймарский язык
@@ -1090,7 +1097,7 @@ os:Азербайджайнаг æвзаг
 pa:ਅਜ਼ੇਰੀ ਭਾਸ਼ਾ
 pl:Język azerski
 ps:آزربايجاني
-pt:Língua azeri
+pt:Azeri, Azerbaijano
 qu:Asar simi
 rm:Lingua aserbeidschanica
 ro:Limba azeră, Limba azeri-turcă, Azeri-turca, Limba azerbaidjaneză, Azerbaidjaneza
@@ -1153,7 +1160,7 @@ nb:Bambara
 nl:Bambara
 nn:Bambara
 pl:Język bambara, Język bamana
-pt:Língua bambara
+pt:Bambara
 qu:Bambara simi
 ru:Бамана, Бамананкан, Язык бамбара, Бамбара язык, Бамбара
 se:Bambaragiella
@@ -1215,7 +1222,7 @@ nn:Basjkirsk
 os:Башкираг æвзаг
 pa:ਬਸ਼ਕੀਰ ਭਾਸ਼ਾ
 pl:Język baszkirski
-pt:Língua bashkir
+pt:Basquir
 ro:Limba bașchiră
 ru:башкирский язык
 sh:Baškirski jezik
@@ -1293,7 +1300,7 @@ nl:Baskisch
 nn:Baskisk
 oc:Basc
 pl:Język baskijski
-pt:língua basca, basco, idioma basco, linguagem basca, euskara, euskera
+pt:Basco
 qu:Yuskara simi
 ro:limba bască
 ru:баскский язык
@@ -1390,7 +1397,7 @@ oc:Bielorús
 os:Белоруссаг æвзаг
 pa:ਬੇਲਾਰੂਸੀ ਭਾਸ਼ਾ
 pl:język białoruski
-pt:Língua bielorrussa
+pt:Bielorrusso
 qu:Bilurusu simi
 ro:Limba bielorusă
 ru:белорусский язык, беларуская мова
@@ -1493,7 +1500,7 @@ or:ବଙ୍ଗଳା ଭାଷା
 os:Бенгайлаг æвзаг
 pa:ਬੰਗਾਲੀ ਭਾਸ਼ਾ
 pl:język bengalski
-pt:língua bengali
+pt:Bengali
 qu:Banla simi
 ro:limba bengaleză
 ru:бенгальский язык, бенгали
@@ -1558,7 +1565,7 @@ nb:bihari
 nl:Bihari
 nn:biharispråk, Bihari
 pl:bihari
-pt:línguas biaris, Língua bihari, Língua biari, Línguas biari
+pt:Biari
 ru:бихарские языки, Бихарский язык
 ta:பீகாரி மொழிகள்
 ug:بىھارى تىلى, Bihari tili
@@ -1607,7 +1614,7 @@ nl:Bislama
 nn:Bislama
 oc:Bislama
 pl:Język bislama
-pt:Língua bislamá, Bislamá
+pt:Bislamá
 ru:бислама, бислама язык
 sh:Bislama jezik, Bislama
 sk:bislamčina
@@ -1671,7 +1678,7 @@ os:Букмол
 pa:ਬੂਕਮਾਲ ਨਾਰਵੇਜਿਅਨ
 pl:Bokmål
 ps:بوکمول
-pt:Bokmål
+pt:Bokmål norueguês
 ro:Bokmål
 ru:букмол
 sk:Bokmål
@@ -1738,7 +1745,7 @@ nl:Bosnisch
 nn:Bosnisk
 oc:Bosnian
 pl:język bośniacki
-pt:Língua bósnia
+pt:Bósnio
 qu:Busna simi
 ro:limba bosniacă
 ru:боснийский язык
@@ -1819,7 +1826,7 @@ nl:Bretons
 nn:Bretonsk
 oc:Breton
 pl:język bretoński
-pt:Língua bretã
+pt:Bretão
 qu:Britun simi
 rm:Lingua bretona
 ro:Limba bretonă
@@ -1916,7 +1923,7 @@ os:Болгайраг æвзаг
 pa:ਬਲਗਾਰੀ
 pl:język bułgarski
 ps:بلغاريايي ژبه
-pt:língua búlgara, idioma búlgaro, linguagem búlgara, búlgaro, български
+pt:Búlgaro
 qu:Bulgarya simi
 ro:limba bulgară
 ru:болгарский язык
@@ -1994,7 +2001,7 @@ oc:lenga birmana
 or:ବର୍ମୀଜ ଭାଷା
 pa:ਬਰਮੀ ਭਾਸ਼ਾ
 pl:Język birmański
-pt:língua birmanesa, birmanês
+pt:Birmanês
 qu:Birmanu simi
 ro:Limba birmană
 ru:бирманский язык
@@ -2082,7 +2089,7 @@ oc:Catalan
 os:Каталайнаг æвзаг
 pa:ਕੈਟਲਨ ਬੋਲੀ
 pl:język kataloński
-pt:língua catalã, catalão, idioma catalão, linguagem catalã
+pt:Catalão
 qu:Katalan simi
 rm:Lingua catalana
 ro:Limba catalană
@@ -2154,7 +2161,7 @@ nl:Chamorro
 nn:Chamorro
 oc:Chamorro
 pl:Język czamorro
-pt:Língua chamorro, Chamorro
+pt:Chamorro
 ru:Чаморро, Язык чаморро
 sh:Chamorro jezik, Čamoro jezik, Čamoroanski jezik
 sm:Gagana Chamorro
@@ -2215,7 +2222,7 @@ nn:Tsjetsjensk
 oc:Chechèn
 os:Цæцæйнаг æвзаг
 pl:Język czeczeński
-pt:checheno, Língua chechena
+pt:Tchetcheno / checheno, Checheno
 ro:limba cecenă
 ru:чеченский язык, нохчийн мотт, нохчийн, чеченский
 rw:Igiceceni
@@ -2268,7 +2275,7 @@ nl:Nyanja, Chewa, Chichewa
 nn:chinyanja, Chichewa, Chichewa språk
 ny:Chilankhulo cha Chichewa, Chicheŵa, Chi-Chewa, Chichewa
 pl:język cziczewa, Język cziniandża, Język chinyanja, Język chichewa, Język niandża
-pt:língua nianja, Cinianja, Língua cinianja, CiNyanja, Nianja, Língua chinianja, Chichewa
+pt:Nianja, Cinianja, Chichewa
 qu:Chichewa simi, Chichiwa simi, Chichewa, Nyanja, Nyanja simi, Chichiwa
 ru:ньянджа, Чичева, Чиньянджа, Ньянджа язык, Чева
 rw:Igicewa, Gicewa, Ikinyanja, Igicicewa
@@ -2367,7 +2374,7 @@ oc:Chinés
 pa:ਚੀਨੀ ਭਾਸ਼ਾ
 pl:język chiński
 ps:چيني
-pt:língua chinesa
+pt:Chinês
 qu:Chun simi
 ro:limba chineză
 ru:китайский язык
@@ -2437,7 +2444,7 @@ nb:Kirkeslavisk, Gammelslavisk, Kirkeslavisk språk, Gammalslavisk, Paleoslavisk
 nl:Kerkslavisch
 nn:Kyrkjeslavisk
 pl:Język cerkiewnosłowiański, Cs., Język cerkiewno-słowiański
-pt:eslavo eclesiástico, Eslavónio eclesiástico, Antigo eslavônico, Língua eslavônica eclesiástica, Eslavônico eclesiástico
+pt:Eslavo eclesiástico, Antigo eslavônico, Eslavônico eclesiástico
 ro:Limba slavonă, Slavona, Limba slavona, Slavona bisericească, Slavonă
 ru:церковнославянский язык, церковнославянский, церковно-славянский алфавит, церковно-славянский язык
 sh:Crkvenoslovenski jezik, Црквенословенски језик, Crkvenoslavenski, Crkvenoslovenski, Crkvenoslavenski jezik
@@ -2497,7 +2504,7 @@ nb:tsjuvasjisk, Tsjuvansk, Tsjuvansk språk, Tsuvasjisk, Tsjuvasjisk språk
 nl:tsjoevasjisch, Tsjoewasjisch
 nn:tsjuvasjisk, Tsjuvansk språk, Tsjuvasjisk språk
 pl:Język czuwaski
-pt:língua tchuvache, Língua chuvache
+pt:Tchuvache / chuvache, Chuvache
 qu:Chuwash simi, Chuwasyu simi, Chuwas simi, Chuwasya simi
 ro:limba ciuvașă, Limba ciuvaşă
 ru:чувашский язык, Чувашский
@@ -2575,7 +2582,7 @@ nn:Kornisk, Cornisk språk, Kornisk språk
 oc:Cornic
 os:Корнаг æвзаг
 pl:Język kornijski, Język kornicki, Język kornwalijski
-pt:Língua córnica, Língua cornualesa, Córnico
+pt:Córnico
 rm:Lingua cornica, Cornic
 ro:Limba cornică
 ru:корнский язык, Корнваллийский язык, Корнваллийский, Корнский, Корнуэльский, Корнуэльский язык
@@ -2641,7 +2648,7 @@ nb:Korsikansk, Korsikansk språk, Korsisk
 nl:Corsicaans
 oc:Còrs, Lenga còrsa
 pl:Język korsykański, Dialekt korsykański
-pt:Língua corsa, Língua córsica, Córsico
+pt:Córsico
 ro:Limba corsicană
 ru:корсиканский язык
 sc:Limba corsicana
@@ -2690,7 +2697,7 @@ nl:Cree, Montagnais
 nn:Cree-montagnais-naskapi-språket
 oc:Cree
 pl:Język kri, Język kriski
-pt:Língua cree
+pt:Cree
 qu:Kri simi, Kriy simi
 ru:кри
 sv:Cree, Nehiyawewin, Nēhiyawēwin, Nihithawiwin, Nîhithawîwin
@@ -2780,7 +2787,7 @@ nn:Kroatisk
 oc:Croat
 os:Хорватаг æвзаг
 pl:Język chorwacki
-pt:Língua croata
+pt:Croata
 qu:Hurwat simi
 ro:Limba croată
 ru:хорватский язык
@@ -2889,7 +2896,7 @@ os:Чехаг æвзаг
 pa:ਚੇਕ ਭਾਸ਼ਾ
 pl:język czeski
 ps:چيکی ژبه
-pt:língua checa, idioma checo, checo, linguagem checa
+pt:Tcheco / checo, Checo
 qu:Chiku simi
 rm:Lingua tscheca
 ro:Limba cehă
@@ -2994,7 +3001,7 @@ oc:Danés
 os:Даниаг æвзаг
 pa:ਡੈਨਿਸ਼ ਭਾਸ਼ਾ
 pl:Język duński
-pt:língua dinamarquesa, dinamarquês, idioma dinamarquês, linguagem dinamarquesa, dansk
+pt:Dinamarquês
 qu:Dan simi
 ro:Limba daneză
 ru:датский язык
@@ -3097,7 +3104,7 @@ os:Нидерландаг æвзаг
 pa:ਡਚ ਬੋਲੀ
 pl:język niderlandzki
 ps:نېدرلنډي, نېدرلنډي ژبه
-pt:língua neerlandesa, neerlandês, idioma neerlandês, linguagem neerlandesa, língua holandesa, holandês, idioma holandês, linguagem holandesa
+pt:Neerlandês, holandês
 qu:Urasuyu simi
 rm:lingua neerlandaisa
 ro:limba neerlandeză
@@ -3183,7 +3190,7 @@ oc:Dzongkha
 pa:ਜੌਙਖਾ ਬੋਲੀ
 pl:Dzongkha
 ps:ژونگخا
-pt:língua butanesa
+pt:Butanês, Dzonga
 qu:Dzonkha simi
 ru:Дзонг-кэ
 sk:Dzongkha
@@ -3309,7 +3316,7 @@ pa:ਅੰਗਰੇਜ਼ੀ ਬੋਲੀ
 pi:आंगलभाषा
 pl:język angielski
 ps:انگليسي
-pt:língua inglesa, inglês, idioma inglês, linguagem inglesa
+pt:Inglês
 qu:Inlish simi
 rm:Lingua englaisa
 ro:limba engleză
@@ -3446,7 +3453,7 @@ oc:Esperanto
 os:Эсперанто
 pa:ਏਸਪੇਰਾਨਤੋ
 pl:Esperanto, Lingvo Internacia
-pt:esperanto
+pt:Esperanto
 qu:Esperanto simi
 rm:Esperanto
 rn:Kiseperanto
@@ -3560,7 +3567,7 @@ oc:estonian
 os:Эстойнаг æвзаг
 pa:ਏਸਟੋਨਿਆਈ ਭਾਸ਼ਾ
 pl:Język estoński
-pt:estónio, idioma estónio, linguagem estónia, estoniano, língua estoniana, idioma estoniano, linguagem estoniana, estónico, linguagem estónica, língua estónica, idioma estónico, eesti keel, língua estónia
+pt:Estoniano, estónio, estônio
 qu:Istunya simi
 ro:limba estonă
 ru:эстонский язык
@@ -3620,7 +3627,7 @@ nn:Ewe
 oc:Ewe
 pa:ਏਬੀ ਭਾਸ਼ਾ
 pl:Język ewe
-pt:Língua ewe
+pt:Ewe
 qu:Ewe simi
 ro:Limba ewe
 ru:эве
@@ -3695,7 +3702,7 @@ nn:færøysk, Færøysk språk
 oc:Feroés
 os:Фарераг æвзаг, Фарерагау
 pl:Język farerski, Farerski
-pt:Língua feroesa, Língua faroesa, Feroês, Língua faroense, Língua feróica
+pt:Feroês, Faroesa, Faroense, Feróica, Islandês das Ilhas Faroé
 ro:Limba feroeză, Limba faroeză
 ru:фарерский язык, Føroyskt, Faroese, Фарерский, Ферейский язык
 rw:Igifero, Gifero
@@ -3756,7 +3763,7 @@ nb:Fijiansk, Fijiansk språk, Fijisk språk, Fijisk
 nl:Fijisch, Fijinees
 nn:Fijiansk
 pl:Język fidżyjski, Język fidżi
-pt:Língua fidjiana, Língua fijiana, Fijiano, Língua vitiana
+pt:Fidjiano / fijiano, Fijiano, Vitiano
 qu:Phiyi simi
 ru:фиджийский язык, Фиджийские языки, Восточнофиджийский язык, Фиджи
 rw:Igifijiyani, Igifiji, Gifijiyani
@@ -3844,7 +3851,7 @@ oc:Finés
 os:Финнаг æвзаг
 pa:ਫ਼ਿਨੀ ਭਾਸ਼ਾ
 pl:Język fiński
-pt:língua finlandesa, finlandês, idioma finlandês, linguagem finlandesa, suomi
+pt:Finlandês
 qu:Phinis simi
 rm:Lingua finlandaisa
 ro:limba finlandeză
@@ -3975,7 +3982,7 @@ os:Францаг æвзаг
 pa:ਫ਼ਰਾਂਸਿਸੀ ਭਾਸ਼ਾ, ਫ੍ਰੈਂਚ ਭਾਸ਼ਾ, French language, ਫਰਾਂਸਿਸੀ, ਫਰਾਂਸਿਸੀ ਭਾਸ਼ਾ, ਫ਼ਰਾਂਸਿਸੀ ਬੋਲੀ, ਫ੍ਰੈਂਚ, ਫਰਾਂਸੀਸੀ ਭਾਸ਼ਾ
 pl:język francuski, Francuski
 ps:فرانسوي
-pt:língua francesa, francês, linguagem francesa, idioma francês
+pt:Francês
 qu:Ransis simi
 rm:lingua franzosa
 ro:limba franceză
@@ -4054,7 +4061,7 @@ nb:Fulfulde, Fulfulde språk, Fula
 nl:Fula, Pulaar, Pular, Fulfulde
 nn:Fulfulde
 pl:Język ful, Język fulani, Język fulfulde, Język fula
-pt:Língua fula, Língua fulah
+pt:Fula
 qu:Fula simi, Fulfulde, Phula simi, Phula, Fulfulde simi, Fula
 ru:фула, язык фула, фула язык, пулар-фульфульде, пулар, фулани, фульбе, фулах, фульфульде
 sq:Gjuha fula
@@ -4129,7 +4136,7 @@ nn:galisisk
 oc:galèc
 os:Галисиаг æвзаг
 pl:język galicyjski
-pt:língua galega, galego, idioma galego, linguagem galega
+pt:Galego
 qu:Galligu simi
 ro:limba galiciană
 ru:галисийский язык
@@ -4219,7 +4226,7 @@ os:Гуырдзиаг æвзаг
 pa:ਜਾਰਜੀਆਈ ਭਾਸ਼ਾ
 pl:Język gruziński
 ps:گرجی ژبه
-pt:Língua georgiana
+pt:Georgiano
 qu:Kartul simi
 ro:limba georgiană
 ru:грузинский язык
@@ -4343,7 +4350,7 @@ os:Немыцаг æвзаг
 pa:ਜਰਮਨ ਭਾਸ਼ਾ, German language, ਜਰਮਨ ਬੋਲੀ, ਜਰਮਨ, ਜ੍ਰਮਨ
 pl:język niemiecki
 ps:آلماني ژبه
-pt:língua alemã, alemão
+pt:Alemão
 qu:Aliman simi
 rm:Lingua tudestga
 ro:limba germană
@@ -4416,7 +4423,7 @@ nl:Gikuyu
 oc:Gikuyu
 pa:ਕਿਕਿਊ ਭਾਸ਼ਾ
 pl:Język kikuju, Język gikuju, Język kuju, Język gikuyu, Język kikuyu
-pt:Língua kikuyu
+pt:Quicuio, Kikuyu
 qu:Kikuyu simi
 ru:Кикуйю, Гикуйю
 rw:Igikuyu, Kikuyu, Ikikuyu, Gikuyu
@@ -4455,7 +4462,7 @@ nb:Gresk, Nygresk, Nygresk språk
 nl:Grieks, Nieuwgrieks, Gemeenschappelijke Nieuw-Griekse taal, Nieuw-Grieks, Kini neo-elliniki glossa, Modern Grieks
 om:Afaan Giriik
 pl:Język grecki, język nowogrecki, Demotyk, Dimotiki, Nowogr., Nowożytna greka, Nwgr., Język grecki współczesny, Język grecki nowożytny, Greka nowożytna, Greka współczesna
-pt:Grego, Língua grega, grego moderno, Demótico, Língua grega moderna
+pt:Grego
 ro:Limba greacă modernă, Limba neogreacă
 ru:Греческий язык, новогреческий язык
 sk:Grécke jazyky, Novogréčtina, Nová gréčtina
@@ -4511,7 +4518,7 @@ nb:Grønlandsk, Kalaallisut språk, Grønlandsk språk, Kalaallisut
 nl:Groenlands, Kalaallisut
 nn:Grønlandsk, Grønlandsk språk
 pl:Język grenlandzki, Kalaallisut
-pt:groenlandês, Língua kalaallisut, Língua gronelandesa, Gronelandês, Kalaallisut, Língua groenlandesa
+pt:Groenlandês, Groelandês, Gronelandês
 qu:Kalalit simi, Kalaallisut
 ru:гренландский язык, Гренландский, Kalaallisut
 sh:Grenlandski jezik, Kalaallisut jezik
@@ -4578,7 +4585,7 @@ nl:Guaraní, Guarani, Guarani taal
 nn:Guaraní, Guarani
 oc:Guaraní
 pl:Język guarani
-pt:língua guarani
+pt:Guarani
 qu:Waraniyi simi, Guaraní simi, Warani simi, Guarani simi
 ro:limba guarani, Limba guaraní
 ru:гуарани, Язык гуарани
@@ -4654,7 +4661,7 @@ or:ଗୁଜୁରାଟି ଭାଷା
 os:Гуджаратаг æвзаг
 pa:ਗੁਜਰਾਤੀ ਭਾਸ਼ਾ, ਗੁਜਰਾਤੀ ਬੋਲੀ, Gujarati language, ਗੁਜਰਾਤੀ
 pl:Język gudźarati
-pt:Língua gujarati
+pt:Gujarati
 qu:Gujarati simi
 ro:Limba gujarati
 ru:гуджарати
@@ -4719,7 +4726,7 @@ nb:haitisk, haitisk kreol, Haitisk kreol språk, Haitisk kreolspråk, Haitisk sp
 nl:Haïtiaans Creools, Haitiaans Creools, Krèyol, Kreyòl, Kreyol, Haiti-Creools, Krèyol ayisyen, Haïtiaans Creool, Patua, Haïti-Creools, Kreyol ayisyen, Haitiaans Creool
 nn:Haitisk, Haitiansk kreolspråk, Haitiansk, Haitiansk kreol, Haitisk kreolsk språk, Haitisk kreolspråk, Haitisk kreol, Haitisk språk, Haitiansk-kreolsk språk, Haitiansk språk
 pl:Język kreolski haitański, Język haitański, Kreolski haitański
-pt:Crioulo haitiano, Língua Crioula Haitiana, Língua haitiana
+pt:Crioulo haitiano
 ro:limba creolă haitiană, Creola haitiană
 ru:гаитянский креольский язык, Гаитянский язык, Аисьен, Гаитийский креольский язык, Гаитянский креольский
 sv:Haitisk kreol, Haitisk kreolska, Haitisk kreolfranska
@@ -4779,7 +4786,7 @@ oc:Haussà
 om:Hawussaa
 pa:ਹੌਸਾ ਭਾਸ਼ਾ
 pl:Język hausa
-pt:Língua haúça, Língua hausa, Língua Haússa
+pt:Hauçá, Haúça
 qu:Hawsa simi, Hawsa, Hausa, Hausa simi
 ru:Хауса, Хауса язык, Язык хауса
 rw:Igihawusa, Gihawusa
@@ -4879,7 +4886,7 @@ nn:Hebraisk
 oc:Ebrieu
 pa:ਹਿਬਰੂ ਭਾਸ਼ਾ
 pl:język hebrajski
-pt:língua hebraica
+pt:Hebraico
 qu:Iwriyu simi
 ro:limba ebraică
 ru:иврит
@@ -4944,7 +4951,7 @@ nb:Herero, Hererospråket
 nl:Herero
 nn:Herero
 pl:Język herero
-pt:hereró, Língua herero
+pt:Herero
 ro:Limba herero, Herero
 ru:Гереро, Гереро язык
 rw:Igiherero, Giherero
@@ -5038,7 +5045,7 @@ or:ହିନ୍ଦୀ ଭାଷା
 pa:ਹਿੰਦੀ ਭਾਸ਼ਾ
 pl:język hindi
 ps:هندي
-pt:língua hindi
+pt:Hindi
 qu:Hindi simi
 ro:limba hindi
 ru:хинди
@@ -5101,7 +5108,7 @@ nb:Hiri motu
 nl:Hiri Motu
 nn:Hiri motu
 pl:Hiri motu, Język hiri motu
-pt:Hiri Motu
+pt:Hiri motu
 ro:Hiri motu, Hiri motou
 ru:Хири-моту, Хиримоту
 sr:хири моту
@@ -5181,7 +5188,7 @@ oc:Ongrés
 os:Венгриаг æвзаг
 pa:ਮਗਯਾਰ
 pl:język węgierski
-pt:língua húngara, húngaro, idioma húngaro, linguagem húngara, magiar, magyar
+pt:Húngaro, Magiar
 qu:Unriya simi
 rm:Lingua ungaraisa
 ro:limba maghiară
@@ -5280,7 +5287,7 @@ nn:Islandsk
 oc:Islandés
 os:Исландиаг æвзаг
 pl:język islandzki
-pt:língua islandesa, islandês, idioma islandês, linguagem islandesa
+pt:Islandês
 qu:Islandya simi
 ro:Limba islandeză
 ru:исландский язык
@@ -5365,7 +5372,7 @@ nn:Ido
 oc:Ido
 pa:ਈਡੋ
 pl:Ido, Esperanto reformita, Język ido
-pt:ido, Língua ido
+pt:Ido
 qu:Ido
 rm:Ido
 ro:Ido, Limba ido
@@ -5429,7 +5436,7 @@ nn:Igbo, Ibo
 oc:Igbo
 pa:ਇਗਬੋ ਭਾਸ਼ਾ
 pl:Język igbo, Język ibo
-pt:Língua igbo
+pt:Ibo, Igbo
 qu:Igbo simi, Igbo, Ibo simi, Ibo
 ro:Limba igbo
 ru:игбо, Язык игбо
@@ -5506,7 +5513,7 @@ nn:Indonesisk
 oc:Bahasa Indonesia
 pa:ਇੰਡੋਨੇਸ਼ੀ ਬੋਲੀ
 pl:Język indonezyjski
-pt:língua indonésia, indonésio, idioma indonésio, linguagem indonésia, Bahasa Indonesia
+pt:Indonésio, Bahasa Indonesia
 qu:Indunisya simi
 ro:Limba indoneziană
 ru:индонезийский язык
@@ -5589,7 +5596,7 @@ oc:Interlingua, Interlingua d'IALA
 om:Iinterliinguwaa
 pa:ਇੰਟਰ ਲਿੰਗੂਆ, ਇੰਟਰ ਲਿੰਗੁਆ
 pl:Interlingua, Postacie interlinguy, Język interlingua, Postacie interlingwy
-pt:Interlíngua, Interlingua de IALA
+pt:Interlíngua
 qu:Interlingua
 rm:Interlingua
 ro:Interlingua
@@ -5645,7 +5652,7 @@ nb:Interlingue
 nl:Interlingue, Occidental
 oc:Interlingue, Occidental
 pl:Occidental, Interlingue
-pt:Interlingue, Língua occidental
+pt:Interlingue, Occidental
 ru:окциденталь, оксиденталь, окциденталь язык, интерлингве, интерлингвэ, оксидэнталь
 sv:Occidental, Interlingue
 ta:கிழக்கிய மொழி
@@ -5697,7 +5704,7 @@ nl:Inuktitut
 nn:Inuktitut, Inuktitut språk
 oc:Inuktitut
 pl:Inuktitut, Alfabet inuicki, Pismo inuickie, Język inuktitut, Język inukitut, Język inuicki, Inupik, Język eskimoski
-pt:Língua inuktitut, Inuctitut, Inuktitut
+pt:Inuctitute, Inuktitut
 qu:Inuyt simi, Inuk simi, Inuktitut simi, Inuyt rimaykuna, Inuktitut, Inuit simi, Inuyt rimay
 ru:Инуктитут, Инуктитут язык
 se:Inuktitut
@@ -5731,7 +5738,7 @@ nb:Inupiak
 nl:Inupiak
 nn:Iñupiaq, Inupiaq, Inupiak
 pl:Język inupiak
-pt:Língua inupiat
+pt:Inupiaque
 ru:аляскинско-инуитские языки, Инюпиак, Инупиак, Аляскинско-инуитский язык
 sv:Iñupiaq, Inupiaq, Iñupiak, Inupiak
 ta:இனுபிக்கு மொழி
@@ -5806,7 +5813,7 @@ no:irsk
 oc:Irlandés
 os:Ирландиаг æвзаг
 pl:Język irlandzki
-pt:língua irlandesa, irlandês, idioma irlandês, linguagem irlandesa, gaélico irlandês, gaélico, gaeilge
+pt:Irlandês, Gaélico irlandês, Gaélico
 qu:Ilanda simi
 rm:Lingua irlandaisa
 ro:Limba irlandeză
@@ -5916,7 +5923,7 @@ oc:Italian
 os:Италиаг æвзаг
 pa:ਇਤਾਲਵੀ ਭਾਸ਼ਾ, ਇਤਾਲਵੀ ਬੋਲੀ, ਇਟਾਲਿਅਨ ਭਾਸ਼ਾ
 pl:język włoski
-pt:italiano, idioma italiano, linguagem italiana, língua italiana
+pt:Italiano
 qu:Italya simi
 rm:Lingua taliana
 ro:limba italiană
@@ -6040,7 +6047,7 @@ or:ଜାପାନୀ ଭାଷା, Japanese language
 pa:ਜਾਪਾਨੀ ਭਾਸ਼ਾ, ਜਾਪਾਨੀ ਬੋਲੀ
 pl:język japoński, Jap., Japoński
 ps:د ياماتو ژبه
-pt:língua japonesa, 日本語, idioma japonês, nihongo, japonês
+pt:Japonês
 qu:Nihun simi, Hapunis simi, Hapun simi
 ro:limba japoneză, Japoneză, Japoneza, Limba japoneza
 ru:японский язык, японский, нихонго, яп., онное чтение
@@ -6127,7 +6134,7 @@ nn:Javanesisk, Javanesisk språk
 os:Явæйаг æвзаг, Явæйнаг æвзаг, Явайнаг æвзаг
 pa:ਜਾਵਾਨੀ ਬੋਲੀ, ਜਵਾਨੀਜ ਭਾਸ਼ਾ
 pl:Język jawajski, Basa Jawa
-pt:Língua javanesa
+pt:Javanês
 qu:Yawa simi
 ro:limba javaneză
 ru:яванский язык, Basa Jawa
@@ -6209,7 +6216,7 @@ oc:Kannada
 or:କନ୍ନଡ଼ ଭାଷା, Kannada language
 pa:ਕੰਨੜ ਭਾਸ਼ਾ, ਕੰਨੜ
 pl:Język kannada, Kannada, Język kannadyjski, Kannara
-pt:Língua canaresa, Canarês, Língua Kannada, Canará, Língua canada, Kannada, Língua canará
+pt:Canarês
 qu:Kannada simi
 ro:Limba kannada
 ru:каннада
@@ -6259,7 +6266,7 @@ nn:Kanuri-språket
 oc:Kanuri
 pa:ਕਨੂਰੀ ਭਾਸ਼ਾ
 pl:Język kanuri
-pt:Língua kanuri, Língua canúri
+pt:Canúri
 ru:Канури
 sw:Kikanuri
 ta:கனுரி மொழி
@@ -6315,7 +6322,7 @@ nn:Kasjmiri, Kasjmirsk, Kashmiri
 or:କାଶ୍ମୀରୀ ଭାଷା, Kashmiri language, କାଶ୍ମିରୀ ଭାଷା
 pa:ਕਸ਼ਮੀਰੀ ਭਾਸ਼ਾ
 pl:Język kaszmirski
-pt:Língua caxemira, Caxemiriano, Língua kashmiri
+pt:Caxemiriano, Caxemira, Caxemíri
 ru:кашмирский язык, Кашмири, Язык кашмири
 sa:कश्मीरी, कश्‍मीरी, काश्मीरी
 se:Kašmirigiella
@@ -6390,7 +6397,7 @@ nn:kasakhisk
 oc:cazac
 pa:ਕਜ਼ਾਖ ਭਾਸ਼ਾ
 pl:język kazachski
-pt:língua cazaque
+pt:Cazaque
 qu:Qasaq simi
 ro:limba kazahă
 ru:казахский язык
@@ -6464,7 +6471,7 @@ nn:Khmer
 oc:khmer
 pa:ਖਮੇਰ ਭਾਸ਼ਾ
 pl:Język khmerski
-pt:Língua khmer
+pt:Quemer
 qu:Khimir simi
 ro:Limba khmeră
 ru:кхмерский язык
@@ -6519,7 +6526,7 @@ nl:Kinyarwanda
 nn:Kinyarwanda
 oc:Kinyarwanda
 pl:Język ruanda-rundi, Kinyarwanda, Języki ruanda-rundi, Język kinyarwanda
-pt:Língua kinyarwanda, Língua ruanda, Kinyarwanda
+pt:Quiniaruanda, Kinyarwanda, Kruanda, Rwanda
 qu:Rwanda simi, Kinyarwanda, Kinyarwanda simi
 rn:Ikinyarwanda, Kinyarwanda
 ru:Руанда, Руандийский язык, Киньяруанда, Язык руанда
@@ -6568,7 +6575,7 @@ nl:Kirundi
 nn:Kirundi
 oc:Kirundi
 pl:Język rundi, Język kirundi
-pt:Língua kirundi, Kirundi, Rundi
+pt:Kirundi, Rundi
 qu:Rundi simi, Kirundi, Kirundi simi
 rn:Ikirundi, Kirundi
 ru:рунди, Кирунди, Язык Кирунди
@@ -6621,7 +6628,7 @@ nn:komi, Syrjensk, Komisk språk, Komi språk
 oc:komi
 os:Коми, Комиаг æвзаг
 pl:język komi, Język zyriański, Język komi-zyriański
-pt:língua komi, Linguagem komi
+pt:Komi
 ru:коми, Общекоми-язык, Язык Коми, Зырянский язык, Коми язык, Коми языки
 se:Komigiella
 sk:komijčina
@@ -6664,7 +6671,7 @@ nb:Kongo, Kikongo
 nl:Kongo, Kikongo
 nn:Kikongo
 pl:Język kongo, Kikongo, Język kikongo
-pt:Kikongo, Língua quicongo, Kikongo language, Língua Kikongo, Quicongo
+pt:Quicongo, Kikongo
 qu:Kongo simi, Kikongo, Kungu simi, Kituba simi, Kikongo simi, Kituba
 ru:Конго, Киконго
 sk:konžština
@@ -6756,7 +6763,7 @@ nv:Kolíya Dineʼé bizaad
 oc:Corean
 pa:ਕੋਰੀਅਨ ਭਾਸ਼ਾ
 pl:język koreański
-pt:coreano, língua coreana
+pt:Coreano
 qu:Kuryu simi
 ro:Limba coreeană
 ru:корейский язык
@@ -6847,7 +6854,7 @@ oc:Curd
 pa:ਕੁਰਦਿਸ਼ ਭਾਸ਼ਾ
 pl:Język kurdyjski, Kurdyjski język, Kurd.
 ps:کوردي ژبه
-pt:língua curda
+pt:Curdo
 qu:Kurdi simi, Kurdu simi, Kurda simi
 ro:Limba kurdă
 ru:курдские языки, Kurdî, курдский, курдский язык
@@ -6887,7 +6894,7 @@ mk:Квањама
 ms:Bahasa Kwanyama
 nl:Kwanyama
 pl:Język kwanyama
-pt:Oshikwanyama, Língua kwanyama, Língua cuanhama, Ochi-kwanyama
+pt:Cuanhama, Oshikwanyama
 ru:кваньяма, киньяма, ошикваньяма
 sv:Kwanyama
 sw:Kikwanyama, Oshiwambo, Oshivambo
@@ -6949,7 +6956,7 @@ nn:Kirgisisk
 oc:Quirguiz
 pa:ਕਿਰਗੀਜ਼ ਭਾਸ਼ਾ
 pl:Język kirgiski
-pt:Língua quirguiz
+pt:Quirguiz
 qu:Kirkis simi
 ro:limba kirghiză
 ru:киргизский язык
@@ -7014,7 +7021,7 @@ ne:लाओ
 nl:Laotiaans
 nn:Laotisk
 pl:Język laotański
-pt:Língua laociana
+pt:Laociano, Lao
 qu:Law simi
 ro:Limba laoțiană
 ru:лаосский язык
@@ -7123,7 +7130,7 @@ os:Латинаг æвзаг
 pa:ਲਾਤੀਨੀ ਭਾਸ਼ਾ
 pl:Łacina, język łaciński
 ps:لاتين ژبه
-pt:latim
+pt:Latim
 qu:Latin simi
 rm:Latin
 ro:limba latină
@@ -7226,7 +7233,7 @@ nl:Lets
 nn:Latvisk
 oc:Leton
 pl:język łotewski
-pt:língua letã, idioma letão, letão, linguagem letã, latviešu
+pt:Letão
 qu:Litunya simi
 ro:limba letonă
 ru:латышский язык, латвийский язык
@@ -7289,7 +7296,7 @@ lt:limburgiečių kalba, Limburgiečių tarmė
 nb:limburgsk, Limburgisk
 nl:limburgs, Limburgse taal, Belgisch Limburgs, Kenmerken van het Limburgs
 pl:język limburski, Dialekt limburski
-pt:língua limburguesa, Limburgio, Limburguês
+pt:Limburguês
 ro:limba limburgheză, Limburgheză
 ru:лимбургский язык, Лимбургские диалекты, Limburgs, Лимбургский диалект, Лимбургское наречие, Лимбургский диалект нидерландского языка, Южнонижнефранкский диалект, Южно-нижнефранкский диалект
 sk:limburčina, Limburgčina
@@ -7333,7 +7340,7 @@ nl:Lingala
 nn:Lingala
 oc:Lingala
 pl:Język lingala, Język ngala, Język kingala
-pt:Língua lingala, Lingala
+pt:Lingala
 qu:Lingala simi, Ngala simi
 ru:Лингала, Язык лингала, Нгала
 rw:Ilingala, Lingala
@@ -7421,7 +7428,7 @@ nn:Litauisk
 oc:Lituanian
 os:Литоваг æвзаг
 pl:język litewski
-pt:língua lituana, lituano, idioma lituano, linguagem lituana, lietuvių kalba
+pt:Lituano
 qu:Lituwa simi
 ro:limba lituaniană
 ru:литовский язык
@@ -7466,6 +7473,7 @@ ja:ルバ・カタンガ語
 kg:Kiluba
 ln:Kiluba
 nl:Luba-Katanga
+pt:Kiluba
 ru:Луба-катанга
 rw:Ikiluba, Kiluba
 sw:Kiluba-Katanga
@@ -7500,7 +7508,7 @@ nl:Luganda, Loeganda
 nn:Luganda
 oc:Luganda
 pl:Język luganda, Język ganda
-pt:Língua luganda, Luganda
+pt:Luganda, Ganda
 qu:Ganda simi, Luganda simi, Luganda
 ro:Ganda
 ru:Луганда, Луганда язык, Ганда
@@ -7571,7 +7579,7 @@ nn:Luxemburgsk
 oc:Luxemborgués
 pa:ਲਕਸਮਬਰਗੀ ਭਾਸ਼ਾ
 pl:Język luksemburski
-pt:Língua luxemburguesa
+pt:Luxemburguês
 ro:Limba luxemburgheză
 ru:люксембургский язык
 se:Luxemburggagiella
@@ -7653,7 +7661,7 @@ nl:Macedonisch
 nn:Makedonsk
 oc:Macedonian
 pl:Język macedoński
-pt:língua macedônia
+pt:Macedônio / macedónio
 qu:Makidunya simi
 ro:Limba macedoneană
 ru:македонский язык
@@ -7729,7 +7737,7 @@ nb:Gassisk
 nl:Plateaumalagasi
 nn:Gassisk
 pl:Język malgaski
-pt:Língua malgaxe
+pt:Malgaxe
 qu:Malagasi simi
 ro:Limba malgașă
 ru:малагасийский язык, мальгашский язык
@@ -7806,7 +7814,7 @@ nl:Maleis
 nn:Malayisk
 oc:Malai
 pl:Język malajski
-pt:Língua malaia
+pt:Malaio
 qu:Malaya simi
 ro:limba malaieză
 ru:малайский язык, малайский
@@ -7881,7 +7889,7 @@ oc:Malayalam
 or:ମଲୟାଲମ
 pa:ਮਲਿਆਲਮ ਭਾਸ਼ਾ, ਮਲਿਆਲਮ
 pl:Język malajalam, Malajalam, Język malajalamski
-pt:malaiala, Malayalam, Malayalama, Língua malayalam, língua malaiala
+pt:Malaiala
 qu:Malayalam simi
 ro:Limba malayalam
 ru:малаялам, малайалам, малайялам, язык малаялам, язык малайалам, малаяламский язык
@@ -7949,7 +7957,7 @@ nn:Dhivehi
 oc:Divehi
 pa:ਦਿਵੇਹੀ ਭਾਸ਼ਾ
 pl:Język malediwski
-pt:Língua divehi
+pt:Diveí, Maldivense, Maldivano
 ru:мальдивский язык, Dhivehi, дхивехи, дивехи
 si:දිවෙහි භාෂාව
 sk:Maldivčina
@@ -8025,7 +8033,7 @@ nn:Maltesisk
 oc:Maltés
 pa:ਮਾਲਟਾਈ ਭਾਸ਼ਾ
 pl:Język maltański
-pt:maltês, lingua maltesa
+pt:Maltês
 qu:Malta simi
 ro:Limba malteză
 ru:мальтийский язык
@@ -8105,7 +8113,7 @@ nn:Manx
 oc:Manés
 os:Мэнаг æвзаг
 pl:Język manx
-pt:Língua manesa
+pt:Manês, Manx, Manquês
 ro:Limba manx
 ru:мэнский язык
 se:Manksgiella
@@ -8178,7 +8186,7 @@ oc:marathi
 or:ମରାଠୀ ଭାଷା
 pa:ਮਰਾਠੀ ਭਾਸ਼ਾ
 pl:język marathi
-pt:marata, lingua marata
+pt:Marata
 qu:Marathi simi
 ro:limba marathi, Marathi
 ru:маратхи
@@ -8233,7 +8241,7 @@ nb:Marshallesisk, Marshallesisk språk
 nl:Marshallees, Marshallisch
 nn:Marshallesisk
 pl:Język marszalski
-pt:Língua marshalesa, Marshalês
+pt:Marshalês
 ru:маршалльский язык, маршалльский, маршальский язык
 rw:Ikimarishali, Kimarishali
 sh:Maršalski jezik
@@ -8287,7 +8295,7 @@ nl:Moldavisch, Moldovisch
 nn:Moldovsk
 oc:Moldau
 pl:Język mołdawski
-pt:Língua moldávia, Língua moldava
+pt:Moldavo, Moldávio
 ro:Limba moldovenească, Româna moldovenească, Idiomul moldovenesc, Limba moldoveneasca, Româna moldovenească estică, Idiomul moldoveneasc, Limba română în Republica Moldova, Moldovenească
 ru:молдавский язык, молдавский
 sh:Moldavski jezik
@@ -8375,7 +8383,7 @@ oc:Mongòl
 pa:ਮੰਗੋਲ ਭਾਸ਼ਾ
 pl:język mongolski
 ps:مغولي ژبه
-pt:Língua mongol
+pt:Mongol
 qu:Muñgul simi
 ro:Limba mongolă
 ru:монгольский язык, монгольский, монгол хэл
@@ -8456,7 +8464,7 @@ nn:Maori, Māori, Maorispråk, Māorispråk
 oc:Maòri
 os:Маори
 pl:Język maori, Maori, Język maoryjski, Język maoryski
-pt:língua maori, Língua māori, Linguagem maori
+pt:Maori
 qu:Mawri simi
 ro:Limba maori
 ru:Маори, Язык маори, Маори язык, Маорийский язык
@@ -8515,7 +8523,7 @@ nl:Nauruaans
 nn:Naurisk
 oc:Nauruan
 pl:Język naurański
-pt:Língua nauruana
+pt:Nauruano
 rm:Lingua nauruaisa
 ru:науруанский язык, Ekakairũ Naoero, наурийский язык, язык науру, науру (язык), науруский язык, Dorerin Naoero
 sv:Nauruanska
@@ -8568,7 +8576,7 @@ nn:Navaho
 nv:Diné bizaad
 oc:Navajo
 pl:język nawaho
-pt:Língua navaja
+pt:Navajo
 qu:Diné simi
 ro:Limba navajo
 ru:навахо
@@ -8598,7 +8606,7 @@ ms:Bahasa Ndonga
 ng:Ndonga
 nl:Ndonga
 pl:Język ndonga, Język ambo
-pt:Ndonga, Língua ndonga
+pt:Ndonga, Xindonga
 ru:Ндонга
 sv:Ndonga
 sw:Kindonga
@@ -8661,7 +8669,7 @@ nn:nepali, Gurkhali
 or:ନେପାଳୀ ଭାଷା
 pa:ਨੇਪਾਲੀ ਭਾਸ਼ਾ
 pl:język nepalski, Nepali, Język nepali, Nep.
-pt:língua nepali, Nepali, Nepalês, Língua nepalesa
+pt:Nepalês, Nepali
 qu:Nipali simi, Nepali simi
 ro:limba nepaleză
 ru:непальский язык, Непали, язык непали, непальский
@@ -8707,7 +8715,7 @@ mk:Северен ндебеле
 nb:nordndebele, nord-ndebele
 nl:Noord-Ndebele, IsiNdbele, IsiNdebele
 pl:Język ndebele północny, Język sindebele
-pt:língua ndebele do norte, Matabele, Sindebele, Ndebele do norte, Sindbele, Isindebele
+pt:Ndebele do norte, Matabele, Sindebele, Sindbele, Isindebele
 ru:северный ндебеле
 sv:Nordndebele, Nord-ndebele
 uk:Північна ндебеле
@@ -8752,7 +8760,7 @@ nb:nordsamisk, Nordsamisk språk, Nord-samisk språk, Samisk, Nord-samisk
 nl:noord-samisch
 nn:nordsamisk, Nord-samisk, Nordsamisk språk
 pl:język północnolapoński
-pt:língua sami setentrional, Sami setentrional
+pt:Lapão setentrional, Sami setentrional
 ru:северносаамский язык, Северо-саамский язык, Северносаамский, Северосаамский язык, Северно-саамский язык, Северносаам.
 se:davvisámegiella, Sámegiella, Northern Sami
 sh:Sjevernolaponski jezik
@@ -8837,7 +8845,7 @@ os:Норвегиаг æвзаг
 pa:ਨਾਰਵੇਈ ਭਾਸ਼ਾ
 pl:język norweski
 ps:ناروېژي ژبه
-pt:Língua norueguesa
+pt:Norueguês
 qu:Nurwiga simi
 rm:Lingua norvegiaisa
 ro:limba norvegiană
@@ -8885,6 +8893,7 @@ ko:이어
 kv:Носу
 mk:носу, ји
 pl:Język nuosu
+pt:Nuosu
 ru:Носу, И языки, Языки и
 ta:நுவோசு மொழி
 uk:Носу
@@ -9023,7 +9032,7 @@ oc:Occitan, Langue d'oc, Provençal
 om:Afaan Occitan
 os:Окситайнаг æвзаг
 pl:Język oksytański
-pt:Língua occitana
+pt:Occitano, Occitânico
 qu:Uqsitan simi
 rm:Lingua occitana
 ro:Limba occitană
@@ -9099,7 +9108,7 @@ oc:oriya
 or:ଓଡ଼ିଆ, ଓଡିଆ, Oriya language, Odia language
 pa:ਉੜੀਆ ਭਾਸ਼ਾ
 pl:język orija, Orija
-pt:língua oriá, Oriá, Oriya
+pt:Oriá
 qu:Oriya simi
 ro:Limba oriya
 ru:ория, Ория язык, Язык ория
@@ -9145,7 +9154,7 @@ nl:Ojibwe, Anishinaabemowin, Ojibwemowin
 nn:Ojibwe-språket
 pa:ਓਜੀਬਵੇ ਭਾਸ਼ਾ
 pl:Język odżibwe, Język odżibwa, Języki odżibwe, Języki odżibue, Język odżibua, Języki odżibua, Język odżibue, Języki odżibwa
-pt:Língua ojíbua
+pt:Ojíbua
 qu:Anishinapay simi, Anishinawi simi, Anishinapi simi
 ru:Оджибве, Оджибва, Собственно оджибва, Язык оджибве, Анишинаабе, Центрально-южный оджибва
 sv:Ojibwa, Anishinabemowin, Anishinaabemovin, Anishinabemovin, Anishinaabemowin, Ojibwe
@@ -9201,7 +9210,7 @@ nl:Oudkerkslavisch, Oudbulgaars, Oud-Kerkslavisch, Oud-Bulgaars, Oud-Slavonisch
 nn:Gammalkyrkjeslavisk
 oc:Eslavon
 pl:Język staro-cerkiewno-słowiański, Język starosłoweński, Język starobułgarski, Starocerkiewnosłowiański, Staro-cerkiewno-słowiański, Język słowianobułgarski, Scs., Język starosłowiański, Język starocerkiewnosłowiański, Język s-c-s
-pt:antigo eslavo eclesiástico, Antigo eslavônico eclesiástico
+pt:Antigo eslavo eclesiástico, Antigo eslavônico eclesiástico
 ro:Limba slavă veche
 ru:старославянский язык, старославянский, словѣ́ньскъ ѩꙁꙑ́къ, древнеславянский язык, старослав, древнецерковнославянский язык, старо-славянский язык, староболгарский язык, древнеболгарский язык
 sh:Staroslavenski jezik, Старословенски језик, Staroslavenski, Staroslovenski, Staroslovenski jezik
@@ -9253,7 +9262,7 @@ oc:Oromo
 om:Afaan Oromoo, Afan Oromo, Afaan Oromo
 pa:ਓਰੋਮ ਭਾਸ਼ਾ
 pl:Język oromo, Język oromski, Język galla
-pt:Língua oromo
+pt:Oromo
 qu:Oromo simi
 ru:оромо, галла
 rw:Icyoromo, Cyoromo
@@ -9319,7 +9328,7 @@ nl:Ossetisch, Osseets
 nn:Ossetisk, Ossetisk språk
 os:Ирон æвзаг, Литературон ирон æвзаг, Иронау
 pl:Język osetyjski, Język osetyński
-pt:Língua osseta, Osseto, Иронау
+pt:Osseto, Osseta
 qu:Usit simi
 ro:Limba osetă
 ru:осетинский язык, Иронау
@@ -9388,7 +9397,7 @@ or:ପାଳି ଭାଷା, ପାଳି ଭାସା
 pa:ਪਾਲੀ ਭਾਸ਼ਾ, ਪਾਲੀ ਬੋਲੀ, ਪਾਲੀ, ਪਾਲਿ ਭਾਸ਼ਾ, ਪਾਲਿ ਬੋਲੀ
 pi:पालि Pāli
 pl:Język pali, Język palijski, Pāli
-pt:Páli, Língua páli, Pāli
+pt:Páli
 ro:Limba pali
 ru:пали
 sa:पालिभाषा
@@ -9467,7 +9476,7 @@ os:Пушту, Пашто
 pa:ਪਸ਼ਤੋ
 pl:Język paszto, Język pasztuński, Język afgański, Paszto
 ps:پښتو ژبه, پښتو
-pt:Língua pachto, Língua pachtun, Língua pashto, Pashtoe, Língua pushtun, Língua pastó, Pukhto, Afghan, Pashto, Pushtun, Língua pushtu, Pashtu, Pushto, Língua pashtu, Pushtu, Pachto, Língua afegã
+pt:Pastó / afegão, Pachto, Afegane
 qu:Pashtu simi, Pastu simi
 ro:Limba paștună, Limba paștu, Limba paştună
 ru:Пушту, Афганский язык, Язык пушту, Пашто, Пуштунский язык, Пушту язык, Авганский язык
@@ -9565,7 +9574,7 @@ os:Персайнаг æвзаг
 pa:ਫ਼ਾਰਸੀ ਬੋਲੀ
 pl:język perski
 ps:پارسي
-pt:língua persa, farsi
+pt:Persa, Farsi
 qu:Pharsi simi
 ro:Limba persană
 ru:персидский язык, фарси
@@ -9683,7 +9692,7 @@ oc:Polonés
 os:Польшæйаг æвзаг
 pa:ਪੋਲਥਾਨੀ ਭਾਸ਼ਾ
 pl:język polski, polszczyzna
-pt:língua polaca, idioma polaco, polaco, polonês, língua polonesa, idioma polonês, język polski, polszczyzna
+pt:Polonês / polaco
 qu:Pulaku simi
 ro:limba polonă, polona, poloneza, pl
 ru:польский язык
@@ -9802,7 +9811,7 @@ oc:Portugués, Lenga portuguesa
 os:Португайлаг æвзаг, Португайлагау
 pa:ਪੁਰਤਗਾਲੀ ਭਾਸ਼ਾ
 pl:język portugalski, Port., Portugalski
-pt:língua portuguesa, português, idioma português, linguagem portuguesa
+pt:Português
 qu:Purtuyis simi, Purtuguis simi, Purtugual simi, Purtugal simi
 rm:Lingua portugaisa
 ro:Limba portugheză, Portugheză, Portugheza, Limba portugheza
@@ -9899,7 +9908,7 @@ or:ପଞ୍ଜାବୀ ଭାଷା, Punjabi language
 pa:ਪੰਜਾਬੀ ਭਾਸ਼ਾ, ਪੰਜਾਬੀ ਬੋਲੀ, ਪੰਜਾਬੀ/پنجابی, ਪੰਜਾਬੀ ਲੇਖਕਾਂ, Panjabi, Punjabi, ਪੰਜਾਬੀ, ਪੰਜਾਬੀ ਕਵੀਆਂ
 pl:Język pendżabski, Pendżabski, Język wschodniopendżabski, Pańdźabi, Pendźabski, Język pendźabski
 ps:پنجابي
-pt:Língua panjabi, Língua punjabi, Punjabi, Língua punjabe, Panjabi
+pt:Panjábi, Punjábi
 qu:Panyabi simi, Punyabi simi, Punyabi, Punjabi simi, Panjabi, Panyabi, Punjabi, Panjabi simi
 ro:Limba punjabă
 ru:панджаби, пенджаби, пенджабский язык, восточный панджаби, язык панджаби, пенджабский, западный пенджабский язык
@@ -9982,7 +9991,7 @@ nn:quechua
 nv:Kéchwa bizaad
 oc:quíchoa, Qechua
 pl:język keczua
-pt:quíchua
+pt:Quíchua
 qu:Qhichwa simi
 rm:quechua
 ro:limbi quechua
@@ -10071,7 +10080,7 @@ nn:Rumensk
 oc:Romanés
 pl:język rumuński
 ps:رومانيايي ژبه
-pt:Língua romena
+pt:Romeno
 qu:Rumanya simi
 rm:Lingua rumena
 ro:limba română
@@ -10163,7 +10172,7 @@ nn:Retoromansk
 oc:Romanch
 os:Романшаг æвзаг
 pl:Język romansz
-pt:Língua romanche
+pt:Romanche, Grisão
 rm:Rumantsch dal Grischun
 ro:Limba retoromană
 ru:романшский язык, Rumantsch, граубюндер, курваль, швейцарский ретороманский язык, романшский, urhjihtnthjvfycrbq
@@ -10282,7 +10291,7 @@ os:Уырыссаг æвзаг
 pa:ਰੂਸੀ ਬੋਲੀ
 pl:język rosyjski
 ps:روسي
-pt:língua russa, russo, linguagem russa, idioma russo, русский
+pt:Russo
 qu:Rusu simi
 rm:lingua russa
 ro:limba rusă
@@ -10363,7 +10372,7 @@ nl:Samoaans
 nn:Samoansk, Samoisk
 oc:Samoan
 pl:Język samoański, Język samoa
-pt:Língua samoana, Samoano
+pt:Samoano
 qu:Samwa simi
 ro:Limba samoană
 ru:самоанский язык, Самоанский, Самоа
@@ -10405,7 +10414,7 @@ nb:sango
 nl:Sango
 oc:sango
 pl:Język sango
-pt:Língua sango, Sangho, Sango
+pt:Sango, Sangho
 ru:санго, язык
 sg:Sängö
 ta:சாங்கோ மொழி
@@ -10570,7 +10579,7 @@ nn:Sardisk
 oc:Sarde
 os:Сардаг æвзаг, Сардинаг æвзаг, Сардиниаг æвзаг
 pl:Język sardyński
-pt:Língua sarda, Sardo
+pt:Sardo, Sardenho
 ro:Limba sardă
 ru:сардинский язык, Сардский язык, Сардинский
 sc:Limba sarda, Sardu
@@ -10652,7 +10661,7 @@ nn:Skotsk-gælisk
 oc:Gaelic escocés
 os:Шотландиаг æвзаг
 pl:Język gaelicki szkocki
-pt:Língua gaélica escocesa
+pt:Gaélico escocês
 qu:Iskut kilta simi
 ro:Limba scoțiană
 ru:шотландский язык, гэльский язык, гаэльский язык, шотландский язык (кельтский)
@@ -10745,7 +10754,7 @@ om:Afaan Sarbiyaa
 os:Сербаг æвзаг
 pa:ਸਰਬੀਆਈ ਭਾਸ਼ਾ
 pl:język serbski
-pt:língua sérvia
+pt:Sérvio
 qu:Sirbya simi
 ro:Limba sârbă
 ru:сербский язык
@@ -10805,7 +10814,7 @@ nl:Shona
 nn:Shona
 oc:Shona
 pl:Język shona, Język chishona, Język szona, Język cziszona
-pt:Língua chona, Língua chixona, SiShona, Xishona, Língua xichona, Língua xona, XiChona, ChiShona, Shona
+pt:Xona
 qu:Shona simi
 ru:шона, ChiShona, чишона, шона (язык), каранга
 sn:ChiShona
@@ -10867,7 +10876,7 @@ or:ସିନ୍ଧି ଭାଷା, ସିନ୍ଧୀ ଭାଷା
 pa:ਸਿੰਧੀ ਭਾਸ਼ਾ
 pl:sindhi, Język sindhi
 ps:سيندي ژبه
-pt:língua sindi
+pt:Sindi
 qu:Sindi simi, Sindhi simi, Sindhi
 ru:синдхи, язык синдхи, синдху, синдхи язык
 sd:سنڌي ٻولي, سنڌی ٻولی
@@ -10933,7 +10942,7 @@ nn:Singalesisk
 oc:Singalés
 pa:ਸਿੰਹਾਲਾ ਭਾਸ਼ਾ
 pl:Język syngaleski
-pt:Língua cingalesa
+pt:Cingalês
 qu:Sinhala simi
 ro:Limba singaleză
 ru:сингальский язык
@@ -11021,7 +11030,7 @@ oc:Eslovac
 os:Словакаг æвзаг
 pa:ਸਲੋਵਾਕ ਭਾਸ਼ਾ
 pl:Język słowacki
-pt:língua eslovaca, eslovaco, linguagem eslovaca, idioma eslovaco, slovenčina, slovenský jazyk
+pt:Eslovaco
 qu:Isluwakya simi
 ro:Limba slovacă
 ru:словацкий язык
@@ -11118,7 +11127,7 @@ nl:Sloveens
 nn:Slovensk
 oc:Eslovèn
 pl:Język słoweński
-pt:língua eslovena, esloveno, idioma esloveno, linguagem eslovena, slovenščina
+pt:Esloveno
 qu:Isluwinya simi
 ro:limba slovenă
 ru:словенский язык
@@ -11192,7 +11201,7 @@ nl:Somalisch
 nn:Somali
 oc:Somali
 pl:język somalijski
-pt:Língua somali
+pt:Somali
 qu:Sumali simi
 ro:limba somaleză
 ru:сомалийский язык
@@ -11247,7 +11256,7 @@ nb:sesotho, sotho, sørsotho, Sesotho språk, Sør-sotho
 nl:Zuid-Sotho, Sesotho
 nn:Sotho, Sesotho
 pl:Język sotho, Język sesotho, Język sesuto
-pt:língua soto do sul, Sesotho, Língua sesotho
+pt:Sesoto, Soto do sul, Sesotho
 qu:Sesotho simi, Sisuthu, Sotho simi, Sesotho, Suthu simi
 ro:Limba sotho
 ru:сесото, сото южный язык, сесото язык, сото, южный сото язык
@@ -11297,7 +11306,7 @@ nb:sørndebele, sør-ndebele
 nl:Zuid-Ndebele
 nn:Sørndebele
 pl:Język ndebele południowy
-pt:língua ndebele, Ndebele
+pt:Ndebele do sul
 ru:южный ндебеле
 sq:Gjuha ndebele
 sv:Sydndebele
@@ -11405,7 +11414,7 @@ os:Испайнаг æвзаг
 pa:ਸਪੈਨਿਸ਼ ਭਾਸ਼ਾ
 pl:język hiszpański
 ps:هسپاني
-pt:língua castelhana, espanhol, castelhano, Idioma espanhol, língua espanhola, idioma castelhano, linguagem espanhola, linguagem castelhana
+pt:Espanhol / castelhano, Castelhano
 qu:Kastilla simi
 rm:Lingua spagnola
 ro:Limba spaniolă
@@ -11485,7 +11494,7 @@ nb:sundanesisk, Sundanesisk språk
 nl:soendanees, Basa sunda, Soendaas, Sundanees
 nn:sunda
 pl:język sundajski
-pt:língua sundanesa
+pt:Sundanês
 qu:Sunda simi
 ru:сунданский язык, Сунданский, Basa Sunda
 se:Sundagiella
@@ -11578,7 +11587,7 @@ om:Swahili
 os:Суахили
 pa:ਸਵਾਹਿਲੀ
 pl:Suahili
-pt:Língua suaíli
+pt:Suaíli
 qu:Swahili simi
 ro:limba swahili
 ru:cуахили
@@ -11642,7 +11651,7 @@ nb:swati, siswati, Swati språk, Swazi
 nl:Swazi, SiSwati
 nn:Swazi
 pl:Język suazi, SiSwati, Język seswati, Język siswati, Język swati, Język swazi
-pt:língua suázi, SiSwati, Língua swazi, Swati, Phuthi, Tekela
+pt:Suázi
 qu:Swasi simi
 ru:свати, SiSwati, свази, свати язык
 ss:SiSwati, Siswazi, Swati, Tekeza, Swazi, Seswati, Thithiza, Phuthi, Isiswazi, Yeyeza, Tekela
@@ -11739,7 +11748,7 @@ oc:Suedés
 os:Шведаг æвзаг
 pa:ਸਵੀਡਿਸ਼ ਭਾਸ਼ਾ
 pl:język szwedzki
-pt:língua sueca, sueco, idioma sueco, linguagem sueca, svenska
+pt:Sueco
 qu:Suwiri simi
 rm:Lingua svedaisa
 ro:Limba suedeză
@@ -11829,7 +11838,7 @@ nn:tagalog
 oc:tagalòg, Lenga tagalòg
 pa:ਤਗਾਲੋਗ
 pl:język tagalski, Tagalog, Język tagalog
-pt:língua tagalo, Tagalog, Tagalo, Língua tagalog, Tagal, Língua tagala
+pt:Tagalo, Tagalog, Tagalogue, Filipino
 qu:Tagalu simi, Tagalog simi, Tagalog, Tagalo simi, Taqaluq simi, Philipinu simi
 ro:Limba tagalog
 ru:тагальский язык, Филипино, Тагальский, Тагалог
@@ -11884,7 +11893,7 @@ nl:Tahitiaans, Tahitisch
 nn:Tahitisk
 oc:Tahitian
 pl:Język tahitański, Język tahiti
-pt:Língua taitiana, Taitiano
+pt:Taitiano
 qu:Tahiti simi
 ru:таитянский язык, Таитянский, Таити
 sr:тахићански језик
@@ -11949,7 +11958,7 @@ os:Таджикаг æвзаг
 pa:ਤਾਜਿਕ ਭਾਸ਼ਾ
 pl:Język tadżycki
 ps:تاجکي ژبه
-pt:Língua tadjique
+pt:Tajique / tadjique
 qu:Tayik simi
 ro:Limba tadjică
 ru:таджикский язык
@@ -12038,7 +12047,7 @@ oc:Tamol
 or:ତାମିଲ ଭାଷା
 pa:ਤਾਮਿਲ ਭਾਸ਼ਾ, ਤਾਮਿਲ, ਤਮਿਲ, ਤਮਿਲ ਭਾਸ਼ਾ, ਤਾਮਿਲ ਬੋਲੀ
 pl:Język tamilski
-pt:Língua tâmil
+pt:Tâmil
 qu:Tamil simi
 ro:limba tamilă
 ru:тамильский язык
@@ -12122,7 +12131,7 @@ oc:Tatar
 os:Тæтæйраг æвзаг, Тæтæйрагау
 pa:ਤਤਾਰ ਭਾਸ਼ਾ
 pl:Język tatarski
-pt:Língua tártara, Língua tatar
+pt:Tártaro
 ro:limba tătară, Tătară, Limba tatară
 ru:татарский язык, Татарча, Tatarça, Татар теле, Tatar tele
 sk:Tatárčina
@@ -12196,7 +12205,7 @@ oc:Telugu
 or:ତେଲୁଗୁ ଭାଷା
 pa:ਤੇਲੁਗੂ ਭਾਸ਼ਾ
 pl:Język telugu
-pt:Língua telugu
+pt:Telugo, Télugo
 qu:Telugu simi
 ro:Limba telugu
 ru:телугу
@@ -12277,7 +12286,7 @@ nn:Thai
 oc:Tai
 pa:ਥਾਈ ਭਾਸ਼ਾ
 pl:Język tajski
-pt:Língua tailandesa
+pt:Tailandês
 qu:Thay simi
 ro:Limba thailandeză
 ru:тайский язык
@@ -12357,7 +12366,7 @@ nn:Tibetansk, Tibetansk språk
 oc:Tibetan
 pa:ਤਿੱਬਤੀ ਭਾਸ਼ਾ
 pl:Język tybetański, Tyb.
-pt:Língua tibetana, Tibetano, Tibetano padrão, Idioma tibetano, Tibetano central
+pt:Tibetano
 qu:Tibet simi, Pui simi
 ro:Limba tibetană, Tibetană
 ru:тибетский язык, Тибетский
@@ -12420,7 +12429,7 @@ nl:Tigrinya
 nn:Tigrinja, Tigrinya
 pa:ਟਿਗਰੀਨਿਆ ਬੋਲੀ, ਟਿਗਰੀਨਿਆ ਭਾਸ਼ਾ
 pl:Język tigrinia, Język tigrynia, Język tigrinja, Język tigrina, Język tigrinya
-pt:Língua tigrínia, Língua tigrina, Tigrinya, Língua tigrinya, Tigrínia, Tigrigna
+pt:Tigrínia, Tigrinha
 ro:Limba tigrinya
 ru:тигринья, тигринэ, тиграй
 sk:Tigriňa
@@ -12475,7 +12484,7 @@ nb:Tongansk, Tonganesisk språk, Tonganesisk, Tongansk språk
 nl:Tongaans
 nn:Tongansk, Tongansk språk
 pl:Język tonga, Język tongijski, Język tongański
-pt:Língua tonganesa, Tonganês
+pt:Tonganês
 qu:Tonga simi, Tunqa simi, Tunga simi
 ru:тонганский язык, Тонга
 sh:Tonganski jezik
@@ -12525,7 +12534,7 @@ nl:Tsonga
 nn:Tsonga
 oc:Tsonga
 pl:Język tsonga, Język czitsonga, Język chitsonga
-pt:língua tsonga, ChiTsonga, Xangana, Changana, Língua changana, Xitsonga, Língua chitsonga, XiChangana
+pt:Tsonga
 ru:тсонга, шангаан, тсонга язык
 sq:Gjuha tsonga
 st:Setsonga
@@ -12578,7 +12587,7 @@ nl:Tswana, Setswana
 nn:Setswana, Tswana
 oc:Tswana
 pl:Język tswana, Język setswana
-pt:língua tswana, SeTswana, Língua SeTswana, Língua tsuana
+pt:Tswana / tsuana
 qu:Tswana simi, Setswana simi, Setswana
 ro:Limba tswana
 ru:тсвана, Язык Тсвана, Сетсвана, Тсвана язык
@@ -12680,7 +12689,7 @@ os:Туркаг æвзаг
 pa:ਤੁਰਕ ਭਾਸ਼ਾ
 pl:język turecki
 ps:ترکي ژبه
-pt:língua turca, turco, idioma turco, linguagem turca
+pt:Turco
 qu:Turku simi
 rm:lingua tirca
 ro:limba turcă
@@ -12769,7 +12778,7 @@ nn:Turkmensk
 oc:Turcmèn
 pl:Język turkmeński
 ps:ترکمني ژبه
-pt:Língua turcomena
+pt:Turcomeno, Turcomano
 qu:Turkmin simi
 ro:Limba turkmenă
 ru:туркменский язык
@@ -12813,7 +12822,7 @@ nb:Twi
 nl:Twi
 oc:Twi
 pl:Język twi
-pt:Língua twi, Língua axânti, Axânti, Língua ashanti, Twi
+pt:Axante, Axânti, Twi
 ru:чви, тви
 sh:Twi jezik
 ta:துவி மொழி
@@ -12901,7 +12910,7 @@ oc:Ucraïnian
 os:Украинаг æвзаг
 pa:ਉਕਰੇਨੀ ਭਾਸ਼ਾ
 pl:język ukraiński
-pt:Língua ucraniana
+pt:Ucraniano
 qu:Ukranya simi
 ro:limba ucraineană
 ru:украинский язык, малорусский язык
@@ -12938,6 +12947,7 @@ wikidata:en: Q8798
 
 en:unknown language
 fr:langue inconnue
+pt:idioma desconhecido, língua desconhecida, desconhecido
 xx:unknown language
 language_code_2:en: xx
 
@@ -13012,7 +13022,7 @@ pa:ਉਰਦੂ ਭਾਸ਼ਾ
 pi:उर्दू भाषा
 pl:Język urdu
 ps:اوردو ژبه
-pt:Língua urdu
+pt:Urdu
 qu:Urdu simi
 ro:limba urdu
 ru:урду
@@ -13090,7 +13100,7 @@ nn:Uigurisk
 oc:Oigor
 pa:ਉਇਗੁਰ ਭਾਸ਼ਾ
 pl:Język ujgurski
-pt:Língua uigur
+pt:Uigur / uigure
 qu:Uyq'ur simi
 ru:уйгурский язык
 se:Uiguragiella
@@ -13168,7 +13178,7 @@ oc:Uzbek
 pa:ਉਜ਼ਬੇਕ ਭਾਸ਼ਾ
 pl:Język uzbecki
 ps:اوزبکي ژبه
-pt:Língua uzbeque
+pt:Usbeque / uzbeque
 qu:Usbik simi
 ro:Limba uzbecă
 ru:узбекский язык, Узбекский разговорник
@@ -13222,7 +13232,7 @@ nl:Venda
 nn:Tshivenda
 oc:Venda
 pl:Język venda
-pt:língua venda
+pt:Venda
 ru:венда
 rw:Ikivenda
 sh:Venda jezik
@@ -13302,7 +13312,7 @@ nn:Vietnamesisk
 oc:Việt
 pa:ਵਿਅਤਨਾਮੀ ਭਾਸ਼ਾ
 pl:język wietnamski
-pt:Língua vietnamita
+pt:Vietnamita
 qu:Witnam simi
 ro:Limba vietnameză
 ru:вьетнамский язык
@@ -13471,7 +13481,7 @@ nn:Walisisk
 oc:Galés
 os:Валлийаг æвзаг
 pl:Język walijski
-pt:língua galesa, galês
+pt:Galês
 qu:Kamri simi
 rm:Lingua valisica
 ro:limba galeză
@@ -13534,6 +13544,7 @@ ne:पश्चिमी फ्रिजी
 nl:Westerlauwers Fries, Fries, Frysk, Westlauwers Fries, Nieuwfries, Friese taal
 nn:Vestfrisisk, Vestfrisisk språk
 pl:Język zachodniofryzyjski
+pt:Frísio ocidental
 ru:западнофризский язык
 sh:Zapadnofrizijski jezik
 sr:западнофризијски језик
@@ -13581,7 +13592,7 @@ nl:Wolof
 nn:Wolof, Wolof-språket
 oc:Wolòf
 pl:Język wolof
-pt:Língua wolof
+pt:Uolofe, uólofe, wolof, jalofo
 qu:Wolof simi
 ru:Волоф, Волоф язык, Язык волоф
 sq:Gjuha volof
@@ -13646,7 +13657,7 @@ nn:Xhosa
 oc:Xhosa
 pa:ਕੋਸਾ ਭਾਸ਼ਾ
 pl:Język xhosa
-pt:língua xhosa
+pt:Xossa
 qu:Xhosa simi
 ru:коса
 rw:Ikigisosa
@@ -13729,7 +13740,7 @@ nl:Jiddisch
 nn:Jiddisch
 oc:Yiddish
 pl:jidysz
-pt:língua iídiche
+pt:Iídiche
 ro:limba idiș
 ru:идиш
 sh:Jidiš
@@ -13788,7 +13799,7 @@ nl:Yoruba
 nn:Joruba, Yoruba
 oc:Ioruba
 pl:Język joruba, Język yoruba
-pt:Língua iorubá, Língua Yoruba
+pt:Iorubá
 qu:Yoruba simi, Yoruba, Yuruwa simi, Yuruba simi
 ro:Limba yoruba
 ru:йоруба, Язык йоруба, Йоруба язык
@@ -13831,7 +13842,7 @@ nb:Zhuang
 nl:Zhuang
 nn:Zhuang
 pl:Język zhuang
-pt:Língua zhuang
+pt:Zhuang
 ru:чжуанский язык
 sv:Zhuang
 ta:சுவாங்கு மொழி
@@ -13897,7 +13908,7 @@ oc:Zulu
 pa:ਜ਼ੁਲੂ ਭਾਸ਼ਾ
 pl:Język zulu
 ps:زولو
-pt:língua zulu
+pt:Zulu
 qu:Zulu simi
 ro:Limba zulu
 ru:зулу, зулусский язык


### PR DESCRIPTION
**Description:**

- I've removed "Língua" from strings like "Língua portuguesa" in Portuguese translations to fix a issue while editing products in Open Food Facts website. Because at this moment, pressing the key "P" in keyboard, it jumps to another language and not "Portuguese" or the first one having the "P" letter.  This affects also the sort order of course. (See  #6046)

- Fixed a few Portuguese translation errors.

- In some cases (4 or 6 of them) I've changed the first existing translation in each string to show simultaneously Brazilian Portuguese and Portuguese (or European Portuguese) in the string shown in interface (where they differ) to reach all Portuguese speaking variations. For example "Thecho / Checo" (pt-br / pt). So this way no user will think "oh this website is in Brazilian Portuguese" or "it's in European Portuguese", it's in both like in Portuguese Wikipedia.

- Added a note in the beginning to help other translators.

**Related issues and discussion:**
#6046 

P.S.: I have to make this changes to https://github.com/openfoodfacts/openfoodfacts-server/blob/main/taxonomies/languages.txt also right? Can someone please explain why there are 2 files apparently about the same thing?  "languages.txt" and  "languages.result.txt"