### PR TITLE
Small fixes for knowledge panels

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -399,7 +399,10 @@ sub process_template($$$) {
 
 	$template_data_ref->{round} = sub($) {
 		return sprintf ("%.0f", $_[0]);
-	};	
+	};
+	$template_data_ref->{sprintf} = sub($$) {
+		return sprintf ($_[0], $_[1]);
+	};		
 	
 	return($tt->process($template_filename, $template_data_ref, $result_content_ref));
 }
@@ -8295,7 +8298,8 @@ HTML
 
 		# Knowledge panels are in development, they can be activated with the "panels" parameter
 		# for debugging and demonstration purposes
-		if (param('panels')) {
+		# Also activate them for moderators
+		if (($User{moderator}) or (param('panels'))) {
 			create_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
 			$template_data_ref->{environment_card_panel} = display_knowledge_panel($product_ref->{"knowledge_panels_" . $lc}, "environment_card");
 		}

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -425,36 +425,6 @@ sub create_ecoscore_panel($$$) {
                 $adjustment_panel_data_ref, $product_ref, $target_lc, $target_cc);
         }
 
-        # Add panels for environmental Eco-Score labels
-        if ((defined $product_ref->{ecoscore_data}) and (defined $product_ref->{ecoscore_data}{adjustments})
-            and (defined $product_ref->{ecoscore_data}{adjustments}{production_system})
-            and (defined $product_ref->{ecoscore_data}{adjustments}{production_system}{labels})) {
-
-            foreach my $labelid (@{$product_ref->{ecoscore_data}{adjustments}{production_system}{labels}}) {
-                my $label_panel_data_ref = {
-                    label => $labelid,
-                    evaluation => "good",
-                };
-
-                # Add label icon
-                my $icon_url = get_tag_image($target_lc, "labels", $labelid);
-                if (defined $icon_url) {
-                    $label_panel_data_ref->{icon_url} = $static_subdomain . $icon_url;
-                }
-
-                # Add properties of interest
-                foreach my $property (qw(environmental_benefits description)) {
-                    my $property_value = get_inherited_property("labels", $labelid, $property . ":" . $target_lc);
-                    if (defined $property_value) {
-                        $label_panel_data_ref->{$property} = $property_value;
-                    }
-                }
-
-                create_panel_from_json_template("environment_label_" . $labelid, "api/knowledge-panels/environment/label.tt.json",
-                    $label_panel_data_ref, $product_ref, $target_lc, $target_cc);
-            }
-        }
-
         # Add panel for the final Eco-Score of the product
         create_panel_from_json_template("ecoscore_total", "api/knowledge-panels/environment/ecoscore/total.tt.json",
             $panel_data_ref, $product_ref, $target_lc, $target_cc);
@@ -464,6 +434,36 @@ sub create_ecoscore_panel($$$) {
         create_panel_from_json_template("ecoscore", "api/knowledge-panels/environment/ecoscore/ecoscore_unknown.tt.json",
             $panel_data_ref, $product_ref, $target_lc, $target_cc);
 	}
+
+    # Add panels for environmental Eco-Score labels
+    if ((defined $product_ref->{ecoscore_data}) and (defined $product_ref->{ecoscore_data}{adjustments})
+        and (defined $product_ref->{ecoscore_data}{adjustments}{production_system})
+        and (defined $product_ref->{ecoscore_data}{adjustments}{production_system}{labels})) {
+
+        foreach my $labelid (@{$product_ref->{ecoscore_data}{adjustments}{production_system}{labels}}) {
+            my $label_panel_data_ref = {
+                label => $labelid,
+                evaluation => "good",
+            };
+
+            # Add label icon
+            my $icon_url = get_tag_image($target_lc, "labels", $labelid);
+            if (defined $icon_url) {
+                $label_panel_data_ref->{icon_url} = $static_subdomain . $icon_url;
+            }
+
+            # Add properties of interest
+            foreach my $property (qw(environmental_benefits description)) {
+                my $property_value = get_inherited_property("labels", $labelid, $property . ":" . $target_lc);
+                if (defined $property_value) {
+                    $label_panel_data_ref->{$property} = $property_value;
+                }
+            }
+
+            create_panel_from_json_template("environment_label_" . $labelid, "api/knowledge-panels/environment/label.tt.json",
+                $label_panel_data_ref, $product_ref, $target_lc, $target_cc);
+        }
+    }    
 }
 
 

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -502,6 +502,11 @@ sub create_environment_card_panel($$$) {
 
     my $panel_data_ref = {};
 
+    # Include the carbon footprint panel if we have data for it
+    if ((defined $product_ref->{ecoscore_data}) and ($product_ref->{ecoscore_data}{status} eq "known")) {
+        $panel_data_ref->{carbon_footprint} = 1;
+    }
+
     # Create panel for palm oil
     if ((defined $product_ref->{ecoscore_data}) and (defined $product_ref->{ecoscore_data}{adjustments})
         and (defined $product_ref->{ecoscore_data}{adjustments}{threatened_species})

--- a/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
+++ b/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
@@ -18,7 +18,7 @@
     "title_element": {
         [% SET driving_100g_rounded = sprintf('%.1f', driving_100g) %]
         "title": "[% f_lang('f_equal_to_driving_km_in_a_petrol_car',  { 'kilometers' => driving_100g_rounded } ) %]",
-        [% SET co2_100g_rounded = co2_100g * 1000 FILTER format('%.0f') %]
+        [% SET co2_100g_rounded = sprintf('%.0f', co2_100g * 1000) %]
         "subtitle": "[% f_lang('f_carbon_footprint_per_100g_of_product', { 'grams' => co2_100g_rounded }) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/car.svg",
         "icon_color_from_evaluation": true,

--- a/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
+++ b/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
@@ -16,9 +16,9 @@
     "evaluation": "good",
     [% END %]
     "title_element": {
-        [% SET driving_100g_rounded = driving_100g FILTER format('%.1f'); %]
+        [% SET driving_100g_rounded = sprintf('%.1f', driving_100g) %]
         "title": "[% f_lang('f_equal_to_driving_km_in_a_petrol_car',  { 'kilometers' => driving_100g_rounded } ) %]",
-        [% SET co2_100g_rounded = co2_100g * 1000 FILTER format('%.0f'); %]
+        [% SET co2_100g_rounded = co2_100g * 1000 FILTER format('%.0f') %]
         "subtitle": "[% f_lang('f_carbon_footprint_per_100g_of_product', { 'grams' => co2_100g_rounded }) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/car.svg",
         "icon_color_from_evaluation": true,

--- a/templates/api/knowledge-panels/environment/environment_card.tt.json
+++ b/templates/api/knowledge-panels/environment/environment_card.tt.json
@@ -15,6 +15,7 @@
                 "panel_id": "ecoscore",
             },
         },
+        [% IF panel.carbon_footprint %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
@@ -22,6 +23,7 @@
                 "panel_ids": ["carbon_footprint"],
             },
         },
+        [% END %]
         [% IF panel.packaging_recycling %]
         {
             "element_type": "panel_group",
@@ -44,7 +46,7 @@
             },
         },
         [% END %]        
-        [% IF product.ecoscore_data.adjustments.production_system.value != 0 %]
+        [% IF product.ecoscore_data.adjustments.production_system.value.defined AND product.ecoscore_data.adjustments.production_system.value != 0 %]
         {
             "element_type": "panel_group",
             "panel_group_element": {

--- a/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
@@ -4,9 +4,9 @@
 [% IF product.packagings %]
     [% FOREACH packaging IN product.packagings %]
         [% IF packaging.recycling.defined %]
-            [% SET recycling_types.$recycling = 1 %]
+            [% SET recycling_types.${packaging.recycling} = 1 %]
         [% ELSE %]
-        [% SET recycling_types.$unknown = 1 %]
+            [% SET recycling_types.$unknown = 1 %]
         [% END %]
     [% END %]
 [% END %]
@@ -57,7 +57,7 @@
     "expanded": "yes",
     "elements": [
         [% FOREACH recycling_type IN ["en:recycle", "en:discard", "en:unknown"] %]
-            [% IF recycling_types.$recycling.defined %]
+            [% IF recycling_types.$recycling_type.defined %]
             {
                 "element_type": "text",
                 "text_element": {
@@ -66,12 +66,15 @@
                     [% IF recycling_type == "en:recycle" %]
                     "evaluation": "good",
                     "icon_url": "[% static_subdomain %]/images/icons/dist/recycle-variant.svg",
+                    "icon_alt": "[% display_taxonomy_tag("packaging_recycling",recycling_type) %]",
                     [% ELSIF recycling_type == "en:discard" %]
                     "evaluation": "bad",
                     "icon_url": "[% static_subdomain %]/images/icons/dist/delete.svg",
+                    "icon_alt": "[% display_taxonomy_tag("packaging_recycling",recycling_type) %]",
                     [% ELSE %]
                     "evaluation": "neutral",
                     "icon_url": "[% static_subdomain %]/images/icons/dist/help.svg",
+                    "icon_alt": "[% lang('unknown') %]",
                     [% END %]                
                     "html": `
                         [% FOREACH packaging IN product.packagings %]

--- a/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
@@ -42,7 +42,7 @@
     "evaluation": "bad",
     "title_element": {
         "title": "[% lang('ecoscore_packaging_impact_high') %]",
-    }
+    },
     [% ELSIF product.ecoscore_data.adjustments.packaging.value <= -5 %]
     "evaluation": "average",
     "title_element": {

--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -12,7 +12,7 @@
 			&rarr; <a href="https://fr.openfoodfacts.org/eco-score-l-impact-environnemental-des-produits-alimentaires">Découvrir l'Eco-Score</a></p>
 				</div>
 				<div class="show-for-large-up large-3 xlarge-2 columns">
-					<a href="https://fr.openfoodfacts.org/eco-score-l-impact-environnemental-des-produits-alimentaires"><img src="https://static.openfoodfacts.org/images/icons/ecoscore-a.svg" alt="Eco-Score"></a>
+					<a href="https://fr.openfoodfacts.org/eco-score-l-impact-environnemental-des-produits-alimentaires"><img src="https://static.openfoodfacts.org/images/attributes/ecoscore-a.svg" alt="Eco-Score"></a>
 				</div>
 			</div>
 		</div>

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -184,7 +184,7 @@
                 <a href="/nova" title="[% a_title %]">
                 [% display_icon('info') %]</a>
             </h4>
-            <a href="/nova" title="[% a_title %]"><img src="/images/misc/nova-group-[% group %].svg" alt="[% display %]" style="margin-bottom:1rem;max-width:100%"></a><br>
+            <a href="/nova" title="[% a_title %]"><img src="/images/attributes/nova-group-[% group %].svg" alt="[% display %]" style="margin-bottom:1rem;max-width:100%"></a><br>
             [% display %]
         [% END %]
     </div>
@@ -247,7 +247,7 @@
 	[% END %]
 	
 	<a href="[% url_for_text("ecoscore") %]" title="[% lang('ecoscore_information') %]">
-		<img src="/images/icons/ecoscore-[% ecoscore_grade_lc %].svg" alt="Eco-score [% ecoscore_grade %]" style="margin-bottom:1rem;max-width:100%">
+		<img src="/images/attributes/ecoscore-[% ecoscore_grade_lc %].svg" alt="Eco-score [% ecoscore_grade %]" style="margin-bottom:1rem;max-width:100%">
 	</a>
 	<br>
   

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -8,7 +8,9 @@
 [% END %]
     <a href="#panel_[% panel_id | replace(':','-') %]_content" class="panel_title[% IF panel.grade %] grade_[% panel.grade %][% END %]">
         [% IF panel.title_element.icon_url.defined %]
-        <img src="[% panel.title_element.icon_url %]" style="[% IF panel.title_element.icon_size == 'small' %]height:36px;[% ELSE %]height:72px;[% END %]float:left;margin-right:1rem;" alt="icon"
+        <img src="[% panel.title_element.icon_url %]"
+            style="[% IF panel.title_element.icon_size == 'small' %]height:36px;[% ELSE %]height:72px;[% END %]float:left;margin-right:1rem;"
+            alt="[% IF panel.title_element.icon_alt.defined %][% panel.title_element.icon_alt %][% ELSE %]icon[% END %]"
             [% IF panel.title_element.icon_color_from_evaluation %]
                 [% IF panel.evaluation == "good" %]
                     class="filter-green"
@@ -93,7 +95,9 @@
                 [% text_element = element_ref.text_element %]
 
                 [% IF text_element.icon_url.defined %]
-                <img src="[% text_element.icon_url %]" style="height:72px;float:left;margin-right:1rem;" alt="icon"
+                <img src="[% text_element.icon_url %]"
+                    style="height:72px;float:left;margin-right:1rem;"
+                    alt="[% IF text_element.icon_alt.defined %][% text_element.icon_alt %][% ELSE %]icon[% END %]"
                     [% IF text_element.icon_color_from_evaluation %]
                         [% IF text_element.evaluation == "good" %]
                             class="filter-green"

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -112,8 +112,12 @@
                         [% END %]    
                     [% END %]
                 >
+                <div style="float:left">
+                [% ELSE %]
+                <div>
                 [% END %]
 
+                
                 [% IF text_element.type == "h1" %]
                     <h4>
                 [% ELSIF text_element.type == "note" %]
@@ -127,6 +131,7 @@
                 [% ELSE %]
                     </div>
                 [% END %]
+                </div>
 
                 [% IF text_element.icon_url.defined %]
                 <hr class="floatclear">


### PR DESCRIPTION
- Fixed some icons paths (the Eco-Score ones existed in prod but not in github)
- Using the result of a FILTER to set a variable in Template::Toolkit works in the dev server, but not in production and in the docker environment. Now exposing the sprintf function directly.
- Fixed the display of packaging components by recycling types
- Fixed the display of environmental labels panels when we don't have an Eco-Score (no Agribalyse category) but when we have organic labels.
- Now showing the panels in the product page for all moderators, in order to uncover issues before we set it for all users.