### PR TITLE
Fixes #4928 Delta export command fails

### DIFF
--- a/scripts/mongodb_dump.sh
+++ b/scripts/mongodb_dump.sh
@@ -32,7 +32,7 @@ else
   LASTTS=$(($(date +%s)-24*60*60))
 fi
 NEWTS=$(date +%s)
-mongoexport --collection products --host $HOST --db $DB --query "{ last_modified_t: { \$gt: $LASTTS, \$lte: $NEWTS } }" | gzip -9 > products_${LASTTS}_${NEWTS}.json.gz
+mongoexport --collection products --host $HOST --db $DB --query "{ \"last_modified_t\": { \"\$gt\": $LASTTS, \"\$lte\": $NEWTS } }" | gzip -9 > products_${LASTTS}_${NEWTS}.json.gz
 
 # Delete all but the last 14 delta files - https://stackoverflow.com/a/34862475/11963
 ls -tp products_*.json.gz | grep -v '/$' | tail -n +14 | xargs -I {} rm -- {}


### PR DESCRIPTION
**Description:**
The delta export command fails with MongoDB 4.4 and throws the error: `Failed: error parsing query as Extended JSON: invalid JSON input`.
This results in empty delta exports for a long time now.

Putting the query parameters in quotes fixed the error. 

I'm not 100% sure if MongoDB 4.4 is used on the server, got the info from https://github.com/openfoodfacts/openfoodfacts-server/issues/4928

**Related issues and discussion:** #4928