### PR TITLE
Improve web template for Nutri-Score and nutrient levels + Create Nutri-Score knowledge panel

### DIFF
--- a/icons/material/warning_black_24dp.svg
+++ b/icons/material/warning_black_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>

--- a/icons/warning.svg
+++ b/icons/warning.svg
@@ -1,0 +1,1 @@
+material/warning_black_24dp.svg

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -90,6 +90,8 @@ BEGIN
 		&display_possible_improvement_description
 		&display_properties
 
+		&data_to_display_nutriscore_and_nutrient_levels
+
 		&count_products
 		&add_params_to_query
 
@@ -9078,7 +9080,7 @@ sub data_to_display_nutriscore_and_nutrient_levels($) {
 		my @nutriscore_warnings = ();
 
 		if (has_tag($product_ref,"misc","en:nutriscore-not-applicable")) {
-			push @nutriscore_warnings, lang("nutriscore_not_applicable");
+			push @nutriscore_warnings, '1' . lang("nutriscore_not_applicable");
 		}
 
 		elsif ((defined $product_ref->{nutrition_grade_fr}) and ($product_ref->{nutrition_grade_fr} =~ /^[abcde]$/)) {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7761,6 +7761,15 @@ CSS
 	my $product_url = product_url($product_ref);
 	$template_data_ref->{this_product_url} = $product_url;
 
+	# Knowledge panels are in development, they can be activated with the "panels" parameter
+	# for debugging and demonstration purposes
+	# Also activate them for moderators
+	if (($User{moderator}) or (param('panels'))) {
+		create_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
+		$template_data_ref->{environment_card_panel} = display_knowledge_panel($product_ref->{"knowledge_panels_" . $lc}, "environment_card");
+		$template_data_ref->{health_card_panel} = display_knowledge_panel($product_ref->{"knowledge_panels_" . $lc}, "health_card");
+	}	
+
 	# On the producers platform, show a link to the public platform
 
 	if ($server_options{producers_platform}) {
@@ -8208,8 +8217,23 @@ HTML
 
 		$template_data_ref->{nutrition_table} = 'defined';
 
-		$template_data_ref->{display_nutrient_levels} = display_nutrient_levels($product_ref);
-		$template_data_ref->{display_field} = display_field($product_ref, "serving_size") . display_field($product_ref, "br") ;
+		# Display Nutri-Score and nutrient levels
+
+		my $template_data_nutriscore_and_nutrient_levels_ref = data_to_display_nutriscore_and_nutrient_levels($product_ref);
+
+		my $nutriscore_html = '';
+		my $nutrient_levels_html = '';
+
+		if (not $template_data_nutriscore_and_nutrient_levels_ref->{do_not_display}) {
+
+			process_template('web/pages/product/includes/nutriscore.tt.html', $template_data_nutriscore_and_nutrient_levels_ref, \$nutriscore_html) || return "template error: " . $tt->error();
+			process_template('web/pages/product/includes/nutrient_levels.tt.html', $template_data_nutriscore_and_nutrient_levels_ref, \$nutrient_levels_html) || return "template error: " . $tt->error();
+		}
+
+		$template_data_ref->{display_nutriscore} =  $nutriscore_html;
+		$template_data_ref->{display_nutrient_levels} =  $nutrient_levels_html;
+
+		$template_data_ref->{display_serving_size} = display_field($product_ref, "serving_size") . display_field($product_ref, "br") ;
 
 		# Compare nutrition data with categories
 
@@ -8299,14 +8323,6 @@ HTML
 		$template_data_ref->{ecoscore_score} = $product_ref->{ecoscore_data}{"score"};
 		$template_data_ref->{ecoscore_data} = $product_ref->{ecoscore_data};
 		$template_data_ref->{ecoscore_calculation_details} = display_ecoscore_calculation_details($cc, $product_ref->{ecoscore_data});
-
-		# Knowledge panels are in development, they can be activated with the "panels" parameter
-		# for debugging and demonstration purposes
-		# Also activate them for moderators
-		if (($User{moderator}) or (param('panels'))) {
-			create_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
-			$template_data_ref->{environment_card_panel} = display_knowledge_panel($product_ref->{"knowledge_panels_" . $lc}, "environment_card");
-		}
 	}
 
 	# Forest footprint
@@ -8543,6 +8559,17 @@ sub display_product_jqm ($) # jquerymobile
 		$html .= "<p>" . lang("barcode") . separator_before_colon($lc) . ": $code</p>\n";
 	}
 
+	# Generate HTML for Nutri-Score and nutrient levels
+	my $template_data_nutriscore_and_nutrient_levels_ref = data_to_display_nutriscore_and_nutrient_levels($product_ref);
+
+	my $nutriscore_html = '';
+	my $nutrient_levels_html = '';
+
+	if (not $template_data_nutriscore_and_nutrient_levels_ref->{do_not_display}) {
+
+		process_template('web/pages/product/includes/nutriscore.tt.html', $template_data_nutriscore_and_nutrient_levels_ref, \$nutriscore_html) || return "template error: " . $tt->error();
+		process_template('web/pages/product/includes/nutrient_levels.tt.html', $template_data_nutriscore_and_nutrient_levels_ref, \$nutrient_levels_html) || return "template error: " . $tt->error();
+	}
 
 	if (($lc eq 'fr') and (has_tag($product_ref, "labels","fr:produits-retires-du-marche-lors-du-scandale-lactalis-de-decembre-2017"))) {
 
@@ -8600,9 +8627,11 @@ HTML
 
 	}
 
+	# Nutri-Score and nutrient levels
 
-	$html .= display_nutrient_levels($product_ref);
+	$html .= $nutriscore_html;
 
+	$html .= $nutrient_levels_html;
 
 	# NOVA groups
 
@@ -8776,7 +8805,11 @@ HTML
 	$html .= "<h2>" . lang("nutrition_data") . "</h2>";
 
 
-	$html .= display_nutrient_levels($product_ref);
+	# Nutri-Score and nutrient levels
+
+	$html .= $nutriscore_html;
+
+	$html .= $nutrient_levels_html;
 
 	$html .= "<div style=\"min-height:${minheight}px\">"
 	. $html_image;
@@ -8939,9 +8972,6 @@ sub display_nutriscore_calculation_details($) {
 
 	my $template_data_ref = {
 
-		lang => \&lang,
-		sep => separator_before_colon($lc),
-
 		beverage_view => $beverage_view,
 		is_fat => $nutriscore_data_ref->{is_fat},
 
@@ -9005,22 +9035,18 @@ sub display_nutriscore_calculation_details($) {
 	return $html;
 }
 
-sub display_nutrient_levels($) {
+
+sub data_to_display_nutriscore_and_nutrient_levels($) {
 
 	my $product_ref = shift;
 
-	my $html = '';
-
-	my $template_data_ref = {
-		lang => \&lang,
-		display_icon => \&display_icon,
-	};
+	my $result_data_ref = {};
 
 	# Do not display nutriscore and traffic lights for some categories of products
 	# do not compute a score for baby foods
 	if (has_tag($product_ref, "categories", "en:baby-foods")) {
 
-			return "";
+		$result_data_ref->{do_not_display} = 1;
 	}
 
 	# do not compute a score for dehydrated products to be rehydrated (e.g. dried soups, coffee, tea)
@@ -9037,120 +9063,117 @@ sub display_nutrient_levels($) {
 				last;
 			}
 			else {
-				return "";
+				$result_data_ref->{do_not_display} = 1;
 			}
 		}
 	}
 
+	# If we can display the Nutri-Score and nutrient levels,
+	# populate the data templates will need to display them
 
-	my $html_nutrition_grade = '';
-	my $html_nutrient_levels = '';
+	if (not $result_data_ref->{do_not_display}) {
 
-	if ((exists $product_ref->{"nutrition_grade_fr"})
-		and ($product_ref->{"nutrition_grade_fr"} =~ /^[abcde]$/)) {
+		# Nutri-Score data
 
-		$template_data_ref->{nutrition_grade} = "exists";
+		my @nutriscore_warnings = ();
 
-		my $grade = $product_ref->{"nutrition_grade_fr"};
-		my $uc_grade = uc($grade);
+		if (has_tag($product_ref,"misc","en:nutriscore-not-applicable")) {
+			push @nutriscore_warnings, lang("nutriscore_not_applicable");
+		}
 
-		my $warning = '';
+		elsif ((defined $product_ref->{nutrition_grade_fr}) and ($product_ref->{nutrition_grade_fr} =~ /^[abcde]$/)) {
 
-		# Do not display a warning for water
-		if (not (has_tag($product_ref, "categories", "en:spring-waters"))) {
+			$result_data_ref->{nutriscore_grade} = $product_ref->{"nutrition_grade_fr"};
 
-			# Warning for tea and herbal tea in bags: state that the Nutri-Score applies
-			# only when reconstituted with water only (no milk, no sugar)
-			if ((has_tag($product_ref, "categories", "en:tea-bags"))
-				or (has_tag($product_ref, "categories", "en:herbal-teas-in-tea-bags"))
-				# many tea bags are only under "en:teas", but there are also many tea beverages under "en:teas"
-				or ((has_tag($product_ref, "categories", "en:teas")) and not (has_tag($product_ref, "categories", "en:tea-based-beverages")))
-				) {
-				$warning .= "<p>" . lang("nutrition_grade_fr_tea_bags_note") . "</p>";
+			# Do not display a warning for water
+			if (not (has_tag($product_ref, "categories", "en:spring-waters"))) {
+
+				# Warning for tea and herbal tea in bags: state that the Nutri-Score applies
+				# only when reconstituted with water only (no milk, no sugar)
+				if ((has_tag($product_ref, "categories", "en:tea-bags"))
+					or (has_tag($product_ref, "categories", "en:herbal-teas-in-tea-bags"))
+					# many tea bags are only under "en:teas", but there are also many tea beverages under "en:teas"
+					or ((has_tag($product_ref, "categories", "en:teas")) and not (has_tag($product_ref, "categories", "en:tea-based-beverages")))
+					) {
+					push @nutriscore_warnings, lang("nutrition_grade_fr_tea_bags_note");
+				}
+
+				# Combined message when we miss both fruits and fiber
+				if ((defined $product_ref->{nutrition_score_warning_no_fiber}) and ($product_ref->{nutrition_score_warning_no_fiber} == 1)
+					and (defined $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts})
+						and ($product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts} == 1)) {
+					push @nutriscore_warnings, lang("nutrition_grade_fr_fiber_and_fruits_vegetables_nuts_warning");
+				}
+				elsif ((defined $product_ref->{nutrition_score_warning_no_fiber}) and ($product_ref->{nutrition_score_warning_no_fiber} == 1)) {
+					push @nutriscore_warnings, lang("nutrition_grade_fr_fiber_warning");
+				}
+				elsif ((defined $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts})
+						and ($product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts} == 1)) {
+					push @nutriscore_warnings, lang("nutrition_grade_fr_no_fruits_vegetables_nuts_warning");
+				}
+
+				if ((defined $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate})
+						and ($product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate} == 1)) {
+					push @nutriscore_warnings, sprintf(lang("nutrition_grade_fr_fruits_vegetables_nuts_estimate_warning"),
+										$product_ref->{nutriments}{"fruits-vegetables-nuts-estimate_100g"});
+				}
+				if ((defined $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category})
+						and ($product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category} ne '')) {
+					push @nutriscore_warnings, sprintf(lang("nutrition_grade_fr_fruits_vegetables_nuts_from_category_warning"),
+										display_taxonomy_tag($lc,'categories',$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category}),
+										$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category_value});
+				}
+				if ((defined $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients})
+						and ($product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients} ne '')) {
+					push @nutriscore_warnings, sprintf(lang("nutrition_grade_fr_fruits_vegetables_nuts_estimate_from_ingredients_warning"),
+										$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value});
+				}
+			}
+		}
+		# The Nutri-Score is unknown
+		else  {
+
+			$result_data_ref->{nutriscore_grade} = "unknown";
+
+			# Missing category?
+			if (has_tag($product_ref,"misc","en:nutriscore-missing-category")) {
+				push @nutriscore_warnings, lang("nutriscore_missing_category");
 			}
 
-			# Combined message when we miss both fruits and fiber
-			if ((defined $product_ref->{nutrition_score_warning_no_fiber}) and ($product_ref->{nutrition_score_warning_no_fiber} == 1)
-				and (defined $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts})
-					and ($product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts} == 1)) {
-				$warning .= "<p>" . lang("nutrition_grade_fr_fiber_and_fruits_vegetables_nuts_warning") . "</p>";
-			}
-			elsif ((defined $product_ref->{nutrition_score_warning_no_fiber}) and ($product_ref->{nutrition_score_warning_no_fiber} == 1)) {
-				$warning .= "<p>" . lang("nutrition_grade_fr_fiber_warning") . "</p>";
-			}
-			elsif ((defined $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts})
-					and ($product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts} == 1)) {
-				$warning .= "<p>" . lang("nutrition_grade_fr_no_fruits_vegetables_nuts_warning") . "</p>";
-			}
-
-			if ((defined $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate})
-					and ($product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate} == 1)) {
-				$warning .= "<p>" . sprintf(lang("nutrition_grade_fr_fruits_vegetables_nuts_estimate_warning"),
-									$product_ref->{nutriments}{"fruits-vegetables-nuts-estimate_100g"}) . "</p>";
-			}
-			if ((defined $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category})
-					and ($product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category} ne '')) {
-				$warning .= "<p>" . sprintf(lang("nutrition_grade_fr_fruits_vegetables_nuts_from_category_warning"),
-									display_taxonomy_tag($lc,'categories',$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category}),
-									$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_from_category_value}) . "</p>";
-			}
-			if ((defined $product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients})
-					and ($product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients} ne '')) {
-				$warning .= "<p>" . sprintf(lang("nutrition_grade_fr_fruits_vegetables_nuts_estimate_from_ingredients_warning"),
-									$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value}) . "</p>";
+			# Missing nutrition facts?
+			if (has_tag($product_ref,"misc","en:nutriscore-missing-nutrition-data")) {
+				push @nutriscore_warnings, lang("nutriscore_missing_nutrition_data");
 			}
 		}
 
-		$html_nutrition_grade .= <<HTML
-<h4>$Lang{nutrition_grade_fr_title}{$lc}
-<a href="/nutriscore" title="$Lang{nutrition_grade_fr_formula}{$lc}">
-@{[ display_icon('info') ]}</a>
-</h4>
-<a href="/nutriscore" title="$Lang{nutrition_grade_fr_formula}{$lc}"><img src="/images/misc/nutriscore-$grade.svg" alt="$Lang{nutrition_grade_fr_alt}{$lc} $uc_grade" style="margin-bottom:1rem;max-width:100%"></a><br>
-$warning
-HTML
-;
+		if (@nutriscore_warnings > 0) {
+			$result_data_ref->{nutriscore_warnings} = \@nutriscore_warnings;
+		}
+
 		if (defined $product_ref->{nutriscore_data}) {
-			$html_nutrition_grade .= display_nutriscore_calculation_details($product_ref->{nutriscore_data});
+			$result_data_ref->{nutriscore_details} = display_nutriscore_calculation_details($product_ref->{nutriscore_data});
+		}
+		
 
+		# Nutrient levels data
+
+		$result_data_ref->{nutrient_levels} = [];
+
+		foreach my $nutrient_level_ref (@nutrient_levels) {
+			my ($nid, $low, $high) = @{$nutrient_level_ref};
+
+			if ((defined $product_ref->{nutrient_levels}) and (defined $product_ref->{nutrient_levels}{$nid})) {
+
+				push @{$result_data_ref->{nutrient_levels}}, {
+					nutrient_level => $product_ref->{nutrient_levels}{$nid},
+					nutriment_prepared => sprintf("%.2e", $product_ref->{nutriments}{$nid . $prepared . "_100g"}) + 0.0,
+					nutriment_quantity => sprintf(lang("nutrient_in_quantity"), "<b>" . $Nutriments{$nid}{$lc} . "</b>", lang($product_ref->{nutrient_levels}{$nid} . "_quantity")),
+				};
+			}
 		}
 	}
 
-	foreach my $nutrient_level_ref (@nutrient_levels) {
-		my ($nid, $low, $high) = @{$nutrient_level_ref};
-
-		if ((defined $product_ref->{nutrient_levels}) and (defined $product_ref->{nutrient_levels}{$nid})) {
-
-			$html_nutrient_levels = '1';
-			push @{$template_data_ref->{nutrient_levels}}, {
-				nutrient_level => $product_ref->{nutrient_levels}{$nid},
-				nutriment_prepared => sprintf("%.2e", $product_ref->{nutriments}{$nid . $prepared . "_100g"}) + 0.0,
-				nutriment_quantity => sprintf(lang("nutrient_in_quantity"), "<b>" . $Nutriments{$nid}{$lc} . "</b>", lang($product_ref->{nutrient_levels}{$nid} . "_quantity")),
-
-			};
-		}
-	}
-
-	# Nutrient Levels Template
-	my $nutrient_levels_html;
-	process_template('web/pages/product/includes/nutrient_levels.tt.html', $template_data_ref, \$nutrient_levels_html) || return "template error: " . $tt->error();
-
-	# 2 columns?
-	$html .= "<div class='row'>";
-	if ($html_nutrition_grade ne '') {
-		$html .= <<HTML
-<div class="small-12 xlarge-6 columns">
-$html_nutrition_grade
-</div>
-HTML
-;
-	}
-	if ($html_nutrient_levels ne '') {
-		$html .= $nutrient_levels_html;
-	}
-	$html .= "</div>";
-
-	return $html;
+	return $result_data_ref;
 }
 
 

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -231,10 +231,6 @@ This parameter sets the desired language for the user facing strings.
 
 The Eco-Score depends on the country of the consumer (as the transport bonus/malus depends on it)
 
-=head3 Return value
-
-The return value is a reference to the resulting knowledge panel data structure.
-
 =cut
 
 sub create_panel_from_json_template ($$$$$$) {
@@ -326,7 +322,6 @@ sub create_panel_from_json_template ($$$$$$) {
             };            
         }
     }
-
 }
 
 
@@ -349,10 +344,6 @@ This parameter sets the desired language for the user facing strings.
 =head4 country code $target_cc
 
 The Eco-Score depends on the country of the consumer (as the transport bonus/malus depends on it)
-
-=head3 Return value
-
-The return value is a reference to the resulting knowledge panel data structure.
 
 =cut
 
@@ -499,10 +490,6 @@ This parameter sets the desired language for the user facing strings.
 
 The Eco-Score depends on the country of the consumer (as the transport bonus/malus depends on it)
 
-=head3 Return value
-
-The return value is a reference to the resulting knowledge panel data structure.
-
 =cut
 
 sub create_environment_card_panel($$$) {
@@ -518,11 +505,6 @@ sub create_environment_card_panel($$$) {
     # Create Eco-Score related panels
     create_ecoscore_panel($product_ref, $target_lc, $target_cc);
 
-    # Include the carbon footprint panel if we have data for it
-    if ((defined $product_ref->{ecoscore_data}) and ($product_ref->{ecoscore_data}{status} eq "known")) {
-        $panel_data_ref->{carbon_footprint} = 1;
-    }
-
     # Create panel for palm oil
     if ((defined $product_ref->{ecoscore_data}) and (defined $product_ref->{ecoscore_data}{adjustments})
         and (defined $product_ref->{ecoscore_data}{adjustments}{threatened_species})
@@ -530,20 +512,14 @@ sub create_environment_card_panel($$$) {
 
         create_panel_from_json_template("palm_oil", "api/knowledge-panels/environment/palm_oil.tt.json",
             $panel_data_ref, $product_ref, $target_lc, $target_cc);
-        
-        # Tell the environment card template to include the palm_oil panel
-        $panel_data_ref->{palm_oil} = 1;
     }
 
     # Create panel for packaging recycling
     create_panel_from_json_template("packaging_recycling", "api/knowledge-panels/environment/packaging_recycling.tt.json",
         $panel_data_ref, $product_ref, $target_lc, $target_cc);
-        
-    # Tell the environment card template to include packaging recycling panel
-    $panel_data_ref->{packaging_recycling} = 1;
 
     # Create panel for manufacturing place
-    $panel_data_ref->{manufacturing_place} = create_manufacturing_place_panel($product_ref, $target_lc, $target_cc);
+    create_manufacturing_place_panel($product_ref, $target_lc, $target_cc);
 
     # Origins of ingredients for the environment card
     create_panel_from_json_template("origins_of_ingredients", "api/knowledge-panels/environment/origins_of_ingredients.tt.json",
@@ -575,11 +551,6 @@ This parameter sets the desired language for the user facing strings.
 
 The Eco-Score depends on the country of the consumer (as the transport bonus/malus depends on it)
 
-=head3 Return value
-
-1 to indicate that the panel has been created
-0 to indicate that the panel was not created (if we don't have enough data for the product)
-
 =cut
 
 sub create_manufacturing_place_panel($$$) {
@@ -607,14 +578,10 @@ sub create_manufacturing_place_panel($$$) {
 
                     create_panel_from_json_template("manufacturing_place", "api/knowledge-panels/environment/manufacturing_place.tt.json",
                         $panel_data_ref, $product_ref, $target_lc, $target_cc);
-
-                    return 1;
                 }
             }
         }
     }
-
-    return 0;  
 }
 
 
@@ -636,10 +603,6 @@ This parameter sets the desired language for the user facing strings.
 =head4 country code $target_cc
 
 We may display country specific recommendations from health authorities, or country specific scores.
-
-=head3 Return value
-
-The return value is a reference to the resulting knowledge panel data structure.
 
 =cut
 
@@ -678,10 +641,6 @@ Returned attributes contain both data and strings intended to be displayed to us
 This parameter sets the desired language for the user facing strings.
 
 =head4 country code $target_cc
-
-=head3 Return value
-
-The return value is 1 if the panel was created, 0 otherwise.
 
 =cut
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5867,3 +5867,15 @@ msgstr "Life cycle analysis score"
 msgctxt "ecoscore_downgraded_non_recyclable_and_non_biodegradable_materials"
 msgid "The score of products with non-recyclable and non-biodegradable packaging materials is capped at 79 (grade B)."
 msgstr "The score of products with non-recyclable and non-biodegradable packaging materials is capped at 79 (grade B)."
+
+msgctxt "nutriscore_not_applicable"
+msgid "Nutri-Score not applicable for this product category."
+msgstr "Nutri-Score not applicable for this product category."
+
+msgctxt "nutriscore_missing_category"
+msgid "The category of the product must be specified in order to compute the Nutri-Score."
+msgstr "The category of the product must be specified in order to compute the Nutri-Score."
+
+msgctxt "nutriscore_missing_nutrition_data"
+msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
+msgstr "The nutrition facts of the product must be specified in order to compute the Nutri-Score."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -2727,13 +2727,19 @@ msgstr ""
 msgctxt "nutrition_grade_fr_fruits_vegetables_nuts_estimate_warning"
 msgid ""
 "Warning: the amount of fruits, vegetables and nuts is not specified on the "
-"label, it was estimated from the list of ingredients: %d%"
+"label, it was manually estimated from the list of ingredients: %d%"
 msgstr ""
 
 msgctxt "nutrition_grade_fr_fruits_vegetables_nuts_from_category_warning"
 msgid ""
 "Warning: the amount of fruits, vegetables and nuts is not specified on the "
 "label, it was estimated from the category (%s) of the product: %d%"
+msgstr ""
+
+msgctxt "nutrition_grade_fr_fruits_vegetables_nuts_estimate_from_ingredients_warning"
+msgid ""
+"Warning: the amount of fruits, vegetables and nuts is not specified on the "
+"label, it was estimated from the list of ingredients: %d%"
 msgstr ""
 
 msgctxt "nutrition_grade_fr_title"
@@ -5879,3 +5885,7 @@ msgstr "The category of the product must be specified in order to compute the Nu
 msgctxt "nutriscore_missing_nutrition_data"
 msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
 msgstr "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
+
+msgctxt "health"
+msgid "Health"
+msgstr "Health"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -2776,12 +2776,16 @@ msgid "Warning: the amounts of fiber and of fruits, vegetables and nuts are not 
 msgstr "Warning: the amounts of fiber and of fruits, vegetables and nuts are not specified, their possible positive contribution to the grade could not be taken into account."
 
 msgctxt "nutrition_grade_fr_fruits_vegetables_nuts_estimate_warning"
-msgid "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was estimated from the list of ingredients: %d%"
-msgstr "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was estimated from the list of ingredients: %d%"
+msgid "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was manually estimated from the list of ingredients: %d%"
+msgstr "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was manually estimated from the list of ingredients: %d%"
 
 msgctxt "nutrition_grade_fr_fruits_vegetables_nuts_from_category_warning"
 msgid "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was estimated from the category (%s) of the product: %d%"
 msgstr "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was estimated from the category (%s) of the product: %d%"
+
+msgctxt "nutrition_grade_fr_fruits_vegetables_nuts_estimate_from_ingredients_warning"
+msgid "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was estimated from the list of ingredients: %d%"
+msgstr "Warning: the amount of fruits, vegetables and nuts is not specified on the label, it was estimated from the list of ingredients: %d%"
 
 msgctxt "nutrition_grade_fr_title"
 msgid "NutriScore color nutrition grade"
@@ -5896,3 +5900,7 @@ msgstr "The category of the product must be specified in order to compute the Nu
 msgctxt "nutriscore_missing_nutrition_data"
 msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
 msgstr "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
+
+msgctxt "health"
+msgid "Health"
+msgstr "Health"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5884,3 +5884,15 @@ msgstr "Life cycle analysis score"
 msgctxt "ecoscore_downgraded_non_recyclable_and_non_biodegradable_materials"
 msgid "The score of products with non-recyclable and non-biodegradable packaging materials is capped at 79 (grade B)."
 msgstr "The score of products with non-recyclable and non-biodegradable packaging materials is capped at 79 (grade B)."
+
+msgctxt "nutriscore_not_applicable"
+msgid "Nutri-Score not applicable for this product category."
+msgstr "Nutri-Score not applicable for this product category."
+
+msgctxt "nutriscore_missing_category"
+msgid "The category of the product must be specified in order to compute the Nutri-Score."
+msgstr "The category of the product must be specified in order to compute the Nutri-Score."
+
+msgctxt "nutriscore_missing_nutrition_data"
+msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
+msgstr "The nutrition facts of the product must be specified in order to compute the Nutri-Score."

--- a/templates/api/knowledge-panels/environment/environment_card.tt.json
+++ b/templates/api/knowledge-panels/environment/environment_card.tt.json
@@ -14,7 +14,7 @@
                 "panel_id": "ecoscore",
             },
         },
-        [% IF panel.carbon_footprint %]
+        [% IF panels.carbon_footprint.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
@@ -23,7 +23,7 @@
             },
         },
         [% END %]
-        [% IF panel.packaging_recycling %]
+        [% IF panels.packaging_recycling.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
@@ -39,12 +39,12 @@
             "panel_group_element": {
                 "title": "[% lang('ecoscore_transportation') %]",
                 "panel_ids": [
-                    [% IF panel.manufacturing_place %]"manufacturing_place",[% END %]
+                    [% IF panels.manufacturing_place.defined %]"manufacturing_place",[% END %]
                     "origins_of_ingredients",
                 ],
             },
         },         
-        [% IF panel.palm_oil %]
+        [% IF panels.palm_oil.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {

--- a/templates/api/knowledge-panels/health/health_card.tt.json
+++ b/templates/api/knowledge-panels/health/health_card.tt.json
@@ -1,0 +1,60 @@
+{
+    "type": "card",
+    "expanded": true,
+    "topics": [
+        "health"
+    ],
+    "title_element": {
+        "title": "[% lang('health') %]",
+    },    
+    "elements": [
+        [% IF panels.nutriscore.defined %]
+        {
+            "element_type": "panel_group",
+            "panel_group_element": {
+                "panel_ids": [
+                    "nutriscore",
+                    [% IF panels.nutriscore_warnings.defined %]
+                        "nutriscore_warnings",
+                    [% END %]
+                ],
+            },
+        },
+        [% END %]
+        [% IF panels.nutriscore.nutrition_facts_table.defined %]
+        {
+            "element_type": "panel",
+            "panel_element": {
+                "panel_id": "nutrition_facts_table",
+            },
+        },
+        [% END %]
+        [% IF panels.nutriscore.ingredients.defined %]
+        {
+            "element_type": "panel_group",
+            "panel_group_element": {
+                "title": "[% lang('ingredients') %]",
+                "panel_ids": ["ingredients"],
+            },
+        },
+        [% END %]
+        [% IF panels.nutriscore.allergens.defined %]
+        {
+            "element_type": "panel_group",
+            "panel_group_element": {
+                "title": "[% lang('allergens') %]",
+                "panel_ids": ["allergens"],
+            },
+        },
+        [% END %]
+        [% IF panels.nutriscore.additives.defined %]
+        {
+            "element_type": "panel_group",
+            "panel_group_element": {
+                "title": "[% lang('additives') %]",
+                "panel_ids": ["additives"],
+            },
+        }, 
+        [% END %]   
+    ],
+}

--- a/templates/api/knowledge-panels/health/ingredients/additives.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/additives.tt.json
@@ -1,0 +1,15 @@
+{
+    "level": "info",
+    "topics": [
+        "health"
+    ],
+    "elements": [   
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[ shown only to moderators] -- New knowledge panel coming soon
+                `,
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/health/ingredients/allergens.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/allergens.tt.json
@@ -1,0 +1,15 @@
+{
+    "level": "info",
+    "topics": [
+        "health"
+    ],
+    "elements": [   
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[ shown only to moderators] -- New knowledge panel coming soon
+                `,
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
@@ -1,0 +1,15 @@
+{
+    "level": "info",
+    "topics": [
+        "health"
+    ],
+    "elements": [   
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[ shown only to moderators] -- New knowledge panel coming soon
+                `,
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore.tt.json
@@ -1,0 +1,20 @@
+{
+    "level": "info",
+    "topics": [
+        "health"
+    ],
+    "title_element": {
+        "icon_url": "[% static_subdomain %]/images/attributes/nutriscore-[% panel.nutriscore_grade %].svg",
+        "title": "[% panel.title %]",
+        "type": "grade",
+        "grade": "[% panel.nutriscore_grade %]",
+    },
+    "elements": [           
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[% panel.nutriscore_details %]`,
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore_warnings.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore_warnings.tt.json
@@ -12,6 +12,7 @@
         {
             "element_type": "text",
             "text_element": {
+                "type": "warning",
                 "html": `[% warning %]
                 `,
             }

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore_warnings.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore_warnings.tt.json
@@ -1,0 +1,22 @@
+{
+    "level": "info",
+    "topics": [
+        "health"
+    ],
+    // We want the Nutri-Score warning panel to always be expanded and shown
+    "type": "inline",
+    [% IF panel.nutriscore_warnings %]
+    "elements": [
+        
+        [% FOREACH warning IN panel.nutriscore_warnings %]
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[% warning %]
+                `,
+            }
+        },
+        [% END %]
+    ]
+    [% END %]  
+}

--- a/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
@@ -1,0 +1,15 @@
+{
+    "level": "info",
+    "topics": [
+        "health"
+    ],
+    "elements": [   
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[ shown only to moderators] -- New knowledge panel coming soon
+                `,
+            }
+        },
+    ]
+}

--- a/templates/api/knowledge-panels/root.tt.json
+++ b/templates/api/knowledge-panels/root.tt.json
@@ -5,8 +5,14 @@
         {
             "element_type": "panel",
             "panel_element": {
-                "panel_id": "environment_card",
+                "panel_id": "health_card",
             },
         },
+        {
+            "element_type": "panel",
+            "panel_element": {
+                "panel_id": "environment_card",
+            },
+        },        
     ],
 }

--- a/templates/web/pages/product/includes/nutrient_levels.tt.html
+++ b/templates/web/pages/product/includes/nutrient_levels.tt.html
@@ -1,16 +1,15 @@
 <!-- start templates/[% component.name %] -->
 
 <!-- Nutrient levels template -->
-<div class="small-12 xlarge-6 columns">
-    <h4>[% lang('nutrient_levels_info') %]
-        <a href="[% lang('nutrient_levels_link') %]" title="[% lang('nutrient_levels_info') %]">
-            [% display_icon('info') %]
-        </a>
-    </h4>
-    [% FOREACH level IN nutrient_levels %]
-        <img src="/images/misc/[% level.nutrient_level %].svg" width="30" height="30" style="vertical-align:middle;margin-right:15px;margin-bottom:4px;"
-        alt="[% lang('${level.nutrient_level}_quantity') %]"> [% level.nutriment_prepared %] g [% level.nutriment_quantity %] <br>
-    [% END %]
-</div>
+
+<h4>[% lang('nutrient_levels_info') %]
+    <a href="[% lang('nutrient_levels_link') %]" title="[% lang('nutrient_levels_info') %]">
+        [% display_icon('info') %]
+    </a>
+</h4>
+[% FOREACH level IN nutrient_levels %]
+    <img src="[% static_subdomain %]/images/misc/[% level.nutrient_level %].svg" width="30" height="30" style="vertical-align:middle;margin-right:15px;margin-bottom:4px;"
+    alt="[% lang('${level.nutrient_level}_quantity') %]"> [% level.nutriment_prepared %] g [% level.nutriment_quantity %] <br>
+[% END %]
 
 <!-- end templates/[% component.name %] -->

--- a/templates/web/pages/product/includes/nutriscore.tt.html
+++ b/templates/web/pages/product/includes/nutriscore.tt.html
@@ -23,7 +23,7 @@
 
 [% IF nutriscore_warnings %]
     [% FOREACH warning IN nutriscore_warnings %]
-        <p>[% warning %]</p>
+        <p class="warning">⚠️ [% warning %]</p>
     [% END %]
 [% END %]
 

--- a/templates/web/pages/product/includes/nutriscore.tt.html
+++ b/templates/web/pages/product/includes/nutriscore.tt.html
@@ -1,0 +1,30 @@
+<!-- start templates/[% component.name %] -->
+
+<h4>[% lang('nutrition_grade_fr_title') %]
+    <a href="/nutriscore" title="[% lang('nutrition_grade_fr_formula') %]">
+        [% display_icon('info') %]</a>
+</h4>
+
+[% IF nutriscore_grade.defined %]
+<a href="/nutriscore" title="[% lang('nutrition_grade_fr_formula') %]">
+    <img src="[% static_subdomain %]/images/misc/nutriscore-[% nutriscore_grade %].svg" alt="[% lang('nutrition_grade_fr_alt}') %] [% nutriscore_grade | ucfirst %]" style="margin-bottom:1rem;max-width:100%">
+</a>
+<br>
+[% END %]
+
+[% IF nutriscore_details.defined %]
+    <p>
+        <a data-dropdown="nutriscore_drop" aria-controls="nutriscore_drop" aria-expanded="false">[% lang('nutriscore_calculation_details') %] &raquo;</a>
+    </p>
+    <div id="nutriscore_drop" data-dropdown-content class="f-dropdown content large" aria-hidden="true" tabindex="-1">
+        [% nutriscore_details %]
+    </div>
+[% END %]
+
+[% IF nutriscore_warnings %]
+    [% FOREACH warning IN nutriscore_warnings %]
+        <p>[% warning %]</p>
+    [% END %]
+[% END %]
+
+<!-- end templates/[% component.name %] -->

--- a/templates/web/pages/product/includes/nutriscore_details.tt.html
+++ b/templates/web/pages/product/includes/nutriscore_details.tt.html
@@ -1,42 +1,36 @@
 <!-- start templates/[% component.name %] -->
 
+<p>[% beverage_view %]</p>
+
+[% IF is_fat %]
+  <p>[% lang('nutriscore_proteins_is_added_fat') %]</p>
+[% END %]
+
+[% FOREACH group IN points_groups %]
+
+  <p> 
+    <strong>[% lang("nutriscore_${group.type}_points") %][% sep %]: [% group.points %]</strong> 
+  </p>
+
+  <ul>
+    [% FOREACH nutrient IN group.nutrients %]
+      <li>
+        <strong>[% lang("nutriscore_points_for_${nutrient.id}") %][% sep %]:
+[% nutrient.points %]&nbsp;</strong>/&nbsp;[% nutrient.maximum %][% lang("points") %]
+([% lang("nutriscore_source_value") %][% sep %]: [% nutrient.value %], 
+        [% lang('nutriscore_rounded_value') %][% sep %]: [% nutrient.rounded %])
+      </li>
+    [% END %]
+  </ul>
+
+[% END %]
+
+<p>[% nutriscore_protein_info %]</p>
+
 <p>
-  <a data-dropdown="nutriscore_drop" aria-controls="nutriscore_drop" aria-expanded="false">[% lang('nutriscore_calculation_details') %] &raquo;</a>
+  <strong>[% lang('nutriscore_score') %][% sep %]: [% score %]</strong>
+  ([% negative_points %] - [% positive_points %])
 </p>
-<div id="nutriscore_drop" data-dropdown-content class="f-dropdown content large" aria-hidden="true" tabindex="-1">
-
-  <p>[% beverage_view %]</p>
-  
-  [% IF is_fat %]
-    <p>[% lang('nutriscore_proteins_is_added_fat') %]</p>
-  [% END %]
-
-  [% FOREACH group IN points_groups %]
-
-    <p> 
-      <strong>[% lang("nutriscore_${group.type}_points") %][% sep %]: [% group.points %]</strong> 
-    </p>
-
-    <ul>
-      [% FOREACH nutrient IN group.nutrients %]
-        <li>
-          <strong>[% lang("nutriscore_points_for_${nutrient.id}") %][% sep %]:
-	[% nutrient.points %]&nbsp;</strong>/&nbsp;[% nutrient.maximum %][% lang("points") %]
-	([% lang("nutriscore_source_value") %][% sep %]: [% nutrient.value %], 
-          [% lang('nutriscore_rounded_value') %][% sep %]: [% nutrient.rounded %])
-        </li>
-      [% END %]
-    </ul>
-
-  [% END %]
-
-    <p>[% nutriscore_protein_info %] </p>
-    <p>
-      <strong>[% lang('nutriscore_score') %][% sep %]: [% score %]</strong>
-      ([% negative_points %] - [% positive_points %])
-    </p>
-    <p><strong>[% lang('nutriscore_grade') %][% sep %]: [% grade %]</strong></p>
-
-</div>
+<p><strong>[% lang('nutriscore_grade') %][% sep %]: [% grade %]</strong></p>
 
 <!-- end templates/[% component.name %] -->

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -184,7 +184,7 @@
                 <a href="/nova" title="[% a_title %]">
                 [% display_icon('info') %]</a>
             </h4>
-            <a href="/nova" title="[% a_title %]"><img src="/images/attributes/nova-group-[% group %].svg" alt="[% display %]" style="margin-bottom:1rem;max-width:100%"></a><br>
+            <a href="/nova" title="[% a_title %]"><img src="[% static_subdomain %]/images/attributes/nova-group-[% group %].svg" alt="[% display %]" style="margin-bottom:1rem;max-width:100%"></a><br>
             [% display %]
         [% END %]
     </div>
@@ -199,8 +199,17 @@
             [% nutrition_image %]
         </div>
         <div class="medium-12 large-8 xlarge-8 xxlarge-8 columns">
-            [% display_nutrient_levels %]
-            [% display_field %]
+
+            <div class='row'>
+                <div class="small-12 xlarge-6 columns">
+                    [% display_nutriscore %]
+                </div>
+                <div class="small-12 xlarge-6 columns">
+                    [% display_nutrient_levels %]
+                </div>      
+            </div>
+      
+            [% display_serving_size %]
 
             [% IF no_nutrition_data == 'on' %]
                 <div class='panel callout'>
@@ -247,7 +256,7 @@
 	[% END %]
 	
 	<a href="[% url_for_text("ecoscore") %]" title="[% lang('ecoscore_information') %]">
-		<img src="/images/attributes/ecoscore-[% ecoscore_grade_lc %].svg" alt="Eco-score [% ecoscore_grade %]" style="margin-bottom:1rem;max-width:100%">
+		<img src="[% static_subdomain %]/images/attributes/ecoscore-[% ecoscore_grade_lc %].svg" alt="Eco-score [% ecoscore_grade %]" style="margin-bottom:1rem;max-width:100%">
 	</a>
 	<br>
   
@@ -279,7 +288,7 @@
 <h4>[% lang('forest_footprint') %]</h4>
 
 <a href="/empreinte-foret-des-produits-alimentaires" title="[% lang('forest_footprint_information') %]" style="float:left">
-	<img src="/images/icons/forest-footprint-[% forest_footprint_data.grade %].svg" alt="[% lang('forest_footprint') %]" style="height:130px" >
+	<img src="[% static_subdomain %]/images/icons/forest-footprint-[% forest_footprint_data.grade %].svg" alt="[% lang('forest_footprint') %]" style="height:130px" >
 </a>
 <div>
 	<p><strong>[% lang("attribute_forest_footprint_${forest_footprint_data.grade}_title") %]</strong><br>

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -191,6 +191,8 @@
     <div class="show-for-large-up large-4 xlarge-4 xxlarge-4 columns" style="padding-left:0">[% ingredients_image %]</div>
 </div>
 
+[% health_card_panel %]
+
 <!-- nutrition table -->
 [% IF nutrition_table == 'defined' %]
     <h2 id="nutrition_data">[% lang("nutrition_data") %]</h2>
@@ -236,11 +238,9 @@
 	<h2 id="environmental_impact">[% lang('environmental_impact') %]</h2>
 [% END %]
 
-[% IF environment_card_panel %]
 
-    [% environment_card_panel %]
+[% environment_card_panel %]
 
-[% END %]
 
 [% IF ecoscore_grade %]
 	<h4>Eco-score

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -1,7 +1,7 @@
 [% panel = panels.$panel_id %]
 <!-- start templates/[% template.name %] - panel_id: [% panel_id %] -->
-[% IF panel.type == "card" %]
-<div class="panel_card" id="[% panel_id | replace(':','-') %]" style="margin-top:0.5rem;margin-bottom:0.5rem;">
+[% IF (panel.type == "card") OR (panel.type == "inline") %]
+<div class="panel_[% panel.type %]" id="[% panel_id | replace(':','-') %]" style="margin-top:0.5rem;margin-bottom:0.5rem;">
 [% ELSE %]
 <ul data-accordion class="panel_accordion accordion" id="[% panel_id | replace(':','-') %]" style="margin-top:0.5rem;margin-bottom:0.5rem;">
 <li class="accordion-navigation">
@@ -71,7 +71,7 @@
     </a>
 
     [% IF panel.elements.defined %]
-    <div id="panel_[% panel_id | replace(':','-') %]_content" class="content panel_content[% IF panel.type == 'card' %]_card[% END %][% IF panel.expanded %] active[% END %]">
+    <div id="panel_[% panel_id | replace(':','-') %]_content" class="content panel_content[% IF (panel.type == 'card') OR (panel.type == 'inline') %]_[% panel.type %][% END %][% IF panel.expanded %] active[% END %]">
     [% FOREACH element_ref IN panel.elements %]
         [% element_type = element_ref.element_type %]
        

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -119,11 +119,13 @@
 
                 
                 [% IF text_element.type == "h1" %]
-                    <h4>
+                    <h4 class="panel_title">
                 [% ELSIF text_element.type == "note" %]
-                    <div class="note">→ 
+                    <div class="panel_text panel_text_note">→ 
+                [% ELSIF text_element.type == "warning" %]
+                    <div class="panel_text panel_text_warning">⚠️ 
                 [% ELSE %]
-                    <div>
+                    <div class="panel_text">
                 [% END %]
                     [% text_element.html %]
                 [% IF text_element.type == "h1" %]


### PR DESCRIPTION
This is to prepare to create a Nutri-Score knowledge panel:

- Created a nutriscore.tt.html template to remove the hardcoded HTML that was in Display.pm
- Separated the preparation of data to be displayed for Nutri-Score and nutrient levels in a new function data_to_display_nutriscore_and_nutrient_levels(). We will also use the result of this data preparation for the corresponding knowledge panels.
- Added new warnings to inform users why the Nutri-Score is not displayed: category exempted  from Nutri-Score, missing category, or missing nutrition data
- Small changes to the nutriscore_details template so that we can reuse it in a knowledge panel
- Added https://static.openfoodfacts.org subdomain to icons URLs to make them absolute
- Added a Health card knowledge panel + Nutri-Score panel