### PR TITLE
fix: use /tmp for compiled templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,6 @@ clean_folders:
 	( rm -rf html/data/i18n/ || true )
 	( rm -rf html/{css,js}/dist/ || true )
 	( rm -rf tmp/ || true )
-	( rm -rf logs/ || true )
+	( rm logs/* logs/apache2/* logs/nginx/* || true )
 
 clean: goodbye hdown prune prune_cache clean_folders

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,6 @@ x-backend-conf: &backend-conf
     # Apache conf
     - ./conf/apache.conf:/etc/apache2/sites-enabled/product-opener.conf
 
-    # Tmpfs
-    - type: tmpfs
-      target: /mnt/podata/tmp
   networks:
     - webnet
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -274,7 +274,7 @@ $tt = Template->new(
 		EVAL_PERL    => 1,
 		STAT_TTL     => 60,                              # cache templates in memory for 1 min before checking if the source changed
 		COMPILE_EXT  => '.ttc',                          # compile templates to Perl code for much faster reload
-		COMPILE_DIR  => $data_root . '/tmp/templates',
+		COMPILE_DIR  => '/tmp/templates',
 		ENCODING     => 'UTF-8',
 		RECURSION    => 1,	# Needed for the knowledge panels that contain subpanels
 	}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -274,7 +274,7 @@ $tt = Template->new(
 		EVAL_PERL    => 1,
 		STAT_TTL     => 60,                              # cache templates in memory for 1 min before checking if the source changed
 		COMPILE_EXT  => '.ttc',                          # compile templates to Perl code for much faster reload
-		COMPILE_DIR  => '/tmp/templates',
+		COMPILE_DIR  => '/tmp/productopener/templates',
 		ENCODING     => 'UTF-8',
 		RECURSION    => 1,	# Needed for the knowledge panels that contain subpanels
 	}


### PR DESCRIPTION
Fixes issue when running dev environment in docker:

after a clean repo checkout, make clean, make dev

```
Creating po_backend_run ... done
Status: 500
Content-type: text/html
<h1>Software error:</h1>
<pre>mkdir /mnt/podata/tmp/templates: Permission denied at /opt/perl/local/lib/perl5/x86_64-linux-gnu-thread-multi/Template/Provider.pm line 378.
```