### PR TITLE
Refactor nutrition table generation, remove carbon footprint, add nutrition table panel

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9970,11 +9970,7 @@ CSS
 
 Generates HTML to display a nutrition table.
 
-The nutrition table can be the nutrition table of a product, or of a category (stats for the categories).
-
-In the case of a product, extra columns can be added to compare the product nutrition facts to the average for its categories.
-
-The resulting data structure can be passed to a template to generate HTML or the JSON data for a knowledge panel.
+Use  data produced by data_to_display_nutrition_table
 
 =head3 Arguments
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -2871,12 +2871,12 @@ sub display_points_ranking($$) {
 	my $ambassadors_points_ref;
 
 	if ($tagtype eq 'users') {
-		$points_ref = retrieve("$data_root/index/users_points.sto");
-		$ambassadors_points_ref = retrieve("$data_root/index/ambassadors_users_points.sto");
+		$points_ref = retrieve("$data_root/data/index/users_points.sto");
+		$ambassadors_points_ref = retrieve("$data_root/data/index/ambassadors_users_points.sto");
 	}
 	else {
-		$points_ref = retrieve("$data_root/index/countries_points.sto");
-		$ambassadors_points_ref = retrieve("$data_root/index/ambassadors_countries_points.sto");
+		$points_ref = retrieve("$data_root/data/index/countries_points.sto");
+		$ambassadors_points_ref = retrieve("$data_root/data/index/ambassadors_countries_points.sto");
 	}
 
 	$html .= "\n\n<table id=\"${tagtype}table\">\n";
@@ -9040,6 +9040,22 @@ sub display_nutriscore_calculation_details($) {
 }
 
 
+=head2 data_to_display_nutriscore_and_nutrient_levels ( $product_ref )
+
+Generates a data structure to display the Nutri-Score and the nutrient levels (food trafic lights).
+
+The resulting data structure can be passed to a template to generate HTML or the JSON data for a knowledge panel.
+
+=head3 Arguments
+
+=head4 Product reference $product_ref
+
+=head3 Return values
+
+Reference to a data structure with needed data to display.
+
+=cut
+
 sub data_to_display_nutriscore_and_nutrient_levels($) {
 
 	my $product_ref = shift;
@@ -9289,40 +9305,53 @@ sub compute_stats_for_products($$$$$$) {
 }
 
 
-sub display_nutrition_table($$) {
+=head2 data_to_display_nutrition_table ( $product_ref, $comparisons_ref )
+
+Generates a data structure to display a nutrition table.
+
+The nutrition table can be the nutrition table of a product, or of a category (stats for the categories).
+
+In the case of a product, extra columns can be added to compare the product nutrition facts to the average for its categories.
+
+The resulting data structure can be passed to a template to generate HTML or the JSON data for a knowledge panel.
+
+=head3 Arguments
+
+=head4 Product reference $product_ref
+
+=head4 Comparisons reference $product_ref
+
+Reference to an array with nutrition facts for 1 or more categories.
+
+=head3 Return values
+
+Reference to a data structure with needed data to display.
+
+=cut
+
+sub data_to_display_nutrition_table($$) {
 
 	my $product_ref = shift;
 	my $comparisons_ref = shift;
 
-	my $html = '';
-
 	# This function populates a data structure that is used by the template to display the nutrition facts table
 	my $template_data_ref = {
-		lang => \&lang,
 
-		tables => [
-			{
-				id => "nutrition",
-				header => {
-					name => lang('nutrition_data_table'),
-					columns => [],
-				},
-				rows => [],
+		nutrition_table => {
+			id => "nutrition",
+			header => {
+				name => lang('nutrition_data_table'),
+				columns => [],
 			},
-			{
-				id => "ecological",
-				header => {
-					name => lang('ecological_data_table'),
-					columns => [],
-				},
-				rows => [],
-			},
-		],
+			rows => [],
+		},
 	};
 
 	my @cols;
 
 	my %col_name = ();
+
+	# We can have nutrition data for the product as sold, and/or prepared
 
 	my @displayed_product_types = ();
 	my %displayed_product_types = ();
@@ -9445,40 +9474,6 @@ CSS
 
 			$i++;
 		}
-
-		# \$( ".show_comparison" ).button();
-
-
-		$initjs .= <<JS
-
-\$('input:radio[name=nutrition_data_compare_type]').change(function () {
-
-	if (\$('input:radio[name=nutrition_data_compare_type]:checked').val() == 'compare_value') {
-		\$(".compare_percent").hide();
-		\$(".compare_value").show();
-	}
-	else {
-		\$(".compare_value").hide();
-		\$(".compare_percent").show();
-	}
-
-}
-);
-
-
-\$(".show_comparison").change(function () {
-	if (\$(this).prop('checked')) {
-		\$("." + \$(this).attr("id")).show();
-	}
-	else {
-		\$("." + \$(this).attr("id")).hide();
-	}
-}
-);
-
-JS
-;
-
 	}
 
 	# Stats for categories
@@ -9495,57 +9490,22 @@ JS
 			# Show checkbox to display/hide stats for the category
 
 			$template_data_ref->{category_stats} = 1;
-
-			$initjs .= <<JS
-
-if (\$.cookie('show_stats') == '1') {
-	\$('#show_stats').prop('checked',true);
-}
-else {
-	\$('#show_stats').prop('checked',false);
-}
-
-if (\$('#show_stats').prop('checked')) {
-	\$(".stats").show();
-}
-else {
-	\$(".stats").hide();
-}
-
-\$("#show_stats").change(function () {
-	if (\$('#show_stats').prop('checked')) {
-		\$.cookie('show_stats', '1', { expires: 365 });
-		\$(".stats").show();
-	}
-	else {
-		\$.cookie('show_stats', null);
-		\$(".stats").hide();
-	}
-}
-);
-
-JS
-;
-
 		}
 	}
 
-	# Tables header columns (for 2 columns: nutrition + ecological)
+	# Data for the nutrition table header
 
-	for (my $i = 0; $i <2 ; $i++) {
+	foreach my $col (@cols) {
 
-		foreach my $col (@cols) {
+		push (@{$template_data_ref->{nutrition_table}{header}{columns}}, {
+			col_id => $col,
+			class => $col_class{$col},
+			name => $col_name{$col},
+		});
 
-      		push (@{$template_data_ref->{tables}[$i]{header}{columns}}, {
-				col_id => $col,
-				class => $col_class{$col},
-				name => $col_name{$col},
-			});
-
-		}
 	}
 
-	# Tables body columns
+	# Data for the nutrition table body
 
 	defined $product_ref->{nutriments} or $product_ref->{nutriments} = {};
 
@@ -9568,7 +9528,7 @@ JS
 	my @nutriments = ();
 	foreach my $nutriment (@{$nutriments_tables{$nutriment_table}}, @unknown_nutriments) {
 		push @nutriments, $nutriment;
-		if (($nutriment eq "fruits-vegetables-nuts-estimate-") and ($User{moderator})) {
+		if (($nutriment eq "fruits-vegetables-nuts-estimate-")) {
 			push @nutriments, "fruits-vegetables-nuts-estimate-from-ingredients-";
 		}
 	}
@@ -9585,11 +9545,10 @@ JS
 
 		next if $nid eq 'sodium';
 
-		my $class = 'main';
-		my $prefix = '';
-
+		# Determine if the nutrient should be shown
 		my $shown = 0;
 
+		# Do not show rows that are optional (id with a trailing -) unless we have non empty data for it
 		if  (($nutriment !~ /-$/)
 			or ((defined $product_ref->{nutriments}{$nid}) and ($product_ref->{nutriments}{$nid} ne ''))
 			or ((defined $product_ref->{nutriments}{$nid . "_100g"}) and ($product_ref->{nutriments}{$nid . "_100g"} ne ''))
@@ -9598,7 +9557,7 @@ JS
 			$shown = 1;
 		}
 
-		# Only show important nutriments if the value is not known
+		# Only show important nutriments (id prefixed with !) if the value is not known
 		# Only show known values for search graph results
 		if ((($nutriment !~ /^!/) or ($product_ref->{id} eq 'search'))
 			and not (((defined $product_ref->{nutriments}{$nid}) and ($product_ref->{nutriments}{$nid} ne ''))
@@ -9607,387 +9566,399 @@ JS
 			$shown = 0;
 		}
 
-		if (($shown) and ($nutriment =~ /^-/)) {
-			$class = 'sub';
-			$prefix = lang("nutrition_data_table_sub") . " ";
-			if ($nutriment =~ /^--/) {
-				$prefix = "&nbsp; " . $prefix;
-			}
-		}
-
-		my $name;
-
-		# display nutrition score only when the country is matching
+		# Show the UK nutrition score only if the country is matching
+		# Always show the FR nutrition score (Nutri-Score)
 
 		if ($nid =~ /^nutrition-score-(.*)$/) {
 			# Always show the FR score and Nutri-Score
 			if (($cc ne $1) and (not ($1 eq 'fr'))) {
 				$shown = 0;
 			}
-			else {
-				$name = '<a href="/nutriscore" title="$product_ref->{nutrition_score_debug}">' . $prefix.$Nutriments{$nid}{$lang} . '</a>';
-			}
 		}
 
-		elsif ((exists $Nutriments{$nid}) and (exists $Nutriments{$nid}{$lang})) {
-			$name = $prefix . $Nutriments{$nid}{$lang};
-
-		}
-		elsif ((exists $Nutriments{$nid}) and (exists $Nutriments{$nid}{en})) {
-			$name = $prefix . $Nutriments{$nid}{en};
-
-		}
-		elsif (defined $product_ref->{nutriments}{$nid . "_label"}) {
-			$name = $product_ref->{nutriments}{$nid . "_label"};
-		}
-
-		my $unit = 'g';
-
-		if ((exists $Nutriments{$nid}) and (exists $Nutriments{$nid}{unit})) {
-			$unit = $Nutriments{$nid}{unit};
-
-		}
-		elsif ((not exists $Nutriments{$nid}) and (defined $product_ref->{nutriments}{$nid . "_unit"})) {
-			$unit = $product_ref->{nutriments}{$nid . "_unit"};
-		}
-
-		my $values;
-		my $values2;
-
-		my @columns;
-		my @extra_row_columns;
-		my @ecological_impact_columns;
-
-		foreach my $col (@cols) {
-
-			$values  = '';    # Value for row
-			$values2 = '';    # Value for extra row (e.g. after the row for salt, we add an extra row for sodium)
-			my $col_class = '';
-			my $percent   = '';
-
-			my $rdfa  = '';    # RDFA property for row
-			my $rdfa2 = '';    # RDFA property for extra row
-
-			my $col_type;
-
-			if (defined $col_class{$col}) {
-				$col_class = ' ' . $col_class{$col} ;
+		if ($shown) {
+		
+			# Level of the nutrient: 1 for main nutrients, 2 for sub-nutrients, 3 for sub-sub-nutrients
+			my $level = 1;
+			
+			if ($nutriment =~ /^-/) {
+				$level = 2;
+				if ($nutriment =~ /^--/) {
+					$level = 3;
+				}
 			}
 
-			if ( $col =~ /compare_(.*)/ ) {    #comparisons
+			# Name of the nutrient
 
-				$col_type = "comparison";
+			my $name;
 
-				my $comparison_ref = $comparisons_ref->[$1];
+			if ((exists $Nutriments{$nid}) and (exists $Nutriments{$nid}{$lang})) {
+				$name = $Nutriments{$nid}{$lang};
 
-				my $value = "";
-				if (defined $comparison_ref->{nutriments}{$nid . "_100g"}) {
-					# energy-kcal is already in kcal
-					if ($nid eq 'energy-kcal') {
-						$value = $comparison_ref->{nutriments}{$nid . "_100g"};
-					}
-					else {
-						$value = $decf->format(g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, $unit));
-					}
-				}
-				# too small values are converted to e notation: 7.18e-05
-				if (($value . ' ') =~ /e/) {
-					# use %f (outputs extras 0 in the general case)
-					$value = sprintf("%f", g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, $unit));
-				}
-
-				# 0.045 g	0.0449 g
-
-				$values = "$value $unit";
-				if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
-					$values = '?';
-				}
-				elsif (($nid eq "energy") or ($nid eq "energy-from-fat")) {
-					# Use the actual value in kcal if we have it
-					my $value_in_kcal;
-					if (defined $comparison_ref->{nutriments}{$nid . "-kcal" . "_100g"}) {
-						$value_in_kcal = $comparison_ref->{nutriments}{$nid . "-kcal" . "_100g"};
-					}
-					# Otherwise convert the value in kj
-					else {
-						$value_in_kcal =  g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, 'kcal');
-					}
-					$values .= "<br>(" . sprintf("%d", $value_in_kcal) . ' kcal)';
-				}
-
-				$percent = $comparison_ref->{nutriments}{"${nid}_100g_%"};
-				if ((defined $percent) and ($percent ne '')) {
-
-					my $percent_numeric_value = $percent;
-					$percent = $perf->format($percent / 100.0);
-					# issue 2273 -  minus signs are rendered with different characters in different locales, e.g. Finnish
-					# so just test positivity of numeric value
-					if ($percent_numeric_value > 0 ) {
-						$percent = "+" . $percent;
-					}
-				}
-				else {
-					$percent = "";
-				}
-
-				if ($nid eq 'sodium') {
-					if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
-						$values2 .= '?';
-					}
-					else {
-						$values2 .= ($decf->format(g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"} * 2.5, $unit))) . " " . $unit;
-					}
-				}
-				if ($nid eq 'salt') {
-					if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
-						$values2 .= '?';
-					}
-					else {
-						$values2 .= ($decf->format(g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"} / 2.5, $unit))) . " " . $unit;
-					}
-				}
-
-				if ($nid eq 'nutrition-score-fr') {
-					# We need to know the category in order to select the right thresholds for the nutrition grades
-					# as it depends on whether it is food or drink
-
-					# if it is a category stats, the category id is the id field
-					if ((not defined $product_ref->{categories_tags})
-						and (defined $product_ref->{id})
-						and ($product_ref->{id} =~ /^en:/)
-							) {
-						$product_ref->{categories} = $product_ref->{id};
-						compute_field_tags($product_ref, "en", "categories");
-					}
-
-					if (defined $product_ref->{categories_tags}) {
-
-						my $nutriscore_grade = compute_nutriscore_grade($product_ref->{nutriments}{$nid . "_100g"},
-							is_beverage_for_nutrition_score($product_ref), is_water_for_nutrition_score($product_ref));
-
-						$values2 .= uc ($nutriscore_grade);
-					}
-				}
 			}
-			else {
-				$col_type = "normal";
-				my $value_unit = "";
+			elsif ((exists $Nutriments{$nid}) and (exists $Nutriments{$nid}{en})) {
+				$name = $Nutriments{$nid}{en};
 
-				# Nutriscore: per serving = per 100g
-				if (($nid =~ /(nutrition-score(-\w\w)?)/)) {
-					# same Nutri-Score for 100g / serving and prepared / as sold
-					$product_ref->{nutriments}{$nid . "_$col"} = $product_ref->{nutriments}{$1 . "_100g"};
+			}
+			elsif (defined $product_ref->{nutriments}{$nid . "_label"}) {
+				$name = $product_ref->{nutriments}{$nid . "_label"};
+			}
+
+			my $unit = 'g';
+
+			if ((exists $Nutriments{$nid}) and (exists $Nutriments{$nid}{unit})) {
+				$unit = $Nutriments{$nid}{unit};
+
+			}
+			elsif ((not exists $Nutriments{$nid}) and (defined $product_ref->{nutriments}{$nid . "_unit"})) {
+				$unit = $product_ref->{nutriments}{$nid . "_unit"};
+			}
+
+			my $values;
+			my $values2;
+
+			my @columns;
+			my @extra_row_columns;
+			my @ecological_impact_columns;
+
+			foreach my $col (@cols) {
+
+				$values  = '';    # Value for row
+				$values2 = '';    # Value for extra row (e.g. after the row for salt, we add an extra row for sodium)
+				my $col_class = '';
+				my $percent   = '';
+
+				my $rdfa  = '';    # RDFA property for row
+				my $rdfa2 = '';    # RDFA property for extra row
+
+				my $col_type;
+
+				if (defined $col_class{$col}) {
+					$col_class = ' ' . $col_class{$col} ;
 				}
 
-				if ((not defined $product_ref->{nutriments}{$nid . "_$col"}) or ($product_ref->{nutriments}{$nid . "_$col"} eq '')) {
-					$value_unit = '?';
-				}
-				else {
+				if ( $col =~ /compare_(.*)/ ) {    #comparisons
 
-					# this is the actual value on the package, not a computed average. do not try to round to 2 decimals.
-					my $value;
+					$col_type = "comparison";
 
-					# energy-kcal is already in kcal
-					if ($nid eq 'energy-kcal') {
-						$value = $product_ref->{nutriments}{$nid . "_$col"};
+					my $comparison_ref = $comparisons_ref->[$1];
+
+					my $value = "";
+					if (defined $comparison_ref->{nutriments}{$nid . "_100g"}) {
+						# energy-kcal is already in kcal
+						if ($nid eq 'energy-kcal') {
+							$value = $comparison_ref->{nutriments}{$nid . "_100g"};
+						}
+						else {
+							$value = $decf->format(g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, $unit));
+						}
 					}
-					else {
-						$value = $decf->format(g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, $unit));
-					}
-
 					# too small values are converted to e notation: 7.18e-05
 					if (($value . ' ') =~ /e/) {
 						# use %f (outputs extras 0 in the general case)
-						$value = sprintf("%f", g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, $unit));
+						$value = sprintf("%f", g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, $unit));
 					}
 
-					$value_unit = "$value $unit";
+					# 0.045 g	0.0449 g
 
-					if (defined $product_ref->{nutriments}{$nid . "_modifier"}) {
-						$value_unit = $product_ref->{nutriments}{$nid . "_modifier"} . " " . $value_unit;
+					$values = "$value $unit";
+					if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
+						$values = '?';
 					}
-
-					if (($nid eq "energy") or ($nid eq "energy-from-fat")) {
+					elsif (($nid eq "energy") or ($nid eq "energy-from-fat")) {
 						# Use the actual value in kcal if we have it
 						my $value_in_kcal;
-						if (defined $product_ref->{nutriments}{$nid . "-kcal" . "_$col"}) {
-							$value_in_kcal = $product_ref->{nutriments}{$nid . "-kcal" . "_$col"};
+						if (defined $comparison_ref->{nutriments}{$nid . "-kcal" . "_100g"}) {
+							$value_in_kcal = $comparison_ref->{nutriments}{$nid . "-kcal" . "_100g"};
 						}
 						# Otherwise convert the value in kj
 						else {
-							$value_in_kcal =  g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, 'kcal');
+							$value_in_kcal =  g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"}, 'kcal');
 						}
-						$value_unit .= "<br>(" . sprintf("%d", $value_in_kcal) . ' kcal)';
+						$values .= "<br>(" . sprintf("%d", $value_in_kcal) . ' kcal)';
 					}
-				}
 
-				if ($nid eq 'sodium') {
-					my $salt;
-					if (defined $product_ref->{nutriments}{$nid . "_$col"}) {
-						$salt = $product_ref->{nutriments}{$nid . "_$col"} * 2.5;
-					}
-					if (exists $product_ref->{nutriments}{"salt" . "_$col"}) {
-						$salt = $product_ref->{nutriments}{"salt" . "_$col"};
-					}
-					if (defined $salt) {
-						$salt = $decf->format(g_to_unit($salt, $unit));
-						if ($col eq '100g') {
-							$rdfa2 = "property=\"food:saltEquivalentPer100g\" content=\"$salt\"";
+					$percent = $comparison_ref->{nutriments}{"${nid}_100g_%"};
+					if ((defined $percent) and ($percent ne '')) {
+
+						my $percent_numeric_value = $percent;
+						$percent = $perf->format($percent / 100.0);
+						# issue 2273 -  minus signs are rendered with different characters in different locales, e.g. Finnish
+						# so just test positivity of numeric value
+						if ($percent_numeric_value > 0 ) {
+							$percent = "+" . $percent;
 						}
-						$salt .= " " . $unit;
 					}
 					else {
-						$salt = "?";
+						$percent = "";
 					}
-					$values2 .= $salt;
-				}
-				elsif ($nid eq 'salt') {
-					my $sodium;
-					if (defined $product_ref->{nutriments}{$nid . "_$col"}) {
-						$sodium = $product_ref->{nutriments}{$nid . "_$col"} / 2.5;
-					}
-					if (exists $product_ref->{nutriments}{"sodium". "_$col"}) {
-						$sodium = $product_ref->{nutriments}{"sodium". "_$col"};
-					}
-					if (defined $sodium) {
-						$sodium = $decf->format(g_to_unit($sodium, $unit));
-						if ($col eq '100g') {
-							$rdfa2 = "property=\"food:sodiumEquivalentPer100g\" content=\"$sodium\"";
+
+					if ($nid eq 'sodium') {
+						if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
+							$values2 .= '?';
 						}
-						$sodium .= " " . $unit;
+						else {
+							$values2 .= ($decf->format(g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"} * 2.5, $unit))) . " " . $unit;
+						}
 					}
-					else {
-						$sodium = "?";
-					}
-					$values2 .= $sodium ;
-				}
-				elsif ($nid eq 'nutrition-score-fr') {
-					# We need to know the category in order to select the right thresholds for the nutrition grades
-					# as it depends on whether it is food or drink
-
-					# if it is a category stats, the category id is the id field
-					if ((not defined $product_ref->{categories_tags})
-						and (defined $product_ref->{id})
-						and ($product_ref->{id} =~ /^en:/)
-							) {
-						$product_ref->{categories} = $product_ref->{id};
-						compute_field_tags($product_ref, "en", "categories");
+					if ($nid eq 'salt') {
+						if ((not defined $comparison_ref->{nutriments}{$nid . "_100g"}) or ($comparison_ref->{nutriments}{$nid . "_100g"} eq '')) {
+							$values2 .= '?';
+						}
+						else {
+							$values2 .= ($decf->format(g_to_unit($comparison_ref->{nutriments}{$nid . "_100g"} / 2.5, $unit))) . " " . $unit;
+						}
 					}
 
-					if (defined $product_ref->{categories_tags}) {
+					if ($nid eq 'nutrition-score-fr') {
+						# We need to know the category in order to select the right thresholds for the nutrition grades
+						# as it depends on whether it is food or drink
 
-						if ($col ne "std") {
+						# if it is a category stats, the category id is the id field
+						if ((not defined $product_ref->{categories_tags})
+							and (defined $product_ref->{id})
+							and ($product_ref->{id} =~ /^en:/)
+								) {
+							$product_ref->{categories} = $product_ref->{id};
+							compute_field_tags($product_ref, "en", "categories");
+						}
 
-							my $nutriscore_grade = compute_nutriscore_grade($product_ref->{nutriments}{$nid . "_$col"},
+						if (defined $product_ref->{categories_tags}) {
+
+							my $nutriscore_grade = compute_nutriscore_grade($product_ref->{nutriments}{$nid . "_100g"},
 								is_beverage_for_nutrition_score($product_ref), is_water_for_nutrition_score($product_ref));
 
 							$values2 .= uc ($nutriscore_grade);
 						}
 					}
 				}
-				elsif ($col eq $product_ref->{nutrition_data_per}) {
-					# % DV ?
-					if ((defined $product_ref->{nutriments}{$nid . "_value"}) and (defined $product_ref->{nutriments}{$nid . "_unit"}) and ($product_ref->{nutriments}{$nid . "_unit"} eq '% DV')) {
-						$value_unit .= ' (' . $product_ref->{nutriments}{$nid . "_value"} . ' ' . $product_ref->{nutriments}{$nid . "_unit"} . ')';
+				else {
+					$col_type = "normal";
+					my $value_unit = "";
+
+					# Nutriscore: per serving = per 100g
+					if (($nid =~ /(nutrition-score(-\w\w)?)/)) {
+						# same Nutri-Score for 100g / serving and prepared / as sold
+						$product_ref->{nutriments}{$nid . "_$col"} = $product_ref->{nutriments}{$1 . "_100g"};
 					}
+
+					if ((not defined $product_ref->{nutriments}{$nid . "_$col"}) or ($product_ref->{nutriments}{$nid . "_$col"} eq '')) {
+						$value_unit = '?';
+					}
+					else {
+
+						# this is the actual value on the package, not a computed average. do not try to round to 2 decimals.
+						my $value;
+
+						# energy-kcal is already in kcal
+						if ($nid eq 'energy-kcal') {
+							$value = $product_ref->{nutriments}{$nid . "_$col"};
+						}
+						else {
+							$value = $decf->format(g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, $unit));
+						}
+
+						# too small values are converted to e notation: 7.18e-05
+						if (($value . ' ') =~ /e/) {
+							# use %f (outputs extras 0 in the general case)
+							$value = sprintf("%f", g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, $unit));
+						}
+
+						$value_unit = "$value $unit";
+
+						if (defined $product_ref->{nutriments}{$nid . "_modifier"}) {
+							$value_unit = $product_ref->{nutriments}{$nid . "_modifier"} . " " . $value_unit;
+						}
+
+						if (($nid eq "energy") or ($nid eq "energy-from-fat")) {
+							# Use the actual value in kcal if we have it
+							my $value_in_kcal;
+							if (defined $product_ref->{nutriments}{$nid . "-kcal" . "_$col"}) {
+								$value_in_kcal = $product_ref->{nutriments}{$nid . "-kcal" . "_$col"};
+							}
+							# Otherwise convert the value in kj
+							else {
+								$value_in_kcal =  g_to_unit($product_ref->{nutriments}{$nid . "_$col"}, 'kcal');
+							}
+							$value_unit .= "<br>(" . sprintf("%d", $value_in_kcal) . ' kcal)';
+						}
+					}
+
+					if ($nid eq 'sodium') {
+						my $salt;
+						if (defined $product_ref->{nutriments}{$nid . "_$col"}) {
+							$salt = $product_ref->{nutriments}{$nid . "_$col"} * 2.5;
+						}
+						if (exists $product_ref->{nutriments}{"salt" . "_$col"}) {
+							$salt = $product_ref->{nutriments}{"salt" . "_$col"};
+						}
+						if (defined $salt) {
+							$salt = $decf->format(g_to_unit($salt, $unit));
+							if ($col eq '100g') {
+								$rdfa2 = "property=\"food:saltEquivalentPer100g\" content=\"$salt\"";
+							}
+							$salt .= " " . $unit;
+						}
+						else {
+							$salt = "?";
+						}
+						$values2 .= $salt;
+					}
+					elsif ($nid eq 'salt') {
+						my $sodium;
+						if (defined $product_ref->{nutriments}{$nid . "_$col"}) {
+							$sodium = $product_ref->{nutriments}{$nid . "_$col"} / 2.5;
+						}
+						if (exists $product_ref->{nutriments}{"sodium". "_$col"}) {
+							$sodium = $product_ref->{nutriments}{"sodium". "_$col"};
+						}
+						if (defined $sodium) {
+							$sodium = $decf->format(g_to_unit($sodium, $unit));
+							if ($col eq '100g') {
+								$rdfa2 = "property=\"food:sodiumEquivalentPer100g\" content=\"$sodium\"";
+							}
+							$sodium .= " " . $unit;
+						}
+						else {
+							$sodium = "?";
+						}
+						$values2 .= $sodium ;
+					}
+					elsif ($nid eq 'nutrition-score-fr') {
+						# We need to know the category in order to select the right thresholds for the nutrition grades
+						# as it depends on whether it is food or drink
+
+						# if it is a category stats, the category id is the id field
+						if ((not defined $product_ref->{categories_tags})
+							and (defined $product_ref->{id})
+							and ($product_ref->{id} =~ /^en:/)
+								) {
+							$product_ref->{categories} = $product_ref->{id};
+							compute_field_tags($product_ref, "en", "categories");
+						}
+
+						if (defined $product_ref->{categories_tags}) {
+
+							if ($col ne "std") {
+
+								my $nutriscore_grade = compute_nutriscore_grade($product_ref->{nutriments}{$nid . "_$col"},
+									is_beverage_for_nutrition_score($product_ref), is_water_for_nutrition_score($product_ref));
+
+								$values2 .= uc ($nutriscore_grade);
+							}
+						}
+					}
+					elsif ($col eq $product_ref->{nutrition_data_per}) {
+						# % DV ?
+						if ((defined $product_ref->{nutriments}{$nid . "_value"}) and (defined $product_ref->{nutriments}{$nid . "_unit"}) and ($product_ref->{nutriments}{$nid . "_unit"} eq '% DV')) {
+							$value_unit .= ' (' . $product_ref->{nutriments}{$nid . "_value"} . ' ' . $product_ref->{nutriments}{$nid . "_unit"} . ')';
+						}
+					}
+
+					if (($col eq '100g') and (defined $product_ref->{nutriments}{$nid . "_$col"})) {
+						my $property = $nid;
+						$property =~ s/-([a-z])/ucfirst($1)/eg;
+						$property .= "Per100g";
+						$rdfa = " property=\"food:$property\" content=\"" . $product_ref->{nutriments}{$nid . "_$col"} . "\"";
+					}
+
+					$values .= $value_unit;
 				}
 
-				if (($col eq '100g') and (defined $product_ref->{nutriments}{$nid . "_$col"})) {
-					my $property = $nid;
-					$property =~ s/-([a-z])/ucfirst($1)/eg;
-					$property .= "Per100g";
-					$rdfa = " property=\"food:$property\" content=\"" . $product_ref->{nutriments}{$nid . "_$col"} . "\"";
-				}
-
-				$values .= $value_unit;
-			}
-
-			if (($nid eq 'carbon-footprint') or ($nid eq 'carbon-footprint-from-meat-or-fish')){
-				push (@ecological_impact_columns, {
+				push (@columns, {
 					value => $values,
+					rdfa => $rdfa,
+					class => $col_class,
+					percent => $percent,
+					type => $col_type,
+				});
+
+				push (@extra_row_columns, {
+					value => $values2,
+					rdfa => $rdfa2,
 					class => $col_class,
 					percent => $percent,
 					type => $col_type,
 				});
 			}
 
-			push (@columns, {
-				value => $values,
-				rdfa => $rdfa,
-				class => $col_class,
-				percent => $percent,
-				type => $col_type,
-			});
 
-			push (@extra_row_columns, {
-				value => $values2,
-				rdfa => $rdfa2,
-				class => $col_class,
-				percent => $percent,
-				type => $col_type,
-			});
-		}
+			# Add the row data to the template
+			push @{$template_data_ref->{nutrition_table}{rows}}, {
+				nid => $nid,
+				level => $level,
+				name => $name,
+				columns => \@columns,
+			};
 
-		if ($shown) {
+			if (($nid eq 'sodium') and ($values2 ne '')) {
 
-			if (($nid ne 'carbon-footprint') and ($nid ne 'carbon-footprint-from-meat-or-fish')) {
-
-				push @{$template_data_ref->{tables}[0]{rows}}, {
-					nid => $nid,
-					class => $class,
-					name => $name,
-					columns => \@columns,
+				push @{$template_data_ref->{nutrition_table}{rows}}, {
+					name => lang("salt_equivalent"),
+					nid => "salt_equivalent",
+					level => 2,
+					columns => \@extra_row_columns,
 				};
-
-				if (($nid eq 'sodium') and ($values2 ne '')) {
-
-					push @{$template_data_ref->{tables}[0]{rows}}, {
-						name => lang("salt_equivalent"),
-						nid => "salt_equivalent",
-						class => "sub",
-						columns => \@extra_row_columns,
-					};
-				}
-
-				if (($nid eq 'salt') and ($values2 ne '')) {
-
-					push @{$template_data_ref->{tables}[0]{rows}}, {
-						name => $Nutriments{sodium}{$lang},
-						nid => "sodium",
-						class => "sub",
-						columns => \@extra_row_columns,
-					};
-				}
-
-				if (($nid eq 'nutrition-score-fr') and ($values2 ne '')) {
-
-					push @{$template_data_ref->{tables}[0]{rows}}, {
-						name => "Nutri-Score",
-						nid => "nutriscore",
-						class => "sub",
-						columns => \@extra_row_columns,
-					};
-				}
 			}
 
-			else {
+			if (($nid eq 'salt') and ($values2 ne '')) {
 
-				push @{$template_data_ref->{tables}[1]->{rows}}, {
-					nid => $nid,
-					class => $class,
-					name => $name,
-					columns => \@ecological_impact_columns,
+				push @{$template_data_ref->{nutrition_table}{rows}}, {
+					name => $Nutriments{sodium}{$lang},
+					nid => "sodium",
+					level => 2,
+					columns => \@extra_row_columns,
+				};
+			}
+
+			if (($nid eq 'nutrition-score-fr') and ($values2 ne '')) {
+
+				push @{$template_data_ref->{nutrition_table}{rows}}, {
+					name => "Nutri-Score",
+					nid => "nutriscore",
+					level => 2,
+					columns => \@extra_row_columns,
 				};
 			}
 		}
 	}
 
-	# Remove the ecological table if we have no rows
-	# 2021-02: remove the ecological table as we now show the Eco-Score
+	return $template_data_ref;
+}
 
-	if ((1) or (scalar @{$template_data_ref->{tables}[1]->{rows}} == 0)) {
-		pop @{$template_data_ref->{tables}};
-	}
+
+=head2 data_to_display_nutrition_table ( $product_ref, $comparisons_ref )
+
+Generates HTML to display a nutrition table.
+
+The nutrition table can be the nutrition table of a product, or of a category (stats for the categories).
+
+In the case of a product, extra columns can be added to compare the product nutrition facts to the average for its categories.
+
+The resulting data structure can be passed to a template to generate HTML or the JSON data for a knowledge panel.
+
+=head3 Arguments
+
+=head4 Product reference $product_ref
+
+=head4 Comparisons reference $product_ref
+
+Reference to an array with nutrition facts for 1 or more categories.
+
+=head3 Return values
+
+HTML for the nutrition table.
+
+=cut
+
+sub display_nutrition_table($$) {
+
+	my $product_ref = shift;
+	my $comparisons_ref = shift;
+
+	my $html = '';
+
+	my $template_data_ref = data_to_display_nutrition_table($product_ref, $comparisons_ref);
 
 	process_template('web/pages/product/includes/nutrition_facts_table.tt.html', $template_data_ref, \$html) || return "template error: " . $tt->error();
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9966,7 +9966,7 @@ CSS
 }
 
 
-=head2 data_to_display_nutrition_table ( $product_ref, $comparisons_ref )
+=head2 display_nutrition_table ( $product_ref, $comparisons_ref )
 
 Generates HTML to display a nutrition table.
 

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -137,11 +137,11 @@ use Log::Any qw($log);
 # the stats are displayed on category pages and used in product pages,
 # as well as in data quality checks and improvement opportunity detection
 
-if (opendir (my $dh, "$data_root/index")) {
+if (opendir (my $dh, "$data_root/data/categories_stats")) {
 	foreach my $file (readdir($dh)) {
 		if ($file =~ /categories_nutriments_per_country.(\w+).sto$/) {
 			my $country_cc = $1;
-			$categories_nutriments_per_country{$country_cc} = retrieve("$data_root/index/categories_nutriments_per_country.$country_cc.sto");
+			$categories_nutriments_per_country{$country_cc} = retrieve("$data_root/data/categories_stats/categories_nutriments_per_country.$country_cc.sto");
 		}
 	}
 	closedir $dh;
@@ -581,7 +581,7 @@ sub mmoll_to_unit {
 		'collagen-meat-protein-ratio-',
 		'cocoa-',
 		'chlorophyl-',
-		'carbon-footprint',
+		'carbon-footprint-',
 		'carbon-footprint-from-meat-or-fish-',
 		'nutrition-score-fr-',
 		'nutrition-score-uk-',
@@ -694,7 +694,7 @@ sub mmoll_to_unit {
 		'collagen-meat-protein-ratio-',
 		'cocoa-',
 		'chlorophyl-',
-		'carbon-footprint',
+		'carbon-footprint-',
 		'carbon-footprint-from-meat-or-fish-',
 		'nutrition-score-fr-',
 		'nutrition-score-uk-',
@@ -807,7 +807,7 @@ sub mmoll_to_unit {
 		'collagen-meat-protein-ratio-',
 		'cocoa-',
 		'chlorophyl-',
-		'carbon-footprint',
+		'carbon-footprint-',
 		'carbon-footprint-from-meat-or-fish-',
 		'nutrition-score-fr-',
 		'nutrition-score-uk-',
@@ -922,7 +922,7 @@ sub mmoll_to_unit {
 		'collagen-meat-protein-ratio-',
 		'cocoa-',
 		'chlorophyl-',
-		'carbon-footprint',
+		'carbon-footprint-',
 		'carbon-footprint-from-meat-or-fish-',
 		'nutrition-score-fr-',
 		'nutrition-score-uk-',
@@ -1030,7 +1030,7 @@ sub mmoll_to_unit {
 		'collagen-meat-protein-ratio-',
 		'cocoa-',
 		'chlorophyl-',
-		'carbon-footprint',
+		'carbon-footprint-',
 		'carbon-footprint-from-meat-or-fish-',
 		'nutrition-score-fr-',
 		'nutrition-score-uk-',

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -1603,10 +1603,6 @@ msgid ""
 "by typing the first letters of their name in the last row of the table."
 msgstr ""
 
-msgctxt "nutrition_data_table_sub"
-msgid "-"
-msgstr ""
-
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
 msgstr ""

--- a/scripts/create_small_categories_nutriments_per_country_for_testing.pl
+++ b/scripts/create_small_categories_nutriments_per_country_for_testing.pl
@@ -11,11 +11,11 @@ use ProductOpener::Store qw/:all/;
 # The real categories_nutriments_per_country.world.sto is too big to store for github,
 # create a smaller version that can be used in unit tests
 
-my $categories_nutriments_per_country_ref = retrieve("$data_root/index/categories_nutriments_per_country.world.sto");
+my $categories_nutriments_per_country_ref = retrieve("$data_root/data/categories_stats/categories_nutriments_per_country.world.sto");
 
 my $test_ref = { "en:cakes" => $categories_nutriments_per_country_ref->{"en:cakes"}};
 
-store("$data_root/index/categories_nutriments_per_country.world.for_unit_tests.sto", $test_ref);
+store("$data_root/data/categories_stats/categories_nutriments_per_country.world.for_unit_tests.sto", $test_ref);
 
 exit(0);
 

--- a/scripts/gen_top_tags_per_country.pl
+++ b/scripts/gen_top_tags_per_country.pl
@@ -47,6 +47,14 @@ use Storable qw/dclone/;
 use Encode;
 use JSON::PP;
 
+# Output will be in the $data_root/data directory
+# data/index: data related to the Open Food Hunt operation (old): points for countries, users and ambassadors
+# data/categories_stats: statistics for the nutrients of categories, used to compare products to their categories
+
+(-e "$data_root/data") or mkdir("$data_root/data", 0755) or die("Could not create target directory $data_root/data : $!\n");
+(-e "$data_root/data/index") or mkdir("$data_root/data/index", 0755) or die("Could not create target directory $data_root/data/index : $!\n");
+(-e "$data_root/data/categories_stats") or mkdir("$data_root/data/categories_stats", 0755) or die("Could not create target directory $data_root/data/categories_stats : $!\n");
+
 # Generate a list of the top brands, categories, users, additives etc.
 
 my @fields = qw (
@@ -83,9 +91,6 @@ entry_dates
 
 # also generate stats for categories
 
-
-
-
 my %countries = ();
 my $total = 0;
 
@@ -97,10 +102,6 @@ my %products = ();
 
 my $l = 'en';
 $lc = $l;
-
-
-
-
 
 my %dates = ();
 
@@ -370,7 +371,7 @@ while (my $product_ref = $cursor->next) {
 # compute points
 # Read ambassadors.txt
 my %ambassadors = ();
-if (open (my $IN, q{<}, "$data_root/ambassadors.txt")) {
+if (open (my $IN, q{<}, "$data_root/data/ambassadors.txt")) {
 	while (<$IN>) {
 		chomp();
 		if (/\s+/) {
@@ -381,7 +382,7 @@ if (open (my $IN, q{<}, "$data_root/ambassadors.txt")) {
 	}
 }
 else {
-	print STDERR "$data_root/ambassadors.txt does not exist\n";
+	print STDERR "$data_root/data/ambassadors.txt does not exist\n";
 }
 
 my %ambassadors_countries_points = (_all_ => {});
@@ -409,11 +410,11 @@ foreach my $country (keys %countries_points) {
 }
 
 
-store("$data_root/index/countries_points.sto", \%countries_points);
-store("$data_root/index/users_points.sto", \%users_points);
+store("$data_root/data/index/countries_points.sto", \%countries_points);
+store("$data_root/data/index/users_points.sto", \%users_points);
 
-store("$data_root/index/ambassadors_countries_points.sto", \%ambassadors_countries_points);
-store("$data_root/index/ambassadors_users_points.sto", \%ambassadors_users_points);
+store("$data_root/data/index/ambassadors_countries_points.sto", \%ambassadors_countries_points);
+store("$data_root/data/index/ambassadors_users_points.sto", \%ambassadors_users_points);
 
 
 
@@ -465,7 +466,7 @@ foreach my $country (keys %{$properties{countries}}) {
 		}
 	}
 
-	store("$data_root/index/categories_nutriments_per_country.$cc.sto", \%categories);
+	store("$data_root/data/categories_stats/categories_nutriments_per_country.$cc.sto", \%categories);
 
 
 	# Dates

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -70,6 +70,10 @@ hr.floatright {
   padding-left: 20px;
 }
 
+.data_table .nutriment_sub_sub .nutriment_label {
+  padding-left: 40px;
+}
+
 input.nutriment_value {
   height: 2.3125rem;
   width: 5rem;

--- a/templates/api/knowledge-panels/health/health_card.tt.json
+++ b/templates/api/knowledge-panels/health/health_card.tt.json
@@ -8,28 +8,24 @@
         "title": "[% lang('health') %]",
     },    
     "elements": [
-        [% IF panels.nutriscore.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
+                "title": "[% lang('nutrition') %]",
                 "panel_ids": [
-                    "nutriscore",
-                    [% IF panels.nutriscore_warnings.defined %]
-                        "nutriscore_warnings",
+                    [% IF panels.nutriscore.defined %]
+                        "nutriscore",
+                        [% IF panels.nutriscore_warnings.defined %]
+                            "nutriscore_warnings",
+                        [% END %]
+                    [% END %]
+                    [% IF panels.nutrition_facts_table.defined %]
+                        "nutrition_facts_table",
                     [% END %]
                 ],
             },
         },
-        [% END %]
-        [% IF panels.nutriscore.nutrition_facts_table.defined %]
-        {
-            "element_type": "panel",
-            "panel_element": {
-                "panel_id": "nutrition_facts_table",
-            },
-        },
-        [% END %]
-        [% IF panels.nutriscore.ingredients.defined %]
+        [% IF panels.ingredients.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
@@ -38,7 +34,7 @@
             },
         },
         [% END %]
-        [% IF panels.nutriscore.allergens.defined %]
+        [% IF panels.allergens.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
@@ -47,7 +43,7 @@
             },
         },
         [% END %]
-        [% IF panels.nutriscore.additives.defined %]
+        [% IF panels.additives.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {

--- a/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
@@ -3,13 +3,54 @@
     "topics": [
         "health"
     ],
+    "type": "inline",
+    "expanded": true,
     "elements": [   
         {
-            "element_type": "text",
-            "text_element": {
-                "html": `[ shown only to moderators] -- New knowledge panel coming soon
-                `,
+            "element_type": "table",
+            "table_element": {
+                "id": "nutrition_facts_table",
+                "title": "[% lang('nutrition_data_table') %]",
+                "columns": [
+                    {
+                        "text": "[% panel.nutrition_table.header.name %]",
+                        "type": "text",
+                        "style": "max-width:15rem",
+                    },
+                    [% FOREACH column IN panel.nutrition_table.header.columns %]
+                        {
+                            "text": "[% column.name %]",
+                            "type": "text",
+                        },
+                    [% END %]
+                ],
+                "rows": [
+                    [% FOREACH row IN panel.nutrition_table.rows %]
+                    {
+                        "values": [
+                            {
+                                // Level is 0 for main nutrients, 1 for sub-nutrients, 2 for sub-sub-nutrients
+                                "level": [% row.level %],
+                                "text": "[% row.name %]",
+                                "style": "max-width:15rem",
+                            },
+                            [% FOREACH column IN row.columns %]
+                            {
+                                [% IF column.type == 'normal' %]
+                                    "text": "[% column.value %]",
+                                [% ELSE %]
+                                    // only display the % difference compared to category
+                                    "text": "[% column.percent %]",
+                                [% END %]
+                                // to do: add "evaluation": "good", "bad" etc. based on whether the nutrient is good or not
+                            },
+                            [% END %]
+                        ]
+                    },
+                    [% END %]
+                ]
             }
-        },
+        },        
+
     ]
 }

--- a/templates/web/pages/product/includes/nutrition_facts_table.tt.html
+++ b/templates/web/pages/product/includes/nutrition_facts_table.tt.html
@@ -29,6 +29,34 @@
 	<label for="nutrition_data_compare_value">[% lang('nutrition_data_compare_value') %]</label>
 
 	<p class="note">&rarr; [% lang('nutrition_data_comparison_with_categories_note') %]</p>
+
+<initjs>
+\$('input:radio[name=nutrition_data_compare_type]').change(function () {
+
+	if (\$('input:radio[name=nutrition_data_compare_type]:checked').val() == 'compare_value') {
+		\$(".compare_percent").hide();
+		\$(".compare_value").show();
+	}
+	else {
+		\$(".compare_value").hide();
+		\$(".compare_percent").show();
+	}
+
+}
+);
+
+
+\$(".show_comparison").change(function () {
+	if (\$(this).prop('checked')) {
+		\$("." + \$(this).attr("id")).show();
+	}
+	else {
+		\$("." + \$(this).attr("id")).hide();
+	}
+}
+);
+</initjs>
+
 [% END %]
 
 <!--  Stats for categories -->
@@ -44,51 +72,79 @@
 		</label>
 	</div>
 
+<initjs>
+if (\$.cookie('show_stats') == '1') {
+	\$('#show_stats').prop('checked',true);
+}
+else {
+	\$('#show_stats').prop('checked',false);
+}
+
+if (\$('#show_stats').prop('checked')) {
+	\$(".stats").show();
+}
+else {
+	\$(".stats").hide();
+}
+
+\$("#show_stats").change(function () {
+	if (\$('#show_stats').prop('checked')) {
+		\$.cookie('show_stats', '1', { expires: 365 });
+		\$(".stats").show();
+	}
+	else {
+		\$.cookie('show_stats', null);
+		\$(".stats").hide();
+	}
+}
+);
+
+JS
+;	
+</initjs>	
+
 [% END %]
 
-[% FOREACH table IN tables %]
 
-	<table id="[% table.id %]_data_table" class="data_table">
-    <caption>[% table.header.name %]</caption>
+<table id="[% nutrition_table.id %]_data_table" class="data_table">
+<caption>[% nutrition_table.header.name %]</caption>
 
-		<!--  Generating table header -->
-		<thead class="nutriment_header">
-			<tr>
-				<th scope="col">[% table.header.name %]</th>
-				[% FOREACH column IN table.header.columns %]
-					<th class="nutriment_value [% column.class %]" scope="col">[% column.name %]</th>
+	<!--  Generating table header -->
+	<thead class="nutriment_header">
+		<tr>
+			<th scope="col">[% nutrition_table.header.name %]</th>
+			[% FOREACH column IN nutrition_table.header.columns %]
+				<th class="nutriment_value [% column.class %]" scope="col">[% column.name %]</th>
+			[% END %]
+		</tr>
+	</thead>
+
+	<tbody>
+		<!--  Generating table body -->
+		[% FOREACH row IN nutrition_table.rows %]
+
+			<tr id="nutriment_[% row.nid %]_tr" class="[% IF row.level == 1 %]nutriment_main[% ELSIF row.level == 2 %]nutriment_sub[% ELSIF row.level == 3 %]nutriment_sub nutriment_sub_sub[% END %]">
+				<td class="nutriment_label">
+					[% row.name %]
+				</td>
+
+				[% FOREACH column IN row.columns %]
+					[% IF column.type == 'normal' %]
+						<td class="nutriment_value [% column.class %]"[% tablevalue.rdfa %]>
+							[% column.value %]
+						</td>
+					[% ELSE %]
+						<td class="nutriment_value [% column.class %]">
+							<span class="compare_percent">[% column.percent %]</span>
+							<span class="compare_value" style="display:none">[% column.value %]</span>
+						</td>
+					[% END %]
 				[% END %]
 			</tr>
-		</thead>
 
-		<tbody>
-			<!--  Generating table body -->
-			[% FOREACH row IN table.rows %]
+		[% END %]
+	</tbody>
 
-				<tr id="nutriment_[% row.nid %]_tr" class="nutriment_[% row.class %]">
-					<td class="nutriment_label">
-						[% row.name %]
-					</td>
-
-					[% FOREACH column IN row.columns %]
-						[% IF column.type == 'normal' %]
-							<td class="nutriment_value [% column.class %]"[% tablevalue.rdfa %]>
-								[% column.value %]
-							</td>
-						[% ELSE %]
-							<td class="nutriment_value [% column.class %]">
-								<span class="compare_percent">[% column.percent %]</span>
-								<span class="compare_value" style="display:none">[% column.value %]</span>
-							</td>
-						[% END %]
-					[% END %]
-				</tr>
-
-			[% END %]
-		</tbody>
-
-	</table>
-
-[% END %]
+</table>
 
 <!-- end templates/[% component.name %] -->

--- a/templates/web/pages/product/includes/nutrition_facts_table.tt.html
+++ b/templates/web/pages/product/includes/nutrition_facts_table.tt.html
@@ -61,7 +61,6 @@
 
 <!--  Stats for categories -->
 [% IF category_stats.defined %]
-
 	<div>
 		<input id="show_stats" type="checkbox">
 		<label for="show_stats">
@@ -105,9 +104,8 @@ JS
 
 [% END %]
 
-
 <table id="[% nutrition_table.id %]_data_table" class="data_table">
-<caption>[% nutrition_table.header.name %]</caption>
+<caption style="display:none">[% nutrition_table.header.name %]</caption>
 
 	<!--  Generating table header -->
 	<thead class="nutriment_header">
@@ -123,14 +121,14 @@ JS
 		<!--  Generating table body -->
 		[% FOREACH row IN nutrition_table.rows %]
 
-			<tr id="nutriment_[% row.nid %]_tr" class="[% IF row.level == 1 %]nutriment_main[% ELSIF row.level == 2 %]nutriment_sub[% ELSIF row.level == 3 %]nutriment_sub nutriment_sub_sub[% END %]">
+			<tr id="nutriment_[% row.nid %]_tr" class="[% IF row.level == 0 %]nutriment_main[% ELSIF row.level == 1 %]nutriment_sub[% ELSIF row.level == 2 %]nutriment_sub nutriment_sub_sub[% END %]">
 				<td class="nutriment_label">
 					[% row.name %]
 				</td>
 
 				[% FOREACH column IN row.columns %]
 					[% IF column.type == 'normal' %]
-						<td class="nutriment_value [% column.class %]"[% tablevalue.rdfa %]>
+						<td class="nutriment_value [% column.class %]"[% IF column.rdfa.defined %][% column.rdfa %][% END %]>
 							[% column.value %]
 						</td>
 					[% ELSE %]

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -139,9 +139,8 @@
                     <tbody>
 
                         [% FOREACH nutriment IN nutriments %]
-                            [%  IF nutriment.nid == 'carbon-footprint' %]
 
-                            [% ELSIF nutriment.shown %]
+                            [% IF nutriment.shown %]
                                 <tr id="nutriment_[% nutriment.enid %]_tr" class="nutriment_[% nutriment.class %]"[% nutriment.display %]>
 
                                     <td>
@@ -197,68 +196,6 @@
             [% END %]
 
             <p class="note">&rarr; [% lang('nutrition_data_table_note') %]</p>
-
-            <table aria-label="nutrition table">
-                <thead class="nutriment_header">
-                    <tr>
-                        <th id="col_1">[% lang('ecological_data_table') %]</th>
-                        <th id="col_2" class="nutriment_col" [% column_display_style_nutrition_data %]>
-                            [% lang('product_as_sold') %]
-                        </th>
-                        <th id="col_3" class="nutriment_col_prepared" [% column_display_style_nutrition_data_prepared %]>
-                            [% lang('prepared_product') %]
-                        </th>
-                        <th id="col_4">
-                            [% lang('unit') %]
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-
-                    [% FOREACH nutriment IN nutriments %]
-
-                        [%  IF nutriment.nid == 'carbon-footprint' %]
-
-                            <tr id="nutriment_[% nutriment.enid %]_tr" class="nutriment_[% nutriment.class %]"[% nutriment.display %]>
-                                <td>
-                                    <!--label starts-->
-                                    [% IF nutriment.nutriments_nid && nutriment.nutriments_nid_lang %]
-                                        <label class="nutriment_label" for="nutriment_[% nutriment.enid %]">[% nutriment.prefix %][% nutriment.nutriments_nid_lang %]</label>
-                                    [% ELSIF nutriment.nutriments_nid && nutriment.nutriments_nid_en %]
-                                        <label class="nutriment_label" for="nutriment_[% nutriment.enid %]">[% nutriment.prefix %][% nutriment.nutriments_nid_en %]</label>
-                                    [% ELSIF nutriment.label_value.defined %]
-                                        <input class="nutriment_label" id="nutriment_[% nutriment.enid %]_label" name="nutriment_[% nutriment.enid %]_label" value="[% nutriment.label_value %]" />
-                                    [% ELSE %]
-                                        <input class="nutriment_label" id="nutriment_[% nutriment.enid %]_label" name="nutriment_[% nutriment.enid %]_label" placeholder="[% nutriment.product_add_nutrient %]"/>
-                                    [% END %]
-                                    <!--label ends-->
-                                </td>
-                                <td class="nutriment_col" [% column_display_style_nutrition_data %]>
-                                    <input class="nutriment_value nutriment_value_as_sold" id="nutriment_[% nutriment.enid %]" name="nutriment_[% nutriment.enid %]" value="[% nutriment.value %]" [% nutriment.disabled %] autocomplete="off"/>
-                                </td>
-                                <td class="nutriment_col_prepared" [% column_display_style_nutrition_data_prepared %]>
-                                    <input class="nutriment_value nutriment_value_prepared" id="nutriment_[% nutriment.enidp %]" name="nutriment_[% nutriment.enidp %]" value="[% nutriment.valuep %]" [% nutriment.disabled %] autocomplete="off"/>
-                                </td>
-
-                                <td>
-                                    <span class="nutriment_unit_percent" id="nutriment_[% nutriment.enid %]_unit_percent"[% nutriment.hide_percent %]>%</span>
-                                    <select class="nutriment_unit" id="nutriment_[% nutriment.enid %]_unit" name="nutriment_[% nutriment.enid %]_unit"[% nutriment.hide_select %] [% nutriment.disabled %]>
-                                        [% FOREACH unit IN nutriment.units_arr %]
-                                            <option value="[% unit.u %]" [% unit.selected %]>[% unit.label %]</option>
-                                        [% END %]
-                                        </select>
-                                </td>
-                            </tr>
-
-                        [% END %]
-
-                    [% END %]
-
-                </tbody>
-
-            </table>
-
-            <p class="note">&rarr; [% lang('ecological_data_table_note') %]</p>
 
         </div><!--nutrient field set-->
 

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -147,12 +147,11 @@
 
             [% ELSIF element_type == "table" %]
                 [% table_element = element_ref.table_element %]
-                <table[% IF element.table_id %] id="[% table_element.table_id %]"[% END %]>
-                    <caption style="text-align:left">[% table_element.title %]</caption>
+                <table[% IF element.table_id %] id="[% table_element.table_id %]"[% END %] aria-label="[% table_element.title %]">
                     <thead>
                         <tr>
                             [% FOREACH column IN table_element.columns %]
-                            <th scope="col">
+                            <th scope="col"[% IF column.style.defined %]style="[% column.style %]"[% END %]>
                                 [% column.text %]
                             </th>
                             [% END %]
@@ -162,7 +161,7 @@
                         [% FOREACH row IN table_element.rows %]
                         <tr[% IF row.id %] id="[% row.id %]"[% END %]>
                             [% FOREACH value IN row.item('values') %]
-                                <td>
+                                <td [% IF value.style.defined %]style="[% value.style %]"[% END %]>
                                     [% IF value.icon_url %]
                                         <span class="icon"><img src="[% value.icon_url %]" alt="icon"></span>
                                     [% END %]
@@ -181,14 +180,21 @@
                                             </div>
                                         </div>
                                         [% value.text %]
-                                    [% ELSIF value.evaluation.defined %]
-                                        <span class="[% IF value.evaluation == 'good' %] green
-                                        [% ELSIF value.evaluation == 'neutral' %] orange
-                                        [% ELSIF value.evaluation == 'bad' %] red
-                                        [% ELSIF value.evaluation == 'unknown' %] grey
-                                        [% END %]">[% value.text %]</span>
                                     [% ELSE %]
-                                        [% value.text %]
+                                        <span
+                                        [% IF value.level.defined %]
+                                            style="padding-left: [% value.level %]rem;"
+                                        [% END %]
+                                        [% IF value.evaluation.defined %]
+                                            class="[% IF value.evaluation == 'good' %] green
+                                            [% ELSIF value.evaluation == 'neutral' %] orange
+                                            [% ELSIF value.evaluation == 'bad' %] red
+                                            [% ELSIF value.evaluation == 'unknown' %] grey
+                                            [% END %]"
+                                        [% END %]
+                                        >
+                                            [% value.text %]
+                                        </span>
                                     [% END %]
                                 </td>                          
                             [% END %]


### PR DESCRIPTION
This PR is in preparation for creating a new knowledge panel to display the nutrition facts table.

- Change gen_top_tags_per_country.pl to generate data in $data_root/data/ instead of $data_root/index/ (so that we can eventually put all internal data generated by product opener in the data/ directory) (done now otherwise the script can't be run in the docker dev environment)
- Separated the template data generation in a new data_to_display_nutrition_table() function, so that we can reuse it to generate the upcoming nutrition table knowledge panel
- Removed a bunch of code related to the outdated carbon footprint (bug #6108)
- More comments
- Added a nutrition facts table knowledge panel
- Added "level" and "style" parameters to the knowlege panel API, in order to display sub nutrients

New knowledge panel for the nutrition facts:

![image](https://user-images.githubusercontent.com/8158668/143289874-483fa2d1-4e8e-42f9-8269-f72539fdf13a.png)

We'll probably need to adjust a bit the table style to make it more condensed.

Also coming at some points: colors to indicate which nutrient is better than other products of the same category.