### PR TITLE
fix: put back compiled templates dir in data_root/tmp

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -276,7 +276,7 @@ $tt = Template->new(
 		EVAL_PERL    => 1,
 		STAT_TTL     => 60,                              # cache templates in memory for 1 min before checking if the source changed
 		COMPILE_EXT  => '.ttc',                          # compile templates to Perl code for much faster reload
-		COMPILE_DIR  => '/tmp/productopener/templates',
+		COMPILE_DIR  => $data_root . "/tmp/templates",
 		ENCODING     => 'UTF-8',
 		RECURSION    => 1,	# Needed for the knowledge panels that contain subpanels
 	}


### PR DESCRIPTION
Somehow I can't get compiled templates to be created in /tmp on the small dev openfoodfacts server, so putting back the compiled templates in $data_root/tmp/templates