### PR TITLE
Simplify donation banner translations

### DIFF
--- a/html/donate/fr.helloasso.html
+++ b/html/donate/fr.helloasso.html
@@ -73,6 +73,9 @@
       .show-when-logged-in {
         display: none;
       }
+      .reason img {
+        height: 100px;
+      }
     </style>
     <script src="https://static.openfoodfacts.org/js/dist/jquery.js"></script>
     <script type="text/javascript">

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5735,12 +5735,14 @@ msgctxt "donation_title"
 msgid "Important: we need your support!"
 msgstr "" 
 
-msgctxt "donation_body"
-msgid "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with 3 employees."
+# variable names between { } must not be translated, {number_of_employees} will be a number
+msgctxt "donation_body_employees"
+msgid "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with {number_of_employees} employees."
 msgstr "" 
 
-msgctxt "donation_why"
-msgid "We need your donations to fund the Open Food Facts 2021 budget and to continue to develop the project. <strong>Thank you! ❤️</strong>"
+# variable names between { } must not be translated, {year} will be the upcoming year
+msgctxt "donation_why_year"
+msgid "We need your donations to fund the Open Food Facts {year} budget and to continue to develop the project."
 msgstr "" 
 
 msgctxt "donation_cta"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5795,13 +5795,15 @@ msgctxt "donation_title"
 msgid "Important: we need your support!"
 msgstr "Important: we need your support!" 
 
-msgctxt "donation_body"
-msgid "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with 3 employees."
-msgstr "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with 3 employees." 
+# variable names between { } must not be translated, {number_of_employees} will be a number
+msgctxt "donation_body_employees"
+msgid "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with {number_of_employees} employees."
+msgstr "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with {number_of_employees} employees." 
 
-msgctxt "donation_why"
-msgid "We need your donations to fund the Open Food Facts 2021 budget and to continue to develop the project. <strong>Thank you! ❤️</strong>"
-msgstr "We need your donations to fund the Open Food Facts 2021 budget and to continue to develop the project. <strong>Thank you! ❤️</strong>" 
+# variable names between { } must not be translated, {year} will be the upcoming year
+msgctxt "donation_why_year"
+msgid "We need your donations to fund the Open Food Facts {year} budget and to continue to develop the project."
+msgstr "We need your donations to fund the Open Food Facts {year} budget and to continue to develop the project." 
 
 msgctxt "donation_cta"
 msgid "Donate"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5603,13 +5603,15 @@ msgctxt "donation_title"
 msgid "Important: we need your support!"
 msgstr "Important : nous avons besoin de votre soutien !"
 
-msgctxt "donation_body"
-msgid "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with 3 employees."
-msgstr "Open Food Facts est un projet collaboratif construit par des dizaines de milliers de bénévoles et géré par une organisation à but non lucratif de 3 salariés."
+# variable names between { } must not be translated, {number_of_employees} will be a number
+msgctxt "donation_body_employees"
+msgid "Open Food Facts is a collaborative project built by tens of thousands of volunteers and managed by a non-profit organization with {number_of_employees} employees."
+msgstr "Open Food Facts est un projet collaboratif construit par des dizaines de milliers de bénévoles et géré par une organisation à but non lucratif avec {number_of_employees} employés." 
 
-msgctxt "donation_why"
-msgid "We need your donations to fund the Open Food Facts 2021 budget and to continue to develop the project. <strong>Thank you! ❤️</strong>"
-msgstr "Nous avons besoin de vos dons pour financer le budget Open Food Facts 2021 et continuer à développer le projet. <strong>Merci ! ️❤️</strong>"
+# variable names between { } must not be translated, {year} will be the upcoming year
+msgctxt "donation_why_year"
+msgid "We need your donations to fund the Open Food Facts {year} budget and to continue to develop the project."
+msgstr "Nous avons besoin de vos dons pour financer le budget {year} d'Open Food Facts et continuer à développer le projet." 
 
 msgctxt "donation_cta"
 msgid "Donate"

--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -24,56 +24,16 @@
 <div id="donate_banner" class="row">
 	<div class="small-12 large-12 xlarge-8 xxlarge-7 columns">
 		<div id="image_banner" style="margin-bottom:1rem;" class="panel callout">
-		[% IF lc == ( 'fr' ) %]
-		
-			<h2>Important : nous avons besoin de votre soutien !</h2>
-			<p>Open Food Facts est un projet collaboratif porté par des dizaines de milliers de bénévoles
-			et géré par une association à but non-lucratif avec 3 salariés.<br>
-			Nous avons besoin de vos dons pour <a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=fr-text">financer le budget 2022 d'Open Food Facts</a>
-			et continuer à développer le projet. <strong>Merci ! ❤️</strong></p>
-			<div class="row">
-				<div class="small-12 large-4 columns">
-			<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=fr-text-button" class="button round" style="margin-bottom:0">
-				Faire un don
-			</a>
-		
-		[% ELSIF lc == ( 'de' ) %]
-
-			<h2>Wichtig: Wir brauchen deine Hilfe!</h2>
-			<p>Open Food Facts ist ein kollaboratives Projekt, welches von zehntausenden Freiwilligen erstellt und von einer Non-Profit-Organisation mit 3 Angestellten gemanagt wird.<br>
-			Wir brauchen eure Spenden, <a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=de-text">um das Open Food Facts Budget 2022 zu finanzieren</a>
-			und das Projekt fortzuführen und weiterzuentwicken. <strong>Danke! ❤️</strong></p>
-			<div class="row">
-				<div class="small-12 large-4 columns">
-			<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=de-text-button" class="button round" style="margin-bottom:0">
-				Spenden
-			</a>
-
-		[% ELSIF lc == ( 'fi' ) %]
-
-			<h2>Tärkeää: tarvitsemme tukeasi!</h2>
-			<p>Open Food Facts on yhteistyöhanke, jonka ovat rakentaneet kymmenet tuhannet vapaaehtoiset ja sitä johtaa voittoa tavoittelematon järjestö, jossa on 3 työntekijää.<br>
-			Tarvitsemme lahjoituksianne <a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=fi-text">Open Food Facts 2022 -budjetin rahoittamiseen</a>
-			 ja hankkeen kehittämisen jatkamiseen. <strong>Kiitos! ❤️</strong></p>
-			<div class="row">
-				<div class="small-12 large-4 columns">
-			<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=fi-text-button" class="button round">
-				Lahjoita
-			</a>
-
-		[% ELSE %]
           
 			<h2>[% lang('donation_title') %]</h2>
-			<p>[% lang('donation_body') %]<br>
-			[% lang('donation_why') %]
+			<p>[% f_lang('donation_body_employees', { number_of_employees => '4' }) %]<br>
+			[% f_lang('donation_why_year', { year => '2022' }) %] <strong>[% lang('thank_you') %] ❤️</strong>
 			</p>
 			<div class="row">
 				<div class="small-12 large-4 columns">
-			<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button" class="button round" style="margin-bottom:0">
-				[% lang('donation_cta') %]
-			</a>
-
-		[% END %]
+					<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button" class="button round" style="margin-bottom:0">
+						[% lang('donation_cta') %]
+					</a>
 				</div>
 				<div class="small-12 large-8 columns">
 					<input id="hide_image_banner" type="checkbox" style="margin-top:1.5rem;margin-bottom:0;">


### PR DESCRIPTION
- Remove some hardcoded translations from the donation banner template
- Make the year and the number of employees variables so that we don't have to update the translations every year