### PR TITLE
ops: new check_perl and build_taxonomies targets

### DIFF
--- a/taxonomies/Makefile
+++ b/taxonomies/Makefile
@@ -1,0 +1,11 @@
+# Pattern rule to build taxonomies, see https://www.gnu.org/software/make/manual/html_node/Pattern-Intro.html#Pattern-Intro
+# this is meant to be run inside the docker container, see build_taxonomies
+%.result.txt: %.txt
+	perl -CS -Ilib ../scripts/build_tags_taxonomy.pl $< 1
+	touch $@
+
+taxonomies: $(wildcard *.result.txt)
+
+.DEFAULT_GOAL := taxonomies
+
+


### PR DESCRIPTION
if sucessful, this will replace scripts/check_perl.js and scripts/refresh_taxonomies.js

@ocervell this will enable running make test, and all the workflow in docker.
I didn't change the pull_request.yml yet.

should help fix #6148 