### PR TITLE
fix precedence issue with or statement

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -9526,11 +9526,13 @@ CSS
 		my $shown = 0;
 
 		# Check if we have a value for the nutrient
-		my $is_nutrient_with_value = ((defined $product_ref->{nutriments}{$nid}) and ($product_ref->{nutriments}{$nid} ne ''))
+		my $is_nutrient_with_value = (
+			((defined $product_ref->{nutriments}{$nid}) and ($product_ref->{nutriments}{$nid} ne ''))
 			or ((defined $product_ref->{nutriments}{$nid . "_100g"}) and ($product_ref->{nutriments}{$nid . "_100g"} ne ''))
 			or ((defined $product_ref->{nutriments}{$nid . "_prepared"}) and ($product_ref->{nutriments}{$nid . "_prepared"} ne ''))
 			or ((defined $product_ref->{nutriments}{$nid . "_modifier"}) and ($product_ref->{nutriments}{$nid . "_modifier"} eq '-'))
-			or ((defined $product_ref->{nutriments}{$nid . "_prepared_modifier"}) and ($product_ref->{nutriments}{$nid . "_prepared_modifier"} eq '-'));
+			or ((defined $product_ref->{nutriments}{$nid . "_prepared_modifier"}) and ($product_ref->{nutriments}{$nid . "_prepared_modifier"} eq '-'))
+		);
 
 		# Show rows that are not optional (id with a trailing -), or for which we have a value
 		if  (($nutriment !~ /-$/) or $is_nutrient_with_value) {


### PR DESCRIPTION
I didn't understand why we had a warning:

Useless use of string eq in void context at /opt/product-opener/lib/ProductOpener/Display.pm line 9533.

That's because of the very weak precedence of the "or" operator:

https://perldoc.perl.org/perlop#Logical-or-and-Exclusive-Or

```
$x = $y or $z;              # bug: this is wrong
($x = $y) or $z;            # really means this
$x = $y || $z;              # better written this way
```