### PR TITLE
Make the heart character in the donation banner red

### DIFF
--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -27,7 +27,7 @@
           
 			<h2>[% lang('donation_title') %]</h2>
 			<p>[% f_lang('donation_body_employees', { number_of_employees => '4' }) %]<br>
-			[% f_lang('donation_why_year', { year => '2022' }) %] <strong>[% lang('thank_you') %] ❤️</strong>
+			[% f_lang('donation_why_year', { year => '2022' }) %] <strong>[% lang('thank_you') %] <span style="color:red">❤️</span></strong>
 			</p>
 			<div class="row">
 				<div class="small-12 large-4 columns">


### PR DESCRIPTION
Some browsers like Chrome actually replace the text character by a colored icon which is red, but others like Chromium do not, in which case we can still style it.

![image](https://user-images.githubusercontent.com/8158668/146368286-5670f976-5bbe-4c47-8650-468a68343ca7.png)
