### PR TITLE
fix: allow unchecking checked boxes in product edit form

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -2576,6 +2576,10 @@ sub assign_nutriments_values_from_request_parameters($$) {
 
 	$log->debug("Nutrition data") if $log->is_debug();
 
+	# Note: browsers do not send any value for checkboxes that are unchecked.
+	# So in order to be able to uncheck values, there needs to be an hidden field with the same name with a false value before the checkbox
+	# and the server will only keep the last value: either the hidden field, or the checkbox if checked.
+
 	if (defined param("no_nutrition_data")) {
 		$product_ref->{no_nutrition_data} = remove_tags_and_quote(decode utf8=>param("no_nutrition_data"));
 	}

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -96,16 +96,16 @@
 
         <!--nutrient fieldset-->
         <div class="fieldset" id="nutrition"><legend>[% lang('nutrition_data') %]</legend>
-            <!-- empty hidden checkbox with the same name so that the browser sends a value when the box is unchecked -->
-            <input type="hidden" name="no_nutrition_data" value="" />
+            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+            <input type="hidden" name="no_nutrition_data_displayed" value="1" />
             <input type="checkbox" id="no_nutrition_data" name="no_nutrition_data" [% nutrition_checked %] />
             <label for="no_nutrition_data" class="checkbox_label">[% lang('no_nutrition_data') %]</label><br/>
             [% display_tab_nutrition_image %]
             [% display_field_serving_size %]
 
             [% FOREACH nutrient IN nutrition_products %]
-                <!-- empty hidden checkbox with the same name so that the browser sends a value when the box is unchecked -->
-                <input type="hidden" name="[% nutrient.nutrition_data %]" value="" />
+                <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                <input type="hidden" name="[% nutrient.nutrition_data %]_displayed" value="1" />
                 <input type="checkbox" id="[% nutrient.nutrition_data %]" name="[% nutrient.nutrition_data %]" [% nutrient.checked %] />
                 <label for="[% nutrient.nutrition_data %]" class="checkbox_label">[% nutrient.nutrition_data_exists %]</label> &nbsp;
                 <input type="radio" id="[% nutrient.nutrition_data_per %]_100g" value="100g" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_100g %] />

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -96,12 +96,16 @@
 
         <!--nutrient fieldset-->
         <div class="fieldset" id="nutrition"><legend>[% lang('nutrition_data') %]</legend>
+            <!-- empty hidden checkbox with the same name so that the browser sends a value when the box is unchecked -->
+            <input type="hidden" name="no_nutrition_data" value="" />
             <input type="checkbox" id="no_nutrition_data" name="no_nutrition_data" [% nutrition_checked %] />
             <label for="no_nutrition_data" class="checkbox_label">[% lang('no_nutrition_data') %]</label><br/>
             [% display_tab_nutrition_image %]
             [% display_field_serving_size %]
 
             [% FOREACH nutrient IN nutrition_products %]
+                <!-- empty hidden checkbox with the same name so that the browser sends a value when the box is unchecked -->
+                <input type="hidden" name="[% nutrient.nutrition_data %]" value="" />
                 <input type="checkbox" id="[% nutrient.nutrition_data %]" name="[% nutrient.nutrition_data %]" [% nutrient.checked %] />
                 <label for="[% nutrient.nutrition_data %]" class="checkbox_label">[% nutrient.nutrition_data_exists %]</label> &nbsp;
                 <input type="radio" id="[% nutrient.nutrition_data_per %]_100g" value="100g" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_100g %] />
@@ -116,7 +120,7 @@
 
             <div style="position:relative">
 
-                <table id="nutrition_data_table" class="data_table" style = "[% tablestyle %]" aria-label="nutrition table">
+                <table id="nutrition_data_table" class="data_table" style="[% tablestyle %]" aria-label="nutrition table">
                     <thead class="nutriment_header">
                         <th id="col_1">
                             [% lang('nutrition_data_table') %]


### PR DESCRIPTION
This fixes an issue with my recent refactoring of the code to handle nutrition facts edit from the web product edit form and the API.

The issue is that when a checkbox is unchecked on a form, the browser actually does not send the field at all. So if the parameter is not there, we don't know if it's because it is not set on purpose (e.g. the API is changing something else), or the box is there but has been unset (through the web edit form).

The trick is to add a hidden field with the same name of the checkbox on the web form. That way we do get the hidden value if the box is unchecked, and the checked value if it is checked.