### PR TITLE
Fix: Reset email capitalization

### DIFF
--- a/cgi/reset_password.pl
+++ b/cgi/reset_password.pl
@@ -75,7 +75,7 @@ if ($action eq 'process') {
 			my $emails_ref = retrieve("$data_root/users/users_emails.sto");
 			if (not defined $emails_ref->{$id}) {
 				# not found, try with lower case email
-				$id = lc $id;
+				lc $id = lc $id;
 			}
 			if (not defined $emails_ref->{$id}) {
 				push @errors, $Lang{error_reset_unknown_email}{$lang};


### PR DESCRIPTION


**Related issues and discussion:** 

Follow up for #5807 and https://github.com/openfoodfacts/openfoodfacts-server/commit/527e31760e47d240a85ffb0e48e4bb74d0754b9c

**What happend**

> If you want to reset your password but enter the email with the wrong capitalization, it says "There is no account with this email".

In https://github.com/openfoodfacts/openfoodfacts-server/commit/527e31760e47d240a85ffb0e48e4bb74d0754b9c @alexgarel updated the code to lowercase the provided email but not the one linked with the account, makes the accuracy rate greater
