### PR TITLE
fix: fix daily tasks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,6 +29,7 @@ jobs:
 
   dev-db-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     strategy:
       matrix:
         env: [mongo-dev]
@@ -56,11 +57,13 @@ jobs:
 
   refresh-products-tags:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     strategy:
       matrix:
         env: [mongo-dev]
     environment: ${{ matrix.env }}
     concurrency: ${{ matrix.env }}
+    needs: dev-db-sync
     steps:
     - name: Refresh MongoDB products_tags collection
       uses: appleboy/ssh-action@master

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,10 @@ import_more_sample_data:
 import_prod_data:
 	@echo "🥫 Importing production data (~2M products) into MongoDB …"
 	@echo "🥫 This might take up to 10 mn, so feel free to grab a coffee!"
+	@echo "🥫 Removing old archive in case you have one"
+	( rm -f openfoodfacts-mongodbdump.tar.gz || true )
 	@echo "🥫 Downloading full MongoDB dump from production …"
-	wget https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz
+	wget --no-verbose https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz
 	@echo "🥫 Copying the dump to MongoDB container …"
 	docker cp openfoodfacts-mongodbdump.tar.gz po_mongodb_1:/data/db
 	@echo "🥫 Restoring the MongoDB dump …"


### PR DESCRIPTION
We had a problem of disk space on preprod.

This is linked to daily failing, and as we did not remove previous archive before using wget, it was uploading archive with a new name, saturating disk space…

Task are failing because of a timeout which was, it seems, too short.