### PR TITLE
feat: example product in API with code=example

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -1346,4 +1346,10 @@ $options{import_sources} = {
 	'database-usda' => "USDA Global Branded Food Products Database",
 };
 
+# Barcode of a sample product returned through the API when the requested code is "example"
+$options{sample_product_code} = "80135463";	# Nutella
+$options{sample_product_code_country_uk} = "5060042641000"; # Tyrrell's lighty salted chips
+$options{sample_product_code_language_de} = "20884680"; # Waffeln Sondey
+$options{sample_product_code_country_at_language_de} = "5411188119098"; # Natur miss kokosnuss Alpro
+
 1;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10144,6 +10144,16 @@ sub display_product_api($) {
 
 	my $request_ref = shift;
 
+	# Is a sample product requested?
+	if ((defined $request_ref->{code}) and ($request_ref->{code} eq "example")) {
+		
+		$request_ref->{code} = $options{"sample_product_code_country_${cc}_language_${lc}"}
+			||  $options{"sample_product_code_country_${cc}"}
+			||  $options{"sample_product_code_language_${lc}"}
+			||	$options{"sample_product_code"}
+			|| "";
+	}	
+
 	my $code = normalize_code($request_ref->{code});
 	my $product_id = product_id_for_owner($Owner_id, $code);
 


### PR DESCRIPTION
fixes #6250

This is to allow queries like https://de.openfoodfacts.org/api/v0/product/example to get back data from a sample product that can be different based on country or language.

The products are specified in Config_off.pm, I just put a few for testing purposes.

In practice it is very likely that we will put fake products with specific fake barcodes, so that we can get exactly the data we want for the onboarding of Smoothie.