### PR TITLE
fix: French translation for appetizers

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -87905,7 +87905,7 @@ da:Forretter
 de:Vorspeisen, Aperitifs, Häppchen
 es:Aperitivos
 fi:alkupalat
-fr:Apéritif
+fr:Amuse-gueules
 he:מתאבנים
 hu:Előételek
 it:Antipasti


### PR DESCRIPTION
some producers send "apéritif" for wine, we should not have it as a translation for "appetizers" which contains food.