### PR TITLE
fix: ensure windows newlines don't break panels

### DIFF
--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -179,7 +179,8 @@ The function converts the multiline string into a single line string.
 
 sub convert_multiline_string_to_singleline($) {
     my $line = shift;
-    $line =~ s/\n/\\n/sg;
+    # \R will match all Unicode newline sequence
+    $line =~ s/\R/\\n/sg;
     # Escape quotes unless they have been escaped already
     # negative look behind to not convert \" to \\"
     $line =~ s/(?<!\\)"/\\"/g;


### PR DESCRIPTION
some producers have imported ingredients lists with \r\n sequences, and that broke the JSON used by knowledge panels.

this fixes the generation of the panels.

we probably need another fix to normalize newlines when we edit products / import data.