### PR TITLE
feat: start of additives panels

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -394,8 +394,22 @@ sub process_template($$$) {
 	$template_data_ref->{url_for_text} = \&url_for_text;
 	$template_data_ref->{product_url} = \&product_url;
 	$template_data_ref->{product_name_brand_quantity} = \&product_name_brand_quantity;
+
+	# Display one taxonomy entry in the target language
 	$template_data_ref->{display_taxonomy_tag} = sub ($$) {
 		return display_taxonomy_tag($lc, $_[0], $_[1]);
+	};
+
+	# Display a list of taxonomy entries in the target language
+	$template_data_ref->{display_taxonomy_tags_list} = sub ($$) {
+		my $tagtype = shift;
+		my $tags_ref = shift;
+		if (defined $tags_ref) {
+			return join(", ", map {display_taxonomy_tag($lc, $tagtype, $_) } @$tags_ref) ;
+		}
+		else {
+			return "";
+		}
 	};
 
 	$template_data_ref->{round} = sub($) {

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -946,7 +946,33 @@ sub create_additives_panel($$$) {
 }
 
 
-sub add_taxonomy_properties_in_target_languages_to_object () {
+=head2 add_taxonomy_properties_in_target_languages_to_object ( $object_ref, $tagtype, $tagid, $properties_ref, $target_lcs_ref )
+
+This function adds to the hash ref $object_ref (for instance a data structure passed to a template) the values
+of selected properties, if they exist in one of the target languages.
+
+For instance for the panel for an additive, we can include a Wikipedia abstract in the requested language if available,
+or in English if not.
+
+=head3 Arguments
+
+=head4 object reference $object_ref
+
+=head4 taxonomy $tagtype
+
+=head4 tag id $tagoid
+
+=head4 list of properties $properties_ref
+
+Properties to add to the resulting object.
+
+=head4 language codes $target_lcs
+
+Reference to an array of preferred languages, with the preferred language first.
+
+=cut
+
+sub add_taxonomy_properties_in_target_languages_to_object ($$$$$) {
 
     my $object_ref = shift;
     my $tagtype = shift;

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -925,6 +925,16 @@ sub create_additives_panel($$$) {
                 additive => $additive,
             };
 
+            # Wikipedia abstracts, in target language or English
+
+            my $target_lcs_ref = [$target_lc];
+            if ($target_lc ne "en") {
+                push @$target_lcs_ref, "en";
+            }
+
+            add_taxonomy_properties_in_target_languages_to_object($additive_panel_data_ref, "additives", $additive,
+                ["wikipedia_url", "wikipedia_title", "wikipedia_abstract"], $target_lcs_ref);
+
             create_panel_from_json_template("additive_" . $additive, "api/knowledge-panels/health/ingredients/additive.tt.json",
                 $additive_panel_data_ref, $product_ref, $target_lc, $target_cc);
         }
@@ -932,6 +942,34 @@ sub create_additives_panel($$$) {
         create_panel_from_json_template("additives", "api/knowledge-panels/health/ingredients/additives.tt.json",
             $additives_panel_data_ref, $product_ref, $target_lc, $target_cc);
 
+    }
+}
+
+
+sub add_taxonomy_properties_in_target_languages_to_object () {
+
+    my $object_ref = shift;
+    my $tagtype = shift;
+    my $tagid = shift;
+
+    my $properties_ref = shift;
+    my $target_lcs_ref = shift;
+
+    foreach my $property (@$properties_ref) {
+        my $property_value;
+        my $property_lc;
+        foreach my $target_lc (@$target_lcs_ref) {
+            $property_value = get_property($tagtype, $tagid, $property . ":" . $target_lc);
+            if (defined $property_value) {
+                $property_lc = $target_lc;
+                last;
+            }
+        }
+        if (defined $property_value) {
+            $object_ref->{$property} = $property_value;
+            $object_ref->{$property . "_lc"} = $property_lc;
+            $object_ref->{$property . "_language"} = display_taxonomy_tag($target_lcs_ref->[0], "languages", $language_codes{$property_lc});
+        }
     }
 }
 

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -984,6 +984,7 @@ sub add_taxonomy_properties_in_target_languages_to_object ($$$$$) {
     foreach my $property (@$properties_ref) {
         my $property_value;
         my $property_lc;
+        # get property value for first language for which it is defined
         foreach my $target_lc (@$target_lcs_ref) {
             $property_value = get_property($tagtype, $tagid, $property . ":" . $target_lc);
             if (defined $property_value) {

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -630,6 +630,9 @@ sub create_health_card_panel($$$) {
     # Create the ingredients panel
     create_ingredients_panel($product_ref, $target_lc, $target_cc);
 
+    # Create the additives panel
+    create_additives_panel($product_ref, $target_lc, $target_cc);
+
     # Create the health_card panel
     create_panel_from_json_template("health_card", "api/knowledge-panels/health/health_card.tt.json",
         $panel_data_ref, $product_ref, $target_lc, $target_cc);    
@@ -836,7 +839,7 @@ sub create_physical_activities_panel($$$) {
 
 =head2 create_ingredients_panel ( $product_ref, $target_lc, $target_cc )
 
-Creates a knowledge panels with the list of ingredients.
+Creates a knowledge panel with the list of ingredients.
 
 =head3 Arguments
 
@@ -859,7 +862,7 @@ sub create_ingredients_panel($$$) {
 	my $target_lc = shift;
 	my $target_cc = shift;
 
-	$log->debug("create ingredients panel", { code => $product_ref->{code}, nutriscore_data => $product_ref->{nutriscore_data} }) if $log->is_debug();
+	$log->debug("create ingredients panel", { code => $product_ref->{code} }) if $log->is_debug();
 
 	# try to display ingredients in the requested language if available
 
@@ -876,13 +879,60 @@ sub create_ingredients_panel($$$) {
     my $panel_data_ref = {
         ingredients_text => $ingredients_text,
         ingredients_text_with_allergens => $ingredients_text_with_allergens,
-        lc => $target_lc,
         ingredients_text_lc => $ingredients_text_lc,
         ingredients_text_language => display_taxonomy_tag($target_lc,'languages',$language_codes{$ingredients_text_lc}),
     };
 
     create_panel_from_json_template("ingredients", "api/knowledge-panels/health/ingredients/ingredients.tt.json",
         $panel_data_ref, $product_ref, $target_lc, $target_cc);
+}
+
+
+=head2 create_additives_panel ( $product_ref, $target_lc, $target_cc )
+
+Creates knowledge panels for additives.
+
+=head3 Arguments
+
+=head4 product reference $product_ref
+
+=head4 language code $target_lc
+
+=head4 country code $target_cc
+
+=cut
+
+sub create_additives_panel($$$) {
+
+	my $product_ref = shift;
+	my $target_lc = shift;
+	my $target_cc = shift;
+
+	$log->debug("create additives panel", { code => $product_ref->{code} }) if $log->is_debug();
+
+    # Create a panel only if the product has additives
+
+    if ((defined $product_ref->{additives_tags}) and (scalar @{$product_ref->{additives_tags}} > 0 )) {
+
+        my $additives_panel_data_ref = {
+        };
+
+        foreach my $additive (@{$product_ref->{additives_tags}}) {
+
+            my $additive_panel_id = "additive_" . $additive;
+
+            my $additive_panel_data_ref = {
+                additive => $additive,
+            };
+
+            create_panel_from_json_template("additive_" . $additive, "api/knowledge-panels/health/ingredients/additive.tt.json",
+                $additive_panel_data_ref, $product_ref, $target_lc, $target_cc);
+        }
+
+        create_panel_from_json_template("additives", "api/knowledge-panels/health/ingredients/additives.tt.json",
+            $additives_panel_data_ref, $product_ref, $target_lc, $target_cc);
+
+    }
 }
 
 1;

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5931,3 +5931,8 @@ msgstr "Missing category"
 msgctxt "nutriscore_missing_nutrition_data_short"
 msgid "Missing nutrition facts"
 msgstr "Missing nutrition facts"
+
+# "source" as in "source of the information"
+msgctxt "source"
+msgid "Source"
+msgstr "Source"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -199,8 +199,8 @@ msgid "All missions"
 msgstr "All missions"
 
 msgctxt "allergens"
-msgid "Allergens"
-msgstr "Allergens"
+msgid "Substances or products causing allergies or intolerances"
+msgstr "Substances or products causing allergies or intolerances"
 
 msgctxt "allergens_p"
 msgid "allergens"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -199,8 +199,8 @@ msgid "All missions"
 msgstr "All missions"
 
 msgctxt "allergens"
-msgid "Substances or products causing allergies or intolerances"
-msgstr "Substances or products causing allergies or intolerances"
+msgid "Allergens"
+msgstr "Allergens"
 
 msgctxt "allergens_p"
 msgid "allergens"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5958,3 +5958,8 @@ msgstr "Missing category"
 msgctxt "nutriscore_missing_nutrition_data_short"
 msgid "Missing nutrition facts"
 msgstr "Missing nutrition facts"
+
+# "source" as in "source of the information"
+msgctxt "source"
+msgid "Source"
+msgstr "Source"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -200,8 +200,8 @@ msgid "All missions"
 msgstr "Toutes les missions"
 
 msgctxt "allergens"
-msgid "Allergens"
-msgstr "Allergènes"
+msgid "Substances or products causing allergies or intolerances"
+msgstr "Substances ou produits provoquant des allergies ou intolérances"
 
 msgctxt "allergens_p"
 msgid "allergens"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -200,8 +200,8 @@ msgid "All missions"
 msgstr "Toutes les missions"
 
 msgctxt "allergens"
-msgid "Substances or products causing allergies or intolerances"
-msgstr "Substances ou produits provoquant des allergies ou intolérances"
+msgid "Allergens"
+msgstr "Allergènes"
 
 msgctxt "allergens_p"
 msgid "allergens"

--- a/templates/api/knowledge-panels/health/health_card.tt.json
+++ b/templates/api/knowledge-panels/health/health_card.tt.json
@@ -34,20 +34,11 @@
             },
         },
         [% END %]
-        [% IF panels.allergens.defined %]
-        {
-            "element_type": "panel_group",
-            "panel_group_element": {
-                "title": "[% lang('allergens') %]",
-                "panel_ids": ["allergens"],
-            },
-        },
-        [% END %]
         [% IF panels.additives.defined %]
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('additives') %]",
+                "title": "[% lang('additives_p').ucfirst %]",
                 "panel_ids": ["additives"],
             },
         }, 

--- a/templates/api/knowledge-panels/health/ingredients/additives.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/additives.tt.json
@@ -3,13 +3,15 @@
     "topics": [
         "health"
     ],
-    "elements": [   
+    "type": "inline",
+    "elements": [
+        [% FOREACH additive IN product.additives_tags %]
         {
-            "element_type": "text",
-            "text_element": {
-                "html": `[ shown only to moderators] -- New knowledge panel coming soon
-                `,
+            "element_type": "panel",
+            "panel_element": {
+                "panel_id": "additive_[% additive %]",
             }
-        },
+        },            
+        [% END %]
     ]
 }

--- a/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
@@ -16,5 +16,25 @@
                 "edit_field_value": `[% panel.ingredients_text %]`,
             },
         },
+        [% IF product.allergens_tags && product.allergens_tags.size %]
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `<strong>[% lang("allergens") %][% sep %]:</strong> 
+                    [% display_taxonomy_tags_list("allergens", product.allergens_tags) %]
+                `,
+            },
+        },
+        [% END %]
+        [% IF product.traces_tags && product.traces_tags.size %]
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `<strong>[% lang("traces") %][% sep %]:</strong> 
+                    [% display_taxonomy_tags_list("traces", product.traces_tags) %]
+                `,
+            },
+        },
+        [% END %]        
     ]
 }

--- a/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients.tt.json
@@ -20,7 +20,7 @@
         {
             "element_type": "text",
             "text_element": {
-                "html": `<strong>[% lang("allergens") %][% sep %]:</strong> 
+                "html": `<strong>[% lang("allergens_p").ucfirst %][% sep %]:</strong> 
                     [% display_taxonomy_tags_list("allergens", product.allergens_tags) %]
                 `,
             },
@@ -30,7 +30,7 @@
         {
             "element_type": "text",
             "text_element": {
-                "html": `<strong>[% lang("traces") %][% sep %]:</strong> 
+                "html": `<strong>[% lang("traces_p").ucfirst %][% sep %]:</strong> 
                     [% display_taxonomy_tags_list("traces", product.traces_tags) %]
                 `,
             },

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -1,12 +1,32 @@
 [% panel = panels.$panel_id %]
 <!-- start templates/[% template.name %] - panel_id: [% panel_id %] -->
 [% IF (panel.type == "card") OR (panel.type == "inline") %]
-<div class="panel_[% panel.type %]" id="[% panel_id | replace(':','-') %]" style="margin-top:0.5rem;margin-bottom:1.5rem;">
+<div class="panel_[% panel.type %]" id="[% panel_id | replace(':','-') %]"
+    [% IF panel.size == "small" %]
+        style="margin-top:0.2rem;margin-bottom:0.2rem;"
+    [% ELSE %]
+        style="margin-top:0.5rem;margin-bottom:1.5rem;"
+    [% END %]
+>
 [% ELSE %]
-<ul data-accordion class="panel_accordion accordion" id="[% panel_id | replace(':','-') %]" style="margin-top:0.5rem;margin-bottom:1.5rem;">
+<ul data-accordion class="panel_accordion accordion" id="[% panel_id | replace(':','-') %]"
+    [% IF panel.size == "small" %]
+        style="margin-top:0.2rem;margin-bottom:0.2rem;"
+    [% ELSE %]
+        style="margin-top:0.5rem;margin-bottom:1.5rem;"
+    [% END %]
+>
 <li class="accordion-navigation">
 [% END %]
-    <a href="#panel_[% panel_id | replace(':','-') %]_content" class="panel_title[% IF panel.title_element.type == "grade" %] grade_[% panel.title_element.grade %][% END %]">
+
+    [% IF panel.title_element.defined %]
+    <a href="#panel_[% panel_id | replace(':','-') %]_content" class="panel_title[% IF panel.title_element.type == "grade" %] grade_[% panel.title_element.grade %][% END %]"
+        [% IF panel.size == "small" %]
+            style="padding:0.1rem;padding-left:1rem;"
+        [% ELSE %]
+            style="padding:1rem;"
+        [% END %]
+    >
         [% IF panel.title_element.icon_url.defined %]
         <img src="[% panel.title_element.icon_url %]"
             style="[% IF panel.title_element.icon_size == 'small' %]height:36px;[% ELSE %]height:72px;[% END %]float:left;margin-right:1rem;"
@@ -26,18 +46,20 @@
             [% END %]
         >
         [% END %]
-        <h3 
+        <h3 style="
             [% IF panel.evaluation == "good" %]
-                style="color:green"
+                color:green;
             [% ELSIF panel.evaluation == "bad" %]
-                style="color:red"
+                color:red;
             [% ELSIF panel.evaluation == "average" %]
-                style="color:darkorange"
+                color:darkorange;
             [% ELSIF panel.evaluation == "neutral" %]
-                style="color:grey"
+                color:grey;
             [% ELSIF panel.evaluation == "unknown" %]
-               style="color:grey"
+               color:grey;
             [% END %]
+            [% IF panel.size == "small" %]font-size:1.1rem;[% END %]
+            "
         >
             [% IF panel.evaluation AND NOT panel.title_element.icon_url.defined %]
                 [% IF panel.evaluation == "good" %]
@@ -69,6 +91,7 @@
         [% END %]
         <hr class="floatclear">
     </a>
+    [% END %]
 
     [% IF panel.elements.defined %]
     <div id="panel_[% panel_id | replace(':','-') %]_content" class="content panel_content[% IF (panel.type == 'card') OR (panel.type == 'inline') %]_[% panel.type %][% END %][% IF panel.expanded %] active[% END %]">
@@ -136,6 +159,16 @@
                     </h4>
                 [% ELSE %]
                     </div>
+                [% END %]
+                [% IF text_element.source_url.defined %]
+                    <em>[% lang("source") %][% sep %]:
+                        <a href="[% text_element.source_url %]">[% text_element.source_text %]
+                            [% IF text_element.source_lc.defined && text_element.source_lc != lc %]
+                            <!-- source is in a different language than the interface -->
+                            ([% text_element.source_language %])
+                            [% END %]
+                        </a>
+                    </em>
                 [% END %]
                 </div>
 


### PR DESCRIPTION
Functional:
- list additives after the list of ingredients, as a list of small panels
- clicking on the additive name opens the additive panel
- additive panel currently consists only of the Wikipedia abstract and link (which are of very different levels of quality and relevance to food products depending on additive and language)
- to be added: a list of the additive functions (colours, raising agent etc.)
- to be added: EFSA table for the risk of overexposure (+ corresponding colors/icons in the list of additives)

Knowledge panel API changes:
- added a size="small" property to panels, so that the list of additives doesn't take a huge amount of vertical space
- added source_text / source_url / source_language to panel text elements

![image](https://user-images.githubusercontent.com/8158668/148769633-6856e82b-ec80-4beb-886b-1fca6714535b.png)
