### PR TITLE
feat: different Nutri-Score icons and text for unknown and not-applicable 

### DIFF
--- a/html/images/attributes/src/nutriscore-not-applicable.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="240"
+   height="130"
+   viewBox="0 0 240 130"
+   id="svg4443"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4445" />
+  <metadata
+     id="metadata4448">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g3904"
+       transform="matrix(0.12353162,0,0,0.1235316,74.040403,2.2774296e-7)">
+      <path
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M -419.31455,2.5984161e-7 H 1163.4092 C 1263.157,2.5984161e-7 1343.4585,80.302045 1343.4585,180.04942 v 632.48114 c 0,99.7474 -80.3015,180.04944 -180.0493,180.04944 H -419.31455 c -99.7474,0 -180.04943,-80.30204 -180.04943,-180.04944 V 180.04942 C -599.36398,80.302045 -519.06195,2.5984161e-7 -419.31455,2.5984161e-7 Z"
+         id="rect5139" />
+      <path
+         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 748.69832,357.79054 h 363.02978 v 586.3148 H 748.69832 Z"
+         id="rect5141" />
+      <path
+         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M -308.51489,357.79054 H 54.515101 v 586.3148 H -308.51489 Z"
+         id="rect5143" />
+      <path
+         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 1069.5561,357.79054 h 90.647 c 75.4498,0 136.1917,60.74128 136.1917,136.19122 v 313.93237 c 0,75.44988 -60.7419,136.19121 -136.1917,136.19121 h -90.647 c -75.44992,0 -136.19182,-60.74133 -136.19182,-136.19121 V 493.98176 c 0,-75.44994 60.7419,-136.19122 136.19182,-136.19122 z"
+         id="rect5151" />
+      <path
+         id="path5631"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 1188.7073,725.89511 v 53.90913 H 1001.8965 V 514.00202 h 183.441 v 53.90923 h -122.0443 v 51.66293 h 104.8239 v 49.79119 h -104.8239 v 56.52974 z" />
+      <path
+         id="path5608"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -443.3889,163.1475 v 76.82604 h -31.03322 V 105.62258 h 24.22101 l 62.6341,78.90753 v -78.90753 h 31.03312 v 134.35096 h -24.97787 z" />
+      <path
+         id="path5610"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -272.94005,213.48179 q 7.94754,0 13.43512,-3.21684 5.48759,-3.40608 8.89369,-8.89366 3.4061,-5.48757 4.73063,-12.48896 1.51381,-7.19062 1.51381,-14.57046 v -68.68929 h 31.03322 v 68.68929 q 0,14.00278 -3.5953,26.11329 -3.4061,12.11051 -10.78597,21.19339 -7.19059,9.08287 -18.54424,14.38123 -11.16435,5.10912 -26.68096,5.10912 -16.08428,0 -27.43783,-5.48758 -11.35364,-5.48757 -18.54423,-14.57045 -7.0014,-9.27211 -10.4075,-21.38262 -3.21682,-12.11051 -3.21682,-25.35638 v -68.68929 h 31.03322 v 68.68929 q 0,7.7583 1.51381,14.75969 1.51381,7.00139 4.91982,12.48896 3.4061,5.48757 8.7045,8.70443 5.48758,3.21684 13.43503,3.21684 z" />
+      <path
+         id="path5612"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -87.101641,132.87122 h -40.872949 v 107.10232 h -31.03322 V 132.87122 h -41.06214 v -27.24864 h 112.968309 z" />
+      <path
+         id="path5614"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -71.945716,239.97354 V 105.62258 h 60.552519 q 9.4613553,0 17.4088021,3.97376 8.1368279,3.97376 14.0027939,10.40747 5.866061,6.43371 9.082878,14.57045 3.406103,8.13675 3.406103,16.46273 0,6.24448 -1.513813,12.11051 -1.513813,5.67679 -4.352248,10.78592 -2.83834,5.10911 -7.001397,9.27211 -3.973676,3.97376 -9.082878,6.81215 l 29.519401,49.95586 H 5.0695552 L -20.665361,196.64062 h -20.247236 v 43.33292 z m 31.033119,-70.39234 h 28.384064 q 5.4874893,0 9.4612602,-5.10912 3.97377096,-5.29834 3.97377096,-13.43509 0,-8.32598 -4.54143896,-13.24587 -4.5414389,-4.9199 -9.8397372,-4.9199 h -27.437919 z" />
+      <path
+         id="path5616"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 54.821346,239.97354 V 105.62258 H 85.85456 v 134.35096 z" />
+      <path
+         id="path5618"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 109.08803,201.56052 v -27.24865 h 58.28175 v 27.24865 z" />
+      <path
+         id="path5620"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 271.06906,144.98173 q -0.56814,-0.75695 -3.97377,-2.8384 -3.40611,-2.08149 -8.51521,-4.35221 -5.10911,-2.27072 -11.16436,-3.97376 -6.05525,-1.70305 -12.1105,-1.70305 -16.65195,0 -16.65195,11.16438 0,3.40609 1.70301,5.6768 1.89229,2.27072 5.29839,4.16299 3.59529,1.70304 8.89359,3.21685 5.29839,1.51381 12.29979,3.40608 9.65055,2.64918 17.4088,5.86604 7.75835,3.02762 13.05665,7.75829 5.48759,4.54144 8.32602,11.16437 3.02763,6.62294 3.02763,15.89505 0,11.3536 -4.35225,19.30112 -4.16296,7.7583 -11.16436,12.67819 -7.0014,4.73066 -16.08427,7.00138 -9.08288,2.0815 -18.73343,2.0815 -7.37987,0 -15.13813,-1.13536 -7.75835,-1.13536 -15.13813,-3.21686 -7.37987,-2.27072 -14.38127,-5.29834 -6.81211,-3.02763 -12.67817,-7.00139 l 13.62432,-27.05942 q 0.75657,0.94614 4.91991,3.59531 4.16296,2.64918 10.21822,5.29835 6.24444,2.64917 13.8135,4.73066 7.56907,2.08149 15.32742,2.08149 16.46275,0 16.46275,-10.02901 0,-3.78453 -2.45996,-6.24448 -2.45995,-2.45995 -6.8122,-4.35221 -4.35216,-2.0815 -10.4075,-3.78453 -5.86597,-1.70304 -12.86737,-3.78454 -9.27206,-2.8384 -16.08427,-6.05526 -6.81221,-3.40608 -11.35365,-7.75829 -4.35215,-4.35221 -6.62291,-10.02901 -2.08149,-5.67681 -2.08149,-13.24587 0,-10.5967 3.97378,-18.73344 3.97377,-8.13676 10.78588,-13.62433 6.8122,-5.6768 15.70589,-8.5152 9.08288,-2.8384 19.1119,-2.8384 7.0014,0 13.81351,1.32459 6.8122,1.32458 13.05665,3.40607 6.24444,2.0815 11.54283,4.73067 5.48759,2.64918 10.02903,5.29835 z" />
+      <path
+         id="path5622"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 299.1189,171.6627 q 0,-12.11051 4.54144,-24.0318 4.54144,-12.1105 13.24593,-21.57184 8.7044,-9.46133 21.19338,-15.32736 12.48889,-5.86603 28.38397,-5.86603 18.92271,0 32.73622,8.13675 14.0028,8.13674 20.81491,21.19339 l -23.84253,16.65195 q -2.27068,-5.29835 -5.86607,-8.70443 -3.406,-3.59531 -7.56906,-5.6768 -4.16296,-2.27072 -8.51521,-3.02762 -4.35215,-0.94615 -8.51512,-0.94615 -8.89368,0 -15.5166,3.59531 -6.62292,3.59531 -10.97517,9.2721 -4.35225,5.67681 -6.43373,12.86742 -2.08148,7.19062 -2.08148,14.57045 0,7.94753 2.45996,15.32737 2.45996,7.37984 7.0014,13.05664 4.73063,5.67681 11.16435,9.08289 6.62292,3.21684 14.75966,3.21684 4.16305,0 8.51521,-0.94614 4.54144,-1.13536 8.51521,-3.21686 4.16296,-2.27071 7.56906,-5.6768 3.4061,-3.5953 5.48759,-8.70443 l 25.35634,14.94891 q -3.02763,7.37985 -9.08288,13.24587 -5.86596,5.86603 -13.62432,9.83979 -7.75825,3.97376 -16.46265,6.05526 -8.7045,2.08149 -17.03042,2.08149 -14.57046,0 -26.87025,-5.86603 -12.11051,-6.05526 -21.0041,-15.89504 -8.7045,-9.83979 -13.62432,-22.32876 -4.73072,-12.48896 -4.73072,-25.35637 z" />
+      <path
+         id="path5624"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 494.34177,241.1089 q -14.94894,0 -27.24873,-5.86603 -12.29969,-5.86603 -21.00409,-15.32737 -8.7045,-9.65055 -13.62432,-21.95029 -4.73073,-12.29974 -4.73073,-25.35638 0,-13.24587 4.91992,-25.54561 5.10911,-12.29973 14.00279,-21.57184 9.08288,-9.46133 21.38258,-14.94891 12.29979,-5.6768 26.87025,-5.6768 14.94884,0 27.24863,5.86603 12.2997,5.86603 21.0041,15.51659 8.70449,9.65056 13.43512,21.9503 4.73073,12.29973 4.73073,24.97792 0,13.24587 -5.1092,25.5456 -4.91983,12.29975 -13.81351,21.76108 -8.89369,9.27211 -21.19338,14.9489 -12.29979,5.67681 -26.87016,5.67681 z m -35.00699,-68.12162 q 0,7.7583 2.27068,15.13814 2.27076,7.19062 6.62301,12.86741 4.54144,5.67681 11.16436,9.08289 6.62292,3.40607 15.13813,3.40607 8.89369,0 15.51661,-3.5953 6.62292,-3.5953 10.97516,-9.27211 4.35216,-5.86603 6.43364,-13.05664 2.27077,-7.37984 2.27077,-14.94891 0,-7.7583 -2.27077,-14.94891 -2.27067,-7.37984 -6.81211,-12.86742 -4.54144,-5.6768 -11.16436,-8.89365 -6.43373,-3.40608 -14.94894,-3.40608 -8.89369,0 -15.51661,3.59531 -6.43373,3.40608 -10.97516,9.08288 -4.35216,5.6768 -6.62292,13.05664 -2.08149,7.19062 -2.08149,14.75968 z" />
+      <path
+         id="path5626"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 579.26023,239.97354 V 105.62258 h 60.55252 q 9.46136,0 17.4089,3.97376 8.13673,3.97376 14.00279,10.40747 5.86597,6.43371 9.08288,14.57045 3.40601,8.13675 3.40601,16.46273 0,6.24448 -1.51381,12.11051 -1.51382,5.67679 -4.35216,10.78592 -2.83843,5.10911 -7.00139,9.27211 -3.97377,3.97376 -9.08288,6.81215 l 29.5193,49.95586 h -35.00688 l -25.73483,-43.33292 h -20.24733 v 43.33292 z m 31.03312,-70.39234 h 28.38407 q 5.48758,0 9.46135,-5.10912 3.97377,-5.29834 3.97377,-13.43509 0,-8.32598 -4.54144,-13.24587 -4.54143,-4.9199 -9.83983,-4.9199 h -27.43792 z" />
+      <path
+         id="path5628"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 800.45146,212.72489 v 27.24865 H 706.0273 V 105.62258 h 92.72107 v 27.24864 h -61.68786 v 26.11329 h 52.98345 v 25.16715 h -52.98345 v 28.57323 z" />
+      <path
+         style="opacity:1;fill:#ee8100;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m -143.28231,357.79054 h 363.03009 v 586.3148 h -363.03009 z"
+         id="rect5209" />
+      <path
+         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 570.95706,357.79054 h 363.02961 v 586.3148 H 570.95706 Z"
+         id="rect5211" />
+      <path
+         id="path5552"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 636.60488,779.80424 V 514.00202 h 99.2079 q 32.94454,0 57.65289,10.4824 24.70836,10.4823 41.18063,28.45201 16.84627,17.96981 25.08293,42.30378 8.61066,23.95958 8.61066,51.28863 0,30.32384 -9.35962,55.0323 -9.35962,24.33397 -26.95457,41.92929 -17.22094,17.22104 -41.92939,26.95467 -24.33397,9.35914 -54.28353,9.35914 z M 805.8199,646.52884 q 0,-17.59542 -4.86681,-31.82148 -4.49243,-14.60034 -13.47729,-25.08274 -8.98485,-10.4823 -22.08785,-16.09788 -13.1029,-5.61549 -29.57517,-5.61549 h -37.81125 v 157.98386 h 37.81125 q 16.84666,0 29.94956,-5.98988 13.1029,-5.98997 21.71346,-16.47227 8.98486,-10.85678 13.47729,-25.08274 4.86681,-14.60043 4.86681,-31.82138 z" />
+      <path
+         style="opacity:1;fill:#e6e6e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 188.25939,357.79054 H 571.5803 v 586.3148 H 188.25939 Z"
+         id="rect5217" />
+      <path
+         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 206.86519,357.79054 H -156.1649 v 586.3148 h 363.03009 z"
+         id="rect5219" />
+      <path
+         id="path5547"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 258.81114,642.4108 q 0,-23.95959 8.98486,-47.54488 8.98495,-23.95968 26.20589,-42.67817 17.22104,-18.71838 41.9294,-30.32384 24.70835,-11.60545 56.15535,-11.60545 37.43696,0 64.76592,16.09788 27.70334,16.09788 41.18062,41.9293 l -47.17049,32.94454 q -4.49243,-10.48231 -11.60546,-17.22095 -6.73864,-7.11302 -14.97482,-11.23116 -8.23609,-4.49243 -16.84656,-5.98988 -8.61057,-1.87183 -16.84666,-1.87183 -17.59532,0 -30.69832,7.11303 -13.1029,7.11303 -21.71337,18.3441 -8.61047,11.23107 -12.72861,25.45712 -4.11804,14.22596 -4.11804,28.8264 0,15.7235 4.86681,30.32394 4.86681,14.60034 13.85167,25.83151 9.35924,11.23107 22.08776,17.96971 13.10299,6.36426 29.20087,6.36426 8.23609,0 16.84656,-1.87183 8.98486,-2.24621 16.84666,-6.36426 8.23608,-4.49242 14.97472,-11.23116 6.73865,-7.11293 10.85679,-17.22094 l 50.16548,29.57516 q -5.98997,14.60044 -17.96972,26.2059 -11.60545,11.60545 -26.95466,19.46716 -15.34912,7.86179 -32.57006,11.97984 -17.22104,4.11804 -33.69331,4.11804 -28.82639,0 -53.16046,-11.60546 -23.95958,-11.97984 -41.55491,-31.44699 -17.22104,-19.46726 -26.95467,-44.17561 -9.35924,-24.70836 -9.35924,-50.16548 z" />
+      <path
+         id="path5544"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 154.55238,711.66905 q 0,17.22104 -7.11303,29.94955 -7.11303,12.72861 -19.46725,21.33909 -12.35413,8.23608 -28.826401,12.72851 -16.472268,4.11804 -34.816366,4.11804 H -65.202505 V 514.00202 H 82.673431 q 13.851669,0 25.082739,5.98997 11.23107,5.98987 19.09287,15.7235 7.8617,9.35924 11.97984,21.71337 4.49243,11.97984 4.49243,24.70845 0,19.09277 -9.73363,35.93942 -9.35924,16.84666 -28.45211,25.45713 22.83653,6.73864 35.93952,23.95958 13.47729,17.22104 13.47729,44.17561 z M 92.032672,699.31492 q 0,-12.35422 -7.113027,-20.9647 -7.113027,-8.61056 -17.969713,-8.61056 H -3.8058597 v 58.02727 H 64.329333 q 11.97984,0 19.841542,-7.8617 7.861797,-7.86179 7.861797,-20.59031 z M -3.8058597,566.41371 v 55.0323 H 56.467536 q 10.108011,0 17.969808,-6.73865 7.861702,-6.73864 7.861702,-20.9646 0,-13.10299 -7.113027,-20.21602 -6.738643,-7.11303 -16.472269,-7.11303 z" />
+      <path
+         style="fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m -383.0037,357.79054 h 90.6476 c 75.4498,0 136.1912,60.74122 136.1912,136.1912 V 807.9141 c 0,75.44987 -60.7414,136.1912 -136.1912,136.1912 h -90.6476 c -75.45,0 -136.1912,-60.74133 -136.1912,-136.1912 V 493.98174 c 0,-75.44998 60.7412,-136.1912 136.1912,-136.1912 z"
+         id="rect5243" />
+      <path
+         id="path5519"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -385.3348,514.00191 h 55.4067 l 96.9616,265.8023 h -62.8941 l -20.5903,-59.52472 h -82.7356 l -20.2159,59.52472 h -62.894 z m 58.776,163.9738 -31.0727,-93.9667 -31.8214,93.9667 z" />
+    </g>
+  </g>
+</svg>

--- a/html/images/attributes/src/nutriscore-not-applicable.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable.svg
@@ -5,11 +5,34 @@
    viewBox="0 0 240 130"
    id="svg4443"
    version="1.1"
+   sodipodi:docname="nutriscore-not-applicable.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview32"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-global="false"
+     inkscape:zoom="1.4020833"
+     inkscape:cx="136.93908"
+     inkscape:cy="65.26003"
+     inkscape:window-width="1141"
+     inkscape:window-height="454"
+     inkscape:window-x="397"
+     inkscape:window-y="682"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4443" />
   <defs
      id="defs4445" />
   <metadata
@@ -23,111 +46,128 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 22.241797,2.5984161e-7 H 217.75823 c 12.322,0 22.24178,9.91984004015839 22.24178,22.24179274015839 V 100.3732 c 0,12.32196 -9.91978,22.2418 -22.24178,22.2418 H 22.241797 C 9.9198394,122.615 -4.1904759e-7,112.69516 -4.1904759e-7,100.3732 V 22.241793 C -4.1904759e-7,9.9198403 9.9198394,2.5984161e-7 22.241797,2.5984161e-7 Z"
+     id="rect5139" />
+  <path
+     style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 166.52832,44.198438 h 44.84566 v 72.428402 h -44.84566 z"
+     id="rect5141" />
+  <path
+     style="fill:#999999;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 35.929059,44.198438 H 80.774742 V 116.62684 H 35.929059 Z"
+     id="rect5143" />
+  <path
+     style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 206.1644,44.198438 h 11.19777 c 9.32044,0 16.82398,7.503468 16.82398,16.823919 v 38.780568 c 0,9.320445 -7.50354,16.823915 -16.82398,16.823915 H 206.1644 c -9.32045,0 -16.824,-7.50347 -16.824,-16.823915 V 61.022357 c 0,-9.320451 7.50355,-16.823919 16.824,-16.823919 z"
+     id="rect5151" />
+  <path
+     id="path5631"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 220.88334,89.670985 v 6.659481 H 197.8063 V 63.495492 h 22.66076 v 6.659494 h -15.07633 v 6.382004 h 12.94907 v 6.150785 h -12.94907 v 6.98321 z" />
+  <path
+     id="path5608"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 19.267854,20.153872 v 9.490444 H 15.43427 V 13.047727 h 2.992061 l 7.737291,9.747573 v -9.747573 h 3.833572 v 16.596589 h -3.085557 z" />
+  <path
+     id="path5610"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 40.323676,26.371747 q 0.981773,0 1.659663,-0.397381 0.67789,-0.420759 1.098652,-1.098648 0.420761,-0.677888 0.584382,-1.542781 0.187003,-0.888269 0.187003,-1.799913 v -8.485297 h 3.833584 v 8.485297 q 0,1.729786 -0.444133,3.225817 -0.420761,1.496031 -1.332408,2.618053 -0.888266,1.122022 -2.2908,1.776537 -1.379151,0.631137 -3.295943,0.631137 -1.986917,0 -3.389439,-0.677889 -1.402534,-0.677888 -2.290799,-1.799911 -0.864894,-1.145399 -1.285655,-2.641429 -0.397379,-1.496031 -0.397379,-3.132315 v -8.485297 h 3.833584 v 8.485297 q 0,0.958396 0.187003,1.823289 0.187004,0.864892 0.607753,1.542781 0.420762,0.677888 1.075281,1.075272 0.67789,0.397381 1.659651,0.397381 z" />
+  <path
+     id="path5612"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 63.280596,16.413795 H 58.231495 V 29.644316 H 54.397911 V 16.413795 h -5.072473 v -3.366068 h 13.955158 z" />
+  <path
+     id="path5614"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 65.152832,29.644316 V 13.047727 h 7.480151 q 1.168776,0 2.150537,0.490884 1.005156,0.490885 1.729788,1.285652 0.724644,0.794766 1.122023,1.799911 0.420761,1.005146 0.420761,2.033667 0,0.771391 -0.187003,1.496031 -0.187004,0.701263 -0.537641,1.332402 -0.350624,0.631136 -0.864894,1.145398 -0.490874,0.490885 -1.122022,0.841516 l 3.646579,6.171128 h -4.324458 l -3.179076,-5.352985 h -2.501173 v 5.352985 z m 3.833572,-8.695679 h 3.506329 q 0.677878,0 1.168765,-0.631138 0.490886,-0.654512 0.490886,-1.659658 0,-1.028521 -0.561011,-1.636283 -0.561011,-0.607763 -1.215519,-0.607763 h -3.38945 z" />
+  <path
+     id="path5616"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 80.812573,29.644316 V 13.047727 h 3.833583 v 16.596589 z" />
+  <path
+     id="path5618"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 87.516224,24.899094 v -3.36607 h 7.199639 v 3.36607 z" />
+  <path
+     id="path5620"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 107.526,17.909825 q -0.0702,-0.09351 -0.49088,-0.350632 -0.42077,-0.25713 -1.0519,-0.537635 -0.63114,-0.280506 -1.37915,-0.490885 -0.74802,-0.210381 -1.49603,-0.210381 -2.05704,0 -2.05704,1.379154 0,0.42076 0.21037,0.701264 0.23376,0.280506 0.65452,0.514261 0.44413,0.210379 1.09864,0.397383 0.65452,0.187003 1.51941,0.420758 1.19215,0.327258 2.15054,0.724641 0.9584,0.374007 1.61291,0.958394 0.67789,0.561012 1.02853,1.379153 0.374,0.818142 0.374,1.963541 0,1.402528 -0.53764,2.384298 -0.51425,0.958395 -1.37915,1.566157 -0.86489,0.584386 -1.98691,0.864892 -1.12203,0.257131 -2.31418,0.257131 -0.91164,0 -1.87003,-0.140253 -0.9584,-0.140253 -1.870041,-0.397384 -0.911647,-0.280505 -1.776541,-0.654512 -0.841511,-0.374008 -1.566155,-0.864893 l 1.683034,-3.342694 q 0.09346,0.116879 0.607765,0.444135 0.514257,0.327257 1.262273,0.654514 0.771385,0.327256 1.706405,0.584386 0.93502,0.257129 1.89342,0.257129 2.03367,0 2.03367,-1.238899 0,-0.467509 -0.30388,-0.771391 -0.30388,-0.303881 -0.84152,-0.537635 -0.53763,-0.257131 -1.28566,-0.467509 -0.72463,-0.21038 -1.58953,-0.467511 -1.14539,-0.350632 -1.986913,-0.748016 -0.841523,-0.420758 -1.402535,-0.958394 -0.537628,-0.537635 -0.818139,-1.238899 -0.257129,-0.701266 -0.257129,-1.636284 0,-1.309027 0.490887,-2.314172 0.490886,-1.005147 1.332397,-1.683035 0.841522,-0.701264 1.940172,-1.051896 1.12203,-0.350632 2.36093,-0.350632 0.86489,0 1.7064,0.163628 0.84152,0.163628 1.61291,0.420758 0.77139,0.257131 1.42591,0.584387 0.67789,0.327257 1.2389,0.654514 z" />
+  <path
+     id="path5622"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 110.99105,21.205768 q 0,-1.49603 0.56101,-2.968686 0.56101,-1.49603 1.63629,-2.664804 1.07527,-1.168774 2.61805,-1.893414 1.54277,-0.72464 3.50632,-0.72464 2.33755,0 4.04396,1.005146 1.72979,1.005144 2.5713,2.618053 l -2.94531,2.057042 q -0.2805,-0.654513 -0.72465,-1.075272 -0.42074,-0.444134 -0.93501,-0.701264 -0.51426,-0.280506 -1.0519,-0.374007 -0.53763,-0.116879 -1.05189,-0.116879 -1.09865,0 -1.91679,0.444134 -0.81814,0.444135 -1.35578,1.145398 -0.53764,0.701265 -0.79477,1.589533 -0.25713,0.888268 -0.25713,1.799911 0,0.981771 0.30389,1.893414 0.30388,0.911644 0.86489,1.612908 0.58438,0.701265 1.37915,1.122024 0.81814,0.397381 1.82329,0.397381 0.51426,0 1.05189,-0.116878 0.56101,-0.140253 1.0519,-0.397384 0.51426,-0.280504 0.93502,-0.701264 0.42076,-0.444133 0.67789,-1.075272 l 3.13231,1.846662 q -0.37401,0.911645 -1.12202,1.636284 -0.72463,0.72464 -1.68304,1.215525 -0.95839,0.490885 -2.03366,0.748016 -1.07528,0.25713 -2.10379,0.25713 -1.79991,0 -3.31933,-0.72464 -1.49603,-0.748016 -2.59467,-1.96354 -1.07528,-1.215525 -1.68303,-2.758308 -0.58439,-1.542781 -0.58439,-3.132312 z" />
+  <path
+     id="path5624"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 135.10724,29.784568 q -1.84666,0 -3.36608,-0.72464 -1.5194,-0.72464 -2.59467,-1.893414 -1.07528,-1.192148 -1.68303,-2.711555 -0.5844,-1.519406 -0.5844,-3.132314 0,-1.636283 0.60777,-3.15569 0.63114,-1.519405 1.72979,-2.664804 1.12202,-1.168773 2.64142,-1.846663 1.51942,-0.701264 3.31933,-0.701264 1.84665,0 3.36607,0.72464 1.5194,0.72464 2.59467,1.916789 1.07528,1.19215 1.65966,2.711556 0.58439,1.519405 0.58439,3.085563 0,1.636283 -0.63115,3.155688 -0.60775,1.519408 -1.7064,2.688181 -1.09865,1.145399 -2.61805,1.846662 -1.51942,0.701265 -3.31932,0.701265 z m -4.32447,-8.415172 q 0,0.958395 0.2805,1.870038 0.28051,0.888269 0.81815,1.589532 0.56102,0.701266 1.37916,1.122024 0.81814,0.420757 1.87003,0.420757 1.09866,0 1.9168,-0.444133 0.81814,-0.444133 1.35577,-1.145398 0.53763,-0.72464 0.79476,-1.612908 0.28051,-0.911644 0.28051,-1.846663 0,-0.958395 -0.28051,-1.846663 -0.2805,-0.911643 -0.84151,-1.589533 -0.56101,-0.701264 -1.37915,-1.098646 -0.79477,-0.420759 -1.84667,-0.420759 -1.09865,0 -1.91679,0.444134 -0.79477,0.420759 -1.35578,1.122023 -0.53763,0.701264 -0.81814,1.612908 -0.25713,0.888269 -0.25713,1.823287 z" />
+  <path
+     id="path5626"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 145.59736,29.644316 V 13.047727 h 7.48015 q 1.16878,0 2.15055,0.490884 1.00514,0.490885 1.72979,1.285652 0.72463,0.794766 1.12202,1.799911 0.42075,1.005146 0.42075,2.033667 0,0.771391 -0.18701,1.496031 -0.187,0.701263 -0.53762,1.332402 -0.35064,0.631136 -0.8649,1.145398 -0.49088,0.490885 -1.12202,0.841516 l 3.64657,6.171128 h -4.32446 l -3.17907,-5.352985 h -2.50118 v 5.352985 z m 3.83357,-8.695679 h 3.50633 q 0.67789,0 1.16878,-0.631138 0.49088,-0.654512 0.49088,-1.659658 0,-1.028521 -0.56101,-1.636283 -0.56101,-0.607763 -1.21553,-0.607763 h -3.38945 z" />
+  <path
+     id="path5628"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 172.92147,26.278246 v 3.36607 H 161.2571 V 13.047727 h 11.45398 v 3.366068 h -7.6204 v 3.225816 h 6.54513 v 3.108938 h -6.54513 v 3.529697 z" />
+  <path
+     style="fill:#ee8100;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 56.340507,44.198438 H 101.1862 V 116.62684 H 56.340507 Z"
+     id="rect5209" />
+  <path
+     style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 144.57165,44.198438 h 44.84564 v 72.428402 h -44.84564 z"
+     id="rect5211" />
+  <path
+     id="path5552"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 152.68124,96.330466 V 63.495492 h 12.25531 q 4.06969,0 7.12195,1.294908 3.05227,1.294895 5.08711,3.514722 2.08105,2.21984 3.09854,5.225854 1.06369,2.959765 1.06369,6.335766 0,3.745953 -1.15621,6.798228 -1.15621,3.006015 -3.32974,5.179593 -2.12734,2.127342 -5.17961,3.329753 -3.00601,1.15615 -6.70573,1.15615 z m 20.9034,-16.463724 q 0,-2.17359 -0.6012,-3.930958 -0.55496,-1.803603 -1.66488,-3.098511 -1.10991,-1.294895 -2.72854,-1.988597 -1.61863,-0.69369 -3.65347,-0.69369 h -4.67089 v 19.515999 h 4.67089 q 2.08109,0 3.69972,-0.73994 1.61862,-0.73995 2.68229,-2.034846 1.10992,-1.341155 1.66488,-3.098511 0.6012,-1.803614 0.6012,-3.930946 z" />
+  <path
+     style="fill:#b2b2b2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 97.29639,44.198438 h 47.35225 V 116.62684 H 97.29639 Z"
+     id="rect5217" />
+  <path
+     style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 99.594795,44.198438 H 54.7491 v 72.428402 h 44.845695 z"
+     id="rect5219" />
+  <path
+     id="path5547"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 106.01176,79.358034 q 0,-2.959766 1.10992,-5.873295 1.10992,-2.959777 3.23725,-5.272103 2.12735,-2.312311 5.17961,-3.745952 3.05226,-1.43364 6.93696,-1.43364 4.62465,0 8.00064,1.988597 3.42224,1.988597 5.08711,5.179594 l -5.82705,4.069691 q -0.55496,-1.294896 -1.43364,-2.127331 -0.83243,-0.878683 -1.84986,-1.387403 -1.01742,-0.554957 -2.08109,-0.73994 -1.06367,-0.23123 -2.08109,-0.23123 -2.17358,0 -3.79221,0.878684 -1.61863,0.878684 -2.68229,2.266076 -1.06367,1.387392 -1.57239,3.144759 -0.50871,1.757355 -0.50871,3.560971 0,1.942349 0.60121,3.745965 0.6012,1.803603 1.71112,3.191008 1.15616,1.387392 2.72853,2.219827 1.61864,0.786187 3.60724,0.786187 1.01741,0 2.08108,-0.23123 1.10991,-0.277478 2.08109,-0.786187 1.01742,-0.554956 1.84985,-1.387404 0.83244,-0.878671 1.34116,-2.12733 l 6.19702,3.653467 q -0.73995,1.803616 -2.21982,3.237257 -1.43364,1.43364 -3.32976,2.404809 -1.8961,0.97118 -4.02343,1.479889 -2.12734,0.508708 -4.16219,0.508708 -3.56097,0 -6.567,-1.433641 -2.95976,-1.479889 -5.13334,-3.884697 -2.12734,-2.404822 -3.32976,-5.457084 -1.15616,-3.052263 -1.15616,-6.197022 z" />
+  <path
+     id="path5544"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 93.132509,87.913617 q 0,2.127342 -0.878684,3.699715 -0.878684,1.572386 -2.404821,2.636052 -1.526126,1.017417 -3.560972,1.572374 -2.034846,0.508708 -4.300922,0.508708 H 65.985832 V 63.495492 h 18.267354 q 1.711119,0 3.098511,0.739951 1.387393,0.739938 2.358573,1.942349 0.971169,1.156162 1.479889,2.682287 0.554958,1.479889 0.554958,3.052275 0,2.35856 -1.202411,4.439654 -1.156163,2.081094 -3.514736,3.14476 2.821034,0.832435 4.439667,2.959765 1.664872,2.127342 1.664872,5.457084 z m -7.723161,-1.526126 q 0,-1.526136 -0.878684,-2.589803 -0.878683,-1.063676 -2.219827,-1.063676 h -8.740578 v 7.168202 h 8.416851 q 1.479889,0 2.451058,-0.971169 0.97118,-0.971179 0.97118,-2.543554 z M 73.570259,69.969992 v 6.798228 h 7.44567 q 1.248659,0 2.21984,-0.832436 0.971168,-0.832435 0.971168,-2.589791 0,-1.618633 -0.878683,-2.497317 -0.832436,-0.878684 -2.034846,-0.878684 z" />
+  <path
+     style="fill:#999999;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.123532;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 26.727335,44.198438 H 37.92518 c 9.320436,0 16.82392,7.50346 16.82392,16.823917 v 38.780567 c 0,9.320438 -7.503484,16.823918 -16.82392,16.823918 H 26.727335 c -9.32046,0 -16.8239191,-7.50348 -16.8239191,-16.823918 V 61.022355 c 0,-9.320457 7.5034591,-16.823917 16.8239191,-16.823917 z"
+     id="rect5243" />
+  <path
+     id="path5519"
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:0.123532px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 30.709913,63.495479 h 6.844479 l 11.977824,32.834983 h -7.76941 L 39.219253,88.977278 H 28.99879 l -2.497303,7.353184 h -7.769398 z m 7.260694,20.255945 -3.838461,-11.607856 -3.930949,11.607856 z" />
   <g
-     id="layer1">
-    <g
-       id="g3904"
-       transform="matrix(0.12353162,0,0,0.1235316,74.040403,2.2774296e-7)">
-      <path
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M -419.31455,2.5984161e-7 H 1163.4092 C 1263.157,2.5984161e-7 1343.4585,80.302045 1343.4585,180.04942 v 632.48114 c 0,99.7474 -80.3015,180.04944 -180.0493,180.04944 H -419.31455 c -99.7474,0 -180.04943,-80.30204 -180.04943,-180.04944 V 180.04942 C -599.36398,80.302045 -519.06195,2.5984161e-7 -419.31455,2.5984161e-7 Z"
-         id="rect5139" />
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 748.69832,357.79054 h 363.02978 v 586.3148 H 748.69832 Z"
-         id="rect5141" />
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M -308.51489,357.79054 H 54.515101 v 586.3148 H -308.51489 Z"
-         id="rect5143" />
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 1069.5561,357.79054 h 90.647 c 75.4498,0 136.1917,60.74128 136.1917,136.19122 v 313.93237 c 0,75.44988 -60.7419,136.19121 -136.1917,136.19121 h -90.647 c -75.44992,0 -136.19182,-60.74133 -136.19182,-136.19121 V 493.98176 c 0,-75.44994 60.7419,-136.19122 136.19182,-136.19122 z"
-         id="rect5151" />
-      <path
-         id="path5631"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 1188.7073,725.89511 v 53.90913 H 1001.8965 V 514.00202 h 183.441 v 53.90923 h -122.0443 v 51.66293 h 104.8239 v 49.79119 h -104.8239 v 56.52974 z" />
-      <path
-         id="path5608"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -443.3889,163.1475 v 76.82604 h -31.03322 V 105.62258 h 24.22101 l 62.6341,78.90753 v -78.90753 h 31.03312 v 134.35096 h -24.97787 z" />
-      <path
-         id="path5610"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -272.94005,213.48179 q 7.94754,0 13.43512,-3.21684 5.48759,-3.40608 8.89369,-8.89366 3.4061,-5.48757 4.73063,-12.48896 1.51381,-7.19062 1.51381,-14.57046 v -68.68929 h 31.03322 v 68.68929 q 0,14.00278 -3.5953,26.11329 -3.4061,12.11051 -10.78597,21.19339 -7.19059,9.08287 -18.54424,14.38123 -11.16435,5.10912 -26.68096,5.10912 -16.08428,0 -27.43783,-5.48758 -11.35364,-5.48757 -18.54423,-14.57045 -7.0014,-9.27211 -10.4075,-21.38262 -3.21682,-12.11051 -3.21682,-25.35638 v -68.68929 h 31.03322 v 68.68929 q 0,7.7583 1.51381,14.75969 1.51381,7.00139 4.91982,12.48896 3.4061,5.48757 8.7045,8.70443 5.48758,3.21684 13.43503,3.21684 z" />
-      <path
-         id="path5612"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -87.101641,132.87122 h -40.872949 v 107.10232 h -31.03322 V 132.87122 h -41.06214 v -27.24864 h 112.968309 z" />
-      <path
-         id="path5614"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M -71.945716,239.97354 V 105.62258 h 60.552519 q 9.4613553,0 17.4088021,3.97376 8.1368279,3.97376 14.0027939,10.40747 5.866061,6.43371 9.082878,14.57045 3.406103,8.13675 3.406103,16.46273 0,6.24448 -1.513813,12.11051 -1.513813,5.67679 -4.352248,10.78592 -2.83834,5.10911 -7.001397,9.27211 -3.973676,3.97376 -9.082878,6.81215 l 29.519401,49.95586 H 5.0695552 L -20.665361,196.64062 h -20.247236 v 43.33292 z m 31.033119,-70.39234 h 28.384064 q 5.4874893,0 9.4612602,-5.10912 3.97377096,-5.29834 3.97377096,-13.43509 0,-8.32598 -4.54143896,-13.24587 -4.5414389,-4.9199 -9.8397372,-4.9199 h -27.437919 z" />
-      <path
-         id="path5616"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 54.821346,239.97354 V 105.62258 H 85.85456 v 134.35096 z" />
-      <path
-         id="path5618"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 109.08803,201.56052 v -27.24865 h 58.28175 v 27.24865 z" />
-      <path
-         id="path5620"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 271.06906,144.98173 q -0.56814,-0.75695 -3.97377,-2.8384 -3.40611,-2.08149 -8.51521,-4.35221 -5.10911,-2.27072 -11.16436,-3.97376 -6.05525,-1.70305 -12.1105,-1.70305 -16.65195,0 -16.65195,11.16438 0,3.40609 1.70301,5.6768 1.89229,2.27072 5.29839,4.16299 3.59529,1.70304 8.89359,3.21685 5.29839,1.51381 12.29979,3.40608 9.65055,2.64918 17.4088,5.86604 7.75835,3.02762 13.05665,7.75829 5.48759,4.54144 8.32602,11.16437 3.02763,6.62294 3.02763,15.89505 0,11.3536 -4.35225,19.30112 -4.16296,7.7583 -11.16436,12.67819 -7.0014,4.73066 -16.08427,7.00138 -9.08288,2.0815 -18.73343,2.0815 -7.37987,0 -15.13813,-1.13536 -7.75835,-1.13536 -15.13813,-3.21686 -7.37987,-2.27072 -14.38127,-5.29834 -6.81211,-3.02763 -12.67817,-7.00139 l 13.62432,-27.05942 q 0.75657,0.94614 4.91991,3.59531 4.16296,2.64918 10.21822,5.29835 6.24444,2.64917 13.8135,4.73066 7.56907,2.08149 15.32742,2.08149 16.46275,0 16.46275,-10.02901 0,-3.78453 -2.45996,-6.24448 -2.45995,-2.45995 -6.8122,-4.35221 -4.35216,-2.0815 -10.4075,-3.78453 -5.86597,-1.70304 -12.86737,-3.78454 -9.27206,-2.8384 -16.08427,-6.05526 -6.81221,-3.40608 -11.35365,-7.75829 -4.35215,-4.35221 -6.62291,-10.02901 -2.08149,-5.67681 -2.08149,-13.24587 0,-10.5967 3.97378,-18.73344 3.97377,-8.13676 10.78588,-13.62433 6.8122,-5.6768 15.70589,-8.5152 9.08288,-2.8384 19.1119,-2.8384 7.0014,0 13.81351,1.32459 6.8122,1.32458 13.05665,3.40607 6.24444,2.0815 11.54283,4.73067 5.48759,2.64918 10.02903,5.29835 z" />
-      <path
-         id="path5622"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 299.1189,171.6627 q 0,-12.11051 4.54144,-24.0318 4.54144,-12.1105 13.24593,-21.57184 8.7044,-9.46133 21.19338,-15.32736 12.48889,-5.86603 28.38397,-5.86603 18.92271,0 32.73622,8.13675 14.0028,8.13674 20.81491,21.19339 l -23.84253,16.65195 q -2.27068,-5.29835 -5.86607,-8.70443 -3.406,-3.59531 -7.56906,-5.6768 -4.16296,-2.27072 -8.51521,-3.02762 -4.35215,-0.94615 -8.51512,-0.94615 -8.89368,0 -15.5166,3.59531 -6.62292,3.59531 -10.97517,9.2721 -4.35225,5.67681 -6.43373,12.86742 -2.08148,7.19062 -2.08148,14.57045 0,7.94753 2.45996,15.32737 2.45996,7.37984 7.0014,13.05664 4.73063,5.67681 11.16435,9.08289 6.62292,3.21684 14.75966,3.21684 4.16305,0 8.51521,-0.94614 4.54144,-1.13536 8.51521,-3.21686 4.16296,-2.27071 7.56906,-5.6768 3.4061,-3.5953 5.48759,-8.70443 l 25.35634,14.94891 q -3.02763,7.37985 -9.08288,13.24587 -5.86596,5.86603 -13.62432,9.83979 -7.75825,3.97376 -16.46265,6.05526 -8.7045,2.08149 -17.03042,2.08149 -14.57046,0 -26.87025,-5.86603 -12.11051,-6.05526 -21.0041,-15.89504 -8.7045,-9.83979 -13.62432,-22.32876 -4.73072,-12.48896 -4.73072,-25.35637 z" />
-      <path
-         id="path5624"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 494.34177,241.1089 q -14.94894,0 -27.24873,-5.86603 -12.29969,-5.86603 -21.00409,-15.32737 -8.7045,-9.65055 -13.62432,-21.95029 -4.73073,-12.29974 -4.73073,-25.35638 0,-13.24587 4.91992,-25.54561 5.10911,-12.29973 14.00279,-21.57184 9.08288,-9.46133 21.38258,-14.94891 12.29979,-5.6768 26.87025,-5.6768 14.94884,0 27.24863,5.86603 12.2997,5.86603 21.0041,15.51659 8.70449,9.65056 13.43512,21.9503 4.73073,12.29973 4.73073,24.97792 0,13.24587 -5.1092,25.5456 -4.91983,12.29975 -13.81351,21.76108 -8.89369,9.27211 -21.19338,14.9489 -12.29979,5.67681 -26.87016,5.67681 z m -35.00699,-68.12162 q 0,7.7583 2.27068,15.13814 2.27076,7.19062 6.62301,12.86741 4.54144,5.67681 11.16436,9.08289 6.62292,3.40607 15.13813,3.40607 8.89369,0 15.51661,-3.5953 6.62292,-3.5953 10.97516,-9.27211 4.35216,-5.86603 6.43364,-13.05664 2.27077,-7.37984 2.27077,-14.94891 0,-7.7583 -2.27077,-14.94891 -2.27067,-7.37984 -6.81211,-12.86742 -4.54144,-5.6768 -11.16436,-8.89365 -6.43373,-3.40608 -14.94894,-3.40608 -8.89369,0 -15.51661,3.59531 -6.43373,3.40608 -10.97516,9.08288 -4.35216,5.6768 -6.62292,13.05664 -2.08149,7.19062 -2.08149,14.75968 z" />
-      <path
-         id="path5626"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 579.26023,239.97354 V 105.62258 h 60.55252 q 9.46136,0 17.4089,3.97376 8.13673,3.97376 14.00279,10.40747 5.86597,6.43371 9.08288,14.57045 3.40601,8.13675 3.40601,16.46273 0,6.24448 -1.51381,12.11051 -1.51382,5.67679 -4.35216,10.78592 -2.83843,5.10911 -7.00139,9.27211 -3.97377,3.97376 -9.08288,6.81215 l 29.5193,49.95586 h -35.00688 l -25.73483,-43.33292 h -20.24733 v 43.33292 z m 31.03312,-70.39234 h 28.38407 q 5.48758,0 9.46135,-5.10912 3.97377,-5.29834 3.97377,-13.43509 0,-8.32598 -4.54144,-13.24587 -4.54143,-4.9199 -9.83983,-4.9199 h -27.43792 z" />
-      <path
-         id="path5628"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 800.45146,212.72489 v 27.24865 H 706.0273 V 105.62258 h 92.72107 v 27.24864 h -61.68786 v 26.11329 h 52.98345 v 25.16715 h -52.98345 v 28.57323 z" />
-      <path
-         style="opacity:1;fill:#ee8100;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m -143.28231,357.79054 h 363.03009 v 586.3148 h -363.03009 z"
-         id="rect5209" />
-      <path
-         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 570.95706,357.79054 h 363.02961 v 586.3148 H 570.95706 Z"
-         id="rect5211" />
-      <path
-         id="path5552"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 636.60488,779.80424 V 514.00202 h 99.2079 q 32.94454,0 57.65289,10.4824 24.70836,10.4823 41.18063,28.45201 16.84627,17.96981 25.08293,42.30378 8.61066,23.95958 8.61066,51.28863 0,30.32384 -9.35962,55.0323 -9.35962,24.33397 -26.95457,41.92929 -17.22094,17.22104 -41.92939,26.95467 -24.33397,9.35914 -54.28353,9.35914 z M 805.8199,646.52884 q 0,-17.59542 -4.86681,-31.82148 -4.49243,-14.60034 -13.47729,-25.08274 -8.98485,-10.4823 -22.08785,-16.09788 -13.1029,-5.61549 -29.57517,-5.61549 h -37.81125 v 157.98386 h 37.81125 q 16.84666,0 29.94956,-5.98988 13.1029,-5.98997 21.71346,-16.47227 8.98486,-10.85678 13.47729,-25.08274 4.86681,-14.60043 4.86681,-31.82138 z" />
-      <path
-         style="opacity:1;fill:#e6e6e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 188.25939,357.79054 H 571.5803 v 586.3148 H 188.25939 Z"
-         id="rect5217" />
-      <path
-         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 206.86519,357.79054 H -156.1649 v 586.3148 h 363.03009 z"
-         id="rect5219" />
-      <path
-         id="path5547"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 258.81114,642.4108 q 0,-23.95959 8.98486,-47.54488 8.98495,-23.95968 26.20589,-42.67817 17.22104,-18.71838 41.9294,-30.32384 24.70835,-11.60545 56.15535,-11.60545 37.43696,0 64.76592,16.09788 27.70334,16.09788 41.18062,41.9293 l -47.17049,32.94454 q -4.49243,-10.48231 -11.60546,-17.22095 -6.73864,-7.11302 -14.97482,-11.23116 -8.23609,-4.49243 -16.84656,-5.98988 -8.61057,-1.87183 -16.84666,-1.87183 -17.59532,0 -30.69832,7.11303 -13.1029,7.11303 -21.71337,18.3441 -8.61047,11.23107 -12.72861,25.45712 -4.11804,14.22596 -4.11804,28.8264 0,15.7235 4.86681,30.32394 4.86681,14.60034 13.85167,25.83151 9.35924,11.23107 22.08776,17.96971 13.10299,6.36426 29.20087,6.36426 8.23609,0 16.84656,-1.87183 8.98486,-2.24621 16.84666,-6.36426 8.23608,-4.49242 14.97472,-11.23116 6.73865,-7.11293 10.85679,-17.22094 l 50.16548,29.57516 q -5.98997,14.60044 -17.96972,26.2059 -11.60545,11.60545 -26.95466,19.46716 -15.34912,7.86179 -32.57006,11.97984 -17.22104,4.11804 -33.69331,4.11804 -28.82639,0 -53.16046,-11.60546 -23.95958,-11.97984 -41.55491,-31.44699 -17.22104,-19.46726 -26.95467,-44.17561 -9.35924,-24.70836 -9.35924,-50.16548 z" />
-      <path
-         id="path5544"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 154.55238,711.66905 q 0,17.22104 -7.11303,29.94955 -7.11303,12.72861 -19.46725,21.33909 -12.35413,8.23608 -28.826401,12.72851 -16.472268,4.11804 -34.816366,4.11804 H -65.202505 V 514.00202 H 82.673431 q 13.851669,0 25.082739,5.98997 11.23107,5.98987 19.09287,15.7235 7.8617,9.35924 11.97984,21.71337 4.49243,11.97984 4.49243,24.70845 0,19.09277 -9.73363,35.93942 -9.35924,16.84666 -28.45211,25.45713 22.83653,6.73864 35.93952,23.95958 13.47729,17.22104 13.47729,44.17561 z M 92.032672,699.31492 q 0,-12.35422 -7.113027,-20.9647 -7.113027,-8.61056 -17.969713,-8.61056 H -3.8058597 v 58.02727 H 64.329333 q 11.97984,0 19.841542,-7.8617 7.861797,-7.86179 7.861797,-20.59031 z M -3.8058597,566.41371 v 55.0323 H 56.467536 q 10.108011,0 17.969808,-6.73865 7.861702,-6.73864 7.861702,-20.9646 0,-13.10299 -7.113027,-20.21602 -6.738643,-7.11303 -16.472269,-7.11303 z" />
-      <path
-         style="fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m -383.0037,357.79054 h 90.6476 c 75.4498,0 136.1912,60.74122 136.1912,136.1912 V 807.9141 c 0,75.44987 -60.7414,136.1912 -136.1912,136.1912 h -90.6476 c -75.45,0 -136.1912,-60.74133 -136.1912,-136.1912 V 493.98174 c 0,-75.44998 60.7412,-136.1912 136.1912,-136.1912 z"
-         id="rect5243" />
-      <path
-         id="path5519"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -385.3348,514.00191 h 55.4067 l 96.9616,265.8023 h -62.8941 l -20.5903,-59.52472 h -82.7356 l -20.2159,59.52472 h -62.894 z m 58.776,163.9738 -31.0727,-93.9667 -31.8214,93.9667 z" />
-    </g>
+     id="path882"
+     transform="matrix(1,0,0,0.65997639,0,39.655751)">
+    <path
+       style="color:#000000;fill:#ffffff;stroke-width:10;stroke-linecap:round;-inkscape-stroke:none"
+       d="M 14.903416,111.62684 226.07919,16.798541"
+       id="path3484" />
+    <path
+       style="color:#000000;fill:#ffffff;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 227.85547,12.125 a 5,5 0 0 0 -3.82422,0.113281 L 12.855469,107.06641 a 5,5 0 0 0 -2.513672,6.60937 5,5 0 0 0 6.609375,2.51172 L 228.12695,21.359375 A 5,5 0 0 0 230.64062,14.75 5,5 0 0 0 227.85547,12.125 Z"
+       id="path3486" />
+  </g>
+  <g
+     id="g3768"
+     transform="matrix(1,0,0,0.65997639,0,39.655751)">
+    <path
+       style="color:#000000;fill:#ffffff;stroke-width:10;stroke-linecap:round;-inkscape-stroke:none"
+       d="M 14.903416,111.62684 226.07919,16.798541"
+       id="path3764" />
+    <path
+       style="color:#000000;fill:#ffffff;stroke-linecap:round;-inkscape-stroke:none"
+       d="m 227.85547,12.125 a 5,5 0 0 0 -3.82422,0.113281 L 12.855469,107.06641 a 5,5 0 0 0 -2.513672,6.60937 5,5 0 0 0 6.609375,2.51172 L 228.12695,21.359375 A 5,5 0 0 0 230.64062,14.75 5,5 0 0 0 227.85547,12.125 Z"
+       id="path3766" />
   </g>
 </svg>

--- a/html/images/attributes/src/nutriscore-unknown.svg
+++ b/html/images/attributes/src/nutriscore-unknown.svg
@@ -1,184 +1,119 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="240"
    height="130"
-   viewBox="0 0 240 130"
-   id="svg4443"
    version="1.1"
-   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)"
-   sodipodi:docname="nutriscore-unknown.svg">
+   id="svg34"
+   sodipodi:docname="nutriscore-unknown.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs4445" />
+     id="defs38" />
   <sodipodi:namedview
-     id="base"
+     id="namedview36"
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.979899"
-     inkscape:cx="48.428778"
-     inkscape:cy="35.126775"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:window-width="2488"
-     inkscape:window-height="1376"
-     inkscape:window-x="72"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:document-rotation="0" />
-  <metadata
-     id="metadata4448">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+     inkscape:zoom="1.4020833"
+     inkscape:cx="119.46508"
+     inkscape:cy="73.818722"
+     inkscape:window-width="1218"
+     inkscape:window-height="848"
+     inkscape:window-x="524"
+     inkscape:window-y="310"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg34" />
+  <path
+     style="opacity:1;fill:#fff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M-419.315 0H1163.41c99.748 0 180.05 80.302 180.05 180.05v632.48c0 99.748-80.302 180.05-180.05 180.05H-419.315c-99.747 0-180.049-80.302-180.049-180.05V180.05C-599.364 80.301-519.062 0-419.314 0z"
+     id="path2"
+     transform="translate(74.04) scale(.12353)" />
+  <path
+     style="opacity:1;fill:#999999;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M-308.515 357.79h363.03v586.315h-363.03z"
+     transform="translate(74.04) scale(.12353)"
+     id="path4" />
+  <path
+     style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M748.698 357.79h363.03v586.315h-363.03z"
+     transform="translate(74.04) scale(.12353)"
+     id="path6" />
+  <path
+     style="opacity:1;fill:#999999;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M-382.381 357.79h90.647c75.45 0 136.192 60.742 136.192 136.192v313.932c0 75.45-60.742 136.191-136.192 136.191h-90.647c-75.45 0-136.191-60.741-136.191-136.19V493.981c0-75.45 60.74-136.191 136.19-136.191z"
+     transform="translate(74.04) scale(.12353)"
+     id="path8" />
+  <path
+     style="opacity:1;fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M570.957 357.79h363.03v586.315h-363.03z"
+     transform="translate(74.04) scale(.12353)"
+     id="path10" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0;word-spacing:0;fill:#fafafa;fill-opacity:0.63070935;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M659.561 779.804V514.002h99.208q32.945 0 57.653 10.482 24.708 10.483 41.18 28.452 16.847 17.97 25.083 42.304 8.61 23.96 8.61 51.289 0 30.324-9.359 55.032-9.358 24.334-26.954 41.93-17.221 17.22-41.93 26.954-24.333 9.36-54.283 9.36zM828.776 646.53q0-17.596-4.867-31.822-4.492-14.6-13.477-25.082-8.985-10.483-22.088-16.098-13.103-5.616-29.575-5.616h-37.811v157.984h37.811q16.847 0 29.95-5.99 13.103-5.99 21.713-16.472 8.985-10.857 13.477-25.083 4.867-14.6 4.867-31.821z"
+     transform="translate(74.04) scale(.12353)"
+     id="path12" />
+  <path
+     style="opacity:1;fill:#fecb02;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M188.26 357.79h383.32v586.315H188.26z"
+     transform="translate(74.04) scale(.12353)"
+     id="path14" />
+  <path
+     style="opacity:1;fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M206.865 357.79h-363.03v586.315h363.03z"
+     transform="translate(74.04) scale(.12353)"
+     id="path16" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0;word-spacing:0;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 97.16,711.669 c 0,11.48067 -2.370667,21.464 -7.112,29.95 -4.742,8.48533 -11.231,15.59833 -19.467,21.339 -8.236667,5.49067 -17.845667,9.73333 -28.827,12.728 -10.981333,2.74533 -22.586667,4.118 -34.816,4.118 H -122.594 V 514.002 H 25.282 c 9.234667,0 17.595667,1.99667 25.083,5.99 7.486667,3.99333 13.851,9.23433 19.093,15.723 5.240667,6.24 9.234,13.478 11.98,21.714 2.994667,7.98667 4.492,16.22267 4.492,24.708 0,12.72867 -3.244667,24.70867 -9.734,35.94 -6.24,11.23067 -15.724,19.71633 -28.452,25.457 15.224667,4.492 27.204667,12.47867 35.94,23.96 8.984667,11.48 13.477,26.205 13.477,44.175 z M 34.641,699.315 c 0,-8.236 -2.371,-15.22433 -7.113,-20.965 -4.742,-5.74 -10.732,-8.61 -17.97,-8.61 h -70.755 v 58.027 H 6.938 c 7.986667,0 14.600333,-2.62067 19.841,-7.862 5.241333,-5.24133 7.862,-12.10467 7.862,-20.59 z M -61.197,566.414 v 55.032 h 60.273 c 6.7386667,0 12.728667,-2.24633 17.97,-6.739 5.241333,-4.492 7.862,-11.48 7.862,-20.964 0,-8.73533 -2.371333,-15.474 -7.114,-20.216 -4.492,-4.742 -9.9826667,-7.113 -16.472,-7.113 z"
+     transform="matrix(0.12353,0,0,0.12353,74.04,0)"
+     id="path18"
+     sodipodi:nodetypes="ccccsccscccscccccscsccscsccscscsc" />
+  <path
+     style="opacity:1;fill:#0039ff;fill-opacity:.629738;fill-rule:evenodd;stroke:#fff;stroke-width:61.0318;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M360.257 281.616h39.326c108.699 0 196.208 87.509 196.208 196.208v343.94c0 108.7-87.509 196.208-196.208 196.208h-39.326c-108.7 0-196.208-87.509-196.208-196.208v-343.94c0-108.7 87.508-196.208 196.208-196.208z"
+     transform="translate(74.04) scale(.12353)"
+     id="path20" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0;word-spacing:0;fill:#fff;fill-opacity:.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M-364.76 514.002h55.406l96.962 265.802h-62.894l-20.59-59.524h-82.736l-20.216 59.524h-62.894zm58.775 163.974-31.072-93.967-31.822 93.967z"
+     transform="translate(74.04) scale(.12353)"
+     id="path22" />
+  <path
+     style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M1069.556 357.79h90.647c75.45 0 136.192 60.742 136.192 136.192v313.932c0 75.45-60.742 136.191-136.192 136.191h-90.647c-75.45 0-136.192-60.741-136.192-136.19V493.981c0-75.45 60.742-136.191 136.192-136.191z"
+     transform="translate(74.04) scale(.12353)"
+     id="path24" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0;word-spacing:0;fill:#fafafa;fill-opacity:0.63070935;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M1208.285 725.895v53.91h-186.811V514.001h183.441v53.91h-122.044v51.662h104.824v49.791H1082.87v56.53z"
+     transform="translate(74.04) scale(.12353)"
+     id="path26" />
+  <path
+     style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:15.9449;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M360.257 281.616h39.326c108.699 0 196.208 87.509 196.208 196.208v343.94c0 108.7-87.509 196.208-196.208 196.208h-39.326c-108.7 0-196.208-87.509-196.208-196.208v-343.94c0-108.7 87.508-196.208 196.208-196.208z"
+     transform="translate(74.04) scale(.12353)"
+     id="path28" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0;word-spacing:0;fill:#7d7d7d;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M-443.389 163.148v76.826h-31.033V105.623h24.22l62.635 78.907v-78.907h31.033v134.35h-24.978zM-272.94 213.482q7.947 0 13.435-3.217 5.488-3.406 8.894-8.894 3.406-5.487 4.73-12.489 1.514-7.19 1.514-14.57v-68.69h31.033v68.69q0 14.003-3.595 26.113-3.406 12.11-10.786 21.194-7.19 9.082-18.544 14.38-11.165 5.11-26.681 5.11-16.084 0-27.438-5.488-11.354-5.487-18.544-14.57-7.002-9.272-10.408-21.383-3.216-12.11-3.216-25.356v-68.69h31.033v68.69q0 7.758 1.514 14.76 1.513 7.001 4.92 12.489 3.405 5.487 8.704 8.704 5.487 3.217 13.435 3.217zM-87.102 132.871h-40.873v107.103h-31.033V132.87h-41.062v-27.248h112.968zM-71.946 239.974V105.623h60.553q9.461 0 17.409 3.973 8.136 3.974 14.002 10.408 5.866 6.434 9.083 14.57 3.406 8.137 3.406 16.463 0 6.245-1.513 12.11-1.514 5.677-4.353 10.786-2.838 5.11-7.001 9.273-3.974 3.973-9.083 6.812l29.52 49.956H5.068l-25.734-43.333h-20.248v43.333zm31.033-70.393h28.384q5.488 0 9.462-5.109 3.973-5.298 3.973-13.435 0-8.326-4.541-13.246t-9.84-4.92h-27.438zM54.821 239.974V105.623h31.033v134.35zM109.088 201.56v-27.248h58.282v27.249zM271.069 144.982q-.568-.757-3.974-2.839-3.406-2.081-8.515-4.352-5.11-2.27-11.164-3.974-6.056-1.703-12.11-1.703-16.653 0-16.653 11.165 0 3.406 1.703 5.677 1.892 2.27 5.299 4.163 3.595 1.703 8.893 3.216 5.299 1.514 12.3 3.406 9.65 2.65 17.409 5.866 7.758 3.028 13.056 7.759 5.488 4.541 8.326 11.164 3.028 6.623 3.028 15.895 0 11.354-4.352 19.301-4.163 7.759-11.165 12.678-7 4.731-16.084 7.002-9.083 2.081-18.733 2.081-7.38 0-15.138-1.135-7.759-1.135-15.138-3.217-7.38-2.27-14.382-5.298-6.812-3.028-12.678-7.002l13.624-27.059q.757.946 4.92 3.595 4.163 2.65 10.219 5.299 6.244 2.649 13.813 4.73 7.57 2.082 15.327 2.082 16.463 0 16.463-10.03 0-3.784-2.46-6.244t-6.812-4.352q-4.352-2.081-10.407-3.784-5.866-1.703-12.868-3.785-9.272-2.838-16.084-6.055-6.812-3.406-11.354-7.759-4.352-4.352-6.623-10.029-2.081-5.676-2.081-13.245 0-10.597 3.974-18.734 3.973-8.137 10.785-13.624 6.813-5.677 15.706-8.515 9.083-2.839 19.112-2.839 7.002 0 13.814 1.325 6.812 1.324 13.056 3.406 6.245 2.081 11.543 4.73 5.488 2.65 10.03 5.299zM299.119 171.663q0-12.11 4.541-24.032 4.542-12.11 13.246-21.572 8.705-9.461 21.194-15.327 12.488-5.866 28.384-5.866 18.922 0 32.736 8.136 14.003 8.137 20.815 21.194l-23.843 16.652q-2.27-5.299-5.866-8.705-3.406-3.595-7.569-5.676-4.163-2.271-8.515-3.028-4.352-.946-8.515-.946-8.894 0-15.517 3.595-6.623 3.596-10.975 9.272-4.352 5.677-6.434 12.868-2.081 7.19-2.081 14.57 0 7.948 2.46 15.328 2.46 7.38 7.001 13.056 4.73 5.677 11.164 9.083 6.623 3.217 14.76 3.217 4.163 0 8.515-.946 4.542-1.135 8.515-3.217 4.163-2.27 7.57-5.677 3.406-3.595 5.487-8.704l25.356 14.949q-3.027 7.38-9.082 13.246-5.866 5.866-13.625 9.84-7.758 3.973-16.462 6.055-8.705 2.081-17.03 2.081-14.571 0-26.871-5.866-12.11-6.055-21.004-15.895-8.705-9.84-13.624-22.328-4.731-12.49-4.731-25.357zM494.342 241.109q-14.95 0-27.249-5.866-12.3-5.866-21.004-15.327-8.705-9.651-13.624-21.95-4.731-12.3-4.731-25.357 0-13.246 4.92-25.546 5.109-12.3 14.003-21.572 9.082-9.46 21.382-14.948 12.3-5.677 26.87-5.677 14.95 0 27.249 5.866 12.3 5.866 21.004 15.516 8.705 9.65 13.435 21.95 4.73 12.3 4.73 24.979 0 13.245-5.108 25.545-4.92 12.3-13.814 21.761-8.893 9.272-21.193 14.95-12.3 5.676-26.87 5.676zm-35.007-68.122q0 7.759 2.27 15.138 2.271 7.191 6.623 12.868 4.542 5.677 11.165 9.083 6.623 3.406 15.138 3.406 8.894 0 15.516-3.596 6.623-3.595 10.976-9.272 4.352-5.866 6.433-13.056 2.271-7.38 2.271-14.95 0-7.757-2.27-14.948-2.271-7.38-6.813-12.867-4.541-5.677-11.164-8.894-6.434-3.406-14.95-3.406-8.893 0-15.516 3.595-6.433 3.406-10.975 9.083-4.352 5.677-6.623 13.057-2.081 7.19-2.081 14.76zM579.26 239.974V105.623h60.553q9.461 0 17.409 3.973 8.136 3.974 14.002 10.408 5.866 6.434 9.083 14.57 3.406 8.137 3.406 16.463 0 6.245-1.514 12.11-1.513 5.677-4.352 10.786-2.838 5.11-7.001 9.273-3.974 3.973-9.083 6.812l29.52 49.956h-35.008l-25.734-43.333h-20.248v43.333zm31.033-70.393h28.384q5.488 0 9.462-5.109 3.973-5.298 3.973-13.435 0-8.326-4.541-13.246t-9.84-4.92h-27.438zM800.451 212.725v27.249h-94.424V105.623h92.721v27.248H737.06v26.114h52.984v25.167H737.06v28.573z"
+     transform="translate(74.04) scale(.12353)"
+     id="path32" />
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1">
-    <g
-       id="g3904"
-       transform="matrix(0.12353162,0,0,0.1235316,74.040403,2.2774296e-7)">
-      <path
-         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M -419.31455,2.5984161e-7 H 1163.4092 C 1263.157,2.5984161e-7 1343.4585,80.302045 1343.4585,180.04942 v 632.48114 c 0,99.7474 -80.3015,180.04944 -180.0493,180.04944 H -419.31455 c -99.7474,0 -180.04943,-80.30204 -180.04943,-180.04944 V 180.04942 C -599.36398,80.302045 -519.06195,2.5984161e-7 -419.31455,2.5984161e-7 Z"
-         id="rect5139"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 748.69832,357.79054 h 363.02978 v 586.3148 H 748.69832 Z"
-         id="rect5141"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M -308.51489,357.79054 H 54.515101 v 586.3148 H -308.51489 Z"
-         id="rect5143"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 1069.5561,357.79054 h 90.647 c 75.4498,0 136.1917,60.74128 136.1917,136.19122 v 313.93237 c 0,75.44988 -60.7419,136.19121 -136.1917,136.19121 h -90.647 c -75.44992,0 -136.19182,-60.74133 -136.19182,-136.19121 V 493.98176 c 0,-75.44994 60.7419,-136.19122 136.19182,-136.19122 z"
-         id="rect5151"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5631"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 1188.7073,725.89511 v 53.90913 H 1001.8965 V 514.00202 h 183.441 v 53.90923 h -122.0443 v 51.66293 h 104.8239 v 49.79119 h -104.8239 v 56.52974 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5608"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -443.3889,163.1475 v 76.82604 h -31.03322 V 105.62258 h 24.22101 l 62.6341,78.90753 v -78.90753 h 31.03312 v 134.35096 h -24.97787 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5610"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -272.94005,213.48179 q 7.94754,0 13.43512,-3.21684 5.48759,-3.40608 8.89369,-8.89366 3.4061,-5.48757 4.73063,-12.48896 1.51381,-7.19062 1.51381,-14.57046 v -68.68929 h 31.03322 v 68.68929 q 0,14.00278 -3.5953,26.11329 -3.4061,12.11051 -10.78597,21.19339 -7.19059,9.08287 -18.54424,14.38123 -11.16435,5.10912 -26.68096,5.10912 -16.08428,0 -27.43783,-5.48758 -11.35364,-5.48757 -18.54423,-14.57045 -7.0014,-9.27211 -10.4075,-21.38262 -3.21682,-12.11051 -3.21682,-25.35638 v -68.68929 h 31.03322 v 68.68929 q 0,7.7583 1.51381,14.75969 1.51381,7.00139 4.91982,12.48896 3.4061,5.48757 8.7045,8.70443 5.48758,3.21684 13.43503,3.21684 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5612"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -87.101641,132.87122 h -40.872949 v 107.10232 h -31.03322 V 132.87122 h -41.06214 v -27.24864 h 112.968309 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5614"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M -71.945716,239.97354 V 105.62258 h 60.552519 q 9.4613553,0 17.4088021,3.97376 8.1368279,3.97376 14.0027939,10.40747 5.866061,6.43371 9.082878,14.57045 3.406103,8.13675 3.406103,16.46273 0,6.24448 -1.513813,12.11051 -1.513813,5.67679 -4.352248,10.78592 -2.83834,5.10911 -7.001397,9.27211 -3.973676,3.97376 -9.082878,6.81215 l 29.519401,49.95586 H 5.0695552 L -20.665361,196.64062 h -20.247236 v 43.33292 z m 31.033119,-70.39234 h 28.384064 q 5.4874893,0 9.4612602,-5.10912 3.97377096,-5.29834 3.97377096,-13.43509 0,-8.32598 -4.54143896,-13.24587 -4.5414389,-4.9199 -9.8397372,-4.9199 h -27.437919 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5616"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 54.821346,239.97354 V 105.62258 H 85.85456 v 134.35096 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5618"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 109.08803,201.56052 v -27.24865 h 58.28175 v 27.24865 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5620"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 271.06906,144.98173 q -0.56814,-0.75695 -3.97377,-2.8384 -3.40611,-2.08149 -8.51521,-4.35221 -5.10911,-2.27072 -11.16436,-3.97376 -6.05525,-1.70305 -12.1105,-1.70305 -16.65195,0 -16.65195,11.16438 0,3.40609 1.70301,5.6768 1.89229,2.27072 5.29839,4.16299 3.59529,1.70304 8.89359,3.21685 5.29839,1.51381 12.29979,3.40608 9.65055,2.64918 17.4088,5.86604 7.75835,3.02762 13.05665,7.75829 5.48759,4.54144 8.32602,11.16437 3.02763,6.62294 3.02763,15.89505 0,11.3536 -4.35225,19.30112 -4.16296,7.7583 -11.16436,12.67819 -7.0014,4.73066 -16.08427,7.00138 -9.08288,2.0815 -18.73343,2.0815 -7.37987,0 -15.13813,-1.13536 -7.75835,-1.13536 -15.13813,-3.21686 -7.37987,-2.27072 -14.38127,-5.29834 -6.81211,-3.02763 -12.67817,-7.00139 l 13.62432,-27.05942 q 0.75657,0.94614 4.91991,3.59531 4.16296,2.64918 10.21822,5.29835 6.24444,2.64917 13.8135,4.73066 7.56907,2.08149 15.32742,2.08149 16.46275,0 16.46275,-10.02901 0,-3.78453 -2.45996,-6.24448 -2.45995,-2.45995 -6.8122,-4.35221 -4.35216,-2.0815 -10.4075,-3.78453 -5.86597,-1.70304 -12.86737,-3.78454 -9.27206,-2.8384 -16.08427,-6.05526 -6.81221,-3.40608 -11.35365,-7.75829 -4.35215,-4.35221 -6.62291,-10.02901 -2.08149,-5.67681 -2.08149,-13.24587 0,-10.5967 3.97378,-18.73344 3.97377,-8.13676 10.78588,-13.62433 6.8122,-5.6768 15.70589,-8.5152 9.08288,-2.8384 19.1119,-2.8384 7.0014,0 13.81351,1.32459 6.8122,1.32458 13.05665,3.40607 6.24444,2.0815 11.54283,4.73067 5.48759,2.64918 10.02903,5.29835 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5622"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 299.1189,171.6627 q 0,-12.11051 4.54144,-24.0318 4.54144,-12.1105 13.24593,-21.57184 8.7044,-9.46133 21.19338,-15.32736 12.48889,-5.86603 28.38397,-5.86603 18.92271,0 32.73622,8.13675 14.0028,8.13674 20.81491,21.19339 l -23.84253,16.65195 q -2.27068,-5.29835 -5.86607,-8.70443 -3.406,-3.59531 -7.56906,-5.6768 -4.16296,-2.27072 -8.51521,-3.02762 -4.35215,-0.94615 -8.51512,-0.94615 -8.89368,0 -15.5166,3.59531 -6.62292,3.59531 -10.97517,9.2721 -4.35225,5.67681 -6.43373,12.86742 -2.08148,7.19062 -2.08148,14.57045 0,7.94753 2.45996,15.32737 2.45996,7.37984 7.0014,13.05664 4.73063,5.67681 11.16435,9.08289 6.62292,3.21684 14.75966,3.21684 4.16305,0 8.51521,-0.94614 4.54144,-1.13536 8.51521,-3.21686 4.16296,-2.27071 7.56906,-5.6768 3.4061,-3.5953 5.48759,-8.70443 l 25.35634,14.94891 q -3.02763,7.37985 -9.08288,13.24587 -5.86596,5.86603 -13.62432,9.83979 -7.75825,3.97376 -16.46265,6.05526 -8.7045,2.08149 -17.03042,2.08149 -14.57046,0 -26.87025,-5.86603 -12.11051,-6.05526 -21.0041,-15.89504 -8.7045,-9.83979 -13.62432,-22.32876 -4.73072,-12.48896 -4.73072,-25.35637 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5624"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 494.34177,241.1089 q -14.94894,0 -27.24873,-5.86603 -12.29969,-5.86603 -21.00409,-15.32737 -8.7045,-9.65055 -13.62432,-21.95029 -4.73073,-12.29974 -4.73073,-25.35638 0,-13.24587 4.91992,-25.54561 5.10911,-12.29973 14.00279,-21.57184 9.08288,-9.46133 21.38258,-14.94891 12.29979,-5.6768 26.87025,-5.6768 14.94884,0 27.24863,5.86603 12.2997,5.86603 21.0041,15.51659 8.70449,9.65056 13.43512,21.9503 4.73073,12.29973 4.73073,24.97792 0,13.24587 -5.1092,25.5456 -4.91983,12.29975 -13.81351,21.76108 -8.89369,9.27211 -21.19338,14.9489 -12.29979,5.67681 -26.87016,5.67681 z m -35.00699,-68.12162 q 0,7.7583 2.27068,15.13814 2.27076,7.19062 6.62301,12.86741 4.54144,5.67681 11.16436,9.08289 6.62292,3.40607 15.13813,3.40607 8.89369,0 15.51661,-3.5953 6.62292,-3.5953 10.97516,-9.27211 4.35216,-5.86603 6.43364,-13.05664 2.27077,-7.37984 2.27077,-14.94891 0,-7.7583 -2.27077,-14.94891 -2.27067,-7.37984 -6.81211,-12.86742 -4.54144,-5.6768 -11.16436,-8.89365 -6.43373,-3.40608 -14.94894,-3.40608 -8.89369,0 -15.51661,3.59531 -6.43373,3.40608 -10.97516,9.08288 -4.35216,5.6768 -6.62292,13.05664 -2.08149,7.19062 -2.08149,14.75968 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5626"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 579.26023,239.97354 V 105.62258 h 60.55252 q 9.46136,0 17.4089,3.97376 8.13673,3.97376 14.00279,10.40747 5.86597,6.43371 9.08288,14.57045 3.40601,8.13675 3.40601,16.46273 0,6.24448 -1.51381,12.11051 -1.51382,5.67679 -4.35216,10.78592 -2.83843,5.10911 -7.00139,9.27211 -3.97377,3.97376 -9.08288,6.81215 l 29.5193,49.95586 h -35.00688 l -25.73483,-43.33292 h -20.24733 v 43.33292 z m 31.03312,-70.39234 h 28.38407 q 5.48758,0 9.46135,-5.10912 3.97377,-5.29834 3.97377,-13.43509 0,-8.32598 -4.54144,-13.24587 -4.54143,-4.9199 -9.83983,-4.9199 h -27.43792 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5628"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 800.45146,212.72489 v 27.24865 H 706.0273 V 105.62258 h 92.72107 v 27.24864 h -61.68786 v 26.11329 h 52.98345 v 25.16715 h -52.98345 v 28.57323 z" />
-      <path
-         style="opacity:1;fill:#ee8100;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m -143.28231,357.79054 h 363.03009 v 586.3148 h -363.03009 z"
-         id="rect5209"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 570.95706,357.79054 h 363.02961 v 586.3148 H 570.95706 Z"
-         id="rect5211"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5552"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 636.60488,779.80424 V 514.00202 h 99.2079 q 32.94454,0 57.65289,10.4824 24.70836,10.4823 41.18063,28.45201 16.84627,17.96981 25.08293,42.30378 8.61066,23.95958 8.61066,51.28863 0,30.32384 -9.35962,55.0323 -9.35962,24.33397 -26.95457,41.92929 -17.22094,17.22104 -41.92939,26.95467 -24.33397,9.35914 -54.28353,9.35914 z M 805.8199,646.52884 q 0,-17.59542 -4.86681,-31.82148 -4.49243,-14.60034 -13.47729,-25.08274 -8.98485,-10.4823 -22.08785,-16.09788 -13.1029,-5.61549 -29.57517,-5.61549 h -37.81125 v 157.98386 h 37.81125 q 16.84666,0 29.94956,-5.98988 13.1029,-5.98997 21.71346,-16.47227 8.98486,-10.85678 13.47729,-25.08274 4.86681,-14.60043 4.86681,-31.82138 z" />
-      <path
-         style="opacity:1;fill:#e6e6e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 188.25939,357.79054 H 571.5803 v 586.3148 H 188.25939 Z"
-         id="rect5217"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 206.86519,357.79054 H -156.1649 v 586.3148 h 363.03009 z"
-         id="rect5219"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5547"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 258.81114,642.4108 q 0,-23.95959 8.98486,-47.54488 8.98495,-23.95968 26.20589,-42.67817 17.22104,-18.71838 41.9294,-30.32384 24.70835,-11.60545 56.15535,-11.60545 37.43696,0 64.76592,16.09788 27.70334,16.09788 41.18062,41.9293 l -47.17049,32.94454 q -4.49243,-10.48231 -11.60546,-17.22095 -6.73864,-7.11302 -14.97482,-11.23116 -8.23609,-4.49243 -16.84656,-5.98988 -8.61057,-1.87183 -16.84666,-1.87183 -17.59532,0 -30.69832,7.11303 -13.1029,7.11303 -21.71337,18.3441 -8.61047,11.23107 -12.72861,25.45712 -4.11804,14.22596 -4.11804,28.8264 0,15.7235 4.86681,30.32394 4.86681,14.60034 13.85167,25.83151 9.35924,11.23107 22.08776,17.96971 13.10299,6.36426 29.20087,6.36426 8.23609,0 16.84656,-1.87183 8.98486,-2.24621 16.84666,-6.36426 8.23608,-4.49242 14.97472,-11.23116 6.73865,-7.11293 10.85679,-17.22094 l 50.16548,29.57516 q -5.98997,14.60044 -17.96972,26.2059 -11.60545,11.60545 -26.95466,19.46716 -15.34912,7.86179 -32.57006,11.97984 -17.22104,4.11804 -33.69331,4.11804 -28.82639,0 -53.16046,-11.60546 -23.95958,-11.97984 -41.55491,-31.44699 -17.22104,-19.46726 -26.95467,-44.17561 -9.35924,-24.70836 -9.35924,-50.16548 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5544"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 154.55238,711.66905 q 0,17.22104 -7.11303,29.94955 -7.11303,12.72861 -19.46725,21.33909 -12.35413,8.23608 -28.826401,12.72851 -16.472268,4.11804 -34.816366,4.11804 H -65.202505 V 514.00202 H 82.673431 q 13.851669,0 25.082739,5.98997 11.23107,5.98987 19.09287,15.7235 7.8617,9.35924 11.97984,21.71337 4.49243,11.97984 4.49243,24.70845 0,19.09277 -9.73363,35.93942 -9.35924,16.84666 -28.45211,25.45713 22.83653,6.73864 35.93952,23.95958 13.47729,17.22104 13.47729,44.17561 z M 92.032672,699.31492 q 0,-12.35422 -7.113027,-20.9647 -7.113027,-8.61056 -17.969713,-8.61056 H -3.8058597 v 58.02727 H 64.329333 q 11.97984,0 19.841542,-7.8617 7.861797,-7.86179 7.861797,-20.59031 z M -3.8058597,566.41371 v 55.0323 H 56.467536 q 10.108011,0 17.969808,-6.73865 7.861702,-6.73864 7.861702,-20.9646 0,-13.10299 -7.113027,-20.21602 -6.738643,-7.11303 -16.472269,-7.11303 z" />
-      <path
-         style="fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m -383.0037,357.79054 h 90.6476 c 75.4498,0 136.1912,60.74122 136.1912,136.1912 V 807.9141 c 0,75.44987 -60.7414,136.1912 -136.1912,136.1912 h -90.6476 c -75.45,0 -136.1912,-60.74133 -136.1912,-136.1912 V 493.98174 c 0,-75.44998 60.7412,-136.1912 136.1912,-136.1912 z"
-         id="rect5243"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5519"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:medium;line-height:90%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:0.446064;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -385.3348,514.00191 h 55.4067 l 96.9616,265.8023 h -62.8941 l -20.5903,-59.52472 h -82.7356 l -20.2159,59.52472 h -62.894 z m 58.776,163.9738 -31.0727,-93.9667 -31.8214,93.9667 z" />
-    </g>
+     aria-label="?"
+     id="text1990"
+     style="font-size:62.9588px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';fill:#ffffff;stroke-width:1.57397">
+    <path
+       d="m 116.00453,91.040926 c 0,-2.056654 0.33578,-3.903445 1.00734,-5.540374 0.67156,-1.636929 2.00692,-3.154105 4.15529,-4.281199 3.88247,-2.036857 5.52554,-4.646645 5.56509,-8.499438 0,-0.881423 -0.16789,-1.657915 -0.50367,-2.329475 -0.33578,-0.671561 -0.77649,-1.23819 -1.32214,-1.699888 -0.54564,-0.461698 -1.19621,-0.797478 -1.95172,-1.007341 -0.71353,-0.251835 -1.44805,-0.377753 -2.20356,-0.377753 -0.92339,0 -1.76284,0.16789 -2.51835,0.503671 -0.75551,0.293807 -1.44805,0.692546 -2.07764,1.196217 -0.58761,0.461698 -1.13326,1.007341 -1.63693,1.636929 -0.46169,0.587615 -0.86043,1.154244 -1.19622,1.699887 l -5.47741,-3.777528 c 0.54564,-1.301148 1.25917,-2.455393 2.1406,-3.462734 0.92339,-1.007341 1.95172,-1.846791 3.08498,-2.518352 1.17523,-0.713533 2.43441,-1.238189 3.77753,-1.57397 1.34312,-0.377753 2.72821,-0.566629 4.15528,-0.566629 1.59495,0 3.16892,0.230849 4.72191,0.692547 1.55298,0.461698 2.93807,1.196217 4.15528,2.203558 1.25917,1.007341 2.26651,2.308489 3.02202,3.903446 0.79748,1.552983 1.19622,3.420761 1.19622,5.603333 0,1.343121 -0.16789,2.539339 -0.50367,3.588652 -0.29381,1.007341 -0.74666,1.922368 -1.32214,2.770187 -2.07584,3.058202 -4.37644,5.086669 -7.01314,7.240262 -0.67016,0.547369 -1.23819,1.196217 -1.69989,1.951723 -0.41973,0.713533 -0.62959,1.594956 -0.62959,2.644269 z m 0.12592,14.669404 v -8.688317 h 6.98843 v 8.688317 z"
+       style="font-weight:bold;font-family:Raleway;-inkscape-font-specification:'Raleway Bold'"
+       id="path30144"
+       sodipodi:nodetypes="csscsscsccccccccssccscsscccccccc" />
   </g>
 </svg>

--- a/html/images/attributes/src/nutriscore-unknown.svg
+++ b/html/images/attributes/src/nutriscore-unknown.svg
@@ -22,12 +22,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="1.4020833"
-     inkscape:cx="119.46508"
-     inkscape:cy="73.818722"
-     inkscape:window-width="1218"
-     inkscape:window-height="848"
-     inkscape:window-x="524"
-     inkscape:window-y="310"
+     inkscape:cx="119.82169"
+     inkscape:cy="74.175334"
+     inkscape:window-width="1157"
+     inkscape:window-height="445"
+     inkscape:window-x="698"
+     inkscape:window-y="829"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg34" />
   <path

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -459,6 +459,7 @@ sub compute_attribute_nutriscore($$) {
 	
 	my $attribute_ref = initialize_attribute($attribute_id, $target_lc);
 	
+	# Nutri-Score A, B, C, D or E
 	if (defined $product_ref->{nutriscore_data}) {
 		$attribute_ref->{status} = "known";
 		
@@ -537,6 +538,20 @@ sub compute_attribute_nutriscore($$) {
 		}
 		$attribute_ref->{icon_url} = "$static_subdomain/images/attributes/nutriscore-$grade.svg";
 	}
+	
+	# Nutri-Score not-applicable: alcoholic beverages, baby food etc.
+	elsif (has_tag($product_ref,"misc","en:nutriscore-not-applicable")) {
+		$attribute_ref->{status} = "known";
+		$attribute_ref->{icon_url} = "$static_subdomain/images/attributes/nutriscore-not-applicable.svg";
+		$attribute_ref->{match} = 0;
+		if ($target_lc ne "data") {
+			$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_title");		
+			$attribute_ref->{description} = lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_description");
+			$attribute_ref->{description_short} = lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_description_short");		
+		}		
+	}
+
+	# Nutri-Score not computed: missing data
 	else {
 		$attribute_ref->{status} = "unknown";
 		$attribute_ref->{icon_url} = "$static_subdomain/images/attributes/nutriscore-unknown.svg";

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -2141,7 +2141,7 @@ sub display_list_of_tags($$) {
 					else {
 						$grade = lang("unknown");
 					}
-					$display = "<img src=\"/images/icons/ecoscore-$tagid.svg\" alt=\"$Lang{ecoscore}{$lc} " . $grade . "\" title=\"$Lang{ecoscore}{$lc} " . $grade . "\" style=\"max-height:80px;\">" ;
+					$display = "<img src=\"/images/attributes/ecoscore-$tagid.svg\" alt=\"$Lang{ecoscore}{$lc} " . $grade . "\" title=\"$Lang{ecoscore}{$lc} " . $grade . "\" style=\"max-height:80px;\">" ;
 				}
 				else {
 					$display = lang("not_applicable");
@@ -2303,24 +2303,24 @@ HTML
 			my $x_title = lang($request_ref->{groupby_tagtype} . "_p");
 
 			if ($request_ref->{groupby_tagtype} eq 'nutrition_grades') {
-				$categories = "'A','B','C','D','E','" . lang("unknown") . "'";
-				$colors = "'#038141','#85bb2f','#fecb02','#ee8100','#e63e11','#a0a0a0'";
+				$categories = "'A','B','C','D','E','" . lang("not_applicable") . "','" . lang("unknown") . "'";
+				$colors = "'#1E8F4E','#60AC0E','#EEAE0E','#FF6F1E','#DF1F1F','#a0a0a0','#a0a0a0'";
 				$series_data = '';
-				foreach my $nutrition_grade ('a','b','c','d','e','unknown') {
+				foreach my $nutrition_grade ('a','b','c','d','e','not-applicable','unknown') {
 					$series_data .= ($products{$nutrition_grade} + 0) . ',';
 				}
 			}
 			elsif ($request_ref->{groupby_tagtype} eq 'ecoscore') {
-				$categories = "'A','B','C','D','E','" . lang("unknown") . "'";
-				$colors = "'#1E8F4E','#60AC0E','#EEAE0E','#FF6F1E','#DF1F1F','#a0a0a0'";
+				$categories = "'A','B','C','D','E','" . lang("not_applicable") . "','" . lang("unknown") . "'";
+				$colors = "'#1E8F4E','#60AC0E','#EEAE0E','#FF6F1E','#DF1F1F','#a0a0a0','#a0a0a0'";
 				$series_data = '';
-				foreach my $ecoscore_grade ('a','b','c','d','e','unknown') {
+				foreach my $ecoscore_grade ('a','b','c','d','e','not-applicable', 'unknown') {
 					$series_data .= ($products{$ecoscore_grade} + 0) . ',';
 				}
 			}
 			elsif ($request_ref->{groupby_tagtype} eq 'nova_groups') {
 				$categories = "'NOVA 1','NOVA 2','NOVA 3','NOVA 4','" . lang("unknown") . "'";
-				$colors = "'#00ff00','#ffff00','#ff6600','#ff0000','#808080'";
+				$colors = "'#00ff00','#ffff00','#ff6600','#ff0000','#a0a0a0'";
 				$series_data = '';
 				foreach my $nova_group (
 					"en:1-unprocessed-or-minimally-processed-foods",

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -2120,19 +2120,17 @@ sub display_list_of_tags($$) {
 			my $display = '';
 			my @sameAs = ();
 			if ($tagtype eq 'nutrition_grades') {
-				if ($tagid ne "not-applicable") {
-					my $grade;
-					if ($tagid =~ /^[abcde]$/) {
-						$grade = uc($tagid);
-					}
-					else {
-						$grade = lang("unknown");
-					}
-					$display = "<img src=\"/images/misc/nutriscore-$tagid.svg\" alt=\"$Lang{nutrition_grade_fr_alt}{$lc} " .$grade . "\" title=\"$Lang{nutrition_grade_fr_alt}{$lc} " .$grade . "\" style=\"max-height:80px;\">" ;
+				my $grade;
+				if ($tagid =~ /^[abcde]$/) {
+					$grade = uc($tagid);
+				}
+				elsif ($tagid eq "not-applicable") {
+					$grade = lang("not_applicable");
 				}
 				else {
-					$display = lang("not_applicable");
+					$grade = lang("unknown");
 				}
+				$display = "<img src=\"/images/attributes/nutriscore-$tagid.svg\" alt=\"$Lang{nutrition_grade_fr_alt}{$lc} " .$grade . "\" title=\"$Lang{nutrition_grade_fr_alt}{$lc} " . $grade . "\" style=\"max-height:80px;\">" ;
 			}
 			elsif ($tagtype eq 'ecoscore') {
 				if ($tagid ne "not-applicable") {
@@ -9040,15 +9038,17 @@ sub data_to_display_nutriscore_and_nutrient_levels($) {
 	# The Nutri-Score is unknown
 	else  {
 
-		$result_data_ref->{nutriscore_grade} = "unknown";
-
 		# Category without Nutri-Score: baby food, alcoholic beverages etc.
 		if (has_tag($product_ref,"misc","en:nutriscore-not-applicable")) {
 				push @nutriscore_warnings, lang("nutriscore_not_applicable");
+				$result_data_ref->{nutriscore_grade} = "not-applicable";
 				$result_data_ref->{nutriscore_unknown_reason} = "not_applicable";
 				$result_data_ref->{nutriscore_unknown_reason_short} = lang("nutriscore_not_applicable_short");
 		}		
 		else {
+
+			$result_data_ref->{nutriscore_grade} = "unknown";
+
 			# Missing category?
 			if (has_tag($product_ref,"misc","en:nutriscore-missing-category")) {
 				push @nutriscore_warnings, lang("nutriscore_missing_category");

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -668,6 +668,7 @@ sub create_nutriscore_panel($$$) {
 	
     my $panel_data_ref = data_to_display_nutriscore_and_nutrient_levels($product_ref);
 
+    # Do not display the Nutri-Score panel if it is not applicable
     if ((not $panel_data_ref->{do_not_display})
         and (not $panel_data_ref->{nutriscore_grade} eq "not-applicable")) {
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4600,12 +4600,20 @@ msgid "Nutri-Score %s"
 msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
-msgid "Nutri-Score not computed"
-msgstr "Nutri-Score not computed"
+msgid "Nutri-Score unknown"
+msgstr "Nutri-Score unknown"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
-msgid "Unknown nutritional quality"
-msgstr "Unknown nutritional quality"
+msgid "Missing data to compute the Nutri-Score"
+msgstr "Missing data to compute the Nutri-Score"
+
+msgctxt "attribute_nutriscore_not_applicable_title"
+msgid "Nutri-Score not-applicable"
+msgstr "Nutri-Score not-applicable"
+
+msgctxt "attribute_nutriscore_not_applicable_description_short"
+msgid "Exempted category"
+msgstr "Exempted category"
 
 msgctxt "attribute_nutriscore_a_description_short"
 msgid "Very good nutritional quality"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4622,12 +4622,20 @@ msgid "Nutri-Score %s"
 msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
-msgid "Nutri-Score not computed"
-msgstr "Nutri-Score not computed"
+msgid "Nutri-Score unknown"
+msgstr "Nutri-Score unknown"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
-msgid "Unknown nutritional quality"
-msgstr "Unknown nutritional quality"
+msgid "Missing data to compute the Nutri-Score"
+msgstr "Missing data to compute the Nutri-Score"
+
+msgctxt "attribute_nutriscore_not_applicable_title"
+msgid "Nutri-Score not-applicable"
+msgstr "Nutri-Score not-applicable"
+
+msgctxt "attribute_nutriscore_not_applicable_description_short"
+msgid "Exempted category"
+msgstr "Exempted category"
 
 msgctxt "attribute_nutriscore_a_description_short"
 msgid "Very good nutritional quality"

--- a/t/expected_test_results/attributes/en-maybe-vegan.json
+++ b/t/expected_test_results/attributes/en-maybe-vegan.json
@@ -15,14 +15,14 @@
          "attributes" : [
             {
                "description" : "",
-               "description_short" : "Unknown nutritional quality",
+               "description_short" : "Missing data to compute the Nutri-Score",
                "grade" : "unknown",
                "icon_url" : "https://server_domain/images/attributes/nutriscore-unknown.svg",
                "id" : "nutriscore",
                "match" : 0,
                "name" : "Nutri-Score",
                "status" : "unknown",
-               "title" : "Nutri-Score not computed"
+               "title" : "Nutri-Score unknown"
             },
             {
                "grade" : "unknown",

--- a/templates/web/pages/product/includes/nutriscore.tt.html
+++ b/templates/web/pages/product/includes/nutriscore.tt.html
@@ -7,7 +7,7 @@
 
 [% IF nutriscore_grade.defined %]
 <a href="/nutriscore" title="[% lang('nutrition_grade_fr_formula') %]">
-    <img src="[% static_subdomain %]/images/misc/nutriscore-[% nutriscore_grade %].svg" alt="[% lang('nutrition_grade_fr_alt}') %] [% nutriscore_grade | ucfirst %]" style="margin-bottom:1rem;max-width:100%">
+    <img src="[% static_subdomain %]/images/attributes/nutriscore-[% nutriscore_grade %].svg" alt="[% lang('nutrition_grade_fr_alt}') %] [% nutriscore_grade | ucfirst %]" style="margin-bottom:1rem;max-width:100%">
 </a>
 <br>
 [% END %]


### PR DESCRIPTION
Differentiate between Nutri-Score computed because we miss some data (category or nutrition facts) and Nutri-Score not applicable for a category.

Fixes #6276

![image](https://user-images.githubusercontent.com/8158668/148995642-4253f595-b51d-418c-8376-a32370a6d34c.png)


![image](https://user-images.githubusercontent.com/8158668/148995535-b0bd185d-6642-46a7-ae53-1b9aca0a3892.png)
