### PR TITLE
Use Smoothie colors and styles on the web for attributes and panels

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -261,30 +261,16 @@ function display_product_summary(target, product) {
 	$.each(product.match_attributes.mandatory.concat(product.match_attributes.very_important, product.match_attributes.important), function (key, attribute) {
 		
 		// vary the color from green to red
-		var color = "#eee";
+		var grade ="unknown";
 		
 		if (attribute.status == "known") {
-			if (attribute.grade == "e") {
-				color = "hsl(0, 100%, 90%)";
-			}
-			else if (attribute.grade == "d") {
-				color = "hsl(30, 100%, 90%)";
-			}
-			else if (attribute.grade == "c") {
-				color = "hsl(60, 100%, 90%)";
-			}
-			else if (attribute.grade == "b") {
-				color = "hsl(90, 100%, 90%)";
-			}
-			else {
-				color = "hsl(120, 100%, 90%)";
-			}
+			grade = attribute.grade;
 		}
 
 		attributes_html += '<li>'
-		+ '<div style="border-radius:12px;background-color:' + color + ';padding:1rem;min-height:96px;">'
+		+ '<div class="attribute_card grade_' + grade + '">'
 		+ '<img src="' + attribute.icon_url + '" style="height:72px;float:right;margin-left:0.5rem;">'
-		+ '<h4>' + attribute.title + '</h4>';
+		+ '<h4 class="grade_' + grade + '_title">' + attribute.title + '</h4>';
 		
 		if (attribute.description_short) {
 			attributes_html += '<span>' + attribute.description_short + '</span>';

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -547,7 +547,7 @@ html[dir="rtl"] {
 // List of products with cards (e.g. search results, facets)
 
 .list_product_a {
-  border-radius:12px;
+  border-radius:8px;
   padding:10px;
   display:block;
   background-color:#eee;
@@ -680,29 +680,39 @@ html[dir="rtl"] {
 // Filters generated from https://codepen.io/sosuke/pen/Pjoqqp
 
 .filter-green {
-  filter: invert(24%) sepia(99%) saturate(1754%) hue-rotate(99deg) brightness(94%) contrast(106%);
+  filter: invert(43%) sepia(100%) saturate(320%) hue-rotate(93deg) brightness(89%) contrast(97%);
 }
 
 .filter-red {
-  filter: invert(36%) sepia(93%) saturate(6688%) hue-rotate(352deg) brightness(94%) contrast(129%);
+  // loss: 4.0, close enough
+  filter: invert(43%) sepia(45%) saturate(992%) hue-rotate(314deg) brightness(99%) contrast(89%);
 }
 
 .filter-orange {
-  filter: invert(64%) sepia(38%) saturate(2742%) hue-rotate(0deg) brightness(105%) contrast(105%);
+  filter: invert(83%) sepia(20%) saturate(6233%) hue-rotate(327deg) brightness(101%) contrast(90%);
 }
 
 .filter-darkorange {
-  filter: invert(66%) sepia(91%) saturate(3673%) hue-rotate(1deg) brightness(105%) contrast(104%);
+  filter: invert(47%) sepia(24%) saturate(4013%) hue-rotate(4deg) brightness(98%) contrast(86%);
 }
 
 .filter-grey {
-  filter: invert(52%) sepia(0%) saturate(1186%) hue-rotate(218deg) brightness(96%) contrast(84%);
+  filter: invert(30%) sepia(0%) saturate(0%) hue-rotate(29deg) brightness(97%) contrast(89%);
 }
 
 /* Accessibility: Adding focus styles on the outer-box of the fake checkbox used for the Foundation switch to classify products according to one's preferences */
 .switch input[type="checkbox"]:focus + label::after {
     outline: rgb(59, 153, 252) auto 5px;
 }
+
+// Attributes cards in summary
+
+.attribute_card {
+  border-radius:8px;
+  padding:1rem;min-height:96px;
+}
+
+// Knowledge panels
 
 // We need a large padding inside panel content so that we can see
 // the hierarchy of panels that contain other panels
@@ -721,52 +731,96 @@ html[dir="rtl"] {
 // as we use them only for knowledge panel, with only 1 openable element
 // per accordion
 .accordion .accordion-navigation>a, .accordion dd>a {
-  background:#fafafa;
+  background:#ffffff;
+  border-radius:8px;
 }
 .accordion .accordion-navigation.active>a, .accordion dd.active>a  {
-  background:#fafafa;
+  background:#ffffff;
 }
 .accordion .accordion-navigation>a:hover, .accordion dd>a:hover {
   background:#f0f0f0;
+  text-decoration:none;
 }
 
 // background colors for attributes and panels
-.grade_unknown {
-  background-color:#efefef !important;
+
+.evaluation_good_title {
+  color:rgba(33,150,83,1);
 }
+
+.evaluation_average_title {
+  color:rgba(222,153,74,1);
+}
+
+.evaluation_bad_title {
+  color:rgba(235,87,87,1);
+}
+
+.evaluation_unknown_title {
+  color:rgba(79,79,79,1);
+}
+
+.evaluation_neutral_title {
+  color:rgba(79,79,79,1);
+}
+
+.grade_unknown {
+  background-color:rgba(79,79,79,0.1) !important;
+}
+a.grade_unknown:hover {
+  background-color:rgba(79,79,79,0.2) !important;
+}
+.grade_unknown_tile {
+  color:rgba(79,79,79,1);
+}
+
 .grade_a {
-  background-color:hsl(120, 100%, 90%) !important;
+  background-color:rgba(33,150,83,0.1) !important;
 }
 a.grade_a:hover {
-  background-color:hsl(120, 100%, 80%) !important;
+  background-color:rgba(33,150,83,0.2) !important;
+}
+.grade_a_title {
+  color:rgba(33,150,83,1);
 }
 
 .grade_b {
-  background-color:hsl(90, 100%, 90%) !important;
+  background-color:rgba(96,172,14,0.1) !important;
 }
 a.grade_b:hover {
-  background-color:hsl(90, 100%, 80%) !important;
+  background-color:rgba(96,172,14,0.2) !important;
+}
+.grade_b_title {
+  color:rgba(96,172,14,1);
 }
 
 .grade_c {
-  background-color:hsl(60, 100%, 90%) !important;
+  background-color:rgba(200,143,1,0.1) !important;
 }
 a.grade_c:hover {
-  background-color:hsl(60, 100%, 80%) !important;
+  background-color:rgba(200,143,1,0.2) !important;
+}
+.grade_c_title {
+  color:rgba(200,143,1,1);
 }
 
 .grade_d {
-  background-color:hsl(30, 100%, 90%) !important;
+  background-color:rgba(224,115,18,0.1) !important;
 }
 a.grade_d:hover {
-  background-color:hsl(30, 100%, 80%) !important;
+  background-color:rgba(224,115,18,0.2) !important;
+}
+.grade_d_title {
+  color:rgba(224,115,18,1);
 }
 
 .grade_e {
-  background-color:hsl(0, 100%, 90%) !important;
+  background-color:rgba(235,87,87,0.1) !important;
 }
 a.grade_e:hover {
-  background-color:hsl(0, 100%, 80%) !important;
+  background-color:rgba(235,87,87,0.2) !important;
 }
-
+.grade_e_title {
+  color:rgba(235,87,87,1);
+}
 

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -23,8 +23,6 @@
     <a href="#panel_[% panel_id | replace(':','-') %]_content" class="panel_title[% IF panel.title_element.type == "grade" %] grade_[% panel.title_element.grade %][% END %]"
         [% IF panel.size == "small" %]
             style="padding:0.1rem;padding-left:1rem;"
-        [% ELSE %]
-            style="padding:1rem;"
         [% END %]
     >
         [% IF panel.title_element.icon_url.defined %]
@@ -37,7 +35,7 @@
                 [% ELSIF panel.evaluation == "bad" %]
                     class="filter-red"
                 [% ELSIF panel.evaluation == "average" %]
-                    class="filter-darkorange"                 
+                    class="filter-orange"                 
                 [% ELSIF panel.evaluation == "neutral" %]
                     class="filter-grey"
                 [% ELSIF panel.evaluation == "unknown" %]
@@ -46,43 +44,24 @@
             [% END %]
         >
         [% END %]
-        <h3 style="
-            [% IF panel.evaluation == "good" %]
-                color:green;
-            [% ELSIF panel.evaluation == "bad" %]
-                color:red;
-            [% ELSIF panel.evaluation == "average" %]
-                color:darkorange;
-            [% ELSIF panel.evaluation == "neutral" %]
-                color:grey;
-            [% ELSIF panel.evaluation == "unknown" %]
-               color:grey;
-            [% END %]
-            [% IF panel.size == "small" %]font-size:1.1rem;[% END %]
-            "
+        <h3 [% IF panel.title_element.type == "grade" %]class="grade_[% panel.title_element.grade %]_title"[% END %]
+            [% IF panel.evaluation.defined %]class="evaluation_[%panel.evaluation %]_title"[% END %]
+            [% IF panel.size == "small" %]style="font-size:1.1rem;"[% END %]
         >
             [% IF panel.evaluation AND NOT panel.title_element.icon_url.defined %]
+                <span class="evaluation_[%panel.evaluation %]_title">
                 [% IF panel.evaluation == "good" %]
-                    <span style="color:green">
-                        [% display_icon("check") %]
-                    </span>
+                    [% display_icon("check") %]
                 [% ELSIF panel.evaluation == "bad" %]
-                    <span style="color:red">
-                        [% display_icon("cancel") %]
-                    </span>
+                    [% display_icon("cancel") %]
                 [% ELSIF panel.evaluation == "average" %]
-                    <span style="color:darkorange">
-                        [% display_icon("check") %]
-                    </span>                    
+                    [% display_icon("check") %]
                 [% ELSIF panel.evaluation == "neutral" %]
-                    <span style="color:grey">
-                        [% display_icon("check") %]
-                    </span>
+                    [% display_icon("check") %]
                 [% ELSIF panel.evaluation == "unknown" %]
-                    <span style="color:grey">
-                        [% display_icon("help") %]
-                    </span>
+                    [% display_icon("help") %]
                 [% END %]
+                </span>
             [% END %]
             [% panel.title_element.title %]
         </h3>
@@ -127,7 +106,7 @@
                         [% ELSIF text_element.evaluation == "bad" %]
                             class="filter-red"
                         [% ELSIF text_element.evaluation == "average" %]
-                            class="filter-darkorange"                 
+                            class="filter-orange"                 
                         [% ELSIF text_element.evaluation == "neutral" %]
                             class="filter-grey"
                         [% ELSIF text_element.evaluation == "unknown" %]


### PR DESCRIPTION
This is to use the colors and styles defined in https://docs.google.com/presentation/d/1fVVAo888BM-rpOAdQvjFhrmWe7NeAdCO2ZRxMzkHEvg/edit?pli=1#slide=id.g10a8b8e61b0_0_274 on the Web as well.

- changed border radius from 12px to 8px
- changed colors for A to E grades and evaluation (good, average, bad) : background color + icon color + text color

Before:

![image](https://user-images.githubusercontent.com/8158668/149133043-614f6dda-04c8-4e9c-a6b8-f09decc77518.png)

After:

![image](https://user-images.githubusercontent.com/8158668/149133122-dafc5cda-1a74-40d6-83ad-51078109fed1.png)
