### PR TITLE
fix: ignore po/site-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/ProductOpener/Config.pm
 lib/ProductOpener/Config2.pm
 lib/ProductOpener/SiteLang.pm
 taxonomies/nutrient_levels.txt
+po/site-specific
 
 # Local files
 .DS_Store?

--- a/po/site-specific
+++ b/po/site-specific
@@ -1,1 +1,0 @@
-/opt/product-opener/po/openfoodfacts


### PR DESCRIPTION
I checked in my docker po/site-specific link by mistake. This is to remove it and add it to gitignore