### PR TITLE
fix: typo in function name in Food.pm 

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -1580,7 +1580,7 @@ sub compute_nutrition_score($) {
 	# do not display warnings about missing fiber and fruits
 
 	if (not ((has_tag($product_ref, "categories", "en:spring-waters"))
-		and not (has_tag($product_ref, "categories", "en:flavored-waters") or as_tag($product_ref, "categories", "en:flavoured-waters")))) {
+		and not (has_tag($product_ref, "categories", "en:flavored-waters") or has_tag($product_ref, "categories", "en:flavoured-waters")))) {
 
 		# compute the score only if all values are known
 		# for fiber, compute score without fiber points if the value is not known

--- a/t/expected_test_results/nutriscore/flavored-spring-water-no-nutrition.json
+++ b/t/expected_test_results/nutriscore/flavored-spring-water-no-nutrition.json
@@ -1,0 +1,60 @@
+{
+   "categories" : "flavoured spring water",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:waters",
+      "en:flavored-waters",
+      "en:flavored-spring-waters"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "18012",
+      "ciqual_food_code:en" : "18008"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-18012",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-18008",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-18012"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:waters",
+      "en:flavored-waters",
+      "en:flavored-spring-waters"
+   ],
+   "food_groups" : "en:waters-and-flavored-waters",
+   "food_groups_tags" : [
+      "en:beverages",
+      "en:waters-and-flavored-waters"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutriscore-not-computed",
+      "en:nutrition-not-enough-data-to-compute-nutrition-score",
+      "en:nutrition-no-saturated-fat",
+      "en:nutriscore-missing-nutrition-data",
+      "en:nutriscore-missing-nutrition-data-energy"
+   ],
+   "nutriments" : {},
+   "nutrition_grades_tags" : [
+      "unknown"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_debug" : "missing energy",
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Waters and flavored waters",
+   "pnns_groups_2_tags" : [
+      "waters-and-flavored-waters",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/flavored-spring-with-nutrition.json
+++ b/t/expected_test_results/nutriscore/flavored-spring-with-nutrition.json
@@ -1,0 +1,107 @@
+{
+   "categories" : "flavoured spring water",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:waters",
+      "en:flavored-waters",
+      "en:flavored-spring-waters"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "18012",
+      "ciqual_food_code:en" : "18008"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-18012",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-18008",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-18012"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:waters",
+      "en:flavored-waters",
+      "en:flavored-spring-waters"
+   ],
+   "food_groups" : "en:waters-and-flavored-waters",
+   "food_groups_tags" : [
+      "en:beverages",
+      "en:waters-and-flavored-waters"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-no-fruits-vegetables-nuts",
+      "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 378,
+      "fat_100g" : 0,
+      "fiber_100g" : 0,
+      "nutrition-score-fr" : 12,
+      "nutrition-score-fr_100g" : 12,
+      "proteins_100g" : 0,
+      "saturated-fat_100g" : 0,
+      "sodium_100g" : 0,
+      "sugars_100g" : 3
+   },
+   "nutriscore_data" : {
+      "energy" : 378,
+      "energy_points" : 10,
+      "energy_value" : 378,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "e",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 12,
+      "positive_points" : 0,
+      "proteins" : 0,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : 0,
+      "saturated_fat_points" : 0,
+      "saturated_fat_ratio" : 0,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 0,
+      "saturated_fat_value" : 0,
+      "score" : 12,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : 3,
+      "sugars_points" : 2,
+      "sugars_value" : 3
+   },
+   "nutriscore_grade" : "e",
+   "nutriscore_score" : 12,
+   "nutriscore_score_opposite" : -12,
+   "nutrition_grade_fr" : "e",
+   "nutrition_grades" : "e",
+   "nutrition_grades_tags" : [
+      "e"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_no_fruits_vegetables_nuts" : 1,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Waters and flavored waters",
+   "pnns_groups_2_tags" : [
+      "waters-and-flavored-waters",
+      "known"
+   ]
+}

--- a/t/expected_test_results/nutriscore/spring-water-no-nutrition.json
+++ b/t/expected_test_results/nutriscore/spring-water-no-nutrition.json
@@ -1,0 +1,98 @@
+{
+   "categories" : "spring water",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:waters",
+      "en:spring-waters"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_food_code:en" : "18430",
+      "ciqual_food_code:en" : "18430"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-18430",
+      "agribalyse-food-code-known",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-18430",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-18430"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:waters",
+      "en:spring-waters"
+   ],
+   "food_groups" : "en:waters-and-flavored-waters",
+   "food_groups_tags" : [
+      "en:beverages",
+      "en:waters-and-flavored-waters"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutrition-no-fruits-vegetables-nuts",
+      "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "nutrition-score-fr" : 0,
+      "nutrition-score-fr_100g" : 0
+   },
+   "nutriscore_data" : {
+      "energy" : null,
+      "energy_points" : 0,
+      "energy_value" : 0,
+      "fiber" : 0,
+      "fiber_points" : 0,
+      "fiber_value" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 0,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 0,
+      "grade" : "a",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 1,
+      "negative_points" : 0,
+      "positive_points" : 0,
+      "proteins" : null,
+      "proteins_points" : 0,
+      "proteins_value" : 0,
+      "saturated_fat" : null,
+      "saturated_fat_points" : 0,
+      "saturated_fat_ratio" : 0,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 0,
+      "saturated_fat_value" : 0,
+      "score" : 0,
+      "sodium" : 0,
+      "sodium_points" : 0,
+      "sodium_value" : 0,
+      "sugars" : null,
+      "sugars_points" : 0,
+      "sugars_value" : 0
+   },
+   "nutriscore_grade" : "a",
+   "nutriscore_score" : 0,
+   "nutriscore_score_opposite" : 0,
+   "nutrition_grade_fr" : "a",
+   "nutrition_grades" : "a",
+   "nutrition_grades_tags" : [
+      "a"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_no_fruits_vegetables_nuts" : 1,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Waters and flavored waters",
+   "pnns_groups_2_tags" : [
+      "waters-and-flavored-waters",
+      "known"
+   ]
+}

--- a/t/nutriscore.t
+++ b/t/nutriscore.t
@@ -83,6 +83,12 @@ my @tests = (
 
 ],
 
+# spring waters
+["spring-water-no-nutrition", { lc=>"en", categories=>"spring water", nutriments=>{}}],
+["flavored-spring-water-no-nutrition", { lc=>"en", categories=>"flavoured spring water", nutriments=>{}}],
+["flavored-spring-with-nutrition", { lc=>"en", categories=>"flavoured spring water", nutriments=>{energy_100g=>378, fat_100g=>0, "saturated-fat_100g"=>0, sugars_100g=>3, sodium_100g=>0, fiber_100g=>0, proteins_100g=>0}}],
+
+
 );
 
 

--- a/taxonomies/categories.result.txt
+++ b/taxonomies/categories.result.txt
@@ -17741,10 +17741,6 @@ nl:Lactosevrije room, Lactosevrije romen, Room zonder lactose, Romen zonder lact
 sv:Laktosfri grädde
 
 < en:Creams
-en:Liquid cream
-fr:Crème de lait semi-épaisse
-
-< en:Creams
 en:Liquid light cream with 4 to 8% fat, Thick light cream with 4 to 8% fat
 fr:Spécialité à base de crème légère fluide à 8% de matières grasses, Spécialité à base de crème légère épaisse à 8% de matières grasses
 agribalyse_food_code:en: 19433
@@ -17759,8 +17755,20 @@ fr:Crèmes sous pression
 nl:Slagroomflessen
 
 < en:Creams
-en:Thick cream
-fr:Crème de lait épaisse
+en:UHT Creams
+de:H-Sahne, H-Schlagsahne
+fi:Iskukuumennetut kermat
+fr:Crèmes UHT
+it:Creme UHT
+nl:UHT room, UHT romen
+agribalyse_proxy_food_code:en: 19415
+agribalyse_proxy_food_name:en: Liquid cream 30% fat, UHT
+agribalyse_proxy_food_name:fr: Crème de lait, 30% MG, semi-épaisse, UHT
+
+< en:Creams
+en:Unfermented creams, Liquid creams, liquid cream
+fr:Crèmes liquides, crèmes fraîches liquides, Crème fraîche liquide, Crème liquide
+it:Panne da cucina, panna da cucina
 
 < en:Creams
 en:Whipped creams
@@ -17807,8 +17815,7 @@ fr:Crèmes fraîches
 fr:Crèmes légères, crèmes fraîches légères, Crème fraîche légère, crème légère
 
 < en:Creams
-fr:Crèmes liquides, crèmes fraîches liquides, Crème fraîche liquide, Crème liquide
-it:Panne da cucina, panna da cucina
+fr:Crèmes semi-épaisses, Crème de lait semi-épaisse
 
 < en:Creamy almond turrón
 es:Turrón de Jijona
@@ -23062,6 +23069,22 @@ fr:Graines de fenugrec entiers
 nl:Hele fenegriekzaden
 
 < en:Fermented creams
+en:Refrigerated 15-20% fat light thick cream
+fr:Crème de lait légère épaisse avec 15 à 20% de matières grasses rayon frais
+agribalyse_food_code:en: 19431
+ciqual_food_code:en: 19431
+ciqual_food_name:en: Thick cream, light, 15-20% fat, refrigerated
+ciqual_food_name:fr: Crème de lait, 15 à 20% MG, légère, épaisse, rayon frais
+
+< en:Fermented creams
+en:Refrigerated 30% fat thick cream
+fr:Crèmes épaisses entières, Crème de lait épaisse à 30% de matières grasses, Crème de lait épaisse à 30% MG
+agribalyse_food_code:en: 19410
+ciqual_food_code:en: 19410
+ciqual_food_name:en: Thick cream 30% fat, refrigerated
+ciqual_food_name:fr: Crème de lait, 30% MG, épaisse, rayon frais
+
+< en:Fermented creams
 en:Sour creams, Crèmes fraîches
 cs:Zakysaná smetana
 de:Sauerrahm
@@ -23219,10 +23242,10 @@ wikidata:en: Q12740385
 
 < en:Creams
 < en:Fermented milk products
-en:Fermented creams
+en:Fermented creams, Thick cream
 de:Fermentierter Rahm, Gesäuerter Rahm
 fi:Fermentoidut kermat
-fr:Crèmes épaisses, crèmes fraîches épaisses, Crème fraîche épaisse
+fr:Crèmes épaisses, crèmes fraîches épaisses, Crème fraîche épaisse, crème épaisse
 hu:Erjesztett krémek
 it:Creme fermentate
 nl:Gefermenteerde room
@@ -24754,6 +24777,10 @@ agribalyse_food_code:en: 18028
 ciqual_food_code:en: 18028
 ciqual_food_name:en: Bottled water, flavoured, without sugar and artificial sweeteners
 ciqual_food_name:fr: Boisson à l'eau minérale ou de source, aromatisée, non sucrée, sans édulcorant
+
+< en:Flavored waters
+en:Flavored spring waters, flavored spring water
+fr:Eaux de sources aromatisées, eau de source aromatisée
 
 < en:Flavored waters
 en:Unsweetened flavored waters, non-sweetened flavored waters, non-sugared flavored waters
@@ -39313,17 +39340,6 @@ en:Liquid vegetable bouillons, Liquid vegetable stocks
 es:Caldos de verduras líquidos, Caldos de verduras en brik
 fr:Bouillons de légumes liquides
 nl:Vloeibare groentebouillons
-
-< en:Liquid cream
-en:UHT Creams
-de:H-Sahne, H-Schlagsahne
-fi:Iskukuumennetut kermat
-fr:Crèmes UHT
-it:Creme UHT
-nl:UHT room, UHT romen
-agribalyse_proxy_food_code:en: 19415
-agribalyse_proxy_food_name:en: Liquid cream 30% fat, UHT
-agribalyse_proxy_food_name:fr: Crème de lait, 30% MG, semi-épaisse, UHT
 
 < en:Lithuanian beers
 lt:Kaimiškas Jovarų alus
@@ -67208,22 +67224,6 @@ de:Camembert aus thermisierter Milch
 fr:Camemberts au lait thermisé
 nl:Camemberts op basis van gethermiseerde melk
 
-< en:Thick cream
-en:Refrigerated 15-20% fat light thick cream
-fr:Crème de lait légère épaisse avec 15 à 20% de matières grasses rayon frais
-agribalyse_food_code:en: 19431
-ciqual_food_code:en: 19431
-ciqual_food_name:en: Thick cream, light, 15-20% fat, refrigerated
-ciqual_food_name:fr: Crème de lait, 15 à 20% MG, légère, épaisse, rayon frais
-
-< en:Thick cream
-en:Refrigerated 30% fat thick cream
-fr:Crème de lait épaisse à 30% de matières grasses, Crème de lait épaisse à 30% MG
-agribalyse_food_code:en: 19410
-ciqual_food_code:en: 19410
-ciqual_food_name:en: Thick cream 30% fat, refrigerated
-ciqual_food_name:fr: Crème de lait, 30% MG, épaisse, rayon frais
-
 < en:Thickeners
 en:Gelatin, Gelatine
 de:Gelatine
@@ -68899,24 +68899,6 @@ en:Mushroom pies
 fr:Tourtes aux champignons
 nl:Champignontaarten
 
-< en:Liquid cream
-< en:UHT Creams
-en:Liquid 15-20% fat light cream UHT
-fr:Crème de lait légère semi-épaisse avec 15 à 20% de matières grasses UHT
-agribalyse_food_code:en: 19430
-ciqual_food_code:en: 19430
-ciqual_food_name:en: Liquid cream, light, 15-20% fat, UHT
-ciqual_food_name:fr: Crème de lait, 15 à 20% MG, légère, semi-épaisse, UHT
-
-< en:Liquid cream
-< en:UHT Creams
-en:Liquid 30% fat UHT cream
-fr:Crème de lait semi-épaisse à 30% de matières grasses UHT
-agribalyse_food_code:en: 19415
-ciqual_food_code:en: 19415
-ciqual_food_name:en: Liquid cream 30% fat, UHT
-ciqual_food_name:fr: Crème de lait, 30% MG, semi-épaisse, UHT
-
 < en:UHT Milks
 ru:Молоко питьевое ультрапастеризованное (ультравысокотемпературно-обработанное), Молоко питьевое ультрапастеризованное, Молоко ультрапастеризованное питьевое, Молоко питьевое ультравысокотемпературно-обработанное
 wikidata:en: Q26867007
@@ -69115,6 +69097,24 @@ fr:Chevrotins, Chevrotin
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0246
 protected_name_type:en: pdo
+
+< en:UHT Creams
+< en:Unfermented creams
+en:Liquid 15-20% fat light cream UHT
+fr:Crème de lait légère semi-épaisse avec 15 à 20% de matières grasses UHT
+agribalyse_food_code:en: 19430
+ciqual_food_code:en: 19430
+ciqual_food_name:en: Liquid cream, light, 15-20% fat, UHT
+ciqual_food_name:fr: Crème de lait, 15 à 20% MG, légère, semi-épaisse, UHT
+
+< en:UHT Creams
+< en:Unfermented creams
+en:Liquid 30% fat UHT cream
+fr:Crème de lait semi-épaisse à 30% de matières grasses UHT
+agribalyse_food_code:en: 19415
+ciqual_food_code:en: 19415
+ciqual_food_name:en: Liquid cream 30% fat, UHT
+ciqual_food_name:fr: Crème de lait, 30% MG, semi-épaisse, UHT
 
 < en:Unleavened breads
 fr:Pains azymes à la farine complète, Pain azyme à la farine complète

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -7938,6 +7938,11 @@ agribalyse_proxy_food_code:en:18012
 agribalyse_proxy_food_name:en:Bottled water, flavoured, w sugar
 agribalyse_proxy_food_name:fr:Boisson à l'eau minérale ou de source, aromatisée, sucrée
 
+#Note: not adding flavored spring waters under spring waters
+<en:Flavored waters
+en:Flavored spring waters, flavored spring water
+fr:Eaux de sources aromatisées, eau de source aromatisée
+
 <en:Flavored waters
 en:Unsweetened flavored waters, non-sweetened flavored waters, non-sugared flavored waters
 de:Zuckerfreies Wasser mit Geschmack


### PR DESCRIPTION
Related issues #6288 #6287

Also add some tests.

But it does not solve the more general issue that typos in function names are currently undetected.