### PR TITLE
add more automatic Equadis imports to public database

### DIFF
--- a/scripts/export_producers_platform_data_to_public_database.sh
+++ b/scripts/export_producers_platform_data_to_public_database.sh
@@ -25,3 +25,15 @@ export PERL5LIB="../lib:${PERL5LIB}"
 
 ./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-carrefour
 
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-lustucru-frais
+
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-garofalo-france
+
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-nestle-waters
+
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-kambly
+
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-kambly-france
+
+./export_and_import_to_public_database.pl --query states_tags=en:to-be-exported --owner org-saint-hubert
+


### PR DESCRIPTION
This is to add more producers from Equadis to the daily exports from the producers platform to the public database.

We'll probably need to do this differently at some point. We have a checkbox in the org settings for daily exports, but it currently has no effect.