### PR TITLE
feat: Fix and improve detection of apps (name and UUID) to populate data sources

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -60,6 +60,7 @@ requires 'File::chmod::Recursive'; # deps: libfile-chmod-perl
 requires 'Devel::Size'; # deps: libdevel-size-perl
 requires 'JSON::Create';
 requires 'JSON::Parse';
+requires 'Data::DeepAccess';
 
 # Mojolicious/Minion
 requires 'Mojolicious::Lite';

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -902,6 +902,21 @@ $options{display_tag_additives} = [
 
 ];
 
+# Used in the data_sources field (e.g. "App - Open Food Facts")
+$options{apps_names} = {
+
+	"elcoco" => "El CoCo",
+	"ethic-advisor" => "Ethic-Advisor",
+	"horizon" => "Horizon",
+	"infood" => "InFood",
+	"isve" => "IsVe",
+	"labeleat" => "LabelEat",
+	"off" => "Open Food Facts",
+	"scanfood" => "Scanfood",
+	"speisekammer" => "Speisekammer",
+	"waistline" => "Waistline",
+	"yuka" => "Yuka"
+};
 
 # Specific users used by apps
 $options{apps_userids} = {

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -906,32 +906,43 @@ $options{display_tag_additives} = [
 # Specific users used by apps
 $options{apps_userids} = {
 
-	"ethic-advisor" => "ethic-advisor",
+	"averment" => "isve",
 	"elcoco" => "elcoco",
+	"ethic-advisor" => "ethic-advisor",
+	"inf" => "infood",
 	"kiliweb" => "yuka",
 	"labeleat" => "labeleat",
+	"prepperapp" => "speisekammer",
+	"scanfood" => "scanfood",
+	"swipe-studio" => "horizon",
 	"waistline-app" => "waistline",
-	"inf" => "infood",
 };
+
+$options{official_app_id} = "off";
+$options{official_app_comment} = "(official (off|open food facts|openfoodfacts)|(off|open food facts|openfoodfacts) (official )?(android |ios )?(official )?app)";
 
 # (app)Official Android app 3.1.5 ( Added by 58abc55ceb98da6625cee5fb5feaf81 )
 # (app)Labeleat1.0-SgP5kUuoerWvNH3KLZr75n6RFGA0
 # (app)Contributed using: OFF app for iOS - v3.0 - user id: 3C0154A0-D19B-49EA-946F-CC33A05E404A
-# (app)Official Android app 3.1.5 ( Added by 58abc55ceb98da6625cee5fb5feaf81 )
 # (app)EthicAdvisorApp-production-2.6.3-user_17cf91e3-52ee-4431-aebf-7d455dd610f0
 # (app)El Coco - user b0e8d6a858034cc750136b8f19a8953d
 
+# app_uuid_prefix must be present to recognize the uuid, if the comment starts with the uuid, put an empty string
 $options{apps_uuid_prefix} = {
 
 	"elcoco" => " user ",
 	"ethic-advisor" => "user_",
-	"kiliweb" => "User :",
 	"labeleat" => "Labeleat([^-]*)-",
-	"waistline-app" => "Waistline:",
+	"off" => "added by",	
+	"scanfood" => "",
+	"waistline" => "Waistline:",
+	"yuka" => "User :",
 };
 
-$options{official_app_id} = "off";
-$options{official_app_comment} = "(official android app|off app)";
+$options{apps_uuid_suffix} = {
+
+	"scanfood" => "scanfood",
+};
 
 
 $options{nova_groups_tags} = {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -183,6 +183,7 @@ use Excel::Writer::XLSX;
 use Template;
 use Data::Dumper;
 use Devel::Size qw(size total_size);
+use Data::DeepAccess qw(deep_get);
 use Log::Log4perl;
 
 use Log::Any '$log', default_adapter => 'Stderr';
@@ -3879,6 +3880,19 @@ HTML
 			if (not defined $user_or_org_ref) {
 				display_error(lang("error_unknown_org"), 404);
 			}
+		}
+		elsif ($tagid =~ /\./) {
+			# App user (format "[app id].[app uuid]")
+
+			my $appid = $`;
+			my $uuid = $';
+
+			my $app_name = deep_get(\%options, "apps_names", $appid) || $appid;
+			my $app_user = f_lang("f_app_user", { app_name => $app_name });
+
+			$title = $app_user;
+			$products_title = $app_user;
+			$display_tag = $app_user;
 		}
 		else {
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -134,7 +134,6 @@ use ProductOpener::Text qw/:all/;
 use CGI qw/:cgi :form escapeHTML/;
 use Encode;
 use Log::Any qw($log);
-use Hash::DeepAccess;
 use Data::DeepAccess qw(deep_get);
 
 use LWP::UserAgent;

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1756,8 +1756,11 @@ sub generate_tags_taxonomy_extract ($$$$) {
 	my $options_ref = shift;
 	my $lcs_ref = shift;
 
+	$log->debug("generate_tags_taxonomy_extract", {tagtype => $tagtype, tags_ref => $tags_ref, options_ref => $options_ref, lcs_ref => $lcs_ref }) if $log->is_debug();
+
 	# Return empty hash if the taxonomy does not exist
 	if (not defined $translations_to{$tagtype}) {
+		$log->debug("taxonomy not found", {tagtype => $tagtype}) if $log->is_debug();
 		return {};
 	}
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5960,3 +5960,8 @@ msgstr "This might not be the answer people want to hear, but there is no safe l
 msgctxt "source"
 msgid "Source"
 msgstr "Source"
+
+# variable names between { } must not be translated
+msgctxt "f_app_user"
+msgid "A user of the {app_name} app"
+msgstr "A user of the {app_name} app"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5988,3 +5988,8 @@ msgstr "This might not be the answer people want to hear, but there is no safe l
 msgctxt "source"
 msgid "Source"
 msgstr "Source"
+
+# variable names between { } must not be translated
+msgctxt "f_app_user"
+msgid "A user of the {app_name} app"
+msgstr "A user of the {app_name} app"

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -526,7 +526,7 @@ while (my $product_ref = $cursor->next) {
 					$product_ref->{rev} = $last_rev;
 					my $blame_ref = {};
 					compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $blame_ref);
-					compute_data_sources($product_ref);
+					compute_data_sources($product_ref, $changes_ref);
 					store("$data_root/products/$path/changes.sto", $changes_ref);
 				}
 				else {
@@ -831,7 +831,11 @@ while (my $product_ref = $cursor->next) {
 		}
 
 		if ($compute_data_sources) {
-			compute_data_sources($product_ref);
+			my $changes_ref = retrieve("$data_root/products/$path/changes.sto");
+			if (not defined $changes_ref) {
+				$changes_ref = [];
+			}
+			compute_data_sources($product_ref, $changes_ref);
 		}
 
 		if ($compute_nova) {
@@ -1016,7 +1020,7 @@ while (my $product_ref = $cursor->next) {
 			}
 			my $blame_ref =  {};
 			compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $blame_ref);
-			compute_data_sources($product_ref);
+			compute_data_sources($product_ref, $changes_ref);
 			store("$data_root/products/$path/changes.sto", $changes_ref);
 		}
 

--- a/t/products.t
+++ b/t/products.t
@@ -96,24 +96,62 @@ compute_and_test_completeness($product_ref, 1.0, 'product all fields');
 
 my @get_change_userid_or_uuid_tests = (
 
-# format: [ input userid, comment passed to the API, resulting app id, resulting userid]
-["real-user", "some random comment", undef, "real-user"],
-["stephane", "Updated via Power User Script", undef, "stephane"],
-["kiliweb", "User : WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ", "yuka", "yuka.WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ"],
-["prepperapp", "Edited by a user of https://speisekammer-app.de", "speisekammer", "prepperapp"],
-["scanfood", "96ce87ae-2f2b-4fd6-90d2-7bfc4388d173-ScanFood", "scanfood", "scanfood.96ce87ae-2f2b-4fd6-90d2-7bfc4388d173"]
+	{
+		userid => undef,
+		comment => "some random comment",
+		expected_app => undef,
+		expected_userid => "openfoodfacts-contributors",
+	},
+	{
+		userid => "real-user",
+		comment => "some random comment",
+		expected_app => undef,
+		expected_userid => "real-user",
+	},	
+	{
+		userid => "stephane",
+		comment => "Updated via Power User Script",
+		expected_app => undef,
+		expected_userid => "stephane",
+	},
+	{
+		userid => "stephane",
+		comment => "Official Open Food Facts Android app 3.6.6 (Added by a99a030f-c836-4551-9ec7-3d387f293e73)",
+		expected_app => "off",
+		expected_userid => "stephane",
+	},
+	{
+		userid => undef,
+		comment => "Official Open Food Facts Android app 3.6.6 (Added by a99a030f-c836-4551-9ec7-3d387f293e73)",
+		expected_app => "off",
+		expected_userid => "off.a99a030f-c836-4551-9ec7-3d387f293e73",
+	},	
+	{
+		userid => "kiliweb",
+		comment => "User : WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ",
+		expected_app => "yuka",
+		expected_userid => "yuka.WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ",
+	},
+	{
+		userid => "prepperapp",
+		comment => "Edited by a user of https://speisekammer-app.de",
+		expected_app => "speisekammer",
+		expected_userid => "prepperapp",
+	},
+	{
+		userid => "scanfood",
+		comment => "96ce87ae-2f2b-4fd6-90d2-7bfc4388d173-ScanFood",
+		expected_app => "scanfood",
+		expected_userid => "scanfood.96ce87ae-2f2b-4fd6-90d2-7bfc4388d173",
+	},
 );
 
-foreach my $test_ref (@get_change_userid_or_uuid_tests) {
+foreach my $change_ref (@get_change_userid_or_uuid_tests) {
 
-	my $change_ref = { userid => $test_ref->[0], comment => $test_ref->[1] };
+	$change_ref->{resulting_userid} = get_change_userid_or_uuid($change_ref);
 
-	my $userid = get_change_userid_or_uuid($change_ref);
-	# the app may have been added to the change data
-	my $app = $change_ref->{app};
-
-	is ($app, $test_ref->[2]) or diag explain $test_ref;
-	is ($userid, $test_ref->[3]) or diag explain $test_ref;
+	is ($change_ref->{app}, $change_ref->{expected_app}) or diag explain $change_ref;
+	is ($change_ref->{resulting_userid}, $change_ref->{expected_userid}) or diag explain $change_ref;
 
 }
 

--- a/t/products.t
+++ b/t/products.t
@@ -92,10 +92,16 @@ foreach my $field (@string_fields) {
 
 compute_and_test_completeness($product_ref, 1.0, 'product all fields');
 
+# Test the function that recognizes the app and app uuid from changes and sets the app and userid
+
 my @get_change_userid_or_uuid_tests = (
-["real-user", "some random comment", "real-user"],
-["stephane", "Updated via Power User Script", "stephane"],
-["kiliweb", "User : WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ", "yuka.WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ"],
+
+# format: [ input userid, comment passed to the API, resulting app id, resulting userid]
+["real-user", "some random comment", undef, "real-user"],
+["stephane", "Updated via Power User Script", undef, "stephane"],
+["kiliweb", "User : WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ", "yuka", "yuka.WjR3OExvb3M5dWNobU1Za29EUHJvdmtwN0p1SVh6MjNDZGdySVE9PQ"],
+["prepperapp", "Edited by a user of https://speisekammer-app.de", "speisekammer", "prepperapp"],
+["scanfood", "96ce87ae-2f2b-4fd6-90d2-7bfc4388d173-ScanFood", "scanfood", "scanfood.96ce87ae-2f2b-4fd6-90d2-7bfc4388d173"]
 );
 
 foreach my $test_ref (@get_change_userid_or_uuid_tests) {
@@ -103,8 +109,11 @@ foreach my $test_ref (@get_change_userid_or_uuid_tests) {
 	my $change_ref = { userid => $test_ref->[0], comment => $test_ref->[1] };
 
 	my $userid = get_change_userid_or_uuid($change_ref);
+	# the app may have been added to the change data
+	my $app = $change_ref->{app};
 
-	is ($userid, $test_ref->[2]) or diag explain $test_ref;
+	is ($app, $test_ref->[2]) or diag explain $test_ref;
+	is ($userid, $test_ref->[3]) or diag explain $test_ref;
 
 }
 

--- a/t/products.t
+++ b/t/products.t
@@ -144,6 +144,21 @@ my @get_change_userid_or_uuid_tests = (
 		expected_app => "scanfood",
 		expected_userid => "scanfood.96ce87ae-2f2b-4fd6-90d2-7bfc4388d173",
 	},
+	{
+		userid => "someuser",
+		comment => "some comment",
+		app_name => "Some App",
+		expected_app => "some-app",
+		expected_userid => "someuser",
+	},
+	{
+		userid => "someuser",
+		comment => "some comment",
+		app_name => "Some App",
+		app_uuid => "423T42fFST423",
+		expected_app => "some-app",
+		expected_userid => "some-app.423T42fFST423",
+	},	
 );
 
 foreach my $change_ref (@get_change_userid_or_uuid_tests) {


### PR DESCRIPTION
We try to identifiy product edits that are made through apps, so that we can populate the data_sources facet. We currently do it by using the comment field that can contain an app name, and in some cases a uuid (used so that we can group contributions by the same user, for instance to check for errors), and/or the specific OFF user used by some app. This has been broken for some time.

This PR:
- refactors the identification of apps through the existing specific app OFF user ids and comments, and fixes issues - fixes #2592 - fixes #3849 - fixes #2195
- adds tests so that it does not become broken again
- add more robust ways for apps to pass their name and user uuid (app_name, app_version and app_uuid) instead of using the comment field - fixes #5195
- add an alternate way to pass the user agent through a query parameter (useful for web frameworks where it's not possible to change the user-agent header), and record that user agent (currently it's savec in the nginx logs, but not in the changes, which makes it useless to identify apps that edit products)
- fixes the pages that show edits from a specific app + uuid

![image](https://user-images.githubusercontent.com/8158668/150403832-ef8b0567-13fb-4b92-a44c-dc1e4fda490e.png)

![image](https://user-images.githubusercontent.com/8158668/150403879-e36b912a-c7d1-4e0c-90d2-e5a89428447d.png)

