### PR TITLE
Change styles for ingredients analysis styles

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -11036,10 +11036,6 @@ sub display_ingredients_analysis($) {
 	if (defined $product_ref->{ingredients_analysis_tags}) {
 
 		my $template_data_ref = {
-			lang => \&lang,
-			display_icon => \&display_icon,
-			title => lang("ingredients_analysis") . separator_before_colon($lc) . ':',
-			disclaimer => lang("ingredients_analysis_disclaimer"),
 			ingredients_analysis_tags => [],
 		};
 
@@ -11059,6 +11055,9 @@ sub display_ingredients_analysis($) {
 					$ingredients_analysis_tag = "en:palm-oil-free";
 					$color = 'green';
 					
+				}
+				elsif ($ingredients_analysis_tag =~ /unknown/) {
+					$color = 'grey';
 				}
 				elsif ($ingredients_analysis_tag =~ /^en:may-/) {
 					$color = 'orange';
@@ -11097,13 +11096,13 @@ sub display_ingredients_analysis($) {
 				elsif ($ingredients_analysis_tag =~ /^en:maybe-/) {
 					$color = 'orange';
 				}
+				elsif ($ingredients_analysis_tag =~ /unknown/) {
+					$color = 'grey';
+				}
 				else {
 					$color = 'green';
 				}
 			}
-
-			# Skip unknown
-			next if $ingredients_analysis_tag =~ /unknown/;
 
 			if ($icon ne "") {
 				$icon = display_icon($icon);

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -1,3 +1,17 @@
+// background colors for attributes and panels
+
+$grade-a-color: #219653;
+$grade-b-color: #60ac0e;
+$grade-c-color: #c88f01;
+$grade-d-color: #e07312;
+$grade-e-color: #eb5757;
+$grade-unknown-color: #4f4f4f;
+
+$evaluation-good-color: #219653;
+$evaluation-average-color: #f2994a;
+$evaluation-bad-color: #eb5757;
+$evaluation-unknown-color: #4f4f4f;
+
 hr.floatclear {
   background: none;
   border: 0;
@@ -384,7 +398,6 @@ h4 > .icon {
 }
 
 .ingredients_analysis {
-  color: white;
   font-size: 1rem;
   padding-left: 0.2rem;
   padding-right: 1rem;
@@ -396,36 +409,36 @@ h4 > .icon {
   }
 
   &.red {
-    background-color: #ec5656;
+    background-color: $evaluation-bad-color;
   }
 
   &.orange {
-    background-color: #f9904c;
+    background-color: $evaluation-average-color; 
   }
 
   &.green {
-    background-color: #47a647;
+    background-color: $evaluation-good-color;
   }
 
   &.grey {
-    background-color: #444444;
+    background-color: $evaluation-unknown-color;
   }
 }
 
 .red {
-  color: #ec5656;
+  color: $evaluation-bad-color;
 }
 
 .orange {
-  color: #f9904c;
+  color: $evaluation-average-color; 
 }
 
 .green {
-  color: #47a647;
+  color: $evaluation-good-color;
 }
 
 .grey {
-  color: #444444;
+  color: $evaluation-unknown-color;
 }
 
 .percent_bar {
@@ -433,15 +446,15 @@ h4 > .icon {
 }
 
 .percent_bar.red {
-  background-color: #ec5656;
+  background-color: $evaluation-bad-color; 
 }
 
 .percent_bar.orange {
-  background-color: #f9904c;
+  background-color: $evaluation-average-color;
 }
 
 .percent_bar.green {
-  background-color: #47a647;
+  background-color: $evaluation-good-color;
 }
 
 
@@ -742,19 +755,6 @@ html[dir="rtl"] {
   text-decoration:none;
 }
 
-// background colors for attributes and panels
-
-$grade-a-color: #219653;
-$grade-b-color: #60ac0e;
-$grade-c-color: #c88f01;
-$grade-d-color: #e07312;
-$grade-e-color: #eb5757;
-$grade-unknown-color: #4f4f4f;
-
-$evaluation-good-color: #219653;
-$evaluation-average-color: #f2994a;
-$evaluation-bad-color: #eb5757;
-$evaluation-unknown-color: #4f4f4f;
 
 
 .evaluation_good_title {

--- a/templates/web/pages/product/includes/ingredients_analysis.tt.html
+++ b/templates/web/pages/product/includes/ingredients_analysis.tt.html
@@ -1,15 +1,15 @@
 <!-- start templates/[% component.name %] -->
 
 <p id="ingredients_analysis">
-	<strong>[% title %]</strong>
+	<strong>[% lang("ingredients_analysis") %][% sep %]:</strong>
 	<br>
 	[% FOREACH tag IN ingredients_analysis_tags %]
-		<span class="alert round label ingredients_analysis [% tag.color %]">
-			<span style="margin-right: 8px;">[% tag.icon %]</span>[% tag.text %]
+		<span class="ingredients_analysis">
+			<span style="margin-right: 8px;color: [% tag.color %]">[% tag.icon %]</span>[% tag.text %]
 		</span>
 	[% END %]
 	<br>
-	<span class="note">&rarr; [% disclaimer %]</span>
+	<span class="note">&rarr; [% lang("ingredients_analysis_disclaimer") %]</span>
 </p>
 
 <!-- end templates/[% component.name %] -->


### PR DESCRIPTION
This is to make the results of ingredients analysis less aggressive, and also to not make them look like buttons. It's also closer to the new styles from the Smoothie app. (colors etc.).

New:

![image](https://user-images.githubusercontent.com/8158668/151014510-f032ff7b-64f8-4636-b5c2-7ea5e38e8580.png)

One more change is that we now display the info that something is unknown (previously we didn't display anything at all), when we have ingredients, but when we are not able to make the determination.

![image](https://user-images.githubusercontent.com/8158668/151015153-de4427b6-6748-4e32-ab18-c893b39785c8.png)


Before:

![image](https://user-images.githubusercontent.com/8158668/151014555-51486ba9-50fb-4944-917b-3eee07fb464c.png)

Note that this design is temporary, it's likely that ingredients analysis results will become clickable knowledge panels.