### PR TITLE
fix: show 'we need your help' message for ingredients analysis only when needed

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10996,8 +10996,8 @@ sub display_ingredients_analysis_details($) {
 	my $unknown_ingredients_html = '';
 	my $unknown_ingredients_help_html = '';
 
-	if ($ingredients_text . $specific_ingredients =~ /unknown_ingredient/) {
-		$template_data_ref->{ingredients_text_comp} = 'unknown_ingredient';
+	if (($ingredients_text . $specific_ingredients) =~ /unknown_ingredient/) {
+		$template_data_ref->{unknown_ingredients} = 1;
 
 		$styles .= <<CSS
 .unknown_ingredient {

--- a/templates/web/pages/product/includes/ingredients_analysis_details.tt.html
+++ b/templates/web/pages/product/includes/ingredients_analysis_details.tt.html
@@ -4,12 +4,12 @@
     <a id="ingredients_analysis_link" data-dropdown="ingredient_analysis_drop" aria-controls="ingredient_analysis_drop" aria-expanded="false">
         [% lang("ingredients_analysis_details") %] &raquo;
     </a>
-    [% IF ingredients_text_comp == 'unknown_ingredient' %]
+    [% IF unknown_ingredients %]
         <strong>[% lang("we_need_your_help") %]</strong>
     [% END %]
 </p>
 <div id="ingredient_analysis_drop" data-dropdown-content class="f-dropdown content large" aria-hidden="true" tabindex="-1">
-    [% IF ingredients_text_comp == 'unknown_ingredient' %]
+    [% IF unknown_ingredients %]
         <p class="unknown_ingredient">[% lang("some_unknown_ingredients") %]</p>
         <div class="callout panel">
             <h3>[% lang("we_need_your_help") %]</h3>


### PR DESCRIPTION
fixes #6341
