### PR TITLE
feat: enable gzip_static and gunzip for OCR json files

### DIFF
--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -163,6 +163,9 @@ server {
 	        add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS';
 		add_header Access-Control-Allow-Headers 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match';
 		add_header Access-Control-Expose-Headers 'Content-Length,Content-Range';
+    # optimize gzip compressed content (like OCR .json stored next to .jpg files)
+    gzip_static always;
+    gunzip on;
 	}
 
         if ($http_referer ~* (jobothoniel.com) ) { return 403; } # blocked since 2021-07-13

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -187,7 +187,8 @@ server {
 	location ~ ^/(.well-known|images|css|js|rss|files|resources|foundation|bower_components)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
+		gzip_static always;
+		gunzip on;
 	}
 
 	location = /robots.txt {


### PR DESCRIPTION
### What
This is to allow keeping only compressed .json.gz files for OCR results.

### Part of 
- #6273