### PR TITLE
fix: details of improvements opportunities

### DIFF
--- a/templates/web/common/includes/display_data_quality_issues_and_improvement_opportunities.tt.html
+++ b/templates/web/common/includes/display_data_quality_issues_and_improvement_opportunities.tt.html
@@ -11,7 +11,7 @@
             <p>[% tagid.properties %]</p>
         [% END %]
 
-            [% tagid.desccription %]
+            [% tagid.description %]
 
     [% END %]
 

--- a/templates/web/common/includes/display_possible_improvement_description.tt.html
+++ b/templates/web/common/includes/display_possible_improvement_description.tt.html
@@ -1,14 +1,14 @@
 <!-- start templates/[% template.name %] -->
 
 <!-- Comparison of product nutrition facts to other products of the same category -->
-[% IF tagid.matches('^en:nutrition-(very-)?high/') %]
+[% IF tagid.match('^en:nutrition-(very-)?high') %]
     <p> [% lang("value_for_the_product") %]: [% product_ref_improvements_data_tagid_product_100g %]
         <br> [% display_taxonomy_tag_improvements_data_category %]: [% product_ref_improvements_data_tagid_category_100g %]
     </p>
 [% END %]
 
 <!-- Opportunities to improve the Nutri-Score by slightly changing the nutrients -->
-[% IF tagid.matches('^en:better-nutri-score') %]
+[% IF tagid.match('^en:better-nutri-score') %]
     <p>
         [% nutriscore_sprintf_data %]
     </p>


### PR DESCRIPTION
The details of the improvements opportunities where not shown anymore on the pro platform. This fixes the templates to show them again.