### PR TITLE
new misc facet values for Eco-Score missing packaging warning

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -592,6 +592,12 @@ sub compute_ecoscore($) {
 		adjustments => {},
 	};
 
+	remove_tag($product_ref,"misc","en:ecoscore-computed");
+	remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
+	remove_tag($product_ref,"misc","en:ecoscore-missing-data-packaging");
+	remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
+	remove_tag($product_ref,"misc","en:ecoscore-not-applicable");
+
 	# Check if we have extended ecoscore_data from the impact estimator
 	# Remove any misc "en:ecoscore-extended-data-version-[..]" tags
 	if (defined $product_ref->{misc_tags}) {
@@ -631,13 +637,8 @@ sub compute_ecoscore($) {
 		
 		add_tag($product_ref,"misc","en:ecoscore-not-applicable");
 		add_tag($product_ref,"misc","en:ecoscore-not-computed");
-		remove_tag($product_ref,"misc","en:ecoscore-computed");
-		remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
-		remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
 	}
 	else {
-		remove_tag($product_ref,"misc","en:ecoscore-not-applicable");
-		
 		# Compute the LCA Eco-Score based on AgriBalyse
 		
 		compute_ecoscore_agribalyse($product_ref);
@@ -750,15 +751,14 @@ sub compute_ecoscore($) {
 			if ($missing_data_warning) {
 				$product_ref->{ecoscore_data}{missing_data_warning} = 1;
 				add_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
-				remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
-			}
-			else {
-				remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
-				add_tag($product_ref,"misc","en:ecoscore-no-missing-data");
+
+				my $packaging_warning = deep_get($product_ref, qw(ecoscore_data adjustments packaging warning));
+				if ((defined $packaging_warning) and ($packaging_warning eq "packaging_data_missing")) {
+					add_tag($product_ref,"misc","en:ecoscore-missing-data-packaging");
+				}
 			}
 			
 			add_tag($product_ref,"misc","en:ecoscore-computed");
-			remove_tag($product_ref,"misc","en:ecoscore-not-computed");		
 		}
 		else {
 			# No AgriBalyse category match
@@ -768,9 +768,6 @@ sub compute_ecoscore($) {
 			$product_ref->{ecoscore_grade} = "unknown";
 			
 			add_tag($product_ref,"misc","en:ecoscore-not-computed");
-			remove_tag($product_ref,"misc","en:ecoscore-computed");
-			remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
-			remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
 		}
 	}
 }

--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -77,7 +77,7 @@ use ProductOpener::Packaging qw/:all/;
 use Storable qw(dclone freeze);
 use Text::CSV();
 use Math::Round;
-use Data::DeepAccess qw(deep_get);
+use Data::DeepAccess qw(deep_get deep_exists);
 
 my %agribalyse = ();
 
@@ -594,7 +594,10 @@ sub compute_ecoscore($) {
 
 	remove_tag($product_ref,"misc","en:ecoscore-computed");
 	remove_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
-	remove_tag($product_ref,"misc","en:ecoscore-missing-data-packaging");
+	remove_tag($product_ref,"misc","en:ecoscore-missing-data-no-packagings");
+	foreach my $missing (qw(labels origins packagings)) {
+		remove_tag($product_ref,"misc","en:ecoscore-missing-data-" . $missing);
+	}
 	remove_tag($product_ref,"misc","en:ecoscore-no-missing-data");
 	remove_tag($product_ref,"misc","en:ecoscore-not-applicable");
 
@@ -752,10 +755,21 @@ sub compute_ecoscore($) {
 				$product_ref->{ecoscore_data}{missing_data_warning} = 1;
 				add_tag($product_ref,"misc","en:ecoscore-missing-data-warning");
 
+				# add facets for missing data
+				foreach my $missing (qw(labels origins packagings)) {
+					if (deep_exists($product_ref, "ecoscore_data", "missing", $missing)) {
+						add_tag($product_ref,"misc","en:ecoscore-missing-data-" . $missing);
+					}
+				}
+				
+				# ecoscore-missing-data-packagings will also be triggered when we have some packaging data that is not complete
+				# e.g. we have a shape like "bottle" but no associated material
+				# also add a facet when we have no packaging information at all
 				my $packaging_warning = deep_get($product_ref, qw(ecoscore_data adjustments packaging warning));
 				if ((defined $packaging_warning) and ($packaging_warning eq "packaging_data_missing")) {
-					add_tag($product_ref,"misc","en:ecoscore-missing-data-packaging");
+					add_tag($product_ref,"misc","en:ecoscore-missing-data-no-packagings");
 				}
+
 			}
 			
 			add_tag($product_ref,"misc","en:ecoscore-computed");

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -1036,6 +1036,8 @@
       "en:nutriscore-computed",
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed",
       "en:forest-footprint-computed",
       "en:forest-footprint-a"

--- a/t/expected_test_results/attributes/en-ecoscore-score-at-20-threshold.json
+++ b/t/expected_test_results/attributes/en-ecoscore-score-at-20-threshold.json
@@ -742,6 +742,10 @@
       "en:nutriscore-missing-nutrition-data-energy",
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nova_group_debug" : "no nova group when the product does not have ingredients",

--- a/t/expected_test_results/attributes/en-nutriscore.json
+++ b/t/expected_test_results/attributes/en-nutriscore.json
@@ -796,6 +796,10 @@
       "en:nutriscore-computed",
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nova_group" : 1,

--- a/t/expected_test_results/ecoscore/carrots-plastic.json
+++ b/t/expected_test_results/ecoscore/carrots-plastic.json
@@ -446,7 +446,6 @@
    "lc" : "fr",
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
-      "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/carrots.json
+++ b/t/expected_test_results/ecoscore/carrots.json
@@ -450,6 +450,7 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/foie-gras.json
+++ b/t/expected_test_results/ecoscore/foie-gras.json
@@ -463,6 +463,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/fr-verseur-en-plastique.json
+++ b/t/expected_test_results/ecoscore/fr-verseur-en-plastique.json
@@ -478,6 +478,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/frozen-vegetable.json
+++ b/t/expected_test_results/ecoscore/frozen-vegetable.json
@@ -450,6 +450,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-non-recyclable-label.json
@@ -496,7 +496,6 @@
    "lc" : "fr",
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
-      "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
+++ b/t/expected_test_results/ecoscore/grade-a-with-recyclable-label.json
@@ -496,7 +496,6 @@
    "lc" : "fr",
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
-      "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil-rspo.json
@@ -403,6 +403,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/ingredient-palm-oil.json
+++ b/t/expected_test_results/ecoscore/ingredient-palm-oil.json
@@ -400,6 +400,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/known-category-butters.json
+++ b/t/expected_test_results/ecoscore/known-category-butters.json
@@ -400,6 +400,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/known-category-margarines.json
+++ b/t/expected_test_results/ecoscore/known-category-margarines.json
@@ -400,6 +400,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/label-ab-hve-msc-asc.json
+++ b/t/expected_test_results/ecoscore/label-ab-hve-msc-asc.json
@@ -409,6 +409,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/label-ab-hve.json
+++ b/t/expected_test_results/ecoscore/label-ab-hve.json
@@ -405,6 +405,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/label-msc-asc.json
+++ b/t/expected_test_results/ecoscore/label-msc-asc.json
@@ -405,6 +405,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/label-organic.json
+++ b/t/expected_test_results/ecoscore/label-organic.json
@@ -403,6 +403,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/lamb-leg.json
+++ b/t/expected_test_results/ecoscore/lamb-leg.json
@@ -446,6 +446,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/milk.json
+++ b/t/expected_test_results/ecoscore/milk.json
@@ -458,7 +458,6 @@
    "lc" : "fr",
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
-      "en:ecoscore-no-missing-data",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -479,6 +479,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -474,6 +474,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -515,6 +515,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -477,6 +477,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -471,6 +471,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -474,6 +474,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -491,6 +491,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -480,6 +480,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unknown-origin.json
@@ -442,6 +442,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
+++ b/t/expected_test_results/ecoscore/origins-of-ingredients-unspecified-origin.json
@@ -439,6 +439,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/packaging-en-bulk.json
+++ b/t/expected_test_results/ecoscore/packaging-en-bulk.json
@@ -410,6 +410,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "bulk",

--- a/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple-over-maximum-malus.json
@@ -425,6 +425,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "1 plastic box, 1 plastic film wrap, 12 individual plastic bags",

--- a/t/expected_test_results/ecoscore/packaging-en-multiple.json
+++ b/t/expected_test_results/ecoscore/packaging-en-multiple.json
@@ -427,6 +427,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "1 cardboard box, 1 plastic film wrap, 6 33cl steel beverage cans",

--- a/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-pet-bottle.json
@@ -410,6 +410,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "PET bottle",

--- a/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-plastic-bottle.json
@@ -409,6 +409,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "Plastic bottle",

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-bottle.json
@@ -410,6 +410,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "bottle",

--- a/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
+++ b/t/expected_test_results/ecoscore/packaging-en-unspecified-material-can.json
@@ -410,6 +410,9 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "packaging_text" : "can",

--- a/t/expected_test_results/ecoscore/packaging-fr-new-shapes.json
+++ b/t/expected_test_results/ecoscore/packaging-fr-new-shapes.json
@@ -476,6 +476,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified-no-a-eco-score.json
@@ -440,6 +440,8 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/packaging-unspecified.json
+++ b/t/expected_test_results/ecoscore/packaging-unspecified.json
@@ -400,6 +400,10 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
+      "en:ecoscore-missing-data-origins",
+      "en:ecoscore-missing-data-packagings",
+      "en:ecoscore-missing-data-no-packagings",
       "en:ecoscore-computed"
    ],
    "packagings" : []

--- a/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
+++ b/t/expected_test_results/ecoscore/sum-of-bonuses-greater-than-25.json
@@ -455,6 +455,7 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-packagings",
       "en:ecoscore-computed"
    ],
    "nutriments" : {

--- a/t/expected_test_results/ecoscore/uk-milk.json
+++ b/t/expected_test_results/ecoscore/uk-milk.json
@@ -459,6 +459,7 @@
    "misc_tags" : [
       "en:ecoscore-extended-data-not-computed",
       "en:ecoscore-missing-data-warning",
+      "en:ecoscore-missing-data-labels",
       "en:ecoscore-computed"
    ],
    "nutriments" : {


### PR DESCRIPTION
This is to add a /misc/en:ecoscore-missing-data-packaging facet.