### PR TITLE
change import_csv_file.pl to allow imports without an org and without setting lc and lang

### DIFF
--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -689,7 +689,7 @@ sub import_csv_file($) {
 		}
 
 		# add data_source "Producers"
-		if (($Org_id !~ /^app-/) and ( $Org_id !~ /^database-/ ) and ($Org_id !~ /^label-/)) {
+		if ((defined $Org_id) and ($Org_id !~ /^app-/) and ( $Org_id !~ /^database-/ ) and ($Org_id !~ /^label-/)) {
 			if (defined $imported_product_ref->{data_sources}) {
 				$imported_product_ref->{data_sources} .= ", Producers, Producer - " . $Org_id;
 			}
@@ -699,17 +699,17 @@ sub import_csv_file($) {
 		}
 
 		if (not defined $imported_product_ref->{lc})  {
-			$log->error("Error - missing language code lc in csv file or global field values", { i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_error();
-			next;
+			$log->warning("Warning - missing language code lc in csv file or global field values", { i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_warning();
 		}
+		else {
+			if ($imported_product_ref->{lc} !~ /^\w\w$/) {
+				$log->error("Error - lc is not a 2 letter language code", { lc => $lc, i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_error();
+				next;
+			}
 
-		if ($imported_product_ref->{lc} !~ /^\w\w$/) {
-			$log->error("Error - lc is not a 2 letter language code", { lc => $lc, i => $i, code => $code, product_id => $product_id, imported_product_ref => $imported_product_ref }) if $log->is_error();
-			next;
+			# Set the $lang field to $lc
+			$imported_product_ref->{lang} = $imported_product_ref->{lc};
 		}
-
-		# Set the $lang field to $lc
-		$imported_product_ref->{lang} = $imported_product_ref->{lc};
 
 		# Clean the input data, populate some fields from other fields (e.g. split quantity found in product name)
 


### PR DESCRIPTION
This is to be able to set a field value for a list of barcodes like this:

./import_csv_file.pl --csv carrefour_fr_codes.20200303.csv --user_id driveoff --comment "carrefour.fr 20220303" --define stores="carrefour.fr" --skip_not_existing_products --no_source 

more scripts/carrefour_fr_codes.20200303.csv 
code
0000030000117
0000030005501
0000030005518
0000030043602
0000030075214
0000030182141
0000030182158
0000030182165
0000030182172
0000030182189
0000030182196
0000030182202
0000030182219
0000040122250
0000040122274
0000040144108
0000040144283
0000040198651
0000040198668

We don't want to change the lc / lang field (main language of the product), and we don't have want to add a new data source.
