### PR TITLE
fix: correct errors in labels taxonomy

### DIFF
--- a/taxonomies/labels.result.txt
+++ b/taxonomies/labels.result.txt
@@ -13,7 +13,7 @@ stopwords:sv:certifierad, ingrediens, ingredienser, godkänd, råvara, enlighet,
 
 
 synonyms:en:carbon, co2
-synonyms:es:carbono, co2, CO<sub>2</sub>
+synonyms:es:carbono, co2, CO<sub>2</sub>, CO2
 synonyms:fi:hiili, co2
 synonyms:fr:carbone, co2
 synonyms:hu:szén, co2
@@ -34,7 +34,7 @@ synonyms:ru:долговечно, надежно, ответственно
 synonyms:en:fabrication, production
 synonyms:es:fabricación, producción, elaborado
 synonyms:fi:valmistus
-synonyms:fr:fabrique
+synonyms:fr:fabrique, fabriqué
 synonyms:ru:изготовление, производство
 
 synonyms:en:flavor, flavour, flavoring, flavouring
@@ -79,13 +79,13 @@ synonyms:hu:nélkül, nem tartalmaz, mentes
 synonyms:it:senza, 0%, zero
 synonyms:nl:zonder, 0%
 synonyms:pt:dem, 0%
-synonyms:ru:без, 0%
+synonyms:ru:без, 0%, 0 %
 
 synonyms:fr:ajout, adjonction
 synonyms:fi:lisätty
 synonyms:ru:дополнение, добавка
 
-synonyms:fr:antibiotique, anti-biotique, anti-biotiques, traitement antibiotique, utilisation d'antibiotique
+synonyms:fr:antibiotique, anti-biotique, anti-biotiques, anti-biotiques, traitement antibiotique, utilisation d'antibiotique
 
 synonyms:fr:dès la fin, après
 
@@ -401,7 +401,7 @@ en:2017 Bronze medal of the German Agricultural Society
 de:DLG Bronzener Preis 2017
 fi:Saksan maatalousyhdistyksen pronssimitali 2017
 fr:Médaille de bronze 2017 de la Société Allemande d'Agriculture
-it:Medaglia di bronzo della Società Agricola Tedesca
+it:Medaglia di bronzo 2017 della Società Agricola Tedesca
 
 < en:Bronze medal of the German Agricultural Society
 en:2018 Bronze medal of the German Agricultural Society
@@ -426,7 +426,7 @@ hu:Kalciumforrás
 it:Fonte di calcio
 nl:Bron van Calcium
 pt:Fonte de calcio
-ru:Обогащено кальцием, источник кальция
+ru:источник кальция
 th:แหล่งของแคลเซียม
 
 en:Carbon compensated product, carbon neutral
@@ -729,7 +729,7 @@ en:cormorant fishing
 de:Kormoranfischerei
 eo:Kormorana fiŝkaptado
 fi:merimetsokalastettu
-fr:pêche au cormoran
+fr:pêche au cormoran, peche au cormoran
 ja:鵜飼い
 nl:aalscholvervisserij, visserij met aalscholvers
 ta:தூண்டில் பறவைகள்
@@ -7364,12 +7364,12 @@ eu_groups:en: en:EU Group A: unprocessed plant products,
 exceptions:en: en:in-conversion products,en:wine
 
 < en:EU Organic
-en:LK-BIO-149
-ca:LK-BIO-149
-de:LK-BIO-149
-es:LK-BIO-149
-it:LK-BIO-149
-nl:LK-BIO-149
+en:LK-BIO-149, LK-BIO-149
+ca:LK-BIO-149, LK-BIO-149
+de:LK-BIO-149, LK-BIO-149
+es:LK-BIO-149, LK-BIO-149
+it:LK-BIO-149, LK-BIO-149
+nl:LK-BIO-149, LK-BIO-149
 xx:LK-BIO-149
 auth_address:en: Meeuwenlaan 4-6, 8011 BZ, Zwolle, Netherlands
 auth_name:en: Control Union Certifications
@@ -10309,7 +10309,7 @@ eu_groups:en: en:EU Group A: unprocessed plant products,en:EU Group B: live anim
 exceptions:en: en: in conversion products,en:wine
 
 < en:EU Organic
-en:RS-BIO-140
+en:RS-BIO-140, RS-BIO-140
 xx:RS-BIO-140
 auth_address:en: Vorderhaslach 1, 91230, Happurg, Germany
 auth_name:en: CERES Certification of Environmental Standards GmbH
@@ -10364,7 +10364,7 @@ eu_groups:en: en:EU Group A: unprocessed plant products,en:EU Group B: live anim
 exceptions:en: en:wine,en:until 30 June 2021
 
 < en:EU Organic
-en:RS-BIO-162
+en:RS-BIO-162, RS-BIO-162
 xx:RS-BIO-162
 auth_address:en: Trg cara Jovana Nenada 15, 24000, Subotica, Serbia
 auth_name:en: Organic Control System
@@ -13509,25 +13509,25 @@ fi:Euroopan vegetaariliitto lakto-ovo-vegetaarinen, EVU lakto-ovo-vegetaarinen
 
 < en:European Vegetarian Union
 < en:Vegan
-en:European Vegetarian Union Vegan, EVU Vegan
+en:European Vegetarian Union Vegan, European Vegetarian Union - Vegan, EVU Vegan
 ca:Unió Vegana Vegetariana Europea, EVU Vegan
 cs:Veganské označení Evropské Vegetariánské Unie, EVU Vegan
-da:Europæiske Vegetarunion Vegansk, European Vegetarian Union Vegansk, EVU Vegan
-de:Europäische Vegetarier-Union Vegan, EVU Vegan
-es:Unión Vegetariana y vegana Europea, Unión Vegetariana Europea Vegano, Unión Vegetariana Europea Vegana, EVU Vegan
+da:Europæiske Vegetarunion Vegansk, European Vegetarian Union Vegansk, Europæiske Vegetarunion - Vegansk, European Vegetarian Union - Vegansk, EVU Vegan
+de:Europäische Vegetarier-Union Vegan, Europäische Vegetarier-Union - Vegan, EVU Vegan
+es:Unión Vegetariana y vegana Europea, Unión Vegetariana Europea Vegano, Unión Vegetariana Europea Vegana, Unión Vegetariana Europea - Vegano, Unión Vegetariana Europea - Vegana, EVU Vegan
 fi:Euroopan vegetaariliitto vegaaninen, EVU vegaaninen, EVU Vegan
-fr:Union Végétarienne Européenne Végétalien, Union Végétarienne Européenne Vegan, EVU Vegan
-it:Unione Vegetariana Europea Vegano, EVU Vegan
-nl:Europese Vegetarische Unie Vegan, EVU Vegan
-sv:Europeiska Vegetariska Unionen Vegan, EVU Vegan
+fr:Union Végétarienne Européenne Végétalien, Union Végétarienne Européenne Vegan, Union Végétarienne Européenne - Végétalien, Union Végétarienne Européenne - Vegan, EVU Vegan
+it:Unione Vegetariana Europea Vegano, Unione Vegetariana Europea - Vegano, EVU Vegan
+nl:Europese Vegetarische Unie Vegan, Europese Vegetarische Unie - Vegan, EVU Vegan
+sv:Europeiska Vegetariska Unionen Vegan, Europeiska Vegetariska Unionen - Vegan, EVU Vegan
 
 < en:European Vegetarian Union
-en:European Vegetarian Union Vegetarian, EVU Vegetarian
-da:Europæiske Vegetarunion Vegetarisk, European Vegetarian Union Vegetarisk, EVU Vegetarian
-de:Europäische Vegetarier-Union Vegetarisch, EVU Vegetarian
-es:Unión Vegetariana Europea Vegetariano, Unión Vegetariana Europea Vegetariana, EVU Vegetarian
-fr:Union Végétarienne Européenne Végétarien, EVU Vegetarian
-sv:Europeiska Vegetariska Unionen Vegetarisk, EVU Vegetarian
+en:European Vegetarian Union Vegetarian, European Vegetarian Union - Vegetarian, EVU Vegetarian
+da:Europæiske Vegetarunion Vegetarisk, European Vegetarian Union Vegetarisk, Europæiske Vegetarunion - Vegetarisk, European Vegetarian Union - Vegetarisk, EVU Vegetarian
+de:Europäische Vegetarier-Union Vegetarisch, Europäische Vegetarier-Union - Vegetarisch, EVU Vegetarian
+es:Unión Vegetariana Europea Vegetariano, Unión Vegetariana Europea Vegetariana, Unión Vegetariana Europea - Vegetariano, Unión Vegetariana Europea - Vegetariana, EVU Vegetarian
+fr:Union Végétarienne Européenne Végétarien, Union Végétarienne Européenne - Végétarien, EVU Vegetarian
+sv:Europeiska Vegetariska Unionen Vegetarisk, Europeiska Vegetariska Unionen - Vegetarisk, EVU Vegetarian
 
 < en:European Vegetarian Union
 < en:Lacto-vegetarian
@@ -13690,7 +13690,7 @@ ca:Ous de gallines lliures
 de:Freilandeier
 es:Huevos de gallinas camperas
 fi:ulkokananmunat, ulkokanalasta
-fr:Œufs de poules élevées en plein air, Œufs de plein air, Œufs plein air, Œufs de poule élevée en plein air, Œuf de poule fermière élevée en liberté
+fr:Œufs de poules élevées en plein air, Œufs de plein air, Œufs plein air, Œufs de poules élevées en plein air, Œufs de poule élevée en plein air, Œufs de poules élevées en plein air, Œuf de poule fermière élevée en liberté
 he:ביצי חופש
 hu:Szabad tartású tojás
 it:Uova da allevamento all'aperto
@@ -13819,7 +13819,7 @@ ingredients:en: en:lamb
 origins:en: en:france
 
 < en:French meat
-fr:Viande de chèvre française, Viande de chèvre Origine France, Chèvre 100% Française, Chèvre 100% France, Chèvre Origine France
+fr:Viande de chèvre française, Viande de chèvre Origine France, Chèvre 100% Française, Viande de chèvre Française, Chèvre 100% France, Chèvre Origine France
 origins:en: en:france
 
 < en:French meat
@@ -14229,7 +14229,7 @@ hu:Kalciumban gazdag
 it:Ricco di calcio
 nl:Rijk aan Calcium
 pt:Rico em cálcio
-ru:Обогащено кальцием, источник кальция
+ru:Обогащено кальцием
 th:แคลเซียมสูง
 
 en:High in salt - Finland
@@ -14382,7 +14382,7 @@ de:ISO 22000:2005
 xx:ISO 22000:2005
 
 en:ISO 9001
-es:ISO 9001, Certificación de calidad ISO 9001
+es:ISO 9001, ISO 9001, Certificación de calidad ISO 9001
 fi:ISO 9001, ISO 9001 laatujärjestelmäsertifikaatti
 fr:ISO 9001, Certifie iso 9001, La certification qualite iso 9001
 hu:ISO 9001, ISO 9001 tanúsítvány
@@ -14459,7 +14459,7 @@ ca:Comprovat Kosher, BC Kosher
 he:בדיקת כשרות
 
 < en:Kosher
-en:Kosher-parve
+en:Kosher-parve, Kosher parve
 ca:Kosher-parve
 fr:Kascher pareve, Kasher pareve, Cacher pareve, casher pareve, kacher pareve, cascher pareve, Kosher pareve, Kascher parve, Kasher parve, Cacher parve, casher parve, kacher parve, cascher parve, Kosher parve
 he:כשר פרווה
@@ -14572,7 +14572,6 @@ hu:Csökkentett zsírtartalmú
 it:Ridotto contenuto di grassi
 nl:Minder vet
 pt:Gordura reduzida, menos gordura
-ru:Низкожирный
 th:ลดไขมัน
 
 en:Low lactose - Finland
@@ -14591,7 +14590,7 @@ it:Pochi o niente grassi, Basso o nessun grasso
 nl:Geen vet of vetarm
 pt:Com pouca ou sem gordura
 ru:Низкожирный или обезжиренный
-th:ไขมันต่ำ
+th:ไขมันต่ำหรือไม่มีเลย
 
 < en:Low or no fat
 en:Low fat, low in fat
@@ -14607,7 +14606,7 @@ it:Basso contenuto di grassi, A basso contenuto di grassi
 nb:Lavt fettinnhold, Naturlig lavt fettinnhold
 nl:Vetarm
 pt:Baixo teor de gordura
-ru:Низкожирный или обезжиренный
+ru:низкожирный
 sv:Låg fetthalt, Naturligt låg fetthalt
 th:ไขมันต่ำ
 
@@ -14649,7 +14648,7 @@ hu:Alacsony sótartalmú vagy sótlan
 it:Con poco sale o senza sale
 nl:Geen of weinig zout
 pt:Baixo ou sem sal
-th:โซเดียมต่ำ
+th:เกลือต่ำหรือไม่มีเลย
 
 < en:Low or no salt
 en:Low salt
@@ -14658,7 +14657,7 @@ de:Salzarm
 es:Bajo en sal
 fi:vähäsuolainen, matalasuolainen, vähän suolaa
 fr:Peu de sel, peu salé, faible teneur en sel, pauvre en sel, très pauvre en sel
-he:מופחת מלח, פחות מלח
+he:דל במלח
 hu:Alacsony sótartalmú
 it:Basso contenuto di sale
 nl:Weinig zout
@@ -14728,7 +14727,7 @@ nl:Weinig suiker
 pl:Niska zawartość cukru, Mała zawartość cukru
 pt:Pouco açucar
 ru:Низкое содержание сахара
-th:น้ำตาลต่ำ
+th:น้ำตาลต่ำหรือไม่มีเลย
 
 < en:Low or no sugar
 en:No sugar, sugar-free
@@ -15045,7 +15044,6 @@ it:Aromi naturali
 nl:Natuurlijke aromas
 pl:aromat naturalny
 pt:Sabores naturais
-th:ใช้สีธรรมชาติ
 
 en:Natural product
 ca:Producte natural
@@ -15270,7 +15268,7 @@ ca:Sense colorants ni aromes artificials
 da:Ingen kunstige smags- eller farvestoffer
 de:Keine künstlichen Farbstoffe oder Aromen
 es:Sin colorantes o saborizantes artificiales
-fi:ei keinotekoisia väriaineita tai aromeja, ei keinotekoisia väri- tai makuaineita
+fi:ei keinotekoisia väriaineita tai aromeja, ei keinotekoisia väriaineita tai aromeja, ei keinotekoisia väri- tai makuaineita
 fr:Sans colorants ni arômes artificiels
 he:ללא צבעי מאכל או חומרים משמרים מלאכותיים
 hu:Mesterséges színezék és ízesítők nélkül
@@ -15474,8 +15472,8 @@ hu:Zselatinmentes, zselatin nélkül
 it:Senza gelatina
 nl:Zonder gelatine, Gelatinevrij
 
-en:No gluten, Gluten-free, Without gluten, Gluten-free-food, free of gluten, Naturally gluten free, ni gluten
-ca:Lliure de gluten, Sense gluten, No gluten, Aliment sense gluten, Sense gluten d'orígen
+en:No gluten, Gluten-free, Without gluten, Gluten-free-food, free of gluten, Naturally gluten free, Gluten free, ni gluten
+ca:Lliure de gluten, Sense gluten, No gluten, Aliment sense gluten, Lliure de gluten, Sense gluten d'orígen
 cs:Bez lepku
 da:Glutenfri
 de:Glutenfrei
@@ -15537,6 +15535,14 @@ label_categories:en: en:Health, en:Environment
 opposite:en: en:Contains GMOs
 
 < en:No GMOs
+de:Ohne Gentechnik
+xx:Ohne Gentechnik
+
+< en:No GMOs
+de:Ohne Gentechnik hergestellt, ARGE Gentechnik-frei
+xx:Ohne Gentechnik hergestellt, ARGE Gentechnik-frei
+
+< en:No GMOs
 en:Non GMO project
 ca:NON GMO Project
 es:Proyecto no OGM
@@ -15544,18 +15550,6 @@ fi:Non GMO project, Ei-GMO-projekti
 it:Progetto non OGM
 pt:Non GMO project, Projeto não OGM
 wikidata:en: Q7754286
-
-< en:No GMOs
-en:Ohne Gentechnik
-cs:Ohne Gentechnik
-de:Ohne Gentechnik
-it:Senza OGM
-nl:Zonder gentechnologie
-
-< en:No GMOs
-en:Ohne Gentechnik hergestellt
-de:Ohne Gentechnik hergestellt, ARGE Gentechnik-frei
-it:Prodotto Senza Ingegneria Genetica
 
 en:No hydrogenated fats
 ca:Sense greixos hidrogenats
@@ -15568,7 +15562,7 @@ it:Senza grassi idrogenati
 pt:Sem gorduras hidrogenadas
 label_categories:en: en:Health, en:Nutrition
 
-en:No lactose, lactose-free, without lactose
+en:No lactose, lactose-free, Lactose free, without lactose
 ca:Sense lactosa, lliure de lactosa
 cs:Bez laktózy
 cz:Bez laktozy
@@ -15768,7 +15762,7 @@ opposite:en: en:fair-trade
 
 en:Non-organic, not organic
 ca:No ecològic
-de:Nicht Bio, nichtbio
+de:Nicht Bio, nicht-bio, nichtbio
 fr:Non-bio
 hu:Nem bio
 it:Non organico
@@ -15821,13 +15815,15 @@ se:Rekommenderas ej till barn samt gravida
 en:Not advised for pregnant women, not recommended for pregnant women
 ca:No recomanat per embarassades
 de:Für Schwangere ungeeignet
-es:Desaconsejado para embarazadas, No aconsejado para embarazadas, No aconsejado para mujeres embarazadas, Desaconsejado para mujeres embarazadas, No recomendado para embarazadas, No recomendado para mujeres embarazadas
+es:Desaconsejado para embarazadas, No aconsejado para embarazadas, No aconsejado para mujeres embarazadas, Desaconsejado para mujeres embarazadas, No recomendado para embarazadas, No recomendado para mujeres embarazadas, No recomendado para mujeres embarazadas
 fi:Ei suositella raskauden aikana
-fr:Non recommandé aux femmes enceintes, non conseillé aux femmes enceintes
+fr:Non recommandé aux femmes enceintes, non conseillé aux femmes enceintes, Déconseillé aux femmes enceintes
 hu:Nem ajánlott várandós nők számára, Nem ajánlott terhes nők számára, várandós nők számára nem ajánlott
 it:Non consigliato per le donne in gravidanza, non raccomandato per le donne in gravidanza
 nl:Niet aanbevolen voor zwangere vrouwen
 pt:Não recomendado para mulheres grávidas
+ru:Не рекомендовано для беременных женщин
+se:Recommanderas ej till gravida
 th:ไม่แนะนำสำหรับคนท้อง
 
 < en:Not advised for specific people
@@ -16024,7 +16020,7 @@ ca:Alt en Omega 3, Ric en Omega 3
 de:Hoher Omega-3-Gehalt
 es:Rico en Omega 3, Alto en Omega 3
 fi:runsaasti omega-3-rasvahappoja, paljon omega-3-rasvahappoja
-fr:Riche en Oméga-3, Riche en acide gras omega 3
+fr:Riche en Oméga-3, Riche en omega 3, Riche en acide gras omega 3
 he:עשיר באומגה 3
 hu:Omega-3 zsírsavakban gazdag
 it:Alto contenuto di Omega 3
@@ -16065,7 +16061,7 @@ ca:Orgànic, de cultiu ecologic
 cs:Bio
 da:Økologisk, Økologiske
 de:Bio, Öko, biologisch, biologische, biologischer, biologisches, Ökologisch, Kontrolliert biologisch, Kontrolliert ökologisch, biologische Landwirtschaft, ökologische Landwirtschaft, biologischer Landbau, ökologischer Landbau, aus kontrolliert biologischem Anbau, biologisch gewonnen, aus kontrolliert biologischer landwirtschaft, aus kontrolliert ökologischer erzeugung, aus kontrolliert ökologischer landwirtschaft, aus kontrolliert ökologischem anbau, aus kontrolliert ökologischem landbau, aus kontrollierter biologischer landwirtschaft, aus kontrollierter ökologischer landwirtschaft, kontrolliert biologischer anbau
-es:Ecológico, ecológica, Producto ecológico, Biológico, Producto biológico, Orgánico, Producto orgánico, Eco, Bio, Ingredientes ecológicos, Ingrediente ecológico, ingredientes procedentes de la agricultura ecológica, ingrediente procedente de la agricultura ecológica, agricultura ecológica, cumple con el reglamento de agricultura ecológica CE 2092/91, procedentes de la agricultura ecológica, procedente de la agricultura ecológica, de agricultura ecológica, Procedente e agricultura ecológica
+es:Ecológico, ecológica, Producto ecológico, Biológico, Producto biológico, Orgánico, Producto orgánico, Eco, Bio, Ingredientes ecológicos, Ingrediente ecológico, ingredientes procedentes de la agricultura ecológica, ingrediente procedente de la agricultura ecológica, agricultura ecológica, cumple con el reglamento de agricultura ecológica CE 2092/91, procedentes de la agricultura ecológica, procedente de la agricultura ecológica, de agricultura ecológica, de agricultura ecologica, Procedente e agricultura ecológica
 fi:Luomu, luomutuotanto, luomutuotantoa, luomuraaka-aine, luonnonmukainen tuotanto, luonnonmukaisesti
 fr:Bio, agriculture biologique, biologique, organic, organique, issu de l'agriculture biologique, issus de l'agriculture biologique, issue de l'agriculture biologique, issues de l'agriculture biologique, ingrédient issu de l'agriculture biologique, ingrédients issus de l'agriculture biologique, Les-ingredients-sont-issus-d-une-agriculture-biologique, ingrédients agricoles issus de l'agriculture biologique, produits issus de l'agriculture biologique, produit issu de l'agriculture biologique, ingrédient agricole issu de l'agriculture biologique, tous les ingrédients agricoles sont issus de l'agriculture biologique, les ingrédients agricoles sont issus de l'agriculture biologique, tous les ingrédients sont issus de l'agriculture biologique, ingrédients bio, ingrédients biologiques, ingrédient bio, ingrédient biologique, issue de l'agriculture biologique controlee
 he:אורגני
@@ -16212,10 +16208,10 @@ wikidata:en: Q17055995
 < en:Organic
 en:KRAV
 ca:Categoria Extra
-de:Klasse “Extra”
+de:Klasse “Extra”, Klasse Extra
 es:Categoría “Extra”
 fi:"Ekstra"-luokka
-fr:Catégorie “Extra”, catégorie supérieure
+fr:Catégorie “Extra”, catégorie supérieure, catégorie extra
 it:Classe &quot;Extra&quot;
 sv:KRAV
 country:en: Sweden
@@ -16645,7 +16641,6 @@ he:בקר טהור
 hu:100% marhahús, Tiszta marhahús
 it:Puro manzo
 nl:puur rund
-pl:Wieprzowina bez domieszek
 
 en:Pure butter
 ca:Mantega pura
@@ -17788,7 +17783,7 @@ es:Café certificado UTZ
 fi:UTZ-sertifioitua kahvia
 fr:Café certifié UTZ
 hu:UTZ Certified Coffee, UTZ tanúsított kávé
-it:Caffè certificato UTZ
+it:Caffè certificato UTZ, Caffe certificato UTZ
 pl:UTZ Certified Coffee
 
 < en:Vegan
@@ -18374,7 +18369,7 @@ fr:100% filet
 fr:Agri-Confiance
 xx:Agri-Confiance
 
-fr:AOC, A.O.C, Appellation d'Origine Contrôlée, Appelation d'Origine Contrôlée
+fr:AOC, A.O.C, Appellation d'Origine Contrôlée, Appelation d'Origine Contrôlée, aoc
 protected_name_type:en: aoc
 
 fr:Approuvé par les familles
@@ -18529,14 +18524,9 @@ fr:Concours mondial du savagnin
 
 fr:Contrat Biolait
 
-fr:Déconseillé aux femmes enceintes
-nl:Niet aanbevolen voor zwangere vrouwen
-ru:Не рекомендовано для беременных женщин
-se:Recommanderas ej till gravida
-
 fr:élevé en fût de chêne
 
-fr:Entrepreneurs + Engagés, E+
+fr:Entrepreneurs + Engagés, E+, Entrepreneurs Engagés, Entrepreneurs Engagés, E+
 label_categories:en: en:Social responsibility
 
 fr:Entreprise du Patrimoine Vivant, EPV
@@ -18803,7 +18793,7 @@ fr:Mondial du Chasselas
 
 fr:Mondial du Merlot & Assemblages by VINEA
 
-fr:Nou la fé
+fr:Nou la fé, NOU LA FE
 
 fr:Nouvelle Agriculture
 
@@ -18906,7 +18896,7 @@ fr:Saveurs de l'Année 2023, Saveur de l'Année 2023
 fr:Saveurs de Normandie
 origins:en: en:france
 
-fr:Saveurs en Or
+fr:Saveurs en Or, Saveurs en'Or
 label_categories:en: en:Geographic label
 origins:en: en:france,fr:Hauts-de-France
 wikidata:en: Q3474531
@@ -18971,10 +18961,6 @@ hu:100% magyar
 
 hu:Budapesti Borfesztivál
 
-hu:Hazai Feldolgozású Termék
-
-hu:Hazai-termék
-
 hu:Hungaricum club
 
 hu:Hungarika
@@ -18987,7 +18973,7 @@ hu:Jó magyar árú
 
 hu:Kiváló minőségű sertéshús
 
-hu:Magyar baromfi, Hatósági állatorvos ellenőrizte
+hu:Magyar baromfi, Hatósági állatorvos ellenőrizte, Magyar baromfi
 
 hu:Magyar lista
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1054,7 +1054,7 @@ hu:Kalciumforrás
 it:Fonte di calcio
 nl:Bron van Calcium
 pt:Fonte de calcio
-ru:Обогащено кальцием, источник кальция
+ru:источник кальция
 th:แหล่งของแคลเซียม
 
 en:Phosphore source
@@ -1451,7 +1451,7 @@ it:Pochi o niente grassi, Basso o nessun grasso
 nl:Geen vet of vetarm
 pt:Com pouca ou sem gordura
 ru:Низкожирный или обезжиренный
-th:ไขมันต่ำ
+th:ไขมันต่ำหรือไม่มีเลย
 
 <en:Low or no fat
 en:Low fat, low in fat
@@ -1467,7 +1467,7 @@ it:Basso contenuto di grassi, A basso contenuto di grassi
 nb:Lavt fettinnhold, Naturlig lavt fettinnhold
 nl:Vetarm
 pt:Baixo teor de gordura
-ru:Низкожирный или обезжиренный
+ru:низкожирный
 sv:Låg fetthalt, Naturligt låg fetthalt
 th:ไขมันต่ำ
 
@@ -1483,7 +1483,6 @@ hu:Csökkentett zsírtartalmú
 it:Ridotto contenuto di grassi
 nl:Minder vet
 pt:Gordura reduzida, menos gordura
-ru:Низкожирный
 th:ลดไขมัน
 
 <en:Reduced fat
@@ -1680,7 +1679,7 @@ hu:Alacsony sótartalmú vagy sótlan
 it:Con poco sale o senza sale
 nl:Geen of weinig zout
 pt:Baixo ou sem sal
-th:โซเดียมต่ำ
+th:เกลือต่ำหรือไม่มีเลย
 
 <en:Low or no salt
 en:Low salt
@@ -1689,7 +1688,7 @@ de:Salzarm
 es:Bajo en sal
 fi:vähäsuolainen, matalasuolainen, vähän suolaa
 fr:Peu de sel, peu salé, faible teneur en sel, pauvre en sel, très pauvre en sel
-he:מופחת מלח
+he:דל במלח
 hu:Alacsony sótartalmú
 it:Basso contenuto di sale
 nl:Weinig zout
@@ -1873,7 +1872,7 @@ nl:Weinig suiker
 pl:Niska zawartość cukru, Mała zawartość cukru
 pt:Pouco açucar
 ru:Низкое содержание сахара
-th:น้ำตาลต่ำ
+th:น้ำตาลต่ำหรือไม่มีเลย
 
 <en:Low sugar
 en:Reduced sugar, Less sugar
@@ -2389,7 +2388,6 @@ it:Aromi naturali
 nl:Natuurlijke aromas
 pl:aromat naturalny
 pt:Sabores naturais
-th:ใช้สีธรรมชาติ
 
 en:Never frozen
 ca:No congelar mai
@@ -2841,18 +2839,16 @@ it:Progetto non OGM
 pt:Non GMO project, Projeto não OGM
 wikidata:en:Q7754286
 
+# German specific label - Do not translate
 <en:No GMOs
-en:Ohne Gentechnik
-cs:Ohne Gentechnik
 de:Ohne Gentechnik
-it:Senza OGM
-nl:Zonder gentechnologie
+xx:Ohne Gentechnik
 # dedicated, widely used symbol of VLOG in Germany https://www.ohnegentechnik.org
 
+# German specific label - Do not translate
 <en:No GMOs
-en:Ohne Gentechnik hergestellt
 de:Ohne Gentechnik hergestellt, ARGE Gentechnik-frei
-it:Prodotto Senza Ingegneria Genetica
+xx:Ohne Gentechnik hergestellt, ARGE Gentechnik-frei
 # dedicated, widely used symbol of http://www.gentechnikfrei.at/
 
 <en:No GMOs
@@ -3144,17 +3140,14 @@ ca:No recomanat per embarassades
 de:Für Schwangere ungeeignet
 es:Desaconsejado para embarazadas, No aconsejado para embarazadas, No aconsejado para mujeres embarazadas, Desaconsejado para mujeres embarazadas, No recomendado para embarazadas, No recomendado para mujeres embarazadas, No recomendado para mujeres embarazadas
 fi:Ei suositella raskauden aikana
-fr:Non recommandé aux femmes enceintes, non conseillé aux femmes enceintes
+fr:Non recommandé aux femmes enceintes, non conseillé aux femmes enceintes, Déconseillé aux femmes enceintes
 hu:Nem ajánlott várandós nők számára, Nem ajánlott terhes nők számára, várandós nők számára nem ajánlott
 it:Non consigliato per le donne in gravidanza, non raccomandato per le donne in gravidanza
 nl:Niet aanbevolen voor zwangere vrouwen
 pt:Não recomendado para mulheres grávidas
-th:ไม่แนะนำสำหรับคนท้อง
-
-fr:Déconseillé aux femmes enceintes
-nl:Niet aanbevolen voor zwangere vrouwen
 ru:Не рекомендовано для беременных женщин
 se:Recommanderas ej till gravida
+th:ไม่แนะนำสำหรับคนท้อง
 
 <en:Not advised for specific people
 en:Not advised for children and pregnant women
@@ -16234,7 +16227,6 @@ he:בקר טהור
 hu:100% marhahús, Tiszta marhahús
 it:Puro manzo
 nl:puur rund
-pl:Wieprzowina bez domieszek
 
 en:Pure butter
 ca:Mantega pura
@@ -17606,6 +17598,7 @@ it:Carne francese
 nl:Frans vlees
 ingredients:en: en:meat
 origins:en: en:france
+# Note: putting 
 
 <fr:Viande Française
 fr:Viande d'agneau français, VAF, Viande d'agneau Origine France, Agneau 100% Français, Viande d'agneau Française, Agneau 100% France, Agneau Origine France
@@ -18218,7 +18211,7 @@ en:2017 Bronze medal of the German Agricultural Society
 de:DLG Bronzener Preis 2017
 fi:Saksan maatalousyhdistyksen pronssimitali 2017
 fr:Médaille de bronze 2017 de la Société Allemande d'Agriculture
-it:Medaglia di bronzo della Società Agricola Tedesca
+it:Medaglia di bronzo 2017 della Società Agricola Tedesca
 
 <en:Bronze medal of the German Agricultural Society
 en:2018 Bronze medal of the German Agricultural Society
@@ -18918,10 +18911,6 @@ en:Quality food from hungary
 fi:laaturuokaa Unkarista
 hu:Kiváló Magyar Termék
 image:en:Quality-food-from-hungary.90x90.jpg
-
-hu:Hazai termék
-
-hu:Hazai feldolgozású termék
 
 hu:Magyar baromfi, Hatósági állatorvos ellenőrizte
 


### PR DESCRIPTION
We now have stronger checks in the taxonomy build process to verify that the same translation in one language is not set for 2 different taxonomy entries.

This fixes the following errors:

Errors in the labels taxonomy definition:
ERROR - ru:обогащено-кальцием already is associated to en:calcium-source - ru:обогащено-кальцием cannot be mapped to entry en:high-in-calcium
ERROR - ru:низкожирный-или-обезжиренный already is associated to en:low-or-no-fat - ru:низкожирный-или-обезжиренный cannot be mapped to entry en:low-fat
ERROR - th:ไขมันต่ำ already is associated to en:low-or-no-fat - th:ไขมันต่ำ cannot be mapped to entry en:low-fat
ERROR - th:โซเดียมต่ำ already is associated to en:low-sodium - th:โซเดียมต่ำ cannot be mapped to entry en:low-or-no-salt
ERROR - he:מופחת-מלח already is associated to en:low-salt - he:מופחת-מלח cannot be mapped to entry en:reduced-salt
ERROR - th:น้ำตาลต่ำ already is associated to en:low-or-no-sugar - th:น้ำตาลต่ำ cannot be mapped to entry en:low-sugar
ERROR - th:ใช้สีธรรมชาติ already is associated to en:natural-colorings - th:ใช้สีธรรมชาติ cannot be mapped to entry en:natural-flavors
ERROR - it:senza-ogm already is associated to en:no-gmos - it:senza-ogm cannot be mapped to entry en:ohne-gentechnik
ERROR - nl:niet-aanbevolen-voor-zwangere-vrouwen already is associated to en:not-advised-for-pregnant-women - nl:niet-aanbevolen-voor-zwangere-vrouwen cannot be mapped to entry fr:deconseille-aux-femmes-enceintes
ERROR - pl:wieprzowina-bez-domieszek already is associated to en:pure-beef - pl:wieprzowina-bez-domieszek cannot be mapped to entry en:pure-pork
ERROR - it:medaglia-di-bronzo-della-societa-agricola-tedesca already is associated to en:bronze-medal-of-the-german-agricultural-society - it:medaglia-di-bronzo-della-societa-agricola-tedesca cannot be mapped to entry en:2017-bronze-medal-of-the-german-agricultural-society
ERROR - hu:hazai-termék already is associated to en:hungarian-domestic-product - hu:hazai-termék cannot be mapped to entry hu:hazai-termék
ERROR - hu:hazai-feldolgozású-termék already is associated to en:hungarian-processed-product - hu:hazai-feldolgozású-termék cannot be mapped to entry hu:hazai-feldolgozású-termék