### PR TITLE
Disable labeler on forks

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -18,6 +18,6 @@ jobs:
 
     steps:
     - uses: actions/labeler@v3.0.2
-      if: ${{ github.repository_owner == 'openfoodfacts' }}
+      if: github.event.pull_request.head.repo.full_name == github.repository
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### What
- Disable labeler on forks because it fails: https://github.com/actions/labeler/issues/31
- Found the right condition @ https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363/3
- It would be nice to use a workaround to reenable it.
- Why are people forking in the 1st place ? Isn't the repo branchable by people outside the org (while disabling checks for safety reasons)?