### PR TITLE
fix: rename languages:en to language_codes:en in countries taxonomy

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2124,9 +2124,9 @@ foreach my $country (keys %{$properties{countries}}) {
 	$country_codes_reverse{$country} = $cc;
 
 	$country_languages{$cc} = ['en'];
-	if (defined $properties{countries}{$country}{"languages:en"}) {
+	if (defined $properties{countries}{$country}{"language_codes:en"}) {
 		$country_languages{$cc} = [];
-		foreach my $language (split(",", $properties{countries}{$country}{"languages:en"})) {
+		foreach my $language (split(",", $properties{countries}{$country}{"language_codes:en"})) {
 			$language = get_string_id_for_lang("no_language", $language);
 			$language =~ s/-/_/;
 			push @{$country_languages{$cc}}, $language;

--- a/scripts/build_countries_taxonomy_from_wikidata.pl
+++ b/scripts/build_countries_taxonomy_from_wikidata.pl
@@ -172,7 +172,7 @@ foreach my $qc (sort {$names{$a} cmp $names{$b}} keys %names) {
 	}
 	
 	# official/used languages line
-	print $OUT "languages:en:" . join(',', map {$languages{$_}} (sort keys %{$countries{$qc}{official_languages}})) . "\n";
+	print $OUT "language_codes:en:" . join(',', map {$languages{$_}} (sort keys %{$countries{$qc}{official_languages}})) . "\n";
 
 	print $OUT "\n";
 

--- a/taxonomies/countries.result.txt
+++ b/taxonomies/countries.result.txt
@@ -136,7 +136,7 @@ zh:阿富汗
 zu:I-Afganistani
 country_code_2:en: AF
 country_code_3:en: AFG
-languages:en: en:pashto,en:prs
+language_codes:en: ps,prs
 wikidata:en: Q889
 
 en:Åland Islands, Åland, Ahvenanmaa, Aaland, Aaland Islands, AX, ALA
@@ -225,7 +225,7 @@ yo:Àwọn Erékùṣù Åland
 zh:奥兰群岛
 country_code_2:en: AX
 country_code_3:en: ALA
-languages:en: en:swedish
+language_codes:en: sv
 
 en:Albania, Republic of Albania, AL, ALB
 ab:Арнауыҭтәыла
@@ -364,7 +364,7 @@ yo:Albáníà
 zh:阿尔巴尼亚
 country_code_2:en: AL
 country_code_3:en: ALB
-languages:en: en:albanian
+language_codes:en: sq
 wikidata:en: Q222
 
 en:Alderney, Aurigny
@@ -412,7 +412,7 @@ uk:Олдерні
 ur:الدرنی, Alderney
 vi:Alderney
 zh:奧爾德尼島, 奥尔德尼, 奥尔德尼群岛
-languages:en: en:english
+language_codes:en: en
 
 en:Algeria, People's Democratic Republic of Algeria, DZ, DZA
 af:Algerië
@@ -550,7 +550,7 @@ zh:阿尔及利亚
 zu:IAljiriya
 country_code_2:en: DZ
 country_code_3:en: DZA
-languages:en: en:arabic,en:french
+language_codes:en: ar,fr
 wikidata:en: Q262
 
 en:American Samoa, AS, ASM
@@ -639,7 +639,7 @@ yo:Sàmóà Amẹ́ríkà
 zh:美屬薩摩亞
 country_code_2:en: AS
 country_code_3:en: ASM
-languages:en: en:english,en:samoan
+language_codes:en: en,sm
 
 en:Andorra, Principality of Andorra, Principality of the Valleys of Andorra, AD, AND
 af:Andorra
@@ -778,7 +778,7 @@ yo:Àndórà
 zh:安道尔, 安道尔公国
 country_code_2:en: AD
 country_code_3:en: AND
-languages:en: en:catalan,en:spanish,en:french,en:portuguese
+language_codes:en: ca,es,fr,pt
 wikidata:en: Q228
 
 en:Angola, Republic of Angola, AO, AGO
@@ -916,7 +916,7 @@ zh:安哥拉
 zu:I-Angola
 country_code_2:en: AO
 country_code_3:en: AGO
-languages:en: en:portuguese
+language_codes:en: pt
 wikidata:en: Q916
 
 en:Anguilla, AI, AIA
@@ -999,7 +999,7 @@ yo:Àngúíllà, Anguilla
 zh:安圭拉, 英屬安圭拉, 安圭拉岛
 country_code_2:en: AI
 country_code_3:en: AIA
-languages:en: en:english
+language_codes:en: en
 
 en:Antarctic, AQ, ATA
 ar:أنتاركتيك
@@ -1033,7 +1033,7 @@ vi:Vùng Nam Cực
 yo:Antárktìkì
 country_code_2:en: AQ
 country_code_3:en: ATA
-languages:en: 
+language_codes:en: 
 
 en:Antarctica
 af:Antarktika
@@ -1158,7 +1158,7 @@ yo:Antárktìkà
 za:Namzgigcouh
 zh:南极洲
 zu:I-Antatika
-languages:en: 
+language_codes:en: 
 
 en:Antigua and Barbuda, AG, ATG
 af:Antigua en Barbuda
@@ -1275,7 +1275,7 @@ yo:Ántígúà àti Bàrbúdà
 zh:安提瓜和巴布达
 country_code_2:en: AG
 country_code_3:en: ATG
-languages:en: en:english
+language_codes:en: en
 
 en:Argentina, Argentine Republic, AR, ARG
 af:Argentinië
@@ -1413,7 +1413,7 @@ yo:Argẹntínà
 zh:阿根廷
 country_code_2:en: AR
 country_code_3:en: ARG
-languages:en: en:spanish
+language_codes:en: es
 wikidata:en: Q414
 
 en:Armenia, Republic of Armenia, AM, ARM
@@ -1556,7 +1556,7 @@ yo:Arméníà
 zh:亞美尼亞
 country_code_2:en: AM
 country_code_3:en: ARM
-languages:en: en:armenian
+language_codes:en: hy
 wikidata:en: Q399
 
 en:Aruba, ISO 3166-1:AW, America/Aruba, Island of Aruba, AW, ABW
@@ -1653,7 +1653,7 @@ yo:Àrúbà, Àrubà, Aruba
 zh:阿魯巴, 阿鲁巴岛, 阿魯巴島, 阿盧巴, 阿鲁巴
 country_code_2:en: AW
 country_code_3:en: ABW
-languages:en: en:dutch,en:pap
+language_codes:en: nl,pap
 wikidata:en: Q21203
 
 en:Ascension Island
@@ -1721,7 +1721,7 @@ ur:جزیرہ اسینشن, Ascension Island
 vi:Đảo Ascension
 yo:Erékùṣù Ascension, Ascension Island
 zh:阿森松岛, 亚森松岛, 亞森欣島, 亞森欣
-languages:en: 
+language_codes:en: 
 
 en:Australia, Commonwealth of Australia, AU, AU, AUS
 ab:Австралиа
@@ -1870,7 +1870,7 @@ zh:澳大利亚
 zu:I-Ostreliya
 country_code_2:en: AU
 country_code_3:en: AUS
-languages:en: en:english
+language_codes:en: en
 wikidata:en: Q408
 
 en:Austria, Österreich, Republic of Austria, Republik Österreich, AT, AUT
@@ -2012,7 +2012,7 @@ zh:奥地利, 奥地利共和国
 zu:I-Ostriya
 country_code_2:en: AT
 country_code_3:en: AUT
-languages:en: en:german
+language_codes:en: de
 wikidata:en: Q40
 
 en:Azerbaijan, Republic of Azerbaijan, AZ, AZE
@@ -2158,7 +2158,7 @@ zh:阿塞拜疆
 zu:Azerbaijan
 country_code_2:en: AZ
 country_code_3:en: AZE
-languages:en: en:azerbaijani
+language_codes:en: az
 wikidata:en: Q227
 
 en:Bahrain, BH, BHR
@@ -2284,7 +2284,7 @@ yo:Báháráìnì
 zh:巴林
 country_code_2:en: BH
 country_code_3:en: BHR
-languages:en: en:arabic
+language_codes:en: ar
 wikidata:en: Q398
 
 en:Bangladesh, East Pakistan, People's Republic of Bangladesh, East Bengal, BD, BGD
@@ -2418,7 +2418,7 @@ yo:Bangladẹ́shì
 zh:孟加拉国
 country_code_2:en: BD
 country_code_3:en: BGD
-languages:en: en:bengali
+language_codes:en: bn
 wikidata:en: Q902
 
 en:Barbados, BB, BRB
@@ -2538,7 +2538,7 @@ yo:Bárbádọ̀s
 zh:巴巴多斯
 country_code_2:en: BB
 country_code_3:en: BRB
-languages:en: en:english
+language_codes:en: en
 wikidata:en: Q244
 
 en:Belarus, White Russia, White Ruthenia, Republic of Belarus, BY, BLR
@@ -2679,7 +2679,7 @@ zh:白俄罗斯
 zu:IBelarusi
 country_code_2:en: BY
 country_code_3:en: BLR
-languages:en: en:russian,en:belarusian
+language_codes:en: ru,be
 wikidata:en: Q184
 
 en:Belgium, Kingdom of Belgium, BE, BEL
@@ -2816,7 +2816,7 @@ yo:Bẹ́ljíọ̀m
 zh:比利时, 比利时王国
 country_code_2:en: BE
 country_code_3:en: BEL
-languages:en: en:dutch,en:french,en:german
+language_codes:en: nl,fr,de
 wikidata:en: Q31
 
 en:Belize, BZ, BLZ
@@ -2943,7 +2943,7 @@ zh:伯利兹
 zu:Belize
 country_code_2:en: BZ
 country_code_3:en: BLZ
-languages:en: en:english
+language_codes:en: en
 wikidata:en: Q242
 
 en:Benin, Republic of Benin, BJ, BEN
@@ -3080,7 +3080,7 @@ zh:贝宁
 zu:IBenini
 country_code_2:en: BJ
 country_code_3:en: BEN
-languages:en: en:french
+language_codes:en: fr
 wikidata:en: Q962
 
 en:Bermuda, Somers Isles, Bermuda Islands, Atlantic/Bermuda, ISO 3166-1:BM, Bermudian Islands, Bermoothes, Virgineola, The Somers Isles, Summers' Isles, Territory of Bermuda, Bermudas, Somers Islands, Colony of Bermuda, Devil's Isles, Summer's Isles, Isle of Devils, BM, BMU
@@ -3174,7 +3174,7 @@ yo:Bẹ̀rmúdà, Bermuda
 zh:百慕大, 百慕達群島, Bermuda, 百慕達, 百慕大群岛, 百幕達
 country_code_2:en: BM
 country_code_3:en: BMU
-languages:en: en:english
+language_codes:en: en
 
 en:Bhutan, Kingdom of Bhutan, BT, BTN
 af:Bhoetan
@@ -3304,7 +3304,7 @@ yo:Bhùtán
 zh:不丹, 不丹王国
 country_code_2:en: BT
 country_code_3:en: BTN
-languages:en: en:dzongkha-language
+language_codes:en: dz
 wikidata:en: Q917
 
 en:Bolivia, BO, BOL
@@ -3438,7 +3438,7 @@ yo:Bòlífíà
 zh:玻利維亞
 country_code_2:en: BO
 country_code_3:en: BOL
-languages:en: en:spanish,en:guarani,en:aymara,en:quechua-languages
+language_codes:en: es,gn,ay,qu
 wikidata:en: Q750
 
 en:Bonaire, Boneiru
@@ -3500,7 +3500,7 @@ ur:بونایر, Bonaire, (بونیر
 vi:Bonaire
 yo:Bonaire
 zh:波内赫, 博奈尔岛, 波奈, 波内赫岛, 波內赫
-languages:en: en:dutch,en:pap
+language_codes:en: nl,pap
 
 en:Bosnia and Herzegovina, Bosnia-Herzegovina, Bosnia, BiH, BA, BIH
 af:Bosnië-Herzegowina
@@ -3633,7 +3633,7 @@ yo:Bósníà àti Hẹrjẹgòfínà
 zh:波斯尼亚和黑塞哥维那
 country_code_2:en: BA
 country_code_3:en: BIH
-languages:en: en:croatian,en:serbian,en:bosnian
+language_codes:en: hr,sr,bs
 wikidata:en: Q225
 
 en:Botswana, BW, BWA
@@ -3771,7 +3771,7 @@ zh:波札那
 zu:IButswana
 country_code_2:en: BW
 country_code_3:en: BWA
-languages:en: en:english,en:tswana
+language_codes:en: en,tn
 wikidata:en: Q963
 
 en:Bouvet Island, BV, BVT
@@ -3836,7 +3836,7 @@ yo:Erékùṣù Bouvet
 zh:布韦岛
 country_code_2:en: BV
 country_code_3:en: BVT
-languages:en: 
+language_codes:en: 
 
 en:Brazil, Federative Republic of Brazil, Brasil, República Federativa do Brasil, BR, BRA
 af:Brasilië
@@ -3982,7 +3982,7 @@ zh:巴西
 zu:IBrazili
 country_code_2:en: BR
 country_code_3:en: BRA
-languages:en: en:portuguese
+language_codes:en: pt
 wikidata:en: Q155
 
 en:British Indian Ocean Territory, IO, IOT
@@ -4048,7 +4048,7 @@ yo:Agbègbè Òkun Índíà Brítánì, British Indian Ocean Territory, The Brit
 zh:英屬印度洋領地, 英属印度洋领地, 英屬印度洋地區
 country_code_2:en: IO
 country_code_3:en: IOT
-languages:en: 
+language_codes:en: 
 
 en:British Virgin Islands, Virgin Islands, BVI, VG, VGB
 af:Britse Maagde-eilande, VK Maagde-eilande, Britse Virgin-eilande, Britse Maagdeeilande, Britse-Maagde-eilande, Brits-Maagde-eilande, British Virgin Islands
@@ -4129,7 +4129,7 @@ yo:Àwọn Erékùṣù Wúndíá Brítánì, The British Virgin Islands, Britis
 zh:英屬維爾京群島, 英屬維京群島, 英屬處女群島, 英属维尔京群岛, 托托拉岛, 英屬處女島
 country_code_2:en: VG
 country_code_3:en: VGB
-languages:en: en:english
+language_codes:en: en
 
 en:Brunei, Nation of Brunei, the Abode of Peace, BN, BRN
 af:Broenei
@@ -4258,7 +4258,7 @@ yo:Brunei
 zh:文莱
 country_code_2:en: BN
 country_code_3:en: BRN
-languages:en: en:malay
+language_codes:en: ms
 wikidata:en: Q921
 
 en:Bulgaria, Republic of Bulgaria, BG, BGR
@@ -4403,7 +4403,7 @@ zh:保加利亚
 zu:IBulgariya
 country_code_2:en: BG
 country_code_3:en: BGR
-languages:en: en:bulgarian
+language_codes:en: bg
 wikidata:en: Q219
 
 en:Burkina Faso, BF, BFA
@@ -4535,7 +4535,7 @@ zh:布吉納法索
 zu:IBukhina Faso
 country_code_2:en: BF
 country_code_3:en: BFA
-languages:en: en:french
+language_codes:en: fr
 wikidata:en: Q965
 
 en:Burundi, Republic of Burundi, BI, BDI
@@ -4669,7 +4669,7 @@ zh:蒲隆地
 zu:IBurundi
 country_code_2:en: BI
 country_code_3:en: BDI
-languages:en: en:french,en:kirundi
+language_codes:en: fr,rn
 wikidata:en: Q967
 
 en:Cambodia, Kingdom of Cambodia, KH, KHM
@@ -4797,7 +4797,7 @@ yo:Kàmbódíà
 zh:柬埔寨
 country_code_2:en: KH
 country_code_3:en: KHM
-languages:en: en:khmer
+language_codes:en: km
 wikidata:en: Q424
 
 en:Cameroon, CM, CMR
@@ -4931,7 +4931,7 @@ zh:喀麦隆
 zu:IKamerooni
 country_code_2:en: CM
 country_code_3:en: CMR
-languages:en: en:french,en:english
+language_codes:en: fr,en
 wikidata:en: Q1009
 
 en:Canada, Dominion of Canada, British North America, CAN, CA, CA, CAN
@@ -5088,7 +5088,7 @@ zh:加拿大
 zu:IKhanada
 country_code_2:en: CA
 country_code_3:en: CAN
-languages:en: en:english,en:french
+language_codes:en: en,fr
 wikidata:en: Q16
 
 en:Cape Verde, Republic of Cape Verde, Cabo Verde, CV, CV, CPV
@@ -5217,7 +5217,7 @@ zh:佛得角
 zu:IKhepi Vedhi
 country_code_2:en: CV
 country_code_3:en: CPV
-languages:en: en:portuguese
+language_codes:en: pt
 wikidata:en: Q1011
 
 en:Caribbean Netherlands, BES islands, BQ, BES, Netherlands Antilles
@@ -5257,7 +5257,7 @@ vi:Caribe Hà Lan
 zh:荷蘭加勒比區
 country_code_2:en: BQ
 country_code_3:en: BES
-languages:en: 
+language_codes:en: 
 
 en:Cayman Islands, KY, CYM
 af:Kaaimanseilande
@@ -5340,7 +5340,7 @@ yo:Àwọn Erékùṣù Káímàn
 zh:開曼群島
 country_code_2:en: KY
 country_code_3:en: CYM
-languages:en: 
+language_codes:en: 
 
 en:Central African Republic, CF, CAF
 af:Sentraal-Afrikaanse Republiek
@@ -5465,7 +5465,7 @@ zh:中非共和國
 zu:Central African Republic
 country_code_2:en: CF
 country_code_3:en: CAF
-languages:en: en:french,en:sango
+language_codes:en: fr,sg
 wikidata:en: Q929
 
 en:Chad, Republic of Chad, République du Tchad, جمهورية تشاد, Ǧumhūriyyat Tšād, Tchad, TD, TCD
@@ -5597,7 +5597,7 @@ zh:乍得
 zu:ITshedi
 country_code_2:en: TD
 country_code_3:en: TCD
-languages:en: en:arabic,en:french
+language_codes:en: ar,fr
 wikidata:en: Q657
 
 en:Chile, CL, CHL
@@ -5752,7 +5752,7 @@ zh:智利
 zu:Chili
 country_code_2:en: CL
 country_code_3:en: CHL
-languages:en: en:spanish
+language_codes:en: es
 wikidata:en: Q298
 
 en:China, PRC, People's Republic of China, CN, CHN
@@ -5899,7 +5899,7 @@ zh:中华人民共和国, 中国, 中國, 中華人民共和國
 zu:IShayina
 country_code_2:en: CN
 country_code_3:en: CHN
-languages:en: en:chinese
+language_codes:en: zh
 wikidata:en: Q148
 
 en:Christmas Island, CX, CXR
@@ -5980,7 +5980,7 @@ yo:Erékùṣù Kérésìmesì, Christmas Island
 zh:圣诞岛, 耶誕島
 country_code_2:en: CX
 country_code_3:en: CXR
-languages:en: 
+language_codes:en: 
 
 en:Cocos (Keeling) Islands, Cocos Islands, Keeling Islands, Territory of the Cocos (Keeling) Islands, CC, CCK
 af:Kokoseilande, Cocos (Keeling) Eilande, Cocos (Keeling)-eilande
@@ -6059,7 +6059,7 @@ yo:Àwọn Erékùṣù Kókósì, Àwọn Erékùsù Kókósì, The Cocos (Keel
 zh:科科斯（基林）群島, 科科斯（基林）群岛, 可可群岛, 可可斯群島, 科科斯群岛, 科科斯群島, 科科斯(基林)群岛
 country_code_2:en: CC
 country_code_3:en: CCK
-languages:en: 
+language_codes:en: 
 
 en:Colombia, Republic of Colombia, CO, COL
 af:Colombia
@@ -6190,7 +6190,7 @@ zh:哥伦比亚
 zu:IKolombiya
 country_code_2:en: CO
 country_code_3:en: COL
-languages:en: en:spanish
+language_codes:en: es
 wikidata:en: Q739
 
 en:Comoros, KM, COM
@@ -6314,7 +6314,7 @@ zh:葛摩
 zu:IsiKhomorosi
 country_code_2:en: KM
 country_code_3:en: COM
-languages:en: en:arabic,en:french
+language_codes:en: ar,fr
 wikidata:en: Q970
 
 en:Cook Islands, CK, COK
@@ -6398,7 +6398,7 @@ yo:Àwọn Erékùṣù Cook, The Cook Islands, Cook Islands
 zh:库克群岛, 庫克群島, 科克群島, 科克群岛
 country_code_2:en: CK
 country_code_3:en: COK
-languages:en: 
+language_codes:en: 
 
 en:Costa Rica, Republic of Costa Rica, CR, CRI
 af:Costa Rica
@@ -6523,7 +6523,7 @@ zh:哥斯达黎加
 zu:Costa Rica
 country_code_2:en: CR
 country_code_3:en: CRI
-languages:en: en:spanish
+language_codes:en: es
 wikidata:en: Q800
 
 en:Côte d'Ivoire, Ivory Coast, Republic of Côte d'Ivoire, CI, CIV
@@ -6655,7 +6655,7 @@ zh:科特迪瓦
 zu:Ugu Emhlophe
 country_code_2:en: CI
 country_code_3:en: CIV
-languages:en: en:french
+language_codes:en: fr
 
 en:Croatia, Republic of Croatia, HR, HRV, HR, HRV
 ab:Хорватиа
@@ -6794,7 +6794,7 @@ za:Gwzlozdiya
 zh:克罗地亚
 country_code_2:en: HR
 country_code_3:en: HRV
-languages:en: en:croatian
+language_codes:en: hr
 wikidata:en: Q224
 
 en:Cuba, Republic of Cuba, CU, CUB
@@ -6924,7 +6924,7 @@ za:Gujbah
 zh:古巴
 country_code_2:en: CU
 country_code_3:en: CUB
-languages:en: en:spanish
+language_codes:en: es
 
 en:Curaçao, Island Territory of Curaçao, Curacau, Curaçoa, Curaςao, Kòrsou, Korsou, Curocao, ISO 3166-1:CW, CUW, Curazao, Curacao, Country of Curaçao, CW, CUW
 af:Curaçao
@@ -6997,7 +6997,7 @@ yo:Curaçao
 zh:库拉索, 库拉骚, 古拉索, 库拉索岛, 庫拉索, 庫拉考, 古拉梳
 country_code_2:en: CW
 country_code_3:en: CUW
-languages:en: en:english,en:dutch,en:pap
+language_codes:en: en,nl,pap
 
 en:Cyprus, Republic of Cyprus, CY, CYP
 af:Siprus
@@ -7126,7 +7126,7 @@ yo:Kíprù
 zh:賽普勒斯
 country_code_2:en: CY
 country_code_3:en: CYP
-languages:en: en:greek,en:turkish
+language_codes:en: el,tr
 
 en:Czech Republic, Czechia, CZ, CZE
 ab:Чехиа
@@ -7265,7 +7265,7 @@ zh:捷克
 zu:ITsheki
 country_code_2:en: CZ
 country_code_3:en: CZE
-languages:en: en:czech
+language_codes:en: cs
 
 en:Democratic Republic of the Congo, DRC, DR Congo, Congo-Kinshasa, Zaire, Congo, Democratic Republic of Congo, CD, COD, Congo DR, Congo DRC
 af:Demokratiese Republiek van die Kongo
@@ -7388,7 +7388,7 @@ zh:刚果民主共和国
 zu:IRiphabliki Labantu weKongo
 country_code_2:en: CD
 country_code_3:en: COD
-languages:en: en:french
+language_codes:en: fr
 
 en:Denmark, DK, Kingdom of Denmark, Danish Kingdom, Danmark, Kongeriget Danmark, DK, DNK
 af:Denemarke
@@ -7530,7 +7530,7 @@ zh:丹麦, 丹麦王国
 zu:IDenimaki
 country_code_2:en: DK
 country_code_3:en: DNK
-languages:en: en:danish
+language_codes:en: da
 
 en:Djibouti, Republic of Djibouti, DJ, DJI
 af:Djiboeti
@@ -7657,7 +7657,7 @@ zh:吉布提
 zu:IJibuthi
 country_code_2:en: DJ
 country_code_3:en: DJI
-languages:en: en:arabic,en:french
+language_codes:en: ar,fr
 
 en:Dominica, DM, DMA
 af:Dominica
@@ -7770,7 +7770,7 @@ yo:Dòmíníkà
 zh:多米尼克
 country_code_2:en: DM
 country_code_3:en: DMA
-languages:en: en:english
+language_codes:en: en
 
 en:Dominican Republic, DO, DOM
 af:Dominikaanse Republiek
@@ -7886,7 +7886,7 @@ yo:Orílẹ̀òmìnira Dómíníkì
 zh:多明尼加共和國
 country_code_2:en: DO
 country_code_3:en: DOM
-languages:en: en:spanish
+language_codes:en: es
 
 en:East Germany, GDR, German Democratic Republic, G.D.R.
 af:Duitse Demokratiese Republiek
@@ -7967,7 +7967,7 @@ vi:Cộng hòa Dân chủ Đức
 yi:מזרח דייטשלאנד
 yo:Ìlàoòrùn Jẹ́mánì
 zh:东德, 德意志民主共和国, 民主德国
-languages:en: 
+language_codes:en: 
 
 en:Ecuador, EC, ECU
 af:Ecuador
@@ -8093,7 +8093,7 @@ yo:Ẹ̀kùàdọ̀r
 zh:厄瓜多尔
 country_code_2:en: EC
 country_code_3:en: ECU
-languages:en: en:spanish
+language_codes:en: es
 
 en:Egypt, Arab Republic of Egypt, مصر, EG, EGY
 ab:Мысры
@@ -8236,7 +8236,7 @@ zh:埃及, 阿拉伯埃及共和國
 zu:IGibhithe
 country_code_2:en: EG
 country_code_3:en: EGY
-languages:en: en:arabic
+language_codes:en: ar
 
 en:El Salvador, SV, SLV
 af:El Salvador
@@ -8357,7 +8357,7 @@ zh:萨尔瓦多
 zu:El Salvador
 country_code_2:en: SV
 country_code_3:en: SLV
-languages:en: en:spanish
+language_codes:en: es
 
 en:Equatorial Guinea, Republic of Equatorial Guinea, GQ, GNQ
 af:Ekwatoriaal-Guinee
@@ -8478,7 +8478,7 @@ zh:赤道几内亚
 zu:IGini Enkabazwe
 country_code_2:en: GQ
 country_code_3:en: GNQ
-languages:en: en:spanish,en:french,en:portuguese
+language_codes:en: es,fr,pt
 
 en:Eritrea, State of Eritrea, ER, ERI
 af:Eritrea
@@ -8610,7 +8610,7 @@ zh:厄立特里亚
 zu:I-Eritrea
 country_code_2:en: ER
 country_code_3:en: ERI
-languages:en: en:arabic,en:english,en:tigrinya
+language_codes:en: ar,en,ti
 
 en:Estonia, Republic of Estonia, Estland, Eesti, EE, EST
 af:Estland
@@ -8749,7 +8749,7 @@ zh:爱沙尼亚
 zu:I-Estoniya
 country_code_2:en: EE
 country_code_3:en: EST
-languages:en: en:estonian
+language_codes:en: et
 
 en:Ethiopia, ET, ETH
 af:Ethiopië
@@ -8891,7 +8891,7 @@ zh:埃塞俄比亚
 zu:I-Ithiopia
 country_code_2:en: ET
 country_code_3:en: ETH
-languages:en: en:amharic
+language_codes:en: am
 
 en:European Union, EU, E.U.
 ab:Европатәи Аидгыла
@@ -9008,7 +9008,7 @@ wa:Union Uropeyinne
 yi:אייראפעישער פארבאנד
 yo:Ìṣọ̀kan Europe
 zh:欧洲联盟
-languages:en: en:english,en:spanish,en:finnish,en:french,en:german,en:portuguese,en:italian,en:croatian,en:dutch,en:romanian,en:bulgarian,en:polish,en:swedish,en:danish,en:czech,en:slovak,en:slovene,en:hungarian,en:estonian,en:latvian,en:lithuanian,en:greek,en:irish,en:maltese
+language_codes:en: en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
 
 en:Falkland Islands, Falklands, Malvinas, Islas Malvinas, FK, FLK
 af:Falkland-eilande
@@ -9104,7 +9104,7 @@ yo:Àwọn Erékùṣù Falkland
 zh:福克兰群岛
 country_code_2:en: FK
 country_code_3:en: FLK
-languages:en: en:english
+language_codes:en: en
 
 en:Faroe Islands, Faeroe Islands, Atlantic/Faroe, Fareo islands, Faeroyene, Far Oer, Faeroerne, Faer Oer, Faroe Isles, Faroer, Färöer, Faeroe Isles, Faroes, Faroese Islands, Foroyar, Faeroes, Faeroer, Føroyar, Faroe Island, The Faroe Islands, Færøer, Færeyjar, Fær Øer, Faeroe Is, The Faeroe Islands, Færøyene, Færøerne, Faröe Islands, Sheep Islands, Færoes, FO, FRO
 af:Faroëreilande, Faeröereilande, Färoër, Färoër-eilande, Färöer
@@ -9206,7 +9206,7 @@ yo:Àwọn Erékùṣù Fàróè, The Faroe Islands, Àwọn Erékùsù Fàróè
 zh:法罗群岛, 法罗群岛行政区划, 法羅群島, 法罗群岛历史, 法罗群岛政治, 法罗群岛教育
 country_code_2:en: FO
 country_code_3:en: FRO
-languages:en: 
+language_codes:en: 
 
 en:Federated States of Micronesia, Micronesia, FSM, FM, FSM
 af:Mikronesië
@@ -9317,7 +9317,7 @@ yo:Mikronésíà
 zh:密克罗尼西亚群岛
 country_code_2:en: FM
 country_code_3:en: FSM
-languages:en: 
+language_codes:en: 
 
 en:Fiji, Republic of Fiji, FJ, FJI
 af:Fidji
@@ -9440,7 +9440,7 @@ zh:斐濟
 zu:IFiji
 country_code_2:en: FJ
 country_code_3:en: FJI
-languages:en: en:english,en:fijian-language
+language_codes:en: en,fj
 
 en:Finland, Republic of Finland, Finlande, Finlandia, Finnland, Finnia, Soome, Land of Thousand Lakes, FI, FIN
 ab:Суоми
@@ -9585,7 +9585,7 @@ zh:芬兰, 芬兰共和国
 zu:IFinlandi
 country_code_2:en: FI
 country_code_3:en: FIN
-languages:en: en:finnish,en:swedish
+language_codes:en: fi,sv
 
 en:France, The Hexagon, French Republic, FR, FRA
 af:Frankryk
@@ -9735,7 +9735,7 @@ zh:法国
 zu:IFulansi
 country_code_2:en: FR
 country_code_3:en: FRA
-languages:en: en:french
+language_codes:en: fr
 
 en:French Guiana, GF, GUF
 af:Frans-Guyana
@@ -9831,7 +9831,7 @@ yo:Gùyánà Fránsì
 zh:法屬圭亞那
 country_code_2:en: GF
 country_code_3:en: GUF
-languages:en: en:french
+language_codes:en: fr
 
 en:French Polynesia, PF, PYF
 af:Frans-Polinesië, Frans-Polynesië, Polynésie française, Franse Polinesië, Franse Polynesia
@@ -9919,7 +9919,7 @@ yo:Polinésíà Fránsì, French Polynesia
 zh:法屬玻里尼西亞, 法屬波利尼西亞群島, 法属玻里尼西亚, 法属玻利尼西亚, 法屬波利尼西亞, 法属波利尼西亚, 法屬波里尼西亞
 country_code_2:en: PF
 country_code_3:en: PYF
-languages:en: en:french
+language_codes:en: fr
 
 en:French Southern and Antarctic Lands, TF, ATF, French Southern Territories
 af:Franse Suidelike en Antarktiese Gebiede, Terres australes et antarctiques françaises, Franse Suidelike gebiede
@@ -9977,7 +9977,7 @@ yo:Àwọn Agbègbè Apágúúsù àti Antárktìkì Fránsì, French Southern a
 zh:法属南部领地, 法屬南部地區, 法屬南方和南極領地, 法屬南半球和南極地區, 法國南半球及南極屬地, 法屬南方及南極陸地, 法屬南部屬地, 法属南方和南极洲领地, 法属南半球和南极陆地, 法属南半球及南极洲领地
 country_code_2:en: TF
 country_code_3:en: ATF
-languages:en: en:french
+language_codes:en: fr
 
 en:Gabon, Gabonese Republic, République Gabonaise, GA, GAB
 af:Gaboen
@@ -10110,7 +10110,7 @@ zh:加蓬
 zu:IGaboni
 country_code_2:en: GA
 country_code_3:en: GAB
-languages:en: en:french
+language_codes:en: fr
 
 en:Galmudug
 af:Galmudug
@@ -10130,7 +10130,7 @@ ru:Галмудуг
 so:Galmudug
 sv:Galmudug, Galmudug State
 uk:Галмудуг
-languages:en: 
+language_codes:en: 
 
 en:Gambia, Republic of the Gambia, the Gambia, GM, GMB
 af:Gambië
@@ -10263,7 +10263,7 @@ zh:冈比亚
 zu:IGambia
 country_code_2:en: GM
 country_code_3:en: GMB
-languages:en: en:english
+language_codes:en: en
 
 en:Georgia, Sakartvelo, gurz-ān, ĵurĵan, ĵurzan, gurğān, Gruzia, GE, GEO
 ab:Қырҭтәыла
@@ -10395,7 +10395,7 @@ yo:Georgia
 zh:格鲁吉亚
 country_code_2:en: GE
 country_code_3:en: GEO
-languages:en: en:georgian
+language_codes:en: ka
 
 en:Germany, FRG, BRD, Bundesrepublik Deutschland, Federal Republic of Germany, DE, DEU
 ab:Алмантәыла
@@ -10553,7 +10553,7 @@ zh:德国, 德意志, 德意志联邦, 德意志联邦共和国, 德国, 德意�
 zu:IJalimani
 country_code_2:en: DE
 country_code_3:en: DEU
-languages:en: en:german
+language_codes:en: de
 
 en:Ghana, Republic of Ghana, GH, GHA
 af:Ghana
@@ -10691,7 +10691,7 @@ zh:加纳
 zu:IGana
 country_code_2:en: GH
 country_code_3:en: GHA
-languages:en: en:english
+language_codes:en: en
 
 en:Gibraltar, GI, GIB
 af:Gibraltar
@@ -10792,7 +10792,7 @@ yo:Gibraltar
 zh:直布罗陀
 country_code_2:en: GI
 country_code_3:en: GIB
-languages:en: en:english
+language_codes:en: en
 
 en:Greece, Hellenic Republic, Hellas, GR, GRC
 ab:Барзентәыла
@@ -10935,7 +10935,7 @@ zh:希腊, 希腊共和国
 zu:IGreki
 country_code_2:en: GR
 country_code_3:en: GRC
-languages:en: en:greek
+language_codes:en: el
 
 en:Greenland, Greenland (country), GL, GRL
 af:Groenland
@@ -11049,7 +11049,7 @@ yo:Grínlándì
 zh:格陵兰
 country_code_2:en: GL
 country_code_3:en: GRL
-languages:en: en:greenlandic
+language_codes:en: kl
 
 en:Grenada, GD, GRD
 af:Grenada
@@ -11164,7 +11164,7 @@ za:Gwzlinznazdaz
 zh:格林纳达
 country_code_2:en: GD
 country_code_3:en: GRD
-languages:en: en:english
+language_codes:en: en
 
 en:Guadeloupe, GP, GLP
 af:Guadeloupe
@@ -11254,7 +11254,7 @@ yo:Guadeloupe
 zh:瓜德罗普
 country_code_2:en: GP
 country_code_3:en: GLP
-languages:en: en:french
+language_codes:en: fr
 
 en:Guam, GU, GUM
 af:Guam
@@ -11347,7 +11347,7 @@ yo:Guam
 zh:關島
 country_code_2:en: GU
 country_code_3:en: GUM
-languages:en: en:english,en:chamorro
+language_codes:en: en,ch
 
 en:Guatemala, GT, GTM
 af:Guatemala
@@ -11470,7 +11470,7 @@ zh:危地马拉
 zu:Guatemala
 country_code_2:en: GT
 country_code_3:en: GTM
-languages:en: en:spanish
+language_codes:en: es
 
 en:Guernsey, Bailliage de Guernesey, Isle of Guernsey, Island of Guernsey, Guensey, Bailiwick of Guernsey, ISO 3166-1:GG, GG, GGY
 af:Guernsey
@@ -11557,7 +11557,7 @@ yo:Guernsey
 zh:根西岛, 耿西岛, 根息岛, 根西行政區, 格恩西岛, 根息島, 根息行政區, 根西行政区, 格恩西島
 country_code_2:en: GG
 country_code_3:en: GGY
-languages:en: 
+language_codes:en: 
 
 en:Guinea, Guinea-Conakry, Republic of Guinea, GN, GIN
 af:Guinee
@@ -11687,7 +11687,7 @@ zh:几内亚
 zu:IGini
 country_code_2:en: GN
 country_code_3:en: GIN
-languages:en: en:french
+language_codes:en: fr
 
 en:Guinea-Bissau, Republic of Guinea-Bissau, GW, GNB
 af:Guinee-Bissau
@@ -11814,7 +11814,7 @@ zh:幾內亞比索
 zu:IGini Bisawu
 country_code_2:en: GW
 country_code_3:en: GNB
-languages:en: en:portuguese
+language_codes:en: pt
 
 en:Guyana, Co-operative Republic of Guyana, GY, GUY
 af:Guyana
@@ -11935,7 +11935,7 @@ yo:Gùyánà
 zh:圭亚那
 country_code_2:en: GY
 country_code_3:en: GUY
-languages:en: en:english
+language_codes:en: en
 
 en:Haiti, Republic of Haiti, HT, HTI
 af:Haïti
@@ -12058,7 +12058,7 @@ yo:Hàítì
 zh:海地
 country_code_2:en: HT
 country_code_3:en: HTI
-languages:en: en:french,en:haitian-creole
+language_codes:en: fr,ht
 
 en:Heard Island and McDonald Islands, HM, HMD
 af:Heard- en McDonaldeilande, Heard en McDonald Eilande
@@ -12117,7 +12117,7 @@ yo:Erékùṣù Heard àti Àwọn Erékùṣù McDonald, Heard Island and McDon
 zh:赫德島和麥克唐納群島, 赫德島, 麥克唐納島, 赫德及麥當勞群島, 麥克唐納群島, 賀得及麥唐納群島
 country_code_2:en: HM
 country_code_3:en: HMD
-languages:en: 
+language_codes:en: 
 
 en:Honduras, HN, HND
 af:Honduras
@@ -12243,7 +12243,7 @@ zh:洪都拉斯
 zu:Honduras
 country_code_2:en: HN
 country_code_3:en: HND
-languages:en: en:spanish
+language_codes:en: es
 
 en:Hong Kong, Hong Kong Special Administrative Region, HKSAR, HKG, HK, Hong Kong SAR, Xianggang, China Hong Kong, Hong Kong, HK, HKG
 af:Hongkong
@@ -12360,7 +12360,7 @@ za:Yanghgangj
 zh:香港, 香港特别行政区, 香港特別行政區
 country_code_2:en: HK
 country_code_3:en: HKG
-languages:en: en:chinese,en:english
+language_codes:en: zh,en
 
 en:Hungary, HU, HUN
 ab:Мадиартәыла
@@ -12499,7 +12499,7 @@ yo:Húngárì
 zh:匈牙利, 匈牙利共和国
 country_code_2:en: HU
 country_code_3:en: HUN
-languages:en: en:hungarian
+language_codes:en: hu
 
 en:Iceland, Republic of Iceland, IS, ISL
 af:Ysland
@@ -12644,7 +12644,7 @@ zh:冰岛
 zu:I-Ayisilandi
 country_code_2:en: IS
 country_code_3:en: ISL
-languages:en: en:icelandic
+language_codes:en: is
 
 en:India, Bharat, Hindustan, IN, IND
 af:Indië
@@ -12798,7 +12798,7 @@ zh:印度
 zu:INdiya
 country_code_2:en: IN
 country_code_3:en: IND
-languages:en: en:english,en:hindi
+language_codes:en: en,hi
 
 en:Indonesia, Republic of Indonesia, NKRI, Negara Kesatuan Republik Indonesia, Republik Indonesia, ID, IDN
 af:Indonesië
@@ -12941,7 +12941,7 @@ za:Yindunizsihya
 zh:印度尼西亚
 country_code_2:en: ID
 country_code_3:en: IDN
-languages:en: en:indonesian
+language_codes:en: id
 
 en:Iran, Islamic Republic of Iran, Persia, IR, IRN
 af:Iran
@@ -13079,7 +13079,7 @@ zh:伊朗
 zu:I-Irani
 country_code_2:en: IR
 country_code_3:en: IRN
-languages:en: en:persian
+language_codes:en: fa
 
 en:Iraq, IQ, IRQ
 af:Irak
@@ -13212,7 +13212,7 @@ zh:伊拉克
 zu:I-Iraki
 country_code_2:en: IQ
 country_code_3:en: IRQ
-languages:en: en:arabic,en:kurdish
+language_codes:en: ar,ku
 
 en:Iraqi Kurdistan
 ar:كردستان العراق, اقليم كردستان, إقليم كردستان, كردستان العراقية, اقليم كردستان العراق, اقليم كوردستان في العراق, إقليم كردستان العراق, اقليم كردستان في شمال العراق, قائمة جزر كردستان العراق, إقليم كردستان في شمال العراق
@@ -13254,7 +13254,7 @@ th:เขตปกครองตนเองเคอร์ดิสถาน�
 tr:Kürdistan Bölgesel Yönetimi, Kürdistan Bölgesel Hükûmeti, Irak Bölgesel Özerk Kürt Yönetimi, Kürdistan Özerk Bölgesi, Kürdistan otonomus Bölgesi, Kuzey Irak Kürt Özerk Bölgesi, Kürdistan otonom Bölgesi, Irak Kürdistan, Irak Kürdistan Özerk Bölgesi, Kürt Özerk Bölgesi, Irak kürdistanı bölgesi, Kürdistan Bölge Yönetimi, Irak Kurdistan Özerk Bölgesi
 uk:Іракський Курдистан
 zh:伊拉克庫德斯坦
-languages:en: 
+language_codes:en: 
 
 en:Ireland, Republic of Ireland, Ireland, Éire, IE, IE, IRL
 af:Republiek van Ierland, Ierse Republiek
@@ -13386,7 +13386,7 @@ zh:爱尔兰共和国, 爱尔兰
 zu:I-Ayilendi, Celts, I-Ayilandi
 country_code_2:en: IE
 country_code_3:en: IRL
-languages:en: en:english,en:irish
+language_codes:en: en,ga
 
 en:Isle of Man, Ellan Vannin, Mann, the Isle of Man, IM, IMN
 af:Man
@@ -13476,7 +13476,7 @@ yo:Erékùṣù ilẹ̀ Man
 zh:曼島
 country_code_2:en: IM
 country_code_3:en: IMN
-languages:en: en:manx,en:english
+language_codes:en: gv,en
 
 en:Israel, State of Israel, IL, ISR
 af:Israel
@@ -13614,7 +13614,7 @@ zh:以色列
 zu:Isreyili
 country_code_2:en: IL
 country_code_3:en: ISR
-languages:en: en:hebrew,en:arabic,en:russian,en:english
+language_codes:en: he,ar,ru,en
 
 en:Italy, Italia, Italian Republic, Italië, IT, ITA
 ab:Италиа
@@ -13767,7 +13767,7 @@ zh:意大利, 意大利共和国
 zu:ITaliya
 country_code_2:en: IT
 country_code_3:en: ITA
-languages:en: en:italian
+language_codes:en: it
 
 en:Jamaica, JA, Commonwealth of Jamaica, Jamdung, JM, JAM
 af:Jamaika
@@ -13890,7 +13890,7 @@ yo:Jamáíkà
 zh:牙买加
 country_code_2:en: JM
 country_code_3:en: JAM
-languages:en: en:english
+language_codes:en: en
 
 en:Jan Mayen
 af:Jan Mayen
@@ -13959,7 +13959,7 @@ ur:جان ماین
 vi:Jan Mayen
 yo:Jan Mayen
 zh:揚馬延島
-languages:en: 
+language_codes:en: 
 
 en:Japan, State of Japan, Land of the Rising Sun, Nihon, Nippon, JP, Nippon-koku, Nihon-koku, JP, JPN
 ab:Иапониа
@@ -14107,7 +14107,7 @@ zh:日本, 日本国
 zu:IJapani
 country_code_2:en: JP
 country_code_3:en: JPN
-languages:en: en:japanese
+language_codes:en: ja
 
 en:Jersey, Balliwick of Jersey, Ile de Jersey, Jerry, JE, JEY
 af:Jersey
@@ -14191,7 +14191,7 @@ yo:Jersey
 zh:澤西島
 country_code_2:en: JE
 country_code_3:en: JEY
-languages:en: en:english,en:french
+language_codes:en: en,fr
 
 en:Jordan, Hashemite Kingdom of Jordan, JO, JOR
 af:Jordanië
@@ -14314,7 +14314,7 @@ yo:Jọ́rdánì
 zh:约旦
 country_code_2:en: JO
 country_code_3:en: JOR
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Kazakhstan, Republic of Kazakhstan, KZ, KAZ
 ab:Ҟазаҟсҭан
@@ -14450,7 +14450,7 @@ za:Hahsazgwswhdanj
 zh:哈萨克斯坦
 country_code_2:en: KZ
 country_code_3:en: KAZ
-languages:en: en:russian,en:kazakh
+language_codes:en: ru,kk
 
 en:Kenya, Republic of Kenya, KE, KEN
 af:Kenia
@@ -14586,7 +14586,7 @@ zh:肯尼亚
 zu:IKenya
 country_code_2:en: KE
 country_code_3:en: KEN
-languages:en: en:english,en:swahili
+language_codes:en: en,sw
 
 en:Kiribati, KI, KIR
 af:Kiribati
@@ -14698,11 +14698,11 @@ yo:Kìrìbátì
 zh:基里巴斯
 country_code_2:en: KI
 country_code_3:en: KIR
-languages:en: en:english
+language_codes:en: en
 
 en:Kosovo, XK
 country_code_2:en: XK
-languages:en: en:albanian,en:serbian,en:bosnian,en:turkish
+language_codes:en: sq,sr,bs,tr
 
 en:Kuwait, State of Kuwait, Dawlat al-Kuwait, دولة الكويت, الكويت, KW, KWT
 af:Koeweit
@@ -14825,7 +14825,7 @@ yo:Kuwaiti
 zh:科威特
 country_code_2:en: KW
 country_code_3:en: KWT
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Kyrgyzstan, Kyrgyz Republic, KG, KGZ
 ab:Ҟырҕызсҭан
@@ -14948,7 +14948,7 @@ yo:Kirgistani
 zh:吉尔吉斯斯坦, 吉尔吉斯共和国
 country_code_2:en: KG
 country_code_3:en: KGZ
-languages:en: en:russian,en:kyrgyz
+language_codes:en: ru,ky
 
 en:Laos, Lao People's Democratic Republic, LA, LAO
 af:Laos
@@ -15074,7 +15074,7 @@ za:Lao
 zh:老挝
 country_code_2:en: LA
 country_code_3:en: LAO
-languages:en: en:lao
+language_codes:en: lo
 
 en:Latvia, Republic of Latvia, Latvian Republic, LV, LVA
 af:Letland
@@ -15210,7 +15210,7 @@ zh:拉脫維亞
 zu:ILatviya
 country_code_2:en: LV
 country_code_3:en: LVA
-languages:en: en:latvian
+language_codes:en: lv
 
 en:Lebanon, Lebanese Republic, LB, LBN
 af:Libanon
@@ -15335,7 +15335,7 @@ yo:Lẹ́bánọ́nì
 zh:黎巴嫩
 country_code_2:en: LB
 country_code_3:en: LBN
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Lesotho, Kingdom of Lesotho, LS, LSO
 af:Lesotho
@@ -15461,7 +15461,7 @@ zh:莱索托
 zu:OSotho
 country_code_2:en: LS
 country_code_3:en: LSO
-languages:en: en:english,en:sotho
+language_codes:en: en,st
 
 en:Liberia, LR, LBR
 af:Liberië
@@ -15587,7 +15587,7 @@ zh:利比里亚
 zu:ILiberia
 country_code_2:en: LR
 country_code_3:en: LBR
-languages:en: en:english
+language_codes:en: en
 
 en:Libya, State of Libya, LY, LBY
 af:Libië
@@ -15722,7 +15722,7 @@ zh:利比亚
 zu:ILibiya
 country_code_2:en: LY
 country_code_3:en: LBY
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Liechtenstein, LI, Principality of Liechtenstein, FL, LI, LIE
 af:Liechtenstein
@@ -15851,7 +15851,7 @@ yo:Líktẹ́nstáìnì
 zh:列支敦斯登
 country_code_2:en: LI
 country_code_3:en: LIE
-languages:en: en:german
+language_codes:en: de
 
 en:Lithuania, Republic of Lithuania, LT, LTU
 ab:Литва
@@ -16002,7 +16002,7 @@ zh:立陶宛, 立陶宛共和国
 zu:ILithuwaniya
 country_code_2:en: LT
 country_code_3:en: LTU
-languages:en: en:lithuanian
+language_codes:en: lt
 
 en:Luxembourg, Luxemburg, Grand Duchy of Luxembourg, LU, LU, LUX
 af:Luxemburg, Luxembourg, Groothertogdom Luxemburg
@@ -16134,7 +16134,7 @@ yo:Lúksẹ́mbọ̀rg, Luxembourg
 zh:卢森堡, 卢森堡大公国, 卢森堡公国
 country_code_2:en: LU
 country_code_3:en: LUX
-languages:en: en:french,en:german,en:luxembourgish,en:english
+language_codes:en: fr,de,lb,en
 
 en:Macau, Macao, Macau Special Administrative Region, Macau Special Administrative Region of the People's Republic of China, Aomen, MO, MAC
 af:Macau
@@ -16235,7 +16235,7 @@ za:Aumwnz
 zh:澳门, 澳门特别行政区, 澳门, 澳門特別行政區, 澳門
 country_code_2:en: MO
 country_code_3:en: MAC
-languages:en: en:portuguese,en:chinese
+language_codes:en: pt,zh
 
 en:Madagascar, Republic of Madagascar, MG, MDG
 af:Madagaskar
@@ -16373,7 +16373,7 @@ zh:马达加斯加
 zu:IMadagasika
 country_code_2:en: MG
 country_code_3:en: MDG
-languages:en: en:french,en:malagasy
+language_codes:en: fr,mg
 
 en:Malawi, Republic of Malawi, MW, MWI
 af:Malawi
@@ -16499,7 +16499,7 @@ zh:马拉维
 zu:IMalawi
 country_code_2:en: MW
 country_code_3:en: MWI
-languages:en: en:english,en:chewa
+language_codes:en: en,ny
 
 en:Malaysia, MY, MYS
 af:Maleisië
@@ -16627,7 +16627,7 @@ za:Majlaizsihya
 zh:马来西亚
 country_code_2:en: MY
 country_code_3:en: MYS
-languages:en: en:malay
+language_codes:en: ms
 
 en:Maldives, MV, MDV
 af:Maledive
@@ -16746,7 +16746,7 @@ yo:Àwọn Maldive
 zh:马尔代夫
 country_code_2:en: MV
 country_code_3:en: MDV
-languages:en: en:maldivian-language
+language_codes:en: dv
 
 en:Mali, ML, MLI
 af:Mali
@@ -16876,7 +16876,7 @@ zh:马里共和国
 zu:IMali
 country_code_2:en: ML
 country_code_3:en: MLI
-languages:en: en:french
+language_codes:en: fr
 
 en:Malta, Republic of Malta, MT, MLT
 af:Malta
@@ -17011,7 +17011,7 @@ zh:马耳他
 zu:IMalta
 country_code_2:en: MT
 country_code_3:en: MLT
-languages:en: en:english,en:maltese
+language_codes:en: en,mt
 
 en:Marshall Islands, Republic of the Marshall Islands, Aolepān Aorōkin M̧ajeļ, MH, MHL
 af:Marshalleilande
@@ -17119,7 +17119,7 @@ yo:Àwọn Erékùṣù Marshall
 zh:馬紹爾群島
 country_code_2:en: MH
 country_code_3:en: MHL
-languages:en: en:english,en:marshallese
+language_codes:en: en,mh
 
 en:Martinique, MQ, MTQ
 af:Martinique
@@ -17208,7 +17208,7 @@ yo:Mártíníkì
 zh:馬提尼克
 country_code_2:en: MQ
 country_code_3:en: MTQ
-languages:en: en:french
+language_codes:en: fr
 
 en:Mauritania, Islamic Republic of Mauritania, MR, MRT
 af:Mauritanië
@@ -17340,7 +17340,7 @@ zh:毛里塔尼亚
 zu:IMoritaniya
 country_code_2:en: MR
 country_code_3:en: MRT
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Mauritius, Republic of Mauritius, Maurice, Île Maurice, Moris, MU, MUS
 af:Mauritius
@@ -17463,7 +17463,7 @@ zh:毛里求斯
 zu:IMorishisi
 country_code_2:en: MU
 country_code_3:en: MUS
-languages:en: en:french,en:english
+language_codes:en: fr,en
 
 en:Mayotte, Department of Mayotte, YT, MYT
 af:Mayotte
@@ -17551,7 +17551,7 @@ zh:马约特
 zu:IMayotte
 country_code_2:en: YT
 country_code_3:en: MYT
-languages:en: en:french
+language_codes:en: fr
 
 en:Mexico, United Mexican States, Mexican Republic, República Mexicana, Estados Unidos Mexicanos, MX, MX, MEX
 af:Meksiko
@@ -17689,7 +17689,7 @@ zh:墨西哥, 墨西哥合眾國
 zu:IMekisiko
 country_code_2:en: MX
 country_code_3:en: MEX
-languages:en: en:spanish
+language_codes:en: es
 
 en:Moldova, Republic of Moldova, MD, MDA
 ab:Молдова
@@ -17819,7 +17819,7 @@ yo:Móldófà
 zh:摩尔多瓦
 country_code_2:en: MD
 country_code_3:en: MDA
-languages:en: en:romanian
+language_codes:en: ro
 
 en:Monaco, Principality of Monaco, MC, MCO
 af:Monaco
@@ -17947,7 +17947,7 @@ yo:Mónakò
 zh:摩纳哥
 country_code_2:en: MC
 country_code_3:en: MCO
-languages:en: en:french
+language_codes:en: fr
 
 en:Mongolia, MN, MNG
 af:Mongolië
@@ -18081,7 +18081,7 @@ za:Mungzguj
 zh:蒙古国
 country_code_2:en: MN
 country_code_3:en: MNG
-languages:en: en:mongolian
+language_codes:en: mn
 
 en:Montenegro, ME, MNE
 af:Montenegro
@@ -18210,7 +18210,7 @@ yo:Montenẹ́grò, Montenegro
 zh:蒙特內哥羅, 門的內哥羅, 门的内哥罗, 黑山共和國, 蒙特內格羅, 黑山, 蒙特尼哥羅, 蒙特尼格羅, 黑山共和国, 蒙特內哥羅共和國, 蒙地內哥羅
 country_code_2:en: ME
 country_code_3:en: MNE
-languages:en: en:serbian
+language_codes:en: sr
 
 en:Montserrat, MS, MSR
 af:Montserrat
@@ -18292,7 +18292,7 @@ yo:Montserrat
 zh:蒙塞拉特島
 country_code_2:en: MS
 country_code_3:en: MSR
-languages:en: en:english
+language_codes:en: en
 
 en:Morocco, Marocco, Kingdom of Morocco, MA, MAR
 af:Marokko
@@ -18420,7 +18420,7 @@ zh:摩洛哥
 zu:IMorokho
 country_code_2:en: MA
 country_code_3:en: MAR
-languages:en: en:arabic,en:french,en:spanish
+language_codes:en: ar,fr,es
 
 en:Mozambique, Republic of Mozambique, MZ, MOZ
 af:Mosambiek
@@ -18548,7 +18548,7 @@ zh:莫桑比克
 zu:IMozambiki
 country_code_2:en: MZ
 country_code_3:en: MOZ
-languages:en: en:portuguese
+language_codes:en: pt
 
 en:Myanmar, Burma, Republic of the Union of Myanmar, Union of Burma, MM, MMR
 af:Mianmar
@@ -18679,7 +18679,7 @@ za:Mienjdien
 zh:缅甸
 country_code_2:en: MM
 country_code_3:en: MMR
-languages:en: en:burmese
+language_codes:en: my
 
 en:Nakhchivan Autonomous Republic
 af:Nachitsjewan, Nachitsjevan, Naxçıvan, Nachitschewan
@@ -18734,7 +18734,7 @@ tr:Nahçıvan Özerk Cumhuriyeti
 uk:Нахічеванська Автономна Республіка, Нахіджеван, Нахиджеван, Нахічевань, Нахічеван, Нахичеванська Автономна Республіка
 vi:Nakhchivan, Nakhichevan
 zh:纳希切万自治共和国, 納希契凡, 納希契凡自治共和國
-languages:en: 
+language_codes:en: 
 
 en:Namibia, Republic of Namibia, NA, NAM
 af:Namibië
@@ -18864,7 +18864,7 @@ zh:纳米比亚
 zu:INamibhiya
 country_code_2:en: NA
 country_code_3:en: NAM
-languages:en: en:english
+language_codes:en: en
 
 en:Nauru, Republic of Nauru, NR, NRU
 af:Nauru
@@ -18981,7 +18981,7 @@ yo:Nàúrù
 zh:諾魯
 country_code_2:en: NR
 country_code_3:en: NRU
-languages:en: en:nauruan
+language_codes:en: na
 
 en:Nepal, Federal Democratic Republic of Nepal, NP, NPL
 af:Nepal
@@ -19114,7 +19114,7 @@ yo:Nepal
 zh:尼泊尔
 country_code_2:en: NP
 country_code_3:en: NPL
-languages:en: en:nepali
+language_codes:en: ne
 
 en:Netherlands, Holland, the Netherlands, NL, NED, NL, NLD
 af:Nederland
@@ -19257,7 +19257,7 @@ zh:荷蘭, 尼德蘭, 尼德蘭王國
 zu:Netherlands
 country_code_2:en: NL
 country_code_3:en: NLD
-languages:en: en:dutch
+language_codes:en: nl
 
 en:New Caledonia, NC, NCL
 af:Nieu-Kaledonië, Nieu-Caledonië, Nouvelle-Calédonie, Nieu-Caledonia
@@ -19345,7 +19345,7 @@ yo:Kalẹdóníà Tuntun, New Caledonia
 zh:新喀里多尼亞, 新喀爾多尼亞, 新克里多尼亞, 新喀里多尼亚群岛, 新喀里多尼亚, 新卡里多尼亞, 新喀里多尼亚岛, New Caledonia
 country_code_2:en: NC
 country_code_3:en: NCL
-languages:en: en:french
+language_codes:en: fr
 
 en:New Zealand, NZ, NZL, Dominion of New Zealand, NZ, NZL
 af:Nieu-Seeland
@@ -19475,7 +19475,7 @@ zh:新西兰
 zu:INyuzilandi
 country_code_2:en: NZ
 country_code_3:en: NZL
-languages:en: en:english,en:māori
+language_codes:en: en,mi
 
 en:Nicaragua, NI, NIC
 af:Nicaragua
@@ -19596,7 +19596,7 @@ zh:尼加拉瓜
 zu:Nicaragua
 country_code_2:en: NI
 country_code_3:en: NIC
-languages:en: en:spanish
+language_codes:en: es
 
 en:Niger, Republic of Niger, NE, NER
 af:Niger
@@ -19722,7 +19722,7 @@ zh:尼日尔
 zu:INayighe
 country_code_2:en: NE
 country_code_3:en: NER
-languages:en: en:french
+language_codes:en: fr
 
 en:Nigeria, Federal Republic of Nigeria, NG, NGA
 af:Nigerië
@@ -19857,7 +19857,7 @@ zh:奈及利亞
 zu:INigeria
 country_code_2:en: NG
 country_code_3:en: NGA
-languages:en: en:english
+language_codes:en: en
 
 en:Niue, NU, NIU
 af:Niue
@@ -19942,7 +19942,7 @@ yo:Niue
 zh:紐埃, 紐埃島, 纽埃岛, 紐威島, 纽鄂岛, 纽埃, Niue, 紐威, 尼烏埃, 纽威岛
 country_code_2:en: NU
 country_code_3:en: NIU
-languages:en: 
+language_codes:en: 
 
 en:Norfolk Island, NF, NFK
 af:Norfolk, Norfolkeiland, Norfolk-eiland
@@ -20020,7 +20020,7 @@ yo:Erékùṣù Norfolk, Norfolk Island, Erékùsù Nọ́rúfọ́lkì
 zh:诺福克岛, 諾福克島
 country_code_2:en: NF
 country_code_3:en: NFK
-languages:en: en:english
+language_codes:en: en
 
 en:North Korea, Democratic People's Republic of Korea, DPRK, PRK, KP, PRK
 af:Noord-Korea
@@ -20145,7 +20145,7 @@ yo:Kòréà Àríwá
 zh:朝鲜民主主义人民共和国, 朝鲜, 北朝鲜, 北韩
 country_code_2:en: KP
 country_code_3:en: PRK
-languages:en: en:korean
+language_codes:en: ko
 
 en:North Macedonia, Republic of North Macedonia, Republic of Macedonia, FYROM, Former Yugoslav Republic of Macedonia, Macedonia, MK, MKD
 af:Republiek Noord-Masedonië
@@ -20275,7 +20275,7 @@ yo:Orílẹ̀-èdè Olómìnira ilẹ̀ Makẹdóníà
 zh:北马其顿
 country_code_2:en: MK
 country_code_3:en: MKD
-languages:en: en:macedonian
+language_codes:en: mk
 
 en:Northern Mariana Islands, MP, MNP
 af:Noordelike Mariana-eilande
@@ -20356,7 +20356,7 @@ yo:Àwọn Erékùṣù Apáàríwá Mariana
 zh:北马里亚纳群岛
 country_code_2:en: MP
 country_code_3:en: MNP
-languages:en: en:english,en:chamorro
+language_codes:en: en,ch
 
 en:Northland State
 ba:Нортленд (Сомали)
@@ -20365,7 +20365,7 @@ it:Northland
 ja:ノースランド国
 ru:Нортленд, Нортланд
 sv:Nordland
-languages:en: 
+language_codes:en: 
 
 en:Norway, Kingdom of Norway, NO, NOR
 af:Noorweë
@@ -20508,7 +20508,7 @@ zh:挪威, 挪威王国
 zu:INoki
 country_code_2:en: NO
 country_code_3:en: NOR
-languages:en: en:bokmal
+language_codes:en: nb
 
 en:Oman, OM, OMN
 af:Oman
@@ -20630,7 +20630,7 @@ yo:Oman
 zh:阿曼
 country_code_2:en: OM
 country_code_3:en: OMN
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Pakistan, PK, PAK
 af:Pakistan
@@ -20766,7 +20766,7 @@ zh:巴基斯坦
 zu:IPakistani
 country_code_2:en: PK
 country_code_3:en: PAK
-languages:en: en:urdu,en:english
+language_codes:en: ur,en
 
 en:Palau, Republic of Palau, Belau, Pelew, PW, PLW
 af:Palau
@@ -20875,7 +20875,7 @@ yo:Páláù
 zh:帛琉
 country_code_2:en: PW
 country_code_3:en: PLW
-languages:en: en:english
+language_codes:en: en
 
 en:Palestinian territories, Palestine, ps
 af:Palestynse Grondgebiede
@@ -20903,7 +20903,7 @@ sk:Palestínske okupované územia
 ur:فلسطینی علاقہ جات
 yo:Àwọn Agbègbè ilẹ̀ Palẹstínì
 zh:巴勒斯坦领土
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Panama, Republic of Panama, PA, PAN
 af:Panama
@@ -21028,7 +21028,7 @@ zh:巴拿马
 zu:Panama
 country_code_2:en: PA
 country_code_3:en: PAN
-languages:en: 
+language_codes:en: 
 
 en:Papua New Guinea, Independent State of Papua New Guinea, PG, PNG
 af:Papoea-Nieu-Guinee
@@ -21141,7 +21141,7 @@ yo:Papua Guinea Titun
 zh:巴布亚新几内亚
 country_code_2:en: PG
 country_code_3:en: PNG
-languages:en: en:english,en:hiri-motu
+language_codes:en: en,ho
 
 en:Paraguay, Republic of Paraguay, PY, PRY
 af:Paraguay
@@ -21263,7 +21263,7 @@ yo:Paragúáì
 zh:巴拉圭
 country_code_2:en: PY
 country_code_3:en: PRY
-languages:en: en:spanish,en:guarani
+language_codes:en: es,gn
 
 en:Peru, PE, PER
 ab:Перу
@@ -21403,7 +21403,7 @@ zh:秘鲁
 zu:Peru
 country_code_2:en: PE
 country_code_3:en: PER
-languages:en: en:spanish
+language_codes:en: es
 
 en:Philippines, Republic of the Philippines, PH, PHL
 af:Filippyne
@@ -21531,7 +21531,7 @@ za:Feihlizbinh
 zh:菲律宾
 country_code_2:en: PH
 country_code_3:en: PHL
-languages:en: en:english,en:tagalog
+language_codes:en: en,tl
 
 en:Pitcairn, Pitcairn Islands, PN, PCN
 af:Pitcairneilande, Pitcairn Eiland, Pitcairn-eilande, Pitcairn Eilande
@@ -21611,7 +21611,7 @@ yo:Àwọn Erékùsù Pitcairn, Pitcairn Islands, The Pitcairn Islands
 zh:皮特凯恩群岛, 匹特揆綸島, 皮特肯島, 皮特克恩島, 皮特凯恩, 皮特凯恩岛, 皮特克恩岛, 皮特开恩群岛, 皮特肯群島, 皮特凯恩行政区划, 皮特凱恩群島, 皮特康島
 country_code_2:en: PN
 country_code_3:en: PCN
-languages:en: 
+language_codes:en: 
 
 en:Poland, Republic of Poland, PL, POL
 ab:Полша
@@ -21761,7 +21761,7 @@ zh:波兰, 波兰共和国
 zu:IPolandi
 country_code_2:en: PL
 country_code_3:en: POL
-languages:en: en:polish
+language_codes:en: pl
 
 en:Portugal, Portuguese Republic, PT, PT, PRT
 af:Portugal
@@ -21904,7 +21904,7 @@ zh:葡萄牙, 葡萄牙共和国, 葡国
 zu:IPhothugali
 country_code_2:en: PT
 country_code_3:en: PRT
-languages:en: en:portuguese
+language_codes:en: pt
 
 en:Puerto Rico, Commonwealth of Puerto Rico, PR, PRI
 af:Puerto Rico
@@ -22007,7 +22007,7 @@ yo:Púẹ́rtò Ríkò
 zh:波多黎各
 country_code_2:en: PR
 country_code_3:en: PRI
-languages:en: en:spanish,en:english
+language_codes:en: es,en
 
 en:Qatar, QA, QAT
 af:Katar
@@ -22133,7 +22133,7 @@ yo:Katar
 zh:卡塔尔
 country_code_2:en: QA
 country_code_3:en: QAT
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Republic of the Congo, Congo-Brazzaville, CG, COG, Congo Republic
 af:Republiek van die Kongo
@@ -22254,7 +22254,7 @@ zh:刚果共和国
 zu:IKongo
 country_code_2:en: CG
 country_code_3:en: COG
-languages:en: en:french
+language_codes:en: fr
 
 en:Republika Srpska
 ar:جمهورية صرب البوسنة
@@ -22311,7 +22311,7 @@ ur:سرپسکا
 vi:Cộng hòa Srpska
 yo:Sérbíà Orílẹ̀-èdè Olómìnira
 zh:塞族共和國
-languages:en: 
+language_codes:en: 
 
 en:Réunion, RE, REU
 af:Réunion
@@ -22401,7 +22401,7 @@ zh:留尼汪
 zu:IRiyunion
 country_code_2:en: RE
 country_code_3:en: REU
-languages:en: en:french
+language_codes:en: fr
 
 en:Romania, Roumania, Rumania, România, RO, ROU
 af:Roemenië
@@ -22538,7 +22538,7 @@ yo:Románíà
 zh:羅馬尼亞
 country_code_2:en: RO
 country_code_3:en: ROU
-languages:en: en:romanian
+language_codes:en: ro
 
 en:Russia, Russian Federation, Russian federation, Rossiyskaya Federatsiya, Россия, Rossijskaja Federatsija, Российская Федерация, 🇷🇺, RU, RUS
 ab:Урыстәыла
@@ -22708,7 +22708,7 @@ zh:俄罗斯
 zu:IRashiya
 country_code_2:en: RU
 country_code_3:en: RUS
-languages:en: en:russian
+language_codes:en: ru
 
 en:Rwanda, Republic of Rwanda, RW, RWA
 af:Rwanda
@@ -22839,7 +22839,7 @@ zh:卢旺达
 zu:IRuwanda
 country_code_2:en: RW
 country_code_3:en: RWA
-languages:en: en:english,en:french,en:kinyarwanda
+language_codes:en: en,fr,rw
 
 en:Saba
 af:Saba
@@ -22894,7 +22894,7 @@ uk:Саба
 ur:سابا, Saba
 vi:Saba
 zh:薩巴, 薩巴島, 沙巴, 萨巴岛
-languages:en: en:english,en:dutch
+language_codes:en: en,nl
 
 en:Saint-Barthélemy, Saint Barthélemy, Ouanalao, Collectivité de Saint-Barthélemy, Saint Barths, Ile Saint-Barthélemy, Saint Barthélémy, St. Barthelemy, St barths, St. Barthélemy, Saint Barts, Saint-Barthélémy, St. Barths, ISO 3166-1:BL, Île Saint-Barthélemy, Saint Bartz, St barts, St. Barth, America/St Barthelemy, Collectivity of Saint Barthélemy, Saint-Barthelemy, Saint Barthelemy, St barthelemy, Saint Barth, BL, BLM
 af:Saint-Barthélemy, Sint-Bartholomeus, Saint Barthélemy, Saint-Barthelemy, Sint-Barthélemy, Sint-Barthelemy, Saint Barthelemy, Sint Barthélemy
@@ -22959,7 +22959,7 @@ yo:Saint Barthélemy, Saint-Barthélemy
 zh:聖巴泰勒米島, 圣巴托罗缪岛, 聖巴托洛繆島, 圣巴泰勒米, 圣巴托洛缪岛, 聖巴瑟米
 country_code_2:en: BL
 country_code_3:en: BLM
-languages:en: en:french
+language_codes:en: fr
 
 en:Saint Helena, Ascension and Tristan da Cunha, Saint Helena and Dependencies, SH, SHN
 af:Sint Helena, Ascension en Tristan da Cunha
@@ -23006,7 +23006,7 @@ yo:Saint Helena, Ascension àti Tristan da Cunha, Saint Helena, Ascension and Tr
 zh:圣赫勒拿、阿森松与特里斯坦达库尼亚
 country_code_2:en: SH
 country_code_3:en: SHN
-languages:en: 
+language_codes:en: 
 
 en:Saint Kitts and Nevis, Saint Christopher and Nevis, Federation of Saint Kitts and Nevis, KN, KNA
 af:St. Kitts en Nevis
@@ -23117,7 +23117,7 @@ yo:Saint Kitts àti Nevis
 zh:聖克里斯多福與尼維斯
 country_code_2:en: KN
 country_code_3:en: KNA
-languages:en: en:english
+language_codes:en: en
 
 en:Saint Lucia, LC, LCA
 af:St. Lucia
@@ -23225,7 +23225,7 @@ yo:Lùsíà Mímọ́
 zh:圣卢西亚
 country_code_2:en: LC
 country_code_3:en: LCA
-languages:en: en:english
+language_codes:en: en
 
 en:Saint Martin, Saint Martin France, Collectivity of Saint Martin, MF, MAF
 af:Saint-Martin, Saint Martin
@@ -23279,7 +23279,7 @@ yo:Ìkólẹ̀jọ Saint Martin, Saint Martin, Collectivity of Saint Martin
 zh:法屬聖馬丁, 法属圣马丁
 country_code_2:en: MF
 country_code_3:en: MAF
-languages:en: en:french
+language_codes:en: fr
 
 en:Saint Pierre and Miquelon, PM, SPM
 af:Saint-Pierre en Miquelon, Saint-Pierre et Miquelon, Saint Pierre en Miquelon, Sint Pierre en Miquelon, Sint-Pierre en Miquelon
@@ -23362,7 +23362,7 @@ yo:Saint Pierre àti Mìkẹ́lọ̀n, Saint Pierre and Miquelon
 zh:圣皮埃尔和密克隆群岛, 聖皮埃蘭和密克隆群島, 聖皮里和米圭隆, 聖匹及密啟倫群島, 圣皮耶和密克罗, 圣皮埃尔和密克隆, 聖皮耶與密克隆群島, 聖皮埃爾島和密克隆島
 country_code_2:en: PM
 country_code_3:en: SPM
-languages:en: en:french
+language_codes:en: fr
 
 en:Saint Vincent and the Grenadines, VC, VCT
 af:St. Vincent en die Grenadines
@@ -23465,7 +23465,7 @@ yo:Saint Vincent àti àwọn Grẹnadínì
 zh:圣文森特和格林纳丁斯
 country_code_2:en: VC
 country_code_3:en: VCT
-languages:en: en:english
+language_codes:en: en
 
 en:Samoa, Western Samoa, Independent State of Samoa, WS, WSM
 af:Samoa
@@ -23577,7 +23577,7 @@ yo:Sàmóà
 zh:萨摩亚
 country_code_2:en: WS
 country_code_3:en: WSM
-languages:en: en:english,en:samoan
+language_codes:en: en,sm
 
 en:San Marino, SM, SMR
 af:San Marino
@@ -23707,7 +23707,7 @@ zh:圣马力诺
 zu:USanti Marino
 country_code_2:en: SM
 country_code_3:en: SMR
-languages:en: en:italian
+language_codes:en: it
 
 en:Sao Tomé and Príncipe, Democratic Republic of São Tomé and Príncipe, São Tomé og Príncipe, ST, STP
 af:São Tomé en Príncipe
@@ -23823,7 +23823,7 @@ zh:圣多美和普林西比
 zu:ISawu Tome noPhrinitshipeyi
 country_code_2:en: ST
 country_code_3:en: STP
-languages:en: en:portuguese
+language_codes:en: pt
 
 en:Saudi Arabia, The Kingdom of Saudi Arabia, SA, SAU
 af:Saoedi-Arabië
@@ -23954,7 +23954,7 @@ yo:Sáúdí Arábíà
 zh:沙特阿拉伯
 country_code_2:en: SA
 country_code_3:en: SAU
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Senegal, Republic of Senegal, SN, SEN
 af:Senegal
@@ -24084,7 +24084,7 @@ zh:塞内加尔
 zu:ISenegal
 country_code_2:en: SN
 country_code_3:en: SEN
-languages:en: en:french
+language_codes:en: fr
 
 en:Serbia, RS, SRB
 af:Serwië
@@ -24221,7 +24221,7 @@ zh:塞尔维亚
 zu:ISerbiya
 country_code_2:en: RS
 country_code_3:en: SRB
-languages:en: en:serbian
+language_codes:en: sr
 
 en:Seychelles, Republic of Seychelles, SC, SYC
 af:Seychelle
@@ -24343,7 +24343,7 @@ zh:塞舌尔
 zu:IsiSeyisheli
 country_code_2:en: SC
 country_code_3:en: SYC
-languages:en: en:french,en:english
+language_codes:en: fr,en
 
 en:Sierra Leone, Republic of Sierra Leone, SL, SLE
 af:Sierra Leone
@@ -24469,7 +24469,7 @@ zh:塞拉利昂
 zu:ISiera Liyoni
 country_code_2:en: SL
 country_code_3:en: SLE
-languages:en: en:english
+language_codes:en: en
 
 en:Singapore, Republic of Singapore, SG, SGP
 af:Singapoer
@@ -24602,7 +24602,7 @@ yo:Singapore
 zh:新加坡, 星加坡
 country_code_2:en: SG
 country_code_3:en: SGP
-languages:en: en:english,en:tamil,en:chinese,en:malay
+language_codes:en: en,ta,zh,ms
 
 en:Sint Eustatius, Statia, Statius, St. Eustatius
 af:Sint Eustatius, Sint-Eustatius
@@ -24653,7 +24653,7 @@ uk:Сінт-Естатіус
 ur:سینٹ ایوسٹائیس, Sint Eustatius
 vi:Sint Eustatius, Saint Eustatius
 zh:圣尤斯特歇斯, 聖佑達修斯, 聖尤斯特歇斯島, 圣尤斯特歇斯岛
-languages:en: en:english,en:dutch
+language_codes:en: en,nl
 
 en:Sint Maarten, St. Maarten, Saint Martin Dutch part, SX, SXM
 af:Sint Maarten, Sint-Maarten
@@ -24710,7 +24710,7 @@ vi:Sint Maarten, Lãnh thổ Đảo Sint Maarten, Lãnh thổ St. Maarten, Lãnh
 zh:荷屬聖馬丁, 荷属圣马丁, 荷屬馬丁尼
 country_code_2:en: SX
 country_code_3:en: SXM
-languages:en: en:english,en:dutch
+language_codes:en: en,nl
 
 en:Slovakia, Slovak Republic, SK, SVK
 af:Slowakye
@@ -24843,7 +24843,7 @@ zh:斯洛伐克
 zu:ISlovaki
 country_code_2:en: SK
 country_code_3:en: SVK
-languages:en: en:slovak
+language_codes:en: sk
 
 en:Slovenia, Republic of Slovenia, Slovenija, Republika Slovenija, SI, SVN
 af:Slowenië
@@ -24978,7 +24978,7 @@ yo:Sloféníà
 zh:斯洛文尼亚
 country_code_2:en: SI
 country_code_3:en: SVN
-languages:en: en:slovene
+language_codes:en: sl
 
 en:Solomon Islands, SB, SLB
 af:Solomoneilande
@@ -25090,7 +25090,7 @@ yo:Àwọn Erékùsù Sólómọ́nì
 zh:所罗门群岛
 country_code_2:en: SB
 country_code_3:en: SLB
-languages:en: en:english
+language_codes:en: en
 
 en:Somalia, Federal Republic of Somalia, SO, SOM
 af:Somalië
@@ -25222,7 +25222,7 @@ zh:索马里
 zu:ISomalia
 country_code_2:en: SO
 country_code_3:en: SOM
-languages:en: en:somali,en:arabic
+language_codes:en: so,ar
 
 en:South Africa, Republic of South Africa, RSA, ZA, ZAF
 af:Suid-Afrika
@@ -25365,7 +25365,7 @@ zh:南非
 zu:IRiphabliki yaseNingizimu Afrika
 country_code_2:en: ZA
 country_code_3:en: ZAF
-languages:en: en:english,en:zulu,en:xhosa,en:afrikaans,en:venda,en:swazi,en:tswana,en:tsonga,en:sotho,en:southern-ndebele
+language_codes:en: en,zu,xh,af,ve,ss,tn,ts,st,nr
 
 en:South Georgia and the South Sandwich Islands, South Georgia, South Sandwich Islands, GS, SGS
 af:Suid-Georgië en die Suidelike Sandwicheilande, Suid-Georgia en die Suidelik Sandwicheilande, Suid-Georgië en die Suide Sandwicheilande, Suid-Georgië en die Suid-Sandwich Eilande, South Georgia and the South Sandwich Islands, Suid-Georgie en die Suidelike Sandwicheilande, Suid-Georgië en de Suidelike Sandwicheilanden, Suid-Georgië en die Suid-Sandwicheilande
@@ -25446,7 +25446,7 @@ yo:Gúúsù Georgia àti Àwọn Erékùṣù Gúúsù Sandwich, South Georgia a
 zh:南喬治亞島與南桑威奇群島, 南喬治亞, 南乔治亚和南桑德韦奇群岛, 南三明治群島, 南乔治亚岛和南桑威奇群岛, 南喬治亞島和南三明治群島, 南喬治亞和桑威奇群島, 南佐治亞島與南桑威奇群島, 南乔治亚与南桑威奇群岛, 南佐治亞及南三文治群島, 南喬治亞與南三明治群島, 南喬治亞群島, 南喬治亞和南三文治群島, 南桑德维奇群岛, 南喬治亞及南三明治群島, 南乔治亚岛和南桑德韦奇岛, 南喬治亞及南桑威奇群島, 南乔治亚岛
 country_code_2:en: GS
 country_code_3:en: SGS
-languages:en: en:english
+language_codes:en: en
 
 en:South Korea, Republic of Korea, ROK, KR, KOR
 af:Suid-Korea
@@ -25582,7 +25582,7 @@ za:Hanzgoz
 zh:大韩民国
 country_code_2:en: KR
 country_code_3:en: KOR
-languages:en: en:korean
+language_codes:en: ko
 
 en:South Sudan, Republic of South Sudan, Southern Sudan, SS, SSD
 af:Suid-Soedan
@@ -25695,7 +25695,7 @@ zh:南蘇丹
 zu:ISudan yaseNingizimu
 country_code_2:en: SS
 country_code_3:en: SSD
-languages:en: en:english
+language_codes:en: en
 
 en:Soviet Union, USSR, U.S.S.R., Soviets, U.S.S.R, The Union of Soviet Socialist Republics, The Soviet Union, Union of soviet socialist republics, Union of Soviet Socialist Republics, The Soviets
 af:Sowjetunie
@@ -25808,7 +25808,7 @@ yi:סאוועטן פארבאנד
 yo:Ìsọ̀kan Sófìẹ̀tì
 za:Suhlienz
 zh:苏联
-languages:en: en:russian
+language_codes:en: ru
 
 en:Spain, Kingdom of Spain, España, Reino de España, ES, ESP
 af:Spanje
@@ -25957,7 +25957,7 @@ zh:西班牙, 西班牙王国
 zu:ISpeyini
 country_code_2:en: ES
 country_code_3:en: ESP
-languages:en: en:spanish,en:catalan,en:basque,en:galician
+language_codes:en: es,ca,eu,gl
 
 en:Sri Lanka, Democratic Socialist Republic of Sri Lanka, LK, LKA
 af:Sri Lanka
@@ -26085,7 +26085,7 @@ yo:Sri Lanka
 zh:斯里蘭卡
 country_code_2:en: LK
 country_code_3:en: LKA
-languages:en: en:sinhala,en:tamil
+language_codes:en: si,ta
 
 en:State of Palestine
 af:Staat van Palestina, Palestinië, Palestina, Palestynse Nasionale Owerheid, Palestynse Owerheid, Palestynse Owerhede
@@ -26142,7 +26142,7 @@ yo:Orílẹ̀-èdè Palẹstínì, State of Palestine
 zh:巴勒斯坦国, 巴勒斯坦國, 巴勒斯坦
 country_code_2:en: PS
 country_code_3:en: PSE
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Sudan, suca, SD, SDN
 af:Soedan
@@ -26280,7 +26280,7 @@ yo:Sudan
 zh:苏丹共和国
 country_code_2:en: SD
 country_code_3:en: SDN
-languages:en: en:arabic,en:english
+language_codes:en: ar,en
 
 en:Suriname, Surinam, Republic of Suriname, Republic of Surinam, Dutch Guiana, SR, SUR
 af:Suriname
@@ -26399,7 +26399,7 @@ yo:Sùrìnámù
 zh:蘇利南
 country_code_2:en: SR
 country_code_3:en: SUR
-languages:en: en:dutch
+language_codes:en: nl
 
 en:Svalbard and Jan Mayen, SJ, SJM
 ar:سفالبارد ويان ماين
@@ -26431,7 +26431,7 @@ yo:Svalbard àti Jan Mayen, Svalbard and Jan Mayen
 zh:斯瓦尔巴和扬马延
 country_code_2:en: SJ
 country_code_3:en: SJM
-languages:en: 
+language_codes:en: 
 
 en:Swaziland, Kingdom of Swaziland, SZ, SWZ
 af:Swaziland
@@ -26556,7 +26556,7 @@ zh:斯威士兰
 zu:ISwazilandi
 country_code_2:en: SZ
 country_code_3:en: SWZ
-languages:en: en:english,en:swazi
+language_codes:en: en,ss
 
 en:Sweden, Kingdom of Sweden, SE, SE, SWE
 ab:Швециа
@@ -26702,7 +26702,7 @@ zh:瑞典, 瑞典王国
 zu:ISwidi
 country_code_2:en: SE
 country_code_3:en: SWE
-languages:en: en:swedish
+language_codes:en: sv
 
 en:Switzerland, Swiss Confederation, CH, CH, CHE
 af:Switserland
@@ -26837,7 +26837,7 @@ za:Nyeiqswq
 zh:瑞士, 瑞士联邦
 country_code_2:en: CH
 country_code_3:en: CHE
-languages:en: en:german,en:french,en:italian
+language_codes:en: de,fr,it
 
 en:Syria, Syrian Arab Republic, SY, SYR
 af:Sirië
@@ -26967,7 +26967,7 @@ yo:Síríà
 zh:叙利亚
 country_code_2:en: SY
 country_code_3:en: SYR
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Taiwan, Republic of China, ROC, Chinese Taipei, Taiwan, TW, TWN
 af:Republiek van Sjina
@@ -27086,7 +27086,7 @@ za:Cunghvaz Minzgoz
 zh:中華民國
 country_code_2:en: TW
 country_code_3:en: TWN
-languages:en: en:chinese
+language_codes:en: zh
 
 en:Tajikistan, Republic of Tajikistan, TJ, TJK
 af:Tadjikistan
@@ -27211,7 +27211,7 @@ yo:Tajikistan
 zh:塔吉克斯坦
 country_code_2:en: TJ
 country_code_3:en: TJK
-languages:en: en:russian,en:tajik
+language_codes:en: ru,tg
 
 en:Tanzania, United Republic of Tanzania, TZ, TZA
 af:Tanzanië
@@ -27349,7 +27349,7 @@ zh:坦桑尼亚
 zu:ITanzania
 country_code_2:en: TZ
 country_code_3:en: TZA
-languages:en: en:english,en:swahili
+language_codes:en: en,sw
 
 en:Thailand, Kingdom of Thailand, TH, THA
 af:Thailand
@@ -27480,7 +27480,7 @@ za:Daigoz
 zh:泰国
 country_code_2:en: TH
 country_code_3:en: THA
-languages:en: en:thai
+language_codes:en: th
 
 en:The Bahamas, Bahamas, Commonwealth of the Bahamas, BS, BHS
 af:Bahamas
@@ -27601,7 +27601,7 @@ yo:Àwọn Bàhámà
 zh:巴哈马
 country_code_2:en: BS
 country_code_3:en: BHS
-languages:en: en:english
+language_codes:en: en
 
 en:Timor-Leste, East Timor, Democratic Republic of Timor-Leste, TL, TLS
 af:Oos-Timor
@@ -27719,7 +27719,7 @@ za:Doeng Divwnq
 zh:东帝汶
 country_code_2:en: TL
 country_code_3:en: TLS
-languages:en: en:portuguese
+language_codes:en: pt
 
 en:Togo, Togolese Republic, TG, TGO
 af:Togo
@@ -27849,7 +27849,7 @@ zh:多哥
 zu:ITogo
 country_code_2:en: TG
 country_code_3:en: TGO
-languages:en: en:french
+language_codes:en: fr
 
 en:Tokelau, TK, TKL
 af:Tokelau
@@ -27925,7 +27925,7 @@ yo:Tokelau
 zh:托克劳群岛, 托克勞, 托克劳行政区划, 托克劳
 country_code_2:en: TK
 country_code_3:en: TKL
-languages:en: 
+language_codes:en: 
 
 en:Tonga, TO, TON
 af:Tonga
@@ -28039,7 +28039,7 @@ yo:Tóngà
 zh:東加
 country_code_2:en: TO
 country_code_3:en: TON
-languages:en: en:english,en:tongan-language
+language_codes:en: en,to
 
 en:Trinidad and Tobago, Republic of Trinidad and Tobago, TT, TTO
 af:Trinidad en Tobago
@@ -28147,7 +28147,7 @@ yo:Trínídád àti Tòbágò
 zh:千里達及托巴哥
 country_code_2:en: TT
 country_code_3:en: TTO
-languages:en: en:english
+language_codes:en: en
 
 en:Tunisia, Republic of Tunisia, TN, TUN
 af:Tunisië
@@ -28276,7 +28276,7 @@ zh:突尼西亞
 zu:ITunisia
 country_code_2:en: TN
 country_code_3:en: TUN
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Turkey, Republic of Turkey, TR, TUR
 ab:Ҭырқәтәыла
@@ -28424,7 +28424,7 @@ zh:土耳其, 土耳其共和国
 zu:ITheki
 country_code_2:en: TR
 country_code_3:en: TUR
-languages:en: en:turkish
+language_codes:en: tr
 
 en:Turkmenistan, TM, TKM
 af:Turkmenistan
@@ -28549,7 +28549,7 @@ yo:Turkmẹ́nìstán
 zh:土库曼斯坦
 country_code_2:en: TM
 country_code_3:en: TKM
-languages:en: en:turkmen
+language_codes:en: tk
 
 en:Turks and Caicos Islands, TC, TCA
 af:Turks- en Caicos-eilande
@@ -28633,7 +28633,7 @@ yo:Àwọn Erékùṣù Turks àti Caicos
 zh:特克斯和凯科斯群岛
 country_code_2:en: TC
 country_code_3:en: TCA
-languages:en: 
+language_codes:en: 
 
 en:Tuvalu, Ellice Islands, TV, TUV
 af:Tuvalu
@@ -28746,7 +28746,7 @@ yo:Tufalu
 zh:圖瓦盧
 country_code_2:en: TV
 country_code_3:en: TUV
-languages:en: en:english
+language_codes:en: en
 
 en:Uganda, Republic of Uganda, UG, UGA
 af:Uganda
@@ -28876,7 +28876,7 @@ zh:乌干达
 zu:IYuganda
 country_code_2:en: UG
 country_code_3:en: UGA
-languages:en: en:english,en:swahili
+language_codes:en: en,sw
 
 en:Ukraine, UA, UKR
 ab:Украина
@@ -29016,7 +29016,7 @@ yo:Ukréìn
 zh:乌克兰
 country_code_2:en: UA
 country_code_3:en: UKR
-languages:en: en:ukrainian
+language_codes:en: uk
 
 en:United Arab Emirates, UAE, AE, ARE
 af:Verenigde Arabiese Emirate
@@ -29140,7 +29140,7 @@ yo:Àwọn Ẹ́mírétì Árábù Aṣọ̀kan
 zh:阿拉伯联合酋长国
 country_code_2:en: AE
 country_code_3:en: ARE
-languages:en: en:arabic
+language_codes:en: ar
 
 en:United Kingdom, United Kingdom of Great Britain and Northern Ireland, UK, GB, GBR
 ab:Британиа Ду
@@ -29284,7 +29284,7 @@ zh:英国, 联合王国, 大不列颠及北爱尔兰联合王国
 zu:Umbuso Ohlangeneyo
 country_code_2:en: UK
 country_code_3:en: GBR
-languages:en: en:english,en:welsh,en:irish,en:scottish-gaelic
+language_codes:en: en,cy,ga,gd
 official_country_code_2:en: GB
 
 en:United States, United States of America, USA, America, the States, U.S., U.S.A., United States, US, 🇺🇸, US, USA
@@ -29448,7 +29448,7 @@ zh:美国, 美利坚合众国, 花旗国
 zu:IMelika
 country_code_2:en: US
 country_code_3:en: USA
-languages:en: en:english
+language_codes:en: en
 
 en:United States Minor Outlying Islands, UM, UMI
 af:Klein afgeleë eilande van die Verenigde State van Amerika
@@ -29497,7 +29497,7 @@ yo:Àwọn Erékùṣù Kékèké Orílẹ̀-èdè Amẹ́ríkà
 zh:美国本土外小岛屿
 country_code_2:en: UM
 country_code_3:en: UMI
-languages:en: 
+language_codes:en: 
 
 en:Uruguay, Oriental Republic of Uruguay, Eastern Republic of Uruguay, República Oriental del Uruguay, UY, URY
 af:Uruguay
@@ -29624,7 +29624,7 @@ yo:Urugúáì
 zh:乌拉圭, 烏拉圭東岸共和國
 country_code_2:en: UY
 country_code_3:en: URY
-languages:en: en:spanish
+language_codes:en: es
 
 en:Uzbekistan, Republic of Uzbekistan, UZ, UZB
 af:Oesbekistan
@@ -29746,7 +29746,7 @@ yo:Ùsbẹ̀kìstán
 zh:乌兹别克斯坦
 country_code_2:en: UZ
 country_code_3:en: UZB
-languages:en: en:uzbek
+language_codes:en: uz
 
 en:Vanuatu, Republic of Vanuatu, VU, VUT
 ab:Вануату
@@ -29861,7 +29861,7 @@ yo:Fanuatu
 zh:瓦努阿图
 country_code_2:en: VU
 country_code_3:en: VUT
-languages:en: en:french,en:english,en:bislama
+language_codes:en: fr,en,bi
 
 en:Vatican City, Vatican City State, Papal State, Holy See, VA, VAT
 af:Vatikaanstad
@@ -29996,7 +29996,7 @@ zh:梵蒂冈
 zu:Indolobha yaseVathikhani
 country_code_2:en: VA
 country_code_3:en: VAT
-languages:en: en:italian,en:latin
+language_codes:en: it,la
 
 en:Venezuela, República Bolivariana de Venezuela, VE, VEN
 af:Venezuela
@@ -30126,7 +30126,7 @@ zh:委內瑞拉
 zu:Venezuela
 country_code_2:en: VE
 country_code_3:en: VEN
-languages:en: en:spanish
+language_codes:en: es
 
 en:Vietnam, Viet Nam, Socialist Republic of Vietnam, VN, VNM
 af:Viëtnam
@@ -30276,7 +30276,7 @@ zh:越南
 zu:IViyetnami
 country_code_2:en: VN
 country_code_3:en: VNM
-languages:en: en:vietnamese
+language_codes:en: vi
 
 en:Virgin Islands of the United States, United States Virgin Islands, U.S. Virgin Islands, VI, VIR
 af:Amerikaanse Maagde-eilande
@@ -30358,7 +30358,7 @@ yo:Àwọn Erékùṣù Wúndíá ti Amẹ́ríkà
 zh:美屬維爾京群島
 country_code_2:en: VI
 country_code_3:en: VIR
-languages:en: en:english
+language_codes:en: en
 
 en:Wallis and Futuna, WF, WLF
 af:Wallis en Futuna, Wallis-et-Futuna, Wallis-en-Futuna
@@ -30437,7 +30437,7 @@ yo:Wallis àti Futuna, Wallis and Futuna, Wallis and Futuna Islands
 zh:瓦利斯和富圖納群島, 瓦利斯及富圖納群島, 瓦里斯和富圖納島, 瓦利斯和富图纳, 沃里斯與伏塔那島, 瓦利斯和富图纳行政区划, 瓦利斯群島和富圖納群島
 country_code_2:en: WF
 country_code_3:en: WLF
-languages:en: 
+language_codes:en: 
 
 en:Western Sahara, eh, West Sahara, Spanish Sahara, EH, ESH
 af:Wes-Sahara
@@ -30536,7 +30536,7 @@ yo:Apáìwọ̀orùn Sàhárà
 zh:西撒哈拉
 country_code_2:en: EH
 country_code_3:en: ESH
-languages:en: 
+language_codes:en: 
 
 en:world
 ar:العالم
@@ -30759,7 +30759,7 @@ zh:也门
 zu:IYemen
 country_code_2:en: YE
 country_code_3:en: YEM
-languages:en: en:arabic
+language_codes:en: ar
 
 en:Yugoslavia, YU, YUG
 af:Joego-Slawië, Joegoeslawië, Joegoslawië, Joegoslawie, Jugoslawië, Joegoslavië
@@ -30844,7 +30844,7 @@ yi:יוגאסלאוויע, יוגאָסלאַוויע, יאגאסלאוויע
 zh:南斯拉夫, 前南斯拉夫
 country_code_2:en: YU
 country_code_3:en: YUG
-languages:en: 
+language_codes:en: 
 
 en:Zambia, Republic of Zambia, ZM, ZMB
 af:Zambië
@@ -30970,7 +30970,7 @@ zh:赞比亚
 zu:IZambiya
 country_code_2:en: ZM
 country_code_3:en: ZMB
-languages:en: en:english
+language_codes:en: en
 
 en:Zimbabwe, Republic of Zimbabwe, ZW, ZWE
 af:Zimbabwe
@@ -31102,5 +31102,5 @@ zh:辛巴威, 津巴布韦, 津巴布韋共和國, 南罗德西亚, 津巴布韋
 zu:IZimbabwe
 country_code_2:en: ZW
 country_code_3:en: ZWE
-languages:en: en:english,en:shona,en:northern-ndebele-language
+language_codes:en: en,sn,nd
 

--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -5,20 +5,20 @@
 # Changes:
 #
 #1. Algeria, add French as 2nd language.
-#< languages:en:ar
+#< language_codes:en:ar
 #---
-#> languages:en:ar,fr
+#> language_codes:en:ar,fr
 #
 #
 #2. Andorra: add Spanish, French and Portuguese
-#< languages:en:ca
+#< language_codes:en:ca
 #---
-#> languages:en:ca,es,fr,pt
+#> language_codes:en:ca,es,fr,pt
 #
 #3. Belgium: change order of languages, put Dutch first
-#< languages:en:fr,de,nl
+#< language_codes:en:fr,de,nl
 #---
-#> languages:en:nl,fr,de
+#> language_codes:en:nl,fr,de
 #
 #4. Bermuda: add English (no languages listed)
 #
@@ -27,57 +27,57 @@
 #6. Remove Brittany from country list
 #
 #7. Canada, put English first
-#< languages:en:fr,en
+#< language_codes:en:fr,en
 #---
-#> languages:en:en,fr
+#> language_codes:en:en,fr
 #
 #8. Cyprus, add Greek and put it first:
-#< languages:en:tr,Q9129
+#< language_codes:en:tr,Q9129
 #---
-#> languages:en:el,tr
+#> language_codes:en:el,tr
 #
 #9. European Union: put English first
-#< languages:en:es,fi,fr,en,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,Q9129,ga,mt
+#< language_codes:en:es,fi,fr,en,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,Q9129,ga,mt
 #---
-#> languages:en:en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
+#> language_codes:en:en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
 #
 #10.  French Polynesia, add French (no language listed)
 #
 #11. Hong Kong, put Chinese first.
-#< languages:en:en,zh
+#< language_codes:en:en,zh
 #---
-#> languages:en:zh,en
+#> language_codes:en:zh,en
 #
 #12. Israel, put Hebrew first, add Russian and English
-#< languages:en:ar,he
+#< language_codes:en:ar,he
 #---
-#> languages:en:he,ar,ru,en
+#> language_codes:en:he,ar,ru,en
 #
 #13. Jersey, put English first
-#< languages:en:fr,en
+#< language_codes:en:fr,en
 #---
-#> languages:en:en,fr
+#> language_codes:en:en,fr
 #
 #14. Luxemburg, add English
-#< languages:en:fr,de,lb
+#< language_codes:en:fr,de,lb
 #---
-#> languages:en:fr,de,lb,en
+#> language_codes:en:fr,de,lb,en
 #
 #15. Madagascar, add French and Malgache
-#languages:en:fr,mg (edited)
+#language_codes:en:fr,mg (edited)
 #
 #16. Mauritius, add French and English
-#languages:en:fr,en
+#language_codes:en:fr,en
 #
 #17. Moldova - remove mo, add ro
-#< languages:en:mo
+#< language_codes:en:mo
 #---
-#> languages:en:ro
+#> language_codes:en:ro
 #
 #18. Morroco, put Arabic first
-#< languages:en:es,ar,fr,Q25448
+#< language_codes:en:es,ar,fr,Q25448
 #---
-#> languages:en:ar,fr,es
+#> language_codes:en:ar,fr,es
 #
 #19. removed "NATO" as a country 
 #
@@ -86,28 +86,28 @@
 #21. Palestinian territories : add "ps" as synonym, Arabic as language
 #
 #22. Rwanda, put English first
-#< languages:en:fr,en,rw
+#< language_codes:en:fr,en,rw
 #---
-#> languages:en:en,fr,rw
+#> language_codes:en:en,fr,rw
 #
 #23. remove Scotland as a country
 #
 #24. Singapore, add Chinese
-#< languages:en:en,ta,Q727694,ms
+#< language_codes:en:en,ta,Q727694,ms
 #---
-#> languages:en:en,ta,zh,ms
+#> language_codes:en:en,ta,zh,ms
 #
 #25. South Africa: put English first
-#< languages:en:zu,xh,af,en,ve,Q33890,ss,tn,ts,st,nr
+#< language_codes:en:zu,xh,af,en,ve,Q33890,ss,tn,ts,st,nr
 #---
-#> languages:en:en,zu,xh,af,ve,ss,tn,ts,st,nr
+#> language_codes:en:en,zu,xh,af,ve,ss,tn,ts,st,nr
 #
 #26. State of Palestine, Palestine, PS, PSE with country code PS
 #
 #27. Switzerland: put German first
-#< languages:en:fr,de,it
+#< language_codes:en:fr,de,it
 #---
-#> languages:en:de,fr,it
+#> language_codes:en:de,fr,it
 #
 #28. United Kingdom, make the country code UK instead of GB.
 #< country_code_2:en:GB
@@ -123,9 +123,9 @@
 #S.A., United States, US, :flag-us:, US, USA
 #
 #30. Vatican: put Italian first
-#< languages:en:la,it
+#< language_codes:en:la,it
 #---
-#> languages:en:it,la
+#> language_codes:en:it,la
 
 # Added Kosovo
 
@@ -493,7 +493,7 @@ zh-yue:阿富汗
 zu:I-Afganistani
 country_code_2:en:AF
 country_code_3:en:AFG
-languages:en:ps,prs
+language_codes:en:ps,prs
 wikidata:en:Q889
 
 en:Albania, Republic of Albania, AL, ALB
@@ -736,7 +736,7 @@ zh-tw:阿爾巴尼亞
 zh-yue:阿爾巴尼亞
 country_code_2:en:AL
 country_code_3:en:ALB
-languages:en:sq
+language_codes:en:sq
 wikidata:en:Q222
 
 en:Alderney, Aurigny
@@ -794,7 +794,7 @@ zh-hant:奧爾德尼島
 zh-hk:奧爾德尼島
 zh-sg:奥尔德尼岛
 zh-tw:奧爾德尼島
-languages:en:en
+language_codes:en:en
 
 en:Algeria, People’s Democratic Republic of Algeria, DZ, DZA
 ace:Aljazair
@@ -1025,7 +1025,7 @@ zh-yue:阿爾及利亞
 zu:IAljiriya
 country_code_2:en:DZ
 country_code_3:en:DZA
-languages:en:ar,fr
+language_codes:en:ar,fr
 wikidata:en:Q262
 
 en:American Samoa, AS, ASM
@@ -1137,7 +1137,7 @@ zh-min-nan:Bí-kok Samoa
 zh-yue:美屬薩摩亞
 country_code_2:en:AS
 country_code_3:en:ASM
-languages:en:en,sm
+language_codes:en:en,sm
 
 en:Andorra, Principality of Andorra, Principality of the Valleys of Andorra, AD, AND
 ace:Andorra
@@ -1382,7 +1382,7 @@ zh-tw:安道爾, 安道爾公國
 zh-yue:安道爾
 country_code_2:en:AD
 country_code_3:en:AND
-languages:en:ca,es,fr,pt
+language_codes:en:ca,es,fr,pt
 wikidata:en:Q228
 
 en:Angola, Republic of Angola, AO, AGO
@@ -1598,7 +1598,7 @@ zh-yue:安哥拉
 zu:I-Angola
 country_code_2:en:AO
 country_code_3:en:AGO
-languages:en:pt
+language_codes:en:pt
 wikidata:en:Q916
 
 en:Anguilla, AI, AIA
@@ -1709,7 +1709,7 @@ zh-min-nan:Anguilla
 zh-yue:安圭拉
 country_code_2:en:AI
 country_code_3:en:AIA
-languages:en:en
+language_codes:en:en
 
 en:Antarctic, AQ, ATA
 ar:أنتاركتيك
@@ -1754,7 +1754,7 @@ vi:Vùng Nam Cực
 yo:Antárktìkì
 country_code_2:en:AQ
 country_code_3:en:ATA
-languages:en:
+language_codes:en:
 
 en:Antarctica
 ace:Antartika
@@ -1965,7 +1965,7 @@ zh-sg:南极洲
 zh-tw:南极洲
 zh-yue:南極洲
 zu:I-Antatika
-languages:en:
+language_codes:en:
 
 en:Antigua and Barbuda, AG, ATG
 ace:Antigua ngon Barbuda
@@ -2131,7 +2131,7 @@ zh-min-nan:Antigua kap Barbuda
 zh-yue:安提瓜巴布達
 country_code_2:en:AG
 country_code_3:en:ATG
-languages:en:en
+language_codes:en:en
 
 en:Argentina, Argentine Republic, AR, ARG
 ace:Argentina
@@ -2364,7 +2364,7 @@ zh-min-nan:Argentina
 zh-yue:阿根廷
 country_code_2:en:AR
 country_code_3:en:ARG
-languages:en:es
+language_codes:en:es
 wikidata:en:Q414
 
 en:Armenia, Republic of Armenia, AM, ARM
@@ -2595,7 +2595,7 @@ zh-min-nan:Hayastan
 zh-yue:亞美尼亞
 country_code_2:en:AM
 country_code_3:en:ARM
-languages:en:hy
+language_codes:en:hy
 wikidata:en:Q399
 
 en:Aruba, ISO 3166-1:AW, America/Aruba, Island of Aruba, AW, ABW
@@ -2731,7 +2731,7 @@ zh-min-nan:Aruba
 zh-yue:阿魯巴島
 country_code_2:en:AW
 country_code_3:en:ABW
-languages:en:nl,pap
+language_codes:en:nl,pap
 wikidata:en:Q21203
 
 en:Ascension Island
@@ -2807,7 +2807,7 @@ vi:Đảo Ascension
 war:Puro Ascension, Ascension Island, Puro han Ascension
 yo:Erékùṣù Ascension, Ascension Island
 zh:阿森松岛, 亚森松岛, 亞森欣島, 亞森欣
-languages:en:
+language_codes:en:
 
 en:Australia, Commonwealth of Australia, AU, AU, AUS
 ab:Австралиа
@@ -3054,7 +3054,7 @@ zh-yue:澳洲
 zu:I-Ostreliya
 country_code_2:en:AU
 country_code_3:en:AUS
-languages:en:en
+language_codes:en:en
 wikidata:en:Q408
 
 en:Austria, Österreich, Republic of Austria, Republik Österreich, AT, AUT
@@ -3312,7 +3312,7 @@ zh-yue:奧地利
 zu:I-Ostriya
 country_code_2:en:AT
 country_code_3:en:AUT
-languages:en:de
+language_codes:en:de
 wikidata:en:Q40
 
 en:Azerbaijan, Republic of Azerbaijan, AZ, AZE
@@ -3545,7 +3545,7 @@ zh-yue:阿塞拜疆
 zu:Azerbaijan
 country_code_2:en:AZ
 country_code_3:en:AZE
-languages:en:az
+language_codes:en:az
 wikidata:en:Q227
 
 en:Bahrain, BH, BHR
@@ -3742,7 +3742,7 @@ zh-min-nan:Bahrain
 zh-yue:巴林
 country_code_2:en:BH
 country_code_3:en:BHR
-languages:en:ar
+language_codes:en:ar
 wikidata:en:Q398
 
 en:Bangladesh, East Pakistan, People's Republic of Bangladesh, East Bengal, BD, BGD
@@ -3951,7 +3951,7 @@ zh-min-nan:Bangladesh
 zh-yue:孟加拉國
 country_code_2:en:BD
 country_code_3:en:BGD
-languages:en:bn
+language_codes:en:bn
 wikidata:en:Q902
 
 en:Barbados, BB, BRB
@@ -4131,7 +4131,7 @@ zh-min-nan:Barbados
 zh-yue:巴巴多斯
 country_code_2:en:BB
 country_code_3:en:BRB
-languages:en:en
+language_codes:en:en
 wikidata:en:Q244
 
 en:Belarus, White Russia, White Ruthenia, Republic of Belarus, BY, BLR
@@ -4360,7 +4360,7 @@ zh-yue:白俄羅斯
 zu:IBelarusi
 country_code_2:en:BY
 country_code_3:en:BLR
-languages:en:ru,be
+language_codes:en:ru,be
 wikidata:en:Q184
 
 en:Belgium, Kingdom of Belgium, BE, BEL
@@ -4608,7 +4608,7 @@ zh-tw:比利時, 比利時王國
 zh-yue:比利時
 country_code_2:en:BE
 country_code_3:en:BEL
-languages:en:nl,fr,de
+language_codes:en:nl,fr,de
 wikidata:en:Q31
 
 en:Belize, BZ, BLZ
@@ -4794,7 +4794,7 @@ zh-yue:伯利茲
 zu:Belize
 country_code_2:en:BZ
 country_code_3:en:BLZ
-languages:en:en
+language_codes:en:en
 wikidata:en:Q242
 
 en:Benin, Republic of Benin, BJ, BEN
@@ -4995,7 +4995,7 @@ zh-yue:貝寧
 zu:IBenini
 country_code_2:en:BJ
 country_code_3:en:BEN
-languages:en:fr
+language_codes:en:fr
 wikidata:en:Q962
 
 en:Bermuda, Somers Isles, Bermuda Islands, Atlantic/Bermuda, ISO 3166-1:BM, Bermudian Islands, Bermoothes, Virgineola, The Somers Isles, Summers' Isles, Territory of Bermuda, Bermudas, Somers Islands, Colony of Bermuda, Devil's Isles, Summer's Isles, Isle of Devils, BM, BMU
@@ -5117,7 +5117,7 @@ zh-min-nan:Bermuda
 zh-yue:百慕達
 country_code_2:en:BM
 country_code_3:en:BMU
-languages:en:en
+language_codes:en:en
 
 en:Bhutan, Kingdom of Bhutan, BT, BTN
 ace:Bhutan
@@ -5316,7 +5316,7 @@ zh-tw:不丹, 不丹王國
 zh-yue:不丹
 country_code_2:en:BT
 country_code_3:en:BTN
-languages:en:dz
+language_codes:en:dz
 wikidata:en:Q917
 
 en:Bolivia, BO, BOL
@@ -5523,7 +5523,7 @@ zh-min-nan:Bolivia
 zh-yue:玻利維亞
 country_code_2:en:BO
 country_code_3:en:BOL
-languages:en:es,gn,ay,qu
+language_codes:en:es,gn,ay,qu
 wikidata:en:Q750
 
 en:Bonaire, Boneiru
@@ -5596,7 +5596,7 @@ yo:Bonaire
 yue:博奈爾島
 zh:波内赫, 博奈尔岛, 波奈, 波内赫岛, 波內赫
 zh-yue:博奈爾島
-languages:en:nl,pap
+language_codes:en:nl,pap
 
 en:Bosnia and Herzegovina, Bosnia-Herzegovina, Bosnia, BiH, BA, BIH
 ace:Bosnia Hèrzègovina
@@ -5817,7 +5817,7 @@ zh-min-nan:Bosna kap Hercegovina
 zh-yue:波斯尼亞
 country_code_2:en:BA
 country_code_3:en:BIH
-languages:en:hr,sr,bs
+language_codes:en:hr,sr,bs
 wikidata:en:Q225
 
 en:Botswana, BW, BWA
@@ -6024,7 +6024,7 @@ zh-yue:波茨華拿
 zu:IButswana
 country_code_2:en:BW
 country_code_3:en:BWA
-languages:en:en,tn
+language_codes:en:en,tn
 wikidata:en:Q963
 
 en:Bouvet Island, BV, BVT
@@ -6103,7 +6103,7 @@ zh-sg:布韦岛
 zh-tw:布韦岛
 country_code_2:en:BV
 country_code_3:en:BVT
-languages:en:
+language_codes:en:
 
 en:Brazil, Federative Republic of Brazil, Brasil, República Federativa do Brasil, BR, BRA
 ace:Brasil
@@ -6356,7 +6356,7 @@ zh-yue:巴西
 zu:IBrazili
 country_code_2:en:BR
 country_code_3:en:BRA
-languages:en:pt
+language_codes:en:pt
 wikidata:en:Q155
 
 en:British Indian Ocean Territory, IO, IOT
@@ -6432,7 +6432,7 @@ zh:英屬印度洋領地, 英属印度洋领地, 英屬印度洋地區
 zh-yue:英屬印度洋領地
 country_code_2:en:IO
 country_code_3:en:IOT
-languages:en:
+language_codes:en:
 
 en:British Virgin Islands, Virgin Islands, BVI, VG, VGB
 af:Britse Maagde-eilande, VK Maagde-eilande, Britse Virgin-eilande, Britse Maagdeeilande, Britse-Maagde-eilande, Brits-Maagde-eilande, British Virgin Islands
@@ -6538,7 +6538,7 @@ zh-min-nan:Britain Virgin Kûn-tó
 zh-yue:英屬處女羣島
 country_code_2:en:VG
 country_code_3:en:VGB
-languages:en:en
+language_codes:en:en
 
 
 en:Brunei, Nation of Brunei, the Abode of Peace, BN, BRN
@@ -6730,7 +6730,7 @@ zh-min-nan:Brunei
 zh-yue:汶萊
 country_code_2:en:BN
 country_code_3:en:BRN
-languages:en:ms
+language_codes:en:ms
 wikidata:en:Q921
 
 en:Bulgaria, Republic of Bulgaria, BG, BGR
@@ -6983,7 +6983,7 @@ zh-yue:保加利亞
 zu:IBulgariya
 country_code_2:en:BG
 country_code_3:en:BGR
-languages:en:bg
+language_codes:en:bg
 wikidata:en:Q219
 
 en:Burkina Faso, BF, BFA
@@ -7178,7 +7178,7 @@ zh-yue:布基納法索
 zu:IBukhina Faso
 country_code_2:en:BF
 country_code_3:en:BFA
-languages:en:fr
+language_codes:en:fr
 wikidata:en:Q965
 
 en:Burundi, Republic of Burundi, BI, BDI
@@ -7376,7 +7376,7 @@ zh-yue:布隆迪
 zu:IBurundi
 country_code_2:en:BI
 country_code_3:en:BDI
-languages:en:fr,rn
+language_codes:en:fr,rn
 wikidata:en:Q967
 
 en:Cambodia, Kingdom of Cambodia, KH, KHM
@@ -7566,7 +7566,7 @@ zh-min-nan:Kampuchea
 zh-yue:柬埔寨
 country_code_2:en:KH
 country_code_3:en:KHM
-languages:en:km
+language_codes:en:km
 wikidata:en:Q424
 
 en:Cameroon, CM, CMR
@@ -7769,7 +7769,7 @@ zh-yue:喀麥隆
 zu:IKamerooni
 country_code_2:en:CM
 country_code_3:en:CMR
-languages:en:fr,en
+language_codes:en:fr,en
 wikidata:en:Q1009
 
 en:Canada, Dominion of Canada, British North America, CAN, CA, CA, CAN
@@ -8035,7 +8035,7 @@ zh-yue:加拿大
 zu:IKhanada
 country_code_2:en:CA
 country_code_3:en:CAN
-languages:en:en,fr
+language_codes:en:en,fr
 wikidata:en:Q16
 
 en:Cape Verde, Republic of Cape Verde, Cabo Verde, CV, CV, CPV
@@ -8225,7 +8225,7 @@ zh-yue:維德角
 zu:IKhepi Vedhi
 country_code_2:en:CV
 country_code_3:en:CPV
-languages:en:pt
+language_codes:en:pt
 wikidata:en:Q1011
 
 en:Caribbean Netherlands, BES islands, BQ, BES, Netherlands Antilles
@@ -8268,7 +8268,7 @@ vi:Caribe Hà Lan
 zh:荷蘭加勒比區
 country_code_2:en:BQ
 country_code_3:en:BES
-languages:en:
+language_codes:en:
 
 en:Cayman Islands, KY, CYM
 af:Kaaimanseilande
@@ -8374,7 +8374,7 @@ zh-min-nan:Cayman Kûn-tó
 zh-yue:開曼群島
 country_code_2:en:KY
 country_code_3:en:CYM
-languages:en:
+language_codes:en:
 
 en:Central African Republic, CF, CAF
 ace:Republik Afrika Teungoh
@@ -8560,7 +8560,7 @@ zh-yue:中非共和國
 zu:Central African Republic
 country_code_2:en:CF
 country_code_3:en:CAF
-languages:en:fr,sg
+language_codes:en:fr,sg
 wikidata:en:Q929
 
 en:Chad, Republic of Chad, République du Tchad, جمهورية تشاد, Ǧumhūriyyat Tšād, Tchad, TD, TCD
@@ -8764,7 +8764,7 @@ zh-yue:乍得
 zu:ITshedi
 country_code_2:en:TD
 country_code_3:en:TCD
-languages:en:ar,fr
+language_codes:en:ar,fr
 wikidata:en:Q657
 
 en:Chile, CL, CHL
@@ -9021,7 +9021,7 @@ zh-yue:智利
 zu:Chili
 country_code_2:en:CL
 country_code_3:en:CHL
-languages:en:es
+language_codes:en:es
 wikidata:en:Q298
 
 en:China, PRC, People's Republic of China, CN, CHN
@@ -9269,7 +9269,7 @@ zh-yue:中華人民共和國
 zu:IShayina
 country_code_2:en:CN
 country_code_3:en:CHN
-languages:en:zh
+language_codes:en:zh
 wikidata:en:Q148
 
 en:Christmas Island, CX, CXR
@@ -9366,7 +9366,7 @@ zh-min-nan:Christmas-tó
 zh-yue:聖誕島
 country_code_2:en:CX
 country_code_3:en:CXR
-languages:en:
+language_codes:en:
 
 en:Cocos (Keeling) Islands, Cocos Islands, Keeling Islands, Territory of the Cocos (Keeling) Islands, CC, CCK
 af:Kokoseilande, Cocos (Keeling) Eilande, Cocos (Keeling)-eilande
@@ -9464,7 +9464,7 @@ zh-min-nan:Cocos
 zh-yue:可可斯
 country_code_2:en:CC
 country_code_3:en:CCK
-languages:en:
+language_codes:en:
 
 en:Colombia, Republic of Colombia, CO, COL
 ace:Kolombia
@@ -9676,7 +9676,7 @@ zh-yue:哥倫比亞
 zu:IKolombiya
 country_code_2:en:CO
 country_code_3:en:COL
-languages:en:es
+language_codes:en:es
 wikidata:en:Q739
 
 en:Comoros, KM, COM
@@ -9853,7 +9853,7 @@ zh-yue:科摩羅
 zu:IsiKhomorosi
 country_code_2:en:KM
 country_code_3:en:COM
-languages:en:ar,fr
+language_codes:en:ar,fr
 wikidata:en:Q970
 
 en:Cook Islands, CK, COK
@@ -9966,7 +9966,7 @@ zh-min-nan:Cook Kûn-tó
 zh-yue:曲克群島
 country_code_2:en:CK
 country_code_3:en:COK
-languages:en:
+language_codes:en:
 
 en:Costa Rica, Republic of Costa Rica, CR, CRI
 ace:Kosta Rika
@@ -10148,7 +10148,7 @@ zh-yue:哥斯達黎加
 zu:Costa Rica
 country_code_2:en:CR
 country_code_3:en:CRI
-languages:en:es
+language_codes:en:es
 wikidata:en:Q800
 
 en:Croatia, Republic of Croatia, HR, HRV, HR, HRV
@@ -10374,7 +10374,7 @@ zh-min-nan:Hrvatska
 zh-yue:克羅地亞
 country_code_2:en:HR
 country_code_3:en:HRV
-languages:en:hr
+language_codes:en:hr
 wikidata:en:Q224
 
 en:Cuba, Republic of Cuba, CU, CUB
@@ -10583,7 +10583,7 @@ zh-min-nan:Cuba
 zh-yue:古巴
 country_code_2:en:CU
 country_code_3:en:CUB
-languages:en:es
+language_codes:en:es
 
 en:Curaçao, Island Territory of Curaçao, Curacau, Curaçoa, Curaςao, Kòrsou, Korsou, Curocao, ISO 3166-1:CW, CUW, Curazao, Curacao, Country of Curaçao, CW, CUW
 af:Curaçao
@@ -10677,7 +10677,7 @@ zh:库拉索, 库拉骚, 古拉索, 库拉索岛, 庫拉索, 庫拉考, 古拉�
 zh-yue:庫拉索島
 country_code_2:en:CW
 country_code_3:en:CUW
-languages:en:en,nl,pap
+language_codes:en:en,nl,pap
 
 en:Cyprus, Republic of Cyprus, CY, CYP
 ace:Siprus
@@ -10892,7 +10892,7 @@ zh-min-nan:Ku-pí-lō͘
 zh-yue:塞浦路斯
 country_code_2:en:CY
 country_code_3:en:CYP
-languages:en:el,tr
+language_codes:en:el,tr
 
 en:Czech Republic, Czechia, CZ, CZE
 ab:Чехиа
@@ -11130,7 +11130,7 @@ zh-yue:捷克
 zu:ITsheki
 country_code_2:en:CZ
 country_code_3:en:CZE
-languages:en:cs
+language_codes:en:cs
 
 en:Côte d'Ivoire, Ivory Coast, Republic of Côte d'Ivoire, CI, CIV
 ace:Panté Gadéng
@@ -11319,7 +11319,7 @@ zh-yue:象牙海岸
 zu:Ugu Emhlophe
 country_code_2:en:CI
 country_code_3:en:CIV
-languages:en:fr
+language_codes:en:fr
 
 en:Democratic Republic of the Congo, DRC, DR Congo, Congo-Kinshasa, Zaire, Congo, Democratic Republic of Congo, CD, COD, Congo DR, Congo DRC
 ace:Republik Demokratik Kongo
@@ -11509,7 +11509,7 @@ zh-yue:剛果民主共和國
 zu:IRiphabliki Labantu weKongo
 country_code_2:en:CD
 country_code_3:en:COD
-languages:en:fr
+language_codes:en:fr
 
 en:Denmark, DK, Kingdom of Denmark, Danish Kingdom, Danmark, Kongeriget Danmark, DK, DNK
 ace:Denmark
@@ -11763,7 +11763,7 @@ zh-yue:丹麥
 zu:IDenimaki
 country_code_2:en:DK
 country_code_3:en:DNK
-languages:en:da
+language_codes:en:da
 
 en:Djibouti, Republic of Djibouti, DJ, DJI
 ace:Djibouti
@@ -11946,7 +11946,7 @@ zh-yue:吉布提
 zu:IJibuthi
 country_code_2:en:DJ
 country_code_3:en:DJI
-languages:en:ar,fr
+language_codes:en:ar,fr
 
 en:Dominica, DM, DMA
 af:Dominica
@@ -12115,7 +12115,7 @@ zh-min-nan:Dominica
 zh-yue:多米尼克
 country_code_2:en:DM
 country_code_3:en:DMA
-languages:en:en
+language_codes:en:en
 
 en:Dominican Republic, DO, DOM
 af:Dominikaanse Republiek
@@ -12290,7 +12290,7 @@ zh-min-nan:Dominic Kiōng-hô-kok
 zh-yue:多明尼加
 country_code_2:en:DO
 country_code_3:en:DOM
-languages:en:es
+language_codes:en:es
 
 en:East Germany, GDR, German Democratic Republic, G.D.R.
 af:Duitse Demokratiese Republiek
@@ -12404,7 +12404,7 @@ yue:東德
 zh:东德, 德意志民主共和国, 民主德国
 zh-min-nan:Tang-tek
 zh-yue:東德
-languages:en:
+language_codes:en:
 
 en:Ecuador, EC, ECU
 ace:Èkuador
@@ -12600,7 +12600,7 @@ zh-min-nan:Ecuador
 zh-yue:厄瓜多爾
 country_code_2:en:EC
 country_code_3:en:ECU
-languages:en:es
+language_codes:en:es
 
 en:Egypt, Arab Republic of Egypt, مصر, EG, EGY
 ab:Мысры
@@ -12843,7 +12843,7 @@ zh-yue:埃及
 zu:IGibhithe
 country_code_2:en:EG
 country_code_3:en:EGY
-languages:en:ar
+language_codes:en:ar
 
 en:El Salvador, SV, SLV
 ace:Èl Salvador
@@ -13019,7 +13019,7 @@ zh-yue:薩爾瓦多
 zu:El Salvador
 country_code_2:en:SV
 country_code_3:en:SLV
-languages:en:es
+language_codes:en:es
 
 en:Equatorial Guinea, Republic of Equatorial Guinea, GQ, GNQ
 af:Ekwatoriaal-Guinee
@@ -13200,7 +13200,7 @@ zh-yue:赤道畿內亞
 zu:IGini Enkabazwe
 country_code_2:en:GQ
 country_code_3:en:GNQ
-languages:en:es,fr,pt
+language_codes:en:es,fr,pt
 
 en:Eritrea, State of Eritrea, ER, ERI
 ace:Eritrea
@@ -13398,7 +13398,7 @@ zh-yue:厄立特里亞
 zu:I-Eritrea
 country_code_2:en:ER
 country_code_3:en:ERI
-languages:en:ar,en,ti
+language_codes:en:ar,en,ti
 
 en:Estonia, Republic of Estonia, Estland, Eesti, EE, EST
 ace:Èstonia
@@ -13637,7 +13637,7 @@ zh-yue:愛沙尼亞
 zu:I-Estoniya
 country_code_2:en:EE
 country_code_3:en:EST
-languages:en:et
+language_codes:en:et
 
 en:Ethiopia, ET, ETH
 ace:Ethiopia
@@ -13854,7 +13854,7 @@ zh-yue:埃塞俄比亞
 zu:I-Ithiopia
 country_code_2:en:ET
 country_code_3:en:ETH
-languages:en:am
+language_codes:en:am
 
 en:European Union, EU, E.U.
 ab:Европатәи Аидгыла
@@ -14048,7 +14048,7 @@ zh-hans:欧洲联盟
 zh-hant:欧洲联盟
 zh-min-nan:Europa Liân-bêng
 zh-yue:歐洲聯盟
-languages:en:en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
+language_codes:en:en,es,fi,fr,de,pt,it,hr,nl,ro,bg,pl,sv,da,cs,sk,sl,hu,et,lv,lt,el,ga,mt
 
 en:Falkland Islands, Falklands, Malvinas, Islas Malvinas, FK, FLK
 ace:Pulo-pulo Falkland
@@ -14178,7 +14178,7 @@ zh-min-nan:Falkland Kûn-tó
 zh-yue:福克蘭羣島
 country_code_2:en:FK
 country_code_3:en:FLK
-languages:en:en
+language_codes:en:en
 
 en:Faroe Islands, Faeroe Islands, Atlantic/Faroe, Fareo islands, Faeroyene, Far Oer, Faeroerne, Faer Oer, Faroe Isles, Faroer, Färöer, Faeroe Isles, Faroes, Faroese Islands, Foroyar, Faeroes, Faeroer, Føroyar, Faroe Island, The Faroe Islands, Færøer, Færeyjar, Fær Øer, Faeroe Is, The Faeroe Islands, Færøyene, Færøerne, Faröe Islands, Sheep Islands, Færoes, FO, FRO
 ace:Pulo-pulo Faroe
@@ -14326,7 +14326,7 @@ zh-min-nan:Mî-iûⁿ Kûn-tó
 zh-yue:法羅群島
 country_code_2:en:FO
 country_code_3:en:FRO
-languages:en:
+language_codes:en:
 
 en:Federated States of Micronesia, Micronesia, FSM, FM, FSM
 ace:Mikronesia
@@ -14474,7 +14474,7 @@ zh-min-nan:Micronesia Liân-pang-kok
 zh-yue:密克羅尼西亞聯邦
 country_code_2:en:FM
 country_code_3:en:FSM
-languages:en:
+language_codes:en:
 
 en:Fiji, Republic of Fiji, FJ, FJI
 ace:Fiji
@@ -14651,7 +14651,7 @@ zh-yue:斐濟
 zu:IFiji
 country_code_2:en:FJ
 country_code_3:en:FJI
-languages:en:en,fj
+language_codes:en:en,fj
 
 en:Finland, Republic of Finland, Finlande, Finlandia, Finnland, Finnia, Soome, Land of Thousand Lakes, FI, FIN
 ab:Суоми
@@ -14906,7 +14906,7 @@ zh-yue:芬蘭
 zu:IFinlandi
 country_code_2:en:FI
 country_code_3:en:FIN
-languages:en:fi,sv
+language_codes:en:fi,sv
 
 en:France, The Hexagon, French Republic, FR, FRA
 ace:Peurancih
@@ -15175,7 +15175,7 @@ zh-yue:法國
 zu:IFulansi
 country_code_2:en:FR
 country_code_3:en:FRA
-languages:en:fr
+language_codes:en:fr
 
 en:French Guiana, GF, GUF
 ace:Guyana Peurancih
@@ -15312,7 +15312,7 @@ zh-min-nan:Guyane
 zh-yue:法屬圭亞那
 country_code_2:en:GF
 country_code_3:en:GUF
-languages:en:fr
+language_codes:en:fr
 
 en:French Polynesia, PF, PYF
 ace:Polinesia Peurancih
@@ -15424,7 +15424,7 @@ zh-min-nan:Hoat-kok Polynésie
 zh-yue:法屬波利尼西亞
 country_code_2:en:PF
 country_code_3:en:PYF
-languages:en:fr
+language_codes:en:fr
 
 en:French Southern and Antarctic Lands, TF, ATF, French Southern Territories
 af:Franse Suidelike en Antarktiese Gebiede, Terres australes et antarctiques françaises, Franse Suidelike gebiede
@@ -15495,7 +15495,7 @@ zh-sg:法属南部领地
 zh-tw:法屬南部領地
 country_code_2:en:TF
 country_code_3:en:ATF
-languages:en:fr
+language_codes:en:fr
 
 en:Gabon, Gabonese Republic, République Gabonaise, GA, GAB
 af:Gaboen
@@ -15703,7 +15703,7 @@ zh-yue:加蓬
 zu:IGaboni
 country_code_2:en:GA
 country_code_3:en:GAB
-languages:en:fr
+language_codes:en:fr
 
 en:Galmudug
 af:Galmudug
@@ -15728,7 +15728,7 @@ uk:Галмудуг
 zh-hans:贾穆杜格
 zh-hant:賈穆杜格
 zh-hk:賈穆杜格
-languages:en:
+language_codes:en:
 
 en:Gambia, Republic of the Gambia, the Gambia, GM, GMB
 ace:Gambia
@@ -15913,7 +15913,7 @@ zh-yue:甘比亞
 zu:IGambia
 country_code_2:en:GM
 country_code_3:en:GMB
-languages:en:en
+language_codes:en:en
 
 en:Georgia, Sakartvelo, gurz-ān, ĵurĵan, ĵurzan, gurğān, Gruzia, GE, GEO
 ab:Қырҭтәыла
@@ -16128,7 +16128,7 @@ zh-min-nan:Sakartvelo
 zh-yue:格魯吉亞
 country_code_2:en:GE
 country_code_3:en:GEO
-languages:en:ka
+language_codes:en:ka
 
 en:Germany, FRG, BRD, Bundesrepublik Deutschland, Federal Republic of Germany, DE, DEU
 ab:Алмантәыла
@@ -16404,7 +16404,7 @@ zh-yue:德國
 zu:IJalimani
 country_code_2:en:DE
 country_code_3:en:DEU
-languages:en:de
+language_codes:en:de
 
 en:Ghana, Republic of Ghana, GH, GHA
 ace:Ghana
@@ -16613,7 +16613,7 @@ zh-yue:加納
 zu:IGana
 country_code_2:en:GH
 country_code_3:en:GHA
-languages:en:en
+language_codes:en:en
 
 en:Gibraltar, GI, GIB
 ace:Gibraltar
@@ -16758,7 +16758,7 @@ zh-min-nan:Gibraltar
 zh-yue:直布羅陀
 country_code_2:en:GI
 country_code_3:en:GIB
-languages:en:en
+language_codes:en:en
 
 en:Greece, Hellenic Republic, Hellas, GR, GRC
 ab:Барзентәыла
@@ -17005,7 +17005,7 @@ zh-yue:希臘
 zu:IGreki
 country_code_2:en:GR
 country_code_3:en:GRC
-languages:en:el
+language_codes:en:el
 
 en:Greenland, Greenland (country), GL, GRL
 af:Groenland
@@ -17173,7 +17173,7 @@ zh-min-nan:Chheⁿ-tē
 zh-yue:格陵蘭
 country_code_2:en:GL
 country_code_3:en:GRL
-languages:en:kl
+language_codes:en:kl
 
 en:Grenada, GD, GRD
 af:Grenada
@@ -17336,7 +17336,7 @@ zh-min-nan:Grenada
 zh-yue:格林納達
 country_code_2:en:GD
 country_code_3:en:GRD
-languages:en:en
+language_codes:en:en
 
 en:Guadeloupe, GP, GLP
 af:Guadeloupe
@@ -17452,7 +17452,7 @@ zh-min-nan:Guadeloupe
 zh-yue:瓜德羅普
 country_code_2:en:GP
 country_code_3:en:GLP
-languages:en:fr
+language_codes:en:fr
 
 en:Guam, GU, GUM
 ace:Guam
@@ -17566,7 +17566,7 @@ zh-min-nan:Guahan
 zh-yue:關島
 country_code_2:en:GU
 country_code_3:en:GUM
-languages:en:en,ch
+language_codes:en:en,ch
 
 en:Guatemala, GT, GTM
 ace:Guatemala
@@ -17748,7 +17748,7 @@ zh-yue:危地馬拉
 zu:Guatemala
 country_code_2:en:GT
 country_code_3:en:GTM
-languages:en:es
+language_codes:en:es
 
 en:Guernsey, Bailliage de Guernesey, Isle of Guernsey, Island of Guernsey, Guensey, Bailiwick of Guernsey, ISO 3166-1:GG, GG, GGY
 ace:Guernsey
@@ -17860,7 +17860,7 @@ zh-min-nan:Guernsey
 zh-yue:根息島
 country_code_2:en:GG
 country_code_3:en:GGY
-languages:en:
+language_codes:en:
 
 en:Guinea, Guinea-Conakry, Republic of Guinea, GN, GIN
 ace:Guinea
@@ -18043,7 +18043,7 @@ zh-yue:畿內亞
 zu:IGini
 country_code_2:en:GN
 country_code_3:en:GIN
-languages:en:fr
+language_codes:en:fr
 
 en:Guinea-Bissau, Republic of Guinea-Bissau, GW, GNB
 ace:Guinea Bissau
@@ -18227,7 +18227,7 @@ zh-yue:畿內亞比紹
 zu:IGini Bisawu
 country_code_2:en:GW
 country_code_3:en:GNB
-languages:en:pt
+language_codes:en:pt
 
 en:Guyana, Co-operative Republic of Guyana, GY, GUY
 ace:Guyana
@@ -18408,7 +18408,7 @@ zh-min-nan:Guyana
 zh-yue:圭亞那
 country_code_2:en:GY
 country_code_3:en:GUY
-languages:en:en
+language_codes:en:en
 
 en:Haiti, Republic of Haiti, HT, HTI
 af:Haïti
@@ -18594,7 +18594,7 @@ zh-min-nan:Haiti
 zh-yue:海地
 country_code_2:en:HT
 country_code_3:en:HTI
-languages:en:fr,ht
+language_codes:en:fr,ht
 
 en:Heard Island and McDonald Islands, HM, HMD
 af:Heard- en McDonaldeilande, Heard en McDonald Eilande
@@ -18665,7 +18665,7 @@ zh-sg:赫德岛和麦克唐纳群岛
 zh-tw:赫德島和麥克唐納群島
 country_code_2:en:HM
 country_code_3:en:HMD
-languages:en:
+language_codes:en:
 
 en:Honduras, HN, HND
 ace:Honduras
@@ -18847,7 +18847,7 @@ zh-yue:洪都拉斯
 zu:Honduras
 country_code_2:en:HN
 country_code_3:en:HND
-languages:en:es
+language_codes:en:es
 
 en:Hong Kong, Hong Kong Special Administrative Region, HKSAR, HKG, HK, Hong Kong SAR, Xianggang, China Hong Kong, Hong Kong, HK, HKG
 ace:Hong Kong
@@ -19015,7 +19015,7 @@ zh-min-nan:Hiong-káng
 zh-yue:香港
 country_code_2:en:HK
 country_code_3:en:HKG
-languages:en:zh,en
+language_codes:en:zh,en
 
 en:Hungary, HU, HUN
 ab:Мадиартәыла
@@ -19262,7 +19262,7 @@ zh-tw:匈牙利, 匈牙利共和國
 zh-yue:匈牙利
 country_code_2:en:HU
 country_code_3:en:HUN
-languages:en:hu
+language_codes:en:hu
 
 en:Iceland, Republic of Iceland, IS, ISL
 ace:Islandia
@@ -19501,7 +19501,7 @@ zh-yue:冰島
 zu:I-Ayisilandi
 country_code_2:en:IS
 country_code_3:en:ISL
-languages:en:is
+language_codes:en:is
 
 en:India, Bharat, Hindustan, IN, IND
 ace:India
@@ -19751,7 +19751,7 @@ zh-yue:印度
 zu:INdiya
 country_code_2:en:IN
 country_code_3:en:IND
-languages:en:en,hi
+language_codes:en:en,hi
 
 en:Indonesia, Republic of Indonesia, NKRI, Negara Kesatuan Republik Indonesia, Republik Indonesia, ID, IDN
 ace:Indônèsia
@@ -19982,7 +19982,7 @@ zh-min-nan:Ìn-nî
 zh-yue:印尼
 country_code_2:en:ID
 country_code_3:en:IDN
-languages:en:id
+language_codes:en:id
 
 en:Iran, Islamic Republic of Iran, Persia, IR, IRN
 ace:Iran
@@ -20208,7 +20208,7 @@ zh-yue:伊朗
 zu:I-Irani
 country_code_2:en:IR
 country_code_3:en:IRN
-languages:en:fa
+language_codes:en:fa
 
 en:Iraq, IQ, IRQ
 ace:Irak
@@ -20423,7 +20423,7 @@ zh-yue:伊拉克
 zu:I-Iraki
 country_code_2:en:IQ
 country_code_3:en:IRQ
-languages:en:ar,ku
+language_codes:en:ar,ku
 
 en:Iraqi Kurdistan
 ar:كردستان العراق, اقليم كردستان, إقليم كردستان, كردستان العراقية, اقليم كردستان العراق, اقليم كوردستان في العراق, إقليم كردستان العراق, اقليم كردستان في شمال العراق, قائمة جزر كردستان العراق, إقليم كردستان في شمال العراق
@@ -20484,7 +20484,7 @@ zh-hant:伊拉克庫德斯坦
 zh-hk:伊拉克庫爾德斯坦
 zh-sg:伊拉克库尔德斯坦
 zh-tw:伊拉克庫德斯坦
-languages:en:
+language_codes:en:
 
 en:Isle of Man, Ellan Vannin, Mann, the Isle of Man, IM, IMN
 ace:Pulo Man
@@ -20609,7 +20609,7 @@ zh-min-nan:Mannin
 zh-yue:馬恩島
 country_code_2:en:IM
 country_code_3:en:IMN
-languages:en:gv,en
+language_codes:en:gv,en
 
 en:Israel, State of Israel, IL, ISR
 ace:Israel
@@ -20835,7 +20835,7 @@ zh-yue:以色列
 zu:Isreyili
 country_code_2:en:IL
 country_code_3:en:ISR
-languages:en:he,ar,ru,en
+language_codes:en:he,ar,ru,en
 
 en:Italy, Italia, Italian Republic, Italië, IT, ITA
 ab:Италиа
@@ -21105,7 +21105,7 @@ zh-yue:意大利
 zu:ITaliya
 country_code_2:en:IT
 country_code_3:en:ITA
-languages:en:it
+language_codes:en:it
 
 en:Jamaica, JA, Commonwealth of Jamaica, Jamdung, JM, JAM
 ace:Jamaika
@@ -21289,7 +21289,7 @@ zh-min-nan:Jamaica
 zh-yue:牙買加
 country_code_2:en:JM
 country_code_3:en:JAM
-languages:en:en
+language_codes:en:en
 
 en:Jan Mayen
 ace:Jan Mayen
@@ -21377,7 +21377,7 @@ zea:Jan Mayen
 zh:揚馬延島
 zh-min-nan:Jan Mayen
 zh-yue:揚馬延島
-languages:en:
+language_codes:en:
 
 en:Japan, State of Japan, Land of the Rising Sun, Nihon, Nippon, JP, Nippon-koku, Nihon-koku, JP, JPN
 ab:Иапониа
@@ -21629,7 +21629,7 @@ zh-yue:日本
 zu:IJapani
 country_code_2:en:JP
 country_code_3:en:JPN
-languages:en:ja
+language_codes:en:ja
 
 en:Jersey, Balliwick of Jersey, Ile de Jersey, Jerry, JE, JEY
 ace:Jersey
@@ -21743,7 +21743,7 @@ zh-min-nan:Jersey
 zh-yue:澤西島
 country_code_2:en:JE
 country_code_3:en:JEY
-languages:en:en,fr
+language_codes:en:en,fr
 
 en:Jordan, Hashemite Kingdom of Jordan, JO, JOR
 ace:Yordania
@@ -21936,7 +21936,7 @@ zh-min-nan:Iok-tàn
 zh-yue:約旦
 country_code_2:en:JO
 country_code_3:en:JOR
-languages:en:ar
+language_codes:en:ar
 
 en:Kazakhstan, Republic of Kazakhstan, KZ, KAZ
 ab:Ҟазаҟсҭан
@@ -22164,7 +22164,7 @@ zh-tw:哈薩克斯坦
 zh-yue:哈薩克
 country_code_2:en:KZ
 country_code_3:en:KAZ
-languages:en:ru,kk
+language_codes:en:ru,kk
 
 en:Kenya, Republic of Kenya, KE, KEN
 ace:Kenya
@@ -22368,7 +22368,7 @@ zh-yue:肯雅
 zu:IKenya
 country_code_2:en:KE
 country_code_3:en:KEN
-languages:en:en,sw
+language_codes:en:en,sw
 
 en:Kiribati, KI, KIR
 ace:Kiribati
@@ -22528,7 +22528,7 @@ zh-min-nan:Kiribati
 zh-yue:基里巴斯
 country_code_2:en:KI
 country_code_3:en:KIR
-languages:en:en
+language_codes:en:en
 
 en:Kuwait, State of Kuwait, Dawlat al-Kuwait, دولة الكويت, الكويت, KW, KWT
 ace:Kuwait
@@ -22715,7 +22715,7 @@ zh-min-nan:Kuwait
 zh-yue:科威特
 country_code_2:en:KW
 country_code_3:en:KWT
-languages:en:ar
+language_codes:en:ar
 
 en:Kyrgyzstan, Kyrgyz Republic, KG, KGZ
 ab:Ҟырҕызсҭан
@@ -22914,7 +22914,7 @@ zh-tw:吉爾吉斯斯坦, 吉爾吉斯共和國
 zh-yue:吉爾吉斯
 country_code_2:en:KG
 country_code_3:en:KGZ
-languages:en:ru,ky
+language_codes:en:ru,ky
 
 en:Laos, Lao People's Democratic Republic, LA, LAO
 ace:Laos
@@ -23111,7 +23111,7 @@ zh-min-nan:Lao-kok
 zh-yue:Laos
 country_code_2:en:LA
 country_code_3:en:LAO
-languages:en:lo
+language_codes:en:lo
 
 en:Latvia, Republic of Latvia, Latvian Republic, LV, LVA
 ace:Latvia
@@ -23338,7 +23338,7 @@ zh-yue:拉脫維亞
 zu:ILatviya
 country_code_2:en:LV
 country_code_3:en:LVA
-languages:en:lv
+language_codes:en:lv
 
 en:Lebanon, Lebanese Republic, LB, LBN
 ace:Lebanon
@@ -23534,7 +23534,7 @@ zh-min-nan:Lī-pa-lùn
 zh-yue:黎巴嫩
 country_code_2:en:LB
 country_code_3:en:LBN
-languages:en:ar
+language_codes:en:ar
 
 en:Lesotho, Kingdom of Lesotho, LS, LSO
 ace:Lesotho
@@ -23728,7 +23728,7 @@ zh-tw:莱索托
 zu:OSotho
 country_code_2:en:LS
 country_code_3:en:LSO
-languages:en:en,st
+language_codes:en:en,st
 
 en:Liberia, LR, LBR
 ace:Liberia
@@ -23916,7 +23916,7 @@ zh-yue:利比利亞
 zu:ILiberia
 country_code_2:en:LR
 country_code_3:en:LBR
-languages:en:en
+language_codes:en:en
 
 en:Libya, State of Libya, LY, LBY
 ace:Libya
@@ -24130,7 +24130,7 @@ zh-yue:利比亞
 zu:ILibiya
 country_code_2:en:LY
 country_code_3:en:LBY
-languages:en:ar
+language_codes:en:ar
 
 en:Liechtenstein, LI, Principality of Liechtenstein, FL, LI, LIE
 ace:Liechtenstein
@@ -24350,7 +24350,7 @@ zh-min-nan:Liechtenstein
 zh-yue:列支敦士登
 country_code_2:en:LI
 country_code_3:en:LIE
-languages:en:de
+language_codes:en:de
 
 en:Lithuania, Republic of Lithuania, LT, LTU
 ab:Литва
@@ -24603,7 +24603,7 @@ zh-yue:立陶宛
 zu:ILithuwaniya
 country_code_2:en:LT
 country_code_3:en:LTU
-languages:en:lt
+language_codes:en:lt
 
 en:Luxembourg, Luxemburg, Grand Duchy of Luxembourg, LU, LU, LUX
 ace:Luksèmburg, Luxemburg
@@ -24846,7 +24846,7 @@ zh-tw:盧森堡, 盧森堡大公國, 盧森堡公國
 zh-yue:盧森堡
 country_code_2:en:LU
 country_code_3:en:LUX
-languages:en:fr,de,lb,en
+language_codes:en:fr,de,lb,en
 
 en:Macau, Macao, Macau Special Administrative Region, Macau Special Administrative Region of the People's Republic of China, Aomen, MO, MAC
 ace:Makèë
@@ -24986,7 +24986,7 @@ zh-min-nan:Ò-mn̂g
 zh-yue:澳門
 country_code_2:en:MO
 country_code_3:en:MAC
-languages:en:pt,zh
+language_codes:en:pt,zh
 
 en:Madagascar, Republic of Madagascar, MG, MDG
 ace:Madagaskar
@@ -25194,7 +25194,7 @@ zh-yue:馬達加斯加
 zu:IMadagasika
 country_code_2:en:MG
 country_code_3:en:MDG
-languages:en:fr,mg
+language_codes:en:fr,mg
 
 en:Malawi, Republic of Malawi, MW, MWI
 ace:Malawi
@@ -25371,7 +25371,7 @@ zh-yue:馬拉維
 zu:IMalawi
 country_code_2:en:MW
 country_code_3:en:MWI
-languages:en:en,ny
+language_codes:en:en,ny
 
 en:Malaysia, MY, MYS
 ace:Malaysia
@@ -25571,7 +25571,7 @@ zh-min-nan:Má-lâi-se-a
 zh-yue:馬來西亞
 country_code_2:en:MY
 country_code_3:en:MYS
-languages:en:ms
+language_codes:en:ms
 
 en:Maldives, MV, MDV
 ace:Maladewa
@@ -25744,7 +25744,7 @@ zh-min-nan:Maldives
 zh-yue:馬爾代夫
 country_code_2:en:MV
 country_code_3:en:MDV
-languages:en:dv
+language_codes:en:dv
 
 en:Mali, ML, MLI
 ace:Mali
@@ -25939,7 +25939,7 @@ zh-yue:馬里
 zu:IMali
 country_code_2:en:ML
 country_code_3:en:MLI
-languages:en:fr
+language_codes:en:fr
 
 en:Malta, Republic of Malta, MT, MLT
 ace:Malta
@@ -26164,7 +26164,7 @@ zh-yue:馬耳他
 zu:IMalta
 country_code_2:en:MT
 country_code_3:en:MLT
-languages:en:en,mt
+language_codes:en:en,mt
 
 en:Marshall Islands, Republic of the Marshall Islands, Aolepān Aorōkin M̧ajeļ, MH, MHL
 ace:Pulo-pulo Marshall
@@ -26311,7 +26311,7 @@ zh-min-nan:Marshall Kûn-tó
 zh-yue:馬紹爾群島
 country_code_2:en:MH
 country_code_3:en:MHL
-languages:en:en,mh
+language_codes:en:en,mh
 
 en:Martinique, MQ, MTQ
 af:Martinique
@@ -26435,7 +26435,7 @@ zh-min-nan:Martinique
 zh-yue:馬提尼克
 country_code_2:en:MQ
 country_code_3:en:MTQ
-languages:en:fr
+language_codes:en:fr
 
 en:Mauritania, Islamic Republic of Mauritania, MR, MRT
 ace:Mauritania
@@ -26638,7 +26638,7 @@ zh-yue:毛里塔尼亞
 zu:IMoritaniya
 country_code_2:en:MR
 country_code_3:en:MRT
-languages:en:ar
+language_codes:en:ar
 
 en:Mauritius, Republic of Mauritius, Maurice, Île Maurice, Moris, MU, MUS
 af:Mauritius
@@ -26812,7 +26812,7 @@ zh-yue:毛厘士
 zu:IMorishisi
 country_code_2:en:MU
 country_code_3:en:MUS
-languages:en:fr,en
+language_codes:en:fr,en
 
 en:Mayotte, Department of Mayotte, YT, MYT
 af:Mayotte
@@ -26928,7 +26928,7 @@ zh-yue:馬約特
 zu:IMayotte
 country_code_2:en:YT
 country_code_3:en:MYT
-languages:en:fr
+language_codes:en:fr
 
 en:Mexico, United Mexican States, Mexican Republic, República Mexicana, Estados Unidos Mexicanos, MX, MX, MEX
 ace:Meksiko
@@ -27168,7 +27168,7 @@ zh-yue:墨西哥
 zu:IMekisiko
 country_code_2:en:MX
 country_code_3:en:MEX
-languages:en:es
+language_codes:en:es
 
 en:Moldova, Republic of Moldova, MD, MDA
 ab:Молдова
@@ -27384,7 +27384,7 @@ zh-min-nan:Moldova
 zh-yue:摩爾多瓦
 country_code_2:en:MD
 country_code_3:en:MDA
-languages:en:ro
+language_codes:en:ro
 
 en:Monaco, Principality of Monaco, MC, MCO
 ace:Monakô
@@ -27595,7 +27595,7 @@ zh-min-nan:Monaco
 zh-yue:摩納哥
 country_code_2:en:MC
 country_code_3:en:MCO
-languages:en:fr
+language_codes:en:fr
 
 en:Mongolia, MN, MNG
 ace:Mongolia
@@ -27801,7 +27801,7 @@ zh-tw:蒙古國
 zh-yue:蒙古國
 country_code_2:en:MN
 country_code_3:en:MNG
-languages:en:mn
+language_codes:en:mn
 
 en:Montenegro, ME, MNE
 ace:Monténègrô
@@ -28009,7 +28009,7 @@ zh-min-nan:O͘-soaⁿ Kiōng-hô-kok
 zh-yue:黑山
 country_code_2:en:ME
 country_code_3:en:MNE
-languages:en:sr
+language_codes:en:sr
 
 en:Montserrat, MS, MSR
 af:Montserrat
@@ -28118,7 +28118,7 @@ zh-min-nan:Montserrat
 zh-yue:蒙塞拉特島
 country_code_2:en:MS
 country_code_3:en:MSR
-languages:en:en
+language_codes:en:en
 
 en:Morocco, Marocco, Kingdom of Morocco, MA, MAR
 ace:Maghribi
@@ -28307,7 +28307,7 @@ zh-yue:摩洛哥
 zu:IMorokho
 country_code_2:en:MA
 country_code_3:en:MAR
-languages:en:ar,fr,es
+language_codes:en:ar,fr,es
 
 en:Mozambique, Republic of Mozambique, MZ, MOZ
 ace:Mozambik
@@ -28498,7 +28498,7 @@ zh-yue:莫三鼻給
 zu:IMozambiki
 country_code_2:en:MZ
 country_code_3:en:MOZ
-languages:en:pt
+language_codes:en:pt
 
 en:Myanmar, Burma, Republic of the Union of Myanmar, Union of Burma, MM, MMR
 ace:Myanmar
@@ -28699,7 +28699,7 @@ zh-min-nan:Myanma
 zh-yue:緬甸
 country_code_2:en:MM
 country_code_3:en:MMR
-languages:en:my
+language_codes:en:my
 
 
 en:Nakhchivan Autonomous Republic
@@ -28776,7 +28776,7 @@ zh-hant:納希契凡自治共和國
 zh-hk:納希契凡自治共和國
 zh-sg:纳希切万自治共和国
 zh-tw:納希契凡自治共和國
-languages:en:
+language_codes:en:
 
 en:Namibia, Republic of Namibia, NA, NAM
 ace:Namibia
@@ -28977,7 +28977,7 @@ zh-yue:納米比亞
 zu:INamibhiya
 country_code_2:en:NA
 country_code_3:en:NAM
-languages:en:en
+language_codes:en:en
 
 en:Nauru, Republic of Nauru, NR, NRU
 ace:Nauru
@@ -29147,7 +29147,7 @@ zh-min-nan:Nauru
 zh-yue:瑙魯
 country_code_2:en:NR
 country_code_3:en:NRU
-languages:en:na
+language_codes:en:na
 
 en:Nepal, Federal Democratic Republic of Nepal, NP, NPL
 ace:Nepal
@@ -29345,7 +29345,7 @@ zh-min-nan:Nepal
 zh-yue:尼泊爾
 country_code_2:en:NP
 country_code_3:en:NPL
-languages:en:ne
+language_codes:en:ne
 
 en:Netherlands, Holland, the Netherlands, NL, NED, NL, NLD
 ace:Beulanda
@@ -29601,7 +29601,7 @@ zh-yue:荷蘭
 zu:Netherlands
 country_code_2:en:NL
 country_code_3:en:NLD
-languages:en:nl
+language_codes:en:nl
 
 en:New Caledonia, NC, NCL
 ace:Kaledonia Barô
@@ -29716,7 +29716,7 @@ zh-min-nan:Sin Calédonie
 zh-yue:新喀里多尼亞
 country_code_2:en:NC
 country_code_3:en:NCL
-languages:en:fr
+language_codes:en:fr
 
 en:New Zealand, NZ, NZL, Dominion of New Zealand, NZ, NZL
 ace:Seulandia Barô
@@ -29924,7 +29924,7 @@ zh-yue:紐西蘭
 zu:INyuzilandi
 country_code_2:en:NZ
 country_code_3:en:NZL
-languages:en:en,mi
+language_codes:en:en,mi
 
 en:Nicaragua, NI, NIC
 ace:Nikaragua
@@ -30097,7 +30097,7 @@ zh-yue:尼加拉瓜
 zu:Nicaragua
 country_code_2:en:NI
 country_code_3:en:NIC
-languages:en:es
+language_codes:en:es
 
 en:Niger, Republic of Niger, NE, NER
 ace:Niger
@@ -30287,7 +30287,7 @@ zh-yue:尼日爾
 zu:INayighe
 country_code_2:en:NE
 country_code_3:en:NER
-languages:en:fr
+language_codes:en:fr
 
 en:Nigeria, Federal Republic of Nigeria, NG, NGA
 ace:Nigeria
@@ -30490,7 +30490,7 @@ zh-yue:尼日利亞
 zu:INigeria
 country_code_2:en:NG
 country_code_3:en:NGA
-languages:en:en
+language_codes:en:en
 
 en:Niue, NU, NIU
 ace:Niue
@@ -30599,7 +30599,7 @@ zh-min-nan:Niue
 zh-yue:紐埃
 country_code_2:en:NU
 country_code_3:en:NIU
-languages:en:
+language_codes:en:
 
 en:Norfolk Island, NF, NFK
 ace:Pulo Norfolk
@@ -30698,7 +30698,7 @@ zh-min-nan:Norfolk-tó
 zh-yue:諾福克島
 country_code_2:en:NF
 country_code_3:en:NFK
-languages:en:en
+language_codes:en:en
 
 en:North Korea, Democratic People's Republic of Korea, DPRK, PRK, KP, PRK
 ace:Korèa Utara
@@ -30905,7 +30905,7 @@ zh-tw:朝鮮民主主義人民共和國, 朝鮮, 北朝鮮, 北韓
 zh-yue:朝鮮民主主義人民共和國
 country_code_2:en:KP
 country_code_3:en:PRK
-languages:en:ko
+language_codes:en:ko
 
 en:North Macedonia, Republic of North Macedonia, Republic of Macedonia, FYROM, Former Yugoslav Republic of Macedonia, Macedonia, MK, MKD
 ace:Makèdonia Utara
@@ -31114,7 +31114,7 @@ zh-yue:馬其頓共和國
 xx:FYROM
 country_code_2:en:MK
 country_code_3:en:MKD
-languages:en:mk
+language_codes:en:mk
 
 en:Northern Mariana Islands, MP, MNP
 ace:Pulo-pulo Mariana Utara
@@ -31210,7 +31210,7 @@ zh-min-nan:Pak Mariana Kûn-tó
 zh-yue:北馬利安納羣島
 country_code_2:en:MP
 country_code_3:en:MNP
-languages:en:en,ch
+language_codes:en:en,ch
 
 en:Northland State
 ba:Нортленд (Сомали)
@@ -31219,7 +31219,7 @@ it:Northland
 ja:ノースランド国
 ru:Нортленд, Нортланд
 sv:Nordland
-languages:en:
+language_codes:en:
 
 en:Norway, Kingdom of Norway, NO, NOR
 ace:Norwègia
@@ -31470,7 +31470,7 @@ zh-yue:挪威
 zu:INoki
 country_code_2:en:NO
 country_code_3:en:NOR
-languages:en:nb
+language_codes:en:nb
 
 en:Oman, OM, OMN
 ace:Oman
@@ -31650,7 +31650,7 @@ zh-min-nan:Oman
 zh-yue:阿曼
 country_code_2:en:OM
 country_code_3:en:OMN
-languages:en:ar
+language_codes:en:ar
 
 en:Pakistan, PK, PAK
 ace:Pakistan
@@ -31868,7 +31868,7 @@ zh-yue:巴基斯坦
 zu:IPakistani
 country_code_2:en:PK
 country_code_3:en:PAK
-languages:en:ur,en
+language_codes:en:ur,en
 
 en:Palau, Republic of Palau, Belau, Pelew, PW, PLW
 ace:Palau
@@ -32024,7 +32024,7 @@ zh-min-nan:Palau
 zh-yue:帛琉
 country_code_2:en:PW
 country_code_3:en:PLW
-languages:en:en
+language_codes:en:en
 
 en:Palestinian territories, Palestine, ps
 af:Palestynse Grondgebiede
@@ -32058,7 +32058,7 @@ sk:Palestínske okupované územia
 ur:فلسطینی علاقہ جات
 yo:Àwọn Agbègbè ilẹ̀ Palẹstínì
 zh:巴勒斯坦领土
-languages:en:ar
+language_codes:en:ar
 
 en:Panama, Republic of Panama, PA, PAN
 ace:Panama
@@ -32255,7 +32255,7 @@ zh-yue:巴拿馬
 zu:Panama
 country_code_2:en:PA
 country_code_3:en:PAN
-languages:en:
+language_codes:en:
 
 en:Papua New Guinea, Independent State of Papua New Guinea, PG, PNG
 ace:Papua New Guinea
@@ -32421,7 +32421,7 @@ zh-min-nan:Papua Sin Guinea
 zh-yue:巴布亞新畿內亞
 country_code_2:en:PG
 country_code_3:en:PNG
-languages:en:en,ho
+language_codes:en:en,ho
 
 en:Paraguay, Republic of Paraguay, PY, PRY
 ace:Paraguay
@@ -32607,7 +32607,7 @@ zh-min-nan:Paraguay
 zh-yue:巴拉圭
 country_code_2:en:PY
 country_code_3:en:PRY
-languages:en:es,gn
+language_codes:en:es,gn
 
 en:Peru, PE, PER
 ab:Перу
@@ -32826,7 +32826,7 @@ zh-yue:秘魯
 zu:Peru
 country_code_2:en:PE
 country_code_3:en:PER
-languages:en:es
+language_codes:en:es
 
 en:Philippines, Republic of the Philippines, PH, PHL
 ace:Filipina
@@ -33025,7 +33025,7 @@ zh-min-nan:Hui-li̍p-pin
 zh-yue:菲律賓
 country_code_2:en:PH
 country_code_3:en:PHL
-languages:en:en,tl
+language_codes:en:en,tl
 
 en:Pitcairn, Pitcairn Islands, PN, PCN
 ace:Pulo-pulo Pitcairn
@@ -33129,7 +33129,7 @@ zh-min-nan:Pitcairn Kûn-tó
 zh-yue:皮特凱恩群島
 country_code_2:en:PN
 country_code_3:en:PCN
-languages:en:
+language_codes:en:
 
 en:Poland, Republic of Poland, PL, POL
 ab:Полша
@@ -33394,7 +33394,7 @@ zh-yue:波蘭
 zu:IPolandi
 country_code_2:en:PL
 country_code_3:en:POL
-languages:en:pl
+language_codes:en:pl
 
 en:Portugal, Portuguese Republic, PT, PT, PRT
 ace:Portugéh
@@ -33647,7 +33647,7 @@ zh-yue:葡萄牙
 zu:IPhothugali
 country_code_2:en:PT
 country_code_3:en:PRT
-languages:en:pt
+language_codes:en:pt
 
 en:Puerto Rico, Commonwealth of Puerto Rico, PR, PRI
 af:Puerto Rico
@@ -33786,7 +33786,7 @@ zh-min-nan:Puerto Rico
 zh-yue:波多黎各
 country_code_2:en:PR
 country_code_3:en:PRI
-languages:en:es,en
+language_codes:en:es,en
 
 en:Qatar, QA, QAT
 ace:Qatar
@@ -33979,7 +33979,7 @@ zh-min-nan:Qatar
 zh-yue:卡塔爾
 country_code_2:en:QA
 country_code_3:en:QAT
-languages:en:ar
+language_codes:en:ar
 
 en:Taiwan, Republic of China, ROC, Chinese Taipei, Taiwan, TW, TWN
 ace:Taywan
@@ -34166,7 +34166,7 @@ zh-tw:中華民國
 zh-yue:臺灣
 country_code_2:en:TW
 country_code_3:en:TWN
-languages:en:zh
+language_codes:en:zh
 
 en:Ireland, Republic of Ireland,Ireland, Éire, IE, IE, IRL
 ace:Irlandia, Ireulandia
@@ -34395,7 +34395,7 @@ zh-yue:愛爾蘭共和國
 zu:I-Ayilendi, Celts, I-Ayilandi
 country_code_2:en:IE
 country_code_3:en:IRL
-languages:en:en,ga
+language_codes:en:en,ga
 
 en:Republic of the Congo, Congo-Brazzaville, CG, COG, Congo Republic
 af:Republiek van die Kongo
@@ -34567,7 +34567,7 @@ zh-yue:剛果
 zu:IKongo
 country_code_2:en:CG
 country_code_3:en:COG
-languages:en:fr
+language_codes:en:fr
 
 en:Republika Srpska
 ar:جمهورية صرب البوسنة
@@ -34637,7 +34637,7 @@ ur:سرپسکا
 vi:Cộng hòa Srpska
 yo:Sérbíà Orílẹ̀-èdè Olómìnira
 zh:塞族共和國
-languages:en:
+language_codes:en:
 
 en:Romania, Roumania, Rumania, România, RO, ROU
 ace:Rumania
@@ -34871,7 +34871,7 @@ zh-min-nan:România
 zh-yue:羅馬尼亞
 country_code_2:en:RO
 country_code_3:en:ROU
-languages:en:ro
+language_codes:en:ro
 
 en:Russia, Russian Federation, Russian federation, Rossiyskaya Federatsiya, Россия, Rossijskaja Federatsija, Российская Федерация, 🇷🇺, RU, RUS
 ab:Урыстәыла
@@ -35160,7 +35160,7 @@ zh-yue:俄羅斯
 zu:IRashiya
 country_code_2:en:RU
 country_code_3:en:RUS
-languages:en:ru
+language_codes:en:ru
 
 en:Rwanda, Republic of Rwanda, RW, RWA
 ace:Rwanda
@@ -35361,7 +35361,7 @@ zh-yue:盧旺達
 zu:IRuwanda
 country_code_2:en:RW
 country_code_3:en:RWA
-languages:en:en,fr,rw
+language_codes:en:en,fr,rw
 
 en:Réunion, RE, REU
 af:Réunion
@@ -35485,7 +35485,7 @@ zh-yue:留尼旺
 zu:IRiyunion
 country_code_2:en:RE
 country_code_3:en:REU
-languages:en:fr
+language_codes:en:fr
 
 en:Saba
 af:Saba
@@ -35551,7 +35551,7 @@ vi:Saba
 yue:薩巴島
 zh:薩巴, 薩巴島, 沙巴, 萨巴岛
 zh-yue:薩巴島
-languages:en:en,nl
+language_codes:en:en,nl
 
 en:Saint Helena, Ascension and Tristan da Cunha, Saint Helena and Dependencies, SH, SHN
 af:Sint Helena, Ascension en Tristan da Cunha
@@ -35614,7 +35614,7 @@ zh-sg:圣赫勒拿、阿森松与特里斯坦达库尼亚
 zh-tw:聖赫倫那、阿森松與特里斯坦達庫尼亞
 country_code_2:en:SH
 country_code_3:en:SHN
-languages:en:
+language_codes:en:
 
 en:Saint Kitts and Nevis, Saint Christopher and Nevis, Federation of Saint Kitts and Nevis, KN, KNA
 af:St. Kitts en Nevis
@@ -35764,7 +35764,7 @@ zh-min-nan:Sèng Kitts kap Nevis
 zh-yue:聖傑氏尼維斯
 country_code_2:en:KN
 country_code_3:en:KNA
-languages:en:en
+language_codes:en:en
 
 en:Saint Lucia, LC, LCA
 af:St. Lucia
@@ -35908,7 +35908,7 @@ zh-min-nan:Sèng Lucia
 zh-yue:聖盧西亞
 country_code_2:en:LC
 country_code_3:en:LCA
-languages:en:en
+language_codes:en:en
 
 en:Saint Martin, Saint Martin France, Collectivity of Saint Martin, MF, MAF
 af:Saint-Martin, Saint Martin
@@ -35977,7 +35977,7 @@ zh-sg:法属圣马丁
 zh-tw:法屬聖馬丁
 country_code_2:en:MF
 country_code_3:en:MAF
-languages:en:fr
+language_codes:en:fr
 
 en:Saint Pierre and Miquelon, PM, SPM
 af:Saint-Pierre en Miquelon, Saint-Pierre et Miquelon, Saint Pierre en Miquelon, Sint Pierre en Miquelon, Sint-Pierre en Miquelon
@@ -36079,7 +36079,7 @@ zh-min-nan:Sèng Pierre kap Miquelon
 zh-yue:聖皮埃爾及密克隆群島
 country_code_2:en:PM
 country_code_3:en:SPM
-languages:en:fr
+language_codes:en:fr
 
 en:Saint Vincent and the Grenadines, VC, VCT
 af:St. Vincent en die Grenadines
@@ -36218,7 +36218,7 @@ zh-min-nan:Sèng Vincent kap Grenadines
 zh-yue:聖文森特和格林納丁斯
 country_code_2:en:VC
 country_code_3:en:VCT
-languages:en:en
+language_codes:en:en
 
 en:Saint-Barthélemy, Saint Barthélemy, Ouanalao, Collectivité de Saint-Barthélemy, Saint Barths, Ile Saint-Barthélemy, Saint Barthélémy, St. Barthelemy, St barths, St. Barthélemy, Saint Barts, Saint-Barthélémy, St. Barths, ISO 3166-1:BL, Île Saint-Barthélemy, Saint Bartz, St barts, St. Barth, America/St Barthelemy, Collectivity of Saint Barthélemy, Saint-Barthelemy, Saint Barthelemy, St barthelemy, Saint Barth, BL, BLM
 af:Saint-Barthélemy, Sint-Bartholomeus, Saint Barthélemy, Saint-Barthelemy, Sint-Barthélemy, Sint-Barthelemy, Saint Barthelemy, Sint Barthélemy
@@ -36291,7 +36291,7 @@ yo:Saint Barthélemy, Saint-Barthélemy
 zh:聖巴泰勒米島, 圣巴托罗缪岛, 聖巴托洛繆島, 圣巴泰勒米, 圣巴托洛缪岛, 聖巴瑟米
 country_code_2:en:BL
 country_code_3:en:BLM
-languages:en:fr
+language_codes:en:fr
 
 en:Samoa, Western Samoa, Independent State of Samoa, WS, WSM
 ace:Samoa
@@ -36446,7 +36446,7 @@ zh-min-nan:Samoa
 zh-yue:薩摩亞
 country_code_2:en:WS
 country_code_3:en:WSM
-languages:en:en,sm
+language_codes:en:en,sm
 
 en:San Marino, SM, SMR
 ace:San Marino
@@ -36659,7 +36659,7 @@ zh-yue:聖馬連奴
 zu:USanti Marino
 country_code_2:en:SM
 country_code_3:en:SMR
-languages:en:it
+language_codes:en:it
 
 en:Sao Tomé and Príncipe, Democratic Republic of São Tomé and Príncipe, São Tomé og Príncipe, ST, STP
 af:São Tomé en Príncipe
@@ -36838,7 +36838,7 @@ zh-yue:聖多美及普林西比
 zu:ISawu Tome noPhrinitshipeyi
 country_code_2:en:ST
 country_code_3:en:STP
-languages:en:pt
+language_codes:en:pt
 
 en:Saudi Arabia, The Kingdom of Saudi Arabia, SA, SAU
 ace:Arab Saudi
@@ -37044,7 +37044,7 @@ zh-min-nan:Saud ê A-la-pek
 zh-yue:沙地阿拉伯
 country_code_2:en:SA
 country_code_3:en:SAU
-languages:en:ar
+language_codes:en:ar
 
 en:Senegal, Republic of Senegal, SN, SEN
 ace:Senegal
@@ -37233,7 +37233,7 @@ zh-yue:塞內加爾
 zu:ISenegal
 country_code_2:en:SN
 country_code_3:en:SEN
-languages:en:fr
+language_codes:en:fr
 
 en:Serbia, RS, SRB
 ace:Sèrbia
@@ -37458,7 +37458,7 @@ zh-yue:塞爾維亞
 zu:ISerbiya
 country_code_2:en:RS
 country_code_3:en:SRB
-languages:en:sr
+language_codes:en:sr
 
 en:Seychelles, Republic of Seychelles, SC, SYC
 af:Seychelle
@@ -37627,7 +37627,7 @@ zh-yue:塞舌爾
 zu:IsiSeyisheli
 country_code_2:en:SC
 country_code_3:en:SYC
-languages:en:fr,en
+language_codes:en:fr,en
 
 en:Sierra Leone, Republic of Sierra Leone, SL, SLE
 ace:Sierra Leone
@@ -37816,7 +37816,7 @@ zh-yue:塞拉利昂
 zu:ISiera Liyoni
 country_code_2:en:SL
 country_code_3:en:SLE
-languages:en:en
+language_codes:en:en
 
 en:Singapore, Republic of Singapore, SG, SGP
 ace:Singapura
@@ -38024,7 +38024,7 @@ zh-min-nan:Sin-ka-pho
 zh-yue:星架坡, 星加坡, 新加坡, 石叻, 新加坡共和國, 新架坡
 country_code_2:en:SG
 country_code_3:en:SGP
-languages:en:en,ta,zh,ms
+language_codes:en:en,ta,zh,ms
 
 en:Sint Eustatius, Statia, Statius, St. Eustatius
 af:Sint Eustatius, Sint-Eustatius
@@ -38083,7 +38083,7 @@ uk:Сінт-Естатіус
 ur:سینٹ ایوسٹائیس, Sint Eustatius
 vi:Sint Eustatius, Saint Eustatius
 zh:圣尤斯特歇斯, 聖佑達修斯, 聖尤斯特歇斯島, 圣尤斯特歇斯岛
-languages:en:en,nl
+language_codes:en:en,nl
 
 en:Sint Maarten, St. Maarten, Saint Martin Dutch part, SX, SXM
 af:Sint Maarten, Sint-Maarten
@@ -38153,7 +38153,7 @@ war:Sint Maarten
 zh:荷屬聖馬丁, 荷属圣马丁, 荷屬馬丁尼
 country_code_2:en:SX
 country_code_3:en:SXM
-languages:en:en,nl
+language_codes:en:en,nl
 
 en:Slovakia, Slovak Republic, SK, SVK
 ace:Slowakia
@@ -38376,7 +38376,7 @@ zh-yue:斯洛伐克
 zu:ISlovaki
 country_code_2:en:SK
 country_code_3:en:SVK
-languages:en:sk
+language_codes:en:sk
 
 en:Slovenia, Republic of Slovenia, Slovenija, Republika Slovenija, SI, SVN
 ace:Slovenia
@@ -38601,7 +38601,7 @@ zh-min-nan:Slovenia
 zh-yue:斯洛文尼亞
 country_code_2:en:SI
 country_code_3:en:SVN
-languages:en:sl
+language_codes:en:sl
 
 en:Solomon Islands, SB, SLB
 ace:Pulo-pulo Solomon
@@ -38756,7 +38756,7 @@ zh-min-nan:Só͘-lô-bûn Kûn-tó
 zh-yue:所羅門群島
 country_code_2:en:SB
 country_code_3:en:SLB
-languages:en:en
+language_codes:en:en
 
 en:Somalia, Federal Republic of Somalia, SO, SOM
 ace:Somalia
@@ -38953,7 +38953,7 @@ zh-yue:索馬里
 zu:ISomalia
 country_code_2:en:SO
 country_code_3:en:SOM
-languages:en:so,ar
+language_codes:en:so,ar
 
 en:South Africa, Republic of South Africa, RSA, ZA, ZAF
 ace:Afrika Seulatan
@@ -39189,7 +39189,7 @@ zh-yue:南非共和國
 zu:IRiphabliki yaseNingizimu Afrika
 country_code_2:en:ZA
 country_code_3:en:ZAF
-languages:en:en,zu,xh,af,ve,ss,tn,ts,st,nr
+language_codes:en:en,zu,xh,af,ve,ss,tn,ts,st,nr
 
 en:South Georgia and the South Sandwich Islands, South Georgia, South Sandwich Islands, GS, SGS
 af:Suid-Georgië en die Suidelike Sandwicheilande, Suid-Georgia en die Suidelik Sandwicheilande, Suid-Georgië en die Suide Sandwicheilande, Suid-Georgië en die Suid-Sandwich Eilande, South Georgia and the South Sandwich Islands, Suid-Georgie en die Suidelike Sandwicheilande, Suid-Georgië en de Suidelike Sandwicheilanden, Suid-Georgië en die Suid-Sandwicheilande
@@ -39289,7 +39289,7 @@ yo:Gúúsù Georgia àti Àwọn Erékùṣù Gúúsù Sandwich, South Georgia a
 zh:南喬治亞島與南桑威奇群島, 南喬治亞, 南乔治亚和南桑德韦奇群岛, 南三明治群島, 南乔治亚岛和南桑威奇群岛, 南喬治亞島和南三明治群島, 南喬治亞和桑威奇群島, 南佐治亞島與南桑威奇群島, 南乔治亚与南桑威奇群岛, 南佐治亞及南三文治群島, 南喬治亞與南三明治群島, 南喬治亞群島, 南喬治亞和南三文治群島, 南桑德维奇群岛, 南喬治亞及南三明治群島, 南乔治亚岛和南桑德韦奇岛, 南喬治亞及南桑威奇群島, 南乔治亚岛
 country_code_2:en:GS
 country_code_3:en:SGS
-languages:en:en
+language_codes:en:en
 
 en:South Korea, Republic of Korea, ROK, KR, KOR
 ace:Korèa Seulatan
@@ -39506,7 +39506,7 @@ zh-min-nan:Hân-kok
 zh-yue:大韓民國
 country_code_2:en:KR
 country_code_3:en:KOR
-languages:en:ko
+language_codes:en:ko
 
 en:South Sudan, Republic of South Sudan, Southern Sudan, SS, SSD
 af:Suid-Soedan
@@ -39673,7 +39673,7 @@ zh-yue:南蘇丹
 zu:ISudan yaseNingizimu
 country_code_2:en:SS
 country_code_3:en:SSD
-languages:en:en
+language_codes:en:en
 
 en:Soviet Union, USSR, U.S.S.R., Soviets, U.S.S.R, The Union of Soviet Socialist Republics, The Soviet Union, Union of soviet socialist republics, Union of Soviet Socialist Republics, The Soviets
 ace:Uni Soviet
@@ -39844,7 +39844,7 @@ zh:苏联
 zh-classical:蘇聯
 zh-min-nan:Soviet Siā-hōe-chú-gī Kiōng-hô-kok Liân-ha̍p
 zh-yue:蘇聯
-languages:en:ru
+language_codes:en:ru
 
 en:Spain, Kingdom of Spain, España, Reino de España, ES, ESP
 ace:Seupanyo
@@ -40108,7 +40108,7 @@ zh-yue:西班牙
 zu:ISpeyini
 country_code_2:en:ES
 country_code_3:en:ESP
-languages:en:es,ca,eu,gl
+language_codes:en:es,ca,eu,gl
 
 en:Sri Lanka, Democratic Socialist Republic of Sri Lanka, LK, LKA
 ace:Srilanka
@@ -40300,7 +40300,7 @@ zh-min-nan:Sri Lanka
 zh-yue:斯里蘭卡
 country_code_2:en:LK
 country_code_3:en:LKA
-languages:en:si,ta
+language_codes:en:si,ta
 
 en:State of Palestine
 af:Staat van Palestina, Palestinië, Palestina, Palestynse Nasionale Owerheid, Palestynse Owerheid, Palestynse Owerhede
@@ -40372,7 +40372,7 @@ zh-sg:巴勒斯坦国
 zh-tw:巴勒斯坦國
 country_code_2:en:PS
 country_code_3:en:PSE
-languages:en:ar
+language_codes:en:ar
 
 en:Sudan, suca, SD, SDN
 ace:Sudan
@@ -40586,7 +40586,7 @@ zh-tw:苏丹共和国
 zh-yue:蘇丹
 country_code_2:en:SD
 country_code_3:en:SDN
-languages:en:ar,en
+language_codes:en:ar,en
 
 en:Suriname, Surinam, Republic of Suriname, Republic of Surinam, Dutch Guiana, SR, SUR
 ace:Suriname
@@ -40764,7 +40764,7 @@ zh-min-nan:Suriname
 zh-yue:蘇里南
 country_code_2:en:SR
 country_code_3:en:SUR
-languages:en:nl
+language_codes:en:nl
 
 en:Svalbard and Jan Mayen, SJ, SJM
 ar:سفالبارد ويان ماين
@@ -40798,7 +40798,7 @@ yo:Svalbard àti Jan Mayen, Svalbard and Jan Mayen
 zh:斯瓦尔巴和扬马延
 country_code_2:en:SJ
 country_code_3:en:SJM
-languages:en:
+language_codes:en:
 
 en:Swaziland, Kingdom of Swaziland, SZ, SWZ
 ace:Swaziland
@@ -40978,7 +40978,7 @@ zh-yue:斯威士蘭
 zu:ISwazilandi
 country_code_2:en:SZ
 country_code_3:en:SWZ
-languages:en:en,ss
+language_codes:en:en,ss
 
 en:Sweden, Kingdom of Sweden, SE, SE, SWE
 ab:Швециа
@@ -41233,7 +41233,7 @@ zh-yue:瑞典
 zu:ISwidi
 country_code_2:en:SE
 country_code_3:en:SWE
-languages:en:sv
+language_codes:en:sv
 
 en:Switzerland, Swiss Confederation, CH, CH, CHE
 ace:Swiss
@@ -41475,7 +41475,7 @@ zh-tw:瑞士, 瑞士聯邦
 zh-yue:瑞士
 country_code_2:en:CH
 country_code_3:en:CHE
-languages:en:de,fr,it
+language_codes:en:de,fr,it
 
 en:Syria, Syrian Arab Republic, SY, SYR
 ace:Suriah
@@ -41678,7 +41678,7 @@ zh-min-nan:Su-lī-a
 zh-yue:敘利亞
 country_code_2:en:SY
 country_code_3:en:SYR
-languages:en:ar
+language_codes:en:ar
 
 en:Tajikistan, Republic of Tajikistan, TJ, TJK
 ace:Tajikistan
@@ -41867,7 +41867,7 @@ zh-min-nan:Tajikistan
 zh-yue:塔吉克
 country_code_2:en:TJ
 country_code_3:en:TJK
-languages:en:ru,tg
+language_codes:en:ru,tg
 
 en:Tanzania, United Republic of Tanzania, TZ, TZA
 ace:Tanzania
@@ -42074,7 +42074,7 @@ zh-yue:坦桑尼亞
 zu:ITanzania
 country_code_2:en:TZ
 country_code_3:en:TZA
-languages:en:en,sw
+language_codes:en:en,sw
 
 en:Thailand, Kingdom of Thailand, TH, THA
 ace:Muang Thai
@@ -42283,7 +42283,7 @@ zh-min-nan:Thài-kok
 zh-yue:泰國
 country_code_2:en:TH
 country_code_3:en:THA
-languages:en:th
+language_codes:en:th
 
 en:The Bahamas, Bahamas, Commonwealth of the Bahamas, BS, BHS
 ace:Bahama
@@ -42463,7 +42463,7 @@ zh-min-nan:Bahamas
 zh-yue:巴哈馬
 country_code_2:en:BS
 country_code_3:en:BHS
-languages:en:en
+language_codes:en:en
 
 en:Timor-Leste, East Timor, Democratic Republic of Timor-Leste, TL, TLS
 ace:Timor Leste
@@ -42646,7 +42646,7 @@ zh-min-nan:Tang Timor
 zh-yue:東帝汶
 country_code_2:en:TL
 country_code_3:en:TLS
-languages:en:pt
+language_codes:en:pt
 
 en:Togo, Togolese Republic, TG, TGO
 ace:Togo
@@ -42829,7 +42829,7 @@ zh-yue:多哥
 zu:ITogo
 country_code_2:en:TG
 country_code_3:en:TGO
-languages:en:fr
+language_codes:en:fr
 
 en:Tokelau, TK, TKL
 ace:Tokelau
@@ -42923,7 +42923,7 @@ zh-min-nan:Tokelau
 zh-yue:托克勞
 country_code_2:en:TK
 country_code_3:en:TKL
-languages:en:
+language_codes:en:
 
 en:Tonga, TO, TON
 ace:Tonga
@@ -43078,7 +43078,7 @@ zh-min-nan:Tonga
 zh-yue:湯加
 country_code_2:en:TO
 country_code_3:en:TON
-languages:en:en,to
+language_codes:en:en,to
 
 en:Trinidad and Tobago, Republic of Trinidad and Tobago, TT, TTO
 af:Trinidad en Tobago
@@ -43237,7 +43237,7 @@ zh-min-nan:Trinidad kap Tobago
 zh-yue:千里達
 country_code_2:en:TT
 country_code_3:en:TTO
-languages:en:en
+language_codes:en:en
 
 en:Tunisia, Republic of Tunisia, TN, TUN
 ace:Tunisia
@@ -43431,7 +43431,7 @@ zh-yue:突尼西亞
 zu:ITunisia
 country_code_2:en:TN
 country_code_3:en:TUN
-languages:en:ar
+language_codes:en:ar
 
 en:Turkey, Republic of Turkey, TR, TUR
 ab:Ҭырқәтәыла
@@ -43693,7 +43693,7 @@ zh-yue:土耳其
 zu:ITheki
 country_code_2:en:TR
 country_code_3:en:TUR
-languages:en:tr
+language_codes:en:tr
 
 en:Turkmenistan, TM, TKM
 ace:Turkmènistan
@@ -43887,7 +43887,7 @@ zh-min-nan:Turkmenistan
 zh-yue:土庫曼
 country_code_2:en:TM
 country_code_3:en:TKM
-languages:en:tk
+language_codes:en:tk
 
 en:Turks and Caicos Islands, TC, TCA
 af:Turks- en Caicos-eilande
@@ -43995,7 +43995,7 @@ zh-min-nan:Turks kap Caicos Kûn-tó
 zh-yue:特克斯與凱科斯群島
 country_code_2:en:TC
 country_code_3:en:TCA
-languages:en:
+language_codes:en:
 
 en:Tuvalu, Ellice Islands, TV, TUV
 ace:Tuvalu
@@ -44156,7 +44156,7 @@ zh-min-nan:Tuvalu
 zh-yue:圖瓦盧
 country_code_2:en:TV
 country_code_3:en:TUV
-languages:en:en
+language_codes:en:en
 
 en:Uganda, Republic of Uganda, UG, UGA
 ace:Uganda
@@ -44355,7 +44355,7 @@ zh-yue:烏干達
 zu:IYuganda
 country_code_2:en:UG
 country_code_3:en:UGA
-languages:en:en,sw
+language_codes:en:en,sw
 
 en:Ukraine, UA, UKR
 ab:Украина
@@ -44596,7 +44596,7 @@ zh-tw:烏克蘭
 zh-yue:烏克蘭
 country_code_2:en:UA
 country_code_3:en:UKR
-languages:en:uk
+language_codes:en:uk
 
 en:United Arab Emirates, UAE, AE, ARE
 ace:Uni Emirat Arab
@@ -44785,7 +44785,7 @@ zh-min-nan:A-la-pek Liân-ha̍p Thâu-lâng-kok
 zh-yue:阿拉伯聯合酋長國
 country_code_2:en:AE
 country_code_3:en:ARE
-languages:en:ar
+language_codes:en:ar
 
 en:United Kingdom, United Kingdom of Great Britain and Northern Ireland, UK, GB, GBR
 ab:Британиа Ду
@@ -45040,7 +45040,7 @@ zu:Umbuso Ohlangeneyo
 country_code_2:en:UK
 official_country_code_2:en:GB
 country_code_3:en:GBR
-languages:en:en,cy,ga,gd
+language_codes:en:en,cy,ga,gd
 
 en:United States Minor Outlying Islands, UM, UMI
 af:Klein afgeleë eilande van die Verenigde State van Amerika
@@ -45093,7 +45093,7 @@ yo:Àwọn Erékùṣù Kékèké Orílẹ̀-èdè Amẹ́ríkà
 zh:美国本土外小岛屿
 country_code_2:en:UM
 country_code_3:en:UMI
-languages:en:
+language_codes:en:
 
 en:United States, United States of America, USA, America, the States, U.S., U.S.A., United States, US, 🇺🇸, US, USA
 ab:Америка Еиду Аштатқәа
@@ -45376,7 +45376,7 @@ zh-yue:美國
 zu:IMelika
 country_code_2:en:US
 country_code_3:en:USA
-languages:en:en
+language_codes:en:en
 
 en:Uruguay, Oriental Republic of Uruguay, Eastern Republic of Uruguay, República Oriental del Uruguay, UY, URY
 ace:Uruguay
@@ -45578,7 +45578,7 @@ zh-tw:烏拉圭, 烏拉圭東岸共和國
 zh-yue:烏拉圭
 country_code_2:en:UY
 country_code_3:en:URY
-languages:en:es
+language_codes:en:es
 
 en:Uzbekistan, Republic of Uzbekistan, UZ, UZB
 ace:Uzbèkistan
@@ -45774,7 +45774,7 @@ zh-min-nan:Uzbekistan
 zh-yue:月即別
 country_code_2:en:UZ
 country_code_3:en:UZB
-languages:en:uz
+language_codes:en:uz
 
 en:Vanuatu, Republic of Vanuatu, VU, VUT
 ab:Вануату
@@ -45936,7 +45936,7 @@ zh-min-nan:Vanuatu
 zh-yue:萬那杜
 country_code_2:en:VU
 country_code_3:en:VUT
-languages:en:fr,en,bi
+language_codes:en:fr,en,bi
 
 en:Vatican City, Vatican City State, Papal State, Holy See, VA, VAT
 ace:Vatikan
@@ -46165,7 +46165,7 @@ zh-yue:梵蒂岡
 zu:Indolobha yaseVathikhani
 country_code_2:en:VA
 country_code_3:en:VAT
-languages:en:it,la
+language_codes:en:it,la
 
 en:Venezuela, República Bolivariana de Venezuela, VE, VEN
 ace:Vènèzuèla
@@ -46380,7 +46380,7 @@ zh-yue:委內瑞拉
 zu:Venezuela
 country_code_2:en:VE
 country_code_3:en:VEN
-languages:en:es
+language_codes:en:es
 
 en:Vietnam, Viet Nam, Socialist Republic of Vietnam, VN, VNM
 ace:Viètnam
@@ -46639,7 +46639,7 @@ zh-yue:越南
 zu:IViyetnami
 country_code_2:en:VN
 country_code_3:en:VNM
-languages:en:vi
+language_codes:en:vi
 
 en:Virgin Islands of the United States, United States Virgin Islands, U.S. Virgin Islands, VI, VIR
 af:Amerikaanse Maagde-eilande
@@ -46743,7 +46743,7 @@ zh:美屬維爾京群島
 zh-min-nan:Bí-kok Virgin Kûn-tó
 country_code_2:en:VI
 country_code_3:en:VIR
-languages:en:en
+language_codes:en:en
 
 en:Wallis and Futuna, WF, WLF
 ace:Wallis ngon Futuna
@@ -46836,7 +46836,7 @@ zh-min-nan:Wallis kap Futuna
 zh-yue:瓦利斯及富圖納群島
 country_code_2:en:WF
 country_code_3:en:WLF
-languages:en:
+language_codes:en:
 
 en:Western Sahara, eh, West Sahara, Spanish Sahara, EH, ESH
 ace:Sahara Barat
@@ -46969,7 +46969,7 @@ zh-min-nan:Sai Sahara
 zh-yue:西撒哈拉
 country_code_2:en:EH
 country_code_3:en:ESH
-languages:en:
+language_codes:en:
 
 en:Yemen, Republic of Yemen, YE, YEM
 ace:Yaman
@@ -47167,7 +47167,7 @@ zh-yue:也門
 zu:IYemen
 country_code_2:en:YE
 country_code_3:en:YEM
-languages:en:ar
+language_codes:en:ar
 
 en:Yugoslavia, YU, YUG
 af:Joego-Slawië, Joegoeslawië, Joegoslawië, Joegoslawie, Jugoslawië, Joegoslavië
@@ -47271,7 +47271,7 @@ zh-classical:南斯拉夫
 zh-yue:南斯拉夫
 country_code_2:en:YU
 country_code_3:en:YUG
-languages:en:
+language_codes:en:
 
 en:Zambia, Republic of Zambia, ZM, ZMB
 ace:Zambia
@@ -47458,7 +47458,7 @@ zh-yue:贊比亞
 zu:IZambiya
 country_code_2:en:ZM
 country_code_3:en:ZMB
-languages:en:en
+language_codes:en:en
 
 en:Zimbabwe, Republic of Zimbabwe, ZW, ZWE
 af:Zimbabwe
@@ -47655,7 +47655,7 @@ zh-yue:津巴布韋
 zu:IZimbabwe
 country_code_2:en:ZW
 country_code_3:en:ZWE
-languages:en:en,sn,nd
+language_codes:en:en,sn,nd
 
 en:Åland Islands, Åland, Ahvenanmaa, Aaland, Aaland Islands, AX, ALA
 ace:Pulo-pulo Aland
@@ -47773,12 +47773,12 @@ zh-min-nan:Åland Kûn-tó
 zh-yue:亞蘭
 country_code_2:en:AX
 country_code_3:en:ALA
-languages:en:sv
+language_codes:en:sv
 
 en:Kosovo, XK
 country_code_2:en:XK
 #country_code_3:en:
 # Albanian Serbian
 # Recognised regional languages	Bosnian Turkish Romani
-languages:en:sq,sr,bs,tr
+language_codes:en:sq,sr,bs,tr
 


### PR DESCRIPTION
- fixes #6463
