### PR TITLE
fix: fix image upload buttons

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -708,12 +708,12 @@ function get_recents(tagfield) {
 			if (! stringStartsWith(id, 'manage')) {
 
       html += '<div style="clear:both" class="command upload_image_div">';
-			html += '<a href="#" class="button small expand" id="imgsearchbutton_' + id + '"> '
+			html += '<a class="button small expand" id="imgsearchbutton_' + id + '"> '
 + '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon"><circle cx="12" cy="12" r="3.2"/><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>'
 + lang().product_js_upload_image
 + '<input type="file" accept="image/*" class="img_input" name="imgupload_' + id + '" id="imgupload_' + id
 + '" data-url="/cgi/product_image_upload.pl" multiple '
-+ 'style="position: absolute;right:0;bottom:0;top:0;cursor:pointer;opacity:0;font-size:40px;"/>'
++ 'style="position: absolute;right:0;bottom:0;top:0;cursor:pointer;opacity:0;width:100%;height:100%;"/>'
 + '</a>'
 + '</div>'
 + '<p class="note">' + lang().product_js_upload_image_note + '</p>'

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -363,14 +363,9 @@ sub display_search_image_form($) {
 	$html .= <<HTML
 <div id="imgsearchdiv_$id">
 
-<a href="#" class="button small expand" id="imgsearchbutton_$id">@{[ display_icon('photo_camera') ]} $product_image_with_barcode
-<input type="file" accept="image/*" class="img_input" name="imgupload_search" id="imgupload_search_$id" style="position: absolute;
-    right:0;
-    bottom:0;
-    top:0;
-    cursor:pointer;
-    opacity:0;
-    font-size:40px;"/>
+<a class="button small expand" id="imgsearchbutton_$id">@{[ display_icon('photo_camera') ]} $product_image_with_barcode
+<input type="file" accept="image/*" class="img_input" name="imgupload_search" id="imgupload_search_$id"
+	style="position: absolute;right:0;bottom:0;top:0;cursor:pointer;opacity:0;width:100%;height:100%;"/>
 </a>
 </div>
 

--- a/templates/web/pages/import_file_upload/import_file_upload.tt.html
+++ b/templates/web/pages/import_file_upload/import_file_upload.tt.html
@@ -6,16 +6,11 @@
 <p>&rarr; <a href="/cgi/generate_sample_import_file.pl">[% lang("download_sample_import_file") %]</a></p>
 
 <form method="post" action="/cgi/import_file_upload.pl" enctype="multipart/form-data" id="upload_file_form">
-	<a href="#" class="button small expand" id="file_input_button_$id">
+	<a class="button small expand" id="file_input_button_$id">
 		<div id="file_input_div_$id">
 			[% display_icon('arrow_upward') %] [% lang("upload_product_data_file") %]
-			<input type="file" accept=".csv,.tsv,.xlsx,.xls,.ods" class="file_input" name="file_input_$id" id="file_input_$id" style="position: absolute;
-	right:0;
-	bottom:0;
-	top:0;
-	cursor:pointer;
-	opacity:0;
-	font-size:60px;"/>
+			<input type="file" accept=".csv,.tsv,.xlsx,.xls,.ods" class="file_input" name="file_input_$id" id="file_input_$id"
+				style="position: absolute;right:0;bottom:0;top:0;cursor:pointer;opacity:0;width:100%;height:100%;"/>
 		</div>
 	</a>
 


### PR DESCRIPTION
Fixes #173

The file upload buttons (for images, and data file on producers platform) have a <a href="#"> link that encapsulate a <input> button. But the button works only in the top half, clicking on the lower half makes the page jump to the top of the page.

There were 2 issues:
- the input button was only half height, fixed by height:100%
- the href="#" makes the browser go to the top of the page (as identified by @chk1).