### PR TITLE
feat: allow barcode and edit link in search results

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -83,14 +83,15 @@ volumes:
   products:
   # those one are volumes shared between off and pro, so we assign hard-coded names
   # see docs/explanations/pro-dev-setup.md
+  # PO_COMMON_PREFIX is there to separate env, eg. for tests
   users:
-    name: po_users
+    name: ${PO_COMMON_PREFIX:-}po_users
   orgs:
-    name: po_orgs
+    name: ${PO_COMMON_PREFIX:-}po_orgs
   podata:  # we also need to share it because users_emails and orgs... are not separated yet
-    name: po_podata
+    name: ${PO_COMMON_PREFIX:-}po_podata
 
 networks:
   # this is a specific network to enable pro platform to join the postgres db
   minion_db:
-    name: minion_db
+    name: ${PO_COMMON_PREFIX:-}minion_db

--- a/html/images/attributes/display_barcode.svg
+++ b/html/images/attributes/display_barcode.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="58.666016"
+   height="47.999996"
+   id="svg8313"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="barcode.svg"
+   inkscape:export-filename="C:\Users\Stéphane\Desktop\Blogs\OpenFoodFacts\openfoodfacts-logo-712x600.png"
+   inkscape:export-xdpi="360"
+   inkscape:export-ydpi="360"
+   viewBox="0 0 54.999389 44.999996"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs8315" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.1916204"
+     inkscape:cx="-1.0966217"
+     inkscape:cy="10.182915"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="1440"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:pagecheckerboard="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8566"
+       originx="-37.000122"
+       originy="-50.00061"
+       spacingx="1"
+       spacingy="1"
+       visible="false"
+       enabled="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata8318">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-37.000122,-50.000609)">
+    <path
+       id="path8011"
+       style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06667"
+       d="m 39.466797,53.333984 v 47.999996 h 2.132812 V 53.333984 Z m 3.199219,0 v 47.999996 h 1.066406 V 53.333984 Z m 4.267578,0 V 101.33398 H 48 V 53.333984 Z m 2.132812,0 v 47.999996 h 3.201172 V 53.333984 Z m 6.400391,0 v 47.999996 h 2.132812 V 53.333984 Z m 3.199219,0 v 47.999996 h 1.066406 V 53.333984 Z m 4.277343,0 0.01758,47.999996 h 2.105468 l -0.01953,-47.999996 z m 5.324219,0 v 47.999996 h 1.066406 V 53.333984 Z m 2.132813,0 v 47.999996 h 1.066406 V 53.333984 Z m 4.265625,0 v 47.999996 h 3.201172 V 53.333984 Z m 4.267578,0 v 47.999996 h 2.132812 V 53.333984 Z m 3.199218,0 v 47.999996 h 1.066407 V 53.333984 Z m 4.267579,0 v 47.999996 h 3.199218 V 53.333984 Z m 4.265625,0 v 47.999996 h 2.134765 V 53.333984 Z m 3.201172,0 v 47.999996 h 1.066406 V 53.333984 Z m 2.132812,0 v 47.999996 h 2.132812 V 53.333984 Z"
+       transform="scale(0.93749999)" />
+  </g>
+</svg>

--- a/html/images/attributes/edit_link.svg
+++ b/html/images/attributes/edit_link.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="69.511047mm"
+   height="127.61408mm"
+   viewBox="0 0 69.511047 127.61408"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="edit-pen.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="0.90331701"
+     inkscape:cx="-58.119131"
+     inkscape:cy="224.17379"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="1440"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1744">
+    <sodipodi:guide
+       position="39.785477,25.600703"
+       orientation="1,0"
+       id="guide1738" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-64.713851,-61.788492)">
+    <g
+       id="g1744"
+       transform="rotate(-24.378941,105.00001,127.52318)">
+      <g
+         id="g3900">
+        <path
+           id="rect31"
+           style="color:#000000;overflow:visible;fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+           d="M 119.46294,157.91542 V 64.762272 c 0,-1.763627 -1.98551,-3.18368 -4.45141,-3.18368 H 94.987952 c -2.465896,0 -4.450893,1.420053 -4.450893,3.18368 v 93.153148"
+           sodipodi:nodetypes="cssssc" />
+        <path
+           id="path135"
+           style="color:#000000;overflow:visible;fill:none;stroke:#000000;stroke-width:7.55906;stroke-miterlimit:4;stroke-dasharray:none"
+           d="m 350.75977,581.57422 -8.12551,15.45445 50.94582,120.11977 h -1.22656 v 14.06836 h 7.32421 v -14.06836 h -1.0664 l 52.2916,-119.71938 c -3.56051,-4.30527 -6.76098,-10.85133 -9.83066,-15.85484 l -9.36719,15.27148 -9.36914,-15.27148 -8.81836,14.37695 -8.82031,-14.37695 -8.81446,14.36914 -8.8164,-14.36914 -9.13868,14.89648 -9.13867,-14.89648 -9.01562,14.69531 z"
+           transform="scale(0.26458333)"
+           sodipodi:nodetypes="cccccccccccccccccccc" />
+        <path
+           id="path3678"
+           style="color:#000000;overflow:visible;fill:none;stroke:#000000;stroke-width:7.55906;stroke-miterlimit:4;stroke-dasharray:none"
+           d="m 350.75977,581.57422 -8.12551,15.45445 50.94582,120.11977 h -1.22656 v 14.06836 h 7.32421 v -14.06836 h -1.0664 l 52.2916,-119.71938 c -3.56051,-4.30527 -6.76098,-10.85133 -9.83066,-15.85484 l -9.36719,15.27148 -9.36914,-15.27148 -8.81836,14.37695 -8.82031,-14.37695 -8.81446,14.36914 -8.8164,-14.36914 -9.13868,14.89648 -9.13867,-14.89648 -9.01562,14.69531 z"
+           transform="scale(0.26458333)"
+           sodipodi:nodetypes="cccccccccccccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -394,12 +394,14 @@ sub initialize_attribute($$) {
 			}
 		}
 
-		foreach my $option_ref (@{$attribute_ref->{options}}) {
-			my $label = lang_in_other_lc(
-				$target_lc, "attribute_value_" . $option_ref->{value} . "_label"
-			);
-			if ((defined $label) and ($label ne "")) {
-				$option_ref->{label} = $label;
+		if (defined $attribute_ref->{options}) {
+			foreach my $option_ref (@{$attribute_ref->{options}}) {
+				my $label = lang_in_other_lc(
+					$target_lc, "attribute_value_" . $option_ref->{value} . "_label"
+				);
+				if ((defined $label) and ($label ne "")) {
+					$option_ref->{label} = $label;
+				}
 			}
 		}
 		

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -778,6 +778,14 @@ $options{attribute_groups} = [
 			"forest_footprint",
 		]
 	],
+	[
+		"search",
+		[
+			# '__' separate possible values, first is default
+			"display_barcode__no__yes",
+			"edit_link__no__yes",
+		]
+	]
 ];
 
 # default preferences for attributes
@@ -786,6 +794,7 @@ $options{attribute_default_preferences} = {
 	"nova" => "important",
 	"ecoscore" => "important",
 };
+
 
 # Used to generate the sample import file for the producers platform
 # possible values: mandatory, recommended, optional.

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5258,6 +5258,26 @@ msgctxt "attribute_forest_footprint_not_computed_description_short"
 msgid "Currently only for products with chicken or eggs"
 msgstr ""
 
+msgctxt "attribute_group_search_name"
+msgid "Search preferences"
+msgstr ""
+
+msgctxt "attribute_display_barcode_setting_name"
+msgid "Display barcode in search results"
+msgstr ""
+
+msgctxt "attribute_edit_link_setting_name"
+msgid "Add an edit link in search results"
+msgstr ""
+
+msgctxt "attribute_value_yes_label"
+msgid "Yes"
+msgstr ""
+
+msgctxt "attribute_value_no_label"
+msgid "No"
+msgstr ""
+
 msgctxt "classify_products_according_to_your_preferences"
 msgid "Classify products according to your preferences"
 msgstr ""

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5288,6 +5288,26 @@ msgctxt "attribute_forest_footprint_not_computed_description_short"
 msgid "Currently only for products with chicken or eggs"
 msgstr "Currently only for products with chicken or eggs"
 
+msgctxt "attribute_group_search_name"
+msgid "Search preferences"
+msgstr "Search preferences"
+
+msgctxt "attribute_display_barcode_setting_name"
+msgid "Display barcode in search results"
+msgstr "Display barcode in search results"
+
+msgctxt "attribute_edit_link_setting_name"
+msgid "Add an edit link in search results"
+msgstr "Add an edit link in search results"
+
+msgctxt "attribute_value_yes_label"
+msgid "Yes"
+msgstr "Yes"
+
+msgctxt "attribute_value_no_label"
+msgid "No"
+msgstr "No"
+
 msgctxt "classify_products_according_to_your_preferences"
 msgid "Classify products according to your preferences"
 msgstr "Classify products according to your preferences"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -4532,6 +4532,7 @@ msgctxt "attribute_nova_setting_name"
 msgid "No or little food processing (NOVA group)"
 msgstr "Pas ou peu de transformation des aliments (groupe NOVA)"
 
+
 # keep %s, it will be replaced by the group 1, 2, 3 or 4
 msgctxt "attribute_nova_group_title"
 msgid "NOVA %s"
@@ -5126,6 +5127,26 @@ msgstr "Très haut risque de déforestation"
 msgctxt "attribute_forest_footprint_not_computed_description_short"
 msgid "Currently only for products with chicken or eggs"
 msgstr "Pour l'instant seulement pour les produits avec du poulet ou des oeufs"
+
+msgctxt "attribute_group_search_name"
+msgid "Search preferences"
+msgstr "Paramètres de recherche"
+
+msgctxt "attribute_display_barcode_setting_name"
+msgid "Display barcode in search results"
+msgstr "Afficher le code barre dans les résultats de recherche"
+
+msgctxt "attribute_edit_link_setting_name"
+msgid "Add an edit link in search results"
+msgstr "Ajouter un lien d'édition de chaque résultat"
+
+msgctxt "attribute_value_yes_label"
+msgid "Yes"
+msgstr "Oui"
+
+msgctxt "attribute_value_no_label"
+msgid "No"
+msgstr "Non"
 
 msgctxt "classify_products_according_to_your_preferences"
 msgid "Classify products according to your preferences"

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -558,6 +558,9 @@ html[dir="rtl"] {
 
 
 // List of products with cards (e.g. search results, facets)
+.search_results li {
+  position: relative;
+}
 
 .list_product_a {
   border-radius:8px;
@@ -585,6 +588,27 @@ html[dir="rtl"] {
 
 .list_product_a_match_no:hover {
   background-color:#faa;
+}
+
+.search_results .list_display_barcode {
+  color: black;
+  font-size: .8em;
+}
+
+.search_results .list_edit_link img {
+  height: 1em;
+}
+
+.search_results .list_edit_link {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0 1em;
+  border-radius: .3em;
+}
+
+.search_results .list_edit_link:hover {
+  background-color: #aaf;
 }
 
 


### PR DESCRIPTION

### Description

Now in search preferences you can ask to have barcode and to have edit link.
It displays them in search results.

### Screenshot
![Capture d’écran de 2022-03-14 19-05-36](https://user-images.githubusercontent.com/144788/158235697-a87150e3-779b-4131-8e85-adf9921eafd1.png)

Then:
![Capture d’écran de 2022-03-14 19-08-26](https://user-images.githubusercontent.com/144788/158235722-458f4011-caa5-4853-bcd6-ef22d7726b53.png)

The pen links to edition.

### Related issue(s) and discussion

- fixes #5994


