### PR TITLE
build: make tests run in isolation

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -83,14 +83,15 @@ volumes:
   products:
   # those one are volumes shared between off and pro, so we assign hard-coded names
   # see docs/explanations/pro-dev-setup.md
+  # PO_COMMON_PREFIX is there to separate env, eg. for tests
   users:
-    name: po_users
+    name: ${PO_COMMON_PREFIX:-}po_users
   orgs:
-    name: po_orgs
+    name: ${PO_COMMON_PREFIX:-}po_orgs
   podata:  # we also need to share it because users_emails and orgs... are not separated yet
-    name: po_podata
+    name: ${PO_COMMON_PREFIX:-}po_podata
 
 networks:
   # this is a specific network to enable pro platform to join the postgres db
   minion_db:
-    name: minion_db
+    name: ${PO_COMMON_PREFIX:-}minion_db


### PR DESCRIPTION
Make tests run in isolation.

We now have integration tests, avoid destroying dev database each time he wants to run tests.