### PR TITLE
fix: release please should trigger actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,16 @@
- name: Run release-please
- on:
-   push:
-     branches:
-       - main
- jobs:
-   release-please:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: GoogleCloudPlatform/release-please-action@v3
-         with:
-           token: ${{ secrets.GITHUB_TOKEN }}
-           release-type: simple
+name: Run release-please
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        with:
+          # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
+          # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          # So this is a personal access token
+          token:  ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: simple


### PR DESCRIPTION
We need actions to be triggered by release please this means using a personal access token instead of the default one.

The secret is already created in the repo.