### PR TITLE
fix: handle both absolute and relative percent values for sub-ingredients

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2345,6 +2345,7 @@ When a percent is specifically set, use this value for percent_min and percent_m
 
 Warning: percent listed for sub-ingredients can be absolute (e.g. "Sugar, fruits 40% (pear 30%, apple 10%)")
 or they can be relative to the parent ingredient (e.g. "Sugar, fruits 40% (pear 75%, apple 25%)".
+We try to detect those cases and rescale the percent accordingly.
 
 Otherwise use 0 for percent_min and total_max for percent_max.
 

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2335,7 +2335,11 @@ sub compute_ingredients_percent_values($$$) {
 
 =head2 init_percent_values($total_min, $total_max, $ingredients_ref)
 
-Initialize the percent, percent_min and percent_max value of a list of ingredients.
+Initialize the percent, percent_min and percent_max value for each ingredient in list.
+
+$ingredients_ref is the list of ingredients (as hash), where parsed percent are already set.
+
+$total_min and $total_max might be set if we have a parent ingredient and are parsing a sub list.
 
 When a percent is specifically set, use this value for percent_min and percent_max.
 

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2381,7 +2381,11 @@ sub init_percent_values($$$) {
 
 	foreach my $ingredient_ref (@{$ingredients_ref}) {
 		if (defined $ingredient_ref->{percent}) {
-			my $percent = ($percent_mode eq "absolute") ? $ingredient_ref->{percent} : $ingredient_ref->{percent} * $total_max / 100;
+			# percent was found in text, take it (with eventual re-scaling)
+			my $percent = ($percent_mode eq "absolute") ? 
+			    $ingredient_ref->{percent} : 
+			    $ingredient_ref->{percent} * $total_max / 100
+			;
 			$ingredient_ref->{percent} = $percent;
 			$ingredient_ref->{percent_min} = $percent;
 			$ingredient_ref->{percent_max} = $percent;

--- a/t/expected_test_results/ingredients/fi-additives-percents.json
+++ b/t/expected_test_results/ingredients/fi-additives-percents.json
@@ -13,31 +13,28 @@
          "ingredients" : [
             {
                "id" : "en:cocoa-butter",
-               "percent" : 15,
-               "percent_estimate" : 15,
+               "percent_estimate" : 22,
                "text" : "kaakaovoi",
                "vegan" : "yes",
                "vegetarian" : "yes"
             },
             {
                "id" : "en:sugar",
-               "percent" : 10,
-               "percent_estimate" : 10,
+               "percent_estimate" : 11,
                "text" : "sokeri",
                "vegan" : "yes",
                "vegetarian" : "yes"
             },
             {
                "id" : "en:milk-proteins",
-               "percent_estimate" : 9.5,
+               "percent_estimate" : 5.5,
                "text" : "maitoproteiini",
                "vegan" : "no",
                "vegetarian" : "yes"
             },
             {
                "id" : "en:chicken-egg",
-               "percent" : 1,
-               "percent_estimate" : 9.5,
+               "percent_estimate" : 5.5,
                "text" : "kananmuna",
                "vegan" : "no",
                "vegetarian" : "yes"
@@ -246,10 +243,10 @@
       "en:e338"
    ],
    "ingredients_text" : "jauho (12%), suklaa (kaakaovoi (15%), sokeri [10%], maitoproteiini, kananmuna 1%) - emulgointiaineet : E463, E432 ja E472 - happamuudensäätöaineet : E322/E333 E474-E475, happo (sitruunahappo, fosforihappo) - suola",
-   "ingredients_with_specified_percent_n" : 4,
-   "ingredients_with_specified_percent_sum" : 38,
-   "ingredients_with_unspecified_percent_n" : 11,
-   "ingredients_with_unspecified_percent_sum" : 53.5,
+   "ingredients_with_specified_percent_n" : 1,
+   "ingredients_with_specified_percent_sum" : 12,
+   "ingredients_with_unspecified_percent_n" : 14,
+   "ingredients_with_unspecified_percent_sum" : 88,
    "known_ingredients_n" : 25,
    "lc" : "fi",
    "nutriments" : {

--- a/t/expected_test_results/ingredients/fr-chocolate-cake.json
+++ b/t/expected_test_results/ingredients/fr-chocolate-cake.json
@@ -13,31 +13,28 @@
          "ingredients" : [
             {
                "id" : "en:cocoa-butter",
-               "percent" : 15,
-               "percent_estimate" : 15,
+               "percent_estimate" : 22,
                "text" : "beurre de cacao",
                "vegan" : "yes",
                "vegetarian" : "yes"
             },
             {
                "id" : "en:sugar",
-               "percent" : 10,
-               "percent_estimate" : 10,
+               "percent_estimate" : 11,
                "text" : "sucre",
                "vegan" : "yes",
                "vegetarian" : "yes"
             },
             {
                "id" : "en:milk-proteins",
-               "percent_estimate" : 9.5,
+               "percent_estimate" : 5.5,
                "text" : "protéines de lait",
                "vegan" : "no",
                "vegetarian" : "yes"
             },
             {
                "id" : "en:egg",
-               "percent" : 1,
-               "percent_estimate" : 9.5,
+               "percent_estimate" : 5.5,
                "text" : "oeuf",
                "vegan" : "no",
                "vegetarian" : "yes"
@@ -244,10 +241,10 @@
       "en:e338"
    ],
    "ingredients_text" : "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%) - émulsifiants : E463, E432 et E472 - correcteurs d'acidité : E322/E333 E474-E475, acidifiant (acide citrique, acide phosphorique) - sel",
-   "ingredients_with_specified_percent_n" : 4,
-   "ingredients_with_specified_percent_sum" : 38,
-   "ingredients_with_unspecified_percent_n" : 11,
-   "ingredients_with_unspecified_percent_sum" : 53.5,
+   "ingredients_with_specified_percent_n" : 1,
+   "ingredients_with_specified_percent_sum" : 12,
+   "ingredients_with_unspecified_percent_n" : 14,
+   "ingredients_with_unspecified_percent_sum" : 88,
    "known_ingredients_n" : 24,
    "lc" : "fr",
    "nutriments" : {

--- a/t/ingredients_percent.t
+++ b/t/ingredients_percent.t
@@ -548,6 +548,114 @@ my @tests = (
 		]
 	],
 
+	# Relative percent
+
+	[ { lc => "en", ingredients_text => "fruits 50% (apple 40%, pear 30%, cranberry, lemon), sugar"},
+		[
+			{
+				'id' => 'en:fruit',
+				'ingredients' => [
+				{
+					'id' => 'en:apple',
+					'percent' => 20,
+					'percent_estimate' => 20,
+					'percent_max' => 20,
+					'percent_min' => 20,
+					'text' => 'apple'
+				},
+				{
+					'id' => 'en:pear',
+					'percent' => 15,
+					'percent_estimate' => 15,
+					'percent_max' => 15,
+					'percent_min' => 15,
+					'text' => 'pear'
+				},
+				{
+					'id' => 'en:cranberry',
+					'percent_estimate' => '11.25',
+					'percent_max' => 15,
+					'percent_min' => '7.5',
+					'text' => 'cranberry'
+				},
+				{
+					'id' => 'en:lemon',
+					'percent_estimate' => '3.75',
+					'percent_max' => '7.5',
+					'percent_min' => 0,
+					'text' => 'lemon'
+				}
+				],
+				'percent' => 50,
+				'percent_estimate' => 50,
+				'percent_max' => 50,
+				'percent_min' => 50,
+				'text' => 'fruits'
+			},
+			{
+				'id' => 'en:sugar',
+				'percent_estimate' => 50,
+				'percent_max' => 50,
+				'percent_min' => 50,
+				'text' => 'sugar'
+			}
+		]
+	],
+
+	# Absolute percent
+
+	[ { lc => "en", ingredients_text => "fruits 50% (apple 20%, pear 15%, cranberry, lemon), sugar"},
+		[
+			{
+				'id' => 'en:fruit',
+				'ingredients' => [
+				{
+					'id' => 'en:apple',
+					'percent' => 20,
+					'percent_estimate' => 20,
+					'percent_max' => 20,
+					'percent_min' => 20,
+					'text' => 'apple'
+				},
+				{
+					'id' => 'en:pear',
+					'percent' => 15,
+					'percent_estimate' => 15,
+					'percent_max' => 15,
+					'percent_min' => 15,
+					'text' => 'pear'
+				},
+				{
+					'id' => 'en:cranberry',
+					'percent_estimate' => '11.25',
+					'percent_max' => 15,
+					'percent_min' => '7.5',
+					'text' => 'cranberry'
+				},
+				{
+					'id' => 'en:lemon',
+					'percent_estimate' => '3.75',
+					'percent_max' => '7.5',
+					'percent_min' => 0,
+					'text' => 'lemon'
+				}
+				],
+				'percent' => 50,
+				'percent_estimate' => 50,
+				'percent_max' => 50,
+				'percent_min' => 50,
+				'text' => 'fruits'
+			},
+			{
+				'id' => 'en:sugar',
+				'percent_estimate' => 50,
+				'percent_max' => 50,
+				'percent_min' => 50,
+				'text' => 'sugar'
+			}
+		]
+	],	
+
 );
 
 foreach my $test_ref (@tests) {

--- a/t/ingredients_percent.t
+++ b/t/ingredients_percent.t
@@ -656,6 +656,105 @@ my @tests = (
 		]
 	],	
 
+	# Relative percent with no indicated percent on the parent ingredient, but with a percent min = percent max on the parent ingredient
+	[ { lc => "en", ingredients_text => "water (60%), fruit concentrate (apple 40%, mango 30%, citrus)"},
+		[
+			{
+				'id' => 'en:water',
+				'percent' => 60,
+				'percent_estimate' => 60,
+				'percent_max' => 60,
+				'percent_min' => 60,
+				'text' => 'water'
+			},
+			{
+				'id' => 'en:fruit-concentrates',
+				'ingredients' => [
+				{
+					'id' => 'en:apple',
+					'percent' => 16,
+					'percent_estimate' => 16,
+					'percent_max' => 16,
+					'percent_min' => 16,
+					'text' => 'apple'
+				},
+				{
+					'id' => 'en:mango',
+					'percent' => 12,
+					'percent_estimate' => 12,
+					'percent_max' => 12,
+					'percent_min' => 12,
+					'text' => 'mango'
+				},
+				{
+					'id' => 'en:citrus-fruit',
+					'percent_estimate' => 12,
+					'percent_max' => 12,
+					'percent_min' => 12,
+					'text' => 'citrus'
+				}
+				],
+				'percent_estimate' => 40,
+				'percent_max' => 40,
+				'percent_min' => 40,
+				'text' => 'fruit concentrate'
+			}
+		]
+	],
+
+
+	# Relative percent with a different percent min and percent max on the parent ingredient
+	[ { lc => "en", ingredients_text => "water (60%), fruit concentrate (apple 40%, mango 30%, citrus), sugar"},
+		[
+			{
+				'id' => 'en:water',
+				'percent' => 60,
+				'percent_estimate' => 60,
+				'percent_max' => 60,
+				'percent_min' => 60,
+				'text' => 'water'
+			},
+			{
+				'id' => 'en:fruit-concentrates',
+				'ingredients' => [
+				{
+					'id' => 'en:apple',
+					'percent_estimate' => 12,
+					'percent_max' => 16,
+					'percent_min' => 8,
+					'text' => 'apple'
+				},
+				{
+					'id' => 'en:mango',
+					'percent_estimate' => 9,
+					'percent_max' => 12,
+					'percent_min' => 6,
+					'text' => 'mango'
+				},
+				{
+					'id' => 'en:citrus-fruit',
+					'percent_estimate' => 9,
+					'percent_max' => 12,
+					'percent_min' => 0,
+					'text' => 'citrus'
+				}
+				],
+				'percent_estimate' => 30,
+				'percent_max' => 40,
+				'percent_min' => 20,
+				'text' => 'fruit concentrate'
+			},
+			{
+				'id' => 'en:sugar',
+				'percent_estimate' => 10,
+				'percent_max' => 20,
+				'percent_min' => 0,
+				'text' => 'sugar'
+			}
+		]
+
+	],
+
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
fixes #6524 

Some manufacturers list absolute % in sub-ingredients, while others list % values that are relative to the sub-ingredient.

We assume that % for sub-ingredients are absolute, this fix detects some cases where the % are relative.