### PR TITLE
fix: Format footer titles as headings in code

### DIFF
--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -189,7 +189,7 @@
 
 <footer>
 	<div class="small-12 medium-6 large-3 columns off">
-		<div class="title">[% lang('site_name') %]</div>
+		<h3 class="title">[% lang('site_name') %]</h3>
 		<p>[% lang('footer_tagline') %]</p>
 		<ul>
 			<li><a href="[% lang('footer_legal_link') %]">[% lang('footer_legal') %]</a></li>
@@ -200,14 +200,14 @@
 		</ul>
 	</div>
 	<div class="small-12 medium-6 large-3 columns app">
-		<div class="title">[% lang('footer_install_the_app') %]</div>
+		<h3 class="title">[% lang('footer_install_the_app') %]</h3>
 		<a href="[% lang('ios_app_link') %]"><img src="[% lang('ios_app_icon_url') %]" alt="[% lang('ios_app_icon_alt_text') %]" width="120" height="40" loading="lazy"></a>
 		<a href="[% lang('android_app_link') %]"><img src="https://static.openfoodfacts.org[% lang('android_app_icon_url') %]" alt="[% lang('android_app_icon_alt_text') %]" width="102" height="40" loading="lazy"></a>
 		<a href="[% lang('windows_phone_app_link') %]"><img src="[% lang('windows_phone_app_icon_url') %]" alt="[% lang('windows_phone_app_icon_alt_text') %]" width="109" height="40" loading="lazy"></a>
 		<a href="[% lang('android_apk_app_link') %]"><img src="https://static.openfoodfacts.org[% lang('android_apk_app_icon_url') %]" alt="[% lang('android_apk_app_icon_alt_text') %]" loading="lazy"></a>
 	</div>
 	<div class="small-12 medium-6 large-3 columns project">
-		<div class="title">[% lang('footer_discover_the_project') %]</div>
+		<h3 class="title">[% lang('footer_discover_the_project') %]</h3>
 		<ul>
 			<li><a href="[% lang('footer_who_we_are_link') %]">[% lang('footer_who_we_are') %]</a></li>
 			<li><a href="[% lang('footer_vision_link') %]">[% lang('footer_vision') %]</a></li>
@@ -221,7 +221,7 @@
 		</ul>
 	</div>
 	<div class="small-12 medium-6 large-3 columns community">
-		<div class="title">[% lang('footer_join_the_community') %]</div>
+		<h3 class="title">[% lang('footer_join_the_community') %]</h3>
 		<p>
 			<a href="[% lang('footer_code_of_conduct_link') %]">[% lang('footer_code_of_conduct') %]</a>
 			<br><br>


### PR DESCRIPTION
### Description

Formatted the titles of the footers as headings with an `<h3>` tag as prescribed in the [Report](https://github.com/openfoodfacts/openfoodfacts-server/files/5702582/Report.OpenFoodFact.15-12-2020.pdf)

### Related issue(s) and discussion
- Fixes #6535
- A part of this issue thread #4640

