### PR TITLE
fix: skip last header line in csv

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -130,7 +130,8 @@ sub load_agribalyse_data() {
 
 		my $row_ref;
 
-		# Skip 3 first lines
+		# Skip 4 first lines
+		$csv->getline ($io);
 		$csv->getline ($io);
 		$csv->getline ($io);
 		$csv->getline ($io);


### PR DESCRIPTION
Seeing:
```
Argument "Transformation" isn't numeric in addition (+) at /opt/product-opener/lib/ProductOpener/Ecoscore.pm line 139, <$io> line 8.
Argument "Emballage" isn't numeric in addition (+) at /opt/product-opener/lib/ProductOpener/Ecoscore.pm line 139, <$io> line 8.
Argument "Transport" isn't numeric in addition (+) at /opt/product-opener/lib/ProductOpener/Ecoscore.pm line 139, <$io> line 8.
Argument "Supermarch\x{e9} et distribution" isn't numeric in addition (+) at /opt/product-opener/lib/ProductOpener/Ecoscore.pm line 139, <$io> line 8.
```
Errors. This may be from adding 0 to an undefined value rather than using a default.

There was no ecoscore popping up on the products on the local dev environment. I see them on the app. Though I'm not sure how to test there. Or quite what to test on the dev environment, as I don't see the ecoscore there to check that it is still there after this change. This does seem to clear the errors on startup.