### PR TITLE
fix: Add explicit labels (using: for & id) to input fields 

### DIFF
--- a/templates/web/common/includes/display_login_register.tt.html
+++ b/templates/web/common/includes/display_login_register.tt.html
@@ -5,17 +5,17 @@
 <form method="post" action="/cgi/session.pl">
 	<div class="row">
 		<div class="small-12 columns">
-			<label>[% lang('login_username_email') %]
-				<input type="text" name="user_id" autocomplete="username" required>
+			<label for="user_id">[% lang('login_username_email') %]
+				<input type="text" name="user_id" id="user_id" autocomplete="username" required>
 			</label>
 		</div>
 		<div class="small-12 columns">
-			<label>[% lang('password') %]
-				<input type="password" name="password" autocomplete="current-password" required>
+			<label for="password" >[% lang('password') %]
+				<input type="password" name="password" id="password" autocomplete="current-password" required>
 			</label>
 		</div>
 		<div class="small-12 columns">
-			<label>
+			<label for "remember_me_checkbox">
 				<input type="checkbox" name="remember_me" checked>
 				[% lang('remember_me') %]
 			</label>

--- a/templates/web/common/includes/display_login_register.tt.html
+++ b/templates/web/common/includes/display_login_register.tt.html
@@ -16,7 +16,7 @@
 		</div>
 		<div class="small-12 columns">
 			<label for="remember_me_checkbox">
-				<input type="checkbox" name="remember_me" checked>
+				<input type="checkbox" name="remember_me" id="remember_me_checkbox" checked>
 				[% lang('remember_me') %]
 			</label>
 		</div>

--- a/templates/web/common/includes/display_login_register.tt.html
+++ b/templates/web/common/includes/display_login_register.tt.html
@@ -15,7 +15,7 @@
 			</label>
 		</div>
 		<div class="small-12 columns">
-			<label for "remember_me_checkbox">
+			<label for="remember_me_checkbox">
 				<input type="checkbox" name="remember_me" checked>
 				[% lang('remember_me') %]
 			</label>

--- a/templates/web/pages/change_password/change_password.tt.html
+++ b/templates/web/pages/change_password/change_password.tt.html
@@ -5,34 +5,34 @@
     <form method="post" action="/cgi/change_password.pl" enctype="multipart/form-data">
         <div class="row">
             <div class="large-12 columns">
-                <label>
+                <label for="current_password">
                     [% lang('password') %]
-                    <input type="password" name="current_password" autocomplete="current-password" required="required" />
+                    <input type="password" name="current_password" id="current_password" autocomplete="current-password" required="required" />
                 </label>
             </div>
         </div>
 
         <div class="row">
             <div class="large-12 columns">
-                <label>
+                <label for="new_password">
                     [% lang('password_new') %]
-                    <input type="password" name="password" autocomplete="new-password" required="required" />
+                    <input type="password" name="password" id="new_password" autocomplete="new-password" required="required" />
                 </label>
             </div>
         </div>
 
         <div class="row">
             <div class="large-12 columns">
-                <label>
+                <label for="password_confirmation">
                     [% lang('password_confirm') %]
-                    <input type="password" name="confirm_password" autocomplete="new-password" required="required" />
+                    <input type="password" name="confirm_password" id="new_password" autocomplete="new-password" required="required" />
                 </label>
             </div>
         </div>
 
         <div class="row">
             <div class="large-12 columns">
-                <label>
+                <label for="submit_form">
                     <input type="submit" name="submit" class="button" />
                 </label>
             </div>

--- a/templates/web/pages/change_password/change_password.tt.html
+++ b/templates/web/pages/change_password/change_password.tt.html
@@ -23,9 +23,9 @@
 
         <div class="row">
             <div class="large-12 columns">
-                <label for="new_password">
+                <label for="new_password_confirm">
                     [% lang('password_confirm') %]
-                    <input type="password" name="confirm_password" id="new_password" autocomplete="new-password" required="required" />
+                    <input type="password" name="confirm_password" id="new_password_confirm" autocomplete="new-password" required="required" />
                 </label>
             </div>
         </div>
@@ -33,7 +33,7 @@
         <div class="row">
             <div class="large-12 columns">
                 <label for="submit_form">
-                    <input type="submit" name="submit" class="button" />
+                    <input type="submit" name="submit" class="button" id="submit_form" />
                 </label>
             </div>
         </div>

--- a/templates/web/pages/change_password/change_password.tt.html
+++ b/templates/web/pages/change_password/change_password.tt.html
@@ -23,7 +23,7 @@
 
         <div class="row">
             <div class="large-12 columns">
-                <label for="password_confirmation">
+                <label for="new_password">
                     [% lang('password_confirm') %]
                     <input type="password" name="confirm_password" id="new_password" autocomplete="new-password" required="required" />
                 </label>

--- a/templates/web/pages/login_form/login.tt.html
+++ b/templates/web/pages/login_form/login.tt.html
@@ -23,7 +23,7 @@
 
     <div class="row">
         <div class="large-12 columns">
-            <label for = "submit">
+            <label for="submit">
                 <input type="submit" name="submit" class="button" />
                 <input type="hidden" name="redirect" value="[% redirect %]"/>
             </label>

--- a/templates/web/pages/login_form/login.tt.html
+++ b/templates/web/pages/login_form/login.tt.html
@@ -23,7 +23,7 @@
 
     <div class="row">
         <div class="large-12 columns">
-            <label>
+            <label for = "submit">
                 <input type="submit" name="submit" class="button" />
                 <input type="hidden" name="redirect" value="[% redirect %]"/>
             </label>

--- a/templates/web/pages/login_form/login.tt.html
+++ b/templates/web/pages/login_form/login.tt.html
@@ -24,7 +24,7 @@
     <div class="row">
         <div class="large-12 columns">
             <label for="submit">
-                <input type="submit" name="submit" class="button" />
+                <input type="submit" name="submit" class="button" id="submit" />
                 <input type="hidden" name="redirect" value="[% redirect %]"/>
             </label>
         </div>

--- a/templates/web/pages/reset_password/reset_password.tt.html
+++ b/templates/web/pages/reset_password/reset_password.tt.html
@@ -5,7 +5,7 @@
     [% INCLUDE 'web/common/includes/error_list.tt.html' %]
     <form method="post" action="/cgi/reset_password.pl" enctype="multipart/form-data">
         [% IF type == 'send_email' %]
-            <label>
+            <label for="username or email">
                 [% lang('userid_or_email') %]
                 <input type="text" name="userid_or_email"/>
             </label>

--- a/templates/web/pages/reset_password/reset_password.tt.html
+++ b/templates/web/pages/reset_password/reset_password.tt.html
@@ -5,9 +5,9 @@
     [% INCLUDE 'web/common/includes/error_list.tt.html' %]
     <form method="post" action="/cgi/reset_password.pl" enctype="multipart/form-data">
         [% IF type == 'send_email' %]
-            <label for="username or email">
+            <label for="userid_or_email">
                 [% lang('userid_or_email') %]
-                <input type="text" name="userid_or_email"/>
+                <input type="text" name="userid_or_email" id="userid_or_email"/>
             </label>
         [% ELSIF type == 'reset' %]
             <table role="presentation">


### PR DESCRIPTION
### Description
This change makes the experience of using a screen reader better for visually impaired people. (prescribed in the [Accessibility Report](https://github.com/openfoodfacts/openfoodfacts-server/files/5702582/Report.OpenFoodFact.15-12-2020.pdf))
This ensures that assistive technology can refer to the correct label when presenting a form control.

### Related issue(s) and discussion
- Fixes #6576
- A part of this issue thread https://github.com/openfoodfacts/openfoodfacts-server/issues/4640

