### PR TITLE
fix: Email address with space

### DIFF
--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -348,6 +348,9 @@ sub check_user_form($$$) {
 	if (not $address) {
 		push @{$errors_ref}, $Lang{error_invalid_email}{$lang};
 	}
+	
+	# If all checks passed, reinitialize with modified email
+	$user_ref->{email} = Email::Valid->address($user_ref->{email});
 
 	if ($type eq 'add') {
 

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -348,9 +348,10 @@ sub check_user_form($$$) {
 	if (not $address) {
 		push @{$errors_ref}, $Lang{error_invalid_email}{$lang};
 	}
-	
-	# If all checks passed, reinitialize with modified email
-	$user_ref->{email} = Email::Valid->address($user_ref->{email});
+	else {
+		# If all checks have passed, reinitialize with modified email
+		$user_ref->{email} = $address;
+	}
 
 	if ($type eq 'add') {
 


### PR DESCRIPTION
### Description

It's possible to create a new user account with an email address that contains spaces.
### Related issue(s) and discussion
- Fixes #4549
- Modified email was not updated to variable after email validation.