### PR TITLE
ci: Ensure that Dependabot is not blocked

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
@@ -9,31 +6,19 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    commit_message:
-      prefix: "chore"
-      include_scope: true
     open-pull-requests-limit: 300
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
         interval: "daily"
-    commit_message:
-      prefix: "chore"
-      include_scope: true
     open-pull-requests-limit: 300
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
         interval: "daily"
-    commit_message:
-      prefix: "chore"
-      include_scope: true
     open-pull-requests-limit: 300
   - package-ecosystem: "docker"
     directory: "/docker/frontend"
     schedule:
         interval: "daily"
-    commit_message:
-      prefix: "chore"
-      include_scope: true
     open-pull-requests-limit: 300

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
     schedule:
         interval: "daily"
     open-pull-requests-limit: 300
+  - package-ecosystem: "pip"
+    directory: "/scripts/packager-codes/non-eu/"
+    schedule:
+        interval: "daily"
+    open-pull-requests-limit: 300

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     commit_message:
       prefix: "chore"
       include_scope: true
-
+    open-pull-requests-limit: 300
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -20,7 +20,7 @@ updates:
     commit_message:
       prefix: "chore"
       include_scope: true
-
+    open-pull-requests-limit: 300
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -28,7 +28,7 @@ updates:
     commit_message:
       prefix: "chore"
       include_scope: true
-
+    open-pull-requests-limit: 300
   - package-ecosystem: "docker"
     directory: "/docker/frontend"
     schedule:
@@ -36,3 +36,4 @@ updates:
     commit_message:
       prefix: "chore"
       include_scope: true
+    open-pull-requests-limit: 300


### PR DESCRIPTION
- Ensure that Dependabot is not blocked because of unmerged deps updates
- Fix error with semantic commit: The property '#/updates/0/' contains additional properties ["commit_message"] outside of the schema when none are allowed