### PR TITLE
fix: Give priority to ingredients over category to estimate fruits/vegetable content for Nutri-Score

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -1639,8 +1639,16 @@ sub compute_nutrition_score($) {
 		$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate} = 1;
 		push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-estimate";
 	}
-	# estimates by category of products. not exact values. it's important to distinguish only between the thresholds: 40, 60 and 80
+	# Use the estimate from the ingredients list if we have one
+	elsif ((not defined $fruits)
+		and (defined $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate-from-ingredients" . $prepared . "_100g"})) {
+		$fruits = $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate-from-ingredients" . $prepared . "_100g"};
+		$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients} = 1;
+		$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value} = $fruits;
+		push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients";
+	}
 	else {
+		# estimates by category of products. not exact values. it's important to distinguish only between the thresholds: 40, 60 and 80
 		foreach my $category_id (@fruits_vegetables_nuts_by_category_sorted ) {
 
 			if (has_tag($product_ref, "categories", $category_id)) {
@@ -1655,21 +1663,12 @@ sub compute_nutrition_score($) {
 			}
 		}
 
-		# Use the estimate from the ingredients list if we have one
-		if ((not defined $fruits)
-			and (defined $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate-from-ingredients" . $prepared . "_100g"})) {
-			$fruits = $product_ref->{nutriments}{"fruits-vegetables-nuts-estimate-from-ingredients" . $prepared . "_100g"};
-			$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients} = 1;
-			$product_ref->{nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value} = $fruits;
-			push @{$product_ref->{misc_tags}}, "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients";
-		}
-
+		# If we do not have a fruits estimate, use 0 and add a warning		
 		if (not defined $fruits) {
 			$fruits = 0;
 			$product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts} = 1;
 			push @{$product_ref->{misc_tags}}, "en:nutrition-no-fruits-vegetables-nuts";
 		}
-
 	}
 
 	if ((defined $product_ref->{nutrition_score_warning_no_fiber}) or (defined $product_ref->{nutrition_score_warning_no_fruits_vegetables_nuts})) {

--- a/t/expected_test_results/nutriscore/en-orange-juice-category-and-ingredients.json
+++ b/t/expected_test_results/nutriscore/en-orange-juice-category-and-ingredients.json
@@ -9,7 +9,7 @@
       "en:fruit-juices",
       "en:orange-juices"
    ],
-   "categories_lc" : "fr",
+   "categories_lc" : "en",
    "categories_properties" : {
       "agribalyse_proxy_food_code:en" : "2011",
       "ciqual_food_code:en" : "2004"
@@ -34,61 +34,89 @@
       "en:fruit-juices",
       "en:orange-juices"
    ],
-   "food_groups" : "en:unsweetened-beverages",
+   "food_groups" : "en:sweetened-beverages",
    "food_groups_tags" : [
       "en:beverages",
-      "en:unsweetened-beverages"
+      "en:sweetened-beverages"
    ],
    "ingredients" : [
       {
-         "id" : "fr:orange juice",
-         "percent_estimate" : 100,
-         "percent_max" : 100,
-         "percent_min" : 100,
-         "text" : "orange juice"
+         "id" : "en:orange-juice",
+         "percent" : 50,
+         "percent_estimate" : 50,
+         "percent_max" : 50,
+         "percent_min" : 50,
+         "text" : "orange juice",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:water",
+         "percent_estimate" : 37.5,
+         "percent_max" : 50,
+         "percent_min" : 25,
+         "text" : "water",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:sugar",
+         "percent_estimate" : 12.5,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       }
    ],
-   "ingredients_analysis" : {
-      "en:palm-oil-content-unknown" : [
-         "fr:orange juice"
-      ],
-      "en:vegan-status-unknown" : [
-         "fr:orange juice"
-      ],
-      "en:vegetarian-status-unknown" : [
-         "fr:orange juice"
-      ]
-   },
+   "ingredients_analysis" : {},
    "ingredients_analysis_tags" : [
-      "en:palm-oil-content-unknown",
-      "en:vegan-status-unknown",
-      "en:vegetarian-status-unknown"
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
    ],
    "ingredients_hierarchy" : [
-      "fr:orange juice"
+      "en:orange-juice",
+      "en:fruit",
+      "en:citrus-fruit",
+      "en:fruit-juice",
+      "en:orange",
+      "en:water",
+      "en:sugar",
+      "en:added-sugar",
+      "en:disaccharide"
    ],
-   "ingredients_n" : 1,
+   "ingredients_n" : 3,
    "ingredients_n_tags" : [
-      "1",
+      "3",
       "1-10"
    ],
    "ingredients_original_tags" : [
-      "fr:orange juice"
+      "en:orange-juice",
+      "en:water",
+      "en:sugar"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
-      "fr:orange-juice"
+      "en:orange-juice",
+      "en:fruit",
+      "en:citrus-fruit",
+      "en:fruit-juice",
+      "en:orange",
+      "en:water",
+      "en:sugar",
+      "en:added-sugar",
+      "en:disaccharide"
    ],
-   "ingredients_text" : "orange juice",
-   "ingredients_with_specified_percent_n" : 0,
-   "ingredients_with_specified_percent_sum" : 0,
-   "ingredients_with_unspecified_percent_n" : 1,
-   "ingredients_with_unspecified_percent_sum" : 100,
-   "known_ingredients_n" : 0,
-   "lc" : "fr",
+   "ingredients_text" : "orange juice 50%, water, sugar",
+   "ingredients_with_specified_percent_n" : 1,
+   "ingredients_with_specified_percent_sum" : 50,
+   "ingredients_with_unspecified_percent_n" : 2,
+   "ingredients_with_unspecified_percent_sum" : 50,
+   "known_ingredients_n" : 9,
+   "lc" : "en",
    "misc_tags" : [
-      "en:nutrition-fruits-vegetables-nuts-from-category",
-      "en:nutrition-fruits-vegetables-nuts-from-category-en-fruit-juices",
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
       "en:nutrition-all-nutriscore-values-known",
       "en:nutriscore-computed"
    ],
@@ -96,10 +124,10 @@
       "energy_100g" : 182,
       "fat_100g" : 0,
       "fiber_100g" : 0.5,
-      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
-      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0,
-      "nutrition-score-fr" : 5,
-      "nutrition-score-fr_100g" : 5,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 50,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 50,
+      "nutrition-score-fr" : 13,
+      "nutrition-score-fr_100g" : 13,
       "proteins_100g" : 0.2,
       "saturated-fat_100g" : 0,
       "sodium_100g" : 0.2,
@@ -112,16 +140,16 @@
       "fiber" : 0.5,
       "fiber_points" : 0,
       "fiber_value" : 0.5,
-      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 100,
-      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 10,
-      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 100,
-      "grade" : "c",
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 50,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 2,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 50,
+      "grade" : "e",
       "is_beverage" : 1,
       "is_cheese" : 0,
       "is_fat" : 0,
       "is_water" : 0,
       "negative_points" : 15,
-      "positive_points" : 10,
+      "positive_points" : 2,
       "proteins" : 0.2,
       "proteins_points" : 0,
       "proteins_value" : 0.2,
@@ -131,7 +159,7 @@
       "saturated_fat_ratio_points" : 0,
       "saturated_fat_ratio_value" : 0,
       "saturated_fat_value" : 0,
-      "score" : 5,
+      "score" : 13,
       "sodium" : 200,
       "sodium_points" : 2,
       "sodium_value" : 200,
@@ -139,26 +167,26 @@
       "sugars_points" : 6,
       "sugars_value" : 8.9
    },
-   "nutriscore_grade" : "c",
-   "nutriscore_score" : 5,
-   "nutriscore_score_opposite" : -5,
-   "nutrition_grade_fr" : "c",
-   "nutrition_grades" : "c",
+   "nutriscore_grade" : "e",
+   "nutriscore_score" : 13,
+   "nutriscore_score_opposite" : -13,
+   "nutrition_grade_fr" : "e",
+   "nutrition_grades" : "e",
    "nutrition_grades_tags" : [
-      "c"
+      "e"
    ],
    "nutrition_score_beverage" : 1,
-   "nutrition_score_warning_fruits_vegetables_nuts_from_category" : "en:fruit-juices",
-   "nutrition_score_warning_fruits_vegetables_nuts_from_category_value" : 100,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value" : 50,
    "pnns_groups_1" : "Beverages",
    "pnns_groups_1_tags" : [
       "beverages",
       "known"
    ],
-   "pnns_groups_2" : "Fruit juices",
+   "pnns_groups_2" : "Sweetened beverages",
    "pnns_groups_2_tags" : [
-      "fruit-juices",
+      "sweetened-beverages",
       "known"
    ],
-   "unknown_ingredients_n" : 1
+   "unknown_ingredients_n" : 0
 }

--- a/t/expected_test_results/nutriscore/en-orange-juice-category-and-ingredients.json
+++ b/t/expected_test_results/nutriscore/en-orange-juice-category-and-ingredients.json
@@ -1,0 +1,164 @@
+{
+   "categories" : "orange juices",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:beverages",
+      "en:plant-based-beverages",
+      "en:fruit-based-beverages",
+      "en:juices-and-nectars",
+      "en:fruit-juices",
+      "en:orange-juices"
+   ],
+   "categories_lc" : "fr",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "2011",
+      "ciqual_food_code:en" : "2004"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-2011",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-2004",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-2011"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:beverages",
+      "en:plant-based-beverages",
+      "en:fruit-based-beverages",
+      "en:juices-and-nectars",
+      "en:fruit-juices",
+      "en:orange-juices"
+   ],
+   "food_groups" : "en:unsweetened-beverages",
+   "food_groups_tags" : [
+      "en:beverages",
+      "en:unsweetened-beverages"
+   ],
+   "ingredients" : [
+      {
+         "id" : "fr:orange juice",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "orange juice"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil-content-unknown" : [
+         "fr:orange juice"
+      ],
+      "en:vegan-status-unknown" : [
+         "fr:orange juice"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "fr:orange juice"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "fr:orange juice"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "fr:orange juice"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "fr:orange-juice"
+   ],
+   "ingredients_text" : "orange juice",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 1,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "known_ingredients_n" : 0,
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-from-category",
+      "en:nutrition-fruits-vegetables-nuts-from-category-en-fruit-juices",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 182,
+      "fat_100g" : 0,
+      "fiber_100g" : 0.5,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0,
+      "nutrition-score-fr" : 5,
+      "nutrition-score-fr_100g" : 5,
+      "proteins_100g" : 0.2,
+      "saturated-fat_100g" : 0,
+      "sodium_100g" : 0.2,
+      "sugars_100g" : 8.9
+   },
+   "nutriscore_data" : {
+      "energy" : 182,
+      "energy_points" : 7,
+      "energy_value" : 182,
+      "fiber" : 0.5,
+      "fiber_points" : 0,
+      "fiber_value" : 0.5,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 100,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 10,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 100,
+      "grade" : "c",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 15,
+      "positive_points" : 10,
+      "proteins" : 0.2,
+      "proteins_points" : 0,
+      "proteins_value" : 0.2,
+      "saturated_fat" : 0,
+      "saturated_fat_points" : 0,
+      "saturated_fat_ratio" : 0,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 0,
+      "saturated_fat_value" : 0,
+      "score" : 5,
+      "sodium" : 200,
+      "sodium_points" : 2,
+      "sodium_value" : 200,
+      "sugars" : 8.9,
+      "sugars_points" : 6,
+      "sugars_value" : 8.9
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 5,
+   "nutriscore_score_opposite" : -5,
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category" : "en:fruit-juices",
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category_value" : 100,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Fruit juices",
+   "pnns_groups_2_tags" : [
+      "fruit-juices",
+      "known"
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/t/expected_test_results/nutriscore/en-orange-juice-category.json
+++ b/t/expected_test_results/nutriscore/en-orange-juice-category.json
@@ -9,7 +9,7 @@
       "en:fruit-juices",
       "en:orange-juices"
    ],
-   "categories_lc" : "fr",
+   "categories_lc" : "en",
    "categories_properties" : {
       "agribalyse_proxy_food_code:en" : "2011",
       "ciqual_food_code:en" : "2004"
@@ -39,7 +39,7 @@
       "en:beverages",
       "en:fruit-juices"
    ],
-   "lc" : "fr",
+   "lc" : "en",
    "misc_tags" : [
       "en:nutrition-fruits-vegetables-nuts-from-category",
       "en:nutrition-fruits-vegetables-nuts-from-category-en-fruit-juices",

--- a/t/expected_test_results/nutriscore/en-orange-juice-category.json
+++ b/t/expected_test_results/nutriscore/en-orange-juice-category.json
@@ -1,0 +1,115 @@
+{
+   "categories" : "orange juices",
+   "categories_hierarchy" : [
+      "en:plant-based-foods-and-beverages",
+      "en:beverages",
+      "en:plant-based-beverages",
+      "en:fruit-based-beverages",
+      "en:juices-and-nectars",
+      "en:fruit-juices",
+      "en:orange-juices"
+   ],
+   "categories_lc" : "fr",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "2011",
+      "ciqual_food_code:en" : "2004"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-2011",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-2004",
+      "ciqual-food-code-known",
+      "agribalyse-known",
+      "agribalyse-2011"
+   ],
+   "categories_tags" : [
+      "en:plant-based-foods-and-beverages",
+      "en:beverages",
+      "en:plant-based-beverages",
+      "en:fruit-based-beverages",
+      "en:juices-and-nectars",
+      "en:fruit-juices",
+      "en:orange-juices"
+   ],
+   "food_groups" : "en:fruit-juices",
+   "food_groups_tags" : [
+      "en:beverages",
+      "en:fruit-juices"
+   ],
+   "lc" : "fr",
+   "misc_tags" : [
+      "en:nutrition-fruits-vegetables-nuts-from-category",
+      "en:nutrition-fruits-vegetables-nuts-from-category-en-fruit-juices",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutriscore-computed"
+   ],
+   "nutriments" : {
+      "energy_100g" : 182,
+      "fat_100g" : 0,
+      "fiber_100g" : 0.5,
+      "nutrition-score-fr" : 5,
+      "nutrition-score-fr_100g" : 5,
+      "proteins_100g" : 0.2,
+      "saturated-fat_100g" : 0,
+      "sodium_100g" : 0.2,
+      "sugars_100g" : 8.9
+   },
+   "nutriscore_data" : {
+      "energy" : 182,
+      "energy_points" : 7,
+      "energy_value" : 182,
+      "fiber" : 0.5,
+      "fiber_points" : 0,
+      "fiber_value" : 0.5,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils" : 100,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_points" : 10,
+      "fruits_vegetables_nuts_colza_walnut_olive_oils_value" : 100,
+      "grade" : "c",
+      "is_beverage" : 1,
+      "is_cheese" : 0,
+      "is_fat" : 0,
+      "is_water" : 0,
+      "negative_points" : 15,
+      "positive_points" : 10,
+      "proteins" : 0.2,
+      "proteins_points" : 0,
+      "proteins_value" : 0.2,
+      "saturated_fat" : 0,
+      "saturated_fat_points" : 0,
+      "saturated_fat_ratio" : 0,
+      "saturated_fat_ratio_points" : 0,
+      "saturated_fat_ratio_value" : 0,
+      "saturated_fat_value" : 0,
+      "score" : 5,
+      "sodium" : 200,
+      "sodium_points" : 2,
+      "sodium_value" : 200,
+      "sugars" : 8.9,
+      "sugars_points" : 6,
+      "sugars_value" : 8.9
+   },
+   "nutriscore_grade" : "c",
+   "nutriscore_score" : 5,
+   "nutriscore_score_opposite" : -5,
+   "nutrition_grade_fr" : "c",
+   "nutrition_grades" : "c",
+   "nutrition_grades_tags" : [
+      "c"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category" : "en:fruit-juices",
+   "nutrition_score_warning_fruits_vegetables_nuts_from_category_value" : 100,
+   "pnns_groups_1" : "Beverages",
+   "pnns_groups_1_tags" : [
+      "beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Fruit juices",
+   "pnns_groups_2_tags" : [
+      "fruit-juices",
+      "known"
+   ]
+}

--- a/t/nutriscore.t
+++ b/t/nutriscore.t
@@ -17,28 +17,32 @@ use ProductOpener::Food qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Nutriscore qw/:all/;
 
-my $expected_dir = dirname(__FILE__) . "/expected_test_results";
-my $testdir = "nutriscore";
+
+
+my $test_name = "nutriscore";
+my $tests_dir = dirname(__FILE__);
+my $expected_dir = $tests_dir . "/expected_test_results/" . $test_name;
 
 my $usage = <<TXT
 
-The expected results of the tests are saved in $expected_dir/$testdir
+The expected results of the tests are saved in $tests_dir/expected_test_results/$test_name
 
-To verify differences and update the expected test results, actual test results
-can be saved to a directory by passing --results [path of results directory]
+To verify differences and update the expected test results,
+actual test results can be saved by passing --update-expected-results
 
 The directory will be created if it does not already exist.
 
 TXT
 ;
 
-my $resultsdir;
+my $update_expected_results;
 
-GetOptions ("results=s"   => \$resultsdir)
+GetOptions ("update-expected-results"   => \$update_expected_results)
   or die("Error in command line arguments.\n\n" . $usage);
+
   
-if ((defined $resultsdir) and (! -e $resultsdir)) {
-	mkdir($resultsdir, 0755) or die("Could not create $resultsdir directory: $!\n");
+if ((defined $update_expected_results) and (! -e $expected_dir)) {
+	mkdir($expected_dir, 0755) or die("Could not create $expected_dir directory: $!\n");
 }
 
 init_emb_codes();
@@ -91,6 +95,25 @@ my @tests = (
 # Cocoa and chocolate powders
 ["cocoa-and-chocolate-powders", { lc => "en", "categories" => "cocoa and chocolate powders", nutriments=>{energy_prepared_100g=>287, fat_prepared_100g=>0, "saturated-fat_prepared_100g"=>1.1, sugars_prepared_100g=>6.3, sodium_prepared_100g=>0.045, fiber_prepared_100g=>1.9, proteins_prepared_100g=>3.8}}],
 
+# fruits and vegetables estimates from category or from ingredients
+[
+	"en-orange-juice-category-and-ingredients",
+	{
+			lc => "en",
+			categories => "orange juices",
+			ingredients_text => "orange juice 50%, water, sugar",
+			nutriments=>{energy_100g=>182, fat_100g=>0, "saturated-fat_100g"=>0, sugars_100g=>8.9, sodium_100g=>0.2, fiber_100g=>0.5, proteins_100g=>0.2},	
+	}
+],
+[
+	"en-orange-juice-category",
+	{
+			lc => "en",
+			categories => "orange juices",
+			nutriments=>{energy_100g=>182, fat_100g=>0, "saturated-fat_100g"=>0, sugars_100g=>8.9, sodium_100g=>0.2, fiber_100g=>0.5, proteins_100g=>0.2},	
+	}
+],
+
 );
 
 
@@ -108,25 +131,25 @@ foreach my $test_ref (@tests) {
 
 	# Save the result
 	
-	if (defined $resultsdir) {
-		open (my $result, ">:encoding(UTF-8)", "$resultsdir/$testid.json") or die("Could not create $resultsdir/$testid.json: $!\n");
+	if (defined $update_expected_results) {
+		open (my $result, ">:encoding(UTF-8)", "$expected_dir/$testid.json") or die("Could not create $expected_dir/$testid.json: $!\n");
 		print $result $json->pretty->encode($product_ref);
 		close ($result);
 	}
-	
-	# Compare the result with the expected result
-	
-	if (open (my $expected_result, "<:encoding(UTF-8)", "$expected_dir/$testdir/$testid.json")) {
-
-		local $/; #Enable 'slurp' mode
-		my $expected_product_ref = $json->decode(<$expected_result>);
-		is_deeply ($product_ref, $expected_product_ref) or diag explain $product_ref;
-	}
 	else {
-		fail("could not load expected_test_results/$testdir/$testid.json");
-		diag explain $product_ref;
-	}
+		# Compare the result with the expected result
+		
+		if (open (my $expected_result, "<:encoding(UTF-8)", "$expected_dir/$testid.json")) {
 
+			local $/; #Enable 'slurp' mode
+			my $expected_product_ref = $json->decode(<$expected_result>);
+			is_deeply ($product_ref, $expected_product_ref) or diag explain $product_ref;
+		}
+		else {
+			fail("could not load $expected_dir/$testid.json");
+			diag explain $product_ref;
+		}
+	}
 }
 
 is (compute_nutriscore_grade(1.56, 1, 0), "c");


### PR DESCRIPTION
- changed the order for the source of the fruits/vegetable estimate, as the estimate from the category is less reliable (a lot of examples seen in a recent producer export: wrong category + too optimistic estimates for some categories).
- added some tests

fixes #6598
