### PR TITLE
fix: Setting param to return scalar

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -871,7 +871,15 @@ sub analyze_request($)
 			param("json", 1);
 		}
 
-		$log->debug("got API request", { api => $request_ref->{api}, api_version => param("api_version"), api_method => param("api_method"), code => $request_ref->{code}, jqm => param("jqm"), json => param("json"), xml => param("xml") } ) if $log->is_debug();
+		$log->debug("got API request", {
+			api => $request_ref->{api},
+			api_version => scalar(param("api_version")),
+			api_method => scalar(param("api_method")),
+			code => $request_ref->{code},
+			jqm => scalar(param("jqm")),
+			json => scalar(param("json")),
+			xml => scalar(param("xml")) }
+		) if $log->is_debug();
 	}
 
 	# /search search endpoint, parameters will be parser by CGI.pm param()


### PR DESCRIPTION
I was seeing:
```
[Wed Apr 13 13:08:09 2022] -e: CGI::param called in list context from /opt/product-opener/lib/ProductOpener/Display.pm line 879, this can lead to vulnerabilities. See the warning in "Fetching the value or values of a single named parameter" at /opt/perl/local/lib/perl5/CGI.pm line 415.
```
Which according to 
https://stackoverflow.com/questions/18668966/perl-cgi-module-passing-param-as-parameters-to-subroutines  
it can be solved by forcing a scalar; with this commit, I am no longer seeing the warning.