### PR TITLE
fix: more precise estimate of ingredients percents min and max

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2462,7 +2462,7 @@ sub set_percent_max_values($$$) {
 		}
 		my $max_percent_max = $total_max - $sum_of_mins_before - $sum_of_mins_after;
 
-		if ($ingredient_ref->{percent_max} > $max_percent_max) {
+		if (($max_percent_max >= 0) and ($ingredient_ref->{percent_max} > $max_percent_max)) {
 			$ingredient_ref->{percent_max} = $max_percent_max;
 			$changed++;
 		}
@@ -2576,7 +2576,7 @@ sub set_percent_min_values($$$) {
 		}
 		my $min_percent_min = $total_min - $sum_of_maxs_before - $sum_of_maxs_after;
 
-		if ($ingredient_ref->{percent_min} < $min_percent_min - 0.1) {
+		if (($min_percent_min > 0) and ($ingredient_ref->{percent_min} < $min_percent_min - 0.1)) {
 
 			# Bail out if the values are not possible
 			if (($min_percent_min > $total_min) or ($min_percent_min > $ingredient_ref->{percent_max})) {

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2454,10 +2454,16 @@ sub set_percent_max_values($$$) {
 
 		# The max of an ingredient must be lower or equal to
 		# the total max minus the sum of the minimums of all
-		# ingredients that appear before.
+		# other ingredients
 
-		if ($ingredient_ref->{percent_max} > $total_max - $sum_of_mins_before) {
-			$ingredient_ref->{percent_max} = $total_max - $sum_of_mins_before;
+		my $sum_of_mins_after = 0;
+		for (my $j = $i; $j < $n; $j++) {
+			$sum_of_mins_after += $ingredients_ref->[$j]{percent_min};
+		}
+		my $max_percent_max = $total_max - $sum_of_mins_before - $sum_of_mins_after;
+
+		if ($ingredient_ref->{percent_max} > $max_percent_max) {
+			$ingredient_ref->{percent_max} = $max_percent_max;
 			$changed++;
 		}
 
@@ -2561,12 +2567,16 @@ sub set_percent_min_values($$$) {
 			$changed++;
 		}
 
-		# The min of the first ingredient in the list must be greater or equal
-		# to the total min minus sum of of the maximums of all the ingredients after.
+		# The min of the ingredient must be greater or equal
+		# to the total min minus the sum of the maximums of all the other ingredients
 
-		my $min_percent_min = $total_min - $sum_of_maxs_after;
+		my $sum_of_maxs_before = 0;
+		for (my $j = 0; $j < ($n - $i); $j++) {
+			$sum_of_maxs_before += $ingredients_ref->[$j]{percent_max};
+		}
+		my $min_percent_min = $total_min - $sum_of_maxs_before - $sum_of_maxs_after;
 
-		if (($i == $n) and ($ingredient_ref->{percent_min} < $min_percent_min - 0.1)) {
+		if ($ingredient_ref->{percent_min} < $min_percent_min - 0.1) {
 
 			# Bail out if the values are not possible
 			if (($min_percent_min > $total_min) or ($min_percent_min > $ingredient_ref->{percent_max})) {

--- a/t/ingredients_percent.t
+++ b/t/ingredients_percent.t
@@ -768,15 +768,15 @@ my @tests = (
 			},
 			{
 				'id' => 'en:carrot-juice',
-				'percent_estimate' => '32.025',
-				'percent_max' => '42.7',
-				'percent_min' => '21.35',
+				'percent_estimate' => '40.2',
+				'percent_max' => '40.2',
+				'percent_min' => '40.2',
 				'text' => 'jus de carotte'
 			},
 			{
 				'id' => 'en:ginger',
 				'percent' => '2.5',
-				'percent_estimate' => '10.675',
+				'percent_estimate' => '2.5',
 				'percent_max' => '2.5',
 				'percent_min' => '2.5',
 				'processing' => 'en:juice',

--- a/t/ingredients_percent.t
+++ b/t/ingredients_percent.t
@@ -755,6 +755,36 @@ my @tests = (
 
 	],
 
+	# Missing % that is not the first or the last
+	[ { lc => "fr", ingredients_text => "Jus de pomme (57,3%), jus de carotte, jus de gingembre (2,5%)."},
+		[
+			{
+				'id' => 'en:apple-juice',
+				'percent' => '57.3',
+				'percent_estimate' => '57.3',
+				'percent_max' => '57.3',
+				'percent_min' => '57.3',
+				'text' => 'Jus de pomme'
+			},
+			{
+				'id' => 'en:carrot-juice',
+				'percent_estimate' => '32.025',
+				'percent_max' => '42.7',
+				'percent_min' => '21.35',
+				'text' => 'jus de carotte'
+			},
+			{
+				'id' => 'en:ginger',
+				'percent' => '2.5',
+				'percent_estimate' => '10.675',
+				'percent_max' => '2.5',
+				'percent_min' => '2.5',
+				'processing' => 'en:juice',
+				'text' => 'gingembre'
+			}
+		]
+	],
+
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
fix for #6612

This change 2 rules to compute percent min and percent max of ingredients based on the other ingredients min and max.

You can see the difference of result in this commit as I first added a test that demonstrated the issue: https://github.com/openfoodfacts/openfoodfacts-server/commit/cba72e31ae084117f42dd8506dd9ff64c6249613