### PR TITLE
fix: Wikidata entries to update

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/12
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           label-operator: AND

--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/12
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           label-operator: AND

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We have [[templatized](https://github.com/openfoodfacts/openfoodfacts-server/tre
 ## Contributors
 
 This project exists thanks to all the people who contribute.
-<a href="https://github.com/openfoodfacts/openfoodfacts-server/graphs/contributors"><img src="https://opencollective.com/openfoodfacts-server/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/openfoodfacts/openfoodfacts-server/graphs/contributors"><img src="https://contrib.rocks/image?repo=openfoodfacts/openfoodfacts-server&columns=16" /></a>
 
 
 ## Backers

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -9148,7 +9148,7 @@ sl:E350, E350 food additive
 sv:E350, natriummalater
 e_number:en:350
 wikidata:en:Q836788
-wikidata:en:Q63534992
+wikidata:en:Q27163168
 additives_classes:en: en:humectant
 vegan:en:yes
 vegetarian:en:yes

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -34778,7 +34778,7 @@ ru:Тёмный шоколад
 sv:Mörk choklad
 th:ดาร์กช็อกโกแลต
 zh:黑巧克力
-wikidata:en:Q2366206
+wikidata:en:Q277628
 agribalyse_proxy_food_code:en:31080
 agribalyse_proxy_food_name:en:Dark chocolate bar, filled with praline
 agribalyse_proxy_food_name:fr:Chocolat noir fourré praliné, tablette


### PR DESCRIPTION
### Description

Wkidata entries get merged overtime. So, exceptions were generated in the Android app due to this merge. 
Affected wikidata due to merge:
- Q63534992
- Q2366206

### Related issue(s) and discussion
- Fixes #6530 
- Updated additives.txt and categories.txt taxonomies with new values.