### PR TITLE
fix: make perl unit test run

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,7 +51,7 @@ jobs:
         git ls-files taxonomies/ | xargs -I{} git log -1 --date=format:%Y%m%d%H%M.%S --format='touch -t %ad "{}"' "{}" | bash
         make build_taxonomies
     - name: test
-      run: make test
+      run: make tests
     - name: test make dev
       run: |
         make dev


### PR DESCRIPTION
There's a typo in the pull request action that prevents Perl unit tests to run.

e.g. for this PR the tests should have been broken: https://github.com/openfoodfacts/openfoodfacts-server/pull/6620