### PR TITLE
fix:  warning message

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5178,7 +5178,7 @@ sub search_and_display_products($$$$$) {
 	$template_data_ref->{sort_by} = $sort_by;
 
 	# Query from search form: display a link back to the search form
-	if ($request_ref->{current_link_query} =~ /action=process/) {
+	if (defined($request_ref->{current_link_query}) && $request_ref->{current_link_query} =~ /action=process/) {
 		$template_data_ref->{current_link_query_edit} = $request_ref->{current_link_query};
 		$template_data_ref->{current_link_query_edit} =~ s/action=process/action=display/;
 	}


### PR DESCRIPTION
Fixes "Use of uninitialized value" warning. This value didn't use a test for if it was defined but the other uses of it had a test for definition, so I added one here as well.