### PR TITLE
fix: Add check for the definition of $user_ref->{org}

### DIFF
--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -196,28 +196,28 @@ if ($action eq 'display') {
 
 		# Professional account
 		push @{$template_data_ref->{sections}}, {
-				id          => "professional",
-				name        => lang("pro_account"),
-				description => "if_you_work_for_a_producer",
-				note        => "producers_platform_description_long",
-				fields      => [
-					{
-						field   => "pro",
-						type    => "checkbox",
-						label   => lang("this_is_a_pro_account"),
-						value   => "off",
-					},
-					{
-						field => "pro_checkbox",
-						type  => "hidden",
-						value => 1,
-					},
-					{
-						field => "requested_org",
-						label => lang("producer_or_brand") . ":",
-					}
-				]
-			};
+			id => "professional",
+			name => lang("pro_account"),
+			description => "if_you_work_for_a_producer",
+			note => "producers_platform_description_long",
+			fields => [
+				{
+					field => "pro",
+					type => "checkbox",
+					label => lang("this_is_a_pro_account"),
+					value => "off",
+				},
+				{
+					field => "pro_checkbox",
+					type => "hidden",
+					value => 1,
+				},
+				{
+					field => "requested_org",
+					label => lang("producer_or_brand") . ":",
+				}
+			]
+		};
 
 		# Teams section
 		# Do not display teams if it is a professional account

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -195,8 +195,7 @@ if ($action eq 'display') {
 		};
 
 		# Professional account
-		if (defined $user_ref->{org}) {
-			push @{$template_data_ref->{sections}}, {
+		push @{$template_data_ref->{sections}}, {
 				id          => "professional",
 				name        => lang("pro_account"),
 				description => "if_you_work_for_a_producer",
@@ -206,7 +205,6 @@ if ($action eq 'display') {
 						field   => "pro",
 						type    => "checkbox",
 						label   => lang("this_is_a_pro_account"),
-						warning => sprintf(lang("this_is_a_pro_account_for_org"), "<b>" . $user_ref->{org} . "</b>"),
 						value   => "off",
 					},
 					{
@@ -220,7 +218,6 @@ if ($action eq 'display') {
 					}
 				]
 			};
-		}
 
 		# Teams section
 		# Do not display teams if it is a professional account

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -290,7 +290,6 @@ if ($action eq 'display') {
 	if ( ( defined $user_ref->{org} ) and ( $user_ref->{org} ne "" ) ) {
 
 		$template_data_ref->{accepted_organization} = $user_ref->{org};
-		$template_data_ref->{pro_account_org} = sprintf(lang("this_is_a_pro_account_for_org"),"<b>" . $user_ref->{org} . "</b>");
 	}
 	elsif ((defined $options{product_type}) and ($options{product_type} eq "food")) {
 		my $requested_org_ref = retrieve_org($user_ref->{requested_org});

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -195,30 +195,32 @@ if ($action eq 'display') {
 		};
 
 		# Professional account
-		push @{$template_data_ref->{sections}}, {
-			id => "professional",
-			name => lang("pro_account"),
-			description => "if_you_work_for_a_producer",
-			note => "producers_platform_description_long",
-			fields => [
-				{
-					field => "pro",
-					type => "checkbox",
-					label => lang("this_is_a_pro_account"),
-					warning => sprintf(lang("this_is_a_pro_account_for_org"),"<b>" . $user_ref->{org} . "</b>"),
-					value => "off",
-				},
-				{
-					field => "pro_checkbox",
-					type => "hidden",
-					value => 1,
-				},
-				{
-					field => "requested_org",
-					label => lang("producer_or_brand") . ":",
-				}
-			]
-		};
+		if (defined $user_ref->{org}) {
+			push @{$template_data_ref->{sections}}, {
+				id          => "professional",
+				name        => lang("pro_account"),
+				description => "if_you_work_for_a_producer",
+				note        => "producers_platform_description_long",
+				fields      => [
+					{
+						field   => "pro",
+						type    => "checkbox",
+						label   => lang("this_is_a_pro_account"),
+						warning => sprintf(lang("this_is_a_pro_account_for_org"), "<b>" . $user_ref->{org} . "</b>"),
+						value   => "off",
+					},
+					{
+						field => "pro_checkbox",
+						type  => "hidden",
+						value => 1,
+					},
+					{
+						field => "requested_org",
+						label => lang("producer_or_brand") . ":",
+					}
+				]
+			};
+		}
 
 		# Teams section
 		# Do not display teams if it is a professional account

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -117,10 +117,6 @@ msgctxt "enter_name_of_org"
 msgid "Please enter the name of your organization (company name or brand)."
 msgstr "Please enter the name of your organization (company name or brand)."
 
-msgctxt "this_is_a_pro_account_for_org"
-msgid "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
-msgstr "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
-
 msgctxt "f_this_is_a_pro_account_for_org"
 msgid "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."
 msgstr "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -121,6 +121,10 @@ msgctxt "this_is_a_pro_account_for_org"
 msgid "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
 msgstr "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
 
+msgctxt "f_this_is_a_pro_account_for_org"
+msgid "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."
+msgstr "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."
+
 msgctxt "add_user_email_body"
 msgid ""
 "Hello <NAME>,\n"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -123,7 +123,9 @@ msgctxt "this_is_a_pro_account_for_org"
 msgid "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
 msgstr "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
 
-
+msgctxt "f_this_is_a_pro_account_for_org"
+msgid "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."
+msgstr "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."
 
 msgctxt "add_user_email_body"
 msgid "Hello <NAME>,\n\n"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -119,10 +119,6 @@ msgctxt "enter_name_of_org"
 msgid "Please enter the name of your organization (company name or brand)."
 msgstr "Please enter the name of your organization (company name or brand)."
 
-msgctxt "this_is_a_pro_account_for_org"
-msgid "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
-msgstr "This account is a professional account associated with the producer or brand %s. You have access to the Platform for Producers."
-
 msgctxt "f_this_is_a_pro_account_for_org"
 msgid "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."
 msgstr "This account is a professional account associated with the producer or brand {org}. You have access to the Platform for Producers."

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -82,8 +82,8 @@
                     <label for="[% field.field %]">	[% field.label %]</label>
                     <input type="email" id="[% field.field %]" name="[% field.field %]" value = "[% field.value %]" autocomplete="email"/>
                 [% ELSIF field.type == 'checkbox' %]
-                    [% IF accepted_organization && section.id == "professional" %]
-                        <p>[% field.warning %]</p>
+                    [% IF accepted_organization && section.id == "professional" && user_org.defined %]
+                        <p>[% f_lang('this_is_a_pro_account_for_org', {'org' => user_org} ) %]</p>
                     [% ELSE %]
                         <label for="[% field.field %]">
                             <input type="checkbox" id="[% field.field %]" name="[% field.field %]" [% IF field.value == 'on' %]checked="checked"[% END %] />

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -82,8 +82,8 @@
                     <label for="[% field.field %]">	[% field.label %]</label>
                     <input type="email" id="[% field.field %]" name="[% field.field %]" value = "[% field.value %]" autocomplete="email"/>
                 [% ELSIF field.type == 'checkbox' %]
-                    [% IF accepted_organization && section.id == "professional" && user_org.defined %]
-                        <p>[% f_lang('this_is_a_pro_account_for_org', {'org' => user_org} ) %]</p>
+                    [% IF accepted_organization && section.id == "professional" %]
+                        <p>[% f_lang('this_is_a_pro_account_for_org', {'org' => accepted_organization}) %]</p>
                     [% ELSE %]
                         <label for="[% field.field %]">
                             <input type="checkbox" id="[% field.field %]" name="[% field.field %]" [% IF field.value == 'on' %]checked="checked"[% END %] />

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -83,7 +83,7 @@
                     <input type="email" id="[% field.field %]" name="[% field.field %]" value = "[% field.value %]" autocomplete="email"/>
                 [% ELSIF field.type == 'checkbox' %]
                     [% IF accepted_organization && section.id == "professional" %]
-                        <p>[% f_lang('this_is_a_pro_account_for_org', {'org' => accepted_organization}) %]</p>
+                        <p>[% f_lang('f_this_is_a_pro_account_for_org', {'org' => accepted_organization}) %]</p>
                     [% ELSE %]
                         <label for="[% field.field %]">
                             <input type="checkbox" id="[% field.field %]" name="[% field.field %]" [% IF field.value == 'on' %]checked="checked"[% END %] />


### PR DESCRIPTION
### Description
Implements an additional check to see if an org associated with the user is defined before executing the code block. 
This fixes an uninitialized value warning.

#### The error
`[Sun Apr 17 11:00:58 2022] -e: Use of uninitialized value in concatenation (.) or string at /opt/product-opener/cgi/user.pl line 208.
`

