### PR TITLE
docs: Enabling Developer Mode on Windows to use symlinks

### DIFF
--- a/docs/introduction/dev-environment-quick-start-guide.md
+++ b/docs/introduction/dev-environment-quick-start-guide.md
@@ -173,9 +173,11 @@ make: *** [build_lang] Error 2
 ```
 
 Solution:
-
+Project needs Symlinks to be enabled.
 traces.result.sto is a symlink to allergens.result.sto
 
+On Windows, You have to enable the 'Developer Mode' in order to use the symlinks.
+To enable Developer Mode: Go under Settings > Update & Security > 'For developers', and turn on the toggle for Developer Mode.
 On Windows systems, the git repository needs to be cloned with symlinks enabled.
 
 You need to remove current directory where you clone the project, and clone the project again, using right options:


### PR DESCRIPTION
Fixes #6640: Enable the Developer Mode on Windows to use Symlinks in dev-environment-quick-start-guide.md
The project requires Symlinks. On Windows, you need to enable the Developer Mode to use Symlinks.

### Description
On Windows, You have to enable the 'Developer Mode' in order to use the symlinks.
To enable Developer Mode: Go under Settings > Update & Security > 'For developers', and turn on the toggle for Developer Mode.



### Related issue(s) and discussion
- Fixes #6639 
- Fixes #6640 
