### PR TITLE
fix: Fixed a typo in French translation

### DIFF
--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5386,7 +5386,7 @@ msgstr "Score environnemental PEF"
 
 msgctxt "ecoscore_incl_climate_change_impact"
 msgid "including impact on climate change"
-msgstr "dont impact sur le changement climatique :"
+msgstr "dont impact sur le changement climatique"
 
 msgctxt "ecoscore_impact_detail_by_stages"
 msgid "Details of the impacts by stages of the life cycle"


### PR DESCRIPTION
https://github.com/openfoodfacts/openfoodfacts-server/issues/6628 Fixed the typo in the French translation in "po/common/fr.po" file.
### Description

### Screenshot
![164070752-298f5e48-b08d-4af5-ad84-781d966a42e5](https://user-images.githubusercontent.com/65444978/164178606-63b57f7a-0c97-4843-8901-fb3d4eb73c0e.png)


### Related issue(s) and discussion
- Fixes #6628 
