### PR TITLE
docs: Document the I18N module using perl-pod format

### DIFF
--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -18,6 +18,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=head1 NAME
+
+ProductOpener::I18N - Reads the .po files from a certain directory and processes them.
+
+=head1 SYNOPSIS
+
+C<ProductOpener::I18N> is used to read all ".po" files from a certain directory and merge them 
+in one hash. The singular & plural entries are seperated into two hashes.
+
+=head1 DESCRIPTION
+
+The module implements the functionality to read and process the .po files from a certain directory.
+The .po files are read and then merged into a single hash which is then seperated into two hashes.
+One of these hashes have all plural entries and the other one has all singular entries.
+The functions used in this module take the directory to look for the .po files and returns two hashrefs.
+
+=cut
+
 package ProductOpener::I18N;
 
 use strict;
@@ -54,6 +72,25 @@ my @metadata_fields = qw<
 # Read all .po files from a directory, merge everything in one hash,
 # returned as a reference to spare the stack.
 #
+=head1 FUNCTIONS
+
+=head2 read_po_files()
+
+C<read_po_files()> takes directory of the .po files as an input parameter, reads and merges them in one hash
+That hash is returned as a reference. (Done to spare the stack) Returning a reference uses a bit less memory since there's no copy.
+This function also cleans up the %Lexicon from gettext metadata 
+and cleans up the empty values that are put in .po files by Crowdin when the string is not translated.
+
+=head3 Arguments
+
+The directory containing .po files are passed as an argument.
+
+=head3 Return values
+
+Returns a reference to a hash on successful execution.
+
+=cut
+
 sub read_po_files {
     my ($dir) = @_;
 
@@ -120,6 +157,24 @@ sub read_po_files {
 # Separate the singular & plural entries from a hash, as returned by
 # read_po_files(), into two hashes. Obviously returned as two hashrefs.
 #
+
+=head1 FUNCTIONS
+
+=head2 split_tags()
+
+C<split_tags()> takes the hashref returned by read_po_files as input parameter seperates it into two hashes seperated by
+if they are singular or plural, respectively and returns them as 2 hashrefs.
+
+=head3 Arguments
+
+A hash is passed as an argument.
+
+=head3 Return values
+
+If the function executes successfully it returns two hash references. 
+If the tags are malformed, it throws a warning.
+
+=cut
 sub split_tags {
     my ($l10n) = @_;
 

--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -158,7 +158,6 @@ sub read_po_files {
 # read_po_files(), into two hashes. Obviously returned as two hashrefs.
 #
 
-=head1 FUNCTIONS
 
 =head2 split_tags()
 


### PR DESCRIPTION
### Description

Documented the `ProductOpener::I18N.pm` file in `perlpod` format.

### Related issue(s) and discussion
- Related Issue https://github.com/openfoodfacts/openfoodfacts-server/issues/2203
- Part of https://github.com/openfoodfacts/openfoodfacts-server/issues/5559

