### PR TITLE
feat: check {variables} are kept in translations 

### DIFF
--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -4187,7 +4187,7 @@ msgstr "Bazı içerikler tanınamadı."
 # variable names between { } must not be translated
 msgctxt "f_move_data_and_photos_to_main_language"
 msgid "Move all data and selected photos in {language} to the main language of the product: {main_language}"
-msgstr "(dilindeki) seçilen fotoğrafları ve tüm verileri ürünün ana diline yerleştirin(ana dil)"
+msgstr "Tüm verileri ve seçilen fotoğrafları {language} ürünün ana diline taşıyın: {main_language}"
 
 msgctxt "move_data_and_photos_to_main_language_replace"
 msgid "Replace existing values and selected photos"

--- a/t/lang.t
+++ b/t/lang.t
@@ -82,7 +82,7 @@ test_logo_exists('logo2x');
 # Test that {variables} are kept in translations
 
 foreach my $stringid (sort keys %Lang) {
-	while ($Lang{$stringid}{en} =~ /{([^}]+)\}/g) {
+	while ($Lang{$stringid}{en} =~ /\{([^}]+)\}/g) {
 		my $variable = $1;
 		foreach my $l (sort keys %{$Lang{$stringid}}) {
 			# Note: the if below is added so that we don't have thousands of tests reported in the output

--- a/t/lang.t
+++ b/t/lang.t
@@ -94,7 +94,4 @@ foreach my $stringid (sort keys %Lang) {
 	}
 }
 
-print "en: $Lang{f_nova_markers_for_nova_group}{en}\n";
-print "es: $Lang{f_nova_markers_for_nova_group}{es}\n";
-
 done_testing();

--- a/t/lang.t
+++ b/t/lang.t
@@ -79,4 +79,22 @@ sub test_logo_exists {
 test_logo_exists('logo');
 test_logo_exists('logo2x');
 
+# Test that {variables} are kept in translations
+
+foreach my $stringid (sort keys %Lang) {
+	while ($Lang{$stringid}{en} =~ /{([^}]+)\}/g) {
+		my $variable = $1;
+		foreach my $l (sort keys %{$Lang{$stringid}}) {
+			# Note: the if below is added so that we don't have thousands of tests reported in the output
+			# only non passing tests are tested with like() and reported.
+			if ($Lang{$stringid}{$l} !~ /\{$variable\}/) {
+				like($Lang{$stringid}{$l}, qr/\{$variable\}/, "$stringid translation in $l contains {$variable}");
+			}
+		}
+	}
+}
+
+print "en: $Lang{f_nova_markers_for_nova_group}{en}\n";
+print "es: $Lang{f_nova_markers_for_nova_group}{es}\n";
+
 done_testing();


### PR DESCRIPTION
Related to #6702

This PR makes the tests fail if some translations removed some {variables}:

```
not ok 743 - f_app_user translation in uk contains {app_name}
#   Failed test 'f_app_user translation in uk contains {app_name}'
#   at lang.t line 91.
Wide character in print at /opt/perl/local/lib/perl5/Test2/Formatter/TAP.pm line 125.
#                   'Користувач додатку'
#     doesn't match '(?^u:\{app_name\})'
not ok 744 - f_energy_expenditure_for_weight_in_kg_lb translation in uk contains {kg}
#   Failed test 'f_energy_expenditure_for_weight_in_kg_lb translation in uk contains {kg}'
#   at lang.t line 91.
Wide character in print at /opt/perl/local/lib/perl5/Test2/Formatter/TAP.pm line 125.
#                   'Використання енергії для людини вагою кг/ фунт'
#     doesn't match '(?^u:\{kg\})'
not ok 745 - f_energy_expenditure_for_weight_in_kg_lb translation in uk contains {lb}
#   Failed test 'f_energy_expenditure_for_weight_in_kg_lb translation in uk contains {lb}'
#   at lang.t line 91.
Wide character in print at /opt/perl/local/lib/perl5/Test2/Formatter/TAP.pm line 125.
#                   'Використання енергії для людини вагою кг/ фунт'
#     doesn't match '(?^u:\{lb\})'
not ok 746 - f_nova_markers_for_nova_group translation in es contains {nova_group}
#   Failed test 'f_nova_markers_for_nova_group translation in es contains {nova_group}'
#   at lang.t line 91.
#                   'Elementos que indican que el producto se encuentra en el grupo(nova_group)'
#     doesn't match '(?^u:\{nova_group\})'
Use of uninitialized value in pattern match (m//) at lang.t line 85.
en: Elements that indicate the product is in the {nova_group} group
es: Elementos que indican que el producto se encuentra en el grupo(nova_group)
1..746
# Looks like you failed 4 tests of 746.

```