### PR TITLE
fix: tests if variable defined before use

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5408,7 +5408,7 @@ sub display_pagination($$$$) {
 	}
 	my $current_link_query = $request_ref->{current_link_query};
 
-	$log->info("current link: $current_link, current_link_query: $current_link_query") if $log->is_info();
+	$log->info("current link and current link query", { current_link => $current_link, current_link_query => $current_link_query }) if $log->is_info();
 
 	if (param("jqm")) {
 		$current_link_query .= "&jqm=1";


### PR DESCRIPTION
On the main page I was seeing the following warning:
```
[Sun May  1 16:45:15 2022] -e: Use of uninitialized value $current_link_query in concatenation (.) or string at /opt/product-opener/lib/ProductOpener/Display.pm line 5411.
```
And on the search page I was seeing:
```
[Sun May  1 16:54:12 2022] -e: Use of uninitialized value $current_link in concatenation (.) or string at /opt/product-opener/lib/ProductOpener/Display.pm line 5411.
```
This seems to be because they weren't being tested for definition, which was happening later on in the code.