### PR TITLE
chore: DE Natriumcarbonat(e) and Ammoniumcarbonat(e)

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -14814,7 +14814,7 @@ bg:E500, E500 food additive
 ca:E500, E500 food additive
 cs:E500, E500 food additive
 da:E500, Natriumcarbonater
-de:E500, Natriumcarbonate
+de:E500, Natriumcarbonat, Natriumcarbonate
 el:E500, E500 food additive
 es:E500, Carbonatos de sodio
 et:E500, E500 food additive
@@ -15302,7 +15302,7 @@ bg:E503(i), Амониев карбонат
 ca:E503(i), Carbonat d'amoni
 cs:E503(i), Uhličitan amonný
 da:E503(i), Ammoniumcarbonat
-de:E503(i), Ammoniumcarbonat
+de:E503(i), Ammoniumcarbonat, ammoniumcarbonate
 el:E503(i), Ανθρακικα αλατα του αμμωνιου
 eo:E503(i), Amonia karbonato
 es:E503(i), Carbonato de amonio, Carbonato amónico, carbonato de aminiaco


### PR DESCRIPTION
Natriumcarbonat and Ammoniumcarbonat doesn't have a "e" in German, but producers sometimes write in "Natriumcarbonate" and "Calciumcarbonate" on the packaging so I added the synonym for "Ammoniumcarbonat" and put the correct spelling first for "Natriumcarbonat".
