### PR TITLE
Add some translations for 'psyllium seed husk'

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -71557,21 +71557,21 @@ it:gambero, gamberi
 <en:vegetable fiber
 en:Psyllium, plantago, psyllium fibre, psyllium husk, psyllium seed husk
 ar:بزر قطونة
-da:Psyllium
-de:Psyllium
-es:Psilio, plantago
+da:Psyllium, psyllium skræl
+de:Psyllium, Flohsamenschalen
+es:Psilio, plantago, cáscara de semilla de psyllium
 fa:بارهنگ کتانی
-fi:psyllium, psylliumkuitu
-fr:fibres de psyllium, psyllium
+fi:psyllium, psylliumkuitu, psylliuminsiemenkuori
+fr:fibres de psyllium, psyllium, enveloppe de psyllium, enveloppes de psyllium
 he:פסיליום
 hi:isabgol
-it:psyllium
-nl:Psyllium, psylliumvezels
-pl:Babka
+it:psyllium, fibra di psillio
+nl:Psyllium, psylliumvezels, vlozaadvezels
+pl:Babka, łuski płesznika
 ro:Psyllium
 ru:Подорожник
 sd:اسپنگر
-sv:Loppfrö, psylliumfiber
+sv:Loppfrö, psylliumfiber, psylliumfröskal
 ta:Isabgol
 uk:Подорожник
 ur:اسپغول


### PR DESCRIPTION
### What

Add some translations for `psyllium seed husk`.

### Related issue(s) and discussion
French:
* `enveloppe de Psyllium` is used by Bjorg brand ([2 products referenced](https://fr.openfoodfacts.org/cgi/search.pl?action=process&tagtype_0=ingredients&tag_contains_0=contains&tag_0=enveloppe%20de%20psyllium&sort_by=unique_scans_n&page_size=20))
* `enveloppes de Psyllium` is used by Schnitzer brand ([13 products referenced](https://fr.openfoodfacts.org/cgi/search.pl?action=process&tagtype_0=ingredients&tag_contains_0=contains&tag_0=enveloppes%20de%20psyllium&sort_by=unique_scans_n&page_size=20))

I added the translations in other languages using the ingredient list of this [product](https://fr.openfoodfacts.org/produit/4022993047080/).
