### PR TITLE
fix: taxonomies API: remove synonyms from root level tags 

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1481,7 +1481,7 @@ sub build_tags_taxonomy($$$) {
 			if (defined $direct_parents{$tagtype}{$tagid}) {
 				@queue = sort keys %{$direct_parents{$tagtype}{$tagid}};
 			}
-			else {
+			elsif (not defined $just_synonyms{$tagtype}{$tagid}) {
 				# Keep track of entries that are at the root level
 				$root_entries{$tagtype}{$tagid} = 1;
 			}


### PR DESCRIPTION
This is to remove synonyms that are not tags from root level tags in the taxonomy.

e.g. in https://world.openfoodfacts.org/api/v2/taxonomy?tagtype=categories&include_root_entries=1&include_children=0&lc=en%2Cfr&cc=fr&fields=name

Remove entries like:

en:sandwich-made-with-french-bread: {
name: {
en: "Sandwich made with French bread"
}
},

Part of #6763