### PR TITLE
fix: make panel ids consistent for ingredients analysis knowledge panels

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -379,9 +379,17 @@ function display_product_summary(target, product) {
 		}
 
 		// check if the product attribute has an associated knowledge panel that exists
-		if ((attribute.panel_id) && (document.getElementById("panel_" + attribute.panel_id))) {
-			// onclick : open the panel content + reflow to make sur all column content is shown
-			card_html = '<a href="#panel_' + attribute.panel_id + '" onclick="document.getElementById(\'panel_' + attribute.panel_id + '_content\').classList.add(\'active\'); $(document).foundation(\'equalizer\', \'reflow\');"' + card_html + '</a>';
+		if (attribute.panel_id) {
+			// note: on the website, the id for the panel contains : instead of - (e.g. for the ingredients_analysis_en:vegan panel)
+			var panel_element_id = 'panel_' + attribute.panel_id.replace(':', '-');
+			if (document.getElementById(panel_element_id)) {
+				// onclick : open the panel content + reflow to make sur all column content is shown			
+				card_html = '<a href="#' + panel_element_id
+				+ '" onclick="document.getElementById(\'' + panel_element_id + '_content\').classList.add(\'active\'); $(document).foundation(\'equalizer\', \'reflow\');"' + card_html + '</a>';
+			}
+			else {
+				card_html = '<div ' + card_html + '</div>';
+			}
 		}
 		else {
 			card_html = '<div ' + card_html + '</div>';

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -312,7 +312,6 @@ sub initialize_attribute($$) {
 		my $analysis_tag = $attribute_id;
 		$analysis_tag =~ s/_/-/g;
 		$attribute_ref->{icon_url} = "$static_subdomain/images/attributes/$analysis_tag.svg";
-		$attribute_ref->{panel_id} = "ingredients_analysis_en-" . $analysis_tag;
 	}
 	elsif ($attribute_id =~ /^(labels)_(.*)$/) {
 		my $tagtype = $1;
@@ -1404,6 +1403,9 @@ sub compute_attribute_ingredients_analysis($$$) {
 	$attribute_ref->{icon_url} = "$static_subdomain/images/attributes/$analysis_tag.svg";
 	# the ingredients_analysis taxonomy contains en:palm-oil and not en:contains-palm-oil
 	$analysis_tag =~ s/contains-(.*)$/$1/;
+
+	# Link to the corresponding knowledge panel (the panel id depends on the value of the property)
+	$attribute_ref->{panel_id} = "ingredients_analysis_en:" . $analysis_tag;
 
 	if ($target_lc ne "data") {
 		$attribute_ref->{title} = display_taxonomy_tag($target_lc, "ingredients_analysis", "en:$analysis_tag");	

--- a/t/expected_test_results/attributes/en-attributes.json
+++ b/t/expected_test_results/attributes/en-attributes.json
@@ -237,7 +237,7 @@
                "id" : "vegan",
                "match" : 0,
                "name" : "Vegan",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:non-vegan",
                "status" : "known",
                "title" : "Non-vegan"
             },
@@ -247,7 +247,7 @@
                "id" : "vegetarian",
                "match" : 0,
                "name" : "Vegetarian",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:non-vegetarian",
                "status" : "known",
                "title" : "Non-vegetarian"
             },
@@ -257,7 +257,7 @@
                "id" : "palm_oil_free",
                "match" : 100,
                "name" : "Palm oil free",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil-free",
                "status" : "known",
                "title" : "Palm oil free"
             }

--- a/t/expected_test_results/attributes/en-ecoscore-score-at-20-threshold.json
+++ b/t/expected_test_results/attributes/en-ecoscore-score-at-20-threshold.json
@@ -203,7 +203,7 @@
                "icon_url" : "https://server_domain/images/attributes/vegan-status-unknown.svg",
                "id" : "vegan",
                "name" : "Vegan",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:vegan-status-unknown",
                "status" : "unknown",
                "title" : "Vegan status unknown"
             },
@@ -212,7 +212,7 @@
                "icon_url" : "https://server_domain/images/attributes/vegetarian-status-unknown.svg",
                "id" : "vegetarian",
                "name" : "Vegetarian",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:vegetarian-status-unknown",
                "status" : "unknown",
                "title" : "Vegetarian status unknown"
             },
@@ -221,7 +221,7 @@
                "icon_url" : "https://server_domain/images/attributes/palm-oil-content-unknown.svg",
                "id" : "palm_oil_free",
                "name" : "Palm oil free",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil-content-unknown",
                "status" : "unknown",
                "title" : "Palm oil content unknown"
             }

--- a/t/expected_test_results/attributes/en-maybe-vegan.json
+++ b/t/expected_test_results/attributes/en-maybe-vegan.json
@@ -220,7 +220,7 @@
                "id" : "vegan",
                "match" : 50,
                "name" : "Vegan",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:maybe-vegan",
                "status" : "known",
                "title" : "Maybe vegan"
             },
@@ -230,7 +230,7 @@
                "id" : "vegetarian",
                "match" : 50,
                "name" : "Vegetarian",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:maybe-vegetarian",
                "status" : "known",
                "title" : "Maybe vegetarian"
             },
@@ -240,7 +240,7 @@
                "id" : "palm_oil_free",
                "match" : 0,
                "name" : "Palm oil free",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil",
                "status" : "known",
                "title" : "Palm oil"
             }

--- a/t/expected_test_results/attributes/en-nova-groups-markers.json
+++ b/t/expected_test_results/attributes/en-nova-groups-markers.json
@@ -230,7 +230,7 @@
                "id" : "vegan",
                "match" : 0,
                "name" : "Vegan",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:non-vegan",
                "status" : "known",
                "title" : "Non-vegan"
             },
@@ -240,7 +240,7 @@
                "id" : "vegetarian",
                "match" : 50,
                "name" : "Vegetarian",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:maybe-vegetarian",
                "status" : "known",
                "title" : "Maybe vegetarian"
             },
@@ -250,7 +250,7 @@
                "id" : "palm_oil_free",
                "match" : 100,
                "name" : "Palm oil free",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil-free",
                "status" : "known",
                "title" : "Palm oil free"
             }

--- a/t/expected_test_results/attributes/en-nutriscore.json
+++ b/t/expected_test_results/attributes/en-nutriscore.json
@@ -224,7 +224,7 @@
                "id" : "vegan",
                "match" : 100,
                "name" : "Vegan",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:vegan",
                "status" : "known",
                "title" : "Vegan"
             },
@@ -234,7 +234,7 @@
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Vegetarian",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:vegetarian",
                "status" : "known",
                "title" : "Vegetarian"
             },
@@ -244,7 +244,7 @@
                "id" : "palm_oil_free",
                "match" : 100,
                "name" : "Palm oil free",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil-free",
                "status" : "known",
                "title" : "Palm oil free"
             }

--- a/t/expected_test_results/attributes/fr-palm-kernel-fat.json
+++ b/t/expected_test_results/attributes/fr-palm-kernel-fat.json
@@ -220,7 +220,7 @@
                "id" : "vegan",
                "match" : 100,
                "name" : "Végétalien",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:vegan",
                "status" : "known",
                "title" : "Végétalien"
             },
@@ -230,7 +230,7 @@
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:vegetarian",
                "status" : "known",
                "title" : "Végétarien"
             },
@@ -240,7 +240,7 @@
                "id" : "palm_oil_free",
                "match" : 0,
                "name" : "Sans huile de palme",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil",
                "status" : "known",
                "title" : "Huile de palme"
             }

--- a/t/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/t/expected_test_results/attributes/fr-palm-oil-free.json
@@ -220,7 +220,7 @@
                "id" : "vegan",
                "match" : 50,
                "name" : "Végétalien",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:maybe-vegan",
                "status" : "known",
                "title" : "Peut-être végétalien"
             },
@@ -230,7 +230,7 @@
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:vegetarian",
                "status" : "known",
                "title" : "Végétarien"
             },
@@ -240,7 +240,7 @@
                "id" : "palm_oil_free",
                "match" : 100,
                "name" : "Sans huile de palme",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil-free",
                "status" : "known",
                "title" : "Sans huile de palme"
             }

--- a/t/expected_test_results/attributes/fr-palm-oil.json
+++ b/t/expected_test_results/attributes/fr-palm-oil.json
@@ -220,7 +220,7 @@
                "id" : "vegan",
                "match" : 100,
                "name" : "Végétalien",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:vegan",
                "status" : "known",
                "title" : "Végétalien"
             },
@@ -230,7 +230,7 @@
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:vegetarian",
                "status" : "known",
                "title" : "Végétarien"
             },
@@ -240,7 +240,7 @@
                "id" : "palm_oil_free",
                "match" : 0,
                "name" : "Sans huile de palme",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:palm-oil",
                "status" : "known",
                "title" : "Huile de palme"
             }

--- a/t/expected_test_results/attributes/fr-vegetable-oils.json
+++ b/t/expected_test_results/attributes/fr-vegetable-oils.json
@@ -220,7 +220,7 @@
                "id" : "vegan",
                "match" : 100,
                "name" : "Végétalien",
-               "panel_id" : "ingredients_analysis_en-vegan",
+               "panel_id" : "ingredients_analysis_en:vegan",
                "status" : "known",
                "title" : "Végétalien"
             },
@@ -230,7 +230,7 @@
                "id" : "vegetarian",
                "match" : 100,
                "name" : "Végétarien",
-               "panel_id" : "ingredients_analysis_en-vegetarian",
+               "panel_id" : "ingredients_analysis_en:vegetarian",
                "status" : "known",
                "title" : "Végétarien"
             },
@@ -240,7 +240,7 @@
                "id" : "palm_oil_free",
                "match" : 50,
                "name" : "Sans huile de palme",
-               "panel_id" : "ingredients_analysis_en-palm-oil-free",
+               "panel_id" : "ingredients_analysis_en:may-contain-palm-oil",
                "status" : "known",
                "title" : "Pourrait contenir de l'huile de palme"
             }


### PR DESCRIPTION
Fixes #6810

- Panel ids for ingredients analysis properties are now all in this format: ingredients_analysis_[value of the ingredients_analysis_tag]
e.g. ingredients_analysis_en:may-contain-palm-oil
- Attributes link to the same panel ids
- On the website interface, some elements ids include the panel id (to create links). The : character is replaced by -. 