### PR TITLE
fix: defining current_link

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -643,6 +643,7 @@ elsif ($action eq 'process') {
 	}
 
 	$request_ref->{current_link_query} = $current_link;
+	$request_ref->{current_link} = $current_link;
 
 	my $html = '';
 	#$query_ref->{lc} = $lc;


### PR DESCRIPTION
In search.pl search_and_display_products is called without defining $request_ref->{current_link} resulting in a warning about an undefined variable. current_link and current_link_query appear to be the same where I see them in the logs. So defining it this way may be alright, though I haven't looked at what process_template ends up doing with template_data_ref which is where the error is coming from. I have yet to understand what current_link and current_link_query are and how they are different from another. They appear to be the path and the arguments, but I'm not sure and could use some guidance.