### PR TITLE
refactor: Refactor and document current_link / current_link_query

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -642,7 +642,6 @@ elsif ($action eq 'process') {
 		}
 	}
 
-	$request_ref->{current_link_query} = $current_link;
 	$request_ref->{current_link} = $current_link;
 
 	my $html = '';
@@ -666,7 +665,7 @@ elsif ($action eq 'process') {
 
 	if (param("generate_map")) {
 
-		$request_ref->{current_link_query} .= "&generate_map=1";
+		$request_ref->{current_link} .= "&generate_map=1";
 
 		# We want products with emb codes
 		$query_ref->{"emb_codes_tags"} = { '$exists' => 1 };
@@ -694,7 +693,7 @@ HTML
 		or param("graph")) {
 
 		$graph_ref->{type} = "scatter_plot";
-		$request_ref->{current_link_query} .= "&graph=1";
+		$request_ref->{current_link} .= "&graph=1";
 
 		# We want existing values for axis fields
 		foreach my $axis ('x','y') {
@@ -735,7 +734,7 @@ HTML
 
 		# Normal search results
 
-		$log->debug("displaying results", { current_link => $request_ref->{current_link}, current_link_query => $request_ref->{current_link_query} }) if $log->is_debug();
+		$log->debug("displaying results", { current_link => $request_ref->{current_link} }) if $log->is_debug();
 
 		${$request_ref->{content_ref}} .= $html . search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $page);
 

--- a/t/display.t
+++ b/t/display.t
@@ -44,6 +44,17 @@ $link = "/spain";
 $tag_prefix = "-";
 is ( add_tag_prefix_to_link($link,$tag_prefix),"/-spain");
 
+#test search query
+my $request_ref->{current_link} = '/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24';
+my $count = 25;
+my $limit = 24;
+my $page = 1;
+is ( display_pagination( $request_ref , $count, $limit, $page), '</ul>' . "\n" . '<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2">2</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>' . "\n");
+
+#test label query
+$request_ref->{current_link} = '/label/organic';
+is ( display_pagination( $request_ref , $count, $limit, $page), '</ul>' . "\n" . '<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/label/organic/2">2</a></li><li><a href="/label/organic/2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>' . "\n");
+
 $lc = 'en';
 my $product_ref = {
 	states           => ['en:front-photo-selected'],

--- a/templates/web/common/includes/list_of_products.tt.html
+++ b/templates/web/common/includes/list_of_products.tt.html
@@ -2,11 +2,11 @@
 <!-- start templates/[% template.name %] -->
 
 <p>[% error %]</p>
-[% IF (current_link_query.defined) && !(jqm.defined) %]
+[% IF (current_link.defined) && !(jqm.defined) %]
     [% IF country != 'en:world' %]
-        <p>&rarr; <a href= "[% world_subdomain %][% current_link_query %]"> [% lang('view_results_from_the_entire_world') %]</a></p>
+        <p>&rarr; <a href= "[% world_subdomain %][% current_link %]"> [% lang('view_results_from_the_entire_world') %]</a></p>
     [% END %]
-    &rarr; <a href="[% current_link_query %]">[% lang('search_link') %]</a><br>
+    &rarr; <a href="[% current_link %]">[% lang('search_link') %]</a><br>
 [% END %]
 [% IF (current_link_query_edit.defined) && !(jqm.defined) %]
     &rarr; <a href="[% current_link_query_edit %]">[% lang('search_edit') %]</a><br>


### PR DESCRIPTION
Potential fix for https://github.com/openfoodfacts/openfoodfacts-server/issues/6819

current_link and current_link_query appear to be the same when I saw them. The primary difference appears to have been that current_link was the current link without arguments however this was applied inconsistently. And where I saw it, it usually had arguments.

The most clear place that this difference was evident that I found was
https://github.com/openfoodfacts/openfoodfacts-server/blob/f63cb9cc0bd75ffa5526d2c1ffe63123d4633f7e/lib/ProductOpener/Display.pm#L5469
As pages can be reached both by url/<number> or url?page=<number>. The former was used when "current_link" was defined and the latter when "current_link_query" was defined. Since both were possible, it seemed reasonable to drop the index function of using /<number> and to use page=<number> exclusively. Though I may be missing some details. Also if this is the case, there may be other code that can be removed as the /<number> might not be needed anymore...Or might if anyone has previously made a link to it, and changing the code would break their link.

Since the two variables were mostly confusing because they appeared to be offering the same content, further documentation of the variable merged into one may not be necessary, though if it is, where should it be put?