### PR TITLE
feat: add explanation with category in the Nutri-Score and Eco-Score knowledge panels when not applicable

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8863,7 +8863,11 @@ sub data_to_display_nutriscore_and_nutrient_levels($) {
 				push @nutriscore_warnings, lang("nutriscore_not_applicable");
 				$result_data_ref->{nutriscore_grade} = "not-applicable";
 				$result_data_ref->{nutriscore_unknown_reason} = "not_applicable";
-				$result_data_ref->{nutriscore_unknown_reason_short} = lang("nutriscore_not_applicable_short");
+				$result_data_ref->{nutriscore_unknown_reason_short} = f_lang("f_attribute_nutriscore_not_applicable_description", {
+					category => display_taxonomy_tag_name($lc, "categories",
+						deep_get($product_ref, qw/nutriscore_data nutriscore_not_applicable_for_category/))
+				}
+			);
 		}
 		else {
 
@@ -8895,7 +8899,8 @@ sub data_to_display_nutriscore_and_nutrient_levels($) {
 		$result_data_ref->{nutriscore_warnings} = \@nutriscore_warnings;
 	}
 
-	if (defined $product_ref->{nutriscore_data}) {
+	# Display the details of the computation of the Nutri-Score if we computed one
+	if ((defined $product_ref->{nutriscore_grade}) and ($product_ref->{nutriscore_grade} =~ /^[a-e]$/)) {
 		$result_data_ref->{nutriscore_details} = display_nutriscore_calculation_details($product_ref->{nutriscore_data});
 	}
 

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -1572,7 +1572,8 @@ sub compute_nutrition_score($) {
 				if (has_tag($product_ref, "categories", $category_id)) {
 					$product_ref->{"nutrition_grades_tags"} = [ "not-applicable" ];
 					add_tag($product_ref,"misc","en:nutriscore-not-applicable");
-					$product_ref->{nutrition_score_debug} = "no nutriscore for category $category_id" . " - ";;
+					$product_ref->{nutrition_score_debug} = "no nutriscore for category $category_id" . " - ";
+					$product_ref->{nutriscore_data} = {nutriscore_not_applicable_for_category => $category_id};
 					last;
 				}
 			}

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -70,6 +70,7 @@ use ProductOpener::PackagerCodes qw/:all/;
 
 use JSON::PP;
 use Encode;
+use Data::DeepAccess qw(deep_get);
 
 =head1 FUNCTIONS
 
@@ -555,6 +556,18 @@ sub create_ecoscore_panel($$$) {
         create_panel_from_json_template("ecoscore_total", "api/knowledge-panels/environment/ecoscore/total.tt.json",
             $panel_data_ref, $product_ref, $target_lc, $target_cc);
 	}
+    # Eco-Score is not applicable
+    elsif ((defined $product_ref->{ecoscore_grade}) and ($product_ref->{ecoscore_grade} eq "not-applicable")) {
+        my $panel_data_ref = {};
+        $panel_data_ref->{subtitle} = f_lang_in_lc($target_lc, "f_attribute_ecoscore_not_applicable_description", {
+                category => display_taxonomy_tag_name($target_lc, "categories",
+                    deep_get($product_ref, qw/ecoscore_data ecoscore_not_applicable_for_category/))
+            }
+        );
+        create_panel_from_json_template("ecoscore", "api/knowledge-panels/environment/ecoscore/ecoscore_not_applicable.tt.json",
+            $panel_data_ref, $product_ref, $target_lc, $target_cc);
+    }
+    # Eco-Score is unknown
 	else {
         my $panel_data_ref = {};
         create_panel_from_json_template("ecoscore", "api/knowledge-panels/environment/ecoscore/ecoscore_unknown.tt.json",
@@ -792,8 +805,13 @@ sub create_nutriscore_panel($$$) {
 	
     my $panel_data_ref = data_to_display_nutriscore_and_nutrient_levels($product_ref);
 
-    $panel_data_ref->{title} = lang_in_other_lc($target_lc, "attribute_nutriscore_" . $panel_data_ref->{nutriscore_grade} . "_description_short");
-
+    if ($panel_data_ref->{nutriscore_grade} eq "not-applicable") {
+        $panel_data_ref->{title} = lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_title");
+    }
+    else {
+        $panel_data_ref->{title} = lang_in_other_lc($target_lc, "attribute_nutriscore_" . $panel_data_ref->{nutriscore_grade} . "_description_short");
+    }
+    
     # Nutri-Score panel: score + details
     create_panel_from_json_template("nutriscore", "api/knowledge-panels/health/nutriscore/nutriscore.tt.json",
         $panel_data_ref, $product_ref, $target_lc, $target_cc);

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -59,6 +59,7 @@ BEGIN
 		&lang
 		&lang_sprintf
 		&f_lang
+		&f_lang_in_lc
 		&lang_in_other_lc
 		%lang_lc
 
@@ -210,6 +211,10 @@ If a translation is not available, the function returns English.
 
 In the .po translation files, we use the msgctxt field for the string id.
 
+=head4 variables hash reference $variables_ref
+
+Reference to a hash that contains values for the variables that will be replaced.
+
 =cut
 
 sub f_lang($$) {
@@ -217,7 +222,44 @@ sub f_lang($$) {
 	my $stringid = shift;
 	my $variables_ref = shift;
 
-	my $translation = lang($stringid);
+	return f_lang_in_lc($lc, $stringid, $variables_ref);
+}
+
+
+=head2 f_lang_in_lc ( $target_lc, $stringid, $variables_ref )
+
+Returns a translation for a specific string id with specific arguments
+in the language $target_lc.
+
+The translation is stored using Python's f-string format with
+named parameters between { }.
+
+e.g. "This is a string with {a_variable} and {another_variable}."
+
+Variables between { } are interpolated with the corresponding entry
+in the $variables_ref hash reference.
+
+If a translation is not available, the function returns English.
+
+=head3 Arguments
+
+=head4 string id $stringid
+
+In the .po translation files, we use the msgctxt field for the string id.
+
+=head4 variables hash reference $variables_ref
+
+Reference to a hash that contains values for the variables that will be replaced.
+
+=cut
+
+sub f_lang_in_lc($$$) {
+
+	my $target_lc = shift;
+	my $stringid = shift;
+	my $variables_ref = shift;
+
+	my $translation = $Lang{$stringid}{$target_lc};
 	if (defined $translation) {
 		# look for string keys between { } and replace them with the corresponding
 		# value in $variables_ref hash reference

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5358,6 +5358,23 @@ msgctxt "delete_user_process"
 msgid "User deleted."
 msgstr "User deleted."
 
+msgctxt "attribute_ecoscore_not_applicable_title"
+msgid "Eco-Score not yet applicable"
+msgstr "Eco-Score not yet applicable"
+
+msgctxt "attribute_ecoscore_not_applicable_description_short"
+msgid "Not yet applicable for the category"
+msgstr "Not yet applicable for the category"
+
+# variable names between { } must not be translated
+msgctxt "f_attribute_ecoscore_not_applicable_description"
+msgid "Not yet applicable for the category: {category}"
+msgstr "Not yet applicable for the category: {category}"
+
+msgctxt "ecoscore_not_applicable_coming_soon"
+msgid "The Eco-Score is not yet applicable for this category, but we are working on adding support for it."
+msgstr "The Eco-Score is not yet applicable for this category, but we are working on adding support for it."
+
 msgctxt "attribute_ecoscore_unknown_title"
 msgid "Eco-Score not computed"
 msgstr "Eco-Score not computed"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4640,8 +4640,13 @@ msgid "Nutri-Score not-applicable"
 msgstr "Nutri-Score not-applicable"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
-msgid "Exempted category"
-msgstr "Exempted category"
+msgid "Not-applicable for the category"
+msgstr "Not-applicable for the category"
+
+# variable names between { } must not be translated
+msgctxt "f_attribute_nutriscore_not_applicable_description"
+msgid "Not-applicable for the category: {category}"
+msgstr "Not-applicable for the category: {category}"
 
 msgctxt "attribute_nutriscore_a_description_short"
 msgid "Very good nutritional quality"
@@ -5971,10 +5976,6 @@ msgstr "Equal to walking {minutes} minutes or {steps} steps"
 msgctxt "f_energy_expenditure_for_weight_in_kg_lb"
 msgid "Energy expenditure for a person weighting {kg} kg / {lb} lb"
 msgstr "Energy expenditure for a person weighting {kg} kg / {lb} lb"
-
-msgctxt "nutriscore_not_applicable_short"
-msgid "Not applicable for this product"
-msgstr "Not applicable for this product"
 
 msgctxt "nutriscore_missing_category_short"
 msgid "Missing category"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4660,8 +4660,13 @@ msgid "Nutri-Score not-applicable"
 msgstr "Nutri-Score not-applicable"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
-msgid "Exempted category"
-msgstr "Exempted category"
+msgid "Not-applicable for the category"
+msgstr "Not-applicable for the category"
+
+# variable names between { } must not be translated
+msgctxt "f_attribute_nutriscore_not_applicable_description"
+msgid "Not-applicable for the category: {category}"
+msgstr "Not-applicable for the category: {category}"
 
 msgctxt "attribute_nutriscore_a_description_short"
 msgid "Very good nutritional quality"
@@ -4832,6 +4837,23 @@ msgstr "Low environmental impact (Eco-Score)"
 msgctxt "attribute_ecoscore_grade_title"
 msgid "Eco-Score %s"
 msgstr "Eco-Score %s"
+
+msgctxt "attribute_ecoscore_not_applicable_title"
+msgid "Eco-Score not yet applicable"
+msgstr "Eco-Score not yet applicable"
+
+msgctxt "attribute_ecoscore_not_applicable_description_short"
+msgid "Not yet applicable for the category"
+msgstr "Not yet applicable for the category"
+
+# variable names between { } must not be translated
+msgctxt "f_attribute_ecoscore_not_applicable_description"
+msgid "Not yet applicable for the category: {category}"
+msgstr "Not yet applicable for the category: {category}"
+
+msgctxt "ecoscore_not_applicable_coming_soon"
+msgid "The Eco-Score is not yet applicable for this category, but we are working on adding support for it."
+msgstr "The Eco-Score is not yet applicable for this category, but we are working on adding support for it."
 
 msgctxt "attribute_ecoscore_unknown_title"
 msgid "Eco-Score not computed"
@@ -5993,10 +6015,6 @@ msgstr "Equal to walking {minutes} minutes or {steps} steps"
 msgctxt "f_energy_expenditure_for_weight_in_kg_lb"
 msgid "Energy expenditure for a person weighting {kg} kg / {lb} lb"
 msgstr "Energy expenditure for a person weighting {kg} kg / {lb} lb"
-
-msgctxt "nutriscore_not_applicable_short"
-msgid "Not applicable for this product"
-msgstr "Not applicable for this product"
 
 msgctxt "nutriscore_missing_category_short"
 msgid "Missing category"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5227,6 +5227,23 @@ msgctxt "delete_user_process"
 msgid "User deleted."
 msgstr "Utilisateur supprimé."
 
+msgctxt "attribute_ecoscore_not_applicable_title"
+msgid "Eco-Score not yet applicable"
+msgstr "Eco-Score pas encore applicable"
+
+msgctxt "attribute_ecoscore_not_applicable_description_short"
+msgid "Not yet applicable for the category"
+msgstr "Pas encore applicable pour la catégorie"
+
+# variable names between { } must not be translated
+msgctxt "f_attribute_ecoscore_not_applicable_description"
+msgid "Not yet applicable for the category: {category}"
+msgstr "Pas encore applicable pour la catégorie : {category}"
+
+msgctxt "ecoscore_not_applicable_coming_soon"
+msgid "The Eco-Score is not yet applicable for this category, but we are working on adding support for it."
+msgstr "L'Eco-Score n'est pas encore applicable pour cette catégorie, mais nous travaillons pour l'ajouter."
+
 msgctxt "attribute_ecoscore_unknown_title"
 msgid "Eco-Score not computed"
 msgstr "Eco-Score non calculé"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -4513,8 +4513,13 @@ msgid "Nutri-Score not-applicable"
 msgstr "Nutri-Score non applicable"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
-msgid "Exempted category"
-msgstr "Catégorie exemptée"
+msgid "Not-applicable for the category"
+msgstr "Non applicable pour la catégorie"
+
+# variable names between { } must not be translated
+msgctxt "f_attribute_nutriscore_not_applicable_description"
+msgid "Not-applicable for the category: {category}"
+msgstr "Non applicable pour la catégorie : {category}"
 
 msgctxt "attribute_nutriscore_a_description_short"
 msgid "Very good nutritional quality"

--- a/t/ecoscore.t
+++ b/t/ecoscore.t
@@ -111,6 +111,13 @@ my @tests = (
 		}
 	],
 	[
+		'exempted-category-sodas',
+		{
+			lc => "en",
+			categories_tags=>["en:sodas"],
+		}
+	],	
+	[
 		'label-organic',
 		{
 			lc => "en",

--- a/t/expected_test_results/ecoscore/exempted-category-sodas.json
+++ b/t/expected_test_results/ecoscore/exempted-category-sodas.json
@@ -1,0 +1,21 @@
+{
+   "categories_tags" : [
+      "en:sodas"
+   ],
+   "ecoscore_data" : {
+      "adjustments" : {},
+      "ecoscore_not_applicable_for_category" : "en:sodas",
+      "status" : "unknown"
+   },
+   "ecoscore_grade" : "not-applicable",
+   "ecoscore_tags" : [
+      "not-applicable"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:ecoscore-extended-data-not-computed",
+      "en:ecoscore-not-applicable",
+      "en:ecoscore-not-computed"
+   ],
+   "packagings" : []
+}

--- a/t/expected_test_results/nutriscore/en-beers-category.json
+++ b/t/expected_test_results/nutriscore/en-beers-category.json
@@ -1,0 +1,63 @@
+{
+   "categories" : "beers",
+   "categories_hierarchy" : [
+      "en:beverages",
+      "en:alcoholic-beverages",
+      "en:beers"
+   ],
+   "categories_lc" : "en",
+   "categories_properties" : {
+      "agribalyse_proxy_food_code:en" : "5000"
+   },
+   "categories_properties_tags" : [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-5000",
+      "agribalyse-proxy-food-code-known",
+      "ciqual-food-code-unknown",
+      "agribalyse-known",
+      "agribalyse-5000"
+   ],
+   "categories_tags" : [
+      "en:beverages",
+      "en:alcoholic-beverages",
+      "en:beers"
+   ],
+   "food_groups" : "en:alcoholic-beverages",
+   "food_groups_tags" : [
+      "en:alcoholic-beverages"
+   ],
+   "lc" : "en",
+   "misc_tags" : [
+      "en:nutriscore-not-computed",
+      "en:nutriscore-not-applicable"
+   ],
+   "nutriments" : {
+      "energy_100g" : 182,
+      "fat_100g" : 0,
+      "fiber_100g" : 0.5,
+      "proteins_100g" : 0.2,
+      "saturated-fat_100g" : 0,
+      "sodium_100g" : 0.2,
+      "sugars_100g" : 8.9
+   },
+   "nutriscore_data" : {
+      "nutriscore_not_applicable_for_category" : "en:alcoholic-beverages"
+   },
+   "nutrition_grades_tags" : [
+      "not-applicable"
+   ],
+   "nutrition_score_beverage" : 1,
+   "nutrition_score_debug" : "no nutriscore for category en:alcoholic-beverages",
+   "pnns_groups_1" : "Alcoholic beverages",
+   "pnns_groups_1_tags" : [
+      "alcoholic-beverages",
+      "known"
+   ],
+   "pnns_groups_2" : "Alcoholic beverages",
+   "pnns_groups_2_tags" : [
+      "alcoholic-beverages",
+      "known"
+   ]
+}

--- a/t/nutriscore.t
+++ b/t/nutriscore.t
@@ -114,6 +114,17 @@ my @tests = (
 	}
 ],
 
+# categories without Nutri-Score
+
+[
+	"en-beers-category",
+	{
+			lc => "en",
+			categories => "beers",
+			nutriments=>{energy_100g=>182, fat_100g=>0, "saturated-fat_100g"=>0, sugars_100g=>8.9, sodium_100g=>0.2, fiber_100g=>0.5, proteins_100g=>0.2},	
+	}
+],
+
 );
 
 

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -96187,6 +96187,10 @@ ru:Мясозаменители
 wikidata:en:Q1343997
 
 <en:Meat analogues
+en:Ham substituts
+fr:Substituts du jambon
+
+<en:Meat analogues
 <en:Breaded products
 en:Vegetarian cordons bleus
 fr:Cordons bleus végétariens
@@ -96205,6 +96209,11 @@ nl:Vegetarische nuggets
 en:Vegan nuggets, plant based nuggets
 fr:Nuggets végans, Nuggets végétaux, 
 nl:Veganistische nuggets, Vegan-nuggets
+
+<en:Meat analogues
+<en:Breaded products
+en:Vegetarian breaded fish substituts
+fr:Substituts du poisson pané
 
 <en:Meat analogues
 en:Veggie grounds
@@ -98389,12 +98398,16 @@ es:Quesos panelas
 fr:Fromages panelas
 #wikidata:en:
 
-<en:Meals
 en:skewers, Kebabs, kebab, kabobs, kabob, kababs, kabab
 es:Pinchos, Brochetas
 fi:vartaat
 fr:Brochettes, brochette
 nl:Spiesjes
+
+<en:Skewers
+<en:Meat alternatives
+en:Vegetarian skewers
+fr:Brochettes végétariennes
 
 <en:Specific products
 en:Edible tableware

--- a/templates/api/knowledge-panels/environment/ecoscore/ecoscore_not_applicable.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/ecoscore_not_applicable.tt.json
@@ -1,0 +1,22 @@
+{
+    "level": "info",
+    "topics": [
+        "environment"
+    ],
+    "title_element": {
+        "icon_url": "[% static_subdomain %]/images/attributes/ecoscore-unknown.svg",
+        "title": "[% lang("attribute_ecoscore_not_applicable_title") %]",
+        "subtitle": "[% panel.subtitle %]",
+        "type": "grade",
+        "grade": "unknown",
+    },
+    "elements": [
+        {
+            "element_type": "text",
+            "text_element": {
+                "type": "summary",
+                "html": "[% lang("ecoscore_not_applicable_coming_soon") %]"
+            }
+        },       
+    ]
+}


### PR DESCRIPTION
When a product does not have a Nutri-Score or an Eco-Score because the product category is excluded from the Nutri-Score and Eco-Score, we now explain why in the corresponding knowledge panel, and we list the category.

![image](https://user-images.githubusercontent.com/8158668/171434472-841ef7cd-c70f-42a7-ab86-557ab6fdbeef.png)

Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/6092 and https://github.com/openfoodfacts/openfoodfacts-server/issues/6774