### PR TITLE
fix: add back nutrition facts table title in knowledge panel

### DIFF
--- a/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
@@ -14,6 +14,7 @@
             "element_type": "table",
             "table_element": {
                 "id": "nutrition_facts_table",
+		"title": "[% lang('nutrition_data_table') %]",
                 // Create a structure to check if we already have seen a column for a given scope
                 // so that we can mark the first one as the default column for the group
                 [% SET scopes = {} %]              

--- a/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
@@ -14,7 +14,7 @@
             "element_type": "table",
             "table_element": {
                 "id": "nutrition_facts_table",
-		"title": "[% lang('nutrition_data_table') %]",
+                "title": "[% lang('nutrition_data_table') %]",
                 // Create a structure to check if we already have seen a column for a given scope
                 // so that we can mark the first one as the default column for the group
                 [% SET scopes = {} %]              


### PR DESCRIPTION
The openfoodfacts-dart package expects a non null title for the table elements in knowledge panels. This adds back the table title that was removed in https://github.com/openfoodfacts/openfoodfacts-server/pull/6839

Hot fix deployed in production as it was breaking scanning and searching in Smoothie.

Related:
https://github.com/openfoodfacts/smooth-app/issues/2203
https://github.com/openfoodfacts/openfoodfacts-dart/issues/477
