### PR TITLE
fix: use correct unit for nutrients expressed in IU or %DV 

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -288,13 +288,14 @@ sub assign_nid_modifier_value_and_unit($$$$$) {
 		$product_ref->{nutriments}{$nid . "_unit"} = $unit;
 		$product_ref->{nutriments}{$nid . "_value"} = $value;
 		
+		# Convert values passed in international units IU or % of daily value % DV to the default unit for the nutrient
 		if (((uc($unit) eq 'IU') or (uc($unit) eq 'UI')) and (defined get_property("nutrients", "zz:$nid", "iu_value:en"))) {
 			$value = $value * get_property("nutrients", "zz:$nid", "iu_value:en") ;
-			$unit = get_property("nutrients", "zz:$nid", "iu_value:en");
+			$unit = get_property("nutrients", "zz:$nid", "unit:en");
 		}
 		elsif  ((uc($unit) eq '% DV') and (defined get_property("nutrients", "zz:$nid", "dv_value:en"))) {
 			$value = $value / 100 * get_property("nutrients", "zz:$nid", "dv_value:en");
-			$unit = get_property("nutrients", "zz:$nid", "dv_value:en");
+			$unit = get_property("nutrients", "zz:$nid", "unit:en");
 		}
 		if ($nid =~ /^water-hardness(_prepared)?$/) {
 			$product_ref->{nutriments}{$nid} = unit_to_mmoll($value, $unit) + 0;

--- a/t/food.t
+++ b/t/food.t
@@ -580,4 +580,31 @@ is_deeply($product_ref,
  }
 ) or diag explain $product_ref;
 
+# Test IU and %DV values
+$product_ref = { 'nutrition_data_per' => '100g' };
+assign_nid_modifier_value_and_unit($product_ref, "vitamin-a", undef, 40, "IU");
+assign_nid_modifier_value_and_unit($product_ref, "vitamin-e", undef, 40, "IU");
+assign_nid_modifier_value_and_unit($product_ref, "calcium", undef, 20, "% DV");
+assign_nid_modifier_value_and_unit($product_ref, "vitamin-d", undef, 20, "% DV");
+
+is_deeply($product_ref,
+ {
+	nutriments => {
+		'calcium' => '0.2',
+		'calcium_unit' => '% DV',
+		'calcium_value' => 20,
+		'vitamin-a' => '1.2e-05',
+		'vitamin-a_unit' => 'IU',
+		'vitamin-a_value' => 40,
+		'vitamin-d' => '8e-06',
+		'vitamin-d_unit' => '% DV',
+		'vitamin-d_value' => 20,
+		'vitamin-e' => '0.0266666666666667',
+		'vitamin-e_unit' => 'IU',
+		'vitamin-e_value' => 40
+	 },
+   'nutrition_data_per' => '100g',
+ }
+) or diag explain $product_ref;
+
 done_testing();


### PR DESCRIPTION
I made a mistake 6 months ago when removing nutrients from Food.pm to use the nutrients taxonomy instead, and the nutrients added with %DV (daily values) or IU (International Units) were not converted correctly to grams.

This fixes it and adds some tests.

Fixes #6882