### PR TITLE
feat: redirect the press to new app blog post (nginx config)

### DIFF
--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -190,7 +190,8 @@ server {
 	location ~ ^/(.well-known|images|css|js|rss|files|resources|foundation|bower_components)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
+		gzip_static always;
+		gunzip on;
 	}
 
 	location = /robots.txt {
@@ -264,6 +265,31 @@ server {
 	location = /ecoscore {
 		return 301 https://$host/eco-score-l-impact-environnemental-des-produits-alimentaires;
 	}
+
+	# 2022-06-13 Redirect press pages to blog post about the new Flutter app
+	location = /presse {
+		return 302 https://blog.openfoodfacts.org/fr/communique-de-presse-nouvelle-appli;
+	}
+
+	location = /press {
+		return 302 https://blog.openfoodfacts.org/en/press-release-new-mobile-app;
+	}
+
+        location = /prensa {
+                return 302 https://blog.openfoodfacts.org/en/press-release-new-mobile-app;
+        }
+
+        location = /stampa {
+                return 302 https://blog.openfoodfacts.org/en/press-release-new-mobile-app;
+        }
+
+        location = /press-and-blogs {
+                return 302 https://blog.openfoodfacts.org/en/press-release-new-mobile-app;
+        }
+
+        location = /pers {
+                return 302 https://blog.openfoodfacts.org/en/press-release-new-mobile-app;
+        }
 
 
 	# Dynamically generated files and CGI scripts are passed


### PR DESCRIPTION
redirect to https://blog.openfoodfacts.org/en/press-release-new-mobile-app