### PR TITLE
fix: uninitialized value

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -743,7 +743,7 @@ HTML
 		$request_ref->{title} = lang("search_results") . " - " . display_taxonomy_tag($lc,"countries",$country);
 
 
-		#This is uesed to have a special share button on some browsers
+		#This is used to have a special share button on some browsers
 		if (not defined $request_ref->{jqm}) {
 			${$request_ref->{content_ref}} .= <<HTML
 <div class="share_button right" style="float:right;margin-top:-10px;display:none;">

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -743,11 +743,11 @@ HTML
 		$request_ref->{title} = lang("search_results") . " - " . display_taxonomy_tag($lc,"countries",$country);
 
 
-
+		#This is uesed to have a special share button on some browsers
 		if (not defined $request_ref->{jqm}) {
 			${$request_ref->{content_ref}} .= <<HTML
 <div class="share_button right" style="float:right;margin-top:-10px;display:none;">
-<a href="$request_ref->{current_link_query_display}&amp;action=display" class="button small" title="$request_ref->{title}">
+<a href="$request_ref->{current_link}&amp;action=display" class="button small" title="$request_ref->{title}">
 	@{[ display_icon('share') ]}
 	<span class="show-for-large-up"> $share</span>
 </a></div>

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -747,7 +747,7 @@ HTML
 		if (not defined $request_ref->{jqm}) {
 			${$request_ref->{content_ref}} .= <<HTML
 <div class="share_button right" style="float:right;margin-top:-10px;display:none;">
-<a href="$request_ref->{current_link}&amp;action=display" class="button small" title="$request_ref->{title}">
+<a href="$request_ref->{current_link}" class="button small" title="$request_ref->{title}">
 	@{[ display_icon('share') ]}
 	<span class="show-for-large-up"> $share</span>
 </a></div>


### PR DESCRIPTION
Add conditional as without it this will make a dead link resulting in a 404

It is not clear to me what the link in this section does and it is not visible on the page. It may be used for search engines? 
If `$request_ref->{current_link_query_display}` isn't defined, and we select the link in the source, it leads to a 404. As it stands without that defined it appears to be broken, though I'm not certain that we don't want this information here even with a dead link. Perhaps we want something more like `$request_ref->{current_link}`?