### PR TITLE
fix: $request_ref->{count} not used

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -768,7 +768,7 @@ HTML
 		if (param('search_terms')) {
 			open (my $OUT, ">>:encoding(UTF-8)", "$data_root/logs/search_log");
 			print $OUT remote_addr() . "\t" . time() . "\t" . decode utf8=>param('search_terms')
-				. "\tpage: $page\tcount:" . $request_ref->{count} . "\n";
+				. "\tpage: $page\n";
 			close ($OUT);
 		}
 	}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6473,7 +6473,6 @@ sub search_and_graph_products($$$) {
 
 	my @products = $cursor->all;
 	my $count = @products;
-	$request_ref->{count} = $count;
 
 	my $html = '';
 
@@ -6607,7 +6606,6 @@ sub search_and_map_products($$$) {
 
 	my @products = $cursor->all;
 	my $count = @products;
-	$request_ref->{count} = $count;
 
 	my $html = '';
 
@@ -11092,7 +11090,6 @@ sub search_and_analyze_recipes($$) {
 
 	my @products = $cursor->all;
 	my $count = @products;
-	$request_ref->{count} = $count;
 
 	my $html = '';
 


### PR DESCRIPTION
$request_ref->{count} shows up 4 times in the code. Though it never appears to be used as three of the times that it appears it is only to define it. The remaining instance that it appears such that it is referenced, does not seem to benefit from the previous three instances where the value is defined. As such this appears to be unused. This commit removes all four instances.
