### PR TITLE
test: unit test for url_for_text

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -325,6 +325,7 @@ my $user_preferences;	# enables using user preferences to show a product summary
 =head2 url_for_text ( $textid )
 
 Return the localized URL for a text. (e.g. "data" points to /data in English and /donnees in French)
+Note: This currently only has ecoscore
 
 =cut
 

--- a/t/display.t
+++ b/t/display.t
@@ -44,6 +44,20 @@ $link = "/spain";
 $tag_prefix = "-";
 is ( add_tag_prefix_to_link($link,$tag_prefix),"/-spain");
 
+#test for URL localization
+#test for path not existing in urls_for_text
+my $textid = '/doesnotexist';
+is (url_for_text($textid), '/doesnotexist');
+
+# test a language other than default (en)
+$textid = '/ecoscore';
+$lc = 'es';
+is (url_for_text($textid), '/eco-score-el-impacto-medioambiental-de-los-productos-alimenticios');
+
+# test for language that does not exist (test defaults to en)
+$lc = 'does not exist';
+is (url_for_text($textid), '/eco-score-the-environmental-impact-of-food-products');
+
 #test search query
 my $request_ref->{current_link} = '/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24';
 my $count = 25;


### PR DESCRIPTION
$lc appears to default to German (de), though how would we test other language codes? Changing $lc in display.t doesn't seem to have an effect. How might we test other languages?