### PR TITLE
fix: Uninitialized value in concatenation warning in ./cgi/search.pl

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -767,7 +767,7 @@ HTML
 		if (param('search_terms')) {
 			open (my $OUT, ">>:encoding(UTF-8)", "$data_root/logs/search_log");
 			print $OUT remote_addr() . "\t" . time() . "\t" . decode utf8=>param('search_terms')
-				. "\tpage: $page\tcount:" . $request_ref->{count} . "\n";
+				. "page: $page\n"
 			close ($OUT);
 		}
 	}


### PR DESCRIPTION
### What it does
I was seeing the error below in the logs.
`[Fri Jun 17 14:21:20 2022] -e: Use of uninitialized value in concatenation (.) or string at /opt/product-opener/cgi/search.pl line 771.`

The change seems to resolve this warning
- Fixes #

