### PR TITLE
fix: "refined wheat flour" and "maida" should be recognized as a type of flour

### DIFF
--- a/t/ingredients_analysis.t
+++ b/t/ingredients_analysis.t
@@ -32,6 +32,8 @@ my @tests = (
 [ { lc => "fr", ingredients_text => "huiles végétales (huile de tournesol', huile de colza)" }, [ "en:palm-oil-free", "en:vegan", "en:vegetarian"] ],
 [ { lc => "fr", ingredients_text => "huiles végétales" }, [ "en:may-contain-palm-oil", "en:vegan", "en:vegetarian"] ],
 [ { lc => "fr", ingredients_text => "huile de poisson" }, [ "en:palm-oil-free", "en:non-vegan", "en:non-vegetarian"] ],
+[ { lc => "en", ingredients_text => "maida, refined wheat flour" }, [ "en:palm-oil-free", "en:vegan", "en:vegetarian"] ],
+
 
 # labels overrides
 

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -54558,6 +54558,9 @@ es:Harinas de trigo escaña cultivada, Harinas de escaña
 fr:Farines de petit épeautre, Farines d'engrain
 nl:Eenkoornmelen
 
+<en:Wheat flours
+en:refined wheat flour, maida
+
 <en:Einkorn wheat flours
 <en:Wheat flour T405
 en:Small spelt flour T45

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -23983,6 +23983,9 @@ fr:Farine de froment T55, Farine de froment T55 pour pains
 fr:farine de blé type 65, farine de blé t65
 nl:tarwemeel T65
 
+<en:wheat flour
+en:refined wheat flour, maida
+
 <fr:farine de blé type 65
 en:Wheat flour type 65, Wheat flour T65
 fr:Farine de blé tendre T65


### PR DESCRIPTION
### What
- Refined wheat flour and _maida_ are two terms that are used interchangeably to refer to white colored/all-purpose flour in the Indian subcontinent.

### Related issue(s) and discussion
- Related Discussion #6540 

