### PR TITLE
feat: "edible" should be recognized as a stop word

### DIFF
--- a/t/tags.t
+++ b/t/tags.t
@@ -496,6 +496,7 @@ is(ProductOpener::Tags::remove_stopwords("ingredients", "fr", "yaourt-a-la-frais
 is(ProductOpener::Tags::remove_stopwords("ingredients", "fr", "du-miel"), "miel");
 is(ProductOpener::Tags::remove_stopwords("ingredients", "fr", "fruits-en-proportion-variable"), "fruits");
 is(ProductOpener::Tags::remove_stopwords("ingredients", "fr", "des-de-tomate"), "des-de-tomate");
+is(ProductOpener::Tags::remove_stopwords("ingredients", "en", "edible-vegetable-oil"), "vegetable-oil");
 
 my $tag_ref = get_taxonomy_tag_and_link_for_lang("fr", "categories", "en:strawberry-yogurts");
 is_deeply($tag_ref, {

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -15,7 +15,7 @@ stopwords:ca:i,de
 stopwords:da:av, af, blandt andet, bl a, inklusive, heraf, indeholder, tilsat
 stopwords:de:und, mit, von, aus, enthält, enthalten, mindestens, in veränderlichen gewichtsanteilen
 stopwords:el:περιέχει
-stopwords:en:contains, contain, from, with, produced with, with added, minimum,including, inter alia
+stopwords:en:contains, contain, from, with, produced with, with added, minimum,including, inter alia, edible
 stopwords:es:contiene,de,del,la,el,las,los,con,y,e,en,minimo,maximo,puede,contener,por,categoria,calibre,minimo,min,vereidad,de cultivo,origen,nota,produccion,controlada
 stopwords:fi:sisältää,muun muassa,valio, koskenlaskija, snellmanin, jossa, noin, käymisen aikana muodostuva
 stopwords:fr:aux,au,de,le,du,la,a,et,avec,ou,en,proportion,variable, contient, élaboré avec, papier traité, minimum, filets tournants et filets, pour souleves,dont,avec,autres,d'autres,d', avec ajout, sachet


### PR DESCRIPTION
### What
This PR adds a unit test for checking the implemented fix and appends _"edible"_ to the list of English **_"stopwords"_**

Observing in issue #6941, most of the unknown-tagged ingredients could be fixed if we ignore the word **_edible_**.

- commit-1: Added a test that should break unless a fix is implemented. **[Confirmed it breaks]**
- commit-2: Added edible to the list of English stopwords

### Related issue(s) and discussion
- Fixes #6941

