### PR TITLE
fix: display_structured_response syntax

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10390,16 +10390,13 @@ sub display_structured_response($)
 			$jsonp = param('callback');
 		}
 
-		if (defined $jsonp) {
-			$jsonp =~ s/[^a-zA-Z0-9_]//g;
-		}
-
 		my $status = $request_ref->{status};
 		if (defined $status) {
 			print header ( -status => $status );
 		}
 
 		if (defined $jsonp) {
+			$jsonp =~ s/[^a-zA-Z0-9_]//g;
 			print header( -type => 'text/javascript', -charset => 'utf-8', -access_control_allow_origin => '*' ) . $jsonp . "(" . $data . ");" ;
 		}
 		else {


### PR DESCRIPTION
There seemed to be two of the same if statements:

`if (defined $jsonp) {`

So I combined the two