### PR TITLE
refactor: removing possibly redundant subs

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6742,23 +6742,6 @@ sub display_on_the_blog($)
 	return;
 }
 
-
-
-sub display_top_block($)
-{
-	my $blocks_ref = shift;
-
-	if (defined $Lang{top_content}{$lang}) {
-		unshift @{$blocks_ref}, {
-			'title'=>lang("top_title"),
-			'content'=>lang("top_content"),
-		};
-	}
-
-	return;
-}
-
-
 sub display_bottom_block($)
 {
 	my $blocks_ref = shift;
@@ -6775,8 +6758,6 @@ sub display_bottom_block($)
 
 	return;
 }
-
-
 
 sub display_page($) {
 

--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -434,11 +434,4 @@ sub org_url($) {
 	return canonicalize_tag_link("orgs", $org_ref->{org_id});
 }
 
-sub org_link($) {
-	
-	my $org_ref = shift;
-	
-	return "<a href=\"" . org_url($org_ref) . "\">" . org_name($org_ref) . "</a>";
-}
-
 1;


### PR DESCRIPTION
### What
1. `display_top_block()` only had a usage in some commented-out code.
2. `org_link()` seems to be unused.

