### PR TITLE
refactor: removing unused export

### DIFF
--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -58,7 +58,6 @@ BEGIN
 
 		&org_name
 		&org_url
-		&org_link
 
 		);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);


### PR DESCRIPTION
The associated function was removed in 6d2d1ba74ec8e475b9094b6204f62030d08d516b, cleaning up leftover export line.