### PR TITLE
docs: add documentation for some methods in `user.pm` and `products.pm` 

### DIFF
--- a/lib/ProductOpener/Index.pm
+++ b/lib/ProductOpener/Index.pm
@@ -169,28 +169,6 @@ sub normalize($) {
 	return $s;
 }
 
-
-sub decode_html($)
-{
-	my $string = shift;
-
-	my $encoding = "windows-1252";
-	if ($string =~ /charset=(.?)utf(-?)8/i) {
-		$encoding = "UTF-8";
-	}
-
-	my $utf8 = $string;
-	if (not utf8::is_utf8($string)) {
-		$utf8 = decode($encoding, $string);
-	}
-
-	$log->debug("decoding", { encoding => $encoding }) if $log->is_debug();
-	$utf8 = decode_entities($utf8);
-
-	return $utf8;
-}
-
-
 sub decode_html_entities($)
 {
 	my $string = shift;

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -241,7 +241,7 @@ sub assign_new_code() {
 =head2 normalize_code()
 
 C<normalize_code()> this function normalizes the product code by:
-- Keeps only digits and removes spaces/dahes etc.
+- Keeps only digits and removes spaces/dashes etc.
 - Normalizes the length by adding leading zeroes or removing the leading zero (in case of 14 digit codes)
 
 =head3 Arguments

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -341,7 +341,11 @@ e.g. off:[code]
 
 =head3 Parameters
 
-$Owner id & $code [Product barcode]
+=head4 Owner id
+
+=head4 Code 
+
+Product barcode
 
 In most cases, pass $Owner_id which is initialized by ProductOpener::Users::init_user()
 
@@ -380,7 +384,8 @@ Returns the server for the product, if it is not on the current server.
 
 =head3 Parameters
 
-$product_id
+=head4 $product_id
+
 Product id of the form [code], [owner-id]/[code], or [server-id]:[code] or [server-id]:[owner-id]/[code]
 
 =head3 Return values
@@ -410,8 +415,9 @@ Returns the data root for the product, possibly on another server.
 
 =head3 Parameters
 
-$product_id
-- Product id of the form [code], [owner-id]/[code], or [server-id]:[code]
+=head4 $product_id
+
+Product id of the form [code], [owner-id]/[code], or [server-id]:[code]
 
 =head3 Return values
 
@@ -442,8 +448,9 @@ Returns the www root for the product, possibly on another server.
 
 =head3 Parameters
 
-$product_id
-- Product id of the form [code], [owner-id]/[code], or [server-id]:[code]
+=head4 $product_id
+
+Product id of the form [code], [owner-id]/[code], or [server-id]:[code]
 
 =head3 Return values
 
@@ -1549,7 +1556,8 @@ to determine if the change was done through an app, the OFF userid, or an app sp
 
 =head3 Parameters
 
-$change_ref reference to a change record
+=head4 $change_ref 
+reference to a change record
 
 =head3 Return value
 
@@ -2425,7 +2433,7 @@ This function is called by the web/panels/panel.tt.html template for knowledge p
 
 =head3 Parameters
 
-Product code or reference to product object $code_or_ref
+=head4 Product code or reference to product object $code_or_ref
 
 =cut
 
@@ -3014,9 +3022,9 @@ e.g. official producer data that should not be changed by anonymous users throug
 Product data is protected if it has an owner and if the corresponding organization has
 the "protect data" checkbox checked.
 
-=head3 Parameters
+=head3 Parameters 
 
-$product_ref
+=head4 $product_ref
 
 =head3 Return values
 


### PR DESCRIPTION
### What
- Documenting `products.pm` and `user.pm` methods
- removal of a possibly unused sub in `Index.pm`
- proposal to remove[ this ](https://github.com/openfoodfacts/openfoodfacts-server/compare/docs/po-modules?expand=1#diff-d6b9a7ba08e9ecb060d8284b1bd62bcd2861eccd7d3f65f479830b915c679761R2201) (has only been utilized in an obsolete script) 



