### PR TITLE
refactor: remove add_users_team unused export

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -112,7 +112,6 @@ BEGIN
 
 		&find_and_replace_user_id_in_products
 
-		&add_users_team
 		);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }


### PR DESCRIPTION
add_users_team gets exported but there is no associated function. Possibly a typo from 0dc31de78cd, supposed to be add_user_teams not add_users_team?