### PR TITLE
feat: parse origins of ingredients field

### DIFF
--- a/t/expected_test_results/ingredients/en-origin-field.json
+++ b/t/expected_test_results/ingredients/en-origin-field.json
@@ -1,0 +1,146 @@
+{
+   "ingredients" : [
+      {
+         "id" : "en:strawberry",
+         "origins" : "en:spain",
+         "percent_estimate" : 58.3333333333333,
+         "percent_max" : 100,
+         "percent_min" : 16.6666666666667,
+         "text" : "Strawberries",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:raspberry",
+         "origins" : "en:new-caledonia",
+         "percent_estimate" : 20.8333333333333,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "raspberries",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:blueberry",
+         "origins" : "en:canada",
+         "percent_estimate" : 10.4166666666667,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "blueberries",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:gooseberry",
+         "percent_estimate" : 5.20833333333333,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "text" : "gooseberries",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:white-peach",
+         "origins" : "en:mexico",
+         "percent_estimate" : 2.60416666666666,
+         "percent_max" : 20,
+         "percent_min" : 0,
+         "text" : "white peaches",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:bell-pepper",
+         "origins" : "en:guatemala",
+         "percent_estimate" : 2.60416666666666,
+         "percent_max" : 16.6666666666667,
+         "percent_min" : 0,
+         "text" : "bell peppers",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {},
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:strawberry",
+      "en:fruit",
+      "en:berries",
+      "en:raspberry",
+      "en:blueberry",
+      "en:gooseberry",
+      "en:white-peach",
+      "en:peach",
+      "en:bell-pepper",
+      "en:vegetable"
+   ],
+   "ingredients_n" : 6,
+   "ingredients_n_tags" : [
+      "6",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:strawberry",
+      "en:raspberry",
+      "en:blueberry",
+      "en:gooseberry",
+      "en:white-peach",
+      "en:bell-pepper"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:strawberry",
+      "en:fruit",
+      "en:berries",
+      "en:raspberry",
+      "en:blueberry",
+      "en:gooseberry",
+      "en:white-peach",
+      "en:peach",
+      "en:bell-pepper",
+      "en:vegetable"
+   ],
+   "ingredients_text" : "Strawberries (Spain), raspberries, blueberries, gooseberries, white peaches, bell peppers. Origin of bell peppers: Guatemala",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 6,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "known_ingredients_n" : 10,
+   "lc" : "en",
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 16.6666666666667,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 16.6666666666667
+   },
+   "origin_en" : "Origin of raspberries: New Caledonia. Blueberries: Canada ; White peaches : Mexico",
+   "specific_ingredients" : [
+      {
+         "id" : "en:raspberry",
+         "ingredient" : "raspberries",
+         "origins" : "en:new-caledonia",
+         "text" : "Origin of raspberries: New Caledonia."
+      },
+      {
+         "id" : "en:blueberry",
+         "ingredient" : "Blueberries",
+         "origins" : "en:canada",
+         "text" : "Blueberries: Canada ;"
+      },
+      {
+         "id" : "en:white-peach",
+         "ingredient" : "White peaches ",
+         "origins" : "en:mexico",
+         "text" : "White peaches : Mexico"
+      },
+      {
+         "id" : "en:bell-pepper",
+         "ingredient" : "bell peppers",
+         "origins" : "en:guatemala",
+         "text" : "Origin of bell peppers: Guatemala"
+      }
+   ],
+   "unknown_ingredients_n" : 0
+}

--- a/t/expected_test_results/ingredients/fr-origin-field.json
+++ b/t/expected_test_results/ingredients/fr-origin-field.json
@@ -196,7 +196,7 @@
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
       "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0
    },
-   "origin_fr" : "Origine des coquillettes : Italie. Origine du Comté AOP 4 mois : France. Origine du jambon supérieur : France. Origine du Vin blanc : Europe. Origine Crème UHT : France. Origine du parmesan : Italie. Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.",
+   "origin_fr" : "Origine des coquillettes : Italie. Origine du Comté AOP 4 mois : France. Origine du jambon supérieur : France. Vin blanc : Europe. Origine Crème UHT : France. Origine du parmesan : Italie. Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.",
    "specific_ingredients" : [
       {
          "id" : "fr:coquillettes",
@@ -217,16 +217,22 @@
          "text" : "Origine du jambon supérieur : France."
       },
       {
-         "id" : "en:white-wine",
-         "ingredient" : "Vin blanc",
-         "origins" : "en:europe",
-         "text" : "Origine du Vin blanc : Europe."
-      },
-      {
          "id" : "en:parmesan",
          "ingredient" : "parmesan",
          "origins" : "en:italy",
          "text" : "Origine du parmesan : Italie."
+      },
+      {
+         "id" : "en:white-wine",
+         "ingredient" : "Vin blanc",
+         "origins" : "en:europe",
+         "text" : "Vin blanc : Europe."
+      },
+      {
+         "id" : "fr:Origine Crème UHT",
+         "ingredient" : "Origine Crème UHT",
+         "origins" : "en:france",
+         "text" : "Origine Crème UHT : France."
       },
       {
          "id" : "en:pepper",

--- a/t/expected_test_results/ingredients/fr-origin-field.json
+++ b/t/expected_test_results/ingredients/fr-origin-field.json
@@ -1,0 +1,239 @@
+{
+   "ingredients" : [
+      {
+         "id" : "fr:Coquillettes",
+         "percent_estimate" : 54.5454545454545,
+         "percent_max" : 100,
+         "percent_min" : 9.09090909090909,
+         "text" : "Coquillettes"
+      },
+      {
+         "id" : "en:comte",
+         "percent_estimate" : 22.7272727272727,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "comté",
+         "vegan" : "no",
+         "vegetarian" : "maybe"
+      },
+      {
+         "id" : "fr:jambon supérieur",
+         "origins" : "en:france",
+         "percent_estimate" : 11.3636363636364,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "jambon supérieur"
+      },
+      {
+         "id" : "en:white-wine",
+         "origins" : "en:europe",
+         "percent_estimate" : 5.68181818181818,
+         "percent_max" : 25,
+         "percent_min" : 0,
+         "text" : "vin blanc",
+         "vegan" : "maybe",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:red-wine",
+         "origins" : "en:italy",
+         "percent_estimate" : 2.84090909090909,
+         "percent_max" : 20,
+         "percent_min" : 0,
+         "text" : "vin rouge",
+         "vegan" : "maybe",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:rose-wine",
+         "origins" : "en:spain",
+         "percent_estimate" : 1.42045454545455,
+         "percent_max" : 16.6666666666667,
+         "percent_min" : 0,
+         "text" : "vin rosé",
+         "vegan" : "maybe",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:uht-cream",
+         "percent_estimate" : 0.710227272727273,
+         "percent_max" : 14.2857142857143,
+         "percent_min" : 0,
+         "text" : "crème UHT",
+         "vegan" : "no",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:parmesan",
+         "origins" : "en:italy",
+         "percent_estimate" : 0.35511363636364,
+         "percent_max" : 12.5,
+         "percent_min" : 0,
+         "text" : "parmesan",
+         "vegan" : "no",
+         "vegetarian" : "maybe"
+      },
+      {
+         "id" : "en:ricotta",
+         "origins" : "en:italy",
+         "percent_estimate" : 0.17755681818182,
+         "percent_max" : 11.1111111111111,
+         "percent_min" : 0,
+         "text" : "ricotta",
+         "vegan" : "no",
+         "vegetarian" : "maybe"
+      },
+      {
+         "id" : "en:salt",
+         "percent_estimate" : 0.0887784090909065,
+         "percent_max" : 10,
+         "percent_min" : 0,
+         "text" : "sel",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:pepper",
+         "origins" : "en:nepal",
+         "percent_estimate" : 0.0887784090909065,
+         "percent_max" : 9.09090909090909,
+         "percent_min" : 0,
+         "text" : "poivre",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:non-vegan" : [
+         "en:comte",
+         "en:uht-cream",
+         "en:parmesan",
+         "en:ricotta"
+      ],
+      "en:palm-oil-content-unknown" : [
+         "fr:Coquillettes",
+         "fr:jambon supérieur"
+      ],
+      "en:vegan-status-unknown" : [
+         "fr:Coquillettes",
+         "fr:jambon supérieur"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "fr:Coquillettes",
+         "fr:jambon supérieur"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "fr:Coquillettes",
+      "en:comte",
+      "en:dairy",
+      "en:cheese",
+      "fr:jambon supérieur",
+      "en:white-wine",
+      "en:alcohol",
+      "en:wine",
+      "en:red-wine",
+      "en:rose-wine",
+      "en:uht-cream",
+      "en:cream",
+      "en:parmesan",
+      "en:ricotta",
+      "en:salt",
+      "en:pepper",
+      "en:seed"
+   ],
+   "ingredients_n" : 11,
+   "ingredients_n_tags" : [
+      "11",
+      "11-20"
+   ],
+   "ingredients_original_tags" : [
+      "fr:Coquillettes",
+      "en:comte",
+      "fr:jambon supérieur",
+      "en:white-wine",
+      "en:red-wine",
+      "en:rose-wine",
+      "en:uht-cream",
+      "en:parmesan",
+      "en:ricotta",
+      "en:salt",
+      "en:pepper"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "fr:coquillettes",
+      "en:comte",
+      "en:dairy",
+      "en:cheese",
+      "fr:jambon-superieur",
+      "en:white-wine",
+      "en:alcohol",
+      "en:wine",
+      "en:red-wine",
+      "en:rose-wine",
+      "en:uht-cream",
+      "en:cream",
+      "en:parmesan",
+      "en:ricotta",
+      "en:salt",
+      "en:pepper",
+      "en:seed"
+   ],
+   "ingredients_text" : "Coquillettes, comté, jambon supérieur, vin blanc, vin rouge (italie), vin rosé (origine : Espagne), crème UHT, parmesan, ricotta (origine Italie), sel, poivre. Origine du poivre: Népal.",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 11,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "known_ingredients_n" : 15,
+   "lc" : "fr",
+   "nutriments" : {
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0
+   },
+   "origin_fr" : "Origine des coquillettes : Italie. Origine du Comté AOP 4 mois : France. Origine du jambon supérieur : France. Origine du Vin blanc : Europe. Origine Crème UHT : France. Origine du parmesan : Italie. Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.",
+   "specific_ingredients" : [
+      {
+         "id" : "fr:coquillettes",
+         "ingredient" : "coquillettes",
+         "origins" : "en:italy",
+         "text" : "Origine des coquillettes : Italie."
+      },
+      {
+         "id" : "fr:Comté AOP 4 mois",
+         "ingredient" : "Comté AOP 4 mois",
+         "origins" : "en:france",
+         "text" : "Origine du Comté AOP 4 mois : France."
+      },
+      {
+         "id" : "fr:jambon supérieur",
+         "ingredient" : "jambon supérieur",
+         "origins" : "en:france",
+         "text" : "Origine du jambon supérieur : France."
+      },
+      {
+         "id" : "en:white-wine",
+         "ingredient" : "Vin blanc",
+         "origins" : "en:europe",
+         "text" : "Origine du Vin blanc : Europe."
+      },
+      {
+         "id" : "en:parmesan",
+         "ingredient" : "parmesan",
+         "origins" : "en:italy",
+         "text" : "Origine du parmesan : Italie."
+      },
+      {
+         "id" : "en:pepper",
+         "ingredient" : "poivre",
+         "origins" : "en:nepal",
+         "text" : "Origine du poivre: Népal"
+      }
+   ],
+   "unknown_ingredients_n" : 2
+}

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -422,8 +422,17 @@ Teneur en citron de 5,5%",
 			lc => "en",
 			ingredients_text => "milk, some unknown ingredient, another unknown ingredient, salt, sugar, pepper, spices, water",
 		}
-	],	
+	],
 
+	# origins field
+	[
+		"fr-origin-field",
+		{
+			lc => "fr",
+			ingredients_text => "Coquillettes, comté, jambon supérieur, vin blanc, vin rouge (italie), vin rosé (origine : Espagne), crème UHT, parmesan, ricotta (origine Italie), sel, poivre. Origine du poivre: Népal.",
+			origin_fr => "Origine des coquillettes : Italie. Origine du Comté AOP 4 mois : France. Origine du jambon supérieur : France. Origine du Vin blanc : Europe. Origine Crème UHT : France. Origine du parmesan : Italie. Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.",
+		}
+	],
 );
 
 

--- a/t/ingredients.t
+++ b/t/ingredients.t
@@ -425,12 +425,23 @@ Teneur en citron de 5,5%",
 	],
 
 	# origins field
+	# also test an ingredient with 2 words: bell peppers, which used to break.
+	[
+		"en-origin-field",
+		{
+			lc => "en",
+			ingredients_text => "Strawberries (Spain), raspberries, blueberries, gooseberries, white peaches, bell peppers. Origin of bell peppers: Guatemala",
+			origin_en => "Origin of raspberries: New Caledonia. Blueberries: Canada ; White peaches : Mexico",
+		}
+	],	
+
+	# origins field
 	[
 		"fr-origin-field",
 		{
 			lc => "fr",
 			ingredients_text => "Coquillettes, comté, jambon supérieur, vin blanc, vin rouge (italie), vin rosé (origine : Espagne), crème UHT, parmesan, ricotta (origine Italie), sel, poivre. Origine du poivre: Népal.",
-			origin_fr => "Origine des coquillettes : Italie. Origine du Comté AOP 4 mois : France. Origine du jambon supérieur : France. Origine du Vin blanc : Europe. Origine Crème UHT : France. Origine du parmesan : Italie. Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.",
+			origin_fr => "Origine des coquillettes : Italie. Origine du Comté AOP 4 mois : France. Origine du jambon supérieur : France. Vin blanc : Europe. Origine Crème UHT : France. Origine du parmesan : Italie. Fabriqué en France. Tomates d'Italie. Origine du riz : Inde, Thaïlande.",
 		}
 	],
 );


### PR DESCRIPTION
Fixes partially #4461 (we could add support for more ways to describe ingredients, like "Strawberries from Spain").

Needed in particular for one producer who sent us data in the origins of ingredients field, in order to have it used for the Eco-Score computations.