### PR TITLE
fix: uninitialized value

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6822,10 +6822,6 @@ sub display_page($) {
 
 	${$content_ref} =~ s/<SITE>/$site/g;
 
-	$title =~ s/<SITE>/$site/g;
-
-	$title =~ s/<([^>]*)>//g;
-
 	my $textid = undef;
 	if ((defined $description) and ($description =~ /^textid:/)) {
 		$textid = $';
@@ -6843,6 +6839,10 @@ sub display_page($) {
 
 	my $canon_title = '';
 	if (defined $title) {
+		$title =~ s/<SITE>/$site/g;
+
+		$title =~ s/<([^>]*)>//g;
+
 		$title = remove_tags_and_quote($title);
 	}
 	my $canon_description = '';


### PR DESCRIPTION
When clicking on the Advanced Search button, two warnings would appear:
```
[Fri Jul  1 16:34:41 2022] -e: Use of uninitialized value $title in substitution (s///) at /opt/product-opener/lib/ProductOpener/Display.pm line 6825.
[Fri Jul  1 16:34:41 2022] -e: Use of uninitialized value $title in substitution (s///) at /opt/product-opener/lib/ProductOpener/Display.pm line 6827.
```
This was because $title was empty, so I put the lines that were causing the error:
```
$title =~ s/<SITE>/$site/g;
$title =~ s/<([^>]*)>//g;
```
In the conditional below them:
```
if (defined $title) {`