### PR TITLE
refactor: add helper function to identify if a product bears a certain tag from a passed list

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8302,47 +8302,17 @@ HTML
 ;
 
 	}
-	elsif (($lc eq 'fr') and (has_tag($product_ref, "categories","en:baby-milks")) and (
+	elsif (($lc eq 'fr') and (has_tag($product_ref, "categories","en:baby-milks")) and (has_baby_brand_tag($product_ref))) 
+	{
 
-		has_tag($product_ref, "brands", "amilk") or
-		has_tag($product_ref, "brands", "babycare") or
-		has_tag($product_ref, "brands", "celia") or
-		has_tag($product_ref, "brands", "celia-ad") or
-		has_tag($product_ref, "brands", "celia-develop") or
-		has_tag($product_ref, "brands", "celia-expert") or
-		has_tag($product_ref, "brands", "celia-nutrition") or
-		has_tag($product_ref, "brands", "enfastar") or
-		has_tag($product_ref, "brands", "fbb") or
-		has_tag($product_ref, "brands", "fl") or
-		has_tag($product_ref, "brands", "frezylac") or
-		has_tag($product_ref, "brands", "gromore") or
-		has_tag($product_ref, "brands", "malyatko") or
-		has_tag($product_ref, "brands", "mamy") or
-		has_tag($product_ref, "brands", "milumel") or
-		has_tag($product_ref, "brands", "neoangelac") or
-		has_tag($product_ref, "brands", "neoangelac") or
-		has_tag($product_ref, "brands", "nophenyl") or
-		has_tag($product_ref, "brands", "novil") or
-		has_tag($product_ref, "brands", "ostricare") or
-		has_tag($product_ref, "brands", "pc") or
-		has_tag($product_ref, "brands", "picot") or
-		has_tag($product_ref, "brands", "sanutri")
-
-
-	)
-
-
-
-	) {
-
-		$html .= <<HTML
-<div id="warning_lactalis_201712" style="display: block; background:#ffcc33;color:black;padding:1em;text-decoration:none;">
-Certains produits de cette marque font partie d'une liste de produits retirés du marché.
-<br><br>
-&rarr; <a href="http://www.lactalis.fr/wp-content/uploads/2017/12/ici-1.pdf">Liste des produits et lots concernés</a> sur le site de <a href="http://www.lactalis.fr/information-consommateur/">Lactalis</a>.
-</div>
-HTML
-;
+			$html .= <<HTML
+	<div id="warning_lactalis_201712" style="display: block; background:#ffcc33;color:black;padding:1em;text-decoration:none;">
+	Certains produits de cette marque font partie d'une liste de produits retirés du marché.
+	<br><br>
+	&rarr; <a href="http://www.lactalis.fr/wp-content/uploads/2017/12/ici-1.pdf">Liste des produits et lots concernés</a> sur le site de <a href="http://www.lactalis.fr/information-consommateur/">Lactalis</a>.
+	</div>
+	HTML
+	;
 
 	}
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8302,17 +8302,18 @@ HTML
 ;
 
 	}
-	elsif (($lc eq 'fr') and (has_tag($product_ref, "categories","en:baby-milks")) and (has_baby_brand_tag($product_ref))) 
+	elsif (($lc eq 'fr') and (has_tag($product_ref, "categories","en:baby-milks")) and (has_one_of_the_tags_from_the_list($product_ref, "brands", ["amilk", "babycare", "celia-ad", "celia-develop", "celia-expert", "celia-nutrition",
+	"enfastar", "fbb", "fl", "frezylac", "gromore", "malyatko", "mamy", "milumel", "milumel", "neoangelac", "nophenyl", "novil", "ostricare", "pc", "picot", "sanutri"]))) 
 	{
 
-			$html .= <<HTML
-	<div id="warning_lactalis_201712" style="display: block; background:#ffcc33;color:black;padding:1em;text-decoration:none;">
-	Certains produits de cette marque font partie d'une liste de produits retirés du marché.
-	<br><br>
-	&rarr; <a href="http://www.lactalis.fr/wp-content/uploads/2017/12/ici-1.pdf">Liste des produits et lots concernés</a> sur le site de <a href="http://www.lactalis.fr/information-consommateur/">Lactalis</a>.
-	</div>
-	HTML
-	;
+		$html .= <<HTML
+<div id="warning_lactalis_201712" style="display: block; background:#ffcc33;color:black;padding:1em;text-decoration:none;">
+Certains produits de cette marque font partie d'une liste de produits retirés du marché.
+<br><br>
+&rarr; <a href="http://www.lactalis.fr/wp-content/uploads/2017/12/ici-1.pdf">Liste des produits et lots concernés</a> sur le site de <a href="http://www.lactalis.fr/information-consommateur/">Lactalis</a>.
+</div>
+HTML
+;
 
 	}
 

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -53,6 +53,7 @@ BEGIN
 		&canonicalize_tag_link
 
 		&has_tag
+		&has_baby_brand_tag
 		&add_tag
 		&remove_tag
 		&is_a

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -319,15 +319,15 @@ sub has_tag($$$) {
 	return $return;
 }
 
-# Helper function to tell if a product is a "baby product"
-sub has_baby_brand_tag($) {
-
-	my $product_ref = shift;
+# Helper function to tell if a product has a certain tag from the passed list
+sub has_one_of_the_tags_from_the_list {
+	
+	my($product_ref, $tagtype, $tag_list_ref) = @_;
+	
 	my $flag = 0;
-	foreach my $brand_name ("amilk", "babycare", "celia-ad", "celia-develop", "celia-expert", "celia-nutrition",
-	"enfastar", "fbb", "fl", "frezylac", "gromore", "malyatko", "mamy", "milumel", "milumel", "neoangelac", "nophenyl",
-	"novil", "ostricare", "pc", "picot", "sanutri") {
-			if ( has_tag($product_ref, "brands", $brand_name) ) {
+
+	foreach my $tag_name (@$tag_list_ref) {
+			if ( has_tag($product_ref, $tagtype, $tag_name) ) {
 				$flag = 1;
 				return $flag;
 			}

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -329,10 +329,10 @@ sub has_one_of_the_tags_from_the_list {
 	foreach my $tag_name (@$tag_list_ref) {
 			if ( has_tag($product_ref, $tagtype, $tag_name) ) {
 				$flag = 1;
-				return $flag;
+				return 1;
 			}
 		}
-	return $flag;
+	return 0;
 }
 
 # Determine if a tag is a child of another tag (or the same tag)

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -318,6 +318,22 @@ sub has_tag($$$) {
 	return $return;
 }
 
+# Helper function to tell if a product is a "baby product"
+sub has_baby_brand_tag($) {
+
+	my $product_ref = shift;
+	my $flag = 0;
+	foreach my $brand_name ("amilk", "babycare", "celia-ad", "celia-develop", "celia-expert", "celia-nutrition",
+	"enfastar", "fbb", "fl", "frezylac", "gromore", "malyatko", "mamy", "milumel", "milumel", "neoangelac", "nophenyl",
+	"novil", "ostricare", "pc", "picot", "sanutri") {
+			if ( has_tag($product_ref, "brands", $brand_name) ) {
+				$flag = 1;
+				return $flag;
+			}
+		}
+	return flag;
+}
+
 # Determine if a tag is a child of another tag (or the same tag)
 # assume tags are already canonicalized
 sub is_a($$$) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -53,7 +53,7 @@ BEGIN
 		&canonicalize_tag_link
 
 		&has_tag
-		&has_baby_brand_tag
+		&has_one_of_the_tags_from_the_list
 		&add_tag
 		&remove_tag
 		&is_a

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -323,12 +323,9 @@ sub has_tag($$$) {
 sub has_one_of_the_tags_from_the_list {
 	
 	my($product_ref, $tagtype, $tag_list_ref) = @_;
-	
-	my $flag = 0;
 
 	foreach my $tag_name (@$tag_list_ref) {
 			if ( has_tag($product_ref, $tagtype, $tag_name) ) {
-				$flag = 1;
 				return 1;
 			}
 		}

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -332,7 +332,7 @@ sub has_baby_brand_tag($) {
 				return $flag;
 			}
 		}
-	return flag;
+	return $flag;
 }
 
 # Determine if a tag is a child of another tag (or the same tag)


### PR DESCRIPTION
### Proposal
Having helper functions where ever we have multiple calls to a function (let's say to `has_tag` like in this case).
I think it makes the if statements look much cleaner and keep the code organized. Also, this offers somewhat better reusability because we can simply add another parameter to the list (in this case, of brands)

_Not sure if I've declared it at the appropriate place. Should it be in `tags.pm`?_

