### PR TITLE
refactor: get_ascii_fileid unused export

### DIFF
--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -31,7 +31,6 @@ BEGIN
 		&get_urlid
 		&get_fileid
 		&get_fileid_punycode
-		&get_ascii_fileid
 		&store
 		&retrieve
 		&store_json


### PR DESCRIPTION
This export appears to be added in commit 23ac0344156, however, I can't find its associated function.