### PR TITLE
refactor: init_languages unused export

### DIFF
--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -63,7 +63,6 @@ BEGIN
 		&lang_in_other_lc
 		%lang_lc
 
-		&init_languages
 
 		&separator_before_colon
 


### PR DESCRIPTION
This export doesn't seem to have a matching function.