### PR TITLE
docs: add .gitbook.yaml

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs
+
+structure:  
+    readme: README.md  
+    summary: SUMMARY.md


### PR DESCRIPTION
telling gitbooks that docs are in the /docs directory

cf https://www.baseten.co/blog/docs-as-code