### PR TITLE
refactor: replace perl "shift" prototype in `Recipes.pm`

### DIFF
--- a/lib/ProductOpener/Recipes.pm
+++ b/lib/ProductOpener/Recipes.pm
@@ -48,8 +48,7 @@ Then each ingredient is matched against the specified list of parents ingredient
 
 package ProductOpener::Recipes;
 
-use utf8;
-use Modern::Perl '2017';
+use ProductOpener::PerlStandards;
 use Exporter    qw< import >;
 
 use Log::Any qw($log);
@@ -109,10 +108,7 @@ specified parent ingredients.
 
 =cut
 
-sub compute_product_recipe($$) {
-
-	my $product_ref = shift;
-	my $parent_ingredients_ref = shift;
+sub compute_product_recipe($product_ref, $parent_ingredients_ref) {
 
 	$log->debug("compute recipe for product", { code => $product_ref->{code}, parent_ingredients_ref => $parent_ingredients_ref }) if $log->is_debug();
 
@@ -194,11 +190,7 @@ sub compute_product_recipe($$) {
 
 =cut
 
-sub add_product_recipe_to_set( $$$) {
-
-    my $recipes_ref = shift;
-    my $product_ref = shift;
-    my $recipe_ref = shift;
+sub add_product_recipe_to_set($recipes_ref, $product_ref, $recipe_ref) {
 
     # Do not add undefined recipes (e.g. products without ingredients)
     if (defined $recipe_ref) {
@@ -222,10 +214,7 @@ sub add_product_recipe_to_set( $$$) {
 
 =cut
 
-sub analyze_recipes( $$) {
-
-    my $recipes_ref = shift;
-    my $original_parent_ingredients_ref = shift;
+sub analyze_recipes($recipes_ref, $original_parent_ingredients_ref) {
 
     # Add "other" and "unknown"
     my $parent_ingredients_ref = [ @$original_parent_ingredients_ref, "other", "unknown" ];


### PR DESCRIPTION
Replacing the "shift" perl prototypes to perl signatures in Recipes.pm