### PR TITLE
fix: Initialization of state variables in list context currently forbidden (perl version < 5.28)

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10150,7 +10150,7 @@ sub display_structured_response($request_ref) {
 		# Note: use "state" to avoid re-initializing the array. This can be seen as a premature optimisation
 		# here but this new perl feature can be used at other places to encapsulate large lists while avoiding
 		# inefficiencies from reinitialization.
-		state @product_fields_to_delete = ("languages", "category_properties", "categories_properties");
+		my @product_fields_to_delete = ("languages", "category_properties", "categories_properties");
 
 		remove_fields($request_ref->{structured_response}{product}, \@product_fields_to_delete);
 


### PR DESCRIPTION
We use Perl 5.24 in production today, and state arrays and hashes can't be initialized:

off@off1:/srv/off-pro/scripts$ perl ../lib/startup_apache2.pl  
Initialization of state variables in list context currently forbidden at ProductOpener/Display.pm line 10153, near ");"

Reverting to a normal variable for now.
