### PR TITLE
fix: return statements

### DIFF
--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -67,6 +67,7 @@ sub wait_dynamic_front() {
 			print("Wainting for dynamicfront to be ready since $count seconds...\n");
 		}
 	}
+	return;
 }
 
 =head2 new_client()
@@ -120,6 +121,7 @@ sub create_user ($ua, $args_ref) {
 	}
 	my $response = $ua->post("http://world.openfoodfacts.localhost/cgi/user.pl", Content => \%fields,);
 	$response->is_success or die("Couldn't create user with " . dump(\%fields) . "\n");
+	return;
 }
 
 1;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4583,6 +4583,7 @@ sub add_params_to_query($request_ref, $query_ref) {
 			}
 		}
 	}
+	return;
 }
 
 
@@ -4598,6 +4599,7 @@ sub initialize_knowledge_panels_options($knowledge_panels_options_ref) {
 	if (param("activate_knowledge_panel_physical_activities")) {
 		$knowledge_panels_options_ref->{activate_knowledge_panel_physical_activities} = 1;
 	}
+	return;
 }
 
 =head2 customize_response_for_product ( $request_ref, $product_ref )
@@ -5544,6 +5546,7 @@ sub search_and_export_products($request_ref, $query_ref, $sort_by) {
 	$request_ref->{title} = lang("search_results");
 	$request_ref->{content_ref} = \$html;
 	display_page($request_ref);
+	return;
 }
 
 
@@ -10990,6 +10993,7 @@ sub display_properties($request_ref) {
 	$request_ref->{page_type} = "properties";
 
 	display_page($request_ref);
+	return;
 }
 
 1;

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -2804,6 +2804,7 @@ sub assign_nutriments_values_from_request_parameters($$) {
 			delete $product_ref->{nutriments}{$key . "_serving"};
 		}
 	}
+	return;
 }
 
 

--- a/lib/ProductOpener/FoodGroups.pm
+++ b/lib/ProductOpener/FoodGroups.pm
@@ -206,6 +206,7 @@ sub compute_pnns_groups($product_ref) {
 		$product_ref->{pnns_groups_1} = "unknown";
 		$product_ref->{pnns_groups_1_tags} = ["unknown", "missing-association"];
 	}
+	return;
 }
 
 
@@ -259,6 +260,7 @@ sub compute_food_groups($product_ref) {
 		$product_ref->{categories_tags} = [@{$product_ref->{original_categories_tags}}];
 		delete $product_ref->{original_categories_tags};
 	}	
+	return;
 }
 
 
@@ -451,6 +453,7 @@ sub temporarily_change_categories_for_food_groups_computation($product_ref) {
 			remove_tag($product_ref, "categories", "en:unsweetened-beverages");
 		}
 	}
+	return;
 }
 
 1;

--- a/lib/ProductOpener/ForestFootprint.pm
+++ b/lib/ProductOpener/ForestFootprint.pm
@@ -221,6 +221,7 @@ sub load_forest_footprint_data() {
 			die("Could not open forest footprint CSV $csv_file: $!");
 		}
 	}
+	return;
 }
 
 
@@ -302,6 +303,7 @@ sub compute_forest_footprint($) {
 		delete $product_ref->{forest_footprint_data};
 		remove_tag($product_ref,"misc","en:forest-footprint-computed");
 	}
+	return;
 }
 
 =head2 add_footprint ( $product_ref, $ingredient_ref, $footprints_ref, $ingredients_category_ref, $footprint_ref )
@@ -391,6 +393,7 @@ sub add_footprint ($$$$$) {
 			last;
 		}
 	}
+	return;
 }
 
 
@@ -580,6 +583,7 @@ sub compute_footprint_of_category($$) {
 			last;
 		}
 	}
+	return;
 }
 
 

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -2286,7 +2286,7 @@ sub update_export_status_for_csv_file($) {
 	$log->debug("update export status done", { products => $i }) if $log->is_debug();
 
 	print STDERR "\n\nupdate export status done\n\n";
-
+	return;
 }
 
 

--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -542,6 +542,7 @@ sub remove_quantity_from_field($$) {
 			$product_ref->{$field} = $`;
 		}		
 	}
+	return;
 }
 
 

--- a/lib/ProductOpener/ImportConvertCarrefourFrance.pm
+++ b/lib/ProductOpener/ImportConvertCarrefourFrance.pm
@@ -576,6 +576,7 @@ sub convert_carrefour_france_files($$) {
     foreach my $nutrient (sort { $nutrients{$b} <=> $nutrients{$a} } keys %nutrients) {
         #print STDERR $nutrient . "\t" . $nutrients{$nutrient} . "\n";
     }
+    return;
 }
 
 

--- a/lib/ProductOpener/MainCountries.pm
+++ b/lib/ProductOpener/MainCountries.pm
@@ -88,6 +88,7 @@ my $all_products_scans_ref;
 sub load_scans_data() {
 	
 	$all_products_scans_ref = retrieve_json("$data_root/products/all_products_scans.json");
+	return;
 }
 
 
@@ -246,6 +247,7 @@ sub compute_main_countries($) {
 			push @{$product_ref->{misc_tags}}, "en:main-countries-new-product";
 		}
 	}
+	return;
 }
 
 1;

--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -281,6 +281,7 @@ sub set_org_gs1_gln($$) {
 		}
 	}
 	store("$data_root/orgs/orgs_glns.sto", $glns_ref);
+	return;
 }
 
 

--- a/lib/ProductOpener/PackagerCodes.pm
+++ b/lib/ProductOpener/PackagerCodes.pm
@@ -256,7 +256,7 @@ sub init_packager_codes() {
 		my $packager_codes_ref = retrieve("$data_root/packager-codes/packager_codes.sto");
 		%packager_codes = %{$packager_codes_ref};
 	}
-
+	return;
 }
 
 sub init_geocode_addresses() {
@@ -266,7 +266,7 @@ sub init_geocode_addresses() {
 		my $geocode_addresses_ref = retrieve("$data_root/packager-codes/geocode_addresses.sto");
 		%geocode_addresses = %{$geocode_addresses_ref};
 	}
-
+	return;
 }
 
 # Slow, so only run these when actually executing, not just checking syntax. See also startup_apache2.pl.

--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -144,6 +144,7 @@ sub init_packaging_taxonomies_regexps() {
 	
 	# used only for debugging
 	#store("packaging_taxonomies_regexps.sto", \%packaging_taxonomies_regexps);
+	return;
 }
 
 
@@ -522,6 +523,7 @@ sub analyze_and_combine_packaging_data($) {
 	}
 	
 	$log->debug("analyze_and_combine_packaging_data - done", { packagings => $product_ref->{packagings} }) if $log->is_debug();
+	return;
 }
 
 1;

--- a/lib/ProductOpener/PerlStandards.pm
+++ b/lib/ProductOpener/PerlStandards.pm
@@ -32,6 +32,7 @@ sub import {
     strict->import;
     feature->import(qw/signatures :5.24/);
     utf8->import;
+    return;
 }
 
 sub unimport {
@@ -39,6 +40,7 @@ sub unimport {
     strict->unimport;
     feature->unimport;
     utf8->unimport;
+    return;
 }
 
 1;

--- a/lib/ProductOpener/Recipes.pm
+++ b/lib/ProductOpener/Recipes.pm
@@ -200,6 +200,7 @@ sub add_product_recipe_to_set($recipes_ref, $product_ref, $recipe_ref) {
             recipe => $recipe_ref,
         };
     }
+    return;
 }
 
 

--- a/lib/ProductOpener/Test.pm
+++ b/lib/ProductOpener/Test.pm
@@ -342,6 +342,7 @@ sub create_sto_from_json ($json_path, $sto_path) {
 
     my $data = decode_json(path($json_path)->slurp_raw());
     store($sto_path, $data);
+    return;
 }
 
 
@@ -415,6 +416,7 @@ sub normalize_product_for_test_comparison($product) {
             deep_set($product, @key, \@sorted);
         }
     }
+    return;
 }
 
 
@@ -434,6 +436,7 @@ sub normalize_products_for_test_comparison($array_ref) {
     for my $product_ref (@$array_ref) {
         normalize_product_for_test_comparison($product_ref);
     }
+    return;
 }
 
 1;

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -209,6 +209,7 @@ sub delete_user($user_ref) {
 	
 	#  re-assign product edits to openfoodfacts-contributors-[random number]
 	find_and_replace_user_id_in_products($userid, $new_userid);
+	return;
 }
 
 =head2 is_admin_user()


### PR DESCRIPTION
Adding return statements to subroutines without them. There should be no more subroutines without return statements at the moment.