### PR TITLE
chore: add construct url sub for tests

### DIFF
--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -154,5 +154,4 @@ sub construct_test_url () {
 	return $url;
 }
 
-
 1;

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -124,4 +124,35 @@ sub create_user ($ua, $args_ref) {
 	return;
 }
 
+=head2 construct_test_url()
+
+Constructs the URL to send the HTTP request to for the API.
+
+=head3 Arguments
+
+Takes in two string arguments, One being the the target and other a prefix. 
+The prefix could be simply the country code (eg: US for America or "World") OR something like ( {country-code}-{language-code} )
+
+An example below
+$target = "/product/35242200055"
+$prefix= "world-fr"  
+
+=head3 Return Value
+
+Returns the constructed URL for the query 
+
+For the example cited above this returns: "http://world-fr.openfoodfacts.localhost/product/35242200055"
+
+=cut
+
+sub construct_test_url () {
+	my $target = "/xxx/yyy";
+	my $prefix = "world-en";
+
+	my $url = "http://${prefix}.openfoodfacts.localhost${target}";
+
+	return $url;
+}
+
+
 1;

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -145,9 +145,7 @@ For the example cited above this returns: "http://world-fr.openfoodfacts.localho
 
 =cut
 
-sub construct_test_url ($$) {
-	my $target = shift;
-	my $prefix = shift;
+sub construct_test_url ($target, $prefix) {
 	my $link = "openfoodfacts.localhost";
 	my $url = "http://${prefix}.${link}${target}";
 	return $url;

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -37,6 +37,7 @@ BEGIN {
 	  &create_user
 	  &new_client
 	  &wait_dynamic_front
+	  &construct_test_url
 	);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -146,7 +146,6 @@ For the example cited above this returns: "http://world-fr.openfoodfacts.localho
 =cut
 
 sub construct_test_url ($target, $prefix) {
-	
 	my $link = "openfoodfacts.localhost";
 	my $url = "http://${prefix}.${link}${target}";
 

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -145,8 +145,9 @@ For the example cited above this returns: "http://world-fr.openfoodfacts.localho
 
 =cut
 
-sub construct_test_url ($target, $prefix, $link) {
-
+sub construct_test_url ($target, $prefix) {
+	
+	my $link = "openfoodfacts.localhost";
 	my $url = "http://${prefix}.${link}${target}";
 
 	return $url;

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -146,8 +146,8 @@ For the example cited above this returns: "http://world-fr.openfoodfacts.localho
 =cut
 
 sub construct_test_url ($$) {
-    my $target = shift;
-    my $prefix = shift;
+	my $target = shift;
+	my $prefix = shift;
 	my $link = "openfoodfacts.localhost";
 	my $url = "http://${prefix}.${link}${target}";
 	return $url;

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -150,7 +150,6 @@ sub construct_test_url ($$) {
     my $prefix = shift;
 	my $link = "openfoodfacts.localhost";
 	my $url = "http://${prefix}.${link}${target}";
-
 	return $url;
 }
 

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -145,7 +145,9 @@ For the example cited above this returns: "http://world-fr.openfoodfacts.localho
 
 =cut
 
-sub construct_test_url ($target, $prefix) {
+sub construct_test_url ($$) {
+    my $target = shift;
+    my $prefix = shift;
 	my $link = "openfoodfacts.localhost";
 	my $url = "http://${prefix}.${link}${target}";
 

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -145,11 +145,9 @@ For the example cited above this returns: "http://world-fr.openfoodfacts.localho
 
 =cut
 
-sub construct_test_url () {
-	my $target = "/xxx/yyy";
-	my $prefix = "world-en";
+sub construct_test_url ($target, $prefix, $link) {
 
-	my $url = "http://${prefix}.openfoodfacts.localhost${target}";
+	my $url = "http://${prefix}.${link}${target}";
 
 	return $url;
 }

--- a/tests/integration/create_user.t
+++ b/tests/integration/create_user.t
@@ -15,7 +15,9 @@ my $ua = new_client();
 create_user($ua, {});
 
 # edit preference accessible
-my $response = $ua->get("http://world.openfoodfacts.localhost/cgi/user.pl?type=edit&userid=test");
+my $url = construct_test_url("/cgi/user.pl?type=edit&userid=test", "world");
+my $response = $ua->get($url);
+
 
 #$DB::single = 1;
 is $response->{_rc}, 200;

--- a/tests/integration/create_user.t
+++ b/tests/integration/create_user.t
@@ -18,7 +18,6 @@ create_user($ua, {});
 my $url = construct_test_url("/cgi/user.pl?type=edit&userid=test", "world");
 my $response = $ua->get($url);
 
-
 #$DB::single = 1;
 is $response->{_rc}, 200;
 


### PR DESCRIPTION
### What

Manually making requests to urls in code could be error prone.
We can pass a prefix and the target path to construct a url to make an http request

