### PR TITLE
feat: Deep nest limit 12

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -55,5 +55,7 @@ equivalent_modules = ProductOpener::PerlStandards
 
 
 # severity 3
+[ControlStructures::ProhibitDeepNests]
+max_nests = 12
 [Variables::ProhibitUnusedVariables]
 # /end severity 3


### PR DESCRIPTION
Adding `[ControlStructures::ProhibitDeepNests]` to .perlcriticrc and limiting nesting to 12 (12 appears to be the most amount of nesting done). I'm planning on adding this for now so that no one can add deeper nesting