### PR TITLE
feat: Cascading elsif limit 13

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -44,7 +44,6 @@ equivalent_modules = Modern::Perl
 equivalent_modules = ProductOpener::PerlStandards
 [Subroutines::RequireFinalReturn]
 
-
 [BuiltinFunctions::RequireBlockMap]
 [BuiltinFunctions::RequireBlockGrep]
 
@@ -57,5 +56,7 @@ equivalent_modules = ProductOpener::PerlStandards
 # severity 3
 [ControlStructures::ProhibitDeepNests]
 max_nests = 12
+[ControlStructures::ProhibitCascadingIfElse]
+max_elsif = 13
 [Variables::ProhibitUnusedVariables]
 # /end severity 3


### PR DESCRIPTION
Adding `[ControlStructures::ProhibitCascadingIfElse]` to .perlcriticrc and limiting the amount of if's/elsif's to 13 (13 appears to be the highest amount of if's/elsif's). I'm planning on adding this for now so that no one can add even more than 13