### PR TITLE
refactor: Prohibit mixed boolean operators policy

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -46,7 +46,7 @@ equivalent_modules = ProductOpener::PerlStandards
 
 [BuiltinFunctions::RequireBlockMap]
 [BuiltinFunctions::RequireBlockGrep]
-
+[ValuesAndExpressions::ProhibitMixedBooleanOperators]
 # Allow `$`', `$&', `$'', because since Perl 5.20.0
 # there are no performance implications any more.
 [-Variables::ProhibitMatchVars]

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -47,6 +47,7 @@ equivalent_modules = ProductOpener::PerlStandards
 [BuiltinFunctions::RequireBlockMap]
 [BuiltinFunctions::RequireBlockGrep]
 [ValuesAndExpressions::ProhibitMixedBooleanOperators]
+
 # Allow `$`', `$&', `$'', because since Perl 5.20.0
 # there are no performance implications any more.
 [-Variables::ProhibitMatchVars]

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -598,7 +598,7 @@ sub create_ecoscore_panel($$$) {
             # Add properties of interest
             foreach my $property (qw(environmental_benefits description)) {
                 my $property_value = get_inherited_property("labels", $labelid, $property . ":" . $target_lc);
-                if (!(defined $property_value) && ($target_lc != "en")) {
+                if (!(defined $property_value) && ($target_lc ne "en")) {
                     # fallback to english
                     $property_value = get_inherited_property("labels", $labelid, $property . ":" . "en");
                 }

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -598,7 +598,7 @@ sub create_ecoscore_panel($$$) {
             # Add properties of interest
             foreach my $property (qw(environmental_benefits description)) {
                 my $property_value = get_inherited_property("labels", $labelid, $property . ":" . $target_lc);
-                if (not defined $property_value && $target_lc != "en") {
+                if (!(defined $property_value) && ($target_lc != "en")) {
                     # fallback to english
                     $property_value = get_inherited_property("labels", $labelid, $property . ":" . "en");
                 }
@@ -1112,7 +1112,7 @@ sub create_ingredients_panel($$$) {
 	}
 
     my $title ="";
-    if (!(defined $product_ref->{ingredients_n}) or ($product_ref->{ingredients_n} == 0)) {
+    if (!(defined $product_ref->{ingredients_n}) || ($product_ref->{ingredients_n} == 0)) {
         $title = lang("no_ingredient");
     } elsif ($product_ref->{ingredients_n} == 1) {
         $title = lang("one_ingredient");


### PR DESCRIPTION
Adding `[ValuesAndExpressions::ProhibitMixedBooleanOperators]` to .perlcriticrc

This policy doesn't allow low-precedence booleans to be combined with high-precedence boolean operators in the same expression.
