### PR TITLE
refactor: reused variables in Ingredients.pm

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1354,8 +1354,6 @@ sub parse_ingredients_text($) {
 
 	# farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%) - émulsifiants : E463, E432 et E472 - correcteurs d'acidité : E322/E333 E474-E475, acidifiant (acide citrique, acide phosphorique) - sel : 1% ...
 
-	my $level = 0;
-
 	# assume commas between numbers are part of the name
 	# e.g. en:2-Bromo-2-Nitropropane-1,3-Diol, Bronopol
 	# replace by a lower comma ‚
@@ -1764,7 +1762,6 @@ sub parse_ingredients_text($) {
 					# Build an array of origins / ingredients possibilities
 					
 					my @maybe_origins_ingredients = ();
-					my $maybe_ingredient;
 					
 					# California almonds
 					if (($product_lc eq "en") and ($ingredient =~ /^(\S+) (.+)$/)) {
@@ -1804,7 +1801,7 @@ sub parse_ingredients_text($) {
 							$ingredient = $maybe_ingredient;
 							$ingredient_id = canonicalize_taxonomy_tag($product_lc, "ingredients", $ingredient);
 							last;
-						}						
+						}
 					}
 	
 					# Try to remove ingredients processing "cooked rice" -> "rice"


### PR DESCRIPTION
Planning on adding `[Variables::ProhibitReusedNames]`, currently cleaning up all of its warnings before adding it in.

Edit: For more info -> https://metacpan.org/pod/Perl::Critic::Policy::Variables::ProhibitReusedNames