### PR TITLE
fix: pb with initial slash in query string of redirects 

### DIFF
--- a/tests/unit/display.t
+++ b/tests/unit/display.t
@@ -30,7 +30,7 @@ is( display_date_tag($t), '<time datetime="2016-08-27T12:08:49">27. August 2016 
 # );
 
 my %request = (
-'query_string'=>'/api/v0/attribute_groups',
+'original_query_string'=>'/api/v0/attribute_groups',
 'referer'=>'http://world.openfoodfacts.localhost/product/3564703999971/huile-d-olive-marque-repere'
 );
 

--- a/tests/unit/display.t
+++ b/tests/unit/display.t
@@ -30,15 +30,16 @@ is( display_date_tag($t), '<time datetime="2016-08-27T12:08:49">27. August 2016 
 # );
 
 my %request = (
-'original_query_string'=>'/api/v0/attribute_groups',
+'original_query_string'=>'api/v0/attribute_groups',
 'referer'=>'http://world.openfoodfacts.localhost/product/3564703999971/huile-d-olive-marque-repere'
 );
-
+print STDERR "before analyze request\n";
 analyze_request(\%request);
 is ( $request{'api'},"v0");
 is ( $request{'page'},"1");
 is ( $request{'api_version'},"0");
 
+print STDERR "after analyze request\n";
 
 # paging tests
 # issue # 1960 - negative query lost during pagination and in other links


### PR DESCRIPTION
fixes #7161

There's something different between docker and production:

in Docker, the QUERY_STRING environment variable is prefixed by / , but not in production. This caused issues with redirect URLs reconstructed with the query string.