### PR TITLE
refactor: enable perl signatures in ImportConvert.pm

### DIFF
--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -43,8 +43,7 @@ convert the product data they contain to a format that can be imported on Open F
 
 package ProductOpener::ImportConvert;
 
-use utf8;
-use Modern::Perl '2017';
+use ProductOpener::PerlStandards;
 use Exporter    qw< import >;
 
 use Log::Any qw($log);
@@ -127,9 +126,7 @@ my $mode = "append";
 
 =cut
 
-sub get_or_create_product_for_code($) {
-
-	my $code = shift;
+sub get_or_create_product_for_code($code) {
 
 	if (not defined $code) {
 		die("Undefined code $code");
@@ -149,11 +146,7 @@ sub get_or_create_product_for_code($) {
 	return $products{$code};
 }
 
-sub assign_value($$$) {
-
-	my $product_ref = shift;
-	my $target = shift;
-	my $value = shift;
+sub assign_value($product_ref, $target, $value) {
 
 	my $field = $target;
 
@@ -216,11 +209,7 @@ sub assign_value($$$) {
 }
 
 
-sub remove_value($$$) {
-
-	my $product_ref = shift;
-	my $target = shift;
-	my $value = shift;
+sub remove_value($product_ref, $target, $value) {
 
 	my $field = $target;
 
@@ -232,9 +221,7 @@ sub remove_value($$$) {
 }
 
 
-sub apply_global_params($) {
-
-	my $product_ref = shift;
+sub apply_global_params($product_ref) {
 
 	$mode = "append";
 
@@ -249,11 +236,7 @@ sub apply_global_params($) {
 
 # some producers send us data for products in different languages sold in different markets
 
-sub assign_main_language_of_product($$$) {
-
-	my $product_ref = shift;
-	my $lcs_ref = shift;
-	my $default_lc = shift;
+sub assign_main_language_of_product($product_ref, $lcs_ref, $default_lc) {
 
 	if ((not defined $product_ref->{lc}) or (not defined $product_ref->{"product_name_" . $product_ref->{lc}})) {
 
@@ -274,11 +257,7 @@ sub assign_main_language_of_product($$$) {
 	return;
 }
 
-sub assign_countries_for_product($$$) {
-
-	my $product_ref = shift;
-	my $lcs_ref = shift;
-	my $default_country = shift;
+sub assign_countries_for_product($product_ref, $lcs_ref, $default_country) {
 
 	foreach my $possible_lc (sort keys %{$lcs_ref}) {
 		if (defined $product_ref->{"product_name_" . $possible_lc}) {
@@ -298,12 +277,7 @@ sub assign_countries_for_product($$$) {
 
 # Match all tags that exist in a taxonomy. Needs the input field to be split, so there must be separators.
 
-sub match_taxonomy_tags($$$$) {
-
-	my $product_ref = shift;
-	my $source = shift;
-	my $target = shift;
-	my $options_ref = shift;
+sub match_taxonomy_tags($product_ref, $source, $target, $options_ref) {
 
 	# logo ab
 	# logo bio européen : nl-bio-01 agriculture pays bas      1
@@ -362,12 +336,7 @@ sub match_taxonomy_tags($$$$) {
 
 # Match only specific tags (e.g. "organic" + "label rouge" in product name)
 
-sub match_specific_taxonomy_tags($$$$) {
-
-	my $product_ref = shift;
-	my $source = shift;
-	my $target = shift;
-	my $tags_ref = shift;
+sub match_specific_taxonomy_tags($product_ref, $source, $target, $tags_ref) {
 
 	my $tag_lc = $product_ref->{lc};
 
@@ -427,9 +396,8 @@ sub match_specific_taxonomy_tags($$$$) {
 	return;
 }
 
-sub match_labels_in_product_name($) {
+sub match_labels_in_product_name($product_ref) {
 
-	my $product_ref = shift;
 	my $tag_lc = $product_ref->{lc};
 
 	my @tags = qw(en:organic en:fair-trade);
@@ -445,8 +413,7 @@ sub match_labels_in_product_name($) {
 }
 
 
-sub split_allergens($) {
-	my $allergens = shift;
+sub split_allergens($allergens) {
 
 	# simple allergen (not an enumeration) -> return _$allergens_
 	if (($allergens !~ /,/)
@@ -467,10 +434,7 @@ Assign it to the quantity and remove it from the field.
 
 =cut
 
-sub assign_quantity_from_field($$) {
-
-	my $product_ref = shift;
-	my $field = shift;
+sub assign_quantity_from_field($product_ref, $field) {
 
 	if ((defined $product_ref->{$field}) and ((not defined $product_ref->{quantity}) or ($product_ref->{quantity} eq ""))) {
 
@@ -515,10 +479,7 @@ If found, remove it from the field.
 
 =cut
 
-sub remove_quantity_from_field($$) {
-
-	my $product_ref = shift;
-	my $field = shift;
+sub remove_quantity_from_field($product_ref, $field) {
 
 	if (defined $product_ref->{$field}) {
 		
@@ -546,9 +507,7 @@ sub remove_quantity_from_field($$) {
 }
 
 
-sub clean_weights($) {
-
-	my $product_ref = shift;
+sub clean_weights($product_ref) {
 
 	# normalize weights
 
@@ -818,9 +777,7 @@ my %unspecified = (
 	],
 );
 
-sub clean_fields($) {
-
-	my $product_ref = shift;
+sub clean_fields($product_ref) {
 
 	$log->debug("clean_fields - start", {  }) if $log->is_debug();
 
@@ -1157,12 +1114,8 @@ sub clean_fields_for_all_products() {
 }
 
 
-sub load_xml_file($$$$) {
-
-	my $file = shift;
-	my $xml_rules_ref = shift;
-	my $xml_fields_mapping_ref = shift;
-	my $code = shift; # can be undef or passed if we already know it from the file name
+sub load_xml_file($file, $xml_rules_ref, $xml_fields_mapping_ref, $code) {
+	# $code can be undef or passed if we already know it from the file name
 
 	# try to guess the code from the file name
 	if ((not defined $code) and ($file =~ /\D(\d{13})\D/)) {
@@ -1520,9 +1473,7 @@ sub load_xml_file($$$$) {
 }
 
 
-sub load_csv_file($) {
-
-	my $options_ref = shift;
+sub load_csv_file($options_ref) {
 
 	my $file = $options_ref->{file};
 	my $encoding = $options_ref->{encoding};
@@ -1723,11 +1674,7 @@ sub load_csv_file($) {
 	return;
 }
 
-sub recursive_list($$);
-sub recursive_list($$) {
-
-	my $list_ref = shift;
-	my $arg = shift;
+sub recursive_list($list_ref, $arg) {
 
 	if (-d $arg) {
 
@@ -1753,11 +1700,10 @@ sub recursive_list($$) {
 	return;
 }
 
-sub get_list_of_files(@) {
+sub get_list_of_files(@files_and_dirs) {
 
 	# Read the list of files or directories passed as parameters
 
-	my @files_and_dirs = @_;
 	my @files = ();
 
 	foreach my $arg (@files_and_dirs) {
@@ -1772,9 +1718,7 @@ sub get_list_of_files(@) {
 
 
 
-sub print_csv_file($) {
-
-	my $file_handle = shift;
+sub print_csv_file($file_handle) {
 
 	my $csv_out = Text::CSV->new ( { binary => 1 , sep_char => "\t", eol => "\n", quote_space => 0 } )  # should set binary attribute.
                  or die "Cannot use CSV: ".Text::CSV->error_diag ();
@@ -1864,13 +1808,7 @@ Reference to a scalar that will be set to the serving size if the nutrition fact
 
 =cut
 
-sub extract_nutrition_facts_from_text($$$$$) {
-
-	my $text_lc = shift;
-	my $text = shift;
-	my $nutrients_ref = shift;
-	my $nutrition_data_per_ref = shift;
-	my $serving_size_ref = shift;
+sub extract_nutrition_facts_from_text($text_lc, $text, $nutrients_ref, $nutrition_data_per_ref, $serving_size_ref) {
 
 	if ((defined $text) and ($text ne "")) {
 


### PR DESCRIPTION
Replacing "shift" prototypes with perl signatures.

There are a few lines like this:
```
                shift @{$xml_fields_mapping_ref};
```
And I'm not sure what to do with them. Could they be deleted?