### PR TITLE
taxonomy: add breading and whole grain flour blend

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -23855,6 +23855,10 @@ sv:mjölblanding
 # ingredient/fr:melange-de-farine has 7 products in 1 language @2020-06-08
 
 <en:flour
+<en:flour blend
+en:whole grain flour blend
+
+<en:flour
 en:cereal flour
 ca:farina de cereal
 cs:obilná mouka
@@ -78256,7 +78260,7 @@ fr:intérieur cône
 # This is a compound ingredient, e.g.:chapelure (farine de blé, levure, sel)
 
 <en:coating
-en:bread crumbs, breadcrumbs
+en:bread crumbs, breadcrumbs, breading
 ar:بقسماط
 be:Паніровачныя сухары
 bg:Галета


### PR DESCRIPTION
### What
Made two edits to ingredients list, to add breading as a synonym for bread crumbs, and added whole grain flour blend as a child of flour blend. Fixes issue on entry for [Trader Joe's chickenless crispy tenders](https://world.openfoodfacts.org/product/00978996/chickenless-crispy-tenders-trader-joe-s)

### Screenshot
<img width="903" alt="image" src="https://user-images.githubusercontent.com/89476471/183262223-d9be0ea6-b3bf-42d8-8d41-555bfc8b59d2.png">


