### PR TITLE
fix: send set-cookie headers in redirects

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -462,7 +462,10 @@ sub redirect_to_url($request_ref, $status_code, $redirect_url) {
 	$r->headers_out->set(Location => $redirect_url);
 
 	if (defined $request_ref->{cookie}) {
-		$r->headers_out->set("Set-Cookie" => $request_ref->{cookie});
+		# Note: mod_perl will not output the Set-Cookie header on a 302 response
+		# unless it is set with err_headers_out instead of headers_out
+		# https://perl.apache.org/docs/2.0/api/Apache2/RequestRec.html#C_err_headers_out_
+		$r->err_headers_out->set("Set-Cookie" => $request_ref->{cookie});
 	}
 
 	$r->status($status_code);


### PR DESCRIPTION
the session cookie was not sent in 302 redirects

This is needed in particular for Kratos auth: https://github.com/openfoodfacts/openfoodfacts-server/pull/7071