### PR TITLE
refactor: specifically ask parameters as scalars

### DIFF
--- a/cgi/change_password.pl
+++ b/cgi/change_password.pl
@@ -70,11 +70,11 @@ if ($ENV{'REQUEST_METHOD'} eq 'POST') {
 		push @errors, lang('error_bad_login_password');
 	}
 
-	if (length(param('password')) < 6) {
+	if (length(scalar param('password')) < 6) {
 		push @errors, lang('error_invalid_password');
 	}
 
-	if (param('password') ne param('confirm_password')) {
+	if ((scalar param('password')) ne (scalar param('confirm_password'))) {
 		push @errors, lang('error_different_passwords');
 	}
 

--- a/cgi/display.pl
+++ b/cgi/display.pl
@@ -43,10 +43,10 @@ use Apache2::Const ();
 # CGI.pm thus adds somepath? at the start of the name of the first parameter.
 # we need to remove it so that we can use the CGI.pm param() function to later access the parameters
 
-my @params = param();
+my @params = multi_param();
 if (defined $params[0]) {
 	my $first_param = $params[0];
-	my $first_param_value = param($first_param);
+	my $first_param_value = scalar param($first_param);
 	$log->debug("replacing first param to remove path from parameter name", { first_param => $first_param, $first_param_value => $first_param_value });
 	CGI::delete($first_param);
 	$first_param =~ s/^(.*?)\?//;
@@ -71,7 +71,7 @@ if ( ((defined $server_options{private_products}) and ($server_options{private_p
 }
 
 if ((defined $request_ref->{api}) and (defined $request_ref->{api_method})) {
-	if (param("api_method") eq "search") {
+	if (scalar param("api_method") eq "search") {
 		# /api/v0/search
 		# FIXME: for an unknown reason, using display_search_results() here results in some attributes being randomly not set
 		# because of missing fields like nova_group or nutriscore_data, but not for all products.
@@ -79,15 +79,15 @@ if ((defined $request_ref->{api}) and (defined $request_ref->{api_method})) {
 		# display_search_results($request_ref);
 		display_tag($request_ref);
 	}
-	elsif (param("api_method") =~ /^preferences(_(\w\w))?$/) {
+	elsif (scalar param("api_method") =~ /^preferences(_(\w\w))?$/) {
 		# /api/v0/preferences or /api/v0/preferences_[language code]
 		display_preferences_api($request_ref, $2);
 	}	
-	elsif (param("api_method") =~ /^attribute_groups(_(\w\w))?$/) {
+	elsif (scalar param("api_method") =~ /^attribute_groups(_(\w\w))?$/) {
 		# /api/v0/attribute_groups or /api/v0/attribute_groups_[language code]
 		display_attribute_groups_api($request_ref, $2);
 	}
-	elsif (param("api_method") eq "taxonomy") {
+	elsif (scalar param("api_method") eq "taxonomy") {
 		display_taxonomy_api($request_ref);
 	}	
 	else {
@@ -96,8 +96,8 @@ if ((defined $request_ref->{api}) and (defined $request_ref->{api_method})) {
 	}
 }
 elsif (defined $request_ref->{search}) {
-	if (param("download") and param("format")) {
-		$request_ref->{format} = param('format');
+	if (scalar param("download") and scalar param("format")) {
+		$request_ref->{format} = scalar param('format');
 		search_and_export_products($request_ref,{}, undef);
 	}
 	else {
@@ -116,7 +116,7 @@ elsif (defined $request_ref->{mission}) {
 elsif (defined $request_ref->{product}) {
 	# if we are passed the field parameter, make the request an API request
 	# this is so that we can easily add ?fields=something at the end of a product url
-	if (defined param("fields")) {
+	if (defined scalar param("fields")) {
 		display_product_api($request_ref);
 	}
 	else {

--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -52,7 +52,7 @@ use boolean;
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $action = param('action') || 'display';
+my $action = scalar param('action') || 'display';
 
 my $title = lang("export_product_data_photos");
 my $html = '';
@@ -66,7 +66,7 @@ if (not defined $Owner_id) {
 # or if the organization has the permission enable_manual_export_to_public_platform checked
 
 my $allow_submit = ($User{moderator}
-		or (defined param("query_code"))
+		or (defined scalar param("query_code"))
 		or ((defined $Org{enable_manual_export_to_public_platform}) and ($Org{enable_manual_export_to_public_platform} eq "on")));
 
 if ($action eq "display") {
@@ -150,20 +150,20 @@ elsif (($action eq "process") and $allow_submit) {
 			$args_ref->{query}{$query} = remove_tags_and_quote(decode utf8=>param($param));
 		}
 	}
-	if (not ((defined param("export_photos")) and (param("export_photos")))) {
+	if (not ((defined scalar param("export_photos")) and (scalar param("export_photos")))) {
 		$args_ref->{do_not_upload_images} = 1;
 	}
 	
-	if (not ((defined param("replace_selected_photos")) and (param("replace_selected_photos")))) {
+	if (not ((defined scalar param("replace_selected_photos")) and (scalar param("replace_selected_photos")))) {
 		$args_ref->{only_select_not_existing_images} = 1;
 	}
 	
-	if ((defined param("only_export_products_with_changes")) and (param("only_export_products_with_changes"))) {
+	if ((defined scalar param("only_export_products_with_changes")) and (scalar param("only_export_products_with_changes"))) {
 		$args_ref->{query}{states_tags} = 'en:to-be-exported';
 	}
 	
 	if ($admin) {
-		if ((defined param("overwrite_owner")) and (param("overwrite_owner"))) {
+		if ((defined scalar param("overwrite_owner")) and (scalar param("overwrite_owner"))) {
 			$args_ref->{overwrite_owner} = 1;
 		}		
 	}

--- a/cgi/import_file_job_status.pl
+++ b/cgi/import_file_job_status.pl
@@ -52,8 +52,8 @@ my $request_ref = ProductOpener::Display::init_request();
 
 my $import_files_ref;
 
-my $file_id = get_string_id_for_lang("no_language", param('file_id'));
-my $import_id = param('import_id');
+my $file_id = get_string_id_for_lang("no_language", scalar param('file_id'));
+my $import_id = scalar param('import_id');
 my $job_id;
 
 my %data = (
@@ -67,10 +67,10 @@ $log->debug("import_file_job_status.pl - start", { data => \%data }) if $log->is
 if (not defined $Owner_id) {
 	$data{error} = "no_owner_defined";
 }
-elsif (not defined param('file_id')) {
+elsif (not defined scalar param('file_id')) {
 	$data{error} = "missing_file_id";
 }
-elsif (not defined param('import_id')) {
+elsif (not defined scalar param('import_id')) {
 	$data{error} = "missing_import_id";
 }
 else {

--- a/cgi/import_file_process.pl
+++ b/cgi/import_file_process.pl
@@ -64,7 +64,7 @@ if (not defined $import_files_ref) {
 	$import_files_ref = {};
 }
 
-my $file_id = get_string_id_for_lang("no_language", param('file_id'));
+my $file_id = get_string_id_for_lang("no_language", scalar param('file_id'));
 
 local $log->context->{file_id} = $file_id;
 
@@ -98,7 +98,7 @@ if ($results_ref->{error}) {
 my $headers_ref = $results_ref->{headers};
 my $rows_ref = $results_ref->{rows};
 
-my $columns_fields_json = param("columns_fields_json");
+my $columns_fields_json = scalar param("columns_fields_json");
 my $columns_fields_ref = decode_json($columns_fields_json);
 
 foreach my $field (keys %$columns_fields_ref) {

--- a/cgi/import_file_select_format.pl
+++ b/cgi/import_file_select_format.pl
@@ -50,7 +50,7 @@ use Log::Any qw($log);
 use Spreadsheet::CSV();
 use Text::CSV();
 
-my $action = param('action') || 'display';
+my $action = scalar param('action') || 'display';
 
 my $request_ref = ProductOpener::Display::init_request();
 
@@ -68,7 +68,7 @@ if (not defined $import_files_ref) {
 	$import_files_ref = {};
 }
 
-my $param_file_id = param('file_id');
+my $param_file_id = scalar param('file_id');
 my $file_id = get_string_id_for_lang("no_language", $param_file_id);
 
 local $log->context->{file_id} = $file_id;

--- a/cgi/import_photos_upload.pl
+++ b/cgi/import_photos_upload.pl
@@ -47,8 +47,8 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $type = param('type') || 'upload';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'upload';
+my $action = scalar param('action') || 'display';
 
 my $title = lang("import_photos_title");
 my $html = '';

--- a/cgi/import_products_categories_from_public_database.pl
+++ b/cgi/import_products_categories_from_public_database.pl
@@ -50,7 +50,7 @@ use Text::CSV();
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $action = param('action') || 'display';
+my $action = scalar param('action') || 'display';
 
 my $title = lang("import_products_categories_from_public_database");
 my $html = '';

--- a/cgi/ingredients.pl
+++ b/cgi/ingredients.pl
@@ -43,10 +43,10 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $code = normalize_code(param('code'));
-my $id = param('id');
-my $ocr_engine = param('ocr_engine');
-my $annotations = param('annotations') | 0;
+my $code = normalize_code(scalar param('code'));
+my $id = scalar param('id');
+my $ocr_engine = scalar param('ocr_engine');
+my $annotations = scalar param('annotations') | 0;
 
 if (not defined $ocr_engine) {
 	$ocr_engine = "tesseract";
@@ -66,7 +66,7 @@ my $product_ref = retrieve_product($product_id);
 
 my $results_ref = {};
 
-if (($id =~ /^ingredients/) and (param('process_image'))) {
+if (($id =~ /^ingredients/) and (scalar param('process_image'))) {
 	extract_ingredients_from_image($product_ref, $id, $ocr_engine, $results_ref);
 	if ($results_ref->{status} == 0) {
 		$results_ref->{ingredients_text_from_image} =~ s/\n/ /g;

--- a/cgi/login.pl
+++ b/cgi/login.pl
@@ -43,7 +43,7 @@ my $template_data_ref = {};
 $log->info('start') if $log->is_info();
 
 my $r = shift;
-my $redirect = param('redirect');
+my $redirect = scalar param('redirect');
 $template_data_ref->{redirect} = $redirect;
 if (defined $User_id) {
 	my $loc = $redirect || $formatted_subdomain;

--- a/cgi/minion_job_status.pl
+++ b/cgi/minion_job_status.pl
@@ -50,7 +50,7 @@ use Text::CSV();
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $job_id = param("job_id");
+my $job_id = scalar param("job_id");
 
 my %data;
 

--- a/cgi/nutrition.pl
+++ b/cgi/nutrition.pl
@@ -44,10 +44,10 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $code = normalize_code(param('code'));
-my $id = param('id');
-my $ocr_engine = param('ocr_engine');
-my $annotations = param('annotations') | 0;
+my $code = normalize_code(scalar param('code'));
+my $id = scalar param('id');
+my $ocr_engine = scalar param('ocr_engine');
+my $annotations = scalar param('annotations') | 0;
 
 if (not defined $ocr_engine) {
 	$ocr_engine = "tesseract";
@@ -67,7 +67,7 @@ my $product_ref = retrieve_product($product_id);
 
 my $results_ref = {};
 
-if (($id =~ /^nutrition/) and (param('process_image'))) {
+if (($id =~ /^nutrition/) and (scalar param('process_image'))) {
 	extract_nutrition_from_image($product_ref, $id, $ocr_engine, $results_ref);
 	if ($results_ref->{status} == 0) {
 		if (not $annotations) {

--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -40,8 +40,8 @@ use Storable qw/dclone/;
 use Encode;
 use Log::Any qw($log);
 
-my $type = param('type') || 'edit';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'edit';
+my $action = scalar param('action') || 'display';
 
 # Passing values to the template
 my $template_data_ref = {lang => \&lang,};
@@ -50,8 +50,8 @@ my $request_ref = ProductOpener::Display::init_request();
 
 my $orgid = $Org_id;
 
-if (defined param('orgid')) {
-	$orgid = get_fileid(param('orgid'), 1);
+if (defined scalar param('orgid')) {
+	$orgid = get_fileid(scalar param('orgid'), 1);
 }
 
 $log->debug("org profile form - start", {type => $type, action => $action, orgid => $orgid, User_id => $User_id})
@@ -88,7 +88,7 @@ my @errors = ();
 if ($action eq 'process') {
 
 	if ($type eq 'edit') {
-		if (param('delete') eq 'on') {
+		if (scalar param('delete') eq 'on') {
 			if ($admin) {
 				$type = 'delete';
 			}

--- a/cgi/packaging.pl
+++ b/cgi/packaging.pl
@@ -43,10 +43,10 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $code = normalize_code(param('code'));
-my $id = param('id');
-my $ocr_engine = param('ocr_engine');
-my $annotations = param('annotations') | 0;
+my $code = normalize_code(scalar param('code'));
+my $id = scalar param('id');
+my $ocr_engine = scalar param('ocr_engine');
+my $annotations = scalar param('annotations') | 0;
 
 if (not defined $ocr_engine) {
 	$ocr_engine = "tesseract";
@@ -66,7 +66,7 @@ my $product_ref = retrieve_product($product_id);
 
 my $results_ref = {};
 
-if (($id =~ /^packaging/) and (param('process_image'))) {
+if (($id =~ /^packaging/) and (scalar param('process_image'))) {
 	extract_packaging_from_image($product_ref, $id, $ocr_engine, $results_ref);
 	if ($results_ref->{status} == 0) {
 		$results_ref->{packaging_text_from_image} =~ s/\n/ /g;

--- a/cgi/product_image.pl
+++ b/cgi/product_image.pl
@@ -46,8 +46,8 @@ my $request_ref = ProductOpener::Display::init_request();
 
 my $template_data_ref = {};
 
-my $code = normalize_code(param('code'));
-my $id = param('id');
+my $code = normalize_code(scalar param('code'));
+my $id = scalar param('id');
 
 $log->debug("start", {code => $code, id => $id}) if $log->is_debug();
 

--- a/cgi/product_image_crop.pl
+++ b/cgi/product_image_crop.pl
@@ -42,26 +42,26 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'add';
+my $action = scalar param('action') || 'display';
 
-my $code = normalize_code(param('code'));
+my $code = normalize_code(scalar param('code'));
 
 my $product_id = product_id_for_owner($Owner_id, $code);
 
-my $imgid = param('imgid');
-my $angle = param('angle');
-my $id = param('id');
-my ($x1,$y1,$x2,$y2) = (param('x1'),param('y1'),param('x2'),param('y2'));
-my $normalize = param('normalize');
-my $white_magic = param('white_magic');
+my $imgid = scalar param('imgid');
+my $angle = scalar param('angle');
+my $id = scalar param('id');
+my ($x1,$y1,$x2,$y2) = (scalar param('x1'),scalar param('y1'),scalar param('x2'),scalar param('y2'));
+my $normalize = scalar param('normalize');
+my $white_magic = scalar param('white_magic');
 
 # The new product_multilingual.pl form will set $coordinates_image_size to "full"
 # the current Android app will not send it, and it will send coordinates related to the ".400" image
 # that has a max width and height of 400 pixels
-my $coordinates_image_size = param('coordinates_image_size') || $crop_size;
+my $coordinates_image_size = scalar param('coordinates_image_size') || $crop_size;
 
-$log->debug("start", { code => $code, imgid => $imgid, x1 => $x1, y1 => $y1, x2 => $x2, y2 => $y2, param_coordinates_image_size => param('coordinates_image_size'), coordinates_image_size => $coordinates_image_size }) if $log->is_debug();
+$log->debug("start", { code => $code, imgid => $imgid, x1 => $x1, y1 => $y1, x2 => $x2, y2 => $y2, param_coordinates_image_size => scalar param('coordinates_image_size'), coordinates_image_size => $coordinates_image_size }) if $log->is_debug();
 
 if (not defined $code) {
 

--- a/cgi/product_image_move.pl
+++ b/cgi/product_image_move.pl
@@ -41,18 +41,18 @@ use Encode;
 use JSON::PP;
 use Log::Any qw($log);
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
-my $code = normalize_code(param('code'));
-my $imgids = param('imgids');
-my $move_to = param('move_to_override');
+my $type = scalar param('type') || 'add';
+my $action = scalar param('action') || 'display';
+my $code = normalize_code(scalar param('code'));
+my $imgids = scalar param('imgids');
+my $move_to = scalar param('move_to_override');
 if ($move_to =~ /^(off|obf|opf|opff)$/) {
 	$move_to .= ':' . $code;
 }
 elsif ($move_to ne 'trash') {
 	$move_to = normalize_code($move_to);
 }
-my $copy_data = param('copy_data_override');
+my $copy_data = scalar param('copy_data_override');
 
 $log->debug("start", { ip => remote_addr(), type => $type, action => $action, code => $code, imgids => $imgids, move_to => $move_to, copy_data => $copy_data }) if $log->is_debug();
 

--- a/cgi/product_image_rotate.pl
+++ b/cgi/product_image_rotate.pl
@@ -36,13 +36,13 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $code = normalize_code(param('code'));
+my $code = normalize_code(scalar param('code'));
 my $product_id = product_id_for_owner($Owner_id, $code);
 my $path = product_path_from_id($product_id);
-my $imgid = param('imgid');
-my $angle = param('angle');
-my $normalize = param('normalize');
-my $white_magic = param('white_magic');
+my $imgid = scalar param('imgid');
+my $angle = scalar param('angle');
+my $normalize = scalar param('normalize');
+my $white_magic = scalar param('white_magic');
 
 $log->debug('start', { code => $code, imgid => $imgid, angle => $angle, normalize => $normalize }) if $log->is_debug(); ## no critic (ProhibitPostfixControls)
 

--- a/cgi/product_image_unselect.pl
+++ b/cgi/product_image_unselect.pl
@@ -42,11 +42,11 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'add';
+my $action = scalar param('action') || 'display';
 
-my $code = normalize_code(param('code'));
-my $id = param('id');
+my $code = normalize_code(scalar param('code'));
+my $id = scalar param('id');
 
 my $product_id = product_id_for_owner($Owner_id, $code);
 

--- a/cgi/product_image_upload.pl
+++ b/cgi/product_image_upload.pl
@@ -42,14 +42,14 @@ use Encode;
 use JSON::PP;
 use Log::Any qw($log);
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
-my $code = normalize_code(param('code'));
+my $type = scalar param('type') || 'add';
+my $action = scalar param('action') || 'display';
+my $code = normalize_code(scalar param('code'));
 # For scan parties, we may get photos in sequence, with the barcode only in the first photo
-my $previous_code = normalize_code(param('previous_code'));
-my $previous_imgid = param('previous_imgid');
-my $imagefield = param('imagefield');
-my $delete = param('delete');
+my $previous_code = normalize_code(scalar param('previous_code'));
+my $previous_imgid = scalar param('previous_imgid');
+my $imagefield = scalar param('imagefield');
+my $delete = scalar param('delete');
 
 local $log->context->{upload_session} = int(rand(100000000));
 
@@ -286,7 +286,7 @@ if ($imagefield) {
 				# Changed 2020-03-05: overwrite already selected images
 				# and ((not defined $product_ref->{images}{$imagefield}) or ($select_image))
 				# Changed 2020-04-20: don't overwrite selected images if the source is the product edit form
-				and ((not defined param('source')) or (param('source') ne "product_edit_form") or (not defined $product_ref->{images}{$imagefield}))
+				and ((not defined scalar param('source')) or (scalar param('source') ne "product_edit_form") or (not defined $product_ref->{images}{$imagefield}))
 				) {
 				$log->debug("selecting image", { imgid => $imgid, imagefield => $imagefield}) if $log->is_debug();
 				process_image_crop($User_id, $product_id, $imagefield, $imgid, 0, undef, undef, -1, -1, -1, -1, "full");

--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -61,7 +61,7 @@ my $interface_version = '20150316.jqm2';
 
 my %response = ();
 
-my $code = param('code');
+my $code = scalar param('code');
 my $product_id;
 
 $log->debug("start", { code => $code, lc => $lc }) if $log->is_debug();
@@ -127,9 +127,9 @@ else {
 
 	# Fix too low salt values
 	# 2020/02/25 - https://github.com/openfoodfacts/openfoodfacts-server/issues/2945
-	if ((defined $User_id) and ($User_id eq 'kiliweb') and (defined param("nutriment_salt"))) {
+	if ((defined $User_id) and ($User_id eq 'kiliweb') and (defined scalar param("nutriment_salt"))) {
 
-		my $salt = param("nutriment_salt");
+		my $salt = scalar param("nutriment_salt");
 
 		if ((defined $product_ref->{nutriments}) and (defined $product_ref->{nutriments}{salt_100g})) {
 
@@ -191,9 +191,9 @@ else {
 	}
 
 	# 26/01/2017 - disallow barcode changes until we fix bug #677
-	if ($User{moderator} and (defined param('new_code'))) {
+	if ($User{moderator} and (defined scalar param('new_code'))) {
 
-		change_product_server_or_code($product_ref, param('new_code'), \@errors);
+		change_product_server_or_code($product_ref, scalar param('new_code'), \@errors);
 		$code = $product_ref->{code};
 		
 		if ($#errors >= 0) {
@@ -222,7 +222,7 @@ else {
 
 	# generate a list of potential languages for language specific fields
 	my %param_langs = ();
-	foreach my $param (param()) {
+	foreach my $param (multi_param()) {
 		if ($param =~ /^(.*)_(\w\w)$/) {
 			if (defined $language_fields{$1}) {
 				$param_langs{$2} = 1;
@@ -233,7 +233,7 @@ else {
 			if (defined $language_fields{$1}) {
 				$param_langs{$2} = 1;
 				# set the product_name_pt value to the value of product_name_pt-BR
-				param($1 . "_" . $2, param($1 . "_" . $2 . "-" . $3));
+				param($1 . "_" . $2, scalar param($1 . "_" . $2 . "-" . $3));
 			}
 		}
 	}
@@ -241,9 +241,9 @@ else {
 
 	# 01/06/2019 --> Yuka always sends fr fields even for Spanish products, try to correct it
 
-	if ((defined $User_id) and ($User_id eq 'kiliweb') and (defined param('cc'))) {
+	if ((defined $User_id) and ($User_id eq 'kiliweb') and (defined scalar param('cc'))) {
 
-		my $param_cc = lc(param('cc'));
+		my $param_cc = lc(scalar param('cc'));
 		$param_cc =~ s/^en://;
 
 		my %lc_overrides = (
@@ -287,16 +287,16 @@ else {
 
 		# 11/6/2018 --> force add_brands and add_countries for yuka / kiliweb
 		if ((defined $User_id) and ($User_id eq 'kiliweb')
-			and (defined param($field))
+			and (defined scalar param($field))
 			and (($field eq 'brands') or ($field eq 'countries'))) {
 
-			param(-name => "add_" . $field, -value => param($field));
+			param(-name => "add_" . $field, -value => scalar param($field));
 			$log->debug("yuka - kiliweb : force add_field", { field => $field, code => $code }) if $log->is_debug();
 
 		}
 
 		# add_brands=additional brand : only add if it does not exist yet
-		if ((defined $tags_fields{$field}) and (defined param("add_$field"))) {
+		if ((defined $tags_fields{$field}) and (defined scalar param("add_$field"))) {
 
 			my $additional_fields = remove_tags_and_quote(decode utf8=>param("add_$field"));
 
@@ -305,7 +305,7 @@ else {
 			$log->debug("add_field", { field => $field, code => $code, additional_fields => $additional_fields, existing_value => $product_ref->{$field} }) if $log->is_debug();
 		}
 
-		elsif (defined param($field)) {
+		elsif (defined scalar param($field)) {
 
 			# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
 			if (($protected_data) and (defined $product_ref->{$field}) and ($product_ref->{$field} ne "")) {
@@ -329,8 +329,8 @@ else {
 				}
 				elsif ($field eq "ecoscore_extended_data") {
 					# we expect a JSON value
-					if (defined param($field)) {
-						$product_ref->{$field} = decode_json(param($field));
+					if (defined scalar param($field)) {
+						$product_ref->{$field} = decode_json(scalar param($field));
 					}
 				}
 				else {
@@ -350,7 +350,7 @@ else {
 
 			foreach my $param_lang (@param_langs) {
 				my $field_lc = $field . '_' . $param_lang;
-				if (defined param($field_lc)) {
+				if (defined scalar param($field_lc)) {
 
 					# Do not allow edits / removal through API for data provided by producers (only additions for non existing fields)
 					if (($protected_data) and (defined $product_ref->{$field_lc}) and ($product_ref->{$field_lc} ne "")) {

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -64,15 +64,15 @@ if ($User_id eq 'unwanted-user-french') {
 }
 
 
-my $type = param('type') || 'search_or_add';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'search_or_add';
+my $action = scalar param('action') || 'display';
 
 my $comment = 'Modification : ';
 
 my @errors = ();
 
 my $html = '';
-my $code = normalize_code(param('code'));
+my $code = normalize_code(scalar param('code'));
 my $product_id;
 
 my $product_ref = undef;
@@ -98,7 +98,7 @@ if ($type eq 'search_or_add') {
 
 	my $r = Apache2::RequestUtil->request();
 	my $method = $r->method();
-	if ((not defined $code) and ((not defined param("imgupload_search")) or ( param("imgupload_search") eq '')) and ($method eq 'POST')) {
+	if ((not defined $code) and ((not defined scalar param("imgupload_search")) or ( scalar param("imgupload_search") eq '')) and ($method eq 'POST')) {
 
 		($code, $product_id) = assign_new_code();
 	}
@@ -118,7 +118,7 @@ if ($type eq 'search_or_add') {
 			$location = product_url($product_ref);
 
 			# jquery.fileupload ?
-			if (param('jqueryfileupload')) {
+			if (scalar param('jqueryfileupload')) {
 
 				$type = 'show';
 			}
@@ -148,7 +148,7 @@ if ($type eq 'search_or_add') {
 		}
 	}
 	else {
-		if (defined param("imgupload_search")) {
+		if (defined scalar param("imgupload_search")) {
 			$log->info("no code found in image") if $log->is_info();
 			$data{error} = lang("image_upload_error_no_barcode_found_in_image_short");
 		}
@@ -161,7 +161,7 @@ if ($type eq 'search_or_add') {
 	$data{location} = $location;
 
 	# jquery.fileupload ?
-	if (param('jqueryfileupload')) {
+	if (scalar param('jqueryfileupload')) {
 
 		my $data = encode_json(\%data);
 
@@ -171,7 +171,7 @@ if ($type eq 'search_or_add') {
 		exit();
 	}
 
-	$template_data_ref->{param_imgupload_search} = param("imgupload_search");
+	$template_data_ref->{param_imgupload_search} = scalar param("imgupload_search");
 
 }
 
@@ -227,8 +227,8 @@ if ($admin) {
 	push @fields, "environment_impact_level";
 
 	# Let admins edit any other fields
-	if (defined param("fields")) {
-		push @fields, split(/,/, param("fields"));
+	if (defined scalar param("fields")) {
+		push @fields, split(/,/, scalar param("fields"));
 	}
 
 }
@@ -253,9 +253,9 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 	exists $product_ref->{new_server} and delete $product_ref->{new_server};
 
 	# 26/01/2017 - disallow barcode changes until we fix bug #677
-	if ($User{moderator} and (defined param("new_code")) and (param("new_code") ne "")) {
+	if ($User{moderator} and (defined scalar param("new_code")) and (scalar param("new_code") ne "")) {
 
-		change_product_server_or_code($product_ref, param("new_code"), \@errors);
+		change_product_server_or_code($product_ref, scalar param("new_code"), \@errors);
 		$code = $product_ref->{code};
 	}
 
@@ -263,8 +263,8 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	my @param_sorted_langs = ();
 	my %param_sorted_langs = ();
-	if (defined param("sorted_langs")) {
-		foreach my $display_lc (split(/,/, param("sorted_langs"))) {
+	if (defined scalar param("sorted_langs")) {
+		foreach my $display_lc (split(/,/, scalar param("sorted_langs"))) {
 			if ($display_lc =~ /^\w\w$/) {
 				push @param_sorted_langs, $display_lc;
 				$param_sorted_langs{$display_lc} = 1;
@@ -277,8 +277,8 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	# Make sure we have the main language of the product (which could be new)
 	# needed if we are moving data from one language to the main language
-	if ((defined param("lang")) and (param("lang") =~ /^\w\w$/) and (not defined $param_sorted_langs{param("lang")} )) {
-		push @param_sorted_langs, param("lang");
+	if ((defined scalar param("lang")) and (scalar param("lang") =~ /^\w\w$/) and (not defined $param_sorted_langs{scalar param("lang")} )) {
+		push @param_sorted_langs, scalar param("lang");
 	}
 
 	$product_ref->{"debug_param_sorted_langs"} = \@param_sorted_langs;
@@ -298,15 +298,15 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 	# Move all data and photos from one language to another?
 	if ($User{moderator}) {
 
-		my $product_lc = param("lang");
+		my $product_lc = scalar param("lang");
 
 		foreach my $from_lc (@param_sorted_langs) {
 
 			my $moveid = "move_" . $from_lc . "_data_and_images_to_main_language";
 
-			if (($from_lc ne $product_lc) and (defined param($moveid)) and (param($moveid) eq "on")) {
+			if (($from_lc ne $product_lc) and (defined scalar param($moveid)) and (scalar param($moveid) eq "on")) {
 
-				my $mode = param($moveid . "_mode") || "replace";
+				my $mode = scalar param($moveid . "_mode") || "replace";
 
 				$log->debug("moving all data and photos from one language to another",
 					{ from_lc => $from_lc, product_lc => $product_lc, mode => $mode }) if $log->is_debug();
@@ -318,14 +318,14 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 					my $from_field = $field . "_" . $from_lc;
 					my $to_field = $field . "_" . $product_lc;
 
-					my $from_value = param($from_field);
+					my $from_value = scalar param($from_field);
 
 					$log->debug("moving field value?",
 							{ from_field => $from_field, from_value => $from_value, to_field => $to_field }) if $log->is_debug();
 
 					if ((defined $from_value) and ($from_value ne "")) {
 
-						my $to_value = param($to_field);
+						my $to_value = scalar param($to_field);
 
 						$log->debug("moving field value",
 							{ from_field => $from_field, from_value => $from_value, to_field => $to_field, to_value => $to_value, mode => $mode }) if $log->is_debug();
@@ -384,7 +384,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	foreach my $field (@param_fields) {
 
-		if (defined param($field)) {
+		if (defined scalar param($field)) {
 
 			# If we are on the public platform, and the field data has been imported from the producer platform
 			# ignore the field changes for non tag fields, unless made by a moderator
@@ -482,7 +482,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	# Obsolete products
 
-	if (($User{moderator} or $Owner_id) and (defined param('obsolete_since_date'))) {
+	if (($User{moderator} or $Owner_id) and (defined scalar param('obsolete_since_date'))) {
 		$product_ref->{obsolete} = remove_tags_and_quote(decode utf8=>param("obsolete"));
 		$product_ref->{obsolete_since_date} = remove_tags_and_quote(decode utf8=>param("obsolete_since_date"));
 	}
@@ -1312,7 +1312,7 @@ HTML
 
 	}
 
-	$template_data_ref_display->{param_fields} = param("fields");
+	$template_data_ref_display->{param_fields} = scalar param("fields");
 	$template_data_ref_display->{type} = $type;
 	$template_data_ref_display->{code} = $code;
 	$template_data_ref_display->{display_product_history} = display_product_history($code, $product_ref);

--- a/cgi/recent_changes.pl
+++ b/cgi/recent_changes.pl
@@ -46,12 +46,12 @@ my $request_ref = ProductOpener::Display::init_request();
 
 my $query_ref = {};
 
-my $limit = 0 + (param('page_size') || $page_size);
+my $limit = 0 + (scalar param('page_size') || $page_size);
 if (($limit < 2) or ($limit > 1000)) {
 	$limit = $page_size;
 }
 
-my $page = 0 + (param('page') || 1);
+my $page = 0 + (scalar param('page') || 1);
 if (($page < 1) or ($page > 1000)) {
 	$page = 1;
 }
@@ -62,8 +62,8 @@ my $request_ref = {
 
 foreach my $parameter ('json') {
 
-	if (defined param($parameter)) {
-		$request_ref->{$parameter} = param($parameter);
+	if (defined scalar param($parameter)) {
+		$request_ref->{$parameter} = scalar param($parameter);
 	}
 }
 

--- a/cgi/remove_products.pl
+++ b/cgi/remove_products.pl
@@ -46,7 +46,7 @@ use Log::Any qw($log);
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $action = param('action') || 'display';
+my $action = scalar param('action') || 'display';
 
 my $title = lang("remove_products_from_producers_platform");
 my $html = '';

--- a/cgi/reset_password.pl
+++ b/cgi/reset_password.pl
@@ -45,11 +45,11 @@ my $template_data_ref = {
 	lang => \&lang,
 };
 
-my $type = param('type') || 'send_email';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'send_email';
+my $action = scalar param('action') || 'display';
 
-my $id = param('userid_or_email');
-my $resetid = param('resetid');
+my $id = scalar param('userid_or_email');
+my $resetid = scalar param('resetid');
 
 $log->info("start", { type => $type, action => $action, userid_or_email => $id, resetid => $resetid }) if $log->is_info();
 
@@ -94,13 +94,13 @@ if ($action eq 'process') {
 		}
 
 	}
-	elsif (($type eq 'reset') and (defined param('resetid'))) {
+	elsif (($type eq 'reset') and (defined scalar param('resetid'))) {
 
-		if (length(param('password')) < 6) {
+		if (length(scalar param('password')) < 6) {
 			push @errors, $Lang{error_invalid_password}{$lang};
 		}
 
-		if (param('password') ne param('confirm_password')) {
+		if (scalar(param('password')) ne scalar(param('confirm_password'))) {
 			push @errors, $Lang{error_different_passwords}{$lang};
 		}
 
@@ -124,8 +124,8 @@ if ($action eq 'display') {
 	push @{$template_data_ref->{errors}}, @errors;
 	
 	if ($type eq 'reset') {
-		$template_data_ref->{token} = param('token');
-		$template_data_ref->{resetid} = param('resetid');
+		$template_data_ref->{token} = scalar param('token');
+		$template_data_ref->{resetid} = scalar param('resetid');
 	}
 }
 
@@ -166,7 +166,7 @@ elsif ($action eq 'process') {
 		}
 	}
 	elsif ($type eq 'reset') {
-		my $userid = get_string_id_for_lang("no_language", param('resetid'));
+		my $userid = get_string_id_for_lang("no_language", scalar param('resetid'));
 		my $user_ref = retrieve("$data_root/users/$userid.sto");
 		
 		$log->debug("resetting password", {userid => $userid }) if $log->is_debug();
@@ -175,7 +175,7 @@ elsif ($action eq 'process') {
 		
 		if (defined $user_ref) {
 
-			if ((defined $user_ref->{token}) and (defined param('token')) and (param('token') eq $user_ref->{token}) and (time() < ($user_ref->{token_t} + 86400*3))) {
+			if ((defined $user_ref->{token}) and (defined scalar param('token')) and (scalar param('token') eq $user_ref->{token}) and (time() < ($user_ref->{token_t} + 86400*3))) {
 				
 				$log->debug("token is valid, updating password", {userid => $userid }) if $log->is_debug();
 				

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -61,41 +61,25 @@ if (user_agent() =~ /apps-spreadsheets/) {
 	);
 }
 
-if (0) {
-	if (param('jqm')) {
-		print "Content-Type: application/json; charset=UTF-8\r\nAccess-Control-Allow-Origin: *\r\n\r\n"
-		  . '{"jqm":"<p>Suite &agrave; l\'&eacute;mission Envoy&eacute; Sp&eacute;cial vous &ecirc;tes extr&egrave;mement nombreuses et nombreux &agrave; essayer l\'app Open Food Facts et le serveur est surcharg&eacute;. Nous avons du temporairement d&eacute;sactiver la recherche de produit (mais le scan est toujours possible). La situation devrait revenir &agrave; la normale bient&ocirc;t.</p> <p>Merci de votre compr&eacute;hension !</p> <p>St&eacute;phane et toute l\'&eacute;quipe b&eacute;n&eacute;vole d\'Open Food Facts</p>"}';
-		return "";
-	}
-	elsif (param('json')) {
-		print "Content-Type: application/json; charset=UTF-8\r\nAccess-Control-Allow-Origin: *\r\n\r\n" . <<JSON
-{ "page_size": "20", "products": [ { "image_small_url": "https://static.openfoodfacts.org/images/misc/yeswescan-313x222.png", "product_name": "Le serveur est surcharge !", "brands": "Merci de votre comprehension", "quantity": "1", "code": "3554748001005", "nutrition_grade_fr": "A" } ], "page": 1, "skip": 0, "count": 1 }
-JSON
-		  ;
-
-		return "";
-	}
-}
-
 my $request_ref = ProductOpener::Display::init_request();
 $request_ref->{search} = 1;
 
-my $action = param('action') || 'display';
+my $action = scalar(param('action')) || 'display';
 
-if ((defined param('search_terms')) and (not defined param('action'))) {
+if ((defined scalar param('search_terms')) and (not defined scalar param('action'))) {
 	$action = 'process';
 }
 
 foreach my $parameter ('fields', 'json', 'jsonp', 'jqm', 'jqm_loadmore', 'xml', 'rss') {
 
-	if (defined param($parameter)) {
-		$request_ref->{$parameter} = param($parameter);
+	if (defined scalar param($parameter)) {
+		$request_ref->{$parameter} = scalar param($parameter);
 	}
 }
 
 # if the query request json or xml, either through the json=1 parameter or a .json extension
 # set the $request_ref->{api} field
-if ((defined param('json')) or (defined param('jsonp')) or (defined param('xml'))) {
+if ((defined scalar param('json')) or (defined scalar param('jsonp')) or (defined scalar param('xml'))) {
 	$request_ref->{api} = 'v0';
 }
 
@@ -134,19 +118,19 @@ my @search_ingredient_classes = (
 my $tags_n = 2;
 my $nutriments_n = 2;
 
-my $search_terms = remove_tags_and_quote(decode utf8 => param('search_terms2'));    #advanced search takes precedence
+my $search_terms = remove_tags_and_quote(decode utf8 => scalar param('search_terms2'));    #advanced search takes precedence
 if ((not defined $search_terms) or ($search_terms eq '')) {
-	$search_terms = remove_tags_and_quote(decode utf8 => param('search_terms'));
+	$search_terms = remove_tags_and_quote(decode utf8 => scalar param('search_terms'));
 }
 
 # check if the search term looks like a barcode
 
-if (    (not defined param('json'))
-	and (not defined param('jsonp'))
-	and (not defined param('jqm'))
-	and (not defined param('jqm_loadmore'))
-	and (not defined param('xml'))
-	and (not defined param('rss'))
+if (    (not defined scalar param('json'))
+	and (not defined scalar param('jsonp'))
+	and (not defined scalar param('jqm'))
+	and (not defined scalar param('jqm_loadmore'))
+	and (not defined scalar param('xml'))
+	and (not defined scalar param('rss'))
 	and ($search_terms =~ /^(\d{4,24})$/))
 {
 
@@ -173,7 +157,7 @@ my @search_nutriments = ();
 my %search_ingredient_classes = ();
 my %search_ingredient_classes_checked = ();
 
-for (my $i = 0; defined param("tagtype_$i"); $i++) {
+for (my $i = 0; defined scalar param("tagtype_$i"); $i++) {
 
 	my $tagtype = remove_tags_and_quote(decode utf8 => param("tagtype_$i"));
 	my $tag_contains = remove_tags_and_quote(decode utf8 => param("tag_contains_$i"));
@@ -184,12 +168,12 @@ for (my $i = 0; defined param("tagtype_$i"); $i++) {
 
 foreach my $tagtype (@search_ingredient_classes) {
 
-	$search_ingredient_classes{$tagtype} = param($tagtype);
+	$search_ingredient_classes{$tagtype} = scalar param($tagtype);
 	not defined $search_ingredient_classes{$tagtype} and $search_ingredient_classes{$tagtype} = 'indifferent';
 	$search_ingredient_classes_checked{$tagtype} = {$search_ingredient_classes{$tagtype} => 'checked="checked"'};
 }
 
-for (my $i = 0; defined param("nutriment_$i"); $i++) {
+for (my $i = 0; defined scalar param("nutriment_$i"); $i++) {
 
 	my $nutriment = remove_tags_and_quote(decode utf8 => param("nutriment_$i"));
 	my $nutriment_compare = remove_tags_and_quote(decode utf8 => param("nutriment_compare_$i"));
@@ -214,7 +198,7 @@ if (    ($sort_by ne 'created_t')
 	$sort_by = 'unique_scans_n';
 }
 
-my $limit = 0 + (param('page_size') || $page_size);
+my $limit = 0 + (scalar param('page_size') || $page_size);
 if (($limit < 2) or ($limit > 1000)) {
 	$limit = $page_size;
 }
@@ -242,11 +226,11 @@ if ($action eq 'display') {
 	my $active_map = '';
 	my $active_graph = '';
 
-	if (param("generate_map")) {
+	if (scalar param("generate_map")) {
 		$active_list = '';
 		$active_map = 'active';
 	}
-	elsif (param("graph")) {
+	elsif (scalar param("graph")) {
 		$active_list = '';
 		$active_graph = 'active';
 	}
@@ -296,7 +280,7 @@ if ($action eq 'display') {
 		{value => "does_not_contain", label => lang("search_does_not_contain")},
 	];
 
-	for (my $i = 0; ($i < $tags_n) or defined param("tagtype_$i"); $i++) {
+	for (my $i = 0; ($i < $tags_n) or defined scalar param("tagtype_$i"); $i++) {
 
 		push @{$template_data_ref->{criteria}},
 		  {
@@ -375,7 +359,7 @@ if ($action eq 'display') {
 		},
 	];
 
-	for (my $i = 0; ($i < $nutriments_n) or (defined param("nutriment_$i")); $i++) {
+	for (my $i = 0; ($i < $nutriments_n) or (defined scalar param("nutriment_$i")); $i++) {
 
 		push @{$template_data_ref->{nutriments}},
 		  {
@@ -488,7 +472,7 @@ elsif ($action eq 'process') {
 
 	my $query_ref = {};
 
-	my $page = 0 + (param('page') || 1);
+	my $page = 0 + (scalar param('page') || 1);
 	if (($page < 1) or ($page > 1000)) {
 		$page = 1;
 	}
@@ -647,7 +631,7 @@ elsif ($action eq 'process') {
 
 		next if defined $search_ingredient_classes{$field};
 
-		if ((defined param($field)) and (param($field) ne '')) {
+		if ((defined scalar param($field)) and (scalar param($field) ne '')) {
 
 			$query_ref->{$field} = decode utf8 => param($field);
 			$current_link .= "\&$field=" . URI::Escape::XS::encodeURIComponent(decode utf8 => param($field));
@@ -663,16 +647,16 @@ elsif ($action eq 'process') {
 	# Graphs
 
 	foreach my $axis ('x', 'y') {
-		if ((defined param("axis_$axis")) and (param("axis_$axis") ne '')) {
+		if ((defined scalar param("axis_$axis")) and (scalar param("axis_$axis") ne '')) {
 			$current_link .= "\&axis_$axis=" . URI::Escape::XS::encodeURIComponent(decode utf8 => param("axis_$axis"));
 		}
 	}
 
-	if ((defined param('graph_title')) and (param('graph_title') ne '')) {
+	if ((defined scalar param('graph_title')) and (scalar param('graph_title') ne '')) {
 		$current_link .= "\&graph_title=" . URI::Escape::XS::encodeURIComponent(decode utf8 => param("graph_title"));
 	}
 
-	if ((defined param('map_title')) and (param('map_title') ne '')) {
+	if ((defined scalar param('map_title')) and (scalar param('map_title') ne '')) {
 		$current_link .= "\&map_title=" . URI::Escape::XS::encodeURIComponent(decode utf8 => param("map_title"));
 	}
 
@@ -694,18 +678,18 @@ elsif ($action eq 'process') {
 
 	my $share = lang('share');
 
-	my $map = param("generate_map") || '';
-	my $graph = param("graph") || '';
-	my $download = param("download") || '';
+	my $map = scalar param("generate_map") || '';
+	my $graph = scalar param("graph") || '';
+	my $download = scalar param("download") || '';
 
 	open(my $OUT, ">>:encoding(UTF-8)", "$data_root/logs/search_log_debug");
-	print $OUT remote_addr() . "\t" . time() . "\t" . decode utf8 => param('search_terms') . " - map: $map 
+	print $OUT remote_addr() . "\t" . time() . "\t" . decode utf8 => scalar(param('search_terms')) . " - map: $map 
 	 - graph: $graph - download: $download - page: $page\n";
 	close($OUT);
 
 	# Graph, map, export or search
 
-	if (param("generate_map")) {
+	if (scalar param("generate_map")) {
 
 		$request_ref->{current_link} .= "&generate_map=1";
 
@@ -732,8 +716,8 @@ HTML
 		display_page($request_ref);
 	}
 	elsif (
-		param("generate_graph_scatter_plot")    # old parameter, kept for existing links
-		or param("graph")
+		scalar param("generate_graph_scatter_plot")    # old parameter, kept for existing links
+		or scalar param("graph")
 	  )
 	{
 
@@ -771,11 +755,11 @@ HTML
 
 		display_page($request_ref);
 	}
-	elsif (param("download")) {
+	elsif (scalar param("download")) {
 
 		# CSV export
 
-		$request_ref->{format} = param('format');
+		$request_ref->{format} = scalar param('format');
 		search_and_export_products($request_ref, $query_ref, $sort_by);
 
 	}
@@ -812,7 +796,7 @@ HTML
 			print "Content-Type: application/json; charset=UTF-8\r\nAccess-Control-Allow-Origin: *\r\n\r\n" . $data;
 		}
 
-		if (param('search_terms')) {
+		if (scalar param('search_terms')) {
 			open(my $OUT, ">>:encoding(UTF-8)", "$data_root/logs/search_log");
 			print $OUT remote_addr() . "\t" . time() . "\t" . decode utf8 => param('search_terms') . "\tpage: $page\n";
 			close($OUT);

--- a/cgi/session.pl
+++ b/cgi/session.pl
@@ -50,8 +50,8 @@ if (defined $User_id) {
 	$template_data_ref->{user_name} = $User{name};
 	$template_data_ref->{server_options_producers} = $server_options{producers_platform};
 
-	my $next_action = param('next_action');
-	my $code = param('code');
+	my $next_action = scalar param('next_action');
+	my $code = scalar param('code');
 	my $r = shift;
 	my $referer = $r->headers_in->{Referer};
 	my $url;
@@ -85,7 +85,7 @@ if (defined $User_id) {
 process_template('web/pages/session/session.tt.html', $template_data_ref, \$html)
   or $html = "<p>" . $tt->error() . "</p>";
 
-if (param('jqm')) {
+if (scalar param('jqm')) {
 
 	my %response;
 	if (defined $User_id) {

--- a/cgi/spellcheck_test.pl
+++ b/cgi/spellcheck_test.pl
@@ -61,10 +61,10 @@ my $separators = qr/($stops\s|$commas|$separators_except_comma)/i;
 
 
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
+my $type = scalar param('type') || 'add';
+my $action = scalar param('action') || 'display';
 
-my $tagtype= get_fileid(param('tagtype'));
+my $tagtype= get_fileid(scalar param('tagtype'));
 
 not defined $tagtype and $tagtype eq 'ingredients';
 

--- a/cgi/sso.pl
+++ b/cgi/sso.pl
@@ -36,8 +36,8 @@ use JSON::PP;
 
 use ProductOpener::Lang qw/:all/;
 
-my $user_id = param('user_id');
-my $user_session = param('user_session');
+my $user_id = scalar param('user_id');
+my $user_session = scalar param('user_session');
 
 my $response_ref = check_session($user_id, $user_session);
 

--- a/cgi/suggest.pl
+++ b/cgi/suggest.pl
@@ -63,7 +63,7 @@ Warning, we are currently doing a brute force search, so avoid setting it too hi
 
 =cut
 
-my $tagtype = param('tagtype');
+my $tagtype = scalar param('tagtype');
 my $string = decode utf8=>param('string');
 # searched term
 my $term = decode utf8=>param('term');
@@ -71,8 +71,8 @@ my $term = decode utf8=>param('term');
 # search language code
 my $search_lc = $lc;
 # superseed by request parameter
-if (defined param('lc')) {
-	$search_lc = param('lc');
+if (defined scalar param('lc')) {
+	$search_lc = scalar param('lc');
 }
 
 my $original_lc = $search_lc;
@@ -86,9 +86,9 @@ if ($term =~ /^(\w\w):/) {
 # max results
 my $limit = 25;
 # superseed by request parameter
-if (defined param('limit')) {
+if (defined scalar param('limit')) {
 	# we put a hard limit however
-	$limit = min(int(param('limit')), 400);
+	$limit = min(int(scalar param('limit')), 400);
 }
 
 

--- a/cgi/test_ingredients_analysis.pl
+++ b/cgi/test_ingredients_analysis.pl
@@ -46,8 +46,8 @@ my $request_ref = ProductOpener::Display::init_request();
 
 my $template_data_ref = {};
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
+my $type = scalar(param('type')) || 'add';
+my $action = scalar(param('action')) || 'display';
 
 my $ingredients_text = remove_tags_and_quote(decode utf8=>param('ingredients_text'));
 

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -38,8 +38,8 @@ use Log::Any qw($log);
 
 my @user_groups = qw(producer database app bot moderator pro_moderator);
 
-my $type = param('type') || 'add';
-my $action = param('action') || 'display';
+my $type = scalar(param('type')) || 'add';
+my $action = scalar(param('action')) || 'display';
 
 # Passing values to the template
 my $template_data_ref = {};
@@ -49,9 +49,9 @@ my $template_data_ref = {};
 # function does not try to authenticate the user (which does not exist yet) with that password
 
 my $new_user_password;
-if (($type eq "add") and (defined param('prdct_mult'))) {
+if (($type eq "add") and (defined scalar param('prdct_mult'))) {
 
-	$new_user_password = param('password');
+	$new_user_password = scalar param('password');
 	param("password", "");
 }
 
@@ -62,9 +62,9 @@ my $request_ref = ProductOpener::Display::init_request();
 
 my $userid = $User_id;
 
-if (defined param('userid')) {
+if (defined scalar param('userid')) {
 
-	$userid = param('userid');
+	$userid = scalar param('userid');
 
 	# The userid looks like an e-mail
 	if ($admin and ($userid =~ /\@/)) {
@@ -104,7 +104,7 @@ my @errors = ();
 if ($action eq 'process') {
 
 	if ($type eq 'edit') {
-		if (param('delete') eq 'on') {
+		if (scalar param('delete') eq 'on') {
 			if ($admin) {
 				$type = 'delete';
 			}
@@ -142,7 +142,7 @@ if ($action eq 'display') {
 	# passed in a form to open a session.
 	# e.g. when a non-logged user clicks on the "Edit product" button
 
-	if (($type eq "add") and (defined param("user_id"))) {
+	if (($type eq "add") and (defined scalar param("user_id"))) {
 		my $user_info = remove_tags_and_quote(scalar param('user_id'));
 		$user_info =~ /^(.+?)@/;
 		if ( defined ($1) ){

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -617,15 +617,17 @@ sub init_request() {
 	# Allow cc and lc overrides as query parameters
 	# do not redirect to the corresponding subdomain
 	my $cc_lc_overrides = 0;
-	if ((defined param('cc')) and ((defined $country_codes{lc(param('cc'))}) or (lc(param('cc')) eq 'world')) ) {
-		$cc = lc(param('cc'));
+	my $param_cc = scalar param('cc');
+	if ((defined $param_cc) and ((defined $country_codes{lc($param_cc)}) or (lc($param_cc) eq 'world')) ) {
+		$cc = lc($param_cc);
 		$country = $country_codes{$cc};
 		$cc_lc_overrides = 1;
 		$log->debug("cc override from request parameter", { cc => $cc }) if $log->is_debug();
 	}
-	if (defined param('lc')) {
+	my $param_lc = scalar param('lc');
+	if (defined $param_lc) {
 		# allow multiple languages in an ordered list
-		@lcs = split(/,/, lc(param('lc')));
+		@lcs = split(/,/, lc($param_lc));
 		if (defined $language_codes{$lcs[0]}) {
 			$lc = $lcs[0];
 			$lang = $lc;
@@ -661,7 +663,7 @@ sub init_request() {
 
 	my $error = ProductOpener::Users::init_user($request_ref);
 	if ($error) {
-		if (not param('jqm')) { # API
+		if (not scalar param('jqm')) { # API
 			display_error($error, undef);
 		}
 	}
@@ -871,7 +873,7 @@ sub analyze_request($request_ref) {
 
 	# if the query request json or xml, either through the json=1 parameter or a .json extension
 	# set the $request_ref->{api} field
-	if ((defined param('json')) or (defined param('jsonp')) or (defined param('xml'))) {
+	if ((defined scalar param('json')) or (defined scalar param('jsonp')) or (defined scalar param('xml'))) {
 		$request_ref->{api} = 'v0';
 	}
 
@@ -909,7 +911,7 @@ sub analyze_request($request_ref) {
 		}
 
 		# If return format is not xml or jqm or jsonp, default to json
-		if ((not defined param("xml")) and (not defined param("jqm")) and (not defined param("jsonp"))) {
+		if ((not defined scalar param("xml")) and (not defined scalar param("jqm")) and (not defined scalar param("jsonp"))) {
 			param("json", 1);
 		}
 
@@ -1599,8 +1601,9 @@ sub get_cache_results($key, $request_ref) {
 
 	# disable caching if ?no_cache=1
 	# or if the user is logged in and no_cache is different from 0
-	if ( ((defined param("no_cache")) and (param("no_cache")))
-		or ((defined $User_id) and not ((defined param("no_cache")) and (param("no_cache") == 0)))
+	my $param_no_cache = scalar param("no_cache");
+	if ( ($param_no_cache)
+		or ((defined $User_id) and not ((defined $param_no_cache) and ($param_no_cache == 0)))
 		) {
 
 		$log->debug("MongoDB no_cache parameter, skip caching", { key => $key }) if $log->is_debug();
@@ -1667,7 +1670,7 @@ sub query_list_of_tags($request_ref, $query_ref) {
 	my $limit;
 
 	#If ?stats=1 or ?filter=  then do not limit results size
-	if ((defined param("stats")) or (defined param("filter")) or (defined param("status")) or (defined param("translate")) ) {
+	if ((defined scalar param("stats")) or (defined scalar param("filter")) or (defined scalar param("status")) or (defined scalar param("translate")) ) {
 		$limit = 999999999999;
 	}
 	elsif (defined $request_ref->{tags_page_size}) {
@@ -1734,7 +1737,7 @@ sub query_list_of_tags($request_ref, $query_ref) {
 
 		# do not use the smaller cached products_tags collection if ?no_cache=1
 		# or if we are on the producers platform
-		if ( ((defined param("no_cache")) and (param("no_cache")))
+		if ( ((defined scalar param("no_cache")) and (scalar param("no_cache")))
 			or ($server_options{producers_platform})) {
 
 			eval {
@@ -1806,7 +1809,7 @@ sub query_list_of_tags($request_ref, $query_ref) {
 
 			# do not use the smaller cached products_tags collection if ?no_cache=1
 			# or if we are on the producers platform
-			if ( ((defined param("no_cache")) and (param("no_cache")))
+			if ( ((defined scalar param("no_cache")) and (scalar param("no_cache")))
 				or ($server_options{producers_platform})) {
 				eval {
 					$log->debug("Executing MongoDB aggregate count query on products collection", { query => $aggregate_count_parameters }) if $log->is_debug();
@@ -1962,7 +1965,7 @@ sub display_list_of_tags($request_ref, $query_ref) {
 			unknown_tags_products => 0,
 		);
 
-		my $missing_property = param("missing_property");
+		my $missing_property = scalar param("missing_property");
 		if ((defined $missing_property) and ($missing_property !~ /:/)) {
 			$missing_property .= ":en";
 			$log->debug("missing_property defined", {missing_property => $missing_property});
@@ -1980,10 +1983,10 @@ sub display_list_of_tags($request_ref, $query_ref) {
 			my $count = $tagcount_ref->{count};
 
 			# allow filtering tags with a search pattern
-			if (defined param("filter")) {
+			if (defined scalar param("filter")) {
 				my $tag_ref = get_taxonomy_tag_and_link_for_lang($lc, $tagtype, $tagid);
 				my $display = $tag_ref->{display};
-				my $regexp = quotemeta(decode("utf8",URI::Escape::XS::decodeURIComponent(param("filter"))));
+				my $regexp = quotemeta(decode("utf8",URI::Escape::XS::decodeURIComponent(scalar param("filter"))));
 				next if ($display !~ /$regexp/i);
 			}
 
@@ -2047,7 +2050,7 @@ sub display_list_of_tags($request_ref, $query_ref) {
 					if ($missing_property) {
 						next if (defined get_inherited_property($tagtype, $tagid, $missing_property));
 					}
-					if ((defined param("status")) and (param("status") eq "unknown")) {
+					if ((defined scalar param("status")) and (scalar param("status") eq "unknown")) {
 						next;
 					}
 				}
@@ -2059,7 +2062,7 @@ sub display_list_of_tags($request_ref, $query_ref) {
 					# ?missing_property=vegan
 					# keep only known tags
 					next if ($missing_property);
-					if ((defined param("status")) and (param("status") eq "known")) {
+					if ((defined scalar param("status")) and (scalar param("status") eq "known")) {
 						next;
 					}
 				}
@@ -2068,12 +2071,12 @@ sub display_list_of_tags($request_ref, $query_ref) {
 			$j++;
 
 			# allow limiting the number of results returned
-			if ((defined param("limit")) and ($j >= param("limit"))) {
+			if ((defined scalar param("limit")) and ($j >= scalar param("limit"))) {
 				last;
 			}
 
 			# do not compute the tag display if we just need stats
-			next if ((defined param("stats")) and (param("stats")));
+			next if ((defined scalar param("stats")) and (scalar param("stats")));
 
 			my $info = '';
 			my $css_class = '';
@@ -2243,11 +2246,11 @@ sub display_list_of_tags($request_ref, $query_ref) {
 		$html .= "</tbody></table></div>";
 
 		# if there are more than $tags_page_size lines, add pagination. Except for ?stats=1 and ?filter display
-		if ($request_ref->{structured_response}{count} >= $tags_page_size and not (defined param("stats")) and not (defined param("filter"))) {
+		if ($request_ref->{structured_response}{count} >= $tags_page_size and not (defined scalar param("stats")) and not (defined scalar param("filter"))) {
 			$html .= "\n<hr>" . display_pagination($request_ref, $request_ref->{structured_response}{count} , $tags_page_size , $request_ref->{page} );
 		}
 
-		if ((defined param("stats")) and (param("stats"))) {
+		if ((defined scalar param("stats")) and (scalar param("stats"))) {
 			#TODO: HERE WE ARE DOING A LOT OF EXTRA WORK BY FIRST CREATING THE TABLE AND THEN DESTROYING IT
 			$html =~ s/<table(.*)<\/table>//is;
 
@@ -2598,6 +2601,8 @@ sub display_list_of_tags_translate($request_ref, $query_ref) {
 
 		my @tagcounts;
 
+		my $param_translate = scalar param("translate");
+
 		foreach my $tagcount_ref (@tags) {
 
 			$i++;
@@ -2633,7 +2638,7 @@ sub display_list_of_tags_translate($request_ref, $query_ref) {
 				next;
 			}
 
-			if ((not param("translate") eq "all") and
+			if ((not ($param_translate eq "all")) and
 				((defined $tag_ref->{display_lc}) and (($tag_ref->{display_lc} eq $lc) or ($tag_ref->{display_lc} ne "en")))) {
 
 				$log->debug("display_list_of_tags_translate - entry $tagid already has a translation to $lc") if $log->is_debug();
@@ -2649,9 +2654,9 @@ sub display_list_of_tags_translate($request_ref, $query_ref) {
 
 				$log->debug("display_list_of_tags_translate - entry $tagid has existing user translation to $lc", $users_translations_ref->{$lc}{$tagid}) if $log->is_debug();
 
-				if (param("translate") eq "add") {
+				if ($param_translate eq "add") {
 					# Add mode: show only entries without translations
-					$log->debug("display_list_of_tags_translate - translate=" . param("translate") . " - skip $tagid entry with existing user translation") if $log->is_debug();
+					$log->debug("display_list_of_tags_translate - translate=" . $param_translate . " - skip $tagid entry with existing user translation") if $log->is_debug();
 					next;
 				}
 				# All, Edit or Review mode: show the new translation
@@ -2662,9 +2667,9 @@ sub display_list_of_tags_translate($request_ref, $query_ref) {
 
 				$log->debug("display_list_of_tags_translate - entry $tagid does not have user translation to $lc") if $log->is_debug();
 
-				if (param("translate") eq "review") {
+				if ($param_translate eq "review") {
 					# Review mode: show only entries with new translations
-					$log->debug("display_list_of_tags_translate - translate=" . param("translate") . " - skip $tagid entry without existing user translation") if $log->is_debug();
+					$log->debug("display_list_of_tags_translate - translate=" . $param_translate . " - skip $tagid entry without existing user translation") if $log->is_debug();
 					next;
 				}
 			}
@@ -3213,10 +3218,10 @@ sub display_tag($request_ref) {
 	if (((defined $newtagid) and ($newtagid ne $tagid)) or ((defined $newtagid2) and ($newtagid2 ne $tagid2))) {
 		$request_ref->{redirect} = $formatted_subdomain . $request_ref->{current_link};
 		# Re-add file suffix, so that the correct response format is kept. https://github.com/openfoodfacts/openfoodfacts-server/issues/894
-		$request_ref->{redirect} .= '.json' if param("json");
-		$request_ref->{redirect} .= '.jsonp' if param("jsonp");
-		$request_ref->{redirect} .= '.xml' if param("xml");
-		$request_ref->{redirect} .= '.jqm' if param("jqm");
+		$request_ref->{redirect} .= '.json' if scalar param("json");
+		$request_ref->{redirect} .= '.jsonp' if scalar param("jsonp");
+		$request_ref->{redirect} .= '.xml' if scalar param("xml");
+		$request_ref->{redirect} .= '.jqm' if scalar param("jqm");
 		$log->info("one or more tagids mismatch, redirecting to correct url", { redirect => $request_ref->{redirect} }) if $log->is_info();
 		redirect_to_url($request_ref, 302, $request_ref->{redirect});
 	}
@@ -4143,7 +4148,7 @@ HTML
 	process_template('web/pages/tag/tag.tt.html', $tag_template_data_ref, \$tag_html) or $tag_html = "<p>tag.tt.html template error: " . $tt->error() . "</p>";
 
 	if (defined $request_ref->{groupby_tagtype}) {
-		if (defined param("translate")) {
+		if (defined scalar param("translate")) {
 			${$request_ref->{content_ref}} .= $tag_html . display_list_of_tags_translate($request_ref, $query_ref);
 		}
 		else {
@@ -4223,7 +4228,7 @@ sub display_search_results($request_ref) {
 	$current_link =~ s/^\&/\?/;
 	$current_link = "/search" . $current_link;
 
-	if ((defined param("user_preferences")) and (param("user_preferences")) and not ($request_ref->{api}) ) {
+	if ((defined scalar param("user_preferences")) and (scalar param("user_preferences")) and not ($request_ref->{api}) ) {
 
 		# The results will be filtered and ranked on the client side
 
@@ -4283,7 +4288,7 @@ JS
 
 		my $query_ref = {};
 
-		if (defined param('parent_ingredients')) {
+		if (defined scalar param('parent_ingredients')) {
 			$html .= search_and_analyze_recipes($request_ref, $query_ref);
 		}
 		else {
@@ -4424,8 +4429,8 @@ sub add_params_to_query($request_ref, $query_ref) {
 	$log->debug("add_params_to_query", { params => {CGI::Vars()} }) if $log->is_debug();
 
 	# nocache was renamed to no_cache
-	if (defined param('nocache')) {
-		param('no_cache', param('nocache'));
+	if (defined scalar param('nocache')) {
+		param('no_cache', scalar param('nocache'));
 	}
 
 	my $and = $query_ref->{"\$and"};
@@ -4438,11 +4443,11 @@ sub add_params_to_query($request_ref, $query_ref) {
 		next if (defined $ignore_params{$field});
 
 		if (($field eq "page") or ($field eq "page_size")) {
-			$request_ref->{$field} = param($field) + 0;	# Make sure we have a number
+			$request_ref->{$field} = scalar param($field) + 0;	# Make sure we have a number
 		}
 
 		elsif ($field eq "sort_by") {
-			$request_ref->{$field} = param($field);
+			$request_ref->{$field} = scalar param($field);
 		}
 
 		# Tags fields can be passed with taxonomy ids as values (e.g labels_tags=en:organic)
@@ -4552,7 +4557,7 @@ sub add_params_to_query($request_ref, $query_ref) {
 			# We can have multiple conditions, separated with a comma
 			# e.g. sugars_100g=>10,<=20
 
-			my $conditions = param($field);
+			my $conditions = scalar param($field);
 
 			$log->debug("add_params_to_query - nutrient conditions", { field => $field, conditions => $conditions}) if $log->is_debug();
 
@@ -4569,7 +4574,7 @@ sub add_params_to_query($request_ref, $query_ref) {
 				}
 				else {
 					$operator = '=';
-					$value = param($field);
+					$value = scalar param($field);
 				}
 
 				$log->debug("add_params_to_query - nutrient condition", { field => $field, condition => $condition, operator => $operator, value => $value}) if $log->is_debug();
@@ -4637,7 +4642,7 @@ Initialize the options for knowledge panels from parameters.
 sub initialize_knowledge_panels_options($knowledge_panels_options_ref) {
 
 	# Activate physical activity knowledge panel only when specified
-	if (param("activate_knowledge_panel_physical_activities")) {
+	if (scalar param("activate_knowledge_panel_physical_activities")) {
 		$knowledge_panels_options_ref->{activate_knowledge_panel_physical_activities} = 1;
 	}
 	return;
@@ -4674,7 +4679,7 @@ sub customize_response_for_product($request_ref, $product_ref) {
 
 	my $carbon_footprint_computed = 0;
 
-	my $fields = param('fields');
+	my $fields = scalar param('fields');
 
 	# For non API queries, we need to compute attributes for personal search
 	if (((not defined $fields) or ($fields eq "")) and ($user_preferences) and (not $request_ref->{api})) {
@@ -4968,7 +4973,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 	my $fields_ref;
 
 	# - for API (json, xml, rss,...), display all fields
-	if (param("json") or param("jsonp") or param("xml") or param("jqm") or $request_ref->{rss}) {
+	if (scalar param("json") or scalar param("jsonp") or scalar param("xml") or scalar param("jqm") or $request_ref->{rss}) {
 		$fields_ref = {};
 	}
 	# - if we use user preferences, we need a lot of fields to compute product attributes: load them all
@@ -5042,7 +5047,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 			else {
 				$log->debug("Counting MongoDB documents for query", { query => $query_ref }) if $log->is_debug();
 				# test if query_ref is empty
-				if (param('no_count')) {
+				if (scalar param('no_count')) {
 					# Skip the count if it is not needed
 					# e.g. for some API queries
 					$log->debug("no_count is set, skipping count") if $log->is_debug();
@@ -5074,7 +5079,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 							}
 						}
 
-						if (($only_tags_filters) and ((not defined param("no_cache")) or (param("no_cache") == 0))) {
+						if (($only_tags_filters) and ((not defined scalar param("no_cache")) or (scalar param("no_cache") == 0))) {
 
 							$count = execute_query(sub {
 								$log->debug("count_documents on smaller products_tags collection", { key => $key_count }) if $log->is_debug();
@@ -5141,7 +5146,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 			$request_ref->{structured_response}{count} = $count;
 
 			# Don't set the cache if no_count was set
-			if (not param('no_count')) {
+			if (not scalar param('no_count')) {
 				set_cache_results($key,$request_ref->{structured_response})
 			}
 		}
@@ -5177,7 +5182,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 		$template_data_ref->{html_count} = $html_count;
 	}
 
-	$template_data_ref->{jqm} = param("jqm");
+	$template_data_ref->{jqm} = scalar param("jqm");
 	$template_data_ref->{country} = $country;
 	$template_data_ref->{world_subdomain} = get_world_subdomain();
 	$template_data_ref->{current_link} = $request_ref->{current_link};
@@ -5266,8 +5271,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 
 			add_images_urls_to_product($product_ref);
 
-			my $jqm = param("jqm");	# Assigning to a scalar to make sure we get a scalar
-			# jqm => param("jqm") in the hash below does not work
+			my $jqm = scalar param("jqm");	# Assigning to a scalar to make sure we get a scalar
 
 			push @{$template_data_ref->{structured_response_products}}, {
 				code => $code,
@@ -5286,7 +5290,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 		# For API queries, if the request specified a value for the fields parameter, return only the fields listed
 		# For non API queries with user preferences, we need to add attributes
 		if (((not defined $request_ref->{api}) and ($user_preferences))
-			or ((defined $request_ref->{api}) and (defined param('fields')))) {
+			or ((defined $request_ref->{api}) and (defined scalar param('fields')))) {
 
 			my $customized_products = [];
 
@@ -5304,7 +5308,7 @@ sub search_and_display_products($request_ref, $query_ref, $sort_by, $limit, $pag
 
 		# 2021-02-25: we now store only nested ingredients, flatten them if the API is <= 1
 
-		if ((defined param("api_version")) and (param("api_version") <= 1)) {
+		if ((defined scalar param("api_version")) and (scalar param("api_version") <= 1)) {
 
 			for my $product_ref (@{$request_ref->{structured_response}{products}}) {
 				if (defined $product_ref->{ingredients}) {
@@ -5403,7 +5407,7 @@ sub display_pagination($request_ref, $count, $limit, $page) {
 
 	$log->info("current link", { current_link => $current_link }) if $log->is_info();
 
-	if (param("jqm")) {
+	if (scalar param("jqm")) {
 		$current_link .= "&jqm=1";
 	}
 
@@ -5494,7 +5498,7 @@ sub display_pagination($request_ref, $count, $limit, $page) {
 
 	# Close the list
 
-	if (defined param("jqm")) {
+	if (defined scalar param("jqm")) {
 		if (defined $next_page_url) {
 			my $loadmore = lang("loadmore");
 			$html .= <<HTML
@@ -5511,7 +5515,7 @@ HTML
 		$html .= "</ul>\n";
 	}
 
-	if (not defined param("jqm")) {
+	if (not defined scalar param("jqm")) {
 		$html .= $html_pages;
 	}
 	return $html;
@@ -5535,8 +5539,8 @@ sub search_and_export_products($request_ref, $query_ref, $sort_by) {
 	my $max_count = $export_limit;
 
 	# Allow admins to change the export limit
-	if (($admin) and (defined param("export_limit"))) {
-		$max_count = param("export_limit");
+	if (($admin) and (defined scalar param("export_limit"))) {
+		$max_count = scalar param("export_limit");
 	}
 
 	my $args_ref = {
@@ -6125,8 +6129,8 @@ sub display_histogram($graph_ref, $products_ref) {
 		my @intervals = ();
 		my $intervals = 10;
 		my $interval = 1;
-		if (defined param('intervals')) {
-			$intervals = param('intervals');
+		if (defined scalar param('intervals')) {
+			$intervals = scalar param('intervals');
 			$intervals > 0 or $intervals = 10;
 		}
 
@@ -6712,7 +6716,7 @@ sub display_page($request_ref) {
 	# and if we have a response in structure format,
 	# do not generate an HTML response and serve the structured data
 
-	if ((param("json") or param("jsonp") or param("xml") or param("jqm") or $request_ref->{rss})
+	if ((scalar param("json") or scalar param("jsonp") or scalar param("xml") or scalar param("jqm") or $request_ref->{rss})
 		and (exists $request_ref->{structured_response})) {
 
 		display_structured_response($request_ref);
@@ -6943,7 +6947,7 @@ sub display_page($request_ref) {
 	}
 
 	my $search_terms = '';
-	if (defined param('search_terms')) {
+	if (defined scalar param('search_terms')) {
 		$search_terms = remove_tags_and_quote(decode utf8=>param('search_terms'))
 	}
 
@@ -6996,8 +7000,8 @@ JS
 	my $user_agent = $ENV{HTTP_USER_AGENT};
 
 	# add a user_agent parameter so that we can test from desktop easily
-	if (defined param('user_agent')) {
-		$user_agent = param('user_agent');
+	if (defined scalar param('user_agent')) {
+		$user_agent = scalar param('user_agent');
 	}
 
 	my $device;
@@ -7362,7 +7366,7 @@ CSS
 
 	my $product_ref;
 
-	my $rev = param("rev");
+	my $rev = scalar param("rev");
 	local $log->context->{rev} = $rev;
 	if (defined $rev) {
 		$log->info("displaying product revision") if $log->is_info();
@@ -7439,7 +7443,7 @@ CSS
 	# Knowledge panels are in development, they can be activated with the "panels" parameter
 	# for debugging and demonstration purposes
 	# Also activate them for moderators
-	if (($User{moderator}) or (param('panels'))) {
+	if (($User{moderator}) or (scalar param('panels'))) {
 		initialize_knowledge_panels_options($knowledge_panels_options_ref);
 		create_knowledge_panels($product_ref, $lc, $cc, $knowledge_panels_options_ref);
 		$template_data_ref->{environment_card_panel} = display_knowledge_panel($product_ref, $product_ref->{"knowledge_panels_" . $lc}, "environment_card");
@@ -8166,7 +8170,7 @@ sub display_product_jqm ($request_ref) {	# jquerymobile
 
 	my $product_ref;
 
-	my $rev = param("rev");
+	my $rev = scalar param("rev");
 	local $log->context->{rev} = $rev;
 	if (defined $rev) {
 		$log->info("displaying product revision on jquery mobile") if $log->is_info();
@@ -9833,15 +9837,15 @@ e.g. https://world.openfoodfacts.org/api/v2/taxonomy?type=labels&tags=en:organic
 
 sub display_taxonomy_api($request_ref) {
 
-	my $tagtype = param('tagtype');
-	my $tags = param('tags');
+	my $tagtype = scalar param('tagtype');
+	my $tags = scalar param('tags');
 	my @tags = split(/,/, $tags);
 
 	my $options_ref = {};
 
 	foreach my $field (qw(fields include_children include_parents include_root_entries)) {
-		if (defined param($field)) {
-			$options_ref->{$field} = param($field);
+		if (defined scalar param($field)) {
+			$options_ref->{$field} = scalar param($field);
 		}
 	}
 
@@ -9880,7 +9884,7 @@ sub display_product_api($request_ref) {
 
 	my $product_ref;
 
-	my $rev = param("rev");
+	my $rev = scalar param("rev");
 	local $log->context->{rev} = $rev;
 	if (defined $rev) {
 		$log->info("displaying product revision") if $log->is_info();
@@ -9897,12 +9901,12 @@ sub display_product_api($request_ref) {
 		$response{status_verbose} = 'no code or invalid code';
 	}
 	elsif ((not defined $product_ref) or (not defined $product_ref->{code})) {
-		if (param("api_version") >= 1) {
+		if (scalar param("api_version") >= 1) {
 			$request_ref->{status} = 404;
 		}
 		$response{status} = 0;
 		$response{status_verbose} = 'product not found';
-		if (param("jqm")) {
+		if (scalar param("jqm")) {
 			$response{jqm} = <<HTML
 $Lang{app_please_take_pictures}{$lang}
 <button onclick="captureImage();" data-icon="off-camera">$Lang{app_take_a_picture}{$lang}</button>
@@ -9910,7 +9914,7 @@ $Lang{app_please_take_pictures}{$lang}
 <p>$Lang{app_take_a_picture_note}{$lang}</p>
 HTML
 ;
-			if (param("api_version") >= 0.1) {
+			if (scalar param("api_version") >= 0.1) {
 
 				my @app_fields = qw(product_name brands quantity);
 
@@ -9962,9 +9966,9 @@ HTML
 		$response{product} = $product_ref;
 
 		# If the request specified a value for the fields parameter, return only the fields listed
-		if (defined param('fields')) {
+		if (defined scalar param('fields')) {
 
-			$log->debug("display_product_api - fields parameter is set", { fields => param('fields') }) if $log->is_debug();
+			$log->debug("display_product_api - fields parameter is set", { fields => scalar param('fields') }) if $log->is_debug();
 
 			my $customized_product_ref = customize_response_for_product($request_ref, $product_ref);
 
@@ -9994,7 +9998,7 @@ HTML
 
 		# 2021-02-25: we now store only nested ingredients, flatten them if the API is <= 1
 
-		if ((defined param("api_version")) and (param("api_version") <= 1)) {
+		if ((defined scalar param("api_version")) and (scalar scalar param("api_version") <= 1)) {
 
 			if (defined $product_ref->{ingredients}) {
 
@@ -10008,7 +10012,7 @@ HTML
 		}
 
 		# Return blame information
-		if (defined param("blame")) {
+		if (scalar param("blame")) {
 			my $path = product_path_from_id($product_id);
 			my $changes_ref = retrieve("$data_root/products/$path/changes.sto");
 			if (not defined $changes_ref) {
@@ -10018,7 +10022,7 @@ HTML
 			compute_product_history_and_completeness($data_root, $product_ref, $changes_ref, $response{blame});
 		}
 
-		if (param("jqm")) {
+		if (scalar param("jqm")) {
 			# return a jquerymobile page for the product
 
 			display_product_jqm($request_ref);
@@ -10197,7 +10201,7 @@ sub display_structured_response($request_ref) {
 
 	$log->debug("Displaying structured response", { json => scalar param("json"), jsonp => scalar param("jsonp"),
 		xml => scalar param("xml"), jqm => scalar param("jqm"), rss => scalar $request_ref->{rss} }) if $log->is_debug();
-	if (param("xml")) {
+	if (scalar param("xml")) {
 
 		# my $xs = XML::Simple->new(NoAttr => 1, NumericEscape => 2);
 		my $xs = XML::Simple->new(NumericEscape => 2);
@@ -10246,11 +10250,11 @@ sub display_structured_response($request_ref) {
 
 		my $jsonp = undef;
 
-		if (defined param('jsonp')) {
-			$jsonp = param('jsonp');
+		if (defined scalar param('jsonp')) {
+			$jsonp = scalar param('jsonp');
 		}
-		elsif (defined param('callback')) {
-			$jsonp = param('callback');
+		elsif (defined scalar param('callback')) {
+			$jsonp = scalar param('callback');
 		}
 
 		my $status = $request_ref->{status};
@@ -10976,7 +10980,7 @@ sub search_and_analyze_recipes($request_ref, $query_ref) {
 
 	if ($count > 0) {
 
-		my $uncanonicalized_parent_ingredients = param('parent_ingredients');
+		my $uncanonicalized_parent_ingredients = scalar param('parent_ingredients');
 
 		# Canonicalize the parent ingredients
 		my $parent_ingredients_ref = [];
@@ -10993,7 +10997,7 @@ sub search_and_analyze_recipes($request_ref, $query_ref) {
 
         	add_product_recipe_to_set($recipes_ref, $product_ref, $recipe_ref);
 
-			if (param("debug")) {
+			if (scalar param("debug")) {
 				$debug .= "product: " . JSON::PP->new->utf8->canonical->encode($product_ref) . "<br><br>\n\n"
 					. "recipe: " . JSON::PP->new->utf8->canonical->encode($recipe_ref) . "<br><br><br>\n\n\n";
 			}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4213,7 +4213,7 @@ sub display_search_results($request_ref) {
 
 	my $current_link = '';
 
-	foreach my $field (param()) {
+	foreach my $field (multi_param()) {
 		if (
 			($field eq "page")
 			or ($field eq "fields")
@@ -4435,7 +4435,7 @@ sub add_params_to_query($request_ref, $query_ref) {
 
 	my $and = $query_ref->{"\$and"};
 
-	foreach my $field (param()) {
+	foreach my $field (multi_param()) {
 
 		$log->debug("add_params_to_query - field", { field => $field }) if $log->is_debug();
 

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -2585,10 +2585,10 @@ sub assign_nutriments_values_from_request_parameters($product_ref, $nutriment_ta
 
 	foreach my $checkbox ("no_nutrition_data", "nutrition_data", "nutrition_data_prepared") {
 
-		if (defined param($checkbox)) {
+		if (defined scalar param($checkbox)) {
 			$product_ref->{$checkbox} = remove_tags_and_quote(decode utf8=>param($checkbox));
 		}
-		elsif (defined param($checkbox . "_displayed")) {
+		elsif (defined scalar param($checkbox . "_displayed")) {
 			$product_ref->{$checkbox} = "";
 		}
 	}
@@ -2625,8 +2625,8 @@ sub assign_nutriments_values_from_request_parameters($product_ref, $nutriment_ta
 		my $saltnid = "salt${product_type}";
 		my $sodiumnid = "sodium${product_type}";
 
-		my $salt = param("nutriment_${saltnid}");
-		my $sodium = param("nutriment_${sodiumnid}");
+		my $salt = scalar param("nutriment_${saltnid}");
+		my $sodium = scalar param("nutriment_${sodiumnid}");
 
 		if ((defined $sodium) and (not defined $salt)) {
 			delete $product_ref->{nutriments}{$saltnid};
@@ -2666,7 +2666,7 @@ sub assign_nutriments_values_from_request_parameters($product_ref, $nutriment_ta
 		foreach my $product_type ("", "_prepared") {
 
 			# do not delete values if the nutriment is not provided
-			next if (not defined param("nutriment_${enid}${product_type}"));
+			next if (not defined scalar param("nutriment_${enid}${product_type}"));
 
 			my $value = remove_tags_and_quote(decode utf8=>param("nutriment_${enid}${product_type}"));
 

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -436,7 +436,7 @@ sub process_search_image_form($filename_ref) {
 	my $imgid = "imgupload_search";
 	my $file = undef;
 	my $code = undef;
-	if ($file = param($imgid)) {
+	if ($file = scalar param($imgid)) {
 		if ($file =~ /\.($supported_extensions)$/i) {
 
 			$log->debug("processing image search form", { imgid => $imgid, file => $file }) if $log->is_debug();
@@ -667,16 +667,16 @@ sub process_image_upload($product_id, $imagefield, $user_id, $time, $comment, $i
 		}
 	}
 	else {
-		$file = param('imgupload_' . $imagefield);
+		$file = scalar param('imgupload_' . $imagefield);
 		if (! $file) {
 			# mobile app may not set language code
 			my $old_imagefield = $imagefield;
 			$old_imagefield =~ s/_\w\w$//;
-			$file = param('imgupload_' . $old_imagefield);
+			$file = scalar param('imgupload_' . $old_imagefield);
 
 			if (! $file) {
 				# producers platform: name="files[]"
-				$file = param("files[]");
+				$file = scalar param("files[]");
 			}
 		}
 	}

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -652,8 +652,8 @@ sub init_product($userid, $orgid, $code, $countryid) {
 
 	# ugly fix: products added by yuka should have country france, regardless of the server ip
 	if ($creator eq 'kiliweb') {
-		if (defined param('cc')) {
-			$country = lc(param('cc'));
+		if (defined scalar param('cc')) {
+			$country = lc(scalar param('cc'));
 			$country =~ s/^en://;
 
 			# 01/06/2019 --> Yuka always sends fr fields even for Spanish products, try to correct it
@@ -2654,7 +2654,7 @@ sub process_product_edit_rules($product_ref) {
 						if (defined $condition) {
 
 							# if field is not passed, skip rule
-							if (not defined param($field)) {
+							if (not defined scalar param($field)) {
 								$log->debug("no value passed -> skip edit rule") if $log->is_debug();
 								next;
 							}
@@ -2696,32 +2696,32 @@ sub process_product_edit_rules($product_ref) {
 								}
 							}
 							elsif ($condition eq '0') {
-								if ((defined param($field)) and ($param_field == 0)) {
+								if ((defined scalar param($field)) and ($param_field == 0)) {
 									$condition_ok = 1;
 								}
 							}
 							elsif ($condition eq 'equal') {
-								if ((defined param($field)) and ($param_field == $value)) {
+								if ((defined scalar param($field)) and ($param_field == $value)) {
 									$condition_ok = 1;
 								}
 							}
 							elsif ($condition eq 'lesser') {
-								if ((defined param($field)) and ($param_field < $value)) {
+								if ((defined scalar param($field)) and ($param_field < $value)) {
 									$condition_ok = 1;
 								}
 							}
 							elsif ($condition eq 'greater') {
-								if ((defined param($field)) and ($param_field > $value)) {
+								if ((defined scalar param($field)) and ($param_field > $value)) {
 									$condition_ok = 1;
 								}
 							}
 							elsif ($condition eq 'match') {
-								if ((defined param($field)) and ($param_field eq $value)) {
+								if ((defined scalar param($field)) and ($param_field eq $value)) {
 									$condition_ok = 1;
 								}
 							}
 							elsif ($condition eq 'regexp_match') {
-								if ((defined param($field)) and ($param_field  =~ /$value/i)) {
+								if ((defined scalar param($field)) and ($param_field  =~ /$value/i)) {
 									$condition_ok = 1;
 								}
 							}

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -272,19 +272,13 @@ sub check_user_form($type, $user_ref, $errors_ref) {
 		$user_ref->{email} = $email;
 	}
 
-	if (defined param('twitter')) {
-		$user_ref->{twitter} = remove_tags_and_quote(decode utf8=>param('twitter'));
-		$user_ref->{twitter} =~ s/^http:\/\/twitter.com\///;
-		$user_ref->{twitter} =~ s/^\@//;
-	}
-
 	# Is there a checkbox to make a professional account
-	if (defined param("pro_checkbox")) {
+	if (defined scalar param("pro_checkbox")) {
 
-		if (param("pro")) {
+		if (scalar param("pro")) {
 			$user_ref->{pro} = 1;
 
-			if (defined param("requested_org")) {
+			if (defined scalar param("requested_org")) {
 				$user_ref->{requested_org} = remove_tags_and_quote(decode utf8=>param("requested_org"));
 
 				my $requested_org_id = get_string_id_for_lang("no_language", $user_ref->{requested_org});
@@ -356,7 +350,7 @@ sub check_user_form($type, $user_ref, $errors_ref) {
 	defined $user_ref->{registered_t} or $user_ref->{registered_t} = time();
 
 	for (my $i = 1; $i <= 3; $i++) {
-		if (defined param('team_' . $i)) {
+		if (defined scalar param('team_' . $i)) {
 			$user_ref->{'team_' . $i} = remove_tags_and_quote(decode utf8=>param('team_' . $i));
 			$user_ref->{'team_' . $i} =~ s/\&lt;/ /g;
 			$user_ref->{'team_' . $i} =~ s/\&gt;/ /g;
@@ -426,10 +420,10 @@ sub check_user_form($type, $user_ref, $errors_ref) {
 		}
 	}
 
-	if (param('password') ne param('confirm_password')) {
+	if (param('password') ne scalar param('confirm_password')) {
 		push @{$errors_ref}, $Lang{error_different_passwords}{$lang};
 	}
-	elsif (param('password') ne '') {
+	elsif (scalar param('password') ne '') {
 		$user_ref->{encrypted_password} = create_password_hash( encode_utf8(decode utf8=>param('password')) );
 	}
 
@@ -698,10 +692,10 @@ sub generate_session_cookie($user_id, $user_session) {
 
 	my $length = 0;
 
-	if ((defined param('length')) and (param('length') > 0)) {
-		$length = param('length');
+	if ((defined scalar param('length')) and (scalar param('length') > 0)) {
+		$length = scalar param('length');
 	}
-	elsif ((defined param('remember_me')) and (param('remember_me') eq 'on')) {
+	elsif ((defined scalar param('remember_me')) and (scalar param('remember_me') eq 'on')) {
 		$length = 31536000 * 10;
 	}
 
@@ -788,22 +782,18 @@ sub init_user($request_ref) {
 	%Org = ();
 
 	# Remove persistent cookie if user is logging out
-	if ((defined param('length')) and (param('length') eq 'logout')) {
+	if ((defined scalar param('length')) and (scalar param('length') eq 'logout')) {
 		$log->debug("user logout") if $log->is_debug();
 		my $session = {} ;
 		$request_ref->{cookie} = cookie (-name=>$cookie_name, -expires=>'-1d',-value=>$session, -path=>'/', -domain=>"$cookie_domain") ;
 	}
 
 	# Retrieve user_id and password from form parameters
-	elsif ( (defined param('user_id')) and (param('user_id') ne '') and
-                       ( ( (defined param('password')) and (param('password') ne ''))
+	elsif ( (defined scalar param('user_id')) and (scalar param('user_id') ne '') and
+                       ( ( (defined scalar param('password')) and (scalar param('password') ne ''))
                          ) ) {
 
-		# CGI::param called in list context from package ProductOpener::Users line 373, this can lead to vulnerabilities.
-		# See the warning in "Fetching the value or values of a single named parameter"
-		# -> use a scalar to avoid calling param() in the list of arguments to remove_tags_and_quote
-		my $param_user_id = param('user_id');
-		$user_id = remove_tags_and_quote($param_user_id) ;
+		$user_id = remove_tags_and_quote(scalar param('user_id')) ;
 
 		if ($user_id =~ /\@/) {
 			$log->info("got email while initializing user", { email => $user_id }) if $log->is_info();
@@ -849,7 +839,7 @@ sub init_user($request_ref) {
 					return ($Lang{error_bad_login_password}{$lang}) ;
 				}
 				# We have the right login/password
-				elsif (not defined param('no_log'))    # no need to store sessions for internal requests
+				elsif (not defined scalar param('no_log'))    # no need to store sessions for internal requests
 				{
 					$log->info("correct password for user provided") if $log->is_info();
 					
@@ -869,11 +859,11 @@ sub init_user($request_ref) {
 	}
 
 	# Retrieve user_id and session from cookie
-	elsif ((defined cookie($cookie_name)) or ((defined param('user_session')) and (defined param('user_id')))) {
+	elsif ((defined cookie($cookie_name)) or ((defined scalar param('user_session')) and (defined scalar param('user_id')))) {
 		my $user_session;
-		if (defined param('user_session')) {
-			$user_session = param('user_session');
-			$user_id = param('user_id');
+		if (defined scalar param('user_session')) {
+			$user_session = scalar param('user_session');
+			$user_id = scalar param('user_id');
 			$log->debug("user_session parameter found", { user_id => $user_id, user_session => $user_session }) if $log->is_debug();
 		}
 		else {


### PR DESCRIPTION
See discussion in https://github.com/openfoodfacts/openfoodfacts-server/issues/7270

I added scalar before param() calls in many places where there was already a scalar context, for instance:

my $field_value = param("field");  -> my $field_value = scalar param("field");

This is so that we keep the scalar if we add a wrapping function (e.g. my $field_value = normalization_function(scalar param("field"));

Otherwise we may get bitten by the signature bug again if the parameter is not passed and we get an empty list from param() in a list context.