### PR TITLE
refactor: show more info in test logs

### DIFF
--- a/tests/integration/search_test.t
+++ b/tests/integration/search_test.t
@@ -125,7 +125,7 @@ my @tests = (
 	[
 		"q3",
 		construct_test_url(
-			"/cgi/search.pl?action=process&code=200000000034,200000000039&fields=code,product_name&json=1", "world"
+			"/api/v2/search?code=200000000039,200000000038&fields=code,product_name", "world"
 		)
 	],
 	[
@@ -149,10 +149,21 @@ if ((defined $update_expected_results) and (!-e $expected_dir)) {
 
 foreach my $test_ref (@tests) {
 	my $testid = $test_ref->[0];
-	my $query_ref = $test_ref->[1];
-	my $json = get($query_ref);
+	my $query_url = $test_ref->[1];
+	my $json = get($query_url);
 
-	my $decoded_json = decode_json($json);
+	my $decoded_json;
+	eval {
+            $decoded_json = decode_json($json);
+            1;
+    }
+	or do {
+		my $json_decode_error = $@;	
+		diag("The query_url $query_url returned a response that is not valid JSON: $json_decode_error");
+		diag("Response content: " . $json);
+		fail($testid);
+		next;
+	};
 
 	my $length = @{$decoded_json->{'products'}};
 	my $count;


### PR DESCRIPTION
@yuktea : I added error messages in the test so that if something fails, we can see in the test logs what failed exactly.

Here the test shows that we can't decode the JSON response of the API because in fact we did not get a response.

You could do something similar when you call get() in order to catch errors.

See: https://metacpan.org/pod/LWP::UserAgent#get
Instead of calling get() directly, you can call 
my $res = $ua->get( $url );

That way you can check the status code of the response etc. in the test, and print it in the test log if it fails.


