### PR TITLE
fix: prevent default mod_perl error message to be appended

### DIFF
--- a/cgi/export_products.pl
+++ b/cgi/export_products.pl
@@ -58,7 +58,7 @@ my $title = lang("export_product_data_photos");
 my $html = '';
 
 if (not defined $Owner_id) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 # Require moderator status to launch the export / import process,

--- a/cgi/import_file_process.pl
+++ b/cgi/import_file_process.pl
@@ -56,7 +56,7 @@ my $js = '';
 my $template_data_ref;
 
 if (not defined $Owner_id) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 my $import_files_ref = retrieve("$data_root/import_files/${Owner_id}/import_files.sto");
@@ -77,7 +77,7 @@ if (defined $import_files_ref->{$file_id}) {
 }
 else {
 	$log->debug("File not found in import_files.sto", { file_id => $file_id }) if $log->is_debug();
-	display_error("File not found.", 404);
+	display_error_and_exit("File not found.", 404);
 }
 
 $log->debug("File found in import_files.sto", { file_id => $file_id,  file => $file, extension => $extension, import_file => $import_files_ref->{$file_id} }) if $log->is_debug();
@@ -92,7 +92,7 @@ if (not defined $all_columns_fields_ref) {
 my $results_ref = load_csv_or_excel_file($file);
 
 if ($results_ref->{error}) {
-	display_error($results_ref->{error}, 200);
+	display_error_and_exit($results_ref->{error}, 200);
 }
 
 my $headers_ref = $results_ref->{headers};
@@ -147,7 +147,7 @@ $import_files_ref->{$file_id}{imports}{$import_id}{converted_t} = time();
 if ($results_ref->{error}) {
 	$import_files_ref->{$file_id}{imports}{$import_id}{convert_error} = $results_ref->{error};
 	store("$data_root/import_files/${Owner_id}/import_files.sto", $import_files_ref);
-	display_error($results_ref->{error}, 200);
+	display_error_and_exit($results_ref->{error}, 200);
 }
 
 my $args_ref = {

--- a/cgi/import_file_select_format.pl
+++ b/cgi/import_file_select_format.pl
@@ -60,7 +60,7 @@ my $js = '';
 my $template_data_ref = {};
 
 if (not defined $Owner_id) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 my $import_files_ref = retrieve("$data_root/import_files/${Owner_id}/import_files.sto");
@@ -82,7 +82,7 @@ if (defined $import_files_ref->{$file_id}) {
 }
 else {
 	$log->debug("File not found in import_files.sto", { file_id => $file_id }) if $log->is_debug();
-	display_error("File not found.", 404);
+	display_error_and_exit("File not found.", 404);
 }
 
 $log->debug("File found in import_files.sto", { file_id => $file_id,  file => $file, extension => $extension, import_file => $import_files_ref->{$file_id} }) if $log->is_debug();
@@ -93,7 +93,7 @@ if ($action eq "display") {
 	my $results_ref = load_csv_or_excel_file($file);
 
 	if ($results_ref->{error}) {
-		display_error($results_ref->{error}, 200);
+		display_error_and_exit($results_ref->{error}, 200);
 	}
 
 	my $headers_ref = $results_ref->{headers};

--- a/cgi/import_file_upload.pl
+++ b/cgi/import_file_upload.pl
@@ -58,7 +58,7 @@ local $log->context->{type} = $type;
 local $log->context->{action} = $action;
 
 if (not defined $Owner_id) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 if ($action eq "process") {

--- a/cgi/import_photos_upload.pl
+++ b/cgi/import_photos_upload.pl
@@ -59,7 +59,7 @@ local $log->context->{type} = $type;
 local $log->context->{action} = $action;
 
 if (not defined $Owner_id) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 

--- a/cgi/import_products_categories_from_public_database.pl
+++ b/cgi/import_products_categories_from_public_database.pl
@@ -58,7 +58,7 @@ my $js = '';
 my $template_data_ref = {};
 
 if (not defined $Owner_id) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 if ($action eq "display") {

--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -70,7 +70,7 @@ if (not defined $org_ref) {
 		$template_data_ref->{org_does_not_exist} = 1;
 	}
 	else {
-		display_error($Lang{error_org_does_not_exist}{$lang}, 404);
+		display_error_and_exit($Lang{error_org_does_not_exist}{$lang}, 404);
 	}
 }
 
@@ -80,7 +80,7 @@ if (not(is_user_in_org_group($org_ref, $User_id, "admins") or $admin or $User{pr
 	$log->debug("user does not have permission to edit org",
 		{orgid => $orgid, org_admins => $org_ref->{admins}, User_id => $User_id})
 	  if $log->is_debug();
-	display_error($Lang{error_no_permission}{$lang}, 403);
+	display_error_and_exit($Lang{error_no_permission}{$lang}, 403);
 }
 
 my @errors = ();
@@ -93,7 +93,7 @@ if ($action eq 'process') {
 				$type = 'delete';
 			}
 			else {
-				display_error($Lang{error_no_permission}{$lang}, 403);
+				display_error_and_exit($Lang{error_no_permission}{$lang}, 403);
 			}
 		}
 		else {

--- a/cgi/product_image.pl
+++ b/cgi/product_image.pl
@@ -52,7 +52,7 @@ my $id = single_param('id');
 $log->debug("start", {code => $code, id => $id}) if $log->is_debug();
 
 if (not defined $code) {
-	display_error(sprintf(lang("no_product_for_barcode"), $code), 404);
+	display_error_and_exit(sprintf(lang("no_product_for_barcode"), $code), 404);
 }
 
 my $product_id = product_id_for_owner($Owner_id, $code);
@@ -60,11 +60,11 @@ my $product_id = product_id_for_owner($Owner_id, $code);
 my $product_ref = retrieve_product($product_id);
 
 if (not(defined $product_ref)) {
-	display_error(sprintf(lang("no_product_for_barcode"), $code), 404);
+	display_error_and_exit(sprintf(lang("no_product_for_barcode"), $code), 404);
 }
 
 if ((not(defined $product_ref->{images})) or (not(defined $product_ref->{images}{$id}))) {
-	display_error(sprintf(lang("no_product_for_barcode"), $code), 404);
+	display_error_and_exit(sprintf(lang("no_product_for_barcode"), $code), 404);
 }
 
 my $imagetext;

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -61,7 +61,7 @@ use Data::Dumper;
 my $request_ref = ProductOpener::Display::init_request();
 
 if ($User_id eq 'unwanted-user-french') {
-	display_error(
+	display_error_and_exit(
 		"<b>Il y a des problèmes avec les modifications de produits que vous avez effectuées. Ce compte est temporairement bloqué, merci de nous contacter.</b>",
 		403
 	);
@@ -96,7 +96,7 @@ if ($type eq 'search_or_add') {
 		$code = process_search_image_form(\$filename);
 	}
 	elsif ($code !~ /^\d{4,24}$/) {
-		display_error($Lang{invalid_barcode}{$lang}, 403);
+		display_error_and_exit($Lang{invalid_barcode}{$lang}, 403);
 	}
 
 	my $r = Apache2::RequestUtil->request();
@@ -187,28 +187,28 @@ if ($type eq 'search_or_add') {
 else {
 	# We should have a code
 	if ((not defined $code) or ($code eq '')) {
-		display_error($Lang{missing_barcode}{$lang}, 403);
+		display_error_and_exit($Lang{missing_barcode}{$lang}, 403);
 	}
 	elsif ($code !~ /^\d{4,24}$/) {
-		display_error($Lang{invalid_barcode}{$lang}, 403);
+		display_error_and_exit($Lang{invalid_barcode}{$lang}, 403);
 	}
 	else {
 		if (    ((defined $server_options{private_products}) and ($server_options{private_products}))
 			and (not defined $Owner_id))
 		{
 
-			display_error(lang("no_owner_defined"), 200);
+			display_error_and_exit(lang("no_owner_defined"), 200);
 		}
 		$product_id = product_id_for_owner($Owner_id, $code);
 		$product_ref = retrieve_product_or_deleted_product($product_id, $User{moderator});
 		if (not defined $product_ref) {
-			display_error(sprintf(lang("no_product_for_barcode"), $code), 404);
+			display_error_and_exit(sprintf(lang("no_product_for_barcode"), $code), 404);
 		}
 	}
 }
 
 if (($type eq 'delete') and (not $User{moderator})) {
-	display_error($Lang{error_no_permission}{$lang}, 403);
+	display_error_and_exit($Lang{error_no_permission}{$lang}, 403);
 }
 
 if ($User_id eq 'unwanted-bot-id') {
@@ -256,7 +256,7 @@ if (($action eq 'process') and (($type eq 'add') or ($type eq 'edit'))) {
 
 	if (not $proceed_with_edit) {
 
-		display_error("Edit against edit rules", 403);
+		display_error_and_exit("Edit against edit rules", 403);
 	}
 
 	$log->debug("phase 1", {code => $code, type => $type}) if $log->is_debug();

--- a/cgi/remove_products.pl
+++ b/cgi/remove_products.pl
@@ -55,11 +55,11 @@ my $template_data_ref = {};
 $template_data_ref->{action} = $action;
 
 if (not $server_options{producers_platform}) {
-	display_error(lang("function_not_available"), 200);
+	display_error_and_exit(lang("function_not_available"), 200);
 }
 
 if ((not defined $Owner_id) or ($Owner_id !~ /^(user|org)-\S+$/)) {
-	display_error(lang("no_owner_defined"), 200);
+	display_error_and_exit(lang("no_owner_defined"), 200);
 }
 
 

--- a/cgi/reset_password.pl
+++ b/cgi/reset_password.pl
@@ -61,7 +61,7 @@ my $userid = undef;
 my $html = '';
 
 if (defined $User_id) {
-	display_error($Lang{error_reset_already_connected}{$lang}, undef);
+	display_error_and_exit($Lang{error_reset_already_connected}{$lang}, undef);
 }
 
 if ($action eq 'process') {
@@ -107,7 +107,7 @@ if ($action eq 'process') {
 	}
 	else {
 		$log->debug("invalid address", {type => $type }) if $log->is_debug();
-		display_error(lang("error_invalid_address"), 404);
+		display_error_and_exit(lang("error_invalid_address"), 404);
 	}
 
 
@@ -190,7 +190,7 @@ elsif ($action eq 'process') {
 			}
 			else {
 				$log->debug("token is invalid", {userid => $userid }) if $log->is_debug();
-				display_error($Lang{error_reset_invalid_token}{$lang}, undef);
+				display_error_and_exit($Lang{error_reset_invalid_token}{$lang}, undef);
 			}
 		}
 	}

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -55,7 +55,7 @@ my $html;
 
 if (user_agent() =~ /apps-spreadsheets/) {
 
-	display_error(
+	display_error_and_exit(
 		"Automated queries using Google Spreadsheet overload the Open Food Facts server. We cannot support them. You can contact us at contact\@openfoodfacts.org to tell us about your use case, so that we can see if there is another way to support it.",
 		200
 	);

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -87,7 +87,7 @@ my $user_ref = {};
 if ($type =~ /^edit/) {
 	$user_ref = retrieve("$data_root/users/$userid.sto");
 	if (not defined $user_ref) {
-		display_error($Lang{error_invalid_user}{$lang}, 404);
+		display_error_and_exit($Lang{error_invalid_user}{$lang}, 404);
 	}
 }
 else {
@@ -95,7 +95,7 @@ else {
 }
 
 if (($type =~ /^edit/) and ($User_id ne $userid) and not $admin) {
-	display_error($Lang{error_no_permission}{$lang}, 403);
+	display_error_and_exit($Lang{error_no_permission}{$lang}, 403);
 }
 
 my $debug = 0;
@@ -109,7 +109,7 @@ if ($action eq 'process') {
 				$type = 'delete';
 			}
 			else {
-				display_error($Lang{error_no_permission}{$lang}, 403);
+				display_error_and_exit($Lang{error_no_permission}{$lang}, 403);
 			}
 		}
 	}

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -63,6 +63,7 @@ BEGIN
 		&display_tag
 		&display_search_results
 		&display_error
+		&display_error_and_exit
 
 		&add_product_nutriment_to_stats
 		&compute_stats_for_products
@@ -199,7 +200,7 @@ our $mongodb_log = Log::Log4perl->get_logger('mongodb');
 $mongodb_log->info("start") if $mongodb_log->is_info();
 
 use Apache2::RequestRec ();
-use Apache2::Const ();
+use Apache2::Const qw(:http :common);
 
 use URI::Find;
 
@@ -691,9 +692,7 @@ sub init_request() {
 
 	my $error = ProductOpener::Users::init_user($request_ref);
 	if ($error) {
-		if (not single_param('jqm')) { # API
-			display_error($error, undef);
-		}
+		display_error_and_exit($error, 403);
 	}
 
 	# %admin is defined in Config.pm
@@ -997,7 +996,8 @@ sub analyze_request($request_ref) {
 			$request_ref->{redirect} = $formatted_subdomain . '/' . $tag_type_singular{products}{$lc} . '/' . $components[1];;
 		}
 		else {
-			display_error(lang("error_invalid_address"), 404);
+			$request_ref->{error_status} = 404;
+			$request_ref->{error_message} = lang("error_invalid_address");
 		}
 	}
 
@@ -1017,7 +1017,8 @@ sub analyze_request($request_ref) {
 			}
 		}
 		else {
-			display_error(lang("error_invalid_address"), 404);
+			$request_ref->{error_status} = 404;
+			$request_ref->{error_message} = lang("error_invalid_address");
 		}
 	}
 
@@ -1207,7 +1208,8 @@ sub analyze_request($request_ref) {
 		}
 		elsif (not defined $request_ref->{groupby_tagtype}) {
 			$log->warn("invalid address, confused by number of components left", { left_components => $#components }) if $log->is_warn();
-			display_error(lang("error_invalid_address"), 404);
+			$request_ref->{error_status} = 404;
+			$request_ref->{error_message} = lang("error_invalid_address");
 		}
 
 		if (($#components >=0) and ($components[-1] =~ /^\d+$/)) {
@@ -1223,7 +1225,7 @@ sub analyze_request($request_ref) {
 		$request_ref->{text} = 'index-pro';
 	}
 
-	$log->debug("request analyzed", { lc => $lc, lang => $lang, request_ref => Dumper($request_ref)}) if $log->is_debug();
+	$log->debug("request analyzed", { lc => $lc, lang => $lang, request_ref => $request_ref}) if $log->is_debug();
 
 
 	return 1;
@@ -1316,6 +1318,15 @@ sub display_date_iso($t) {
 	}
 }
 
+
+=head2 display_error ( $error_message, $status )
+
+Display an error message using the site template.
+
+The request is not terminated by this function, it will continue to run.
+
+=cut
+
 sub display_error($error_message, $status) {
 
 	my $html = "<p>$error_message</p>";
@@ -1325,8 +1336,23 @@ sub display_error($error_message, $status) {
 		status => $status,
 		page_type => "error",
 	});
+}
+
+
+=head2 display_error_and_exit ( $error_message, $status )
+
+Display an error message using the site template, and terminate the request immediately.
+
+Any code after the call to display_error_and_exit() will not be executed.
+
+=cut
+
+sub display_error_and_exit($error_message, $status) {
+
+	display_error($error_message, $status);
 	exit();
 }
+
 
 # Specific index for producer on the platform for producers
 sub display_index_for_producer($request_ref) {
@@ -3911,7 +3937,7 @@ HTML
 			$user_or_org_ref = retrieve_org($orgid);
 
 			if (not defined $user_or_org_ref) {
-				display_error(lang("error_unknown_org"), 404);
+				display_error_and_exit(lang("error_unknown_org"), 404);
 			}
 		}
 		elsif ($tagid =~ /\./) {
@@ -3934,7 +3960,7 @@ HTML
 			$user_or_org_ref = retrieve("$data_root/users/$tagid.sto");
 
 			if (not defined $user_or_org_ref) {
-				display_error(lang("error_unknown_user"), 404);
+				display_error_and_exit(lang("error_unknown_user"), 404);
 			}
 		}
 
@@ -7122,7 +7148,10 @@ HTML
 	# Replace urls for texts in links like <a href="/ecoscore"> with a localized name
 	$html =~ s/(href=")(\/[^"]+)/$1 . url_for_text($2)/eg;
 
+	my $status = $request_ref->{status} || $request_ref->{error_status} || 200;
+
 	my $http_headers_ref = {
+		'-status' => $status,
 		'-expires' => '-1d',
 		'-charset' => 'UTF-8',
 	};
@@ -7133,14 +7162,13 @@ HTML
 	}
 
 	print header(%$http_headers_ref);
-	
-	my $status = $request_ref->{status};
-	if (defined $status) {
-		print header ( -status => $status );
-		my $r = Apache2::RequestUtil->request();
-		$r->rflush;
-		$r->status($status);
-	}
+
+	my $r = Apache2::RequestUtil->request();
+	$r->rflush;
+	# Setting the status makes mod_perl append a default error to the body
+	# $r->status($status);
+	# Send 200 instead.
+	$r->status(200);
 
 	binmode(STDOUT, ":encoding(UTF-8)");
 
@@ -7149,6 +7177,7 @@ HTML
 	print $html;
 	return;
 }
+
 
 sub display_image_box($product_ref, $id, $minheight_ref) {
 
@@ -7302,7 +7331,7 @@ sub display_product($request_ref) {
 	local $log->context->{code} = $code;
 
 	if ($code !~ /^\d{4,24}$/) {
-		display_error($Lang{invalid_barcode}{$lang}, 403);
+		display_error_and_exit($Lang{invalid_barcode}{$lang}, 403);
 	}
 
 	my $product_id = product_id_for_owner($Owner_id, $code);
@@ -7406,7 +7435,7 @@ CSS
 	}
 
 	if (not defined $product_ref) {
-		display_error(sprintf(lang("no_product_for_barcode"), $code), 404);
+		display_error_and_exit(sprintf(lang("no_product_for_barcode"), $code), 404);
 	}
 
 	$title = product_name_brand_quantity($product_ref);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1336,6 +1336,7 @@ sub display_error($error_message, $status) {
 		status => $status,
 		page_type => "error",
 	});
+	return;
 }
 
 

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -372,7 +372,7 @@ sub check_user_form($type, $user_ref, $errors_ref) {
 			print $log remote_addr() . "\t" . time() . "\t" . $user_ref->{name} . "\n";
 			close($log);
 			# bail out, return 200 status code
-			display_error("", 200);
+			display_error_and_exit("", 200);
 		}
 	}
 


### PR DESCRIPTION
Fixes #7330 .

Also fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/7288 which should help https://github.com/openfoodfacts/smooth-app/issues/2793#issuecomment-1234184480

I renamed display_error() to display_error_and_exit() to make it more clear what the function actually does.

I tried a bunch of different ways to make Apache / mod_perl send back a non 200 status code while not appending a default error body, and the only solution that seems to work is to output the 404 status code and tell Apache it is a 200.