### PR TITLE
taxonomy: Create generic categ Poulardes

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -87093,6 +87093,9 @@ it:Carciofi
 la:Cynara scolymus
 nl:Artisjokken
 ru:Артишоки
+agribalyse_food_code:en:20052
+ciqual_food_code:en:20052
+ciqual_food_name:en:Artichoke, globe, raw
 
 <en:Artichokes
 it:Carciofo Spinoso di Sardegna
@@ -87154,9 +87157,6 @@ ciqual_food_name:fr:Artichaut, cuit
 en:Fresh artichokes, Artichoke globe
 fr:Artichauts frais
 season_in_country_fr:en: 5,6,7,8,9
-agribalyse_food_code:en:20052
-ciqual_food_code:en:20052
-ciqual_food_name:en:Artichoke, globe, raw
 
 <en:Artichokes
 <en:Frozen vegetables

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -76563,21 +76563,13 @@ protected_name_type:en: pgi
 agribalyse_food_code:en:12759
 ciqual_food_code:en:12759
 ciqual_food_name:en:Tomme cheese, from mountain or Savoy
-
+wikidata:en:Q1247472
 
 <en:French cheeses
 fr:Gruyère
 protected_name_file_number:en: PGI-FR-0612
 protected_name_type:en: pgi
 origins:en: en:France
-
-
-<en:French cheeses
-fr:Morbier
-protected_name_file_number:en: PDO-FR-0179
-protected_name_type:en: pdo
-origins:en: en:France
-wikidata:en:Q1247472
 
 <fr:Tommes
 <en:French cheeses

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -60024,6 +60024,13 @@ ciqual_food_code:en:11002
 ciqual_food_name:en:Chervil, fresh
 ciqual_food_name:fr:Cerfeuil, frais
 
+<en:Plant-based foods
+fr:Cerfeuil tubéreux, Cerfeuil bulbeux
+de:Knolliger Kälberkropf, Knollenkerbel, Rüben-Kälberkropf, Kerbelrübe, Knollen-Kälberkropf
+wikidata:en:Q1777420
+agribalyse_proxy_food_code:en:20181
+agribalyse_proxy_food_name:fr:Panais, cru
+
 <en:Garden chervil products
 <en:Aromatic herbs
 en:Garden chervil leaves, Chervil leaves

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -71886,7 +71886,14 @@ protected_name_type:en: pdo
 origins:en: en:France
 #wikidata:en:
 
+<en:Poultries
+fr:Poulardes
+agribalyse_proxy_food_code:en:36050
+agribalyse_proxy_food_name:en:Capon, meat and skin, raw
+agribalyse_proxy_food_name:fr:Chapon, viande et peau, cru
+
 <en:Poultries from Bresse
+<fr:Poulardes
 fr:Poularde de Bresse
 protected_name_file_number:en: PDO-FR-0145-AM01
 protected_name_type:en: pdo
@@ -71901,6 +71908,7 @@ origins:en: en:France
 #wikidata:en:
 
 <en:Poultries
+<fr:Poulardes
 fr:Poularde du Périgord
 protected_name_file_number:en: PGI-FR-01373
 protected_name_type:en: pgi


### PR DESCRIPTION
• Link all **Poularde*** to new generic parent Poulardes and assign Chapons Agribalyse proxy
• Move Agribalyse code to parent en:**artichokes** categ : all other fruits and veg. have the "fresh" subcateg linked to the parent, and it is the parent that has the Agribalyse code
• fr:**morbier** had double entry [removed] ; Wikidata for double entry was wrong : moved to correct place in Tomme de Savoie
• Create **Cerfeuil tubéreux** with Agribalyse proxy on Parnips