### PR TITLE
fix: fix /ecoscore redirect

### DIFF
--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -263,7 +263,10 @@ server {
 	}
 
 	location = /ecoscore {
-		return 301 https://$host/eco-score-l-impact-environnemental-des-produits-alimentaires;
+		if ( $host ~ "^fr\..*" ) {
+			return 301 https://$host/eco-score-l-impact-environnemental-des-produits-alimentaires;
+		}
+		return 301 https://$host/eco-score-the-environmental-impact-of-food-products;
 	}
 
 	# 2022-06-13 Redirect press pages to blog post about the new Flutter app


### PR DESCRIPTION
for non french countries

- fixes: #7389 

### What
de.openfoodfacts.org/ecoscore did a wrong redirect to french page, as well as any non french country…

I changed the nginx redirect rule (yes this is one of the case [where a if is ok](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/))

**this is already deployed on production (off1)**