### PR TITLE
taxonomy: fix typos

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -24807,7 +24807,7 @@ origins:en: en:Italy
 #wikidata:en:
 
 <en:Wines from Italy
-it:Mitterberg tra Cauria e Tel,
+it:Mitterberg tra Cauria e Tel
 de:Mitterberg zwischen Gfrill und Toll
 origins:en: en:Italy
 #wikidata:en:
@@ -80003,7 +80003,7 @@ ciqual_food_name:fr:Sandwich (aliment moyen)
 
 <en:Sandwiches
 en:Sandwich made with loaf bread, Club sandwich
-fr:sandwich club, sandwich triangle, sandwich pain de mie,
+fr:sandwich club, sandwich triangle, sandwich pain de mie
 wikidata:en:Q1093380
 
 <en:Sandwiches
@@ -96283,7 +96283,7 @@ nl_be:Taartdeeg
 
 <en:Pie dough
 en:Shortcrust pastry
-fr:Pâtes brisées, Pâte brisée, Pâtes à tarte brisées,
+fr:Pâtes brisées, Pâte brisée, Pâtes à tarte brisées
 nl:Zanddegen
 nl_be:Zanddeeg
 agribalyse_food_code:en:23410


### PR DESCRIPTION
Some tags lists had orphan commas (empty tag)