### PR TITLE
taxonomy: added some missing countries in HR

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -758,6 +758,7 @@ ga:Alderney
 gd:Alderney
 gl:Alderney
 he:אולדרני, אלדרני, אלדרניי
+hr:Alderney
 hu:Alderney
 id:Alderney
 it:Alderney, Aurigny
@@ -1734,6 +1735,7 @@ gd:An Antartaig
 got:𐌰𐌽𐍄𐌰𐍂𐌺𐍄𐌹𐌺𐌰
 gu:એન્ટાર્કટીકા
 hsb:Antarktis
+hr:Antarktika
 hu:Antarktisz
 hy:Անտարկտիկա
 ilo:Antártiko
@@ -5553,6 +5555,7 @@ fy:Bonêre
 gl:Bonaire
 gsw:Bonaire
 he:בונייר
+hr:Bonaire
 hu:Bonaire
 hy:Բոնեյրե
 id:Bonaire, Teritorio Insular di Boneiru, Teritori Pulau Bonaire, Eilandgebied Bonaire
@@ -8242,6 +8245,7 @@ fa:جزایر کارائیب هلند, جزاير كارائيب هلند, کا�
 fr:Pays-Bas caribéens, Bonaire Saint-Eustache et Saba, Îles BES, Antilles Néerlandaises
 frr:BES-eilunen, BES eilunen, BES-eilun, Aparte gemeen, Besondere Gemeinde
 fy:Karibysk Nederlân, BES-eilannen
+hr:Karipska Nizozemska
 id:Kepulauan BES
 it:Isole BES, Caraibi Olandesi, Municipalità olandesi d'oltremare
 ja:ボネール、シント・ユースタティウスおよびサバ, オランダ領カリブ, BES諸島, カリブ・オランダ
@@ -15714,6 +15718,7 @@ eo:Galmudugo, Galmudug
 es:Galmudug
 fi:Galmudug
 fr:Galmudug
+hr:Galmudug
 it:Galmudugh, Galmudug
 ja:ガルムドゥグ
 nl:Galmudug
@@ -28726,6 +28731,7 @@ ga:Poblacht Fhéinrialaitheach Nakhichevan
 gag:Nahçıvan
 gl:Nakhichevan - Naxçıvan, Nakhichevan, Nakhicheván
 he:נחיצ'יבאן, רפובליקת נחיצ'בן, רפובליקת נחיצ'יבאן
+hr:Nahičevanska Autonomna Republika
 hu:Nahicseván
 hy:Նախիջևանի Ինքնավար Հանրապետություն, Նախիջևանի ԻՀ, Նախիջևաին ինքնավար հանրապետություն, ՆԻՀ
 id:Nakhichevan, Nakhchivan, Republik Otonomi Nakhichevan
@@ -35514,6 +35520,7 @@ ga:Saba
 gl:Saba
 gsw:Saba
 he:סאבא, סייבא
+hr:Saba
 hu:Saba
 hy:Սաբա
 id:Saba
@@ -35572,6 +35579,7 @@ es:Santa Elena, Ascensión y Tristán de Acuña, Santa Helena, Ascensión y Tris
 et:Saint Helena, Saint Helena asumaa ja sõltkonnad, Saint Helena, Ascension ja Tristan da Cunha, Saint Helena asumaa
 fi:Saint Helena, Ascension ja Tristan da Cunha
 fr:Sainte-Hélène, Ascension et Tristan da Cunha, Sainte-Hélène, Saint Helena and Dependencies, Sainte-Helene, Sainte-Hélène et ses dépendances, Saint Helena, Ascension and Tristan da Cunha
+hr:Sveta Helena, Ascension i Tristan da Cunha
 hu:Szent Ilona, Ascension és Tristan da Cunha
 id:Saint Helena Ascension dan Tristan da Cunha, Saint Helena dan Dependensinya
 it:Sant'Elena, Ascensione e Tristan da Cunha
@@ -35937,6 +35945,7 @@ fi:Saint-Martin
 fr:Saint-Martin, Grand Case, TFFG
 gsw:Saint-Martin
 he:סן מרטן
+hr:Saint-Martin, Zajednica Sveti Martin
 hu:Saint-Martin
 hy:Սեն Մարտեն
 id:Saint Martin, Collectivité de Saint-Martin, Collectivity of Saint Martin
@@ -38050,6 +38059,7 @@ fy:Sint Eustaasjes, Statia
 gl:San Eustaquio, Sint Eustatius
 gsw:Sint Eustatius
 he:סנט אוסטתיוס, סנט אוסטטיוס
+hr:Sveti Eustahije
 hu:Sint Eustatius
 hy:Սինտ Էվստատիուս
 id:Sint Eustatius, St. Eustasius, Saint Eustatius
@@ -38113,6 +38123,7 @@ frr:Sint Maarten
 fy:Sint Marten, Sint Maarten
 ga:Sint Maarten
 he:סנט מארטן
+hr:Sint Maarten, Zemlja Sveti Martin
 hu:Sint Maarten
 id:Sint Maarten, Eilandgebied Sint Maarten
 it:Sint Maarten, Sint-Maarten, St. Maarten
@@ -40326,6 +40337,7 @@ fr:État de Palestine, Palestine, Propositions pour la création d'un État pale
 frr:Palestina
 ga:Stát na Palaistíne
 he:מדינה פלסטינית, מדינה פלשתינית, פלשטין, מדינת פלסטין, מדינה פלסטינאית, המדינה הפלסטינית, מדינה פלשתינאית
+hr:Država Palestina
 id:Negara Palestina
 ilo:Estado iti Palestina
 is:Palestínuríki
@@ -40779,6 +40791,7 @@ et:Svalbard ja Jan Mayen
 fa:سوالبارد و یان ماین, سوالبارد و يان ماين
 fi:Svalbard ja Jan Mayen, SJM
 fr:Svalbard et Jan Mayen, Svalbard et île Jan Mayen, Svalbard et ile jan mayen
+hr:Svalbard i Jan Mayen
 id:Svalbard dan Jan Mayen
 it:Svalbard e Jan Mayen
 ja:スヴァールバル諸島およびヤンマイエン島, スバールバル諸島・ヤンマイエン島
@@ -45064,6 +45077,7 @@ fa:جزایر کوچک حاشیه‌ای ایالات متحده
 fi:Yhdysvaltain pienet erillissaaret
 fr:Îles mineures éloignées des États-Unis
 frr:United States Minor Outlying Islands
+hr:Mali udaljeni otoci SAD-a
 hu:Az Amerikai Egyesült Államok lakatlan külbirtokai
 ia:Insulas minor peripheric del Statos Unite
 id:Kepulauan Terluar Kecil Amerika Serikat

--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -1735,7 +1735,6 @@ gd:An Antartaig
 got:𐌰𐌽𐍄𐌰𐍂𐌺𐍄𐌹𐌺𐌰
 gu:એન્ટાર્કટીકા
 hsb:Antarktis
-hr:Antarktika
 hu:Antarktisz
 hy:Անտարկտիկա
 ilo:Antártiko


### PR DESCRIPTION
Added missing countries in HR

FYI, I used wikidata, wikipedia and the Croatian encyclopedia (https://www.enciklopedija.hr/, from the Miroslav Krleža Lexicographic Institute) as sources.