### PR TITLE
feat: API to login and get user username, name and email 

### DIFF
--- a/cgi/auth.pl
+++ b/cgi/auth.pl
@@ -40,13 +40,35 @@ $log->info('start') if $log->is_info();
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $status = 403;
+my $status;
+my $response_ref;
 
 if (defined $User_id) {
 	$status = 200;
+
+	# Return basic data about the user
+	$response_ref = {
+		status => 1,
+		status_verbose => 'user signed-in',
+		user_id => $User_id,
+		user => {
+			email => $User{email},
+			name => $User{name},
+		},
+	};
+
+	use JSON::PP;
+
+}
+else {
+	$status = 403;
+	$response_ref = {
+		status => 0,
+		status_verbose => 'user not signed-in',
+	};
 }
 
-print header(-status => $status);
+my $json = JSON::PP->new->allow_nonref->canonical->utf8->encode($response_ref);
 
 # We need to send the header Access-Control-Allow-Credentials=true so that websites
 # such has hunger.openfoodfacts.org that send a query to world.openfoodfacts.org/cgi/auth.pl
@@ -63,5 +85,12 @@ if ($origin =~ /^https:\/\/[a-z0-9-.]+\.${server_domain}(:\d+)?$/) {
 	$r->err_headers_out->set("Access-Control-Allow-Origin", $origin);
 }
 
+print header(-status => $status, -type => 'application/json', -charset => 'utf-8');
+print $json;
+
 $r->rflush;
-$r->status($status);
+
+# Setting the status makes mod_perl append a default error to the body
+# $r->status($status);
+# Send 200 instead.
+$r->status(200);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -692,7 +692,15 @@ sub init_request() {
 
 	my $error = ProductOpener::Users::init_user($request_ref);
 	if ($error) {
-		display_error_and_exit($error, 403);
+		# TODO: currently we always display an HTML message if we were passed a bad user_id and password combination
+		# even if the request is an API request
+
+		# for requests to /cgi/auth.pl, we will now return a JSON body, set in /cgi/auth.pl
+		# but it would be good to later have a more consistent behaviour for all API requests
+		if ($r->uri() !~ /\/cgi\/auth\.pl/) {
+			print $r->uri();
+			display_error_and_exit($error, 403);
+		}
 	}
 
 	# %admin is defined in Config.pm


### PR DESCRIPTION
This is to address #7361 so that the Flutter app can get the username and name of an user who authenticated with an email address.

but it could also be a step to have a more uniform handling of errors in the API (specifically errors related to users not identified or bad logins and passwords supplied).

I'm proposing that we extend the /cgi/auth.pl API which currently:

- checks if an user is identified (either through a session cookie on the *.openfoodfacts.org domain, or by passing user_id and password)
- returns a 200 status code if the user is logged in, or a 403 otherwise

The extension would be to add a JSON body:
- when the user is logged in:

```json
{
    "status": 1,
    "status_verbose": "user signed-in",
    "user": {
        "email": "my email",
        "name": "Stéphane Gigandet"
    },
    "user_id": "test2"
}

```
- when the user is not logged in:
```json
{
    "status": 0,
    "status_verbose": "user not signed-in"
}
```

With the proposed code, this behaviour would only apply to /cgi/auth.pl

But we could decide to extend it to all other API calls (e.g. product edit). If invalid userid / password are supplied, we return a JSON body to explain why (instead of returning an HTML content today).

I think we could keep the existing status: 0 that we have in most APIs I think (get and search product, product edit, auth), and maybe add an "error" id + and "error_message" in the language requested.

cc @VaiTon @M123-dev @monsieurtanuki @g123k 