### PR TITLE
fix: more responsive donate banner

### DIFF
--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -6,7 +6,7 @@
 <div id="donate_banner" class="block black short" style="background-color:#6D85D9">
 	
 		<div id="donate_image_banner_outside">
-			<div class="row">
+			<div class="row hide-for-small">
 
 				<div id="donate_image_banner_inside">
 
@@ -25,6 +25,28 @@
 
 				</div>
 			</div>
+
+			<div class="row hide-for-medium-up">
+
+				<div id="donate_image_banner_inside" style="min-height:90px;padding-top:10px;">
+
+					<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button" class="button round white-button" style="float:left;margin-right:2rem;">
+						<span class="material-symbols-outlined material-symbols-button">volunteer_activism</span>
+						[% lang('donation_cta') %]
+					</a>
+				</div>
+
+				<div class="small-12 columns">
+					<p class="">[% f_lang('donation_body_employees', { number_of_employees => '7' }) %]<br>
+					[% f_lang('donation_why_year', { year => '2022' }) %] <strong>[% lang('thank_you') %] <span style="color:red">❤️</span></strong>
+					</p>
+					<input id="hide_image_banner" type="checkbox" style="margin-top:1.5rem;margin-bottom:0;">
+					<label for="hide_image_banner">
+						<span id="hide_image_banner_hide"class="text-white">[% lang('donation_banner_hide') %]</span>
+					</label>
+
+				</div>
+			</div>			
 			
 		</div>
 	


### PR DESCRIPTION
This is to make the donate banner less tall on small screens.

Small screen:

![image](https://user-images.githubusercontent.com/8158668/194905548-d7ae6c24-210b-4852-98ef-2b797d217d33.png)

No change for medium screens and large screens:

![image](https://user-images.githubusercontent.com/8158668/194905618-359635d4-edbb-408f-8664-1bf3b0efa781.png)

![image](https://user-images.githubusercontent.com/8158668/194905655-87e60550-4182-4b3d-a75b-460f6c7c5290.png)

