### PR TITLE
fix: add body parameter to auth.pl

### DIFF
--- a/cgi/auth.pl
+++ b/cgi/auth.pl
@@ -86,7 +86,14 @@ if ($origin =~ /^https:\/\/[a-z0-9-.]+\.${server_domain}(:\d+)?$/) {
 }
 
 print header(-status => $status, -type => 'application/json', -charset => 'utf-8');
-print $json;
+
+# 2022-10-11 - The OFF flutter app is expecting an empty body
+# see https://github.com/openfoodfacts/smooth-app/issues/3118
+# only send a body if we have the body=1 parameter
+# TODO: remove this condition when new versions of the app are deployed
+if (single_param("body")) {
+	print $json;
+}
 
 $r->rflush;
 

--- a/cgi/auth.pl
+++ b/cgi/auth.pl
@@ -87,7 +87,7 @@ if ($origin =~ /^https:\/\/[a-z0-9-.]+\.${server_domain}(:\d+)?$/) {
 
 print header(-status => $status, -type => 'application/json', -charset => 'utf-8');
 
-# 2022-10-11 - The OFF flutter app is expecting an empty body
+# 2022-10-11 - The Open Food Facts Flutter app is expecting an empty body
 # see https://github.com/openfoodfacts/smooth-app/issues/3118
 # only send a body if we have the body=1 parameter
 # TODO: remove this condition when new versions of the app are deployed


### PR DESCRIPTION
This is to fix https://github.com/openfoodfacts/smooth-app/issues/3118

auth.pl?body=1 --> returns a JSON body
auth.pl --> does not return a body

Plan:
- update openfoodfacts-dart to call auth.pl?body=1 and expect a JSON body
- deploy new Flutter app

Possibly:
- wait until most instances of the apps have been updated
- make sending a body the default for auth.pl

cc @M123-dev @monsieurtanuki 