### PR TITLE
fix: display front image first in product edit form 

### DIFF
--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -107,6 +107,14 @@
             </div>
         </section>        
 
+        <section id="product_image" class="card fieldset">
+            <div class="card-section">
+                <legend>[% lang("product_image") %]</legend>
+                <input type="hidden" id="sorted_langs" name="sorted_langs" value="[% product_ref_sorted_langs %]"/>
+                [% display_tab_product_picture %]
+            </div>
+        </section>        
+
         <section id="product_characteristics" class="fieldset card">
             <div class="card-section">
                 <legend>[% lang('product_characteristics') %]</legend>
@@ -123,14 +131,6 @@
                 [% FOREACH field IN display_fields_arr %]
                     [% field %]
                 [% END %]
-            </div>
-        </section>
-
-        <section id="product_image" class="card fieldset">
-            <div class="card-section">
-                <legend>[% lang("product_image") %]</legend>
-                <input type="hidden" id="sorted_langs" name="sorted_langs" value="[% product_ref_sorted_langs %]"/>
-                [% display_tab_product_picture %]
             </div>
         </section>
 


### PR DESCRIPTION
### What
- fixes #7518

### Part of
- #7295 