### PR TITLE
fix: added missing template data reference which prevented passing on of d…

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7504,6 +7504,7 @@ sub display_page ($request_ref) {
 	$template_data_ref->{canon_url} = $canon_url;
 	$template_data_ref->{meta_description} = $meta_description;
 	$template_data_ref->{canon_title} = $canon_title;
+	$template_data_ref->{canon_description} = $canon_description;
 	$template_data_ref->{og_images} = $og_images;
 	$template_data_ref->{og_images2} = $og_images2;
 	$template_data_ref->{options_favicons} = $options{favicons};


### PR DESCRIPTION
…escription into html


### What

added line 7507 which creates a (missing) reference for the webpage description; "canon_description" is already used on site_layout.tt.html but wasn't referenced before hence not loading data.

### Screenshot
![image](https://user-images.githubusercontent.com/71108160/197377074-2eeec2cd-a8f1-4069-be5e-98f962fc8f66.png)
![image](https://user-images.githubusercontent.com/71108160/197377094-9b57e1f3-6f26-48df-a964-35cb792c86bb.png)
![image](https://user-images.githubusercontent.com/71108160/197377122-b4a52885-508e-4429-b0fa-9e53efba1084.png)

### Related issue(s) and discussion
- Fixes #7422

