### PR TITLE
fix: added url check function to make sure link had https prefix, adds the…

### DIFF
--- a/cgi/org.pl
+++ b/cgi/org.pl
@@ -136,6 +136,9 @@ if ($action eq 'process') {
 			}
 
 			# Other fields
+			foreach my $field ("link"){
+				$org_ref->{$field} = check_valid_link($field);
+			}
 
 			foreach my $field ("name", "link") {
 				$org_ref->{$field} = remove_tags_and_quote(decode utf8 => single_param($field));
@@ -143,6 +146,8 @@ if ($action eq 'process') {
 					delete $org_ref->{$field};
 				}
 			}
+
+			
 
 			if (not defined $org_ref->{name}) {
 				push @errors, $Lang{error_missing_org_name}{$lang};

--- a/lib/ProductOpener/Text.pm
+++ b/lib/ProductOpener/Text.pm
@@ -276,6 +276,23 @@ sub remove_tags_and_quote ($s) {
 	return $s;
 }
 
+sub check_valid_link ($s) {
+	#if no link provided
+	if (not defined $s or $s eq "") {
+		$s = "";
+		return "";
+	}
+
+	#check if valid (prefixed link)
+	if ($s =~ m{^(http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?'#'%[\]@!\$&'\(\)\*\+,;=.]+$}) {
+		return $s;
+	}
+
+	#else, return prefix + link
+	return "https://${s}"
+}
+
+
 sub xml_escape ($s) {
 
 	# Remove tags


### PR DESCRIPTION
… prefix if it doesn't

### What
organization-provided (link to official website) URL could be missing the (https://) prefix which prevented <a> tag from correctly redirecting. Added a function that checks for valid URL and adds a prefix if it doesn't already have one. 


### Related issue(s) and discussion
- Fixes #6022

