### PR TITLE
taxonomy: add descriptions and comments as taxonomy fields

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -817,8 +817,6 @@ ro:Produse apicole, Produse de apicultură, Produse apicultură, Produse de apic
 ru:Продукция пчеловодства, Продукты пчеловодства
 wikidata_category:en:Q7189914
 
-# description:en:ROYAL JELLY is a honey bee secretion that is used in the nutrition of larvae, as well as adult queens. Royal jelly is collected and sold as a dietary supplement for humans, but the European Food Safety Authority has concluded that the current evidence does not support the claim that consuming royal jelly will give health benefits in humans.
-
 <en:Bee products
 en:Royal jelly
 ar:هلام ملكي
@@ -883,6 +881,8 @@ zh:蜂王漿
 # zh-tw:蜂王漿
 wikipedia:en:https://en.wikipedia.org/wiki/Royal_jelly
 wikidata:en:Q202501
+description:en:Royal jelly is a honey bee secretion that is used in the nutrition of larvae, as well as adult queens. Royal jelly is collected and sold as a dietary supplement for humans, but the European Food Safety Authority has concluded that the current evidence does not support the claim that consuming royal jelly will give health benefits in humans.
+
 
 <en:Bee products
 en:Pollens
@@ -1141,8 +1141,6 @@ en:Wine-based alcoholic beverages
 fr:Boissons alcoolisées à base de vin
 
 
-# description:en:A punch, Sangria traditionally consists of red wine and chopped fruit, often with other ingredients or spirits.
-
 <en:Wine-based alcoholic beverages
 en:Sangria
 xx:Sangria
@@ -1152,6 +1150,7 @@ ciqual_food_code:en:1017
 ciqual_food_name:en:Sangria
 ciqual_food_name:fr:Sangria
 wikidata:en:Q273296
+description:en:A punch, Sangria traditionally consists of red wine and chopped fruit, often with other ingredients or spirits.
 
 <en:Alcoholic beverages
 en:Pastis
@@ -4923,8 +4922,6 @@ ciqual_food_name:fr:Boisson énergisante, non sucrée, avec édulcorants
 
 
 
-# description:en:LEMONADE can be any one of a variety of sweetened beverages found throughout the world, but which are traditionally all characterized by a lemon flavor.
-
 <en:Sodas
 en:lemonade, Lemonades
 ar:شراب الليمون
@@ -5001,6 +4998,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lemonade
 agribalyse_proxy_food_code:en:18010
 agribalyse_proxy_food_name:en:Lemonade, with sugar
 agribalyse_proxy_food_name:fr:Limonade, sucrée
+description:en:Lemonade can be any one of a variety of sweetened beverages found throughout the world, but which are traditionally all characterized by a lemon flavor.
 
 <en:Lemonades
 en:Lemonade with sugar
@@ -7109,11 +7107,11 @@ la:Smilax regelii, Smilax aspera
 nl:Sarsaparilla
 wikidata:en:Q161119
 
-# description:en:LIQUORICE is the root of Glycyrrhiza glabra from which a sweet flavour can be extracted.
 
 <en:Plant-based foods
 en:Liquorice roots, licorice roots
 fr:Bâtons de réglisse, bâton de réglisse
+description:en:Liquorice is the root of Glycyrrhiza glabra from which a sweet flavour can be extracted.
 
 <en:Plant-based foods
 <en:Cooking helpers
@@ -30012,8 +30010,7 @@ th:ขนมปังกรอบและเค๊ก
 zh:饼干和蛋糕
 food_groups:en: en:Biscuits and cakes
 pnns_group_2:en:Biscuits and cakes
-
-# description:en:A BISCUIT is a flour-based baked food product, which is typically hard, flat and unleavened.
+description:en:A biscuit is a flour-based baked food product, which is typically hard, flat and unleavened.
 
 # for English, we make cookies a synonym of biscuits
 # for other languages, cookies a separate entry corresponding to "Drop cookies" in English
@@ -30671,8 +30668,6 @@ ciqual_food_code:en:24049
 ciqual_food_name:en:Biscuit shortbread, with butter
 ciqual_food_name:fr:Biscuit sec au beurre, sablé, galette ou palet
 
-# description:en:The PETIT BEURRE, or Véritable Petit Beurre, also known under the initials VPB, is a kind of shortbread from Nantes, that is best known in France. It is the Petit Beurre of the LU society, which has become a success worldwide.
-
 # mainIngredient:en:wheat
 <en:Biscuits
 en:Petit-Beurre, Butter biscuit
@@ -30696,6 +30691,7 @@ agribalyse_food_code:en:24015
 ciqual_food_code:en:24015
 ciqual_food_name:en:Butter biscuit (cookie)
 ciqual_food_name:fr:Biscuit sec petit beurre
+description:en:The petit beurre, or Véritable Petit Beurre, also known under the initials VPB, is a kind of shortbread from Nantes, that is best known in France. It is the Petit Beurre of the LU society, which has become a success worldwide.
 
 <en:Petit-Beurre
 en:Butter biscuit with chocolate
@@ -30842,8 +30838,6 @@ ciqual_food_code:en:24009
 ciqual_food_name:en:Speculoos biscuit
 ciqual_food_name:fr:Spéculoos
 
-# description:en:SPECULAAS is a type of spiced shortcrust biscuit, traditionally baked for consumption on or just before St Nicholas' day in the Netherlands (5 December), Belgium (6 December), and around Christmas in Germany and Austria. Today most speculaas versions are made from white (wheat) flour, brown sugar, butter and spices.
-# comment:en:This is different from speculoos, which is a sugar-based variant with only cinnamon.
 
 # mainIngredient:en:wheat
 # <en:compound
@@ -30874,8 +30868,8 @@ zh:斯派庫魯斯
 # pcd:Spéculaas
 wikidata:en:Q6591
 wikipedia:en:https://en.wikipedia.org/wiki/Speculaas
-
-#decription:en:Small round biscuits (1-2 cm) with a large range spices. Can only be obtained in the months up to 5 december (Saint Nicolas)
+description:en:Speculaas is a type of small (1-2 cm) spiced shortcrust biscuit, traditionally baked for consumption on or just before St Nicholas' day in the Netherlands (5 December), Belgium (6 December), and around Christmas in Germany and Austria. Today most speculaas versions are made from white (wheat) flour, brown sugar, butter and spices.
+comment:en:This is different from speculoos, which is a sugar-based variant with only cinnamon.
 
 <en:Speculaas
 nl:Kruidnoten, Speculaasnoten
@@ -31719,8 +31713,6 @@ ciqual_food_name:en:Bread, French bread (baguette or ball), with yeast
 ciqual_food_name:fr:Pain, baguette ou boule, au levain
 
 
-# description:en:BREAD CRUMBS are sliced residue of dry bread, used for breading or crumbing foods, topping casseroles, stuffing poultry, thickening stews, adding inexpensive bulk to soups, meatloaves and similar foods, and making a crisp and crunchy covering for fried foods, especially breaded cutlets like tonkatsu and schnitzel.
-
 <en:Breads
 en:Bread crumbs, breadcrumbs
 ar:بقسماط
@@ -31763,6 +31755,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bread_crumbs
 ciqual_food_code:en:7500
 ciqual_food_name:en:Breadcrumbs
 ciqual_food_name:fr:Chapelure
+description:en:Bread crumbs are sliced residue of dry bread, used for breading or crumbing foods, topping casseroles, stuffing poultry, thickening stews, adding inexpensive bulk to soups, meatloaves and similar foods, and making a crisp and crunchy covering for fried foods, especially breaded cutlets like tonkatsu and schnitzel.
 
 <en:Bread crumbs
 en:Wheat crumbs
@@ -32247,7 +32240,6 @@ ciqual_food_code:en:7260
 ciqual_food_name:en:Bread, home-made, with flour for home-made bread preparation
 ciqual_food_name:fr:Pain blanc maison (avec farine pour machine à pain)
 
-# description:en:A CROUTON is a piece of sautéed or rebaked bread, often cubed and seasoned, that is used to add texture and flavor to salads as an accompaniment to soups and stews, or eaten as a snack food.
 
 # <en:compound
 # mainIngredient:en:wheat
@@ -32285,6 +32277,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Crouton
 agribalyse_food_code:en:7430
 ciqual_food_code:en:7430
 ciqual_food_name:en:Croutons
+description:en:A crouton is a piece of sautéed or rebaked bread, often cubed and seasoned, that is used to add texture and flavor to salads as an accompaniment to soups and stews, or eaten as a snack food.
 
 <en:Croutons
 en:Croutons for spreads
@@ -32425,13 +32418,14 @@ nl:Speciale broden, Speciaal brood
 pt:Pães especiais
 zh:特殊面包
 
-#comment:en:Do not confuse these with the small snacks
 <en:Special breads
 en:Bread Pretzels
 de:Brot Brezeln
 fr:Pains Bretzels, Pain bretzel, Pains bretzel
 nl:Brood Pretzels
 wikidata:en:Q160525
+comment:en:Do not confuse these with the small snacks
+
 
 <en:Special breads
 en:English muffins
@@ -32690,8 +32684,6 @@ ciqual_food_name:en:Malted cocoa or chocolate powder for beverage, with sugar
 ciqual_food_name:fr:Poudre maltée, cacaotée ou au chocolat pour boisson, sucrée, enrichie en vitamines et minéraux
 
 
-# description:en:CAKE is a form of sweet food that is usually baked. The most commonly used cake ingredients include flour, sugar, eggs, butter or oil or margarine, a liquid, and leavening agents, such as baking soda or baking powder. Common additional ingredients and flavourings include dried, candied, or fresh fruit, nuts, cocoa, and extracts such as vanilla, with numerous substitutions for the primary ingredients. Cakes can also be filled with fruit preserves, nuts or dessert sauces (like pastry cream), iced with buttercream or other icings, and decorated with marzipan, piped borders, or candied fruit.
-
 <en:Biscuits and cakes
 # <en:compound
 en:Cakes
@@ -32800,6 +32792,7 @@ ciqual_food_name:en:Cake (average)
 ciqual_food_name:fr:Gâteau (aliment moyen)
 # category/cakes has 6408 products @2019-05-20
 # ingredient/fr:gâteau has 59 products in french @2019-02-06
+description:en:Cake is a form of sweet food that is usually baked. The most commonly used cake ingredients include flour, sugar, eggs, butter or oil or margarine, a liquid, and leavening agents, such as baking soda or baking powder. Common additional ingredients and flavourings include dried, candied, or fresh fruit, nuts, cocoa, and extracts such as vanilla, with numerous substitutions for the primary ingredients. Cakes can also be filled with fruit preserves, nuts or dessert sauces (like pastry cream), iced with buttercream or other icings, and decorated with marzipan, piped borders, or candied fruit.
 
 # Note: en:dessert-mixes is a category that changes the computation of the Nutri-Score, the canonical name should not be changed without corresponding code changes
 <en:Cooking helpers
@@ -35232,8 +35225,6 @@ fr:Confiseries du Nord-Pas-de-Calais
 nl:Suikergoed uit Nord-Pas-de-Calais in Frankrijk
 
 
-# description:en:NOUGAT is a family of confections made with sugar or honey, roasted nuts (almonds, walnuts, pistachios, hazelnuts, and macadamia nuts are common), whipped egg whites, and sometimes chopped candied fruit.
-
 <en:Confectioneries
 # mainIngredient:en:sugar
 en:nougats, nougat
@@ -35304,6 +35295,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Nougat
 agribalyse_food_code:en:31033
 ciqual_food_code:en:31033
 ciqual_food_name:en:Nougat
+description:en:Nougat is a family of confections made with sugar or honey, roasted nuts (almonds, walnuts, pistachios, hazelnuts, and macadamia nuts are common), whipped egg whites, and sometimes chopped candied fruit.
 
 
 <fr:Nougats
@@ -35644,7 +35636,6 @@ de:Mantecados und Polvorón mit Olivenöl
 es:Mantecados y polvorones de aceite de oliva
 fr:Mantecados et polvorones á l'huile d'olive
 
-# description:en:MARZIPAN is a confection consisting primarily of sugar or honey and almond meal (ground almonds), sometimes augmented with almond oil or extract.
 
 # mainIngredient:en:sugar
 <en:Confectioneries
@@ -35710,6 +35701,7 @@ zh:杏仁膏
 wikidata:en:Q106252
 wikipedia:en:https://en.wikipedia.org/wiki/Marzipan
 # ingredient/fr:massepain has 27 products in 4 languages @2019-02-12
+description:en:Marzipan is a confection consisting primarily of sugar or honey and almond meal (ground almonds), sometimes augmented with almond oil or extract.
 
 
 <en:Marzipan
@@ -40674,8 +40666,6 @@ ciqual_food_code:en:12741
 ciqual_food_name:en:Firm cheese, around 27% fat, Maasdam-type cheese
 ciqual_food_name:fr:Fromage à pâte ferme environ 27% MG type Maasdam
 
-# description:en:Gouda is a sweet, creamy, yellow cow's milk cheese originating from the Netherlands.
-# comment: Gouda is NOT a protected name. It can be made anywhere.
 <en:Uncooked pressed cheeses
 <en:Cow cheeses
 en:Gouda
@@ -40694,7 +40684,8 @@ agribalyse_food_code:en:12736
 ciqual_food_code:en:12736
 ciqual_food_name:en:Gouda cheese, from cow's milk
 origins:en: en:The Netherlands
-#wikidata:en:
+description:en:Gouda is a sweet, creamy, yellow cow's milk cheese originating from the Netherlands.
+comment:en:Gouda is NOT a protected name. It can be made anywhere.
 
 <en:Gouda
 en:Goudas with cumin
@@ -40707,7 +40698,6 @@ it:Gouda con cumino
 nl:Goudse Komijnenkazen
 #wikidata:en:
 
-# comment:en: ripings process < 4 weeks
 <en:Gouda
 en:Young Goudas, Young Gouda
 de:Junge Goudas, Junger Gouda
@@ -40715,37 +40705,39 @@ fi:nuori gouda
 fr:Goudas jeunes, Gouda jeune
 it:Gouda giovane
 nl:Jonge Goudas
+comment:en:ripings process < 4 weeks
 
-# comment:en: ripings process 8 <-> 10 weeks
+
 <en:Gouda
 en:Young matured Goudas
 nl:Jong belegen Goudas
+comment:en:ripings process 8 <-> 10 weeks
 
-# comment:en: ripings process 16 <-> 18 weeks
 <en:Gouda
 en:Matured Gouda
 fr:Goudas mi-vieux
 de:Mittelalter Gouda
 fi:Kypsytetyt Goudat
 nl:Belegen Gouda
+comment:en:ripings process 16 <-> 18 weeks
 
-# comment:en: ripings process 7 <-> 9 months
 <en:Gouda
 en:Extra matured Gouda
 nl:Extra belegen Gouda
+comment:en:ripings process 7 <-> 9 months
 
-# comment:en: ripings process 10 <-> 12 months
 <en:Gouda
 en:Old Goudas
 de:Alter Gouda
 fr:Goudas vieux
 nl:Oude Goudas
+comment:en:ripings process 10 <-> 12 months
 
-# comment:en: ripings process > 12 months
 <en:Gouda
 fr:Goudas extra-vieux, Goudas de Noël
 de:Extra alte Goudas
 nl:Goudas extra oud, Overjarige Gouda
+comment:en:ripings process > 12 months
 
 <en:Young Goudas
 en:Young Goudas with herbs
@@ -40996,8 +40988,6 @@ en:Fresh cream cheese with sheeps's milk
 fr:Fromages blancs au lait de chèvre
 en:Fresh cream cheese with goat's milk
 
-# description:en:SHEEP MILK CHEESE is a cheese prepared from sheep milk.
-
 # <en:ingredient:en:cheese
 # <en:sheeps milk
 <en:Cheeses
@@ -41031,6 +41021,8 @@ wikipedia:en:https://en.wikipedia.org/wiki/Sheep_milk_cheese
 agribalyse_food_code:en:12824
 ciqual_food_code:en:12824
 ciqual_food_name:en:Soft ripened cheese with bloomy rind, from ewe's milk, Camembert-type cheese
+description:en:Sheep milk cheese is a cheese prepared from sheep milk.
+
 
 <en:sheep's-milk cheeses
 en:Old sheep cheese
@@ -43816,7 +43808,6 @@ fr:Skyrs nature, Skyr nature
 en:Fruit skyrs, Fruit skyr
 fr:Skyrs aux fruits, Skyr aux fruits
 
-# description:en:QUARK is a type of fresh dairy product made by warming soured milk until the desired amount of curdling is met, and then straining it.
 
 <en:Fermented milk products
 # <en:ingredient:en:cheese
@@ -43871,6 +43862,7 @@ ciqual_food_name:en:Quark, plain or fruit (average)
 ciqual_food_name:fr:Fromage blanc nature ou aux fruits (aliment moyen)
 # ingredient/nl:kwark has 2 products @2019-05-24
 # category/quark has 221 products @2019-05-24
+description:en:Quark is a type of fresh dairy product made by warming soured milk until the desired amount of curdling is met, and then straining it.
 
 <en:Plain fermented dairy desserts
 <en:Quarks
@@ -46660,7 +46652,7 @@ fr:Compotes de pomme, Compotes de pommes, Compote de pommes
 he:לפתן תפוחים, קומפוט תפוחים
 hu:Almakompótok
 it:Composte di mela
-#comment:en:In dutch there is a difference between compote and moes. The former has pieces in it, while the later is more finely ground.
+comment:en:In dutch there is a difference between compote and moes. The former has pieces in it, while the later is more finely ground.
 nl:Appelcompotes, Applemoezen, Appelmoes
 sv:Äppelmos
 wikidata:en:Q618345
@@ -49456,8 +49448,6 @@ it:Uova da galline allevate in gabbie
 nl:Legbatterij eieren
 wikidata:en:Q35855119
 
-# description:en:QUAIL EGGS are the eggs layed by a quail. They can be prepared the same as chicken eggs.
-
 <en:Bird eggs
 # <en:ingredient:en:egg
 en:Quail eggs, Quail egg
@@ -49480,6 +49470,7 @@ ciqual_food_code:en:22050
 ciqual_food_name:en:Quail egg, raw
 ciqual_food_name:fr:Oeuf de caille, cru
 # ingredient/fr:oeufs-de-cailles has 25 products @2019-05-23
+description:en:Quail eggs are the eggs layed by a quail. They can be prepared the same as chicken eggs.
 
 <en:Bird eggs
 en:Duck eggs
@@ -53021,7 +53012,6 @@ en:Plain porridge
 fr:Porridge nature
 nl:Pappen (gewoon)
 
-# description:en:MUESLI is a breakfast dish based on raw rolled oats and other ingredients like grains, fresh or dried fruits, seeds and nuts, that may be mixed with milk, soy milk, almond milk, other plant milks, yogurt, or fruit juice.
 
 <en:Breakfast cereals
 en:Mueslis, Muesli, Granola
@@ -53083,6 +53073,7 @@ agribalyse_proxy_food_code:en:32128
 agribalyse_proxy_food_name:en:Muesli, flakes (Bircher-style)
 agribalyse_proxy_food_name:fr:Muesli floconneux ou de type traditionnel
 # ingredient/fr:muesli has 46 products in 4 languages @2019-02-07
+description:en:Muesli is a breakfast dish based on raw rolled oats and other ingredients like grains, fresh or dried fruits, seeds and nuts, that may be mixed with milk, soy milk, almond milk, other plant milks, yogurt, or fruit juice.
 
 <en:Mueslis
 <en:Cereals with fruits
@@ -54798,7 +54789,7 @@ vi:Phụ gia thực phẩm
 zh:食品添加剂
 #vec:Aditivo ałimentar
 wikidata:en:Q189567
-#description:en:substances added to food to preserve flavor or enhance its taste, appearance, or other qualities
+description:en:substances added to food to preserve flavor or enhance its taste, appearance, or other qualities
 
 <en:Food additives
 en:Soy lecithin
@@ -55348,7 +55339,6 @@ fr:Dessert glacé feuilleté vanille fruits rouges
 <en:Frozen dessert puff pastry
 fr:Dessert glacé feuilleté chocolat brownie
 
-# description:en:ICE CREAM is a sweetened frozen food typically eaten as a snack or dessert. It may be made from dairy milk or cream, or soy, cashew, coconut or almondmilk, and is flavored with a sweetener, either sugar or an alternative, and any spice, such as cocoa or vanilla. Colourings are usually added, in addition to stabilizers.
 
 <en:Ice creams and sorbets
 en:ice creams, ice cream
@@ -55510,6 +55500,8 @@ agribalyse_proxy_food_name:fr:Glace ou crème glacée, cône (taille standard)
 # usage:en:Ice cream:organic cream, organic milk, organic cane sugar, organic egg yolks, organic vanilla extract, organic locust bean gum, organic guar gum
 # usage:fr:glace (sucre, kirsch de Bâle-Campagne)
 nova:en:3
+description:en:Ice cream is a sweetened frozen food typically eaten as a snack or dessert. It may be made from dairy milk or cream, or soy, cashew, coconut or almondmilk, and is flavored with a sweetener, either sugar or an alternative, and any spice, such as cocoa or vanilla. Colourings are usually added, in addition to stabilizers.
+
 
 <en:Ice creams
 en:Ice cream bars, Ice creams on a stick
@@ -59242,7 +59234,6 @@ food_groups:en: en:Dried fruits
 pnns_group_2:en:Dried fruits
 who_id:en:16
 
-# description:en:DATE, the fruit of the date palm (Phoenix dactylifera). Dry or soft dates are eaten out-of-hand, or may be pitted and stuffed with fillings such as almonds, walnuts, pecans, candied orange and lemon peel, tahini, marzipan or cream cheese.
 
 <en:fruit
 # <en:category:en:Dried fruits
@@ -59295,6 +59286,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Date_palm#Fruits
 agribalyse_proxy_food_code:en:13011
 agribalyse_proxy_food_name:en:Date, pulp and peel, dried
 agribalyse_proxy_food_name:fr:Datte, pulpe et peau, sèche
+description:en:Date, the fruit of the date palm (Phoenix dactylifera). Dry or soft dates are eaten out-of-hand, or may be pitted and stuffed with fillings such as almonds, walnuts, pecans, candied orange and lemon peel, tahini, marzipan or cream cheese.
 
 <en:Fruit pastes
 <en:Dates
@@ -60869,7 +60861,6 @@ la:Satureja montana
 nl:Bergbonenkruid
 wikidata:en:Q160186
 
-# description:en:Tarragon (Artemisia dracunculus), is a species of perennial herb in the sunflower family. Tarragon is one of the four fines herbes of French cooking, and is particularly suitable for chicken, fish, and egg dishes.
 
 <en:Aromatic herbs
 en:tarragon
@@ -60957,6 +60948,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Tarragon
 agribalyse_proxy_food_code:en:11092
 agribalyse_proxy_food_name:en:Tarragon, fresh
 agribalyse_proxy_food_name:fr:Estragon, frais
+description:en:Tarragon (Artemisia dracunculus), is a species of perennial herb in the sunflower family. Tarragon is one of the four fines herbes of French cooking, and is particularly suitable for chicken, fish, and egg dishes.
 
 <en:Tarragon
 <en:Fresh aromatic plants
@@ -68046,7 +68038,6 @@ nl:Courgettecrèmesoepen
 <en:Cream of vegetable soups
 fr:Veloutés de légumes du soleil
 
-# description:en:BROTH is a savory liquid made of water in which bones, meat, fish, or vegetables have been simmered.
 
 en:broths, broths, stock, bouillon, Stocks
 af:bouillon
@@ -68124,6 +68115,7 @@ zh:清汤
 wikidata:en:Q275068
 wikipedia:en:https://en.wikipedia.org/wiki/Broth
 # category/broths has 527 products @2019-05-19
+description:en:Broth is a savory liquid made of water in which bones, meat, fish, or vegetables have been simmered.
 
 <en:Broths
 <en:Dried products to be rehydrated
@@ -75575,8 +75567,6 @@ zh:冷肉
 <fr:Saucissons
 fr:Saucissons artisanaux, Saucisson artisanal
 
-# description:en:CHORIZO or chouriço is a type of pork sausage. In Europe, chorizo is a fermented, cured, smoked sausage, which may be sliced and eaten without cooking, or added as an ingredient to add flavor to other dishes. Elsewhere, some sausages sold as chorizo may not be fermented and cured, and require cooking before eating. Spanish chorizo and Portuguese chouriço get their distinctive smokiness and deep red color from dried, smoked, red peppers.
-
 <fr:saucissons
 en:chorizo, chorizos
 af:Chorizo
@@ -75631,6 +75621,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Chorizo
 agribalyse_food_code:en:30315
 ciqual_food_code:en:30315
 ciqual_food_name:en:Spicy pork sausage with red pepper, no precision
+description:en:Chorizo or chouriço is a type of pork sausage. In Europe, chorizo is a fermented, cured, smoked sausage, which may be sliced and eaten without cooking, or added as an ingredient to add flavor to other dishes. Elsewhere, some sausages sold as chorizo may not be fermented and cured, and require cooking before eating. Spanish chorizo and Portuguese chouriço get their distinctive smokiness and deep red color from dried, smoked, red peppers.
 
 <en:chorizo
 en:Spicy pork sausage in large slices
@@ -77623,7 +77614,6 @@ es:Harinas de setas, Setas en polvo, Setas deshidratadas en polvo
 fr:Poudres de champignons
 nl:Paddestoelenpoeders
 
-# description:en:PASTA is type of noodle typically made from an unleavened dough of durum wheat flour mixed with water or eggs, and formed into sheets or various shapes, then cooked by boiling or baking. Rice flour, or legumes such as beans or lentils, are sometimes used in place of wheat flour to yield a different taste and texture, or as a gluten-free alternative. Pasta is a staple food of Italian cuisine.
 
 # <en:dough
 <en:Plant-based foods
@@ -77734,6 +77724,8 @@ wikidata:en:Q178
 wikipedia:en:https://en.wikipedia.org/wiki/Pasta
 carbon_footprint_fr_foodges_ingredient:fr:Pâtes sèches
 # ingredient/fr:pâtes-alimentaires has 115 products 2019-05-20
+description:en:Pasta is type of noodle typically made from an unleavened dough of durum wheat flour mixed with water or eggs, and formed into sheets or various shapes, then cooked by boiling or baking. Rice flour, or legumes such as beans or lentils, are sometimes used in place of wheat flour to yield a different taste and texture, or as a gluten-free alternative. Pasta is a staple food of Italian cuisine.
+
 
 <en:Cereals and their products
 <en:Pastas
@@ -78578,7 +78570,6 @@ ciqual_food_code:en:9810
 ciqual_food_name:en:Dried pasta, raw
 ciqual_food_name:fr:Pâtes sèches standard, crues
 
-# description:en:RAVIOLI are a type of dumpling comprising a filling enveloped in thin pasta dough.
 
 # <en:compound
 <en:Stuffed Pastas
@@ -78629,6 +78620,7 @@ ciqual_food_name:en:Pasta (e.g. ravioli), filled, cooked
 ciqual_food_name:fr:Pâtes fraîches farcies (ex : raviolis), cuites (aliment moyen)
 # ingredient/ravioli has 92 products in 6 languages @2019-02-17
 # ravioli (water, durum wheat, 24% cream cheese, egg [open-air] 7%, mascarpone cheese, bread crumbs, coconut cream, 1% lemon juice, broth of vegetables, sugar, whey powder, juice of limes 0.3%, iodized cooking salt, lemon zest 0.2%, lemon extract 0.1%, syrup of limes, spices)
+description:en:Ravioli are a type of dumpling comprising a filling enveloped in thin pasta dough.
 
 <en:Stuffed pasta
 en:Pasta stuffed with fish
@@ -86373,7 +86365,7 @@ wikidata:en:Q151070
 en:Caster sugars, Superfine sugars
 fr:Sucres en poudre, Sucre en poudre
 nl:Griessuiker
-#comment:en:has sugar grain size (0.35 mm) between powders and granulated
+comment:en:has sugar grain size (0.35 mm) between powders and granulated
 
 <en:Sugars
 en:Granulated sugars, White sugars, Refined sugars, White sugar, Refined sugar
@@ -87968,7 +87960,6 @@ ciqual_food_name:fr:Betterave rouge, cuite
 <en:Beet
 fr:Betteraves sous vide
 
-# description:en:BROCCOLI is an edible green plant in the cabbage family whose large flowering head is eaten as a vegetable
 
 <en:Vegetables
 # <en:ingredient:en:vegetable
@@ -88063,6 +88054,8 @@ agribalyse_food_code:en:20057
 ciqual_food_code:en:20057
 ciqual_food_name:en:Broccoli, raw
 ciqual_food_name:fr:Brocoli, cru
+description:en:Broccoli is an edible green plant in the cabbage family whose large flowering head is eaten as a vegetable
+
 
 <en:Broccoli
 <en:Fresh vegetables
@@ -88431,7 +88424,6 @@ ciqual_food_code:en:20025
 ciqual_food_name:en:Celeriac, cooked
 ciqual_food_name:fr:Céleri-rave, cuit
 
-# description:en:CHARD (Beta vulgaris subsp. vulgaris, Cicla-Group and Flavescens-Group) is a green leafy vegetable. Chard, like other green leafy vegetables, has highly nutritious leaves, making it a popular component of healthy diets.Fresh young chard can be used raw in salads. Mature chard leaves and stalks are typically cooked (like in pizzoccheri) or sautéed; the bitterness fades with cooking, leaving a refined flavor which is more delicate than that of cooked spinach.
 
 # <en:Vegetable rods
 <en:vegetable
@@ -88501,6 +88493,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Chard
 agribalyse_proxy_food_code:en:20004
 agribalyse_proxy_food_name:en:Swiss chard, raw
 agribalyse_proxy_food_name:fr:Bette ou blette, crue
+description:en:Chard (Beta vulgaris subsp. vulgaris, Cicla-Group and Flavescens-Group) is a green leafy vegetable. Chard, like other green leafy vegetables, has highly nutritious leaves, making it a popular component of healthy diets.Fresh young chard can be used raw in salads. Mature chard leaves and stalks are typically cooked (like in pizzoccheri) or sautéed; the bitterness fades with cooking, leaving a refined flavor which is more delicate than that of cooked spinach.
 
 <en:Chards
 <en:Fresh vegetables
@@ -88549,7 +88542,6 @@ es:Pepinos frescos
 fr:Concombre frais
 season_in_country_fr:en: 5,6,7,8,9,10
 
-# description:en:Cichorium endivia is a species of flowering plant belonging to the genus Cichorium, which is widely cultivated as one of the species of similar bitter-leafed vegetables known as endive and escarole.
 
 # <en:Vegetables
 <en:vegetable
@@ -88599,6 +88591,8 @@ agribalyse_food_code:en:20090
 ciqual_food_code:en:20090
 ciqual_food_name:en:Escaroles
 ciqual_food_name:fr:Scarole, crue
+description:en:Cichorium endivia is a species of flowering plant belonging to the genus Cichorium, which is widely cultivated as one of the species of similar bitter-leafed vegetables known as endive and escarole.
+
 
 <en:Leaf vegetables
 en:Belgian endives, Witloof
@@ -88647,7 +88641,6 @@ ciqual_food_code:en:20163
 ciqual_food_name:en:Green endive, raw
 ciqual_food_name:fr:Chicorée verte, crue
 
-# description:en:FENNEL (Foeniculum vulgare) is a flowering plant species in the carrot family. The bulb, foliage, and fruits of the fennel plant are used in many of the culinary traditions of the world. The bulb is a crisp vegetable that can be sautéed, stewed, braised, grilled, or eaten raw. Young tender leaves are used for garnishes, as a salad, to add flavor to salads, to flavor sauces to be served with puddings, and also in soups and fish sauce.
 
 <en:Plant-based foods
 # <en:ingredient:en:vegetable
@@ -88746,6 +88739,7 @@ agribalyse_food_code:en:20028
 ciqual_food_code:en:20028
 ciqual_food_name:en:Fennel, raw
 ciqual_food_name:fr:Fenouil, cru
+description:en:Fennel (Foeniculum vulgare) is a flowering plant species in the carrot family. The bulb, foliage, and fruits of the fennel plant are used in many of the culinary traditions of the world. The bulb is a crisp vegetable that can be sautéed, stewed, braised, grilled, or eaten raw. Young tender leaves are used for garnishes, as a salad, to add flavor to salads, to flavor sauces to be served with puddings, and also in soups and fish sauce.
 
 <en:fennel
 fr:Fenouil frais
@@ -88881,7 +88875,6 @@ es:Ajos tiernos, Brotes de ajo
 fr:Aillets
 hu:Zöld foghagyma
 
-# description:en:The LEEK is a vegetable, a cultivar of Allium ampeloprasum, the broadleaf wild leek. Leeks have a mild, onion-like taste. In its raw state, the vegetable is crunchy and firm. The edible portions of the leek are the white base of the leaves (above the roots and stem base), the light green parts, and to a lesser extent the dark green parts of the leaves. Leeks are typically chopped into slices 5–10 mm thick. The slices have a tendency to fall apart, due to the layered structure of the leek. The different ways of preparing the vegetable are: boiling, frying or raw.
 
 <en:Vegetable rods
 # <en:ingredient:en:vegetable
@@ -88976,6 +88969,8 @@ agribalyse_food_code:en:20039
 ciqual_food_code:en:20039
 ciqual_food_name:en:Leek, raw
 ciqual_food_name:fr:Poireau, cru
+description:en:The leek is a vegetable, a cultivar of Allium ampeloprasum, the broadleaf wild leek. Leeks have a mild, onion-like taste. In its raw state, the vegetable is crunchy and firm. The edible portions of the leek are the white base of the leaves (above the roots and stem base), the light green parts, and to a lesser extent the dark green parts of the leaves. Leeks are typically chopped into slices 5–10 mm thick. The slices have a tendency to fall apart, due to the layered structure of the leek. The different ways of preparing the vegetable are: boiling, frying or raw.
+
 
 <en:Leeks
 <en:Cooked vegetables
@@ -88999,9 +88994,6 @@ protected_name_file_number:en: PGI-FR-0198
 protected_name_type:en: pgi
 origins:en: en:France
 #wikidata:en:
-
-# description:en:LETTUCE (Lactuca sativa) is an annual plant of the daisy family, Asteraceae. It is most often grown as a leaf vegetable, but sometimes for its stem and seeds. Lettuce is most often used for salads, although it is also seen in other kinds of food, such as soups, sandwiches and wraps; it can also be grilled.
-# comment:en:There is a mixup between the popular translations of Lactuca and Lactuca Sativa. Not sure which one should be used. For the moment they are combined.
 
 <en:Leeks
 en:Leeks fondue, Slow-simmered leeks
@@ -89125,6 +89117,9 @@ agribalyse_food_code:en:20031
 ciqual_food_code:en:20031
 ciqual_food_name:en:Lettuce, raw
 ciqual_food_name:fr:Laitue, crue
+description:en:Lettuce (Lactuca sativa) is an annual plant of the daisy family, Asteraceae. It is most often grown as a leaf vegetable, but sometimes for its stem and seeds. Lettuce is most often used for salads, although it is also seen in other kinds of food, such as soups, sandwiches and wraps; it can also be grilled.
+comment:en:There is a mixup between the popular translations of Lactuca and Lactuca Sativa. Not sure which one should be used. For the moment they are combined.
+
 
 <en:Lettuces
 fr:Sucrines
@@ -89172,8 +89167,6 @@ agribalyse_proxy_food_name:fr:Laitue iceberg, crue
 ciqual_food_code:en:20123
 ciqual_food_name:fr:Batavia, crue
 
-# description:en:The ONION (Allium cepa L.), also known as the bulb onion or common onion, is a vegetable that is the most widely cultivated species of the genus Allium. They are usually served cooked, as a vegetable or part of a prepared savoury dish, but can also be eaten raw or used to make pickles or chutneys.
-
 <en:Culinary plants
 <en:Onions and their products
 #<en:ingredient:en:vegetable
@@ -89218,6 +89211,7 @@ agribalyse_food_code:en:20034
 ciqual_food_code:en:20034
 ciqual_food_name:en:Onion, raw
 ciqual_food_name:fr:Oignon, cru
+description:en:The onion (Allium cepa L.), also known as the bulb onion or common onion, is a vegetable that is the most widely cultivated species of the genus Allium. They are usually served cooked, as a vegetable or part of a prepared savoury dish, but can also be eaten raw or used to make pickles or chutneys.
 
 <en:onions
 it:Cipolla bianca di Margherita
@@ -89829,8 +89823,6 @@ fr:Courges spaghetti
 nl:Spaghettipompoenen
 wikidata:en:Q2142043
 
-# description:en:The RADISH (Raphanus raphanistrum subsp. sativus or Raphanus sativus) is an edible root vegetable of the Brassicaceae family. The root of the radish is usually eaten raw, although tougher specimens can be steamed. The raw flesh has a crisp texture and a pungent, peppery flavor.
-
 # <en:vegetable
 <en:Vegetables
 en:Radishes, radish
@@ -89955,6 +89947,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Radish
 # ingredient/fr:Radis has 393 products in 4 languages @2019-05-16
 # category/radish has 2 products @2019-05-22
 # usage:en:fruit and vegetable concentrates (safflower, radish, black carrot, lemon, hibiscus)
+description:en:The radish (Raphanus raphanistrum subsp. sativus or Raphanus sativus) is an edible root vegetable of the Brassicaceae family. The root of the radish is usually eaten raw, although tougher specimens can be steamed. The raw flesh has a crisp texture and a pungent, peppery flavor.
 
 <en:Radishes
 <en:Fresh vegetables
@@ -90050,7 +90043,6 @@ ciqual_food_code:en:4000
 ciqual_food_name:en:Tapioca, raw
 ciqual_food_name:fr:Tapioca ou Perles du Japon, cru
 
-# description:en:RHUBARB is a cultivated plant in the genus Rheum in the family Polygonaceae. Rhubarb is stewed with sugar or used in pies and desserts, but it can also be put into savoury dishes or pickled. Rhubarb can be dehydrated and infused with fruit juice.
 
 # <en:vegetable
 <en:Vegetable rods
@@ -90085,6 +90077,7 @@ season_in_country_fr:en: 4,5,6
 agribalyse_proxy_food_code:en:13047
 agribalyse_proxy_food_name:en:Rhubarb, stalk, raw
 agribalyse_proxy_food_name:fr:Rhubarbe, tige, crue
+description:en:Rhubarb is a cultivated plant in the genus Rheum in the family Polygonaceae. Rhubarb is stewed with sugar or used in pies and desserts, but it can also be put into savoury dishes or pickled. Rhubarb can be dehydrated and infused with fruit juice.
 
 <en:Rhubarbs
 <en:Fresh fruits
@@ -90142,8 +90135,6 @@ ciqual_food_code:en:20280
 ciqual_food_name:en:Romanesco cauliflower or romanesco broccoli, raw
 ciqual_food_name:fr:Chou romanesco ou brocoli à pomme, cru
 
-# description:en:SCALLIONS are vegetables of various Allium onion species. Spring onions may be cooked or used raw as a part of salads, salsas or Asian recipes. Diced scallions are used in soup, noodle and seafood dishes, sandwiches, curries and as part of a stir fry. In many Eastern sauces, the bottom half-centimetre (quarter-inch) of the root is commonly removed before use.
-# comment:en:do not mix green onion with welsh onion
 
 <en:Vegetables
 # <en:onion
@@ -90180,6 +90171,8 @@ wikipedia:en:https://en.wikipedia.org/wiki/Scallion
 # ingredient/fr:oignon-vert has 45 products in 6 languages @2018-12-06
 # ingredient/fr:oignons-de-printemps has 47 products @2018-12-06
 # category/scallions has 7 products @2019-05-22
+description:en:Scallions (green onions) are vegetables of various Allium onion species. Spring onions may be cooked or used raw as a part of salads, salsas or Asian recipes. Diced scallions are used in soup, noodle and seafood dishes, sandwiches, curries and as part of a stir fry. In many Eastern sauces, the bottom half-centimetre (quarter-inch) of the root is commonly removed before use.
+comment:en:do not mix green onion with welsh onion
 
 <en:Leaf vegetables
 en:New Zealand spinach
@@ -90275,8 +90268,6 @@ ciqual_food_code:en:4102
 ciqual_food_name:en:Sweet potato, cooked
 ciqual_food_name:fr:Patate douce, cuite
 
-# description:en:The TURNIP (Brassica rapa subsp. rapa) is a root vegetable commonly grown in temperate climates worldwide for its white, fleshy taproot.
-# comment:en:Translations are not easy as one has to distinguish between turnip, swede and rutabaga. Sometimes they are all called turnip. Thus some translations might be wrong (taken from wikidata).
 
 <en:Vegetables
 en:turnip, turnips
@@ -90364,6 +90355,8 @@ zh:芜菁
 # yue:大頭菜
 wikidata:en:Q3916957
 wikipedia:en:https://en.wikipedia.org/wiki/Turnip
+description:en:The turnip (Brassica rapa subsp. rapa) is a root vegetable commonly grown in temperate climates worldwide for its white, fleshy taproot.
+comment:en:Translations are not easy as one has to distinguish between turnip, swede and rutabaga. Sometimes they are all called turnip. Thus some translations might be wrong (taken from wikidata).
 
 <en:Turnip
 en:Rutabaga, Swede
@@ -92477,7 +92470,6 @@ es:Mantecas de soja
 fr:Beurres de soja
 nl:Sojaboonpastas
 
-# description:en:TOFU is a food prepared by coagulating soy milk and then pressing the resulting curds into solid white blocks of varying softness. Tofu has very little flavor or smell of its own. Consequently, tofu can be used in both savory or sweet dishes, acting as a bland background for presenting the flavors of the other ingredients used. In order to flavor the tofu it is often marinated in soy sauce, chillis, sesame oil, etc.
 
 <en:Legumes and their products
 <en:Meat alternatives
@@ -92577,6 +92569,8 @@ ciqual_food_code:en:20904
 ciqual_food_name:en:Tofu, plain
 ciqual_food_name:fr:Tofu, nature
 nova:en:3
+description:en:Tofu is a food prepared by coagulating soy milk and then pressing the resulting curds into solid white blocks of varying softness. Tofu has very little flavor or smell of its own. Consequently, tofu can be used in both savory or sweet dishes, acting as a bland background for presenting the flavors of the other ingredients used. In order to flavor the tofu it is often marinated in soy sauce, chillis, sesame oil, etc.
+
 
 <en:Tofu
 en:Plain tofu
@@ -94946,7 +94940,6 @@ nl:Producten op basis van verse planten
 ro:Alimente proaspete pe bază de plante
 zh:新鲜蔬菜食品
 
-# description:en:HEART OF PALM is a vegetable harvested from the inner core and growing bud of certain palm trees. Heart of palm may be eaten on its own, and often it is eaten in a salad. Hearts of palm are rich in fiber, potassium, iron, zinc, phosphorus, copper, vitamins B2, B6, and C.
 
 <en:Fresh plant-based foods
 # <en:ingredient:en:vegetable
@@ -94977,6 +94970,7 @@ agribalyse_proxy_food_code:en:20018
 agribalyse_proxy_food_name:en:Palm heart, canned, drained
 agribalyse_proxy_food_name:fr:Coeur de palmier, appertisé, égoutté
 # fr:coeurs-de-palmier has 16 products in 3 languages @2018-10-19
+description:en:Heath of palm is a vegetable harvested from the inner core and growing bud of certain palm trees. Heart of palm may be eaten on its own, and often it is eaten in a salad. Hearts of palm are rich in fiber, potassium, iron, zinc, phosphorus, copper, vitamins B2, B6, and C.
 
 <en:Canned plant-based foods
 en:Canned hearts of palm
@@ -95481,8 +95475,6 @@ ciqual_food_code:en:7225
 ciqual_food_name:en:Brioche or Vienna bread
 ciqual_food_name:fr:Pain brioché ou viennois
 
-# description:en:BRIOCHE is a bread of French origin that is similar to a highly enriched pastry, and whose high egg and butter content (400 grams for each kilogram of flour) give it a rich and tender crumb.
-
 <en:Viennoiseries
 en:Brioches, Brioche
 ar:بريوش
@@ -95528,6 +95520,7 @@ ciqual_food_name:en:Brioche
 ciqual_food_name:fr:Brioche, sans précision
 # ingredient/fr:brioche has 35 products @2019-01-28
 # category/brioches has 1483 products @2019-05-20
+description:en:Brioche is a bread of French origin that is similar to a highly enriched pastry, and whose high egg and butter content (400 grams for each kilogram of flour) give it a rich and tender crumb.
 
 <en:Brioches
 fr:Brioches tressées
@@ -95688,8 +95681,6 @@ fr:Pancakes
 it:Pancake
 nl:Pancakes
 
-# description:en:A CRÊPE is a type of very thin pancake. Crêpes are usually of two types: sweet crêpes (crêpes sucrées) and savoury galettes (crêpes salées). Crêpes are served with a variety of fillings, from the simplest with only sugar to flambéed crêpes Suzette or elaborate savoury galettes.
-# comment:en:A separate category for the dutch category pannenkoek, might be needed. A french crepe is seen as a special pannenkoek, een flensje
 
 # <en:compound
 <en:Crêpes and galettes
@@ -95772,6 +95763,8 @@ wikidata:en:Q12200
 wikipedia:en:https://en.wikipedia.org/wiki/Crêpe
 # ingredient/fr:crepe has 142 products in 4 languages @2019-02-05
 # category/crepes has 582 products @2019-05-18
+description:en:A crêpe is a type of very thin pancake. Crêpes are usually of two types: sweet crêpes (crêpes sucrées) and savoury galettes (crêpes salées). Crêpes are served with a variety of fillings, from the simplest with only sugar to flambéed crêpes Suzette or elaborate savoury galettes.
+comment:en:A separate category for the dutch category pannenkoek, might be needed. A french crêpe is seen as a special pannenkoek, een flensje
 
 <en:Crêpes
 en:Plain crepes


### PR DESCRIPTION
### What

Add description and comment as taxonomy fields.This way, we can display category description (and optional comments about tricky classification decisions about this category) in Hunger Games.
Category description could be used to on mobile apps and on web.

I only converted comments to taxonomy fields, other descriptions/comments can be added later.