### PR TITLE
taxonomy: Add Swedish plural form of "dried"

### DIFF
--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -877,7 +877,7 @@ pt:seco, seca, secos, secas
 ro:uscate
 ru:сушеный, Сушеное, сушёная, сушёный
 sk:sušené
-sv:torkad
+sv:torkad, torkade
 th:ตาก, ออบแห้ง
 uk:сушена
 


### PR DESCRIPTION
### What

Add Swedish plural form of "dried" to taxonomies

Triggered by "torkade dadlar" (dried dates) not being recognized in https://world.openfoodfacts.org/product/7310240001785/granola-kakao-och-hallon-pauluns
