### PR TITLE
uipoeder test

### DIFF
--- a/tests/unit/ingredients_processing.t
+++ b/tests/unit/ingredients_processing.t
@@ -400,7 +400,20 @@ my @tests = (
 	#                           D U T C H ( N L )
 	#
 ##################################################################
-
+	[
+		{
+			lc => "nl",
+				ingredients_text =>
+				"uipoeder"
+		},
+		[
+			{
+				'id' => 'en:onion',
+				'processing' => 'en:powder',
+				'text' => 'ui'
+			}
+		]
+	],
 	[
 		{
 			lc => "nl",


### PR DESCRIPTION
### What
A separate test for `nl:uipoeder`. Both `ui` and `poeder` are in the taxonomies, but are not recognised.