### PR TITLE
ci: fix small typo that created a second dependencies label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -159,7 +159,7 @@ tests:
 - t/**/*
 - lib/ProductOpener/Test.pm
 
-dependancies:
+dependencies:
 - package.json
 - package-lock.json
 


### PR DESCRIPTION
ci: fix small typo that created a second dependencies label