### PR TITLE
feat: extra donation banner at page bottom

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7594,7 +7594,7 @@ sub display_page ($request_ref) {
 	my $search_terms = '';
 	if (defined single_param('search_terms')) {
 		$search_terms = remove_tags_and_quote(decode utf8 => single_param('search_terms'));
-	}
+	}	
 
 	my $image_banner = "";
 	my $link = lang("donate_link");
@@ -7612,24 +7612,24 @@ sub display_page ($request_ref) {
 
 	if (
 		not($server_options{producers_platform})
-		and (  (not(defined cookie('hide_image_banner_2021')))
-			or (not(cookie('hide_image_banner_2021') eq '1')))
+		and (  (not(defined cookie('hide_image_banner_2022')))
+			or (not(cookie('hide_image_banner_2022') eq '1')))
 		)
 	{
 		$template_data_ref->{banner} = $banner;
 
 		$initjs .= <<'JS';
-if ($.cookie('hide_image_banner_2021') == '1') {
-	$('#hide_image_banner').prop('checked', true);
-	$('#donate_banner').remove();
+if ($.cookie('hide_image_banner_2022') == '1') {
+	$('.hide_image_banner').prop('checked', true);
+	$('#donate_banner_top').remove();
 }
 else {
-	$('#hide_image_banner').prop('checked', false);
-	$('#donate_banner').show();
-	$('#hide_image_banner').change(function () {
-		if ($('#hide_image_banner').prop('checked')) {
-			$.cookie('hide_image_banner_2021', '1', { expires: 90, path: '/' });
-			$('#donate_banner').remove();
+	$('.hide_image_banner').prop('checked', false);
+	$('#donate_banner_top').show();
+	$('.hide_image_banner').change(function () {
+		if (($('#hide_image_banner1').prop('checked')) || ($('#hide_image_banner2').prop('checked'))) {
+			$.cookie('hide_image_banner_2022', '1', { expires: 90, path: '/' });
+			$('#donate_banner_top').remove();
 		}
 	});
 }

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -1157,12 +1157,12 @@ span.ico-bold {
   @include button( 10, $white);
 }
 
-#donate_image_banner_outside {
+.donate_image_banner_outside {
   margin-bottom:1rem;
   background: no-repeat url(/images/illustrations/donate-heart.svg)
 }
 
-#donate_image_banner_inside {
+.donate_image_banner_inside {
   @media only screen and (max-width: 100rem) {margin-left:140px;}
 }
 

--- a/templates/web/common/includes/donate_banner_bottom.tt.html
+++ b/templates/web/common/includes/donate_banner_bottom.tt.html
@@ -1,16 +1,14 @@
 
 <!-- start templates/[% component.name %] -->
 
-[% IF banner %]
-
-<div id="donate_banner_top" class="donate_banner block black short" style="background-color:#6D85D9">
+<div id="donate_banner_bottom" class="donate_banner block black short" style="background-color:#6D85D9">
 	
 		<div class="donate_image_banner_outside">
 			<div class="row hide-for-small">
 
 				<div class="donate_image_banner_inside">
 
-					<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button" class="button round white-button" style="float:left;margin-right:2rem;">
+					<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button-bottom-banner" class="button round white-button" style="float:left;margin-right:2rem;">
 						<span class="material-icons material-symbols-button">volunteer_activism</span>
 						[% lang('donation_cta') %]
 					</a>
@@ -18,11 +16,6 @@
 					<p class="">[% f_lang('donation_body_employees', { number_of_employees => '8' }) %]<br>
 					[% f_lang('donation_why_year', { year => '2022' }) %] <strong>[% lang('thank_you') %] <span style="color:red">❤️</span></strong>
 					</p>
-					<input class="hide_image_banner" id="hide_image_banner1" type="checkbox" style="margin-top:1.5rem;margin-bottom:0;">
-					<label for="hide_image_banner1">
-						<span id="hide_image_banner_hide1" class="text-white">[% lang('donation_banner_hide') %]</span>
-					</label>
-
 				</div>
 			</div>
 
@@ -30,7 +23,7 @@
 
 				<div class="donate_image_banner_inside" style="min-height:90px;padding-top:10px;">
 
-					<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button" class="button round white-button" style="float:left;margin-right:2rem;">
+					<a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2022&utm_term=en-text-button-bottom-banner" class="button round white-button" style="float:left;margin-right:2rem;">
 						<span class="material-icons material-symbols-button">volunteer_activism</span>
 						[% lang('donation_cta') %]
 					</a>
@@ -40,17 +33,9 @@
 					<p class="">[% f_lang('donation_body_employees', { number_of_employees => '8' }) %]<br>
 					[% f_lang('donation_why_year', { year => '2022' }) %] <strong>[% lang('thank_you') %] <span style="color:red">❤️</span></strong>
 					</p>
-					<input class="hide_image_banner" id="hide_image_banner2" type="checkbox" style="margin-top:1.5rem;margin-bottom:0;">
-					<label for="hide_image_banner2">
-						<span id="hide_image_banner_hide2" class="text-white">[% lang('donation_banner_hide') %]</span>
-					</label>
-
 				</div>
 			</div>			
-			
 		</div>
-	
 </div>
-[% END %]
 
 <!-- end templates/[% component.name %] -->

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -286,6 +286,9 @@
 					</div>
 				</div>
 			</div>
+
+			[% INCLUDE 'web/common/includes/donate_banner_bottom.tt.html' %]
+
 			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
 				<div class="row">
 					<div class="small-12 large-6 columns v-space-normal block_off">
@@ -318,6 +321,7 @@
 					</div>
 				</div>
 			</div>
+
 			<div class="block_off block_dark block_ristreto" id="footer_block">
 
 				<div id="footer_block_image_banner_outside">


### PR DESCRIPTION
This adds an extra donation banner at the bottom of the page. The banner at the top can be hidden, and the banner at the bottom is always shown.

Also changed the cookie name, which will make all users see the banner again.

Changed number of employees from 7 to 8.

![image](https://user-images.githubusercontent.com/8158668/201675135-c7ac98fd-1ae6-4be5-beb2-97bf8bf9d81e.png)
