### PR TITLE
fix: do not preload Minion module 

### DIFF
--- a/lib/startup_apache2.pl
+++ b/lib/startup_apache2.pl
@@ -52,6 +52,13 @@ use Cache::Memcached::Fast ();
 use URI::Escape::XS ();
 use File::chmod::Recursive;
 
+# The line 'use Minion;', either in this startup script, or in a module
+# loaded by it (e.g. Producers.pm) causes Apache+modperl to exit.
+# A reason / workaround has not been found yet, so commenting out the preloading
+# of Minion and Producers.
+# Corresponding issue: https://github.com/openfoodfacts/openfoodfacts-server/issues/7695
+#use Minion ();
+
 use ProductOpener::Config qw/:all/;
 
 use Log::Any qw($log);
@@ -94,7 +101,7 @@ use ProductOpener::Export qw/:all/;
 use ProductOpener::Import qw/:all/;
 use ProductOpener::ImportConvert qw/:all/;
 use ProductOpener::Numbers qw/:all/;
-use ProductOpener::Producers qw/:all/;
+#use ProductOpener::Producers qw/:all/;
 use ProductOpener::ProducersFood qw/:all/;
 use ProductOpener::GeoIP qw/:all/;
 use ProductOpener::GS1 qw/:all/;


### PR DESCRIPTION
A (bad) workaround for #7695 but I didn't find another solution (and I didn't find the actual reason for the issue either)