### PR TITLE
fix: data quality alcoholic beverages category without alcohol value

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1171,7 +1171,7 @@ sub check_categories ($product_ref) {
 
 	# Check alcohol content
 	if (has_tag($product_ref, "categories", "en:alcoholic-beverages")) {
-		if (!(defined $product_ref->{nutriments}->{alcohol_value}) || $product_ref->{nutriments}->{alcohol_value} == 0) {
+		if (!(defined $product_ref->{nutriments}{alcohol_value}) || $product_ref->{nutriments}{alcohol_value} == 0) {
 			push @{$product_ref->{data_quality_warnings_tags}}, 'en:alcoholic-beverages-category-without-alcohol-value';
 		}
 		if (has_tag($product_ref, "categories", "en:non-alcoholic-beverages")) {
@@ -1180,8 +1180,8 @@ sub check_categories ($product_ref) {
 		}
 	}
 
-	if (    defined $product_ref->{nutriments}->{alcohol_value}
-		and $product_ref->{nutriments}->{alcohol_value} > 0
+	if (    defined $product_ref->{nutriments}{alcohol_value}
+		and $product_ref->{nutriments}{alcohol_value} > 0
 		and not has_tag($product_ref, "categories", "en:alcoholic-beverages"))
 	{
 

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1171,7 +1171,7 @@ sub check_categories ($product_ref) {
 
 	# Check alcohol content
 	if (has_tag($product_ref, "categories", "en:alcoholic-beverages")) {
-		if (!(defined $product_ref->{alcohol_value}) || $product_ref->{alcohol_value} == 0) {
+		if (!(defined $product_ref->{nutriments}->{alcohol_value}) || $product_ref->{nutriments}->{alcohol_value} == 0) {
 			push @{$product_ref->{data_quality_warnings_tags}}, 'en:alcoholic-beverages-category-without-alcohol-value';
 		}
 		if (has_tag($product_ref, "categories", "en:non-alcoholic-beverages")) {
@@ -1180,13 +1180,13 @@ sub check_categories ($product_ref) {
 		}
 	}
 
-	if (    defined $product_ref->{alcohol_value}
-		and $product_ref->{alcohol_value} > 0
+	if (    defined $product_ref->{nutriments}->{alcohol_value}
+		and $product_ref->{nutriments}->{alcohol_value} > 0
 		and not has_tag($product_ref, "categories", "en:alcoholic-beverages"))
 	{
 
 		push @{$product_ref->{data_quality_warnings_tags}}, 'en:alcohol-value-without-alcoholic-beverages-category';
-	}
+	}	
 
 	# Plant milks should probably not be dairies https://github.com/openfoodfacts/openfoodfacts-server/issues/73
 	if (has_tag($product_ref, "categories", "en:plant-milks") and has_tag($product_ref, "categories", "en:dairies")) {

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1186,7 +1186,7 @@ sub check_categories ($product_ref) {
 	{
 
 		push @{$product_ref->{data_quality_warnings_tags}}, 'en:alcohol-value-without-alcoholic-beverages-category';
-	}	
+	}
 
 	# Plant milks should probably not be dairies https://github.com/openfoodfacts/openfoodfacts-server/issues/73
 	if (has_tag($product_ref, "categories", "en:plant-milks") and has_tag($product_ref, "categories", "en:dairies")) {


### PR DESCRIPTION
**Important**: changes are applied **only** after editing the products that are wrongly reported by the data quality issue (i.e. product that are listed with this data quality issue will be removed only after editing them again).


### What
Replaced ```$product_ref->{alcohol_value}``` by ```$product_ref->{nutriments}{alcohol_value}``` in the file in _lib/ProductOpener/DataQualityFood.pm_

### Why
There are as many "en:alcoholic-beverages-category-without-alcohol-value" data quality issues (https://hr.openfoodfacts.org/data-quality/en:alcoholic-beverages-category-without-alcohol-value) as there are "en:alcoholic-beverages" products (https://hr.openfoodfacts.org/category/en:alcoholic-beverages). But many products have the alcohol value.

### Screenshot
Screenshot of the bug (urls differ):
![image](https://user-images.githubusercontent.com/110821832/201925275-41025e58-3b98-4fa3-a920-05de0d88c38b.png)

Screenshot before (left) and after (right) the devs:
![image](https://user-images.githubusercontent.com/110821832/201926029-175883da-dd4f-4340-aa8a-8bafe7b431cb.png)

