### PR TITLE
fix: make command to install perl dev modules

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,10 @@ PRODUCT_OPENER_PORT=80
 PRODUCT_OPENER_FLAVOR=openfoodfacts
 PRODUCT_OPENER_FLAVOR_SHORT=off
 
+# do you want extended dev packages
+# (removed on standard builds to speed installation up and gain in stability)
+# PERL_CPAN_DEV=cpanfile_dev
+
 # if 1 we log emails instead of sending them
 # useful in dev mode
 OFF_LOG_EMAILS=1

--- a/.env
+++ b/.env
@@ -28,9 +28,9 @@ PRODUCT_OPENER_PORT=80
 PRODUCT_OPENER_FLAVOR=openfoodfacts
 PRODUCT_OPENER_FLAVOR_SHORT=off
 
-# do you want extended dev packages
+# do you want extended dev packages ?
 # (removed on standard builds to speed installation up and gain in stability)
-# PERL_CPAN_DEV=cpanfile_dev
+# CPANMOPTS=--with-develop  --with-feature=off_server_dev_tools
 
 # if 1 we log emails instead of sending them
 # useful in dev mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # Base user uid / gid keep 1000 on prod, align with your user on dev
 ARG USER_UID=1000
 ARG USER_GID=1000
+# options for cpan installs
 ARG CPANMOPTS=
+ARG PERL_CPAN_DEV=
 
 ######################
 # Base modperl image stage
@@ -155,13 +157,17 @@ RUN usermod --uid $USER_UID www-data && \
 ######################
 FROM modperl AS builder
 ARG CPANMOPTS
+ARG PERL_CPAN_DEV
 WORKDIR /tmp
 
 # Install Product Opener from the workdir.
-COPY ./cpanfile /tmp/cpanfile
-
+COPY ./cpanfile* /tmp/
 # Add ProductOpener runtime dependencies from cpan
-RUN --mount=type=cache,id=cpanm-cache,target=/root/.cpanm cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps .
+RUN --mount=type=cache,id=cpanm-cache,target=/root/.cpanm \
+    cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . && \
+    if [[ -n "$PERL_CPAN_DEV" ]];then \
+        cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . --cpanfile $PERL_CPAN_DEV;\
+    fi
 
 
 ######################

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 # options for cpan installs
 ARG CPANMOPTS=
-ARG PERL_CPAN_DEV=
 
 ######################
 # Base modperl image stage
@@ -157,18 +156,13 @@ RUN usermod --uid $USER_UID www-data && \
 ######################
 FROM modperl AS builder
 ARG CPANMOPTS
-ARG PERL_CPAN_DEV
 WORKDIR /tmp
 
 # Install Product Opener from the workdir.
 COPY ./cpanfile* /tmp/
 # Add ProductOpener runtime dependencies from cpan
 RUN --mount=type=cache,id=cpanm-cache,target=/root/.cpanm \
-    cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . && \
-    if [[ -n "$PERL_CPAN_DEV" ]];then \
-        cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . --cpanfile $PERL_CPAN_DEV;\
-    fi
-
+    cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps .
 
 ######################
 # backend production image stage

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,3 @@ guard-%: # guard clause for targets that require an environment variable (usuall
    		exit 1; \
 	fi;
 
-install_perl_dev_modules: # Perl modules that ease development but are not needed for GitHub actions
-	@echo "🥫 Installing Perl dev modules"
-	${DOCKER_COMPOSE} run -u root backend cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . --cpanfile cpanfile_dev
-

--- a/Makefile
+++ b/Makefile
@@ -329,3 +329,8 @@ guard-%: # guard clause for targets that require an environment variable (usuall
    		echo "Environment variable '$*' is not set"; \
    		exit 1; \
 	fi;
+
+install_perl_dev_modules: # Perl modules that ease development but are not needed for GitHub actions
+	@echo "🥫 Installing Perl dev modules"
+	${DOCKER_COMPOSE} run -u root backend cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . --cpanfile cpanfile_dev
+

--- a/cpanfile
+++ b/cpanfile
@@ -100,15 +100,6 @@ on 'develop' => sub {
   requires 'Test::Perl::Critic', '>=1.04', '<2.0'; # perl-critic refuse to install without this explicit deps
   requires 'Perl::Critic', '>= 1.140, < 2.0'; # libperl-critic-perl has 1.132 vs 1.138, and all the depended on packages are old too.
   requires 'Apache::DB', '>= 0.18, < 1.00'; # old non-working version also available as the Debian package libapache-db-perl 0.14
-# Moved modules that are not needed by GitHub actions to cpanfile_dev
-# They can be installed with "make install_perl_dev_modules"
-# Devel::REPL makes some GitHub actions tests fail (maybe interminently)
-# https://github.com/openfoodfacts/openfoodfacts-server/issues/7699
-#  requires 'Devel::REPL';
-# Also removing other modules
-#  requires 'Term::ReadLine::Gnu', '>= 1.42, < 2.0'; # readline support for the Perl debugger. libterm-readline-gnu-perl is available.
-#  requires 'Perl::LanguageServer';
-#  requires 'Hash::SafeKeys';  # Perl::LanguageServer dependency
   requires 'Perl::Tidy';
   requires 'Perl::Critic';
 }

--- a/cpanfile
+++ b/cpanfile
@@ -84,6 +84,7 @@ requires 'Action::CircuitBreaker';
 requires 'Action::Retry'; # deps: libmath-fibonacci-perl
 
 on 'test' => sub {
+  requires 'Data::Dump';
   requires 'Test::More', '>= 1.302186, < 2.0';
   requires 'Test::MockModule';
   requires 'Mock::Quick';

--- a/cpanfile
+++ b/cpanfile
@@ -102,4 +102,14 @@ on 'develop' => sub {
   requires 'Apache::DB', '>= 0.18, < 1.00'; # old non-working version also available as the Debian package libapache-db-perl 0.14
   requires 'Perl::Tidy';
   requires 'Perl::Critic';
-}
+};
+
+feature "off_server_dev_tools", "Optional development tools" => sub {
+  # Modules needed to ease development but not need to run CI tasks or automated tests
+  # on GitHub, or for production
+  # For docker, use CPANMOPTS=--with-develop  --with-feature=off_server_dev_tools
+  requires 'Devel::REPL';
+  requires 'Term::ReadLine::Gnu', '>= 1.42, < 2.0'; # readline support for the Perl debugger. libterm-readline-gnu-perl is available.
+  requires 'Perl::LanguageServer';
+  requires 'Hash::SafeKeys';  # Perl::LanguageServer dependency
+};

--- a/cpanfile
+++ b/cpanfile
@@ -100,10 +100,15 @@ on 'develop' => sub {
   requires 'Test::Perl::Critic', '>=1.04', '<2.0'; # perl-critic refuse to install without this explicit deps
   requires 'Perl::Critic', '>= 1.140, < 2.0'; # libperl-critic-perl has 1.132 vs 1.138, and all the depended on packages are old too.
   requires 'Apache::DB', '>= 0.18, < 1.00'; # old non-working version also available as the Debian package libapache-db-perl 0.14
-  requires 'Devel::REPL';
-  requires 'Term::ReadLine::Gnu', '>= 1.42, < 2.0'; # readline support for the Perl debugger. libterm-readline-gnu-perl is available.
-  requires 'Perl::LanguageServer';
-  requires 'Hash::SafeKeys';  # Perl::LanguageServer dependency
+# Moved modules that are not needed by GitHub actions to cpanfile_dev
+# They can be installed with "make install_perl_dev_modules"
+# Devel::REPL makes some GitHub actions tests fail (maybe interminently)
+# https://github.com/openfoodfacts/openfoodfacts-server/issues/7699
+#  requires 'Devel::REPL';
+# Also removing other modules
+#  requires 'Term::ReadLine::Gnu', '>= 1.42, < 2.0'; # readline support for the Perl debugger. libterm-readline-gnu-perl is available.
+#  requires 'Perl::LanguageServer';
+#  requires 'Hash::SafeKeys';  # Perl::LanguageServer dependency
   requires 'Perl::Tidy';
   requires 'Perl::Critic';
 }

--- a/cpanfile_dev
+++ b/cpanfile_dev
@@ -1,7 +1,0 @@
-# Modules needed to ease development but not need to run CI tasks or automated tests
-# on GitHub, or for production
-
-requires 'Devel::REPL';
-requires 'Term::ReadLine::Gnu', '>= 1.42, < 2.0'; # readline support for the Perl debugger. libterm-readline-gnu-perl is available.
-requires 'Perl::LanguageServer';
-requires 'Hash::SafeKeys';  # Perl::LanguageServer dependency

--- a/cpanfile_dev
+++ b/cpanfile_dev
@@ -1,0 +1,7 @@
+# Modules needed to ease development but not need to run CI tasks or automated tests
+# on GitHub, or for production
+
+requires 'Devel::REPL';
+requires 'Term::ReadLine::Gnu', '>= 1.42, < 2.0'; # readline support for the Perl debugger. libterm-readline-gnu-perl is available.
+requires 'Perl::LanguageServer';
+requires 'Hash::SafeKeys';  # Perl::LanguageServer dependency

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -9,7 +9,7 @@ x-backend-conf: &backend-conf
     args:
       USER_UID: ${USER_UID:-1000}
       USER_GID: ${USER_GID:-1000}
-      CPANMOPTS: "--with-develop"
+      CPANMOPTS: "${CPANMOPTS:---with-develop}"
   volumes:
     # mount local folder for reload on dev changes.
     # Note that this means /opt/product-opener/html/images/product wont be connected to product_images volume
@@ -71,7 +71,6 @@ services:
       args:
         USER_UID: ${USER_UID:-1000}
         USER_GID: ${USER_GID:-1000}
-        PERL_CPAN_DEV: ${PERL_CPAN_DEV:-}
     volumes:
       - ./html:/opt/product-opener/html/
       - ./icons:/opt/product-opener/icons

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -71,6 +71,7 @@ services:
       args:
         USER_UID: ${USER_UID:-1000}
         USER_GID: ${USER_GID:-1000}
+        PERL_CPAN_DEV: ${PERL_CPAN_DEV:-}
     volumes:
       - ./html:/opt/product-opener/html/
       - ./icons:/opt/product-opener/icons


### PR DESCRIPTION
Trying to fix https://github.com/openfoodfacts/openfoodfacts-server/issues/7699

This removes some modules that are not needed by GitHub actions, and creates a "make install_perl_dev_modules" to install them.