### PR TITLE
build: deploy v3 documentation

### DIFF
--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -50,7 +50,15 @@ jobs:
           docker run --rm \
             -v $(pwd)/docs/reference:/data -v $(pwd)/gh_pages/:/output \
             ghcr.io/redocly/redoc/cli:latest \
-            build -o /output/reference/api/index.html api.yml && \
+            build -o /output/reference/api-v3/index.html api.yml && \
+          sudo chown $UID -R gh_pages
+
+      - name: Generate openapi html for v3 with ghcr.io/redocly/redoc/cli:latest
+        run : |
+          docker run --rm \
+            -v $(pwd)/docs/reference:/data -v $(pwd)/gh_pages/:/output \
+            ghcr.io/redocly/redoc/cli:latest \
+            build -o /output/reference/api/index.html api-v3.yml && \
           sudo chown $UID -R gh_pages
 
       - name: Deploy API documentation to Github Pages

--- a/docs/reference/api-v3.md
+++ b/docs/reference/api-v3.md
@@ -1,0 +1,5 @@
+# v3 OpenAPI documentation
+
+See api-v3.yml for edition.
+
+Do not write anything here, it is meant to be overwritten by html generated from api-v3.yml


### PR DESCRIPTION
We have api published at https://openfoodfacts.github.io/openfoodfacts-server/reference/api/ but we also want api-v3 to be visible at https://openfoodfacts.github.io/openfoodfacts-server/reference/api-v3/