### PR TITLE
docs: include sorting to search in open api

### DIFF
--- a/docs/reference/api.yml
+++ b/docs/reference/api.yml
@@ -232,6 +232,7 @@ paths:
         - $ref: '#/components/parameters/categories_tags_en'
         - $ref: '#/components/parameters/labels_tags_en'
         - $ref: '#/components/parameters/fields'
+        - $ref: '#/components/parameters/sort_by'
     parameters: []
   /cgi/suggest.pl:
     get:
@@ -282,12 +283,11 @@ paths:
                     properties:
                       images:
                         type: object
-                        # review the regex expression for pattern properties
                         patternProperties:
-                          '/^\d+$/':
+                          /^\d+$/:
                             $ref: ./schemas/images/image.yaml
-                          '(front|ingredients|nutrition|packaging|other)_\w\w(-\w\w)?':
-                            $ref: ./schemas/images/selected_image.yaml                           
+                          (front|ingredients|nutrition|packaging|other)_\w\w(-\w\w)?:
+                            $ref: ./schemas/images/selected_image.yaml
                   status:
                     type: integer
                     example: 1
@@ -352,6 +352,27 @@ components:
       name: categories_tags_en
       description: |
         The category of products you are searching for.
+    sort_by:
+      schema:
+        type: string
+        example: product_name
+        enum:
+          - product_name
+          - last_modified_t
+          - last_modified_t_complete_first
+          - scans_n
+          - unique_scans_n
+          - created_t
+          - completeness
+          - popularity_key
+          - popularity
+          - nutriscore_score
+          - nova_score
+          - nothing
+          - ecoscore_score
+      in: query
+      name: sort_by
+      description: The allowed values  used to sort/order the search results.
     labels_tags_en:
       schema:
         type: string

--- a/docs/reference/api.yml
+++ b/docs/reference/api.yml
@@ -359,20 +359,25 @@ components:
         enum:
           - product_name
           - last_modified_t
-          - last_modified_t_complete_first
           - scans_n
           - unique_scans_n
           - created_t
           - completeness
           - popularity_key
-          - popularity
           - nutriscore_score
           - nova_score
           - nothing
           - ecoscore_score
       in: query
       name: sort_by
-      description: The allowed values  used to sort/order the search results.
+      description: |
+        The allowed values  used to sort/order the search results.
+
+        * `product_name` sorts on name      
+        * `ecoscore_score`, `nova_score`, `nutriscore_score` rank on the [Eco-Score](https://world.openfoodfacts.org/eco-score-the-environmental-impact-of-food-products), [Nova](https://world.openfoodfacts.org/nova), or [Nutri-Score](https://world.openfoodfacts.org/nutriscore)
+        * `scans_n`, `unique_scans_n` and `popularity_key` are about product popularity: number of scans on unique scans, rank of product
+        * `created_t`, `last_modified_t`, are about creation and modification dates
+        * `nothing`, tells not to sort at all (because if you do not provide the sort_by argument we default to sorting on popularity (for food) or last modification date)
     labels_tags_en:
       schema:
         type: string


### PR DESCRIPTION
- Include the sort_by parameter to the open API file
- Indicate the allowed values for sort as enum