### PR TITLE
fix: move photos/data to main language

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -898,7 +898,7 @@ CSS
 
 			# For moderators, add a checkbox to move all data and photos to the main language
 			# this needs to be below the "add (language name) in all field labels" above, so that it does not change this label.
-			if (($User{moderator}) and ($tabsid eq "front_image")) {
+			if (($User{moderator}) and ($tabsid eq "product")) {
 
 				my $msg = f_lang(
 					"f_move_data_and_photos_to_main_language",

--- a/templates/web/pages/product_edit/display_input_tabs.tt.html
+++ b/templates/web/pages/product_edit/display_input_tabs.tt.html
@@ -22,8 +22,8 @@
         [% IF tab.tabid != "new" %]
             <div class="tabs content[% tab.active %][% tab.new_lc %] tabs_[% tab.tabid %]" id="tabs_[% tabsid %]_[% tab.tabid %]">
                 
-                [% IF moderator && tabsid == "front_image" %]
-                    <div class="move_data_and_images_to_main_language" id="[% tab.moveid %]_div" style="display:hidden">
+                [% IF moderator && tabsid == "product" %]
+                    <div class="move_data_and_images_to_main_language" id="[% tab.moveid %]_div" style="display:none;">
                         <input class="move_data_and_images_to_main_language_checkbox" type="checkbox" id="[% tab.moveid %]" name="[% tab.moveid %]" />
                         <label for="[% tab.moveid %]" class="checkbox_label">[% tab.msg %]</label><br/>
                         <div id="[% tab.moveid %]_radio" style="display:hidden">

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -105,15 +105,7 @@
         [% END %]
 
             </div>
-        </section>        
-
-        <section id="product_image" class="card fieldset">
-            <div class="card-section">
-                <legend>[% lang("product_image") %]</legend>
-                <input type="hidden" id="sorted_langs" name="sorted_langs" value="[% product_ref_sorted_langs %]"/>
-                [% display_tab_product_picture %]
-            </div>
-        </section>        
+        </section>              
 
         <section id="product_characteristics" class="fieldset card">
             <div class="card-section">
@@ -133,6 +125,14 @@
                 [% END %]
             </div>
         </section>
+
+        <section id="product_image" class="card fieldset">
+            <div class="card-section">
+                <legend>[% lang("product_image") %]</legend>
+                <input type="hidden" id="sorted_langs" name="sorted_langs" value="[% product_ref_sorted_langs %]"/>
+                [% display_tab_product_picture %]
+            </div>
+        </section>          
 
         <section id="ingredients" class="card fieldset">
             <div class="card-section">


### PR DESCRIPTION
This PR moves the "product characteristics" section above the "front image" section in the product edit form, and puts the checkbox for moderators to move data and photos to another language close to the main language field.

![image](https://user-images.githubusercontent.com/8158668/203987984-eda2f0c5-c57f-41ed-a777-c198515fd781.png)
