### PR TITLE
docs: remove excess examples from the open api

### DIFF
--- a/docs/reference/api.yml
+++ b/docs/reference/api.yml
@@ -108,7 +108,6 @@ paths:
           multipart/form-data:
             schema:
               $ref: ./requestBodies/add_photo_to_existing_product.yaml
-            examples: {}
         description: ''
   /cgi/ingredients.pl:
     parameters: []
@@ -192,20 +191,6 @@ paths:
           multipart/form-data:
             schema:
               $ref: ./requestBodies/add_or_edit_a_product.yaml
-            examples:
-              example-1:
-                value:
-                  code: '0074570036004'
-                  user_id: myusername
-                  password: mypassword
-          application/json:
-            schema:
-              type: object
-              properties: {}
-          application/xml:
-            schema:
-              type: object
-              properties: {}
       tags:
         - Write Requests
       description: |
@@ -246,7 +231,6 @@ paths:
             application/json:
               schema:
                 type: array
-              examples: {}
       operationId: get-cgi-suggest.pl
       parameters:
         - $ref: '#/components/parameters/tagtype'

--- a/docs/reference/requestBodies/add_or_edit_a_product.yaml
+++ b/docs/reference/requestBodies/add_or_edit_a_product.yaml
@@ -16,4 +16,3 @@ required:
   - code
   - user_id
   - password
-examples: []

--- a/docs/reference/responses/add_or_edit_a_product.yaml
+++ b/docs/reference/responses/add_or_edit_a_product.yaml
@@ -2,10 +2,7 @@ type: object
 properties:
   status_verbose:
     type: string
+    example: fields saved
   status:
     type: integer
-x-examples:
-  example-1:
-    status_verbose: fields saved
-    status: 1
-examples: []
+    example: 1


### PR DESCRIPTION
I removed excess examples from everything except product schema. The examples in the product schema is quite bulky and confusing. I need help with it, please.