### PR TITLE
fix: put back front image first in product edit form

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -898,7 +898,7 @@ CSS
 
 			# For moderators, add a checkbox to move all data and photos to the main language
 			# this needs to be below the "add (language name) in all field labels" above, so that it does not change this label.
-			if (($User{moderator}) and ($tabsid eq "product")) {
+			if (($User{moderator}) and ($tabsid eq "front_image")) {
 
 				my $msg = f_lang(
 					"f_move_data_and_photos_to_main_language",

--- a/templates/web/pages/product_edit/display_input_tabs.tt.html
+++ b/templates/web/pages/product_edit/display_input_tabs.tt.html
@@ -22,7 +22,7 @@
         [% IF tab.tabid != "new" %]
             <div class="tabs content[% tab.active %][% tab.new_lc %] tabs_[% tab.tabid %]" id="tabs_[% tabsid %]_[% tab.tabid %]">
                 
-                [% IF moderator && tabsid == "product" %]
+                [% IF moderator && tabsid == "front_image" %]
                     <div class="move_data_and_images_to_main_language" id="[% tab.moveid %]_div" style="display:none;">
                         <input class="move_data_and_images_to_main_language_checkbox" type="checkbox" id="[% tab.moveid %]" name="[% tab.moveid %]" />
                         <label for="[% tab.moveid %]" class="checkbox_label">[% tab.msg %]</label><br/>

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -105,11 +105,12 @@
         [% END %]
 
             </div>
-        </section>              
-
-        <section id="product_characteristics" class="fieldset card">
+        </section>
+        
+        <section id="product_image" class="card fieldset">
             <div class="card-section">
-                <legend>[% lang('product_characteristics') %]</legend>
+                <legend>[% lang("product_image") %]</legend>
+                <input type="hidden" id="sorted_langs" name="sorted_langs" value="[% product_ref_sorted_langs %]"/>
 
                 <label for="lang"> [% lang('lang') %] </label>
                 <select name="lang" id="lang">
@@ -118,6 +119,14 @@
                     [% END %]
                 </select>
 
+                [% display_tab_product_picture %]
+            </div>
+        </section>         
+
+        <section id="product_characteristics" class="fieldset card">
+            <div class="card-section">
+                <legend>[% lang('product_characteristics') %]</legend>
+
                 [% display_tab_product_characteristics %]
 
                 [% FOREACH field IN display_fields_arr %]
@@ -125,14 +134,6 @@
                 [% END %]
             </div>
         </section>
-
-        <section id="product_image" class="card fieldset">
-            <div class="card-section">
-                <legend>[% lang("product_image") %]</legend>
-                <input type="hidden" id="sorted_langs" name="sorted_langs" value="[% product_ref_sorted_langs %]"/>
-                [% display_tab_product_picture %]
-            </div>
-        </section>          
 
         <section id="ingredients" class="card fieldset">
             <div class="card-section">


### PR DESCRIPTION
This is to put back the front image first in the product edit form, above the product characteristics section.

The "main language" field is moved from characteristics to the front image section.

![image](https://user-images.githubusercontent.com/8158668/204574862-249cec1f-fc34-4f02-bbfd-93ce0d18b90e.png)
