### PR TITLE
fix: Data quality issues related to energy

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -580,13 +580,22 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 				$computed_energy += $grams * $energy_per_gram;
 			}
 
-			# Compare to specified energy value
-			if (   ($computed_energy < ($specified_energy * 0.9 - 5))
-				or ($computed_energy > ($specified_energy * 1.1 + 5)))
+			# Compare to specified energy value with a tolerance of 30% + an additiontal tolerance of 5
+			if (   ($computed_energy < ($specified_energy * 0.7 - 5))
+				or ($computed_energy > ($specified_energy * 1.3 + 5)))
 			{
 				# we have a quality problem
 				push @{$product_ref->{data_quality_errors_tags}},
 					"en:energy-value-in-$unit-does-not-match-value-computed-from-other-nutrients";
+			}
+
+			# Compare to specified energy value with a tolerance of 15% + an additiontal tolerance of 5
+			if (   ($computed_energy < ($specified_energy * 0.85 - 5))
+				or ($computed_energy > ($specified_energy * 1.15 + 5)))
+			{
+				# we have a quality warning
+				push @{$product_ref->{data_quality_warnings_tags}},
+					"en:energy-value-in-$unit-may-not-match-value-computed-from-other-nutrients";
 			}
 
 			$nutriments_ref->{"energy-${unit}_value_computed"} = $computed_energy;


### PR DESCRIPTION
### What

* Increase detection percentage for en:energy-value-in-$unit-does-not-match-value-computed-from-other-nutrients, to avoird many false positive (10% -> 30%)
* Create a data quality warning for products upper than 15%
* Better comments

### Related issue(s) and discussion
- Slightly improves #7683

