### PR TITLE
feat: add packaging parts fields to import template

### DIFF
--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -127,17 +127,15 @@ foreach my $group_ref (@$select2_options_ref) {
 			$comment .= lang("separate_values_with_commas") . "\n\n";
 		}
 
-		my $note = lang($field_id . "_note");
-		my $import_note = lang($field_id . "_import_note");
+		# Add notes that are defined in the .po files
+		foreach my $note_field ("note", "note_2", "note_3", "import_note") {
+			my $note = lang($field_id . "_" . $note_field);
+			if ($note ne "") {
+				$comment .= $note . "\n\n";
+			}
+		}
+
 		my $example = lang($field_id . "_example");
-
-		if ($note ne "") {
-			$comment .= lang($field_id . "_note") . "\n\n";
-		}
-
-		if ($import_note ne "") {
-			$comment .= lang($field_id . "_import_note") . "\n\n";
-		}
 
 		if ($example ne "") {
 

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -661,7 +661,7 @@ sub display_input_field ($product_ref, $field, $language) {
 		$value =~ s/\n/ /g;
 	}
 
-	foreach my $note ("_note", "_note_2") {
+	foreach my $note ("_note", "_note_2", "_note_3") {
 		if (defined $Lang{$fieldtype . $note}{$lang}) {
 
 			push(

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -738,12 +738,13 @@ $options{import_export_fields_groups} = [
 	["ingredients", ["ingredients_text", "allergens", "traces"]],
 	["nutrition"],
 	["nutrition_other"],
-	["packaging"],	
+	["packaging"],
 	[
 		"other",
 		[
-			"conservation_conditions", "warning", "preparation",
-			"nutriscore_score_producer", "nutriscore_grade_producer", "nova_group_producer",
+			"conservation_conditions", "warning",
+			"preparation", "nutriscore_score_producer",
+			"nutriscore_grade_producer", "nova_group_producer",
 			"recipe_idea", "customer_service",
 			"link",
 		]

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -723,7 +723,6 @@ $options{import_export_fields_groups} = [
 			"quantity_value_unit", "net_weight_value_unit",
 			"drained_weight_value_unit", "volume_value_unit",
 			"serving_size_value_unit", "packaging",
-			"packaging_text",
 			"brands", "brand_owner",
 			"categories", "categories_specific",
 			"labels", "labels_specific",
@@ -739,15 +738,14 @@ $options{import_export_fields_groups} = [
 	["ingredients", ["ingredients_text", "allergens", "traces"]],
 	["nutrition"],
 	["nutrition_other"],
+	["packaging"],	
 	[
 		"other",
 		[
-			"nutriscore_score_producer", "nutriscore_grade_producer",
-			"nova_group_producer", "conservation_conditions",
-			"warning", "preparation",
-			"recipe_idea", "recycling_instructions_to_recycle",
-			"recycling_instructions_to_discard", "customer_service",
-			"link"
+			"conservation_conditions", "warning", "preparation",
+			"nutriscore_score_producer", "nutriscore_grade_producer", "nova_group_producer",
+			"recipe_idea", "customer_service",
+			"link",
 		]
 	],
 	[

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -1549,7 +1549,7 @@ JSON
 			}
 
 			for (my $i = 1; $i <= 5; $i++) {
-				my $packaging_i = lang("packaging") . " " . $i . " - ";
+				my $packaging_i = lang("packaging_part_short") . " " . $i . " - ";
 				foreach my $property ("number_of_units", "shape", "material", "recycling", "weight", "quantity_per_unit") {
 					my $name = $packaging_i . lang("packaging_" . $property);
 					my $field = "packaging_${i}_{$property}";

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -1491,6 +1491,9 @@ JSON
 		my $group_id = $group_ref->[0];
 		my $select2_group_ref = {text => lang("fields_group_" . $group_id), children => [], group_id => $group_id};
 
+		# For some specific groups, we generate the corresponding lists of fields
+
+		# List of nutrients
 		if (($group_id eq "nutrition") or ($group_id eq "nutrition_other")) {
 
 			# Go through the nutriment table
@@ -1538,6 +1541,23 @@ JSON
 					};
 			}
 		}
+		# Packaging
+		if ($group_id eq "packaging") {
+			foreach my $field ("packaging_text", "recycling_instructions_to_recycle", "recycling_instructions_to_discard") {
+				my $name = lang($field);
+				push @{$select2_group_ref->{children}}, {id => "$field", text => ucfirst($name)};
+			}
+
+			for (my $i = 1; $i <= 5; $i++) {
+				my $packaging_i = lang("packaging") . " " . $i . " - ";
+				foreach my $property ("number_of_units", "shape", "material", "recycling", "weight", "quantity_per_unit") {
+					my $name = $packaging_i . lang("packaging_" . $property);
+					my $field = "packaging_${i}_{$property}";
+					push @{$select2_group_ref->{children}}, {id => "$field", text => ucfirst($name)};
+				}
+			}
+		}
+		# Other groups have fields listed directly in the $options{import_export_fields_groups} structure
 		else {
 
 			foreach my $field (@{$group_ref->[1]}) {

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -1543,14 +1543,18 @@ JSON
 		}
 		# Packaging
 		if ($group_id eq "packaging") {
-			foreach my $field ("packaging_text", "recycling_instructions_to_recycle", "recycling_instructions_to_discard") {
+			foreach
+				my $field ("packaging_text", "recycling_instructions_to_recycle", "recycling_instructions_to_discard")
+			{
 				my $name = lang($field);
 				push @{$select2_group_ref->{children}}, {id => "$field", text => ucfirst($name)};
 			}
 
 			for (my $i = 1; $i <= 5; $i++) {
 				my $packaging_i = lang("packaging_part_short") . " " . $i . " - ";
-				foreach my $property ("number_of_units", "shape", "material", "recycling", "weight", "quantity_per_unit") {
+				foreach
+					my $property ("number_of_units", "shape", "material", "recycling", "weight", "quantity_per_unit")
+				{
 					my $name = $packaging_i . lang("packaging_" . $property);
 					my $field = "packaging_${i}_{$property}";
 					push @{$select2_group_ref->{children}}, {id => "$field", text => ucfirst($name)};

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5104,6 +5104,11 @@ msgctxt "packaging_parts"
 msgid "Packaging parts"
 msgstr "Packaging parts"
 
+# A short name for a physical piece of packaging (e.g. in English, "packaging" instead of "packaging part"). Used with a number (e.g. "Packaging 1" to identify a packaging part)
+msgctxt "packaging_part_short"
+msgid "Packaging"
+msgstr "Packaging"
+
 # Number of packaging parts
 msgctxt "packaging_number"
 msgid "Number"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -4845,6 +4845,10 @@ msgctxt "packaging_text_note_2"
 msgid "Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD."
 msgstr "Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD."
 
+msgctxt "packaging_text_note_3"
+msgid "Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both."
+msgstr "Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both."
+
 msgctxt "product_js_extract_packaging"
 msgid "Extract the recycling instructions and/or packaging information from the picture"
 msgstr "Extract the recycling instructions and/or packaging information from the picture"
@@ -6412,8 +6416,27 @@ msgctxt "api_impact_field_ignored"
 msgid "Field ignored"
 msgstr "Field ignored"
 
+# Unit = element, not unit of measure
+msgctxt "packaging_number_of_units"
+msgid "Number of units"
+msgstr "Number of units"
+
+# Unit = element, not unit of measure
+msgctxt "packaging_weight"
+msgid "Weight of one empty unit"
+msgstr "Weight of one empty unit"
+
+# Unit = element, not unit of measure
+msgctxt "packaging_quantity_per_unit"
+msgid "Quantity of product contained per unit"
+msgstr "Quantity of product contained per unit"
+
 # variable names between { } must not be translated
 msgctxt "f_help_categorize_on_hunger_games"
 msgid "Help categorize more {title} on Hunger Games"
 msgstr "Help categorize more {title} on Hunger Games"
+
+msgctxt "packagings_complete"
+msgid "All the packaging parts of the product are listed."
+msgstr "All the packaging parts of the product are listed."
 

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4916,6 +4916,10 @@ msgctxt "packaging_text_note_2"
 msgid "Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD."
 msgstr "Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD."
 
+msgctxt "packaging_text_note_3"
+msgid "Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both."
+msgstr "Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both."
+
 msgctxt "product_js_extract_packaging"
 msgid "Extract the recycling instructions and/or packaging information from the picture"
 msgstr "Extract the recycling instructions and/or packaging information from the picture"
@@ -5133,6 +5137,11 @@ msgstr "Eco-Score"
 msgctxt "packaging_parts"
 msgid "Packaging parts"
 msgstr "Packaging parts"
+
+# A short name for a physical piece of packaging (e.g. in English, "packaging" instead of "packaging part"). Used with a number (e.g. "Packaging 1" to identify a packaging part)
+msgctxt "packaging_part_short"
+msgid "Packaging"
+msgstr "Packaging"
 
 # Number of packaging parts
 msgctxt "packaging_number"
@@ -6419,7 +6428,26 @@ msgctxt "api_impact_field_ignored"
 msgid "Field ignored"
 msgstr "Field ignored"
 
+# Unit = element, not unit of measure
+msgctxt "packaging_number_of_units"
+msgid "Number of units"
+msgstr "Number of units"
+
+# Unit = element, not unit of measure
+msgctxt "packaging_weight"
+msgid "Weight of one empty unit"
+msgstr "Weight of one empty unit"
+
+# Unit = element, not unit of measure
+msgctxt "packaging_quantity_per_unit"
+msgid "Quantity of product contained per unit"
+msgstr "Quantity of product contained per unit"
+
 # variable names between { } must not be translated
 msgctxt "f_help_categorize_on_hunger_games"
 msgid "Help categorize more {title} on Hunger Games"
 msgstr "Help categorize more {title} on Hunger Games"
+
+msgctxt "packagings_complete"
+msgid "All the packaging parts of the product are listed."
+msgstr "All the packaging parts of the product are listed."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -4969,7 +4969,12 @@ msgstr "Éco-Score"
 # Parts meaning individual elements
 msgctxt "packaging_parts"
 msgid "Packaging parts"
-msgstr "Parties de l'emballage"
+msgstr "Elements d'emballage"
+
+# A short name for a physical piece of packaging (e.g. in English, "packaging" instead of "packaging part"). Used with a number (e.g. "Packaging 1" to identify a packaging part)
+msgctxt "packaging_part_short"
+msgid "Packaging"
+msgstr "Emballage"
 
 # Number of packaging parts
 msgctxt "packaging_number"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -4711,6 +4711,10 @@ msgctxt "packaging_text_note_2"
 msgid "Try to be as specific as possible. For plastic, please indicate if it is opaque or transparent, colored, PET or PEHD."
 msgstr "Essayez d'être aussi précis que possible. Pour le plastique, merci d'indiquer s'il est opaque ou transparent, coloré, PET ou PEHD."
 
+msgctxt "packaging_text_note_3"
+msgid "Data from this field will be combined with any data provided for each packaging part. It is possible to provide one or the other, or both."
+msgstr "Les données de ce champ seront combinées avec les éventuelles données fournies pour chaque élément d'emballage. Il est possible de fournir l'un ou l'autre, ou les deux."
+
 msgctxt "product_js_extract_packaging"
 msgid "Extract the recycling instructions and/or packaging information from the picture"
 msgstr "Extraire les instructions de recyclage et/ou les informations d'emballage depuis l'image"
@@ -4962,6 +4966,7 @@ msgctxt "ecoscore_s"
 msgid "Eco-Score"
 msgstr "Éco-Score"
 
+# Parts meaning individual elements
 msgctxt "packaging_parts"
 msgid "Packaging parts"
 msgstr "Parties de l'emballage"
@@ -6201,3 +6206,17 @@ msgctxt "environment"
 msgid "Environment"
 msgstr "Environnement"
 
+# Unit = element, not unit of measure
+msgctxt "packaging_number_of_units"
+msgid "Number of units"
+msgstr "Nombre d'éléments"
+
+# Unit = element, not unit of measure
+msgctxt "packaging_weight"
+msgid "Weight of one empty unit"
+msgstr "Poids d'un élément vide"
+
+# Unit = element, not unit of measure
+msgctxt "packaging_quantity_per_unit"
+msgid "Quantity of product contained per unit"
+msgstr "Quantité de produit contenue par élément"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
@@ -424,7 +424,7 @@
                            ]
                         }
                      ],
-                     "title" : "Parties de l'emballage"
+                     "title" : "Elements d'emballage"
                   }
                }
             ],

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
@@ -425,7 +425,7 @@
                            ]
                         }
                      ],
-                     "title" : "Parties de l'emballage"
+                     "title" : "Elements d'emballage"
                   }
                }
             ],


### PR DESCRIPTION
This is to add fields related to packaging parts in the Excel template that is generated on the pro platform by https://fr.pro.openfoodfacts.org/cgi/import_file_upload.pl

I put a copy of the generated file for French here: https://world.openfoodfacts.org/files/openfoodfacts_import_packagings_fr.xlsx

![image](https://user-images.githubusercontent.com/8158668/204787918-3e7b37fd-0712-4297-b668-3d7a0dfb304a.png)


Note that the pro platform is still running an old version of the code with the old design (without knowledge panels). So we may have to wait a bit to deploy this (but we can link to the generated file).