### PR TITLE
taxonomy: fix typo for the Shrimp category

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -83857,7 +83857,7 @@ bg:Скариди
 de:Garnele
 es:Camarones, Camarón
 fi:pirpana
-fr:Crevettes tous
+fr:Crevettes
 he:שרימפס, חסילונים
 it:Gambero
 nl:Garnalen


### PR DESCRIPTION

### What
taxonomies: fix typo for the Shrimp category