### PR TITLE
Solve issue #7786: Barcode is not visible in the edit mode.

### DIFF
--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -129,6 +129,9 @@
 
                 [% display_tab_product_characteristics %]
 
+                [% lang("barcode") %]  
+                <input type="text"  name="code" value="[% code %]">
+
                 [% FOREACH field IN display_fields_arr %]
                     [% field %]
                 [% END %]

--- a/templates/web/pages/product_edit/product_edit_form_display_user-moderator.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display_user-moderator.tt.html
@@ -6,7 +6,7 @@
     </p>
 
     <input type="hidden"  name="type" value="[% type %]">
-    <input type="hidden"  name="code" value="[% code %]">
+    <input type="text"  name="code" value="[% code %]">
     <input type="hidden"  name="action" value="process">
 
     <label for="comment" style="margin-left:10px">[% lang("delete_comment") %]</label>


### PR DESCRIPTION

### What

Added the barcode value in the product_edit_form_display file, and also updated the code input type from hidden to text.

### Screenshot
<img width="558" alt="Screenshot 2022-12-16 at 12 19 20 AM" src="https://user-images.githubusercontent.com/84325475/207942975-ed403b0b-4ec9-41ed-8ff6-8769373d8ebf.png">

### Related issue(s) and discussion

- Fixes #7786

