### PR TITLE
fix: https for the footer

### DIFF
--- a/po/common/en.po
+++ b/po/common/en.po
@@ -4449,7 +4449,7 @@ msgstr "If you would like to help, join the #ingredients channel on <a href=\"ht
 
 msgctxt "footer_producers_link"
 msgid "https://world.pro.openfoodfacts.org/"
-msgstr "http://world.pro.openfoodfacts.org/"
+msgstr "https://world.pro.openfoodfacts.org/"
 
 msgctxt "footer_producers"
 msgid "Producers"


### PR DESCRIPTION

### What
- This is the kind of errors that might happen when you don't generate en.po from common.pot using GetText commands
- fix: https for the footer