### PR TITLE
taxonomy: added some stopwords for ingredients in Croatian

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -159,7 +159,7 @@ my %may_contain_regexps = (
 		"saattaa sisältää pienehköjä määriä muita|saattaa sisältää pieniä määriä muita|saattaa sisältää pienehköjä määriä|saattaa sisältää pieniä määriä|voi sisältää vähäisiä määriä|saattaa sisältää hivenen|saattaa sisältää pieniä|saattaa sisältää jäämiä|sisältää pienen määrän|jossa käsitellään myös|saattaa sisältää myös|joka käsittelee myös|jossa käsitellään|saattaa sisältää",
 	fr =>
 		"peut également contenir|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace",
-	hr => "može sadržavati|može sadržati",
+	hr => "može sadržavati|može sadržati|proizvod može sadržavati",
 	is => "getur innihaldið leifar|gæti innihaldið snefil|getur innihaldið",
 	it =>
 		"Pu[òo] contenere tracce di|pu[òo] contenere|che utilizza anche|possibili tracce|eventuali tracce|possibile traccia|eventuale traccia|tracce|traccia",
@@ -306,6 +306,8 @@ my %abbreviations = (
 	fi => [["mikro.", "mikrobiologinen"], ["mm.", "muun muassa"], ["sis.", "sisältää"], ["n.", "noin"],],
 
 	fr => [["vit.", "Vitamine"], ["Mat. Gr.", "Matières Grasses"],],
+
+	hr => [["temp.", "temperaturi"],],
 
 	nb => [["bl. a.", "blant annet"], ["inkl.", "inklusive"], ["papr.", "paprika"],],
 
@@ -1967,6 +1969,8 @@ sub parse_ingredients_text ($product_ref) {
 								'^täysjyväsisältö',
 							],
 
+							'hr' => ['^u tragovima$',],
+
 							'it' => ['^in proporzion[ei] variabil[ei]$',],
 
 							'nb' => ['^Pakket i beskyttende atmosfære$',],
@@ -3392,7 +3396,7 @@ my %phrases_before_ingredients_list = (
 		'composition',
 	],
 
-	hr => ['Sastojci',],
+	hr => ['HR', 'HR BiH', 'HR/BIH', 'Sastojci', 'Sastojci/Sestavine'],
 
 	hu => ['(ö|ő|o)sszetev(ö|ő|o)k', 'összetétel',],
 
@@ -3682,7 +3686,21 @@ my %phrases_after_ingredients_list = (
 	],
 
 	hr => [
-		'Čuvati na (hladnom|suhom|temperaturi)',    # store in...
+		'Bez konzervans',    # without preservatives
+		'Čuvati na (hladnom|sobnoj temperaturi|suhom|temperaturi)',    # store in...
+		'Najbolje upotrijebiti do',    # best before
+		'Nakon otvaranja',    # after opening
+		'Pakirano u (kontroliranoj|zaštitnoj) atmosferi',    # packed in a ... atmosphere
+		'Pasterizirano',    # Pasteurized
+		'Proizvođač',    # producer
+		'Prosječna hranjiva vrijednost',    # Average nutritional value
+		'Upotrijebiti do datuma',    # valid until
+		'Upozorenje',    # warning
+		'Uputa',    # instructions
+		'Vakuumirana',    # Vacuumed
+		'Vrijeme kuhanja',    # Cooking time
+		'Zbog (mutan|prisutnosti)',    # Due to ...
+		'Zemlja porijekla',    # country of origin
 	],
 
 	hu => [


### PR DESCRIPTION
not sure for the label

added some stopwords in ingredients.pm, based on the following observations:

> 
>     see lib/ProductOpener/ingredients.pm
>         ignore_regexps (-> les informations en gras, etc.)
>             "u tragovima" (https://hr.openfoodfacts.org/product/3850104295072/kajen%C5%A1ki-papar-mljeveni-vegeta)
>       
>         may_contain_regexps
>             "proizvod može sadržavati" (https://hr.openfoodfacts.org/product/4337185925511/sultaninen-kaufland)
>       
>         phrases_before_ingredients_list:
>             "HR" (https://hr.openfoodfacts.org/product/3859892109134/per%C5%A1in-usitnjeni-%C5%A1afram)
>             "HR BiH " (https://hr.openfoodfacts.org/product/3858881086296/guatemala-100-arabica-franck, https://hr.openfoodfacts.org/product/3850104294426/crni-papar-vegeta)
>             "HR/BIH " (https://hr.openfoodfacts.org/product/3859892109080/papar-crnu-miljeveni-%C5%A1afram)
>             "Sastojci/Sestavine: " (https://hr.openfoodfacts.org/product/5907707051029/vanilija-aroma-dr-oetker)
>         phrases_before_ingredients_list_uppercase
>         phrases_after_ingredients_list
>             "Bez konzervans" (https://hr.openfoodfacts.org/product/4056489332176/vegan-spread-smoked-tofu-vemondo)
>             "Čuvati na sobnoj temperaturi." (https://hr.openfoodfacts.org/product/3859890733676/krafna-s-lino-ladom-lino-lada)
>             "Čuvati na temp." (https://hr.openfoodfacts.org/product/3859889622677/maslac-sa-cvijeyom-soli-veronika)
>             "Najbolje upotrijebiti do" (https://hr.openfoodfacts.org/product/3856015313249/suncokretovo-ulje-zvijezda, https://hr.openfoodfacts.org/product/4337185462399/tomato-paste-double-concentrated-kaufland, https://hr.openfoodfacts.org/product/3858882210010/suncokretovo-ulje-zvijezda)
>             "Nakon otvaranja" (https://hr.openfoodfacts.org/product/3859889622394/gr%C4%8Dki-tip-jogurta-veronika)
>             "Pakirano u kontroliranoj atmosferi." (https://hr.openfoodfacts.org/product/3858886934578/chips-x-cut-tommy)
>             "Pakirano u zaštitnoj atmosferi." (https://hr.openfoodfacts.org/product/4018077773419/crunchips-x-cut-salted)
>             "Pasterizirano" (https://hr.openfoodfacts.org/product/3859893027956/%C5%A1ljiva-d%C5%BEem-regina-adriatica, https://hr.openfoodfacts.org/product/3859893027857/malina-extra-d%C5%BEem-regina-adriatica)
>             "Proizvođač" (https://hr.openfoodfacts.org/product/5907707051029/vanilija-aroma-dr-oetker, https://hr.openfoodfacts.org/product/3850104223624/glatko-p%C5%A1eni%C4%8Dno-bra%C5%A1no-tip-550-bijelo-podravka)
>             "Prosječna hranjiva vrijednost u 100g" (https://hr.openfoodfacts.org/product/3859889622547/ribani-sir-veronika)
>             "Prosječne hranjive vrijednosti na 100 g" (https://hr.openfoodfacts.org/product/3850354002055/kiselo-vrhnje-20-mm-dukat)
>             "Upotrijebiti do datuma" (https://hr.openfoodfacts.org/product/3850108051919/camembert-sa-%C5%A1arenim-paprom-vindija)
>             "Upozorenje" (https://hr.openfoodfacts.org/product/4337185925511/sultaninen-kaufland)
>             "Uputa" (https://hr.openfoodfacts.org/product/3858881682290/cetina)
>             "Vakuumirana" (https://hr.openfoodfacts.org/product/3850291049311/colombia-100-arabica-franck, https://hr.openfoodfacts.org/product/3858881086296/guatemala-100-arabica-franck)
>             "Vrijeme kuhanja: 10-12 minuta." (https://hr.openfoodfacts.org/product/5201013014519/kritharaki-delphi)
>             "Zbog mutan i moguće je pojavljivanje taloga." (https://hr.openfoodfacts.org/product/3850131005118/hidra-iso-citrus-zagreba%C4%8Dka-pivovara)
>             "Zbog prisutnosti voćnih vlakana" (https://hr.openfoodfacts.org/product/3850131005651/hidra-up-orange-zagreba%C4%8Dka-pivovara)
>             "Zemlja porijekla" (https://hr.openfoodfacts.org/product/3859892109134/per%C5%A1in-usitnjeni-%C5%A1afram, https://hr.openfoodfacts.org/product/3859892109080/papar-crnu-miljeveni-%C5%A1afram)
>             