### PR TITLE
fix: responsive product list css

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -813,54 +813,6 @@ html[dir="rtl"] {
   background-color: #aaf;
 }
 
-// Horizontally and vertically center images
-.list_product_img_div {
-  height: 100px;
-  text-align: center;
-  line-height: 100px;
-}
-
-.list_product_img {
-  height: auto;
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.list_product_name {
-  margin-top: 0.2rem;
-  line-height: 20px;
-}
-
-.list_product_icons {
-  height: 24px;
-  margin-right: 0.2rem;
-  margin-top: 0.2rem;
-}
-
-// For small screen, cards take the full width, move the image to the left
-@media #{$small-only} {
-  .list_product_img_div {
-    width: 100px;
-    float: left;
-    margin-right: 1em;
-  }
-  .list_product_a {
-    min-height: 120px;
-  }
-  .list_product_icons {
-    height: 36px;
-  }
-}
-
-// For medium screen, force the height of the product name so that icons
-// below are vertically aligned with other cards on the same line
-@media #{$medium-up} {
-  .list_product_name {
-    height: 80px;
-    overflow: hidden;
-  }
-}
-
 .tabs a:focus {
   outline: none;
 }

--- a/scss/_product-list.scss
+++ b/scss/_product-list.scss
@@ -103,6 +103,10 @@ $productsGutter:12;
     font-size: 14px;
     color: $black;
     display: inline-flex;
+    // Force the height of the product name so that icons
+    // below are vertically aligned with other cards on the same line
+    height:82px;
+    overflow: hidden;
 }
 
 .list_product_icons {
@@ -111,23 +115,7 @@ $productsGutter:12;
     margin-top: 0.2rem;
 }
 
-// For small screen, cards take the full width, move the image to the left
-@media #{$small-only} {
-    .list_product_img_div {
-        width: 100px;
-        float: left;
-        margin-right: 1em;
-    }
-    .list_product_a {
-        min-height: 120px;
-    }
-    .list_product_icons {
-        height: 36px;
-    }
-}
 
-// For medium screen, force the height of the product name so that icons
-// below are vertically aligned with other cards on the same line
 @media #{$medium-up} {
     .list_product_name {
         overflow: hidden;


### PR DESCRIPTION
Related to https://github.com/openfoodfacts/openfoodfacts-server/issues/7499
Continuation of https://github.com/openfoodfacts/openfoodfacts-server/pull/7916

This removes CSS code that was duplicated between _off.scss and _product-list.scss

It removes some special behaviour from the old design: on small screen, we had only 1 product card per line, but now we have 2.

When we have multiple cards per line (which is now always the case), we fix some heights so that the attribute icons are vertically aligned on the different product cards.

![image](https://user-images.githubusercontent.com/8158668/210232872-0dc742b2-cc7e-42f9-b207-d29ab4bbef65.png)
