### PR TITLE
fix: Packagings display improvements on product page

### DIFF
--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -698,7 +698,8 @@ sub create_environment_card_panel ($product_ref, $target_lc, $target_cc, $option
 		$panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref);
 
 	# Create the environment_card panel
-	create_panel_from_json_template("environment_card", "api/knowledge-panels/environment/environment_card.tt.json",
+	$panel_data_ref->{packaging_image} = data_to_display_image($product_ref, "packaging", $target_lc),
+		create_panel_from_json_template("environment_card", "api/knowledge-panels/environment/environment_card.tt.json",
 		$panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref);
 	return;
 }

--- a/templates/api/knowledge-panels/environment/environment_card.tt.json
+++ b/templates/api/knowledge-panels/environment/environment_card.tt.json
@@ -30,7 +30,7 @@
                 "panel_ids": ["carbon_footprint"],
             },
         },
-        [% END %]     
+        [% END %]    
         [% IF panels.packaging_recycling.defined %]
         {
             "element_type": "panel_group",
@@ -40,6 +40,9 @@
                 "panel_ids": [
                     "packaging_recycling"
                 ],
+                [% IF panel.packaging_image.defined %]
+                "image": [% encode_json(panel.packaging_image) %],
+                [% END %]
             },
         },
         [% END %]

--- a/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
@@ -92,7 +92,7 @@
                                     [% IF packaging.quantity_per_unit %][% packaging.quantity_per_unit %] [% END %]
                                 </strong>
                                     [% IF packaging.material %]
-                                        ([% display_taxonomy_tag_name('packaging_materials',packaging.material) %][% IF packaging.weight_per_unit %] [% packaging.weight_per_unit %] g[% END %])
+                                        ([% display_taxonomy_tag_name('packaging_materials',packaging.material) %][% IF packaging.weight_measured %][% sep %]: [% packaging.weight_measured %] g[% END %])
                                     [% END %]
                                     <br>
                             [% END %]

--- a/templates/web/panels/image.tt.html
+++ b/templates/web/panels/image.tt.html
@@ -4,7 +4,9 @@
 
 <figure itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject" style="margin-bottom:0">
    
-    <img style="border-radius:10px;margin-bottom:0.5rem;" [% IF image.type == 'front' %]id="og_image" [% END %] class="product_image" src="[% image.sizes.400.url %]" width="[% image.sizes.400.width %]" height="[% image.sizes.400.height %]" alt="[% image.alt %]" itemprop="thumbnail" loading="lazy">
+    <a data-reveal-id="drop_[% image.type %]">
+        <img style="border-radius:10px;margin-bottom:0.5rem;" [% IF image.type == 'front' %]id="og_image" [% END %] class="product_image" src="[% image.sizes.400.url %]" width="[% image.sizes.400.width %]" height="[% image.sizes.400.height %]" alt="[% image.alt %]" itemprop="thumbnail" loading="lazy">
+    </a>
 
     <meta itemprop="imgid" content="[% image.type %]">
     


### PR DESCRIPTION
Changes to the product display page:

- Display the weight per unit of each packaging component
- Display the packagings image in the knowledge panel - Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/7919
- Make knowledge panels images clickable to zoom - Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/7624

![image](https://user-images.githubusercontent.com/8158668/210543179-80c7819b-5da9-473b-8313-34d9823848f2.png)
(i selected a random part of the image, imagine it's a packaging image :) )  
