### PR TITLE
feat: add placeholder count check to check-translations.sh

### DIFF
--- a/scripts/check-translations.sh
+++ b/scripts/check-translations.sh
@@ -24,9 +24,27 @@ do
     then
         ERRORS=`expr $ERRORS + 1`
         echo "contains errors!"
-    else
-        echo "ok"
     fi
+    while read -r line
+    do
+        if [[ $line =~ ^msgid ]]
+        then
+            msgid=$line
+        elif [[ $line =~ ^msgstr ]]
+        then
+            msgstr=$line
+            # Count the number of %s placeholders in the msgid and msgstr lines
+            msgid_placeholders=$(echo "$msgid" | grep -o "%s" | wc -l)
+            msgstr_placeholders=$(echo "$msgstr" | grep -o "%s" | wc -l)
+            if [ $msgid_placeholders -ne $msgstr_placeholders ]
+            then
+                ERRORS=`expr $ERRORS + 1`
+                echo "ERROR: The number of placeholders in the msgid and msgstr lines are different."
+                echo "msgid: $msgid"
+                echo "msgstr: $msgstr"
+            fi
+        fi
+    done < "$filename"
 done
 echo ""
 if [ $ERRORS -gt 0 ]; then


### PR DESCRIPTION
### What
- Modified the `check-translations.sh` shell script to check if the number of placeholders in `msgstr` and `msgid` are same.
### Screenshot
For `en.po` (no errors)
![image](https://user-images.githubusercontent.com/41837037/211159844-61a06b4d-e263-4f5a-9b42-482133056d17.png)
For `aa.po`  (86 occurrences)
![image](https://user-images.githubusercontent.com/41837037/211159862-f12f837b-c9e2-4baf-8799-3fe696a2b061.png)


### Related issue(s) and discussion
- Fixes #7906 

