### PR TITLE
fix: URGENT - add cors headers for static resources

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -61,7 +61,7 @@ server {
 	location ~ ^/(.well-known|fonts|images|js|css|rss|data|files|resources)/ {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
-		#add_header Access-Control-Allow-Origin *;
+		include conf.d/off.cors-headers.include;
 		try_files $uri $uri/ =404;
 	}
 


### PR DESCRIPTION
was forgotten for docker-compose deployment
