### PR TITLE
feat: new dump, aside the current one

### DIFF
--- a/scripts/mongodb_dump.sh
+++ b/scripts/mongodb_dump.sh
@@ -14,11 +14,17 @@ cd $DIR
 
 mongoexport --collection products --host $HOST --db $DB | gzip > data/$PREFIX-products.jsonl.gz
 
+mongodump --collection products --host $HOST --db $DB --gzip --archive="data/${PREFIX}-mongodbdump.gz"
+
 mongodump --collection products --host $HOST --db $DB
 tar cvfz data/$PREFIX-mongodbdump.tar.gz dump
 pushd data/ > /dev/null
 sha256sum $PREFIX-mongodbdump.tar.gz > sha256sum
 md5sum $PREFIX-mongodbdump.tar.gz > md5sum
+
+sha256sum $PREFIX-mongodbdump.gz > gz-sha256sum
+md5sum $PREFIX-mongodbdump.gz > gz-md5sum
+
 
 # Export delta of products modified in the last 24h or since last run of the script
 mkdir -p delta


### PR DESCRIPTION
First step of https://github.com/openfoodfacts/openfoodfacts-server/issues/7962

For deployment: the new export should take the same time as the old one. About 30 minutes?
It might be necessary to **start the export a bit earlier** to be sure it won't impact other processes (eg. Mirabelle is downloading the CSV file at 5:00 CET).