### PR TITLE
taxonomy: add 'collard greens' as both an ingredient and a category

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -90697,7 +90697,7 @@ fr:Chou frais
 season_in_country_fr:en: 1,2,3,10,11,12
 
 <en:Leaf vegetables
-en:Collard, Collard greens
+en:Collard greens, Collard
 wikidata:en:Q14879985
 
 <en:Vegetable rods

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -90696,6 +90696,10 @@ bg:Прясно зеле
 fr:Chou frais
 season_in_country_fr:en: 1,2,3,10,11,12
 
+<en:Leaf vegetables
+en:Collard, Collard greens
+wikidata:en:Q14879985
+
 <en:Vegetable rods
 en:Cardoons, Artichoke thistles
 ca:card

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -46202,6 +46202,10 @@ ciqual_food_name:en:Curly kale, raw
 ciqual_food_name:fr:Chou frisé, cru
 # 2029 in 13 languages @2021-10-19
 
+<en:vegetable
+en:collard, collard greens
+wikidata:en:Q14879985
+
 <en:kale
 en:baby kale
 de:Kohlsprossen

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -46203,7 +46203,7 @@ ciqual_food_name:fr:Chou frisé, cru
 # 2029 in 13 languages @2021-10-19
 
 <en:vegetable
-en:collard, collard greens
+en:collard greens, collard
 wikidata:en:Q14879985
 
 <en:kale


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Adds ["collard greens"](https://en.wikipedia.org/wiki/Collard_(plant)), a variety of leafy green vegetable, to both the OpenFoodFacts `ingredients` and also `categories` taxonomies.

### Related issue(s) and discussion
Resolves #7315