### PR TITLE
feat: add data quality issue for negatives values in nutrition table

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -740,6 +740,10 @@ sub check_nutrition_data ($product_ref) {
 						$nid_non_zero++;
 					}
 				}
+				# negative value in nutrition table
+				if ($product_ref->{nutriments}{$nid} < 0) {
+						push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-value-negative-$nid2";
+				}
 			}
 
 			$nid_n++;

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -742,7 +742,7 @@ sub check_nutrition_data ($product_ref) {
 				}
 				# negative value in nutrition table
 				if ($product_ref->{nutriments}{$nid} < 0) {
-						push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-value-negative-$nid2";
+					push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-value-negative-$nid2";
 				}
 			}
 


### PR DESCRIPTION
This may resolve #7984  (@CharlesNepote, @raphael0202)

1. More context
- see all of the errors: https://mirabelle.openfoodfacts.org/products?sql=select+url%2C+creator%2C%0D%0A--created_datetime%2C+last_modified_datetime%2C+product_name%2C%0D%0A%5Benergy-kj_100g%5D%2C+%5Benergy-kcal_100g%5D%2C+energy_100g%2C%0D%0A--%5Benergy-from-fat_100g%5D%2C+%0D%0Afat_100g%2C+%5Bsaturated-fat_100g%5D%2C%0D%0A--%5B-butyric-acid_100g%5D%2C+%5B-caproic-acid_100g%5D%2C+%5B-caprylic-acid_100g%5D%2C+%5B-capric-acid_100g%5D%2C+%5B-lauric-acid_100g%5D%2C+%5B-myristic-acid_100g%5D%2C+%5B-palmitic-acid_100g%5D%2C+%5B-stearic-acid_100g%5D%2C+%5B-arachidic-acid_100g%5D%2C+%5B-behenic-acid_100g%5D%2C+%5B-lignoceric-acid_100g%5D%2C+%5B-cerotic-acid_100g%5D%2C+%5B-montanic-acid_100g%5D%2C+%5B-melissic-acid_100g%5D%2C+%5Bmonounsaturated-fat_100g%5D%2C+%5Bpolyunsaturated-fat_100g%5D%2C+%5Bomega-3-fat_100g%5D%2C+%5B-alpha-linolenic-acid_100g%5D%2C+%5B-eicosapentaenoic-acid_100g%5D%2C+%5B-docosahexaenoic-acid_100g%5D%2C+%5Bomega-6-fat_100g%5D%2C+%5B-linoleic-acid_100g%5D%2C+%5B-arachidonic-acid_100g%5D%2C+%5B-gamma-linolenic-acid_100g%5D%2C+%5B-dihomo-gamma-linolenic-acid_100g%5D%2C%0D%0A%5Bomega-9-fat_100g%5D%2C+%0D%0A--+%5B-oleic-acid_100g%5D%2C+%5B-elaidic-acid_100g%5D%2C+%5B-gondoic-acid_100g%5D%2C+%5B-mead-acid_100g%5D%2C+%5B-erucic-acid_100g%5D%2C+%5B-nervonic-acid_100g%5D%2C%0D%0A%5Btrans-fat_100g%5D%2C+cholesterol_100g%2C+%0D%0Acarbohydrates_100g%2C+sugars_100g%2C%0D%0A--+%5B-sucrose_100g%5D%2C+%5B-glucose_100g%5D%2C+%5B-fructose_100g%5D%2C+%5B-lactose_100g%5D%2C+%5B-maltose_100g%5D%2C+%5B-maltodextrins_100g%5D%2C+starch_100g%2C+polyols_100g%2C+%5B-erythritol_100g%5D%2C%0D%0Afiber_100g%2C+%5Bsoluble-fiber_100g%5D%2C+%5Binsoluble-fiber_100g%5D%2C+proteins_100g%2C+casein_100g%2C+%5Bserum-proteins_100g%5D%2C+nucleotides_100g%2C+%0D%0Asalt_100g%2C+sodium_100g%2C+alcohol_100g%2C+%0D%0A%5Bvitamin-a_100g%5D%2C+%5Bbeta-carotene_100g%5D%2C+%5Bvitamin-d_100g%5D%2C+%5Bvitamin-e_100g%5D%2C+%5Bvitamin-k_100g%5D%2C+%5Bvitamin-c_100g%5D%2C+%5Bvitamin-b1_100g%5D%2C+%5Bvitamin-b2_100g%5D%2C+%5Bvitamin-pp_100g%5D%2C+%5Bvitamin-b6_100g%5D%2C+%5Bvitamin-b9_100g%5D%2C+folates_100g%2C+%5Bvitamin-b12_100g%5D%2C+biotin_100g%2C+%5Bpantothenic-acid_100g%5D%2C+silica_100g%2C+bicarbonate_100g%2C+potassium_100g%2C+chloride_100g%2C+calcium_100g%2C+phosphorus_100g%2C+iron_100g%2C+magnesium_100g%2C+zinc_100g%2C+copper_100g%2C+manganese_100g%2C+fluoride_100g%2C+selenium_100g%2C+chromium_100g%2C+molybdenum_100g%2C+iodine_100g%2C+caffeine_100g%2C+taurine_100g%2C+ph_100g%2C%0D%0A%5Bfruits-vegetables-nuts_100g%5D%2C+%5Bfruits-vegetables-nuts-dried_100g%5D%2C+%5Bfruits-vegetables-nuts-estimate_100g%5D%2C+%5Bfruits-vegetables-nuts-estimate-from-ingredients_100g%5D%2C+%5Bcollagen-meat-protein-ratio_100g%5D%2C+cocoa_100g%2C+chlorophyl_100g%2C+%5Bcarbon-footprint_100g%5D%2C+%5Bcarbon-footprint-from-meat-or-fish_100g%5D%2C+%5Bnutrition-score-fr_100g%5D%2C+%5Bnutrition-score-uk_100g%5D%2C+%5Bglycemic-index_100g%5D%2C+%5Bwater-hardness_100g%5D%2C+choline_100g%2C+phylloquinone_100g%2C+%5Bbeta-glucan_100g%5D%2C+inositol_100g%2C+%0D%0Acarnitine_100g%0D%0Afrom+%5Ball%5D+%0D%0Awhere+true%0D%0Aand+%28energy_100g+%3C+0%0D%0A++++--or+%5Benergy-from-fat_100g%5D%0D%0A+++++or+%5Bmonounsaturated-fat_100g%5D+%3C+0%0D%0A+++++or+%5Bpolyunsaturated-fat_100g%5D+%3C+0%0D%0A+++++or+%5Bomega-3-fat_100g%5D+%3C+0%0D%0A+++++or+%5Bomega-6-fat_100g%5D+%3C0%0D%0A+++++or+%5Bomega-9-fat_100g%5D+%3C+0%0D%0A+++++or+%5Btrans-fat_100g%5D+%3C+0%0D%0A+++++or+cholesterol_100g+%3C+0+%0D%0A+++++or+fat_100g+%3C+0%0D%0A+++++or+%5Bsaturated-fat_100g%5D+%3C+0%0D%0A+++++or+carbohydrates_100g+%3C+0%0D%0A+++++or+sugars_100g+%3C+0%0D%0A+++++or+fiber_100g+%3C+0%0D%0A+++++or+%5Bsoluble-fiber_100g%5D+%3C+0%0D%0A+++++or+%5Binsoluble-fiber_100g%5D+%3C+0%0D%0A+++++or+proteins_100g+%3C+0%0D%0A+++++or+casein_100g+%3C+0%0D%0A+++++or+%5Bserum-proteins_100g%5D+%3C+0%0D%0A+++++or+nucleotides_100g+%3C+0%0D%0A+++++or+salt_100g+%3C+0%0D%0A+++++or+sodium_100g+%3C+0%0D%0A+++++or+alcohol_100g+%3C+0%0D%0A+++++or+%5Bvitamin-a_100g%5D+%3C+0%0D%0A+++++or+%5Bbeta-carotene_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-d_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-e_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-k_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-c_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-b1_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-b2_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-pp_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-b6_100g%5D+%3C+0%0D%0A+++++or+%5Bvitamin-b9_100g%5D+%3C+0%0D%0A+++++or+folates_100g+%3C+0%0D%0A+++++or+%5Bvitamin-b12_100g%5D+%3C+0%0D%0A+++++or+biotin_100g+%3C+0%0D%0A+++++or+%5Bpantothenic-acid_100g%5D+%3C+0%0D%0A+++++or+silica_100g+%3C+0%0D%0A+++++or+bicarbonate_100g+%3C+0%0D%0A+++++or+potassium_100g+%3C+0%0D%0A+++++or+chloride_100g+%3C+0%0D%0A+++++or+calcium_100g+%3C+0%0D%0A+++++or+phosphorus_100g+%3C+0%0D%0A+++++or+iron_100g+%3C+0%0D%0A+++++or+magnesium_100g+%3C+0%0D%0A+++++or+zinc_100g+%3C+0%0D%0A+++++or+copper_100g+%3C+0%0D%0A+++++or+manganese_100g+%3C+0%0D%0A+++++or+fluoride_100g+%3C+0%0D%0A+++++or+selenium_100g+%3C+0%0D%0A+++++or+chromium_100g+%3C+0%0D%0A+++++or+molybdenum_100g+%3C+0%0D%0A+++++or+iodine_100g+%3C+0%0D%0A+++++or+caffeine_100g+%3C+0%0D%0A+++++or+taurine_100g+%3C+0%0D%0A+++++or+ph_100g+%3C+0%0D%0A+++++or+%5Bfruits-vegetables-nuts_100g%5D+%3C+0%0D%0A+++++or+%5Bfruits-vegetables-nuts-dried_100g%5D+%3C+0%0D%0A+++++or+%5Bfruits-vegetables-nuts-estimate_100g%5D+%3C+0%0D%0A+++++or+%5Bfruits-vegetables-nuts-estimate-from-ingredients_100g%5D+%3C+0%29%0D%0A%0D%0Aorder+by+rowid+limit+210
- see one of them in the api: https://world.openfoodfacts.org/api/2/product/0028400231053

2. Devs were done on Gitpod
 - See changes in lib/ProductOpener/DataQualityFood.pm file.
 - For testing, in http://world.openfoodfacts.localhost/, we can modify a product and include negative values, such has:
![pr_do_error](https://user-images.githubusercontent.com/110821832/212542809-fd1c9675-9603-40a6-8904-deb3d5d4294b.png)
 - Thanks to the Power-user-script we can directly see when saving the changes, that the new error is raised:
![pr_do_error_2](https://user-images.githubusercontent.com/110821832/212542939-1bfc7581-d32a-4364-a8f1-2d1f137acaeb.png)
- We can also see all products having this error by adding "/data-quality/en:nutrition-value-negative-fiber" (for world (http://world.openfoodfacts.localhost) or country) or "/data-quality/nutrition-value-negative-fiber" (only for world) in the url:
![pr_result](https://user-images.githubusercontent.com/110821832/212543210-b3d2e7d2-693e-4130-91f8-7d5c25a6e7ca.png)
- make checks, was run before to commit and open the pull request

3. Discussion
- name of the error is "en:nutrition-value-negative-*name of the negative element*" because it is explicit enough and consistent with existing errors like "en:nutrition-value-over-105-*name of the element*"
- after having put negative values, the errors are not visible in "http://world.openfoodfacts.localhost/data-quality" beside trying couple of commands (make build_lang, docker-compose restart, make up). Ping @stephanegigandet and @alexgarel, do you know what command to run for that?):
![pr_still_unsolved](https://user-images.githubusercontent.com/110821832/212543587-f318d311-8cb6-4c44-b770-f0b0d4c38fe4.png)

