### PR TITLE
taxonomy: fix some issue on ingredient taxonomy

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -41412,7 +41412,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Rosa_canina
 #                                Strawberry
 #
 ###################################################################################################
-en:description:The garden strawberry (or simply strawberry; Fragaria × ananassa) is a widely grown hybrid species of the genus Fragaria, collectively known as the strawberries.
+# en:description:The garden strawberry (or simply strawberry; Fragaria × ananassa) is a widely grown hybrid species of the genus Fragaria, collectively known as the strawberries.
 
 <en:berries
 en:strawberry, strawberries
@@ -63860,7 +63860,7 @@ vegan:en:yes
 vegetarian:en:yes
 
 
-en:description:WASABI (Eutrema japonicum or Wasabia japonica) or Japanese horseradish is a plant of the Brassicaceae family.
+# en:description:WASABI (Eutrema japonicum or Wasabia japonica) or Japanese horseradish is a plant of the Brassicaceae family.
 
 <en:plant
 en:wasabi
@@ -73551,7 +73551,7 @@ fr:miel italien d'acacia
 
 <en:acacia honey
 <fr:mélange de miels originaires et non originaires de l'ue
-fr:Mélanges de miels d'Acacia originaires et non originaires de l'Union Européenne, melange de miels d'acacia originaires et non-originaires de l'union europeenne issus de l'agriculture biologique
+fr:Mélanges de miels d'Acacia originaires et non originaires de l'Union Européenne
 
 <en:acacia honey
 fr:miel d'acacia des forets preservées d'Europe


### PR DESCRIPTION
- two comments were not prefixed with '#', so it was part of the taxonomy
- remove useless synonym for 'fr:Mélanges de miels d'Acacia originaires et non originaires de l'Union Européenne'