### PR TITLE
taxonomy: fix bee friendly label name

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -19396,9 +19396,9 @@ pt:Maçãs da França
 origins:en: en:france
 ingredients:en: en:apple
 
-en:bee friendly, I protect the bees
-fr:bee friendly, Je protège les abeilles
-xx:bee friendly
+en:Bee Friendly, I protect the bees
+fr:Bee Friendly, Je protège les abeilles
+xx:Bee Friendly
 
 en:Honey from France
 de:Honig aus Frankreich

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -19396,8 +19396,9 @@ pt:Maçãs da França
 origins:en: en:france
 ingredients:en: en:apple
 
-en:I protect the bees
-fr:Je protège les abeilles
+en:bee friendly, I protect the bees
+fr:bee friendly, Je protège les abeilles
+xx:bee friendly
 
 en:Honey from France
 de:Honig aus Frankreich


### PR DESCRIPTION
Bee friendly was added, see #7231 but under the wrong name (the tagline instead of the real name)

