### PR TITLE
fix: exclude nutrition id containing nutrition-score

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -740,8 +740,8 @@ sub check_nutrition_data ($product_ref) {
 						$nid_non_zero++;
 					}
 				}
-				# negative value in nutrition table
-				if ($product_ref->{nutriments}{$nid} < 0) {
+				# negative value in nutrition table, exclude key containing "nutrition-score" as they can be negative
+				if (($product_ref->{nutriments}{$nid} < 0) and (index($nid, "nutrition-score") == -1)) {
 					push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-value-negative-$nid2";
 				}
 			}


### PR DESCRIPTION
excluding all nutriments containing "nutrition-score" (nutrition-score, nutrition-score-fr)

Tested that negative value is still working for common nutriment. **But** it is not possible to test negative nutrition-score itself because there are no examples in the test data and I do not know how to create such negative nutrition-score.

could fix #7988 