### PR TITLE
build: When detecting MacOS then use MacOS-specific 'sysctl' command for setting CPU_COUNT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,17 @@ ENV_FILE ?= .env
 NAME = "ProductOpener"
 MOUNT_POINT ?= /mnt
 DOCKER_LOCAL_DATA ?= /srv/off/docker_data
+OS := $(shell uname)
 
 export DOCKER_BUILDKIT=1
 export COMPOSE_DOCKER_CLI_BUILD=1
 UID ?= $(shell id -u)
 export USER_UID:=${UID}
-export CPU_COUNT=$(shell nproc || echo 1)
+ifeq ($(OS), Darwin)
+  export CPU_COUNT=$(shell sysctl -n hw.logicalcpu || echo 1)
+else
+  export CPU_COUNT=$(shell nproc || echo 1)
+endif
 export MSYS_NO_PATHCONV=1
 
 # load env variables
@@ -230,7 +235,7 @@ test-stop:
 	${DOCKER_COMPOSE_TEST} stop
 
 # usage:  make test-unit test=test-name.t
-test-unit: guard-test 
+test-unit: guard-test
 	@echo "🥫 Running test: 'tests/unit/${test}' …"
 	${DOCKER_COMPOSE_TEST} up -d memcached postgres mongodb
 	${DOCKER_COMPOSE_TEST} run --rm backend perl tests/unit/${test}
@@ -263,7 +268,7 @@ bash:
 
 
 # TO_CHECK look at changed files (compared to main) with extensions .pl, .pm, .t
-# the ls at the end is to avoid removed files. 
+# the ls at the end is to avoid removed files.
 # We have to finally filter out "." as this will the output if we have no file
 TO_CHECK=$(shell git diff origin/main --name-only | grep  '.*\.\(pl\|pm\|t\)$$' | xargs ls -d 2>/dev/null | grep -v "^.$$" )
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->
Added a Check which sets the CPU_COUNT variable via sysctl instead of nproc if run on MacOS. Otherwise building via the Makefile would fail because on MacOS because nproc doesn't exist on MacOS. 

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[8040]

