### PR TITLE
taxonomy: adding Cocamidopropyl betaine in allergens

### DIFF
--- a/taxonomies.obf/allergens.txt
+++ b/taxonomies.obf/allergens.txt
@@ -113,6 +113,8 @@ cas_number:en:106-22-9 / 1117-61-9 / 7540-51-4
 human_evidence:en:++
 eu_lists:en:Established contact allergens in humans
 
+en:COCAMIDOPROPYL BETAINE
+cas_number:en: 61789-40-0
 
 en:COUMARIN
 cas_number:en: 91-64-5


### PR DESCRIPTION
I need to watch out for Cocamidopropyl betaine because I might be allergic to it. It wasn't yet listed as a allergent. [According to Wikipedia](https://en.wikipedia.org/wiki/Cocamidopropyl_betaine#Safety) the allergent status is  controversial. 🤷