### PR TITLE
fix: underline links

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -310,7 +310,7 @@ a.disabled_rule_button {
 }
 
 a.button:hover {
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 .level_3,
@@ -1325,3 +1325,31 @@ $section-blue: #6d85d9;
 }
 
 .if-empty-dnone:empty { display: none !important; }
+
+// underline links
+#main_container a {
+  text-decoration:underline;
+}
+// except buttons
+a.button {
+  text-decoration:none !important;
+}
+// except product cards etc.
+a.list_product_a {
+  text-decoration:none !important;
+}
+a.tab_language {
+  text-decoration:none !important;
+}
+a.attribute_card {
+  text-decoration:none !important;
+}
+a.panel_title {
+  text-decoration:none !important;
+}
+.field_value a {
+  text-decoration:none !important;
+}
+.accordion-navigation a {
+  text-decoration:none !important;
+}

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -926,6 +926,7 @@ html[dir="rtl"] {
 
 a.attribute_card {
   color: $body-font-color;
+  text-decoration: none;
 }
 
 a.attribute_card:hover {
@@ -1339,9 +1340,6 @@ a.list_product_a {
   text-decoration:none !important;
 }
 a.tab_language {
-  text-decoration:none !important;
-}
-a.attribute_card {
   text-decoration:none !important;
 }
 a.panel_title {


### PR DESCRIPTION
This is to make sure links are differentiated visually, with an underline.

e.g. previously those links were almost invisible:

![image](https://user-images.githubusercontent.com/8158668/217233844-cf3d6023-6a58-4ec0-a95f-3ec862e7315d.png)
