### PR TITLE
fix: remove underlined links in tables/dropdowns

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -1351,3 +1351,9 @@ a.panel_title {
 .accordion-navigation a {
   text-decoration:none !important;
 }
+.f-dropdown a {
+  text-decoration:none !important;
+}
+.dataTable a {
+  text-decoration:none !important;
+}


### PR DESCRIPTION
This removes the underline for links in some dropdowns (e.g. the "Explore by" button) and tables (e.g. list of tags in /categories etc.)