### PR TITLE
fix: support /api/v0/products (with a s)

### DIFF
--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -189,6 +189,11 @@ sub analyze_request ($request_ref) {
 
 		$request_ref->{api_action} = $components[2];
 
+		# Also support "products" in order not to break apps that were using it
+		if ($request_ref->{api_action} eq 'products') {
+			$request_ref->{api_action} = 'product';
+		}
+
 		# If the api_action is different than "search", check if it is the local path for "product"
 		# so that urls like https://fr.openfoodfacts.org/api/v3/produit/4324232423 work (produit instead of product)
 		# this is so that we can quickly add /api/v3/ to get the API


### PR DESCRIPTION
Needed for old versions of the Horizon app

test: https://world.openfoodfacts.org/api/v0/products/3017620422003/nutella-ferrero