### PR TITLE
taxonomy: add :de: alias for plant protein

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -29107,7 +29107,7 @@ sv:proteinhydrolysat
 en:plant protein, vegetable protein, vegetal protein
 bg:растителен протеин
 cs:rostlinné proteiny
-de:pflanzliches Eiweiß
+de:pflanzliches Eiweiß, Pflanzenprotein, Pflanzenproteine
 es:proteína vegetal
 fi:kasviproteiini
 fr:protéines végétales, protéine végétale


### PR DESCRIPTION
### What

Adds German synonyms for plant protein, e.g. https://de.openfoodfacts.org/produkt/7610227935219/plant-based-filet-h%C3%A4hnchen-art-green-mountain

### Screenshot
none

### Related issue(s) and discussion
none
