### PR TITLE
ci: use mongodb new gz dump for staging

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -77,6 +77,13 @@ jobs:
     concurrency: ${{ matrix.env }}
     needs: dev-db-sync
     steps:
+    - name: Set various variable for staging (net) deployment
+      if: matrix.env == 'mongo-dev'
+      run: |
+        # deploy target
+        echo "SSH_HOST=10.1.0.200" >> $GITHUB_ENV
+        echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
+        echo "SSH_USERNAME=off" >> $GITHUB_ENV
     - name: Refresh MongoDB products_tags collection
       uses: appleboy/ssh-action@master
       with:

--- a/.github/workflows/mongo-deploy.yml
+++ b/.github/workflows/mongo-deploy.yml
@@ -99,6 +99,7 @@ jobs:
         script_stop: false
         script: |
           cd ${{ matrix.env }}
+          make down
           make up
 
     - name: Check services are up

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ import_prod_data:
 	wget --no-verbose https://static.openfoodfacts.org/data/gz-sha256sum -P ./html/data
 	cd ./html/data && sha256sum --check gz-sha256sum
 	@echo "🥫 Restoring the MongoDB dump …"
-	${DOCKER_COMPOSE} exec -T mongodb //bin/sh -c "cd /data/db && mongorestore --drop --gzip --archive=../data/import/openfoodfacts-mongodbdump.gz"
+	${DOCKER_COMPOSE} exec -T mongodb //bin/sh -c "cd /data/db && mongorestore --drop --gzip --archive=/import/openfoodfacts-mongodbdump.gz"
 	rm html/data/openfoodfacts-mongodbdump.tar.gz && rm html/data/gz-sha256sum
 
 #--------#

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ import_prod_data:
 	wget --no-verbose https://static.openfoodfacts.org/data/gz-sha256sum -P ./html/data
 	cd ./html/data && sha256sum --check gz-sha256sum
 	@echo "🥫 Restoring the MongoDB dump …"
-	${DOCKER_COMPOSE} exec -T mongodb //bin/sh -c "cd /data/db && mongorestore --drop --gzip --archive=/import/openfoodfacts-mongodbdump.gz"
+	${DOCKER_COMPOSE} exec -T mongodb //bin/sh -c "cd /data/db && mongorestore --quiet --drop --gzip --archive=/import/openfoodfacts-mongodbdump.gz"
 	rm html/data/openfoodfacts-mongodbdump.tar.gz && rm html/data/gz-sha256sum
 
 #--------#

--- a/docker/mongodb.yml
+++ b/docker/mongodb.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - dbdata:/data/db
       # a volume to get data to import
-      - ./html/data:/data/import
+      - ./html/data:/import
     ports:
       - 27017:27017
     networks:

--- a/docker/mongodb.yml
+++ b/docker/mongodb.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - dbdata:/data/db
       # a volume to get data to import
-      - ./html/data:/import
+      - ../html/data:/import
     ports:
       - 27017:27017
     networks:

--- a/docker/mongodb.yml
+++ b/docker/mongodb.yml
@@ -6,6 +6,8 @@ services:
     command: mongod --wiredTigerCacheSizeGB ${MONGODB_CACHE_SIZE}
     volumes:
       - dbdata:/data/db
+      # a volume to get data to import
+      - ./html/data:/data/import
     ports:
       - 27017:27017
     networks:
@@ -22,4 +24,4 @@ networks:
 volumes:
   dbdata:
     external: true
-  
+


### PR DESCRIPTION
Using new openfoodfacts-mongodbdump.gz dump to restore staging.

Also using a bind mounted directory to avoid copying files around.

Part of:
- #7962 