### PR TITLE
feat: added Croatian language taxonomy for processing

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1735,6 +1735,7 @@ sub parse_ingredients_text ($product_ref) {
 											   ($product_lc eq 'en')
 											or ($product_lc eq 'es')
 											or ($product_lc eq 'fr')
+											or ($product_lc eq 'hr')
 											or ($product_lc eq 'it')
 										)
 										and ($new_ingredient =~ /(^($regexp)\b|\b($regexp)$)/i)

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1725,7 +1725,7 @@ de:geräuchert, geräucherte
 es:ahumada, ahumado, ahumadas, ahumados
 fi:savustettu, savustetut, savustettua
 fr:fumé,fumés,fumée,fumées
-hr:dimljeni
+hr:dimljena, dimljeni
 hu:füstölt, füstölve
 it:affumicato, affumicata, affumicati, affumicate
 nl:gerookt, gerookte

--- a/tests/unit/ingredients_processing.t
+++ b/tests/unit/ingredients_processing.t
@@ -27,7 +27,7 @@ my @tests = (
 		{
 			lc => "en",
 			ingredients_text => "raw milk, sliced tomatoes, garlic powder, powdered eggplant,
-			courgette powder, sieved ham"
+				courgette powder, sieved ham"
 		},
 		[
 			{
@@ -168,11 +168,60 @@ my @tests = (
 		]
 	],
 
-##################################################################
+	[
+		{lc => "en", ingredients_text => "smoked sea salt, smoked turkey"},
+		[
+			{
+				'id' => 'en:sea-salt',
+				'processing' => 'en:smoked',
+				'text' => 'sea salt'
+			},
+			{
+				'id' => 'en:turkey',
+				'processing' => 'en:smoked',
+				'text' => 'turkey'
+			}
+		]
+	],
+
+	# ingredient with (processing) in parenthesis
+	[
+		{lc => "en", ingredients_text => "garlic (powdered)",},
+		[
+			{
+				'id' => 'en:garlic',
+				'processing' => 'en:powder',
+				'text' => 'garlic'
+			}
+		]
+	],
+
+	[
+		{lc => "en", ingredients_text => "pasteurized eggs"},
+		[
+			{
+				'id' => 'en:egg',
+				'processing' => 'en:pasteurised',
+				'text' => 'eggs'
+			}
+		]
+	],
+
+	[
+		{lc => "en", ingredients_text => "dry whey"},
+		[
+			{
+				'id' => 'en:whey',
+				'processing' => 'en:dried',
+				'text' => 'whey'
+			}
+		]
+	],
+	##################################################################
 	#
 	#                           S P A N I S H   ( E S )
 	#
-##################################################################
+	##################################################################
 
 	[
 		{
@@ -214,17 +263,44 @@ my @tests = (
 		]
 	],
 
-##################################################################
+	[
+		{lc => "es", ingredients_text => "tofu ahumado, panceta ahumada"},
+		[
+			{
+				'id' => 'en:tofu',
+				'processing' => 'en:smoked',
+				'text' => 'tofu'
+			},
+			{
+				'id' => 'en:bacon',
+				'processing' => 'en:smoked',
+				'text' => 'panceta'
+			}
+		]
+	],
+
+	[
+		{lc => "es", ingredients_text => "pimientos amarillos deshidratados"},
+		[
+			{
+				'id' => 'en:yellow-bell-pepper',
+				'processing' => 'en:dehydrated',
+				'text' => 'pimientos amarillos'
+			}
+		]
+	],
+
+	##################################################################
 	#
 	#                           F R E N C H ( F R )
 	#
-##################################################################
+	##################################################################
 
 	[
 		{
 			lc => "fr",
 			ingredients_text => "dés de jambon frits, tomates crues en dés,
-			tomates bio pré-cuites, poudre de noisettes, banane tamisé"
+				tomates bio pré-cuites, poudre de noisettes, banane tamisé"
 		},
 		[
 			{
@@ -360,17 +436,56 @@ my @tests = (
 		]
 	],
 
+	[
+		{
+			lc => "fr",
+			ingredients_text => "sel marin fumé, jambon fumé, arôme de fumée, lardons fumés au bois de hêtre "
+		},
+		[
+			{
+				'id' => 'en:sea-salt',
+				'processing' => 'en:smoked',
+				'text' => 'sel marin'
+			},
+			{
+				'id' => 'en:ham',
+				'processing' => 'en:smoked',
+				'text' => 'jambon'
+			},
+			{
+				'id' => 'en:smoke-flavouring',
+				'text' => "ar\x{f4}me de fum\x{e9}e"
+			},
+			{
+				'id' => 'en:lardon',
+				'processing' => 'en:beech-smoked',
+				'text' => 'lardons'
+			}
+		]
+	],
+
+	[
+		{lc => "fr", ingredients_text => "piment (en poudre)"},
+		[
+			{
+				'id' => 'en:chili-pepper',
+				'processing' => 'en:powder',
+				'text' => 'piment'
+			}
+		]
+	],
+
 	# test for jus and concentré with extra "de"
 	#	[ { lc => "fr", ingredients_text => "jus concentré de baies de sureau"},
 	#		[
 	#		]
 	#	],
 
-##################################################################
+	##################################################################
 	#
 	#                           F I N N I SH ( F I )
 	#
-##################################################################
+	##################################################################
 	# test for mehu inside an ingredient
 
 	#	[ { lc => "fi", ingredients_text => "hedelmätäysmehutiivisteet"},
@@ -399,11 +514,11 @@ my @tests = (
 	# 	]
 	# ],
 
-##################################################################
+	##################################################################
 	#
 	#                           D U T C H ( N L )
 	#
-##################################################################
+	##################################################################
 
 	[
 		{
@@ -456,11 +571,11 @@ my @tests = (
 		]
 	],
 
-##################################################################
+	##################################################################
 	#
 	#                           G E R M A N ( D E )
 	#
-##################################################################
+	##################################################################
 
 	# de:pulver and variants
 	[
@@ -547,7 +662,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte gegart, gegarte haselnüsse, gegarter mandeln, gegartes passionsfrucht,
-			sellerie dampfgegart, dampfgegarte acerola, dampfgegarter spinat"
+				sellerie dampfgegart, dampfgegarte acerola, dampfgegarter spinat"
 		},
 		[
 			{
@@ -613,7 +728,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte gepökelt, gepökeltes haselnüsse,
-			passionsfrucht ungepökelt"
+				passionsfrucht ungepökelt"
 		},
 		[
 			{
@@ -639,7 +754,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte gepoppt, gepuffte haselnüsse,
-			passionsfrucht gepufft, gepuffter passionsfrucht, gepufftes sellerie"
+				passionsfrucht gepufft, gepuffter passionsfrucht, gepufftes sellerie"
 		},
 		[
 			{
@@ -675,7 +790,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte geschält, geschälte haselnüsse, geschälter mandeln,
-			passionsfrucht ungeschält, ungeschälte sellerie"
+				passionsfrucht ungeschält, ungeschälte sellerie"
 		},
 		[
 			{
@@ -711,7 +826,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte geschwefelt, geschwefelte haselnüsse,
-			passionsfrucht ungeschwefelt, geschwefelte sellerie"
+				passionsfrucht ungeschwefelt, geschwefelte sellerie"
 		},
 		[
 			{
@@ -819,8 +934,8 @@ my @tests = (
 			lc => "de",
 			ingredients_text =>
 				"konzentriert schalotte, konzentrierter haselnüsse, konzentrierte mandeln, konzentriertes acerolakirschen,
-			zweifach konzentriert, 2 fach konzentriert, doppelt konzentriertes, zweifach konzentriertes, 2-fach konzentriert, dreifach konzentriert,
-			200fach konzentriertes, eingekochter"
+				zweifach konzentriert, 2 fach konzentriert, doppelt konzentriertes, zweifach konzentriertes, 2-fach konzentriert, dreifach konzentriert,
+				200fach konzentriertes, eingekochter"
 		},
 		[
 			{
@@ -884,11 +999,11 @@ my @tests = (
 			lc => "de",
 			ingredients_text =>
 				"Schalotte zerkleinert, zerkleinerte haselnüsse, zerkleinerter mandeln, zerkleinertes passionsfrucht,
-			sellerie grob zerkleinert,
-			acerolakirschen fein zerkleinert, fein zerkleinerte spinat,
-			zwiebel zum teil fein zerkleinert,
-			haselnüsse feinst zerkleinert,
-			überwiegend feinst zerkleinert Feigen"
+				sellerie grob zerkleinert,
+				acerolakirschen fein zerkleinert, fein zerkleinerte spinat,
+				zwiebel zum teil fein zerkleinert,
+				haselnüsse feinst zerkleinert,
+				überwiegend feinst zerkleinert Feigen"
 		},
 		[
 			{
@@ -949,7 +1064,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "haselnüsse gehackt und geröstet,
-			gehackte und geröstete haselnuss, gehobelte und gehackte mandeln"
+				gehackte und geröstete haselnuss, gehobelte und gehackte mandeln"
 		},
 		[
 			# change on 17:01
@@ -976,7 +1091,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte gemahlen, gemahlene mandeln, gemahlener zwiebel,
-			fein gemahlen haselnüsse, grob gemahlen spinat, frischgemahlen sellerie"
+				fein gemahlen haselnüsse, grob gemahlen spinat, frischgemahlen sellerie"
 		},
 		[
 			{
@@ -1017,10 +1132,10 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte getrocknet, getrocknete mandeln, getrockneter zwiebel,
-			 haselnüsse in getrockneter form, halbgetrocknete spinat, halbgetrocknet sellerie, Feigen halb getrocknet,
-			 Holunder gefriergetrocknet, gefriergetrocknete Papaya, gefriergetrocknetes Kiwi, sonnengetrocknet Ananas,
-			 sonnengetrocknete Pflaumen, an der Sonne getrocknete Grapefruit, Guaven luftgetrocknet, luftgetrockneter Hagebutten,
-			 Traube sprühgetrocknet, sprühgetrockneter Tamarinde"
+				 haselnüsse in getrockneter form, halbgetrocknete spinat, halbgetrocknet sellerie, Feigen halb getrocknet,
+				 Holunder gefriergetrocknet, gefriergetrocknete Papaya, gefriergetrocknetes Kiwi, sonnengetrocknet Ananas,
+				 sonnengetrocknete Pflaumen, an der Sonne getrocknete Grapefruit, Guaven luftgetrocknet, luftgetrockneter Hagebutten,
+				 Traube sprühgetrocknet, sprühgetrockneter Tamarinde"
 		},
 		[
 			{
@@ -1128,7 +1243,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "hartkäse gesalzen, haselnüsse gesalzene, haselnüsse gesalzenes,
-			gesalzener haselnuss, ungesalzen schalotte, ungesalzene mandeln"
+				gesalzener haselnuss, ungesalzen schalotte, ungesalzene mandeln"
 		},
 		[
 			{
@@ -1231,7 +1346,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "hartkäse gehobelt, haselnüsse gehackt,
-		, gehobelte und gehackte mandeln, Dickmilch in scheiben geschnitten"
+			, gehobelte und gehackte mandeln, Dickmilch in scheiben geschnitten"
 		},
 		[
 			{
@@ -1287,7 +1402,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte mariniert, zwiebel marinierte, spinat marinierter,
-		mariniertes sellerie"
+			mariniertes sellerie"
 		},
 		[
 			{
@@ -1318,7 +1433,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalotte geschnitten, zwiebel mittelfein geschnittenen, spinat feingeschnitten,
-			fein geschnittenen sellerie, feingeschnittener Mandeln, handgeschnittene haselnüsse"
+				fein geschnittenen sellerie, feingeschnittener Mandeln, handgeschnittene haselnüsse"
 		},
 		[
 			{
@@ -1413,7 +1528,7 @@ my @tests = (
 		{
 			lc => "de",
 			ingredients_text => "Schalottewürfel, spinat gewürfelt, gewürfelte sellerie,
-			zwiebel in würfel geschnitten, mandeln in würfel"
+				zwiebel in würfel geschnitten, mandeln in würfel"
 		},
 		[
 			{
@@ -1444,121 +1559,59 @@ my @tests = (
 		]
 	],
 
+##################################################################
+	#
+	#                           C R O A T I A N ( H R )
+	#
+##################################################################
+
+	# inspired by 3858881083103
 	[
-		{lc => "en", ingredients_text => "smoked sea salt, smoked turkey"},
+		{lc => "hr", ingredients_text => "papar crni mljeveni"},
 		[
 			{
-				'id' => 'en:sea-salt',
-				'processing' => 'en:smoked',
-				'text' => 'sea salt'
-			},
-			{
-				'id' => 'en:turkey',
-				'processing' => 'en:smoked',
-				'text' => 'turkey'
+				'id' => 'en:black-pepper',
+				'processing' => 'en:ground',
+				'text' => 'papar crni'
 			}
 		]
 	],
-
+	# inspired by 8017596108852
 	[
 		{
-			lc => "fr",
-			ingredients_text => "sel marin fumé, jambon fumé, arôme de fumée, lardons fumés au bois de hêtre "
+			lc => "hr",
+			ingredients_text =>
+				"dehidrirani umak, suncokretovo ulje u prahu, dimljeni slanina, antioksidans (ekstrakt ružmarina)"
 		},
 		[
 			{
-				'id' => 'en:sea-salt',
-				'processing' => 'en:smoked',
-				'text' => 'sel marin'
+				'id' => 'en:sauce',
+				'processing' => 'en:dehydrated',
+				'text' => 'umak'
 			},
 			{
-				'id' => 'en:ham',
-				'processing' => 'en:smoked',
-				'text' => 'jambon'
-			},
-			{
-				'id' => 'en:smoke-flavouring',
-				'text' => "ar\x{f4}me de fum\x{e9}e"
-			},
-			{
-				'id' => 'en:lardon',
-				'processing' => 'en:beech-smoked',
-				'text' => 'lardons'
-			}
-		]
-	],
-
-	[
-		{lc => "es", ingredients_text => "tofu ahumado, panceta ahumada"},
-		[
-			{
-				'id' => 'en:tofu',
-				'processing' => 'en:smoked',
-				'text' => 'tofu'
+				'id' => 'en:sunflower-oil',
+				'processing' => 'en:powder',
+				'text' => 'suncokretovo ulje'
 			},
 			{
 				'id' => 'en:bacon',
 				'processing' => 'en:smoked',
-				'text' => 'panceta'
-			}
-		]
-	],
-
-	# ingredient with (processing) in parenthesis
-	[
-		{lc => "en", ingredients_text => "garlic (powdered)",},
-		[
+				'text' => 'slanina'
+			},
 			{
-				'id' => 'en:garlic',
-				'processing' => 'en:powder',
-				'text' => 'garlic'
-			}
+				'id' => 'en:antioxidant',
+				'text' => 'antioksidans',
+				'ingredients' => [
+					{
+						'id' => "en:rosemary",
+						'processing' => "en:extract",
+						'text' => "ru\x{17e}marina"
+					}
+				],
+			},
 		]
-	],
-
-	[
-		{lc => "fr", ingredients_text => "piment (en poudre)"},
-		[
-			{
-				'id' => 'en:chili-pepper',
-				'processing' => 'en:powder',
-				'text' => 'piment'
-			}
-		]
-	],
-
-	[
-		{lc => "en", ingredients_text => "pasteurized eggs"},
-		[
-			{
-				'id' => 'en:egg',
-				'processing' => 'en:pasteurised',
-				'text' => 'eggs'
-			}
-		]
-	],
-
-	[
-		{lc => "en", ingredients_text => "dry whey"},
-		[
-			{
-				'id' => 'en:whey',
-				'processing' => 'en:dried',
-				'text' => 'whey'
-			}
-		]
-	],
-
-	[
-		{lc => "es", ingredients_text => "pimientos amarillos deshidratados"},
-		[
-			{
-				'id' => 'en:yellow-bell-pepper',
-				'processing' => 'en:dehydrated',
-				'text' => 'pimientos amarillos'
-			}
-		]
-	],
+	]
 
 );
 


### PR DESCRIPTION
WHAT?
Added Croatian language for food processing
Added 2 unit tests *
(added 1 more entry in Croatian taxonomy for processing)
(there were a couple of tests at the end in different language, there are now at the end of their respective languages => and after "make lint" it looks like a lot of things have changed in the file, sorry for that)


\* **Remark**: the case where [ingredient + processing] is a sub-ingredient in parenthesis was not yet included in the tests (like "antioksidans (ekstrakt ružmarina)"). That was a bit tricky to handle, but now it is included in the tests as well.