### PR TITLE
taxonomy: improve taxonomy for products available in Croatia

### DIFF
--- a/docs/reference/schemas/product.yaml
+++ b/docs/reference/schemas/product.yaml
@@ -1959,10 +1959,16 @@ Product:
                   type: string
     serving_quantity:
       type: string
+      description: |
+        Serving quantity entered 
+        by contributors. It must 
+        contain digits and known unit.
     serving_size:
       type: string
       description: |
-        Serving size in g (or ml).
+        Serving size in g (or ml). 
+        It is extracted from 
+        serving_quantity.
     serving_size_imported:
       type: string
     sortkey:

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -150,7 +150,8 @@ my %may_contain_regexps = (
 	en =>
 		"it may contain traces of|possible traces|traces|may also contain|also may contain|may contain|may be present",
 	bg => "продуктът може да съдържа следи от|може да съдържа следи от|може да съдържа",
-	cs => "může obsahovat",
+	bs => "može da sadrži"
+	cs => "může obsahovat", "může obsahovat stopy",
 	da => "produktet kan indeholde|kan indeholde spor af|kan indeholde spor|eventuelle spor|kan indeholde|mulige spor",
 	de => "Kann enthalten|Kann Spuren|Spuren",
 	es => "puede contener huellas de|puede contener trazas de|puede contener|trazas|traza",
@@ -159,7 +160,7 @@ my %may_contain_regexps = (
 		"saattaa sisältää pienehköjä määriä muita|saattaa sisältää pieniä määriä muita|saattaa sisältää pienehköjä määriä|saattaa sisältää pieniä määriä|voi sisältää vähäisiä määriä|saattaa sisältää hivenen|saattaa sisältää pieniä|saattaa sisältää jäämiä|sisältää pienen määrän|jossa käsitellään myös|saattaa sisältää myös|joka käsittelee myös|jossa käsitellään|saattaa sisältää",
 	fr =>
 		"peut également contenir|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace",
-	hr => "može sadržavati|može sadržavati tragove|može sadržati|proizvod može sadržavati|sadrži",
+	hr => "Mogući sadržaj|može sadržavati|može sadržavati tragove|može sadržati|proizvod može sadržavati|sadrži",
 	is => "getur innihaldið leifar|gæti innihaldið snefil|getur innihaldið",
 	it =>
 		"Pu[òo] contenere tracce di|pu[òo] contenere|che utilizza anche|possibili tracce|eventuali tracce|possibile traccia|eventuale traccia|tracce|traccia",
@@ -1732,10 +1733,15 @@ sub parse_ingredients_text ($product_ref) {
 									(
 										#($product_lc =~ /^(en|es|it|fr)$/)
 										(
-											   ($product_lc eq 'en')
+											   ($product_lc eq 'bs')
+											or ($product_lc eq 'cs')
+											or ($product_lc eq 'en')
 											or ($product_lc eq 'es')
 											or ($product_lc eq 'fr')
 											or ($product_lc eq 'it')
+											or ($product_lc eq 'mk')
+											or ($product_lc eq 'sl')
+											or ($product_lc eq 'sr')
 										)
 										and ($new_ingredient =~ /(^($regexp)\b|\b($regexp)$)/i)
 									)
@@ -1886,6 +1892,9 @@ sub parse_ingredients_text ($product_ref) {
 
 						# Remove some sentences
 						my %ignore_regexps = (
+							'bs' => [
+								'u promjenljivom odnosu',  # in a variable ratio
+							],
 
 							'da' => [
 								'^Mælkechokoladen indeholder (?:også andre vegetabilske fedtstoffer end kakaosmør og )?mindst',
@@ -1969,7 +1978,13 @@ sub parse_ingredients_text ($product_ref) {
 								'^täysjyväsisältö',
 							],
 
-							'hr' => ['^u tragovima$',],
+							'hr' => [
+								'^u tragovima$', # in traces
+								'označene podebljano', # marked in bold
+								'savjet kod alergije',  # allergy advice
+								'uključujući žitarice koje sadrže gluten', # including grains containing gluten
+								'za alergene', # for allergens
+							],
 
 							'it' => ['^in proporzion[ei] variabil[ei]$',],
 
@@ -1987,6 +2002,11 @@ sub parse_ingredients_text ($product_ref) {
 								'^углеводы$', '^не менее$',
 								'^средние значения$', '^содержат$',
 								'^идентичный натуральному$', '^(g|ж|ул)$'
+							],
+
+							'sl' => [
+								'lahko vsebuje',
+								'lahko vsebuje sledi', # may contain traces
 							],
 
 							'sv' => [
@@ -3396,7 +3416,7 @@ my %phrases_before_ingredients_list = (
 		'composition',
 	],
 
-	hr => ['HR BiH', 'HR/BIH', 'naziv proizvoda', 'popis sastojaka', 'Sastojci', 'Sastojci/Sestavine'],
+	hr => ['HR BiH', 'HR/BIH', 'naziv', 'naziv proizvoda', 'popis sastojaka', 'sastav', 'sastojci', 'sastojci/sestavine'],
 
 	hu => ['(ö|ő|o)sszetev(ö|ő|o)k', 'összetétel',],
 
@@ -3701,6 +3721,7 @@ my %phrases_after_ingredients_list = (
 		'upotrijebiti do datuma',    # valid until
 		'upozorenje',    # warning
 		'uputa',    # instructions
+		'uvjeti čuvanja',  # storage conditions
 		'uvoznik za',    # importer
 		'vakuumirana',    # Vacuumed
 		'vrijeme kuhanja',    # Cooking time

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -150,8 +150,8 @@ my %may_contain_regexps = (
 	en =>
 		"it may contain traces of|possible traces|traces|may also contain|also may contain|may contain|may be present",
 	bg => "продуктът може да съдържа следи от|може да съдържа следи от|може да съдържа",
-	bs => "može da sadrži"
-	cs => "může obsahovat", "může obsahovat stopy",
+	bs => "može da sadrži",
+	cs => "může obsahovat|může obsahovat stopy",
 	da => "produktet kan indeholde|kan indeholde spor af|kan indeholde spor|eventuelle spor|kan indeholde|mulige spor",
 	de => "Kann enthalten|Kann Spuren|Spuren",
 	es => "puede contener huellas de|puede contener trazas de|puede contener|trazas|traza",
@@ -1893,7 +1893,7 @@ sub parse_ingredients_text ($product_ref) {
 						# Remove some sentences
 						my %ignore_regexps = (
 							'bs' => [
-								'u promjenljivom odnosu',  # in a variable ratio
+								'u promjenljivom odnosu',    # in a variable ratio
 							],
 
 							'da' => [
@@ -1979,11 +1979,11 @@ sub parse_ingredients_text ($product_ref) {
 							],
 
 							'hr' => [
-								'^u tragovima$', # in traces
-								'označene podebljano', # marked in bold
-								'savjet kod alergije',  # allergy advice
-								'uključujući žitarice koje sadrže gluten', # including grains containing gluten
-								'za alergene', # for allergens
+								'^u tragovima$',    # in traces
+								'označene podebljano',    # marked in bold
+								'savjet kod alergije',    # allergy advice
+								'uključujući žitarice koje sadrže gluten',    # including grains containing gluten
+								'za alergene',    # for allergens
 							],
 
 							'it' => ['^in proporzion[ei] variabil[ei]$',],
@@ -2006,7 +2006,7 @@ sub parse_ingredients_text ($product_ref) {
 
 							'sl' => [
 								'lahko vsebuje',
-								'lahko vsebuje sledi', # may contain traces
+								'lahko vsebuje sledi',    # may contain traces
 							],
 
 							'sv' => [
@@ -3416,7 +3416,8 @@ my %phrases_before_ingredients_list = (
 		'composition',
 	],
 
-	hr => ['HR BiH', 'HR/BIH', 'naziv', 'naziv proizvoda', 'popis sastojaka', 'sastav', 'sastojci', 'sastojci/sestavine'],
+	hr =>
+		['HR BiH', 'HR/BIH', 'naziv', 'naziv proizvoda', 'popis sastojaka', 'sastav', 'sastojci', 'sastojci/sestavine'],
 
 	hu => ['(ö|ő|o)sszetev(ö|ő|o)k', 'összetétel',],
 
@@ -3721,7 +3722,7 @@ my %phrases_after_ingredients_list = (
 		'upotrijebiti do datuma',    # valid until
 		'upozorenje',    # warning
 		'uputa',    # instructions
-		'uvjeti čuvanja',  # storage conditions
+		'uvjeti čuvanja',    # storage conditions
 		'uvoznik za',    # importer
 		'vakuumirana',    # Vacuumed
 		'vrijeme kuhanja',    # Cooking time

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -169,6 +169,7 @@ pt:E101, Riboflavina, Vitamina b2, Vitamina G
 ro:E101, Riboflavină, Vitamina B2
 sk:E101, Riboflavín, Vitamín G, Ovoflavín, Vitamín B2, Laktoflavín
 sl:E101, Riboflavin, Vitamin B2
+sr:E101, boje riboflavin
 sv:E101, Riboflavin, Vitamin B2, B2-vitamin
 tr:E101, Riboflavin, B2 Vitamini, B2 Vitamin, Vitamin B2, Laktoflavin
 e_number:en:101
@@ -570,7 +571,7 @@ ro:E120, Coșenilă, acid carminic, carmine, Acidului carminic, carmin
 ru:E120, Кошениль, карминовая кислота, кармин, кармины
 sh:E120, Carmine
 sk:E120, Košenila, kyselina karmínová, karmíny
-sl:E120, Košenilja, karminska kislina, karmini
+sl:E120, Košenilja, karminska kislina, karmini, karmin
 sv:E120, Karmin, karminsyra, E 120
 th:E120, ชาดลิ้นจี่
 tr:E120, Karmin
@@ -1640,7 +1641,7 @@ es:E150c, Caramelo amónico, El caramelo amónico, caramelo de panadería, caram
 et:E150c, Ammooniumkaramell
 fi:E150c, Ammoniummenetelmän sokerikulööri, Ammoniummenetelmän sokerikulööriä
 fr:E150c, Caramel ammoniacal, Caramel E150c, E150c caramel
-hr:E150c
+hr:E150c, amonijačni karamel
 hu:E150c, Ammóniás karamell
 it:E150c, Caramello ammoniacale
 lt:E150c, Amoniakinė karamelė
@@ -1682,7 +1683,7 @@ es:E150d, Caramelo de sulfito amónico, Caramelo sulfito de amoníaco, caramelo 
 et:E150d, Ammooniumsulfitkaramell
 fi:E150d, Ammoniumsulfiittimenetelmän sokerikulööri, Ammoniumsulfiittimenetelmän sokerikulööriä
 fr:E150d, Caramel au sulfite d'ammonium, Caramel E150d, E150d (caramel), E150d caramel, Caramel IV - procédé au sulfite ammoniacal, Caramel IV, C.I. Natural Brown 10, FEMA no. 2235
-hr:E150d
+hr:E150d, sulfitno amonijačni karamel
 hu:E150d, Szulfitos ammóniás karamell
 it:E150d, Caramello solfito-ammoniacale
 lt:E150d, Sulfitinė amoniakinė karamelė
@@ -1931,7 +1932,7 @@ es:E160, Carotenoides
 et:E160, E160 food additive
 fi:E160, Karotenoidit, Karotenoideja
 fr:E160, Caroténoïdes, carotènes, Caroténoïde, caroténoïdes mélangés
-hr:E160, bojilo karoteni, karoteni
+hr:E160, bojilo karoteni, karoteni, koncentrat boje iz mrkve
 hu:E160, Karotinoidok
 it:E160, E160 food additive
 lt:E160, E160 food additive
@@ -2193,6 +2194,7 @@ ro:E160c, Extract de ardei roșu, capsantină, capsorubină
 ru:E160c, Экстракт паприки, капсантин, капсорубин
 sk:E160c, Paprikový extrakt, kapsantín, kapsorubín
 sl:E160c, Izvleček paprike, kapsantin, kapsorubin
+sr:E160c, ekstrakt paprike
 sv:E160c, Paprikaoleoresin, kapsantin, kapsorubin, Paprikaextrakt
 tr:E160c, Paprika ekstraktı
 e_number:en:160c
@@ -2739,7 +2741,7 @@ fa:E163, آنتوسیانین
 fi:E163, Antosyaanit, Antosyaani, Antosyaaneja, Antosyaania, Antosyaaniväri, Antosyaaniväriä, Antosyaanivärit, Antosyaanivärejä
 fr:E163, Anthocyanes, Anthocyane, Anthocyanines
 he:E163, אנתוציאנין
-hr:E163, antocijanin, bojilo antocijani
+hr:E163, antocijanin, antocijani, bojilo antocijani
 hu:E163, Antocianinok, Antociánok
 hy:E163, Անտոցիաններ
 id:E163, Antosianin
@@ -2997,6 +2999,7 @@ ga:E164, cróch
 gl:E164, azafrán
 he:E164, זעפרן
 hi:E164, केसर
+hr:E164, koncentrat za bojenje iz šafrana
 hu:E164, šafran
 id:E164, kuma-kuma
 io:E164, safrano
@@ -4455,6 +4458,7 @@ et:E223, Naatriumdisulfit, Naatriumpürosulfit
 fa:E223, سدیم متابی‌سولفیت
 fi:E223, Natriumdisulfiitti, Natriummetabisulfiitti, Pyrosulfiitti, Natriumpyrosulfiitti, Natriumdisulfiittia, Natriummetabisulfiittia, Pyrosulfiittia, Natriumpyrosulfiittia
 fr:E223, Disulfite de sodium, métabisulfite de sodium, Pyrosulfite, disulfites de sodium, metabisulfite de sodium e223
+hr:E223, Natrijev Metabisulfite
 hu:E223, Nátrium-metabiszulfit, Piroszulfit
 hy:E223, Նատրիումի պիրոսուլֆիտ
 id:E223, Natrium metabisulfit
@@ -6222,7 +6226,7 @@ gl:E290, Dióxido de carbono
 gv:E290, Daa-ocseed charboan
 he:E290, פחמן דו-חמצני
 hi:E290, कार्बन डाईऑक्साइड
-hr:E290, Ugljikov oksid, ugljikov dioksid, ugljični dioksid, CO₂
+hr:E290, Ugljikov oksid, ugljikov dioksid, ugljični dioksid, CO₂, CO2
 ht:E290, Dyoksid kabòn
 hu:E290, Szén-dioxid
 hy:E290, ածխաթթու գազ
@@ -6458,11 +6462,12 @@ es:E300, Ácido ascórbico, Ácido l-ascórbico, Ácido L-ascórbico
 et:E300, Askorbiinhape
 fi:E300, Askorbiinihappo, L-askorbiinihappo, Askorbiinihappoa, L-askorbiinihappoa, c-vitamiini
 fr:E300, Acide ascorbique, Acide L-ascorbique, Acide ascorbique (L-), Acide L(+)-ascorbique, Ascorbate, vitamine c
-hr:E300, askorbinska kiselina, l-askorbinska kiselina
+hr:E300, askorbinska kiselina, l-askorbinska kiselina, antioksidat e300, askrobinska kiselina
 hu:E300, Aszkorbinsav, l-aszkorbinsav
 it:E300, Acido ascorbico, acido l-ascorbico, Ascorbato
 lt:E300, Askorbo rūgštis, l-askorbo rūgštis, Askorbinas
 lv:E300, Askorbīnskābe, l-askorbīnskābe
+mk:E300, аскорбинска киселина
 mt:E300, Aċidu askorbiku, aċidu l-askorbiku
 nb:E300, Askorbinsyre, L-Askorbinsyre
 nl:E300, Ascorbinezuur
@@ -6734,6 +6739,7 @@ es:E306, Extracto rico en tocoferoles, Extracto rico en tocoferol, mezcla de toc
 et:E306, Tokoferoolikontsentraat
 fi:E306, Tokoferoliuute, Tokoferoliuutetta
 fr:E306, Extrait riche en tocophérols, extraits riches en tocophérol, Extraits riches en tocophérols, extraits d'origine naturelle riches en tocophérols, mélange de tocophérols
+hr:E306, mješavina tokoferola obogačena
 hu:E306, Tokoferolban gazdag kivonat, tokoferolok, természetes tokoferolok, vegyes tokoferolok
 it:E306, Estratto ricco in tocoferolo, estratto ricco in tocoferoli, estratto ricco di tocoferolo, estratto ricco di tocoferoli
 lt:E306, Tokoferolių koncentruotas ekstraktas
@@ -7736,7 +7742,7 @@ wikidata:en:Q594836
 vegan:en:yes
 vegetarian:en:yes
 
-en:E330, Citric acid
+en:E330, citric acid, acity regulator-citric acid
 af:Sitroensuur
 ar:E330, حمض الليمون
 az:E330, Limon turşusu
@@ -7760,7 +7766,7 @@ ga:E330, Aigéad citreach
 gl:E330, Ácido cítrico
 he:E330, חומצה ציטרית
 hi:E330, सिट्रिक अम्ल
-hr:E330, kiselina limunska kiselina, limunska, limunska kiselina, limunska kiseline, kiselinski dodatak limunska kiselnia
+hr:E330, kiselina limunska kiselina, limunska, limunska kiselina, limunska kiseline, kiselinski dodatak limunska kiselnia, regulator kiselosti limunska kiselina, citratna kiselina
 hu:E330, Citromsav
 hy:E330, Կիտրոնաթթու
 id:E330, Asam sitrat
@@ -7857,7 +7863,7 @@ es:E331, Citratos de sodio
 et:E331
 fi:E331, Natriumsitraatit, natriumsitraatti
 fr:E331, Citrates de sodium
-hr:E331, natrijevi citrati, natrijev citrat, regulator kiselosti natrijevi citrati
+hr:E331, natrijevi citrati, natrijev citrat, natrij citrat, regulator kiselosti natrijevi citrati
 hu:E331, nátrium-citrátok
 it:E331, Citrati di sodio
 lt:E331, natrio citratas
@@ -8192,6 +8198,7 @@ et:E333(iii), Kaltsiumtsitraat
 fa:E333(iii), کلسیم سیترات
 fi:E333(iii), Trikalsiumsitraatti, Trikalsiumsitraattia
 fr:E333(iii), Citrate tricalcique, Citrate de tricalcium
+hr:E333(iii), trikalcijcitrat
 hu:E333(iii), Trikalcium-citrát
 it:E333(iii), Citrato tricalcico
 lt:E333(iii), Trikalcio citratas
@@ -8557,6 +8564,7 @@ it:E339, fosfati di sodio, Fosfato di sodio
 ja:E339, リン酸塩
 lt:E339, Natrio fosfatas
 lv:E339, Nātrija fosfāts
+mk:E339, стабилизатор натриум фосфати
 mt:E339, Fosfat tas-sodju
 nl:E339, natriumfosfaten, Natriumorthofosfaten, Natriumfosfaat
 nn:E339, natriumfosfat
@@ -8838,6 +8846,7 @@ es:E341, Fosfatos de calcio, Fosfato de calcio, Fosfato cálcico, Sales Cálcica
 et:E341, E341 food additive
 fi:E341, Kalsiumfosfaatti, Kalsiumfosfaattia
 fr:E341, Phosphates de calcium, Orthophosphates de calcium
+hr:E341
 hu:E341, Kalcium-foszfátok, kalcium-foszfát
 it:E341, E341 food additive
 lt:E341, E341 food additive
@@ -10469,6 +10478,7 @@ ro:E407, Caragenan
 ru:E407, Каррагинан и его соли, Каррагинан, Ирландский мох, Карраген
 sk:E407, Karagénan, Karagén
 sl:E407, Karagenan
+sr:E407, karagenan
 sv:E407, Karragenan
 sw:E407, Karragenan
 ta:E407, கராகீனன்
@@ -10627,6 +10637,7 @@ ro:E410, Gumă din semințe de carruba, Gumă din semințe de roșcov
 ru:E410, Камедь рожкового дерева
 sk:E410, Karobová guma, Guma z karobových bôbov
 sl:E410, Gumi iz zrn rožičevca
+sr:E410
 sv:E410, E410 food additive
 uk:E410, Камедь рожкового дерева
 zh:E410, 刺槐豆膠
@@ -10691,9 +10702,11 @@ nl:E412, Guarpitmeel, Cyamopsisgom, Guargom
 pl:E412, Guma guar, Guma cyamopsis
 pt:E412, Goma de guar, Goma de cyamopsis, Goma guar
 ro:E412, Gumă de guar, Gumă de Cyamopsis
+rs:E412
 ru:E412, Гуаровая камедь,Гуаран
 sk:E412, Guarová guma, Guma cyamopsis
 sl:E412, Guar gumi, guma cyamopsis
+sr:E412
 sv:E412, Guarkärnmjöl, Guargummi, Guarmjöl, Guarkärnsmjöl
 tr:E412, Guar zamkı, Guar gam, Guar gum, Guar gamı
 e_number:en:412
@@ -10764,6 +10777,7 @@ hu:E414, Gumiarábikum, Akácmézga
 it:E414, Gomma d'acacia, Gomma arabica
 lt:E414, Akacijų derva (gumiarabikas), Gumiarabikas
 lv:E414, Akācijas sveķi
+mk:E414
 mt:E414, Gomma tal-akaċja
 nl:E414, Arabische gom
 pl:E414, Guma akacjowa, Guma arabska
@@ -10900,6 +10914,7 @@ nl:E417, Taragom
 pl:E417, Guma tara
 pt:E417, Goma de tara
 ro:E417, Gumă tara
+rs:E417
 sk:E417, Guma tara
 sl:E417, Tara gumi
 sv:E417, Taragummi, Tarakärnmjöl
@@ -11926,7 +11941,7 @@ fr:E440, Pectines, Pectine
 ga:E440, Peictin
 gl:E440, Pectina
 he:E440, פקטין
-hr:E440, pektin
+hr:E440, pektin, eko pektin
 hu:E440, Pektin, Pektinek
 hy:E440, Պեկտինյան նյութեր
 id:E440, Pektin
@@ -11938,6 +11953,7 @@ ko:E440, 펙틴
 ky:E440, Пектиндер
 lt:E440, Pektinas
 lv:E440, pektīnvielas
+mk:E440
 mt:E440, E440 food additive
 nb:E440, Pektiner
 nl:E440, Pectine, pectines, pectinen
@@ -12162,6 +12178,7 @@ it:E445, Esteri della glicerina della resina del legno
 ja:E445, ウッドロジングリセリンエステル
 lt:E445, Medienos kanifolijos glicerolio esteriai
 lv:E445, Kolofonija glicerīna esteri
+mk:E445
 mt:E445, Esteri tal-gliċerol tar-rożin tal-injam
 nb:E445, Glyserolestere av trekolofonium
 nl:E445, Glycerolesters van houthars
@@ -13490,6 +13507,7 @@ it:E466, Carbossimetilcellulosa sodica, carbossimetilcellulosa, gomma di cellulo
 ja:E466, カルボキシメチルセルロース
 lt:E466, Natrio karboksimetilceliuliozė, karboksimetilceliuliozė, celiuliozės derva, CMC, NaCMC
 lv:E466, Nātrija karboksimetilceluloze, karboksimetilceluloze, celulozes sveķi, CMC, NaCMC
+mk:E466, карбокси метил целулоза
 mt:E466, Ċelluloża karbossimetilika tas-sodju, ċelluloża karbossimetilika, gomma taċ-ċelluloża, CMC, NaCMC
 nl:E466, Natriumcarboxymethylcellulose, carboxymethylcellulose, cellulosegom, natriumcarboxylmethylcellulose
 pl:E466, Sól sodowa karboksymetylocelulozy, karboksymetyloceluloza, guma celulozowa, CMC, NaCMC
@@ -13702,6 +13720,7 @@ es:E470b, Sales magnésicas de ácidos grasos, sales de magnesio de ácidos gras
 et:E470b, Rasvhapete magneesiumisoolad
 fi:E470b, Rasvahappojen magnesiumsuolat, Rasvahappojen magnesiumsuoloja
 fr:E470b, Sels de magnésium d'acides gras, Sel de magnésium d'acides gras
+hr:E470b, magn. soli masnih kiselina
 hu:E470b, Zsírsavak magnéziumsói
 it:E470b, Sali di magnesio degli acidi grassi
 lt:E470b, Magnesium salts of fatty acids
@@ -13725,7 +13744,7 @@ en:E471, Mono- and diglycerides of fatty acids, Glyceryl monostearate, Glyceryl 
 ar:E471, أحادي وثنائي الجليسريدات للأحماض الدهنية
 bg:E471, Моно- и диглицериди на мастни киселини, Глицерил моностеарат, глицерил монопалмитат, глицерил моноолеат, и т.н., моностеарин, монопалмитин, моноолеин
 ca:E471, Monoglicèrids i diglicèrids d'àcids grassos, Monoglicèrid o diglicèrid d'àcids grassos, monoglicèrids i diglicèrids dels àcids grassos
-cs:E471, Mono- a diglyceridy mastných kyselin, Glycerylmonostearát, glycerylmonopalmitát, glycerylmonooleát, monostearin, monopalmitin, monoolein
+cs:E471, Mono- a diglyceridy mastných kyselin, mono a diglyceridy mastných kyselin, Glycerylmonostearát, glycerylmonopalmitát, glycerylmonooleát, monostearin, monopalmitin, monoolein
 da:E471, Mono- og diglycerider af fedtsyrer, Glycerylmonostearat, glycerylmonopalmitat
 de:E471, Mono- und Diglyceride von Speisefettsäuren, Glycerylmonostearat, Glycerylmonopalmitat, Glycerylmonooleat, Monostearin, Monopalmitin, Monoolein
 el:E471, Μονο- και διγλυκεριδια λιπαρων οξεων, Μονοστεατικό γλυκερύλιο, μονοπαλμιτικό γλυκερύλιο, μονοελαϊκό γλυκερύλιο, μονοστεατίνη, μονοπαλμιτίνη
@@ -13733,7 +13752,7 @@ es:E471, mono- y diglicéridos de ácidos grasos, Monoglicéridos y diglicérido
 et:E471, Rasvhapete mono- ja diglütseriidid, Glütserüülmonostearaat, glütserüülmonopalmitaat, glütserüülmonooleaat, monosteariin, monopalmitiin
 fi:E471, Rasvahappojen mono- ja diglyseridit, Glyseryylimonostearaatti, Glyseryylimonopalmitaatti, Glyseryylimono-oleaatti, Monosteariini, Monopalmitiini, Mono-oleiini
 fr:E471, Mono- et diglycérides d'acides gras, Mono- et diglycérides d'acides gras alimentaires, Monoglycérides et diglycérides d'acides gras, Mono et diglycérides d'acides gras, Monostéarate de glycérine, Monopalmitate de glycérine, Monooléate de glycérine, Monostéarine, monopalmitine, monooléine, Mono and diglycerides of fatty acids, glyceryl monostearate, glyceryl distearate , Monostéarine
-hr:E471, mono- i digliceridi masnih kiselina, mono - i digliceridi masnih kiselina, emulgator mono - i digliceridi masnih kiselina
+hr:E471, mono- i digliceridi masnih kiselina, mono - i digliceridi masnih kiselina, emulgator mono - i digliceridi masnih kiselina, monogliceridi i digliceridi masnih kiselina
 hu:E471, Zsírsavak mono- és digliceridjei, Gliceril-monosztearát, Gliceril-monopalmitát, Gliceril-monooleát, Monosztearin, monopalmitin, monoolein
 it:E471, Mono- e digliceridi degli acidi grassi, Monostearato di glicerile, monopalmitato di glicerile, monooleato di glicerile, monostearina, monopalmitina, monooleina, mono- e digliceridi degli acidi grassi alimentari
 lt:E471, Riebalų rūgščių mono- ir digliceridai, Glicerilmonostearatas, glicerilmonopalmitatas, glicerilmonooleatas, monostearinas, monopalmitinas, monooleinas
@@ -15441,7 +15460,7 @@ fi:E503(ii), Ammoniumvetykarbonaatti, Ammoniumvetykarbonaattia, hirvensarvisuola
 fr:E503(ii), Carbonate acide d'ammonium, bicarbonate d'ammonium
 gl:E503(ii), Bicarbonato amónico
 hi:E503(ii), अमोनियम बाईकार्बोनेट
-hr:E503(ii), amonijev hidrogen karbonat
+hr:E503(ii), amonijev hidrogenkarbonat, amonijev hidrogen karbonat, tvar za rahljanje e503ii
 hu:E503(ii), Ammónium-hidrogén-karbonát
 is:E503(ii), Ammoníumbíkarbónat
 it:E503(ii), Carbonato acido di ammonio, carbonato acido d'ammonio, Bicarbonato di ammonio
@@ -16421,7 +16440,7 @@ gl:E524, Hidróxido de sodio
 gv:E524, Hydrocseed sodjum
 he:E524, נתרן הידרוקסידי
 hi:E524, क्षारातु उदजारेय
-hr:E524, natrijev hidroksid
+hr:E524, natrijev hidroksid, tvar za regulaciju kiselosti e524
 hu:E524, Nátrium-hidroxid, Lúg
 hy:E524, Նատրիումի հիդրօքսիդ
 id:E524, Natrium hidroksida
@@ -16966,7 +16985,7 @@ fr:E551, Dioxyde de silicium, silice, Gel bleu de silice, Gel 60 de silice, Diox
 ga:Silice
 he:E551, צורן דו-חמצני
 hi:E551, सिलिका
-hr:E551, Silicijev dioksid, silicijum dioksid
+hr:E551, silicijev dioksid, silicijum dioksid
 hu:E551, Szilícium-dioxid, Szilika
 hy:E551, Սիլիցիումի երկօքսիդ
 id:E551, Silikon dioksida
@@ -17948,7 +17967,7 @@ sh:E621, Mononatrijum glutamat
 si:E621, මොනොසෝඩියම් ග්ලූටමේට්
 sk:E621, Glutaman sodný, Glutaman sodný, E 621
 sl:E621, Mononatrijev glutamat, natrijev glutamat, mononatrijevgluamat
-sr:E621, Mononatrijum glutamat
+sr:E621, Mononatrijum glutamat, pojačivači arome mononatrijum-glutaminat
 su:E621, Monosodium glutamat
 sv:E621, Mononatriumglutamat, Natriumglutamat, Monosodiumglutamat, E 621, Smaksalt, Weijing
 ta:E621, மோனோ சோடியம் குளூட்டாமேட்
@@ -18442,6 +18461,7 @@ ro:E635, 5'-ribonucleotidă disodică
 ru:E635, e635, 5-рибонуклеотиды натрия 2-замещенные, 2-замещенный 5'-гуанилат натрия, 5 гуанилат натрия 2 замещенный
 sk:E635, 5'-ribonukleotid disodný
 sl:E635, Dinatrijev 5'-ribonukleotid
+sr:E635, dinatrijum 5'-ribonukleotidi
 sv:E635, Dinatrium-5'-ribonukleotider
 e_number:en:635
 wikidata:en:Q18967210
@@ -21115,6 +21135,7 @@ it:E950, Acesulfame K, acesulfame potassico
 ja:E950, アセスルファムK
 lt:E950, Acesulfamas k, Acesulfamo kalis
 lv:E950, Acesulfāms k, Acesulfamkālijs
+mk:E950, ацесулфам к
 mt:E950, Aċesulfam k, Aċesulfam tal-potassju
 nb:E950, Acesulfam K
 nl:E950, Acesulfaam-k, Acesulfaam-kalium
@@ -21224,7 +21245,7 @@ bg:E952, цикламова киселина и нейните натриеви 
 ca:E952, Àcid ciclàmic i les seves sals de sodi i calci
 cs:E952, Kyselina cyklamová a její sodná a vápenatá sůl
 da:E952, Cyclaminsyre samt na- og ca-salte deraf
-de:E952, Cyclamat, Cyclaminsäure, Cyclohexylsulfaminsäure, N-Cyclohexylsulfaminsäure
+de:E952, Cyclamat, Cyclaminsäure, Cyclohexylsulfaminsäure, N-Cyclohexylsulfaminsäure, Natrium Cyclamat
 el:E952, Κυκλαμικο οξυ και τα αλατα του με νατριο και ασβεστιο, Κυκλαμικό οξύ
 eo:E952, Ciklamato
 es:E952, Ciclamato, Ciclamatos, Ácido ciclámico y sus sales de sodio y calcio, ciclamato sodico
@@ -21408,6 +21429,7 @@ it:E955, Sucralosio, C12H19Cl3O8
 ja:E955, スクラロース
 lt:E955, Sukralozė
 lv:E955, Sukraloze
+mk:E955, засладувач сукралоза
 mt:E955, Sukralożju
 nl:E955, Sucralose
 pl:E955, Sukraloza, Splenda

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -25,6 +25,7 @@ it: Acidificante, acidificanti
 ja: 酸味料
 lt: Rūgštis
 lv: Skābe
+mk: киселина
 mt: Aċidu
 nb: Syre, Syrer
 nl: Voedingszuur, voedingszuren
@@ -70,7 +71,7 @@ fi: Happamuudensäätöaine, Happamuudensäätöaineet, Happamuudensäätöainet
 fr: Correcteur d’acidité, régulateur de l'acidité, régulateur d'acidité, agent tampon, ajusteur du pH, alcali, base, tampon
 ga: Rialtán aigéadachta
 he:מווסת חומציות
-hr: regulator kiselosti, regulatori kiselosti
+hr: regulator kiselosti, regulatori kiselosti, tvar za rahljanje, tvar za regulaciju, tvar za regulaciju kiselost
 hu: Savanyúságot szabályozó anyag, Savanyúságot szabályozó anyagok, Savanyúságot szabályzó anyag, Savanyúságot szabályzó anyagok
 id: pengatur keasaman
 is: Sýrustillir, Sýrustillar
@@ -87,6 +88,7 @@ ro: Corector de aciditate, Regulator de aciditate, regulatori de aciditate
 ru:Регулятор кислотности, регуляторы кислотности
 sk: Regulátor kyslosti
 sl: Sredstvo za uravnavanje kislosti
+sr: regulator kiselosti
 sv: Surhetsreglerande medel, Surhetsreglerandemedel, Surhetsregulator
 wikidata:en:Q898753
 description:en:Acidity regulators are substances which alter or control the acidity or alkalinity of a foodstuff.
@@ -215,12 +217,13 @@ et: Antioksüdant
 fi: Hapettumisenestoaine, Hapettumisenestoainetta, Hapettumisenestoaineet, Hapettumisenestoaineita, Antioksidantti
 fr: Antioxydant, antioxygène, antibrunissant, antioxydant synergique, anti-oxydant
 ga: Frithocsaídeoir
-hr: antioksidans, antioksidant
+hr: antioksidans, antioksidant, antioksidat
 hu: Antioxidáns, antioxidánsok
 it: Antiossidante, antiossidanti, agente antiossidante, agenti antiossidanti
 ja: 酸化防止剤
 lt: Antioksidantas
 lv: Antioksidants
+mk: антиоксиданс
 mt: Antiossidant
 nb: Antioxidant, Antioksidant
 nl: antioxidant, antioxidanten
@@ -360,6 +363,7 @@ is: Litarefni
 it: Colorante, coloranti, alimento colorante
 lt: Dažiklis
 lv: Krāsa
+mk: боја
 mt: Kulur
 nb: Farge, Farve, Fargestoff, Fargestoffer, fødevarer der farver
 nl: Kleuren, Kleurstof, kleurstoffen, kleurend levensmiddel
@@ -369,6 +373,7 @@ ro: Colorant, coloranți
 ru: Краситель, красители, краситель пищевой, пищевые красители, пищевой краситель
 sl: Barvilo
 sk: Farbivo
+sr: boja
 sv: Färg, Färgämne, Färgämnen, färgande livsmedel
 zh:色素
 wikidata:en:Q753009
@@ -451,13 +456,14 @@ et: Emulgaator
 fi: Emulgointiaine, Emulgointiainetta, Emulgointiaineet, Emulgointiaineita
 fr: Émulsifiant, agent de dispersion, agent de surface, agent de suspension, agent d'ajustement de la densité, inhibiteur de cristallisation, nébulisant, plastifiant
 ga: Eiblitheoir
-hr: emulgator, emulgatori, emlgatori
+hr: emulgator, emulgatori, emlgatori, emuglator
 hu: Emulgeálószer, emulgeálószerek, kristályosodásgátló, sűrűségszabályozó szer, diszpergálószer, lágyító, felületaktív anyag, szuszpenziós szer
 is: Yruefni
 it: Emulsionante, emulsionanti, agente emulsionante, agenti emulsionanti
 ja: 乳化剤
 lt: Emulsiklis, emulsikliai
 lv: Emulgators
+mk: емулгатор
 mt: Emulsifikant
 nb: Emulgeringsmiddel, Emulgator, Emulgatorer
 nl: Emulgator, Emulgatoren
@@ -755,7 +761,7 @@ et:Želeeriv aine
 fi:Hyytelöimisaine, Hyytelöimisainetta, Hyytelöimisaineet, Hyytelöimisaineita
 fr:Gélifiant, Agent gélifiant
 ga:Oibreán glóthúcháin
-hr:tvar za želiranje
+hr:tvar za želiranje, tvar za želiranje pektin, sredstvo za želiranje
 hu:Zselésítőanyag, zselésítő anyag, zselésítő
 it:Gelificante, gelificanti, agente gelificante, agenti gelificanti
 lt:Stingdiklis
@@ -1157,6 +1163,7 @@ is:bindiefni
 it: Stabilizzante, stabilizzanti, agente stabilizzante, agenti stabilizzanti, legante, leganti
 lt: Stabilizatorius
 lv: Stabilizētājs
+mk: стабилизатор, стабилизатори
 mt: Stabbilizzatur
 nb: Stabilisator, Stabilisatorer
 nl: Stabilisator, Stabilisatoren
@@ -1202,19 +1209,20 @@ bg: Подсладител, подсладители
 ca: Edulcorant, esdulcorants
 cs: Sladidlo
 da: Sødestof, Sødestoffer, Kunstigt sødemiddel, sødemiddel
-de: Süßungsmittel, süssungsmittel
+de: süßungsmittel, süssungsmittel, sußungsmittel
 el: Γλυκαντικό
 es: Edulcorante, Endulzante, edulcorante intenso, edulcorante masivo
 et: Magusaine
 fi: Makeutusaine, Makeutusainetta, Makeutusaineet, Makeutusaineita
 fr: Édulcorant, édulcorant de charge, édulcorant intense
 ga: Milseoir
-hr: sladila, sladilo, zaslađivač
+hr: sladila, sladilo, zaslađivač, zaslađivanje
 hu: Édesítőszer, édesítőszerek
 it: Edulcorante, edulcoranti, dolcificante, dolcificanti
 ja: 甘味料
 lt: Saldiklis
 lv: Saldinātājs
+mk: сладила
 mt: Dolċifikant
 nb: Søtningsmiddel, Søtstoff, Søtstoffer
 nl: Zoetstof, Zoetstoffen
@@ -1268,6 +1276,7 @@ it: Addensante, addensanti, agente addensante, agenti addensanti
 ja: 増粘剤
 lt: Tirštiklis
 lv: Biezinātājs
+mk: згуснувач
 mt: Aġent li jgħaqqad
 nb: Fortykningsmiddel, Fortykningsmidler
 nl: Verdikkingsmiddel, Verdikkingsmiddelen
@@ -1277,7 +1286,8 @@ pt: Espessante, espessantes
 ro: Agent de îngroșare, agenți de îngroșare
 ru:Загуститель
 sk: Zahusťovadlo
-sl: Sladilo
+sl: Sladilo, zgoščevalec
+sr: zgušnjavači
 sv: Förtjockningsmedel, naturlig förtjockningsmedel
 wikidata:en:Q911138
 description:en:Thickeners are substances which increase the viscosity of a foodstuff.
@@ -1313,7 +1323,7 @@ es:Vitaminas
 et:Vitamiinid
 fi:Vitamiinit, Vitamiineja
 fr:Vitamines
-hr:vitamini, vitamins
+hr:vitamini, vitamins, vitamin complex
 hu:Vitaminok
 it:Vitamine
 lt:Vitaminai

--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -24,7 +24,8 @@ sr:ništa, nijedan, nijedno, bez alergena, nema alergena, bez, 0
 en:gluten, cereals containing gluten, barley, barley malt flour, malted barley, malted barley extract, malted barley flour, kamut, rye, rye flour, spelt, speltflour, wheat, wheat flour, wheatflour, wheat semolina, oats, oat fiber
 ar:غلوتين
 bg:глутен, ечемик, ечемичен, ечемично-малцов, пшеница, пшенично, пшеничено, ръж, овес, спелта, камут, хоросан, вид едра твърда пшеница, лимец, булгур 
-cs:lepek, pšenice, žito, ječmen, oves, špalda, kamut
+bs:gluten
+cs:lepek, pšenice, žito, ječmen, oves, špalda, kamut, obilovin obsahujících lepe
 da:gluten, hvede, durumhvede, rug, byg, havre, spelt, kamut, bygmalt, bygmaltmel, bygmaltekstrakt, havremel, hvedemel, durumhvedemel, fuldkornshvede, fuldkornshvedemel, havregryn, ruggryn, havreflager, speltflager, hvedeklid, hvedestivelse, hvedegluten, bygmalteddike, kornprodukter som indeholder gluten
 de:Gluten, Weizen, Roggen, Gerste, Hafer, Dinkel, Kamut, Gerstenmehl, Gerstenvollkornmehl, Hafer-Vollkornmehl, Haferflocken, Haferkleie, Hafervollkornflocken, Hafervollkornmehl, Vollkorn-Hafer, Vollkorn-Haferflocken, Vollkorn-Hafermehl, Vollkornhafermehl, Vollkornhafer, Vollkornhaferflocken, Vollkornhaferschrot, Vollkornweizenmehl, Weizenvollkornmehl, Weizenmehl, Weizengluten, Weizensauerteig, Hartweizen, Gluten enthaltendes Getreide, Gluten-enthaltendes-Getreide, Gerstenmalzextrakt, Gerstenmalz, Weizenstärke, Hartweizengriess, Hartweizengrieß, Roggenmehl, Weizenmalzmehl, Dinkelmehl, Gerstenmalzmehl, Weizenmalz, Roggenvollkornmehl, Weizenkleber, Roggenvollkornschrot, Dinkelvollkornmehl, Hafermehl, Weizenflocken, Weizenvollkornflocken, Weizengrieß, Weizengriess, Weizenkleie, Gerstenflocken, Weizenquellmehl, Roggenflocken, Vollkorn-Weizenflocken, Weizenvollkornschrot, Weizenspeisekleie, Weichweizenmehl, Dinkelflocken, Roggenvollkornflocken, Malzmehl, Dinkelvollkornflocken, Dinkelvollkornschrot, Roggenschrot, Gersten, Weizenrostmalzmehl, Vollkornweizen, Haferfaser
 ee:nisu, odrasiirup, odralinnaseekstrakt
@@ -35,7 +36,7 @@ fi:gluteeni, gluteenia, gluteenista, gluteenit, gluteeneja, gluteeneista, vehnä
 fr:gluten, blé, seigle, orge, épeautre, kamut, son de blé, blé complet, gluten de blé, fibre de blé, malt d'orge, malt, froment, farine de blé, farine de froment, boulgour, petit épeautre, céréales contenant du gluten, blé dur, épeautre, petit épeautre, grand épeautre, farine d'épeautre
 ga:glútan, cruithneacht, seagal, eorna, coirce, speilt, camut, céréeale, céréales
 he:גלוטן, קמח, סמולינה, דורום, חיטה, לתת כשות, מדגנים, דגנים
-hr:gluten, glutena, ječmeni, ječmeni slad, ječam, ječma, ječmeno, ječmenog, psenicu, pšenična, pšenične, pšenični, pšenično, pšenično brašno, pšeničnog glutena, pšenični gluten, pšenični gluten u aromi, pšenično pirovo, pšenicu, raži, raženo, zobena, zobene, zobeno, žitarica koje sadrže gluten, žitarice koje sadrže gluten
+hr:gluten, glutena, ječmeni, ječmeni slad, ječam, ječma, ječmeno, ječmenog, psenicu, pšenična, pšenice, pšenične, pšenični, pšenično, pšenično brašno, pšeničnog glutena, pšenični gluten, pšenični gluten u aromi, pšenično pirovo, pšenicu, raži, raženo, zobena, zobene, zobeno, žitarica koje sadrže gluten, žitarice koje sadrže gluten
 hu:glutén, búza, búzaliszt, búzarost, búzadara, búzacsíra, búzafehérje, búzakorpa, búzamaláta, búzapehely, búzakeményítő, búzasikér, tönkölybúza, tönkölybúzaliszt, tönkölybúzapehely, durumbúza, durumbúzaliszt, rozs, rozsliszt, rozspehely, durumrozsliszt, árpa, árpaliszt, árpapehely, árpamaláta, árpadara, árpacsíra, zab, zabliszt, zabpehely, zabkorpa, durumliszt, durum liszt, Grahamliszt, Graham liszt, kenyérliszt, kenyér liszt, rétesliszt, rétes liszt, kamut, alakor, bulgur, glutént, glutént tartalmazó gabona, glutént tartalmazó gabonafélék
 is:glúten
 it:glutine, grano, segale, orzo, farro, kamut, frumento, farina di frumento, farina di frumento integrale
@@ -51,7 +52,7 @@ pt:glúten, trigo, centeio, cevada, aveia, malte, extrato de malte, espelta, tri
 ro:gluten, grâu, secară, orz, ovăz, grâu spelt, grâu dur, griș de grău
 ru:глютен, пшеница, рожь, ячмень, овёс, полба (камут) (спельта) (двузернянка) (фарро), манная крупа
 sk:pšenica, pšenica obyčajná, raž, jačmeň, ovos, pšenica, špalda, cirok, glutén, lepok
-sl:gluten, pšenica, rž, ječmen, oves, pira, kamut
+sl:gluten, pšenica, pšenico, rž, ječmen, oves, pira, kamut
 sr:pšenica, pšenično, pšenični, gluten, glutenom, glutenski, surutka, surutke, surutkom, spelta, pšenični griz
 sv:gluten, vete, durumvete, råg, korn, havre, spelt, kamut, dinkel, dinkelvete, vetemjöl, durumvetemjöl, rågmjöl, kornmjöl, havremjöl, speltmjöl, kamutmjöl, havrekorn, vetekli, rågkli, kornkli, havrekli, speltkli, kamutkli, veteflingor, rågflingor, kornflingor, havreflingor, speltflingor, kamutflingor, dinkelflingor, fullkornsvete, fullkornsdurumvete, fullkornsråg, fullkornskorn, fullkornshavre, fullkornsspelt, fullkornskamut, fullkornsvetemjöl, fullkornsdurumvetemjöl, fullkornsrågmjöl, fullkornshavremjöl, fullkornsveteflingor, fullkornsrågflingor, fullkornshavreflingor, fullkornsspeltflingor, fullkornskamutflingor, fullkornsrågkross, malt, vetemalt, vetemaltextrakt, rågmalt, rågmaltextrakt, kornmalt, kornmaltextrakt, kornmaltsextrakt, havremalt, havremaltextrakt, speltmalt, speltmaltextrakt, kamutmalt, kamutmaltextrakt, dinkelmalt, vetegryn, råggryn, korngryn, havregryn, speltgryn, kamutgryn, vetegroddar, råggroddar, korngroddar, havregroddar, speltgroddar, kamutgroddar, vetefibrer, vetestärkelse, kornmaltvinäger, vetedextros, vetegluten, råggluten, korngluten, havreglute, sädesslag, andra sädesslag, spannmål som innehåller gluten
 th:กลูเต็น,ข้าวสาลี,ข้าวไร,บาร์เลย์
@@ -136,7 +137,7 @@ fi:kala, kalaa, kalasta, kalat, kaloja, kaloista, kalaöljy, kalaöljyä, kalaö
 fr:poisson, poissons, cabillaud, morue, maquereau, flétan, turbot, colin, haddock, aiglefin, saumon, sole, truite, thon, sardine, sardines, loup, colin d'Alaska, anchois, brochet, hareng, harengs, merlu, lieu, merlan, saumon fumé, rouget, limande, tacaud
 ga:éisc, iasc, trosc, troisc, leadhbóg, leadhbóige, cadóg, cadóige, bradán, bradáin, sól, sóil, breac, bric, tuinnín
 he:דג, דגים, טונה, סלמון, קוד, מקרל, ברבוניה, הליבוט, דניס, סול, סרדינים
-hr:riba, skuša
+hr:riba, ribe, skuša
 hu:hal, halak, tőkehal, tőkehalfilé, makréla, hering, heringfilé, lazac, lazacfilé, pisztráng, tonhal, szardínia, lepényhal, rombuszhal, sprotni, alaszkai tőkehal
 it:pesce
 jp:魚,サバ,サケ
@@ -161,7 +162,7 @@ wikidata:en:Q600396
 en:peanuts, peanut, arachis hypogaea
 ar:فول سوداني
 bg:фъстъци, arachis hypogaea
-cs:jádra podzemnice olejné, arašídy, arachis hypogaea
+cs:jádra podzemnice olejné, arašídů, arašídy, arachis hypogaea
 da:jordnødder, jordnød, arachis hypogaea
 de:Erdnüsse, Erdnuss, Erdnüssen, arachis hypogaea, Erdnusskerne
 el:αραχίδες, αραχίδα, arachis hypogaea
@@ -222,7 +223,7 @@ pt:soja, sementes de soja, grão de soja, lecitina de soja
 ro:soia, lecitină din soia
 ru:соя, соевые бобы
 sk:sójové bôby, sójové, sója, sóje, sójových bôbov
-sl:zrnje soje, soje
+sl:zrnja soje, zrnje soje, soje, sojo
 sr:soja, sojin, sojino, sojin lecitin, sojino brašno
 sv:soja, sojabönor, sojalecitin, sojabönolja, sojaprotein, sojasås, sojamjöl
 th:ถั่วเหลือง
@@ -241,7 +242,7 @@ fi:maito, maidon, maitoa, maidosta, maidot, maitoja, maidoista, kevytmaito, kevy
 fr:lait, lactose, laitier, laitiere, laitiers, crème, beurre, bas-beurre, babeurre, beurre patissier, petit-lait, yaourt, fromage, méton, lait cru, Emmental, comte, bleu, edam, lactique, lactiques, ferments lactiques, cheddar, reblochon, parmesan, mimolette, crème de lait, fromage de vache, fromage de chèvre, gouda, lait écrémé, lait entier, lactoserum, lactosérum, mozzarella, protéines de lait, crème fraiche, ricotta, fromage blanc, mascarpone, caséinate, caséine, poudre de lait, Produits laitiers et dérivées, Produits laitiers et dérivés, Produits laitiers, Gorgonzola, Roquefort, Fromage fondu, Fromage frais, Feta, Raclette, laits et dérivés y compris lactose, lait de vache, lait de chèvre, lait de brebis, dérivés laitiers, protéines laitières, beurre concentré, gruyère, lait demi-écrémé, lait écrémé, lait frais
 ga:bainne, lachtós
 he:חלב, לקטוז, חלבון חלב, גבינה, יוגורט, חמאה, שמנת
-hr:laktoza, laktoze, maslac, mlijeka, mlijeko, mliječna, mliječne, mliječnih, sir, sirutka, vrhnje
+hr:laktoza, laktoze, maslac, mlijeka, mlijeko, mliječna, mliječne, mliječno, mliječnih, sir, sirutka, vrhnje
 hu:tej, laktóz, tejsavó, savó, tejtermék, tejtermékek, tejszín, tejfehérje, tejpor, tejsavópor, savópor, tejzsír, tejet, tejcukor, tehéntej, joghurt, joghurtpor, joghurt kultúra, sajt, vaj
 is:mjólk, undanrenna, nýmjólk, léttmjólk
 it:latte, lattosio, parmigiano reggiano, grana padano
@@ -266,7 +267,8 @@ zh:乳,乳糖,奶油,鮮奶油,忌廉,黃油,奶油,牛油
 en:nuts, almonds, hazelnuts, walnuts, cashews, cashew, pecan nuts, pecan,  Brazil nuts, pistachio nuts, pistachio, macadamia, Macadamia nuts, Queensland nuts, tree nuts, treenuts, other nuts
 ar:بندقة, الكاجو, المكاداميا, الفستقجوز, لوز
 bg:ядки, бадеми, лешници, орехи, кашу, пеканови ядки,  бразилски орехи, шамфъстък, орехи макадамия, орехи Куинсленд
-cs:skořápkové plody, mandle, lískové ořechy, vlašské ořechy, kešu ořechy, pekanové ořechy,  para ořechy, pistácie, makadamie
+bs:bademe, lešnike
+cs:skořápkové plody, skořápko plodů , mandle, lískové ořechy, vlašské ořechy, kešu ořechy, pekanové ořechy,  para ořechy, pistácie, makadamie
 da:nødder, mandel, mandler, hasselnød, hasselnødder, valnødder, cashewnødder, pekannødder, paranødder, pistacienød, pistacienødder, queenslandnødder, macadamianødder, andre nødder
 de:Schalenfrüchte, Schalenfrüchten, Mandel, Mandeln, Mandelkerne, Mandelstücke, Mandelstückchen, Haselnüsse, Haselnüssen, Haselnussmasse, Haselnusskerne, Haselnussmark, Haselnusspaste, Walnüsse, Walnusskerne, Walnussöl, Kaschunüsse, Pecannüsse,  Paranüsse, Paranusskerne, Pistazien, Macadamianüsse, Queenslandnüsse, Cashewkerne, Cashewnüsse, Nüsse, Haselnuss, Haselnussstücke, Erdnussöl, andere Nüsse
 el:καρποί με κέλυφος, αμύγδαλα, φουντούκια, καρύδια, καρύδια κάσιους, καρύδια πεκάν, καρύδια Βραζιλίας, φυστίκια, καρύδια μακαντάμια, καρύδια Κουίνσλαντ
@@ -276,7 +278,7 @@ fi:pähkinät, pähkinä, pähkinää, pähkinästä, pähkinöitä, pähkinöis
 fr:fruits à coque, amandes, noisettes, noix, noix de cajou, noix de pécan, noix du Brésil, pistaches, noix de Macadamia, noix du Queensland, fruits secs, autres fruits secs, autres fruits à coque, fruits secs à coque, fruits à coque dure
 ga:cnónna,  almóinní, cnónna coill, gallchnónna, cnónna caisiú, cnónna peagáin, cnónna Brasaíleacha, cnónna pistéise, cnónna macadaíme, cnónna Thír na Banríona
 he:אגוזים, שקדים, פקאן, אגוז ברזיל, אגוז מלך, פיסטוק, קשיו, ערמונים,מקדמיה
-hr:orašaste plodove, orašastih plodova, orašasto voće, orašastog voća, ostalih orašastih plodova, ostalog orašastog voća, drugo orašasto voće, badem, badema, bademe, bademi, lješnjak, lješnjaka, lješnjake, lješnjaci, pistacije
+hr:orašaste plodove, orašastih plodova, orašasto voće, orašastog voća, ostalih orašastih plodova, ostalog orašastog voća, drugo orašasto voće, drugog orašastog voća, badem, badema, bademe, bademi, lješnjak, lješnjaka, lješnjake, lješnjaci, pistacije, drugih orašastih plodova
 hu:diófélék, mandula, mogyoró, dió, kesudió, pekándió, brazil dió, pisztácia, makadámia, queenslandi dió, dióféléket
 is:hnetur
 it:frutta a guscio, mandorle, nocciole, noci, noci di acagiù, noci di pecan,  noci del Brasile, pistacchi, noci macadamia, noci del Queensland
@@ -326,7 +328,7 @@ pt:aipo
 ro:țelină
 ru:сельдерей
 sk:zeler, zeleru
-sl:listna zelena
+sl:listna zelena, zeleno, zelene
 sr:celer, celera
 sv:selleri, rotselleri, blekselleri, sellerifrö
 th:ขึ้นฉ่าย
@@ -361,7 +363,7 @@ pt:mostarda
 ro:muștar
 ru:горчица
 sk:horčica, horčice
-sl:gorčično seme
+sl:gorčice, gorčično seme, gorčičnih semen
 sr:senf, slačica
 sv:senap, senapsfrö, senapsfröpulver, senapspulver, senapsmjöl
 th:มัสตาร์ด
@@ -396,7 +398,7 @@ pt:sementes de sésamo, sésamo
 ro:semințe de susan
 ru:сезам, кунжут
 sk:sezamové semeno, sezamových semien
-sl:sezamovo seme, sezamovo
+sl:sezamovo seme, sezamovo, sezamovega semena
 sr:susam, susamovo seme, seme susama
 sv:sesamfrön, sesam
 th:งา

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -100806,6 +100806,7 @@ en:Pâté, Paté, Pate
 de:Pasteten
 es:Paté
 fr:Pâté
+hr:pašteta
 pl:Pasztet, Pasztety
 ru:Паштет
 ciqual_food_code:en:8332

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -338,6 +338,7 @@ wikidata:en:Q53792073
 <en:E322i
 en:soya lecithin, soy lecithin, soybean lecithin
 bg:соев лецитин, соеви лецитини
+bs:emulgator sojin lecitin
 ca:Lecitina de soja, lecitines de soja
 cs:sójový lecitin
 da:sojalecitin, sojalecitiner, sojalecithin, sojalecithiner
@@ -524,7 +525,7 @@ de:Rindergelatine
 es:Gelatina de ternera
 fi:nautaliivate, nautagelatiini, naudan liivate, liivate naudasta
 fr:gélatine de bœuf, gélatine de boeuf, gélatine bovine
-hr:goveda želatina
+hr:goveda želatina, goveđa želatina
 hu:marhazselatin
 it:gelatina di manzo
 lt:jautienos želatina
@@ -775,7 +776,7 @@ el:λυσοζύμη από το ΑΥΓΟ
 es:lisozima de huevo
 fi:lysotsyymi kananmunasta
 fr:lysozyme d'œuf, lysozyme d'oeuf
-hr:jajčani lizozim, lizozim iz jaja, lisozim iz jaja
+hr:jajčani lizozim, lizozim iz jaja, lisozim iz jaja, lizozim (iz jaja)
 it:lisozima da uovo, lisozima d'uovo
 nl:lysozym uit ei, lysozym van ei
 pl:lizozym z jaj
@@ -830,6 +831,7 @@ de:modifizierte Kartoffelstärke
 es:almidón modificado de patata, almidon de patata modificado
 fi:muunnettu perunatärkkelys, modifioitu perunatärkkelys
 fr:amidon modifié de pomme de terre, amidon modifié de pommes de terre, amidon de pomme de terre modifié, amidon transformé de pommes de terre, amidon de pommes de terre modifié, amidon transformé de pomme de terre, fécule de pomme de terre modifiée, fécule modifiée de pommes de terre
+hr:modificirani krumpirov škrob
 hu:módosított burgonyakeményítő
 it:amido di patate modificiate, amido modificato di patata
 nb:modifisert potetstivelse
@@ -838,6 +840,7 @@ pl:skrobia modyfikowana ziemniaczana, skrobia ziemniaczana modyfikowana, modyfik
 pt:amido modificado de batata, amido de batata modificado
 ro:amidon modificat din cartofi
 ru:модифицированный крахмал
+sl:modificiran krompirjev škrob
 sv:modifierad potatisstärkelse
 # fr:fécule-de-pomme-de-terre-modifiée has 40 products in 3 languages @2018-10-15
 # fr:e1404 has 19 products in 4 languages @2018-10-15
@@ -965,7 +968,7 @@ es:fermentos lácticos, fermentos lácteos, cultivos lácticos, ferments del yog
 et:juuretis
 fi:maitohappokäyte, maitohappokannat, maitohappoviljelmä, elävä jogurttiviljelmä, elävä jogurttibakteeriviljelmä, elävät jogurttibakteeriviljelmät, maitohappobakteeriviljelmä, maitohappobakteeriviljelmät, maitohappobakteerit, maitohappobakteerikanta, maitohappobakteerikannat, juustoviljelmä, juustoviljelmät, hapankulttuuri, jogurttihapate, maitohappobakteeri, käynnistin kulttuuri
 fr:ferment lactique, ferments lactique, ferments lactiques, ferment lactiques, culture de bactéries lactiques, cultures lactiques, ferment lactique du yaourt, ferments lactiques du yaourt, ferments vivants du yaourt
-hr:jogurtna kultura, mljekarska kultura, mljekarske kulture, sirna kultura, starter kultura, baktrije mliječnog vrenja, bakterije mliječne kiseline
+hr:jogurtna kultura, jogurtne kulture, mljekarska kultura, mljekarske kulture, mlijekarske kulture, sirna kultura, starter kultura, baktrije mliječnog vrenja, bakterije mliječne kiseline, kultura plemenitih plijesni, sirište mljekarske kulture
 hu:tejsavbaktériumok, tejsavbaktérium, starterkultúra, starter kultúra, tejsavbaktérium-tenyészet, tejsavbaktérium kultúra, joghurtkultúra, joghurtkultúrák, sajtkultúra, sajtkultúrák
 it:fermenti lattici, coltura di batteri acidolattici, fermenti lattici vivi, fermenti latici vivi, fermenti lattici dello yogurt
 nb:melkesyrekultur, starterkultur, yoghurtkultur, yoghurtbakterier, syrekultur
@@ -1046,6 +1049,7 @@ et:Bifidobakter
 fa:بیفیدوباکتر
 fi:bifidus, bifidus-viljelmä
 fr:bifidus, culture de bifidus, bifidobactérium
+hr:bifidobacterium, bifidobacterium BB-12
 hu:bifidus, bifidusz, bifidusz kultúra, bifiduszbaktérium
 it:Bifidobacterium
 ja:ビフィズス菌
@@ -1078,6 +1082,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bifidobacterium
 en:Bifidobacterium bifidum
 xx:Bifidobacterium bifidum
 fi:bifidobacterium bifidum, bifidobacterium sp
+hr:bifidobacterium bifidum BB-12
 zh:比菲德氏菌
 # zh-tw:比菲德氏菌
 wikidata:en:Q2902072
@@ -1088,6 +1093,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bifidobacterium_bifidum
 <en:bifidus
 en:Bifidobacterium lactis, Bifidobacterium animalis, B. lactis, B. animalis
 xx:Bifidobacterium lactis, b. lactis
+hr:bifidobacterium animalis BB-12
 es:Bifidobacterium lactis, Bifidobacterium animalis sp lactis
 wikidata:en:Q62854400
 wikipedia:en:https://en.wikipedia.org/wiki/Bifidobacterium_animalis
@@ -1113,6 +1119,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bifidobacterium_longum
 en:bifidus actiregularis, b. actiregularis
 xx:bifidus actiregularis, b. actiregularis
 de:Bifidus ActiRegularis, Bifidus Kultur ActiRegularis
+hr:Bifidus Actiregularis® kultura, Bifidus Actiregularis® kultura (CNCM 1-2494 min 4x)
 ru:бифидобактерии-actiregularis, бифидобактерии actiregularis
 # ingredient/bifidus-actiregularis has 142 products in 5 languages @2019-07-08
 
@@ -1125,6 +1132,7 @@ fr:ferments lactiques dont bifidobacterium
 en:kefir ferments, kefir cultures, live kefir cultures, active kefir cultures, kefir grains microflora
 es:fermentos de kéfir, cultivos microbianos de kéfir, levaduras de kéfir, fermentos propios del kéfir
 fr:ferments du kéfir, culture de kéfir, cultures de kéfir
+hu:kefirkultúra
 pl:kultury kefirowe, żywe kultury bakterii kefirowych
 
 <en:lactic ferments
@@ -1176,7 +1184,7 @@ bg:Lactobacillus acidophilus, L. acidophilus
 xx:Lactobacillus acidophilus, L. acidophilus
 fa:لاکنوباسیلوس اسیدوفیلوس
 fi:Lactobacillus acidophilus, L. acidophilus
-hr:lactobacillus acidophilus La-5, kultura Lactobacillus acidophilus
+hr:lactobacillus acidophilus La-5, kultura Lactobacillus acidophilus, mikrobiološke kulture Lactobacillus acidophilus La-5
 kk:Ацидофилин таяқшасы
 ro:Lapte acidofil
 ru:Lactobacillus acidophilus, Ацидофильная палочка
@@ -1205,6 +1213,7 @@ bg:Лактобацилус булгарикус, Lactobacillus bulgaricus, Lact
 es:lactobacilus delbrueckii sp Bulgaricus, Lactobacillus delbrueckii subspecies bulgaricus
 fi:Lactobacillus bulgaricus, L. bulgaricus
 fr:L bulgaricus, bulgaricus
+hr:lactobacillus bulgaricus
 xx:Lactobacillus bulgaricus, L. bulgaricus
 wikidata:en:Q47455075
 wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_delbrueckii_subsp._bulgaricus
@@ -1278,7 +1287,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_rhamnosus
 <en:Lactobacillus rhamnosus
 en:Lactobacillus rhamnosus GG
 xx:Lactobacillus rhamnosus GG, LGG
-hr:kultura Lactobacillus rhamnosus
+hr:kultura Lactobacillus rhamnosus, kultura Lactobacillus rhamnosus (LGG)
 # ingredient/fi:Lactobacillus-rhamnosus-GG has 1 product in 2 languages @2020-06-08
 
 # description:en:BACILLUS COAGULANS is a lactic acid-forming bacterial species. B. coagulans is often marketed as Lactobacillus sporogenes or a 'sporeforming lactic acid bacterium' probiotic, but this is an outdated name due to taxonomic changes in 1939.
@@ -1308,6 +1317,7 @@ en:Streptococcus thermophilus, s.thermophilus
 xx:Streptococcus thermophilus, s.thermophilus
 bg:streptococcus thermophilus, Streptococcus salivarius subsp. thermophilus
 fi:Streptococcus thermophilus, s. thermophilus
+hr:streptococcus thermophilus
 es:Streptococcus thermophilus, thermophilus
 ja:サーモフィラス菌
 zh:嗜热链球菌
@@ -1969,7 +1979,7 @@ sk:maslo
 sl:maslo
 so:subag
 sq:gjalpa
-sr:mаслац
+sr:mаслац, maslac
 su:mentéga
 sv:smör
 sw:siagi
@@ -2289,7 +2299,7 @@ gv:Bainney
 he:חלב
 hr:mlijeko, mlijeka
 ht:Lèt
-hu:Tej, Tejet
+hu:Tej, Tejet, tejből
 hy:Կաթ
 ia:Lacte
 id:Susu
@@ -2339,7 +2349,7 @@ sd:کير
 sh:Mlijeko
 si:සත්ත්‍ව කිරි
 sk:Mlieko
-sl:Mleko
+sl:mleko
 sn:Mukaka
 so:Caano
 sq:Qumështi
@@ -2628,6 +2638,7 @@ id:Susu skim
 is:Undanrenna
 it:Latte scremato, latte senza grassi, latte magro
 lt:Nugriebtas pienas
+mk:обрано млеко
 ms:Susu skim
 nb:Skummet melk
 nl:Magere melk, Taptemelk, ondermelk, afgeroomde melk, vetvrije melk
@@ -2822,6 +2833,7 @@ de:Frische fettarme Milch
 <en:milk
 en:whole milk, full cream milk
 bg:пълномаслено мляко
+bs:punomasno mleko
 ca:llet sencera
 cs:Plnotučné mléko
 da:sødmaelk
@@ -3508,6 +3520,7 @@ es:leche condensada azucarada, leche azucarada condensada
 et:magustatud kondenspiim
 fi:makeutettu kondensoitu maito, makeutettu maitotiiviste, sokeroitu maitotiiviste, sokeroitua maitotiivistettä
 fr:lait concentré sucré, lait condensé sucré
+hr:ugušćeno zaslađeno mlijeko
 hu:édesített sűrített tej, cukrozott sűrített tej
 it:latte concentrato zuccherato
 lt:saldintas kondensuotas pienas
@@ -4405,7 +4418,7 @@ ru:Молочная сыворотка
 sh:Surutka
 sk:Srvátka
 sl:Sirotka
-sr:Сурутка
+sr:Сурутка, surutka
 sv:Vassle, vassla
 te:పాల విరుగుడు
 th:หางนม
@@ -4485,6 +4498,7 @@ de:Sauermolke
 <en:whey
 en:sweet whey
 ca:sèrum de la llet ensucrat
+cs:sladká SYROVÁTKA
 de:Süßmolke, Süssmolke
 es:suero de leche azucarado, lactosuero azucarado
 fi:makea hera, makeutettu hera
@@ -4656,6 +4670,7 @@ sl:Smetana
 sn:Ruomba
 so:Labeen
 sq:Pana
+sr:pavlaka
 sv:Grädde
 sw:Samli
 ta:பாலாடை
@@ -5000,7 +5015,7 @@ nl:Smetana
 pl:Śmietana
 ro:Smântână
 ru:Сметана
-sl:Kisla smetana
+sl:Kisla smetana, smetana
 sr:Павлака
 sv:Smetana
 uk:Сметана
@@ -5367,6 +5382,7 @@ se:vuostá
 sh:Sir
 si:Sir
 sk:Syr
+sl:sir
 so:jiss
 sq:djathi
 sr:сир
@@ -5887,6 +5903,7 @@ hr:mješavina topljenih sireva i sireva u prahu
 <en:cheese
 en:semi-hard cheeses
 hr:polutvrdi sirevi
+sl:poltrdi sir
 
 <en:cheese
 en:hard cheese
@@ -5910,6 +5927,7 @@ de:Hartkäse Fettstufe
 <en:cheese
 en:soft cheese
 de:Weichkäse
+hr:meki sirevi
 nl:zachte kaas
 
 <en:soft cheese
@@ -6605,6 +6623,8 @@ ko:프로마주 프레
 ms:Fromage blanc
 nl:verse kaas
 pt:queijo branco
+sl:sveži sir 
+sr:sveži sir
 # en-ca:Fromage blanc
 # en-gb:Fromage blanc
 wikidata:en:Q3323634
@@ -6635,6 +6655,7 @@ es:Queso quark
 fi:Rahka, maitorahka
 fr:quark
 he:גבינה לבנה
+hr:quark sir
 hu:túró
 hy:Կաթնաշոռ
 id:Quark
@@ -6848,7 +6869,7 @@ mk:Горгонѕола
 ro:Brânză Gorgonzola
 ru:Горгондзола
 sd:گارگونزولا
-sl:Gorgonzola
+sl:gorgonzola, sir gorgonzola
 sr:горгонзола
 uk:Ґорґонцола
 xx:gorgonzola
@@ -6945,6 +6966,7 @@ ja:グラナ・パダーノ
 ko:그라나 파다노
 nl:Grana Padano, Grana Padano kaas
 ru:Грана падано
+sl:ribani trdi sir Grana Padano
 xx:Grana Padano
 uk:Грана Падано
 zh:格拉娜·帕達諾芝士
@@ -9223,7 +9245,7 @@ bo:ཚྭ།
 br:Holen
 bs:so, kuhinjska so
 ca:sal, sal comuna, sal de cuina
-cs:Sůl, jedlá sůl
+cs:Sůl, jedlá sůl, jedlá sûl
 cy:Halen
 da:Husholdningssalt, køkkensalt, bordsalt, salt
 de:Speisesalz, Kochsalz, Tafelsalz, Salz
@@ -9242,7 +9264,7 @@ gn:Juky
 gu:મીઠું
 he:מלח, מלח שולחן, מלח לבישול, מלח יבש
 hi:साधारण नमक
-hr:sol, kuhinjska sol
+hr:sol, kuhinjska sol, jestiva sol
 hu:só, étkezési só, konyhasó, asztali só
 id:Garam dapur
 ig:Ńnú
@@ -9282,11 +9304,11 @@ sd:لوڻ
 sh:So
 si:ලුණු
 sk:jedlá soľ
-sl:Sol, Kuhinjska sol, jedilna sol
+sl:sol, kuhinjska sol, jedilna sol, jedilna morska sol
 sn:Munyu
 so:Milix, Cusbo
 sq:Kripa
-sr:Со, so
+sr:Со, so, kuhinjska so
 su:Uyah
 sv:salt, koksalt, bordssalt, bordssalt utan jod
 ta:உப்பு
@@ -9742,7 +9764,7 @@ es:Sal yodada
 fa:نمک یددار
 fi:jodioitu suola, jodia sisältävä suola, jodisuola
 fr:Sel iodé, sel de cuisine iodé
-hr:jodirana sol, jodirona kuhinjska sol
+hr:jodirana sol, jodirona kuhinjska sol, kuhinjska sol jodirana
 hu:jódozott só
 id:Garam beryodium
 it:Sale iodato
@@ -9752,6 +9774,7 @@ pl:sól jodowana
 pt:Sal iodado
 ro:sare iodată, sare iodata
 ru:Йодированная поваренная соль, соль йодированная
+sl:jodirana sol
 sv:joderat salt, joderad salt, jodsalt, salt med jod
 th:เกลือเสริมไอโอดีน
 uk:Йодована сіль
@@ -9801,7 +9824,7 @@ de:jodiertes Meersalz
 es:sal marina yodada, sal de mar yodada
 fi:jodioitu merisuola
 fr:sel marin iodé
-hr:morska sol jodirana
+hr:morska sol jodirana, sitna jodirana morska sol, krupna jodirana morska sol
 hu:jódozott tengeri só
 it:sale marino iodato
 pl:sól morska jodowana, jodowana sól morska
@@ -9832,6 +9855,10 @@ ciqual_food_name:fr:Sel au céleri
 en:potassium salt, potassium chloride
 bg:калиева сол
 pl:sól potasowa, mineralna sól potasowa
+
+<en:salt
+en:processed salt
+de:verarbeitetes Salz
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -11659,6 +11686,7 @@ nl:Varkensvlees
 pl:mięso wieprzowe
 pt:carne de suíno, carne de porco
 ro:carne de porc, carne porc
+sl:svinjsko meso
 sv:fläskkött, griskött, svinkött, fläsk, kött från gris
 zh:猪肉
 carbon_footprint_fr_foodges_ingredient:fr:Viande de porc
@@ -12387,6 +12415,7 @@ es:Lomo de cerdo
 eu:txerri-solomo
 fr:longe de porc
 gl:lombo de porco
+hr:svinjski but
 it:lonza di maiale
 ko:등심
 pt:lombo
@@ -12487,6 +12516,7 @@ no:svinelever
 pl:wątroba wieprzowa
 ro:ficat de porc, ficat porc
 ru:Свиная печень, печень свиная
+sl:svinjska jetra
 sv:Grislever
 zh:猪肝
 #yue:豬膶
@@ -12754,6 +12784,7 @@ de:Kalbsfleisch, Kalbfleisch
 es:carne de ternera
 fi:vasikanliha
 fr:viande de veau
+hr:juneće meso
 hu:borjúhús
 nl:kalfsvlees
 sv:kalvkött
@@ -13360,7 +13391,7 @@ es:Almidón modificado de maiz, almidon de maiz modificado, almidones de maiz mo
 et:modifitseeritud maisitärklis
 fi:muunnettu maissitärkkelys, modifioitu maissitärkkelys, muunneltu maissitärkkelys, muunnettua maissitärkkelystä
 fr:amidon transformé de maïs, amidon de maïs transformé, amidon modifié de maïs, amidon de maïs modifié, amidons modifié de maïs, amidons modifiés de maïs
-hr:modificirani kukuruzni škrob
+hr:modificirani kukuruzni škrob, kukuruzni modificirani škrob
 hu:módosított kukoricakeményítő
 is:umbreytt maíssterkja
 it:amido modificato di mais, amido di mais modificato
@@ -13373,6 +13404,7 @@ ro:amidon modificat din porumb, amidon modificat de porumb
 ru:крахмал кукурузный модифицированный
 sk:modifikovaný kukuričný škrob
 sl:modificiran koruzni škrob
+sr:modifikovani kukuruzni skrob
 sv:modifierad majsstärkelse
 
 <en:modified starch
@@ -14042,6 +14074,7 @@ de:Rindernierenfett
 <en:dairy
 en:milkfat, milk fat
 bg:млечна мазнина
+bs:mlečna mast
 cs:mléčný tuk
 da:mælkefedt
 de:Milchfett
@@ -14068,6 +14101,7 @@ vegetarian:en:yes
 <en:milkfat
 en:milk fat without lactose
 hr:mliječne masti bez laktoze
+mk:млечна маст без лактоза
 
 <en:milkfat
 nl:gefractioneerd melkvet
@@ -14483,7 +14517,7 @@ ar:زيت النخيل
 be:Пальмавы алей
 bg:Палмово масло
 ca:Oli de palma, oli vegetal de palma
-cs:Palmový olej
+cs:palmový olej
 cz:palmu olejovou
 da:Palmeolie
 de:Palmöl, Ölpalme
@@ -15272,6 +15306,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Olive_pomace_oil
 <en:vegetable oil and fat
 en:rapeseed oil, rapeseed fat, rapeseed oil and fat
 bg:рапично масло
+bs:repičino
 ca:oli de nabina, oli vegetal de nabina
 cs:řepkový olej, olej řepkový
 da:rapsolie
@@ -15401,6 +15436,7 @@ es:aceite hidrogenado de colza
 #<en:hydrogenated colza oil
 #fr:huile de colza totalement hydrogénée, huiles végétales de colza totalement hydrogénée
 #fi:kokonaan kovetettu rapsiöljy
+#hr:potpuno hidrogenirano repičino ulje
 #nb:fullherdet rapsolje
 #sv:fullhärdad rapsolja
 # ingredient/fr:huile-de-colza-totalement-hydrogenee has 41 products in 4 languages @2020-06-10
@@ -16104,7 +16140,7 @@ fi:auringonkukkaöljy, auringonkukkaöljyä
 fr:huile de tournesol, huile de graines de tournesol, huile tournesol, huile végétale de tournesol, graisses végétales de tournesol
 gl:Aceite de xirasol
 he:שמן חמניות
-hr:suncokretovo ulje, pripravak suncokretovog ulja
+hr:suncokretovo ulje, suncokretno ulje, pripravak suncokretovog ulja, ulje suncokreta
 hu:napraforgóolaj, napraforgó olaj, napraforgó étolaj
 id:Minyak biji bunga matahari
 is:Sólblómaolía
@@ -17027,6 +17063,7 @@ en:barley malt vinegar, malt barley vinegar
 de:gerstenmalzessig
 fi:ohramallasetikka
 fr:vinaigre de malt d'orge
+hr:slad ječma
 nl:gerstemoutazijn
 pl:ocet ze słodu jęczmiennego
 sv:kornmaltsvinäger
@@ -17195,7 +17232,7 @@ gl:Etanol
 gu:ઇથેનોલ
 he:אתנול
 hi:इथेनॉल
-hr:etanol
+hr:etanol, etilni alkohol
 hu:etanol
 hy:Էթիլ սպիրտ
 id:Etanol
@@ -17824,7 +17861,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Tequila
 #description:en:WINE is an alcoholic beverage made from fermented grapes.
 
 <en:alcohol
-en:wine
+en:wine, fruit wine
 af:wyn
 am:የወይን ጠጅ
 an:Vin
@@ -19124,6 +19161,16 @@ ciqual_food_name:en:Sake or rice wine
 ciqual_food_name:fr:Saké ou Alcool de riz
 
 <en:alcohol
+en:rakia
+hr:rakija
+wikidata:en:Q931946
+wikipedia:en:https://en.wikipedia.org/wiki/Rakia
+
+<en:rakia
+en:rakia sugar
+hr:šećer rakija 
+
+<en:alcohol
 en:rice wine
 bg:оризово вино
 ca:vi d'arròs
@@ -19156,6 +19203,7 @@ ciqual_food_name:fr:Vodka
 # nova:en:flavouring
 en:flavouring, flavour, flavor, flavoring, aroma, flavours, flavors, flavourings, flavorings, aromas
 bg:аромат, аромати, ароматизант, ароматизанти
+bs:aroma
 ca:Aromes, aroma
 cs:Aroma, aromata
 da:smagsstof, smagstoffer, aroma, aromaer
@@ -19173,6 +19221,7 @@ it:aroma, aromi
 ja:香料
 lt:kvapioji medžiaga
 lv:aromatizētājs
+mk:арома
 nb:aroma, aromaer, smakstilsetninger
 nl:aroma, aroma's, smaakstof, smaakstoffen, aromas
 no:aroma
@@ -19180,6 +19229,7 @@ pl:aromat, aromaty
 pt:aromatizante,aroma,aromas
 ro:aromă, aroma, arome
 sk:aróma
+sl:arome
 sv:arom, aromer, smakämnen, aromämne, aromämnen
 zh:调味剂
 vegan:en:maybe
@@ -19209,7 +19259,7 @@ sv:smakberedning
 en:natural flavouring, natural flavour, natural flavor, natural flavoring, natural flavourings, natural flavorings, natural flavours, natural flavors, natural aroma, natural aromas
 bg:натурален аромат, натурални ароматизанти, натурален ароматизант, естествен ароматизант, натурални аромати
 ca:Aroma natural, aromes naturals
-cs:přírodní aroma
+cs:přírodní aroma, přírod aroma
 da:naturlig aroma, naturlige smagsstoffer, naturlige aromaer
 de:natürliches Aroma, natürliche Aromen, natürliche Aromastoffe
 es:aroma natural, aromas naturales,saborizante natural
@@ -19221,12 +19271,15 @@ hu:természetes aroma, természetes aromák, természetazonos aroma, természeta
 is:náttúruleg bragðefni
 it:aroma naturale, aromi naturali
 lv:dabīgs aromatizētājs
+mk:природна арома
 nb:naturlig aroma
 nl:Natuurlijke smaakstoffen, natuurlijke smaak, natuurlijk aroma, natuurlijke aroma's
 pl:Naturalny aromat, naturalne aromaty, aromat naturalny, aromaty naturalne
 pt:aroma natural
 ro:aromă naturală, aroma naturala, arome naturale
 ru:Натуральный ароматизатор, ароматизатор натуральный, натуральные ароматизаторы, ароматизаторы натуральные, натуральные вкусоароматические вещества
+sl:naravna aroma
+sr:prirodne arome
 sv:naturlig arom, naturliga aromer, naturlig smakämne, naturliga smakämnen, naturligt smakämne, naturliga aromämnen
 zh:天然调味剂
 vegan:en:maybe
@@ -19282,6 +19335,7 @@ de:mit anderen natürlichen Aromen, andere natürliche Aromen
 es:con otros aromas naturales
 fi:muut luontaiset aromit
 fr:avec autres arômes naturels, autres arômes naturels
+hr:sa ostalim prirodnim aromama
 is:með öðrum náttúrulegum bragðefnum
 nl:Met andere natuurlijke smaakstoffen
 ru:ароматизатор идентичный натуральному
@@ -19558,6 +19612,10 @@ it:Aroma naturale alla banana
 nl:natuurlijke bananensmaak
 
 <en:natural flavouring
+en:blueberry aroma
+hr:aroma borovnice
+
+<en:natural flavouring
 en:natural cola flavouring
 de:natürliches Cola-Aroma, natürliches Colaaroma
 fi:luontainen kola-aromi
@@ -19577,6 +19635,7 @@ en:elderberry flavouring
 bg:аромат на бъз
 de:Holunderaroma, Holunder-Aroma
 fr:arôme de sureau
+hr:bazgine bobice
 hu:bodza aroma
 
 <en:natural flavouring
@@ -19673,6 +19732,7 @@ en:peach flavouring
 de:Pfirsicharoma, Pfirsich-Aroma
 fi:persikka-aromi
 fr:arôme de pêche
+hr:aroma breskve
 hu:őszibarack aroma
 
 <en:natural flavouring
@@ -20105,6 +20165,11 @@ it:Aroma di menta naturale
 nl:natuurlijk muntaroma
 sv:naturlig mintsmak
 
+<en:natural mint flavouring
+<en:natural citrus flavouring
+en:natural aroma of mint and citrus
+hr:prirodna aroma mente i citrusa 
+
 <en:flavouring
 en:smoke flavouring, smoke flavour, aroma of smoke, smoked flavour
 bg:пушилен ароматизант
@@ -20283,6 +20348,10 @@ es:aroma de frutas, aroma de fruta, aroma frutal
 fi:hedelmäaromi
 fr:arôme de fruit, arômes de fruits
 hu:gyümölcsaroma, gyümölcs aroma
+
+<en:flavouring
+en:peach aroma
+hr:aroma breskve
 
 <en:flavouring
 en:passion fruit flavouring, passion fruit flavour
@@ -20478,6 +20547,7 @@ en:bergamot orange flavouring, bergamot flavouring
 de:Bergamottenaroma, Bergamotten-Aroma
 fi:bergamottiaromi
 fr:arôme de bergamote
+hr:aroma bergamota
 hu:természetes bergamot narancs aroma
 it:Aroma di bergamotto
 
@@ -20870,7 +20940,7 @@ fi:vilja, viljat
 fr:céréale, céréales
 ga:céréeale, céréales
 he:דגן
-hr:žitarice, proizvodi od žitarica
+hr:žitarica, žitarice, proizvodi od žitarica
 hu:gabona, gabonafélék
 it:cereali
 nl:granen, gemaakt van granen
@@ -21091,7 +21161,7 @@ gn:avati mirĩ
 gu:ઘઉં
 he:חיטה
 hi:गेहूँ
-hr:pšenica, pšenicu
+hr:pšenica, pšenicu, pšenične
 ht:ble
 hu:búza
 hy:ցորեն
@@ -21270,7 +21340,7 @@ el:σίτος ολικής αλέσεως
 es:trigo integral
 fi:täysjyvävehnä
 fr:blé complet
-hr:pšenična od cjelovitog zrna
+hr:pšenična od cjelovitog zrna, cjelovito zrno pšenice
 hu:teljes kiőrlésű búza
 it:frumento integrale
 lt:viso kviečių rupiniai
@@ -21604,7 +21674,7 @@ pt:sêmola de trigo duro
 ro:griș din grâu, griș de grău
 ru:борошно з пшеннци тверднх сортив
 sk:krupica z tvrdej pšenice
-sl:pšenični zdrob durum
+sl:pšenični zdrob durum, pšenični durum zdrob
 sr:krupica durum pšenice
 sv:durumvetegryn
 tr:durum buğdayı ırmığı
@@ -21863,6 +21933,7 @@ hu:búzadara
 it:semolino di frumento
 nl:tarwegries, tarwegriesmeel
 pt:sêmola de trigo
+sl:pšenični zdrob
 sv:vetegryn
 wikipedia:en:https://en.wikipedia.org/wiki/Semolina
 wikidata:en:Q381350
@@ -22947,7 +23018,7 @@ ro:amarant
 ru:Амарант
 sa:|वास्तुकम्}}
 sk:amarant
-sl:amarante
+sl:amarante, amaranta
 sr:амарант
 su:bayem
 tr:amaranthus
@@ -23180,7 +23251,7 @@ eu:olo-malutak
 fi:kaurahiutale, kaurahiutaleet, kaurahiutaleita
 fr:flocons d'avoine, flocon d'avoine
 he:פתיתי שיבולת שועל
-hr:zobene pahuljice
+hr:zobene pahuljice, valjani zob
 hu:zabpehely
 hy:Վարսակի փաթիլներ
 it:fiocchi di avena, fiocchi d'avena
@@ -23662,6 +23733,7 @@ de:Roggenflocken
 es:copos de centeno
 fi:ruishiutale
 fr:flocons de seigle
+hr:ražene pahuljice
 hu:rozspehely
 it:fiocchi di segale
 ja:ライ麦フレーク
@@ -23911,6 +23983,7 @@ de:Dinkel-Sprossen, Dinkel Sprossen, Dinkelkeimlinge
 fr:flocons d'épeautre
 de:Dinkelflocken
 fi:spelttihiutale
+hr:pirove pahuljice
 hu:tönkölybúzapehely
 it:fiocchi di quinoa
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:flocons-d'épeautre
@@ -24318,7 +24391,7 @@ fa:آرد گندم
 fi:vehnäjauho, vehnäjauhoa
 fr:farine de blé, farines de blé, farine de froment
 he:קמח חיטה
-hr:pšenično bijelo brašno, pšenično brašno
+hr:pšenično bijelo brašno, pšenično brašno, pšenicno brašno
 hu:búzaliszt
 is:hveitimjöl
 it:farina di frumento, farina di grano
@@ -24451,7 +24524,7 @@ bg:бяло пшенично брашно тип 500, брашно тип 500, �
 en:wheat flour type 550, flour type 550
 bg:бяло пшенично брашно тип 550
 de:Weizenmehl Type 550
-hr:pšenično brašno tip 550, pšenično brašno T-550, pšenično brašno T 550, pšenično brašno tip 550 glatko bijelo, brašno T-550
+hr:pšenično brašno tip 550, pšenično brašno T-550, pšenično brašno T 550, pšenično brašno tip 550 glatko bijelo, brašno pšenično T-550, brašno T-550
 
 <en:wheat flour
 en:wheat flour type 850 semi-white
@@ -24871,6 +24944,7 @@ pl:Mąka sojowa
 pt:farinha de soja
 ro:făină de soia, faina de soia
 ru:Соевая мука
+sl:teksturirana sojina moka
 sr:sojino brašno
 sv:sojamjöl, sojabönsmjöl, mjöl av sojabönor
 tr:soya unu
@@ -25899,6 +25973,7 @@ pl:ryż brązowy
 pt:arroz integral
 ru:kоричневый рис
 th:ข้าวกล้อง
+sl:rjavi riž
 sv:brunt fullkornris, råris
 ciqual_food_code:en:9102
 ciqual_food_name:en:Rice, brown, raw
@@ -26770,6 +26845,7 @@ es:Harina de algarroba, harina de garrofin
 et:Jaanileivapuujahu
 fi:carob
 fr:caroube, farine de caroube
+hr:rogač
 hu:karob, karob liszt
 it:carruba
 nl:carob, johannesbroodmeel, carobpoeder
@@ -26777,6 +26853,10 @@ pl:karob, karobu, karobowy, karobowe, karobowa
 sv:Johannesbrödfrö
 vegan:en:yes
 vegetarian:en:yes
+
+<en:carob seeds
+en:caroube dalmate
+hr:dalmatinski rogač
 
 # question
 
@@ -27018,6 +27098,7 @@ bg:биологична захар, био захар
 de:Zucker aus ökologischem Anbau
 fi:luomusokeri, luomu sokeri
 fr:sucre bio, sucre issu de l'agriculture biologique
+hr:eko šećer
 hu:bio cukor
 
 <en:sugar
@@ -28087,6 +28168,7 @@ vegetarian:en:yes
 <en:glucose
 en:glucose syrup
 bg:глюкозен сироп, сироп от глюкоза, глюкозов сироп
+bs:glukozni sirup
 ca:xarop de glucosa
 cs:glukózový sirup
 da:glukosesirup, glucosesirup
@@ -28369,7 +28451,7 @@ sv:Glukos-Fruktos
 en:glucose-fructose syrup, fructose-glucose syrup, glucose and fructose syrup
 bg:глюкозо-фруктозен сироп, сироп от глюкоза и фруктоза, фруктозо-глюкозен сироп
 ca:Xarop de glucosa-fructosa, xarop de glicosa-fructosa, xarop de glucosa i fructosa
-cs:glukózo-fruktózový sirup, glukózový-fruktózový sirup
+cs:glukózo-fruktózový sirup, glukózový-fruktózový sirup, glukózovo-fruktózový sirup
 da:glukos-fruktossirap, glukose-fruktosesirup
 de:Glukose-Fruktose-Sirup, Glukose-Fruktosesirup, Glukose Fruktose sirup, Glucose-Fructose-Sirup, Fruktose-Glukose-Sirup
 el:σιρόπι γλυκόζης-φρουκτόζης
@@ -28377,7 +28459,7 @@ es:jarabe de glucosa y fructosa, jarabe de glucosa-fructosa
 et:glükoosi-fruktoosisiirup, glükoosifruktoosisiirup
 fi:glukoosi-fruktoosisiirappi, glukoosi-fruktoosisiirappia, fruktoosi-glukoosisiirappi, glukoosi-fruktoosi-siirappi
 fr:sirop de glucose-fructose, sirop de glucose et de fructose, sirop de fructose-glucose
-hr:fruktozno-glukozni sirup, glukozno-fruktozni sirup
+hr:fruktozno-glukozni sirup, glukozno-fruktozni sirup, glukozno-fruktani sirup
 hu:glükóz-fruktóz szirup, fruktóz-glükóz-szirup, glükóz-fruktózszirup, fruktóz-glükózszörp, glükóz-fruktózszörp
 it:sciroppo di glucosio-fruttosio, sciroppo di fruttosio-glucosio
 ja:果糖ぶどう糖液糖
@@ -28444,7 +28526,7 @@ de:Invertzuckersirup
 es:Jarabe de azúcar invertido
 fi:inverttisokerisiirappi, inverttisokerisiirappia
 fr:sirop de sucre inverti, sucre liquide inverti, sucre inverti en sirop
-hr:invertni šećerni sirup
+hr:invertni šećerni sirup, sirup invertnog šećera, sirup invertnog šečera
 hu:invertcukor szirup, invertcukor-szirup, invertcukorszirup
 it:sciroppo di zucchero invertito
 lv:invertcukura sīrups
@@ -28732,6 +28814,7 @@ ro:dextroză, dextroza
 ru:Декстроза
 sk:dextróza
 sl:dekstroza
+sr:dekstroza
 sv:dextros
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/dextrose
 # 29818 products in 30 languages @2018-09-24
@@ -28849,7 +28932,7 @@ es:jarabe de agave, sirope de agave
 fa:اگاو
 fi:agavesiirappi
 fr:sirop d’agave
-hr:sirup od agave
+hr:sirup od agave, agavin sirup
 hu:agaveszirup
 id:Agave nectar
 is:agave-síróp
@@ -29030,7 +29113,6 @@ pl:Białko
 pt:proteína, proteínas
 qu:prutina
 ro:Proteine
-rs:Proteini
 ru:Белки
 sh:Protein
 si:ප්‍රෝටීන්
@@ -29038,7 +29120,7 @@ sk:Bielkoviny
 sl:Beljakovine
 so:Borotiin
 sq:Proteina
-sr:Протеин
+sr:Протеин, Proteini
 su:Protéin
 sv:Protein
 sw:Protini
@@ -29257,6 +29339,7 @@ pt:Proteína de soja
 ro:proteină de soia, proteina de soia, proteină vegetală din soia, proteina vegetala din soia
 ru:Соевый протеин, соевый белок
 sk:sójová bielkovina
+sl:sojini proteini
 sv:sojaprotein, sojaproteinpeparat
 allergens:en: en:soybeans
 
@@ -29499,12 +29582,15 @@ hr:mliječne bjelančevine, mliječnih bjelančevina
 hu:tejfehérjék, tejfehérje
 it:proteine del latte
 ja:乳たんぱく質
+mk:млечни протеини
 nl:melkeiwit, melkeiwitten, melk eiwit
 pl:Białka mleczne, białka mleka, białko mleka
 pt:proteína do leite, proteínas lácteas
 ro:proteină din lapte, proteine din lapte, proteine de lapte
 ru:молочный белок, молочные белки
 sk:mliečnu bielkovinu, mliečne bielkoviny
+sl:mlečne beljakovine
+sr:mliječni proteini, mlečni proteini
 sv:mjölkprotein
 nova:en:4
 vegetarian:en:yes
@@ -29844,6 +29930,7 @@ pl:krem kakaowy
 en:cocoa butter, cacao butter, cocoa fat
 ar:زبدة الكاكاو
 bg:какаово масло
+bs:kakao maslac
 ca:mantega de cacau
 cs:kakaové máslo
 da:kakaosmør
@@ -29932,6 +30019,7 @@ fr:beurre de cacao émulsifiant
 <en:cocoa
 en:cocoa paste, cocoa mass, chocolate liquor
 bg:какаова маса, какао маса
+bs:kakao masa
 ca:pasta de cacau, massa de cacau
 cs:kakaová hmota
 da:kakaomasse
@@ -30000,6 +30088,7 @@ id:Kakao padat
 it:cacao in polvere
 ja:ココアパウダー
 ko:코코아 가루
+mk:какао во прав
 ms:Pepejal koko
 nb:kakaopulver
 nl:cacaopoeder
@@ -30037,7 +30126,7 @@ es:cacao magro en polvo, cacao desgrasado en polvo, cacao en polvo desgrasado, c
 et:lahja kakaopulber, vähendatud rasvasisaldusega kakaopulber
 fi:vähärasvainen kaakaojauhe, vähärasvaista kaakaojauhetta
 fr:poudre de cacao maigre, poudre de cacao dégraissé, cacao dégraissé en poudre, cacao en poudre dégraissé, cacao maigre en poudre, cacao sec dégraissé, poudre de cacao à teneur réduite en matières grasses
-hr:kakao u prahu smanjene masnoce, nemasni kakao prah, nemasni kakao u prahu, kakao prah smanjene masti, kakaov prah smanjene masti, kakao smanjene masnoće u prahu, kakaov prahu smanjene mast
+hr:kakao u prahu smanjene masnoce, nemasni kakao prah, nemasni kakao u prahu, kakao prah smanjene masti, kakaov prah smanjene masti, kakao smanjene masnoće u prahu, kakaov prahu smanjene mast, kakao prah sa reduciranim sadržajem kakao maslaca
 hu:zsírszegény kakaópor
 it:cacao magro in polvere, cacao scremato in polvere
 lt:liesi kakavos milteliai
@@ -30432,6 +30521,7 @@ de:Schokoladenfüllung
 es:Relleno de chocolate, Relleno de cacao, Relleno cacao
 fi:suklaatäyte
 fr:fourrage au chocolat, fourrage chocolat
+hr:keks s kakaom
 it:ripieno al cioccolato
 # ingredient/fr:fourrage-au-chocolat has 40 products in 4 languages @2019-05-25
 
@@ -31463,7 +31553,7 @@ ru:Соя, соевый, сои
 rw:Soya
 sh:Soja
 sk:sójové
-sl:Soja, soje
+sl:soja, soje
 sr:Соја
 sv:soja
 sw:Soya
@@ -31746,7 +31836,7 @@ es:gluten de trigo
 et:nisugluteen
 fi:vehnägluteeni
 fr:gluten de blé, gluten de froment
-hr:pšeničnog glutena,  pšenični gluten
+hr:pšeničnog glutena, pšenični gluten
 hu:Búzaglutén
 it:glutine di grano, glutine di frumento
 nb:hvetegluten
@@ -31754,6 +31844,7 @@ nl:tarwegluten
 pl:gluten pszenny
 pt:glúten de trigo
 ro:gluten de grâu, gluten din grâu
+sl:pšenični gluten
 sv:vetegluten
 
 <en:wheat gluten
@@ -31887,7 +31978,7 @@ bn:ইস্ট
 br:Goell
 bs:Kvasci
 ca:Rent,llevat
-cs:Kvasinky
+cs:Kvasinky, kvasničný
 cy:Burum
 da:gær, gærsvamp
 de:Hefe, Hefen
@@ -32170,7 +32261,7 @@ en:yeast extract
 bg:екстракт от мая, екстракти от мая
 bs:ekstrakt kvasca
 ca:Extracte de llevat
-cs:Výtažek z kvasnic, kvasnicový extrakt
+cs:Výtažek z kvasnic, kvasnicový extrakt, kvasničný extrakt
 da:gærekstrakt
 de:Hefeextrakt
 el:εκχύλισμα μαιάς
@@ -33483,7 +33574,7 @@ fr:fruit
 gl:Froita
 he:פרי
 hi:फल
-hr:Voće
+hr:voće, voćni
 hu:gyümölcs
 hy:միրգ
 ia:fructo
@@ -33901,7 +33992,7 @@ fr:specialité de fruits pomme poire
 en:fruits preparation
 de:Fruchtzubereitung
 fr:préparation de fruits
-hr:voćni pripravak
+hr:voćni pripravak, voćno punjenje
 it:preparazione di frutta
 sv:fruktberedning
 # usage:de:Fruchtzubereitung (Zucker, Pfirsichsaft aus Pfirsichsaftkonzentrat, Wasser, Pfirsichmark, Maracujasaft aus Maracujasaftkonzentrat, modifizierte Stärke, natürliches Aroma, Säurungsmittel: Citronensäure; Säureregulator: Natriumcitrat)
@@ -34118,8 +34209,13 @@ sv:aprikoskärnor
 # 97 products @2018-09-29
 
 <en:apricot
+en:apricot marmalade
 es:mermelada de albaricoque
+hr:marmelada marelica
 
+<en:flavouring
+en:apricot flavouring
+hr:aroma marelice
 
 ###################################################################################################
 #
@@ -34622,6 +34718,13 @@ zh:大果蔓越梅
 wikidata:en:Q149397
 wikipedia:en:https://en.wikipedia.org/wiki/Vaccinium_macrocarpon
 
+##########################################
+#              Flavourings
+##########################################
+
+<en:flavouring
+en:cranberry flavouring
+hr:aroma brusnice
 
 ###################################################################################################
 #
@@ -34673,6 +34776,7 @@ kv:Манго
 lb:Mango
 lv:Mango
 mg:Manga
+mk:манго
 ms:Mangga
 my:သရက်သီး
 nl:mango
@@ -35219,7 +35323,7 @@ es:ciruela
 et:ploom
 fi:luumu
 fr:prune, prunes
-hr:šljiva
+hr:šljiva, šljive
 it:prugna
 ms:plum, Prun
 nl:pruim, pruimen
@@ -35245,6 +35349,9 @@ ciqual_food_name:fr:Prune, crue
 <en:plum
 en:plum sugar
 
+<en:plum
+en:organic plum
+hr:eko šljiva
 
 # description:en:A prune is a dried plum of any cultivar, mostly Prunus domestica or European Plum.
 # wikidata has an issue not distinguishing between the fresh fruit and the dried fruit
@@ -35923,6 +36030,7 @@ ja:リンゴジュース
 kk:aлма шырыны
 ko:사과 주스
 lt:obuolių sultys
+mk:сок од јаболко
 nb:eplemost
 nl:appelsap
 nn:eplemost
@@ -35961,6 +36069,7 @@ sv:ekologisk äppeljuice
 
 <en:apple juice
 en:pure apple juice
+cs:jablečná šťáva
 de:reiner Apfelsaft
 fr:pur jus de pomme
 it:Succo mela puro
@@ -35983,6 +36092,7 @@ de:Apfeldicksaft, Apfelsaftkonzentrat
 es:jarabe de manzana
 fi:omenamehutiiviste
 fr:concentré de jus de pomme, jus de pommes concentré
+hr:koncentrirani sok jabuke
 it:concentrato di succo di mele
 nl:appeldiksap, appelsap ingedikt tot stroop, geconcentreerd appelsap, appelsapconcentraat
 pl:zagęszczony sok jabłkowy, koncentrat soku jabłkowego
@@ -36000,6 +36110,7 @@ de:Apfelsaft aus Konzentrat, Apfelsaft aus Apfelsaftkonzentrat
 es:Zumo de manzana desde concentrado, zumo de manzana a partir de concentrado, jugo de manzana procedente de concentrado
 fi:omenamehu tiivisteestä
 fr:jus de pomme à base de concentré, jus de pomme à base de jus concentré, Jus de pomme à base de jus de pomme concentré, jus de pomme à partir de concentré
+hr:jabuke od koncentriranog soka, Sok od jabuke od koncentriranog soka
 hu:sűrített almalé, almalé sűrítmény, almalé koncentrátum, almalé koncentrátumból
 it:succo di mele a base di concentrato
 nl:appelsap uit concentraat
@@ -36907,7 +37018,7 @@ el:χυμός λεμονιού
 es:zumo de limón, jugo de limón
 fi:sitruunamehu, sitruunatäysmehu
 fr:jus de citron
-hr:sok od limuna, soka limuna
+hr:sok od limuna, soka limuna, limunov sok, limunovog soka
 hu:Citromlé
 it:succo di limone
 ja:レモンジュース
@@ -37530,7 +37641,7 @@ fr:jus d'orange
 ga:Sú oráistí
 gl:Zume de laranxa
 he:מיץ תפוזים
-hr:sok od naranče, voćni sok naranče
+hr:sok od naranče, voćni sok naranče, narančin sok
 hu:Narancslé
 hy:Նարնջի հյութ
 id:Sari buah jeruk
@@ -37628,7 +37739,7 @@ de:Orangensaft aus Konzentrat, Orangensaft aus Orangensaftkonzentrat
 es:Zumo de naranja desde concentrado, zumo de naranja a partir de concentrado, jugo de naranja procedente de concentrado
 fi:appelsiinimehu tiivisteestä, tiivisteestä valmistettu appelsiinitäysmehu, appelsiinitäysmehu tiivisteestä, appelsiinitäysmehu appelsiinitäysmehutiivisteestä, appelsiinitäysmehua tiivisteestä
 fr:jus d'orange à base de concentré, jus d'orange à base de jus d'orange concentré, jus d'orange à base de jus concentré, jus d'orange à partir de concentré
-hr:sok od naranče iz koncentrata soka naranče, sok od naranče koncentrata soka naranče, sok od naranče od koncentriranog soka
+hr:sok od naranče iz koncentrata soka naranče, sok od naranče koncentrata soka naranče, sok od naranče od koncentriranog soka, sok od naranče od koncentrirana soka
 hu:narancslé narancslé-koncentrátumból
 it:succo d'arancia a base di concentrato
 nl:Sinaasappelsap uit sapconcentraat
@@ -37714,7 +37825,7 @@ es:cáscara de naranja, corteza de naranja,ralladura de naranja
 et:apelsinikoor
 fi:appelsiininkuori, appelsiinikuori
 fr:zeste d'orange, zestes d'orange, écorce d'orange, écorces d'orange, écorces d'oranges
-hr:narančina korica, kora od naranča, kora gorke naranče
+hr:narančina korica, narančina kora, kora od naranča, kora gorke naranče, korica naranče
 hu:narancshéj
 it:scorza d'arancia, scorze di arancia, scorze d'arancia, buccla d'arancia
 lt:apelsinų žievelė
@@ -37809,7 +37920,9 @@ nb:naturling smak fra eterisk appelsinolje
 sv:smak från eterisk apelsinolja
 # ingredient/fi:eteerinen-appelsiiniöljyaromi has 1 product in 1 language @2020-06-08
 
-
+<en:fruit
+en:sweet Valencia orange
+hr:slatka naranča Valencia
 
 ###################################################################################################
 #
@@ -37839,7 +37952,7 @@ fi:pomeranssi, pomeranssin
 fr:bigaradier, Oranges de Séville
 gl:laranxeira amarga
 he:חושחש
-hr:gorka naranča
+hr:gorka naranča, gorka naranča Sevilla
 ht:zoranj konmenn
 hu:keserű narancs
 id:jeruk pahit
@@ -38093,7 +38206,7 @@ fo:sólber
 fr:cassis, baies de cassis
 ga:grosella
 he:ענבי שועל
-hr:crni ribiz
+hr:crni ribiz, crnog ribiza
 hu:fekete ribizli
 io:kasiso
 is:sólber
@@ -38154,6 +38267,7 @@ description:nl:de vrucht (bes) van de Ribes nigrum
 
 <en:blackcurrant
 en:blackcurrant juice from concentrate
+cs:ovocná šťáva z koncentrátu černého rybízu
 de:schwarzer Johannisbeersaft aus Konzentrat, schwarze Johannisbeere-Konzentrat
 es:zumo de cassis a base de concentrado
 fi:mustaherukkamehu tiivisteestä
@@ -38251,6 +38365,7 @@ da:blåbær
 de:Wilde Heidelbeeren
 fi:villimustikka
 fr:myrtille sauvage
+hr:divlja borovnica
 it:mirtilli selvatici
 nl:wilde bosbes, wilde blauwe bosbessen, wilde bosbessen
 pl:borówka dzika, borówki dzikie
@@ -38306,7 +38421,12 @@ de:Heidelbeersaft aus Heidelbeerkonzentrat
 es:Concentrado de jugo de zarzamora
 fi:mustikkamehu tiivisteestä, mustikkatäysmehu tiivisteestä, mustikkatäysmehua tiivisteestä
 fr:jus de myrtille à base de concentré, jus de myrtille à base de jus concentré
+hr:sok od borovnice od koncentriranog soka borovnice
 sv:blåbärssaft av koncentrat
+
+<en:blueberry
+en:blueberry dressing
+hr:preljev od borovnica
 
 ###################################################################################################
 #
@@ -38547,7 +38667,7 @@ gu:ચેરી
 gy:shillish
 he:דובדבן
 hi:आलूबालू
-hr:trešnja
+hr:trešnja, trešnje
 ht:Seriz
 hu:cseresznye
 hy:բալ
@@ -38667,6 +38787,10 @@ carbon_footprint_fr_foodges_value:fr:1.3
 ciqual_food_code:en:13008
 ciqual_food_name:en:Cherry, pitted, raw
 ciqual_food_name:fr:Cerise, dénoyautée, crue
+
+<en:cherry
+en:organic cherry
+hr:eko višnja
 
 <en:cherry
 en:wild cherry
@@ -38891,7 +39015,7 @@ ar:أرونية
 az:Aroniya
 bg:Арония
 ca:Aronia
-cs:temnoplodec
+cs:temnoplodec, arónie
 cy:Llwyn aeron tagu coch
 da:Surbær
 de:Aronia, Apfelbeer, Apfelbeeren
@@ -38903,7 +39027,7 @@ fa:انگورک گلوگیر
 fi:marja-aronia
 fr:aronie, aronia
 he:ארוניה
-hr:aronija, aronija plod
+hr:aronija, aronija plod, aronije
 hy:արոնիա
 it:aronia
 ja:アロニア属
@@ -39272,7 +39396,7 @@ fr:datte, dattes
 gl:Dátil
 gu:બોર
 he:תמר, תמרים
-hr:datulje, datumi, datum
+hr:datulja, datulje, datumi, datum
 ht:Dat
 ia:Dactylo
 it:dattero, datteri
@@ -39369,6 +39493,7 @@ en:concentrated date juice
 
 #comment:en:This can refer to the flower of the berries
 en:elder
+cs:černého bezu
 de:Holunder
 es:Saúco
 fi:selja
@@ -39389,7 +39514,7 @@ de:Holunderbeer, Holunderbeere, Holunderbeeren
 es:bayas del sauco
 fi:seljanmarja
 fr:baie de sureau, baies de sureau
-hr:bazga plod
+hr:bazga, bazge, bazga plod
 nl:vlierbes
 pl:owoc czarnego bzu, owoce czarnego bzu, jagody czarnego bzu, jagoda czarnego bzu
 sv:fläderbär
@@ -39505,7 +39630,7 @@ et:Viigimari
 fi:viikuna
 fr:figue
 gl:Figo
-hr:smokva
+hr:smokva, smokve
 ia:fico
 it:fico, fichi
 ko:무화과
@@ -39527,6 +39652,10 @@ ciqual_food_code:en:13012
 ciqual_food_name:en:Fig, raw
 ciqual_food_name:fr:Figue, crue
 # 570 products @2018-09-29
+
+<en:fig
+en:organic fig
+hr:eko smokva
 
 <en:fig
 en:Pajarero Figs
@@ -40722,6 +40851,7 @@ it:frutto della passione, maracuja
 jv:markisah
 la:Passiflora
 lt:valgomoji pasiflora
+mk:маракуја
 ms:pokok markisa
 nb:pasjonsfrukt
 nl:passievrucht, maracuja, markieza
@@ -40844,6 +40974,7 @@ ja:パイナップル
 kg:Nanasi
 la:Ananas comosus
 lo:ໝາກນັດ
+mk:ананас
 nl:ananas
 no:ananas
 nv:Bilasáana diwozhí
@@ -41133,7 +41264,7 @@ fr:framboise
 ga:Sú craobh
 gd:Sùbh-craoibh
 hi:रसभरी
-hr:malina, maline
+hr:malina, maline, plod maline
 ht:Franbwaz
 hu:málna
 hy:Ազնվամորի
@@ -41399,7 +41530,7 @@ fa:میوه گل رز
 fi:Ruusunmarja, kiulukka
 fr:cynorrhodon, fruit de l'églantier
 ga:mogóir róis
-hr:šipak, šipak plod, plod šipka, plodovi šipka
+hr:šipak, šipak plod, plod šipka, plodovi šipka, šipka
 hu:csipkebogyó
 hy:մասուր
 it:Cinorrodo
@@ -41969,6 +42100,7 @@ de:weiße Traube
 es:uva blanca
 fi:vaalea viinirypäle
 fr:raisin blanc, raisins blancs
+hr:bijelog grožđa
 it:uva bianca
 nl:witte druif, witte druiven
 ciqual_food_code:en:13044
@@ -42016,6 +42148,10 @@ fr:raisin rouge, raisins rouges
 en:red seedless grape
 de:rote kernlose Traube, rote kernlose Trauben
 fr:raisin rouge sans pépin
+
+<en:red grape
+en:red grape fruit juice
+hr:voćni sok crvenog grožđa
 
 # description:en:A RAISIN is a dried grape.
 
@@ -42360,6 +42496,7 @@ de:Traubenmost
 es:Mosto de uva
 fi:puristemehu, rypäleen puristemehu
 fr:moût de raisin
+hr:mošt grožđa
 it:mosto d'uva
 nl:druivenmost
 ro:must de struguri
@@ -42375,7 +42512,7 @@ de:Traubenmostkonzentrat, konzentrierter Traubenmost
 es:Mosto de uvas desde concentrado, mosto concentrado de uva
 fi:rypäleen puristemehuntiiviste
 fr:moût de raisin concentré
-hr:koncentrirani grožiani mošt
+hr:koncentrirani grožiani mošt, koncentrirani grožđani mošt
 it:mosto d'uva concentrato
 nl:geconcentreerde druivenmost
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:moût-de-raisin-concentré
@@ -42857,6 +42994,14 @@ fr:Lambrusco Salamino
 wikipedia:de:https://de.wikipedia.org/wiki/Lambrusco_Salamino
 wikidata:en:Q1801495
 # ingredient/fr:Lambrusco-Salamino has 1 product @2019-01-20
+
+
+# desciption:en:Vinova loza (lat. Vitis vinifera) is a plant from the Vitaceae family. Some of the common names in Croatia are čokot, loza, trs, vinoloza or wine vine.
+
+<en:varietal
+en:vitis vinifera
+hr:loza
+wikipedia:hr:https://hr.wikipedia.org/wiki/Vinova_loza
 
 
 # description:en:Malbec (pronounced [mal.bɛk]) is a purple grape variety used in making red wine.
@@ -43371,7 +43516,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Syrah
 <en:varietal
 en:teran
 de:terrano
-hr:teran
+hr:teran, vino teran
 sv:terrano
 wikidata:en:Q1437894
 wikipedia:en:https://en.wikipedia.org/wiki/Teran_grape
@@ -43611,6 +43756,7 @@ nl:Groente, groenten
 pl:Warzywo, warzywa
 pt:vegetal
 ru:Овощ
+sr:povrće
 sv:grönsak, grönsaker
 zh:蔬菜
 vegan:en:yes
@@ -44666,7 +44812,7 @@ sk:Cesnak kuchynský
 sl:Česen
 so:Toon
 sq:hudhra
-sr:бели лук
+sr:бели лук, beli luk
 sv:vitlök
 sw:Kitunguu saumu
 ta:பூண்டு
@@ -45136,7 +45282,7 @@ gu:રીંગણ
 gv:Lus ny h-oohyn
 he:חציל
 hi:बैंगन
-hr:Patlidžan
+hr:patlidžan, plavi patlidžan
 ht:Berejèn
 hu:padlizsán
 hy:բադրիջան
@@ -45578,6 +45724,7 @@ es:sirope de remolacha
 <en:beetroot
 en:beetroot juice
 bg:сок от цвекло
+cs:šťáva z červené řepy
 de:Randensaft
 es:jugo de remolacha
 fi:punajuurimehu
@@ -46637,7 +46784,7 @@ sl:Navadno korenje
 sm:taloti
 so:kaaroot
 sq:karrotë
-sr:шаргарепа
+sr:шаргарепа, šargarepa
 su:wortel
 sv:morot, morötter
 sw:karoti
@@ -47014,7 +47161,7 @@ sh:Celer
 sk:Zeler voňavý, zeler
 sl:Navadna zelena, listna zelena
 sq:Selinoja
-sr:Целер
+sr:Целер, celer
 su:Salédri
 sv:Selleri
 ta:சிவரிக்கீரை
@@ -47160,6 +47307,7 @@ nl:knolselderij
 pl:seler korzeń, korzeń selera
 ro:rădăcină de țelină
 ru:корень сельдерея
+sr:koren celera
 sv:Rotselleri
 # ru:сельдерей пахучий translation error, see also en:celery
 allergens:en: en:celery
@@ -47649,6 +47797,14 @@ en:leek powder
 de:Lauchpulver
 #15 in 2 @2021-10-26
 
+# description:en:Asclepias is a genus of herbaceous, perennial, flowering plants known as milkweeds.
+<en:root vegetable
+en:asclepias
+sr:miluk
+wikidata:en:Q162153
+wikipedia:en:https://en.wikipedia.org/wiki/Asclepias
+
+
 # description:en:The ONION (Allium cepa L.), also known as the bulb onion or common onion, is a vegetable that is the most widely cultivated species of the genus Allium. They are usually served cooked, as a vegetable or part of a prepared savoury dish, but can also be eaten raw or used to make pickles or chutneys.
 
 # <en:class:en:Vegetables
@@ -47854,6 +48010,7 @@ pl:czerwona cebula, cebula czerwona
 ro:ceapă roșie
 ru:красный лук
 sq:qepë e kuqe
+sr:crveni luk
 sv:rödlök
 wikidata:en:Q622350
 wikipedia:en:https://en.wikipedia.org/wiki/Red_onion
@@ -47922,6 +48079,7 @@ pl:czosnek dęty
 pt:cebolleta
 ro:ceapă de tuns
 ru:Лук-батун
+sl:čebula
 sr:аљма
 su:Bawang daun
 sv:Piplök, walesisk lök
@@ -48211,7 +48369,7 @@ ru:Пастернак
 sh:Paškanat
 sk:paštrnák
 sl:Pastinak
-sr:Пашканат
+sr:Пашканат, paškanat
 sv:Palsternacka
 th:พาซนิพ
 tl:Pastinaca
@@ -48954,6 +49112,7 @@ rw:Epinari
 sd:پالڪ
 se:spináhtta
 sh:Špinat
+sl:Špinača
 sq:spinaqi
 sr:спанаћ
 sv:spenat
@@ -49345,7 +49504,7 @@ pl:tapioka
 pt:tapioca
 ru:тапиока
 sk:tapiokový škrob
-sl:tapioka
+sl:tapioka, tapiokin škrob
 su:tapioka
 sv:tapioka, tapiokastärkelse
 uk:тапіока
@@ -49645,6 +49804,7 @@ de:getrocknete Kartoffelflocken
 es:copos de patata deshidratados
 fi:kuivatut perunahiutaleet
 fr:flocons de pomme de terre déshydratés
+sl:krompirjevi kosmiči
 # fr:flocons-de-pomme-de-terre-déshydratés has 100 products in 2 languages @2018-10-15
 
 <en:potato flakes
@@ -49842,6 +50002,7 @@ pl:papryka czerwona, czerwona papryka
 pt:pimento vermelho
 ro:ardei gras roșu
 ru:Красный перец, перец красный, перец красный молотый, паприка красная
+sr:crvena paprika
 sv:röd paprika
 ciqual_food_code:en:20087
 ciqual_food_name:en:Sweet pepper, red, raw
@@ -50105,7 +50266,7 @@ de:scharfe chilischoten, scharfe Pfefferoni, Paprika scharf
 es:guindilla fuerte
 fi:tuliset chilit, tulinen chili
 fr:piment fort, piments forts
-hr:ljuta začinska paprika
+hr:ljuta začinska paprika, peperoncini, mini ljute papričice cijele, feferoni ljuti
 it:peperoncino piccante
 nl:scherpe peperoni, scherpsmakende pepers
 # ingredient/fr:piment-fort has 391 products in 7 languages @2019-04-14
@@ -50258,6 +50419,7 @@ de:Jamaikapfeffer
 es:pimienta de Jamaica
 fi:maustepippuri
 fr:piment de la jamaïque, piment de jamaïque
+hr:pimen
 it:Pepe di Giamaica, pepe garofanato, pimenteira
 nb:allehånde
 nl:Jamaicaanse peper
@@ -50802,6 +50964,7 @@ nl:tomatenpurée, tomatenconcentraat, tomatenpuree
 pl:przecier pomidorowy
 ru:томатное поре
 sk:bravčové mäso
+sr:pire od paradajza
 sv:tomatpuré, tomatpyré, tomatpure, mosade tomater
 carbon_footprint_fr_foodges_ingredient:fr:Sauce tomate
 carbon_footprint_fr_foodges_value:fr:2.9
@@ -53630,7 +53793,7 @@ fy:Mangel
 ga:almóinní
 gl:Améndoa
 he:שקד
-hr:badem, bademi
+hr:badem, bademi, bademova jezgra
 hu:mandula
 ia:amandola
 it:mandorla, mandorle
@@ -53719,7 +53882,7 @@ pl:masa migdałowa
 
 <en:almond
 en:blanches almonds, almonds blanched
-de:blanchierte Mandlen, Mandeln blanchiert
+de:blanchierte Mandlen, blanchierten mandeln, mandeln blanchiert
 es:almendras peladas
 fr:amandes blanchies
 pl:migdały blanszowane
@@ -53950,7 +54113,7 @@ et:kašupähklid, India pähkel, kašupähkleid
 fi:cashewpähkinä, cashewpähkinät, cashew
 fr:noix de cajou
 ga:cnónna caisiú
-hr:indijski oraščići
+hr:indijski oraščići, indijski oraščić
 hu:kesudió
 it:noci di acagiù, anacardi
 ja:カシューナッツ
@@ -54422,6 +54585,7 @@ ar:فول سوداني
 ay:Chuqupa
 az:Araxis
 bg:фъстък, фъстъци
+bs:kikiriki
 ca:Cacauet, cacauets
 cs:arašídy
 da:jordnødder, jordnød, peanuts
@@ -54485,7 +54649,7 @@ ciqual_food_name:en:Peanut
 <en:peanut
 en:peanut paste
 de:Erdnusspaste
-hr:pasta od kikirikija
+hr:pasta od kikirikija, kikiriki pasta
 
 <en:peanut
 en:roasted peanuts
@@ -54832,7 +54996,7 @@ ciqual_food_name:fr:Noix, fraîche
 
 <en:walnut
 en:walnut kernel, walnuts shelled
-de:Walnusskerne
+de:Walnusskerne, Walnusskern
 es:nuez mondada
 fi:kuoreton saksanpähkinä, kuorettomat saksanpähkinät
 fr:cerneaux de noix
@@ -55275,7 +55439,7 @@ sa:जीरकम्
 sd:اڇو جيرو
 si:සූදුරු
 sl:orientalska kumina
-sr:кумин
+sr:кумин, kim
 su:jinten bodas
 sv:spiskummin
 sw:jira
@@ -55543,7 +55707,7 @@ bg:слънчогледово семе, Слънчогледови семки
 bn:সূর্যমুখী বীজ
 bs:sjemenke od suncokreta
 ca:llavors de gira-sol, pipes de gira-sol
-cs:slunecnicová seminka
+cs:slunecnicová seminka, slunečnicová semínka
 cv:Хĕвелчамăш
 da:Solsikkekerner, solsikkefrø
 de:Sonnenblumenkerne
@@ -55631,6 +55795,7 @@ et:Linaseemned, linaseeme
 fa:تخم کتان
 fi:pellavansiemen, pellavansiemenet, pellavansiemeniä
 fr:graine de lin, graines de lin
+hr:lanene sjemenke
 hu:Lenmag
 it:semi di lino
 nb:linfrø
@@ -55733,6 +55898,7 @@ pt:pimenta
 ro:piper
 ru:Перец
 sl:poper
+sr:biber
 sv:peppar
 tr:biber
 ur:کالی مرچ
@@ -55895,7 +56061,7 @@ et:must pipar
 fi:mustapippuri
 fr:poivre noir
 ga:piobar dubh
-hr:crni papar, papar crni
+hr:crni papar, papar crni, plod crnog papra, piper nigrum
 hu:feketebors
 it:pepe nero
 ja:黒胡椒
@@ -56197,6 +56363,7 @@ fa:ارده
 fr:crème de sésame, tahin, tahina, tahiné
 he:טחינה
 hi:ताहिनी
+hr:tahini
 hy:Թահին
 it:Tahina
 ja:芝麻醤
@@ -56388,7 +56555,7 @@ en:spice, spices
 # bg:подправка, подправки is already a condiment
 bs:začini
 ca:Espècies
-cs:Koření
+cs:koření
 da:krydderi, krydderier
 de:Gewürze, Würze, Speisewürze, Suppenwürze
 el:Μπαχαρικό, μπαχαρικά
@@ -56397,7 +56564,7 @@ et:vürtsid
 fi:mauste, mausteet
 fr:épice, épices, aromate
 he:תבלין
-hr:začin, začini
+hr:začin, začini, zači
 is:krydd
 it:spezie
 nb:krydder, krydderi, krydderier
@@ -56405,6 +56572,7 @@ nl:specerijen, specerij
 no:krydder
 ru:Специи, пряности
 sl:začimbe
+sr:začini
 sv:krydda, kryddor, kryddört
 zh:香料
 vegan:en:yes
@@ -56448,6 +56616,7 @@ nb:urt, urte
 nl:Kruiden
 pl:Zioło, zioła, ziół, mieszanka ziół
 pt:plantas aromáticas
+sl:zelišča
 sv:örter, örtkryddor, kryddörter
 vegan:en:yes
 vegetarian:en:yes
@@ -56521,6 +56690,7 @@ nb:krydder og krydderekstrakter
 pl:ekstrakty przypraw i ziół, ekstrakt przypraw i ziół
 ro:condimente și extracte de condimente
 ru:экстракты специй
+sl:začimbe in ekstrati začimb
 sv:kryddor och kryddextrakt
 # ingredient/fr:epices-et-extrait-d'epices has 135 products in 3 languages @2020-05-21
 
@@ -56991,7 +57161,7 @@ gl:cúrcuma
 gu:હળદર
 he:כורכום
 hi:हल्दी
-hr:kurkuma
+hr:kurkuma, curcuma domestica, korijen kurkume
 hu:kurkuma
 id:kunyit
 io:kurkumo
@@ -57518,6 +57688,7 @@ el:κιννάμωμον η κασσία
 et:hiina kaneelipuu
 fi:kassiakaneli
 fr:cannelle de chine
+hr:kora kineskog cimeta, cinnamomum aromaticum
 id:kayu manis cina
 it:cassia
 ja:シナニッケイ
@@ -57898,7 +58069,7 @@ bo:བཅའ་ལྒ།
 br:Jinjebr
 bs:Đumbir
 ca:gingebre
-cs:zázvor
+cs:zázvor, zázvorová
 cy:Sinsir
 da:Ingefær, Ingefær rod
 de:Ingwer
@@ -57916,7 +58087,7 @@ gl:Sinxebra
 gu:આદુ
 he:זנגביל
 hi:अदरक
-hr:đumbir, đumbira
+hr:đumbir, đumbira, korijen đumbira
 ht:jenjanm
 hu:gyömbér
 hy:կոճապղպեղ
@@ -59020,6 +59191,7 @@ fr:menthe verte
 ga:cartlainn gharraí
 gl:hortelá verde
 he:נענע קרחת
+hr:zelene metvice
 hu:fodormenta
 it:menta spicata, menta romana, menta gentile
 ja:スペアミント
@@ -59089,7 +59261,7 @@ ga:lus an phiobair
 gl:menta común
 he:נענע חריפה
 hi:पिपरमिंट
-hr:paprena metvica
+hr:paprena metvica, paprene metvice
 hu:borsmenta
 hy:անանուխ
 id:pepermin
@@ -59573,7 +59745,7 @@ sh:peršin
 sk:petržlen
 sl:peteršilj
 sq:majdanozi
-sr:першун
+sr:першун, peršun
 sv:persilja
 ta:வோக்கோசு
 tl:kinchay
@@ -59651,6 +59823,7 @@ la:Petroselinum crispum var. tuberosum
 nl:peterseliewortel
 pl:korzeń pietruszki, pietruszka korzeń
 sl:jeva korenina
+sr:koren peršuna
 wikidata:en:Q68220931
 # 113 @2021-09-16
 
@@ -60235,7 +60408,7 @@ ga:oragán cumhra
 gl:maiorana
 he:מיורן
 hi:मरुआ
-hr:majoran, origanum majorana
+hr:majoran, origanum majorana, mažuran, divlji mažuran
 hu:majoránna
 id:marjoram
 io:majorano
@@ -60339,7 +60512,7 @@ es:orégano
 et:pune, oregaano
 fi:oregano
 fr:origan
-hr:origana, oregano, mažuran, divlji mažuran
+hr:origana, origano, oregano 
 hu:oregánó, szurokfű
 it:origano
 ja:オレガノ
@@ -60503,6 +60676,7 @@ ro:arpagic
 ru:лук скорода
 sk:pažítka
 sl:drobnjak
+sr:vlašac
 sv:gräslök
 ta:இனப்பூண்டு
 tr:yaprak soğanı
@@ -61177,6 +61351,15 @@ de:Hopfenöl
 fi:humalaöljy
 sv:humleolja
 # ingredient/en:hop-oil has 1 product in 1 language @2020-06-13
+
+<en:hops
+en:processed hops
+hr:prerađeni hmelj
+
+<en:hops
+en:hop preparation
+hr:pripravak od hmelja
+
 
 <en:plant
 fr:pétales de jasmin
@@ -62603,6 +62786,7 @@ fi:rooibos, kapinroibospensas, kapinroibos, rooibos-pensaan lehti
 fr:rooibos
 gl:Rooibos
 he:רויבוש
+hr:afričkog crvenog grma, aspalanthus linearis
 hu:Vörös fokföldirekettye
 id:Rooibos
 it:Rooibos
@@ -62691,7 +62875,7 @@ fa:روزل
 fi:teehibiskus, hibiskus, hibiskuksen kukka
 fr:fleurs de carcadé, fleurs d'hibiscus, hibiscus
 gu:અંબાડી
-hr:hibiskus cvijet, cvijet hibiskusa, cvjetovi hibiskusa, hibiskusa
+hr:hibiskus cvijet, cvijet hibiskusa, cvjetovi hibiskusa, Hibiskus, hibiskusa
 hu:rozella
 id:Rosela
 it:flori di carcadè, Ibisco
@@ -62986,6 +63170,7 @@ es:concentrado de cártamo con efecto colorante
 <en:plant
 bg:листа от стевия, листа стевия
 de:steviablätter
+hr:stevia list
 
 # description:en:Helianthus or SUNFLOWER (/ˌhiːliˈænθəs/)[2] is a genus of plants comprising about 70 species
 # en:sunflower is only found as a specication, i.e. oil (sunflower, ...)
@@ -63864,6 +64049,7 @@ en:Bourbon vanilla beans, vanilla bean Bourbon, bourbon vanilla bean, Bourbon va
 de:Bourbon-Vanilleschote
 fi:bourbon-vaniljakodat
 fr:gousses de vanille bourbon, fève de vanille bourbon
+hr:sjemenke bourbon vanilije
 it:baccello di vaniglia Bourbon, bacche di vaniglia Bourbon, bourbon vanilla bean
 # ingredient/fr:gousses-de-vanille-bourbon has 50 products in 4 languages @2019-02-24
 
@@ -63896,6 +64082,9 @@ fr:grains de vanille épuisés, grains de vanille épuisée, graines de vanille 
 it:semi di vaniglia estratti
 # ingredient/fr:grains-de-vanille-épuisés has 31 products in 5 languages @2019-02-24
 
+<en:vanilla
+en:vanilla preparation
+hr:pripravak vanilija
 
 
 en:vine leaves
@@ -64598,6 +64787,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Saccharina_japonica
 
 <en:seaweed
 en:laver
+de:laver
 
 # en:description:Nori (海苔) is the Japanese name for edible seaweed (a "sea vegetable") species of the red algae genus Pyropia, including P. yezoensis and P. tenera.
 
@@ -69504,7 +69694,7 @@ fr:thon listao, bonite à ventre rayé, Thon rose, Thon rosé
 ga:Boiníotó aigéanach
 gl:Atún listado
 he:אטונס שחור קווים
-hr:prugasta tuna, katsuwonus pelamis
+hr:prugasta tuna, katsuwonus pelamis, tuna prugasta
 hu:Csíkoshasú tonhal
 id:Cakalang
 is:Randatúnfiskur
@@ -69550,6 +69740,9 @@ description:nl:De echte bonito (Katsuwonus pelamis) is een straalvinnige vis uit
 decription:pt:O bonito, bonito-listado, gaiado, atum-bonito e atum-gaiado (Katsuwonus pelamis) é uma espécie de peixes da família Scombridae com distribuição natural cosmopolita nas águas tropicais e temperadas.
 # 644 products in 16 @2021-09-03
 
+<en:skipjack tuna
+en:skipjack tuna fillet
+hr:fileti tune prugaste
 
 #category/yellowfin-tunas
 <en:tuna
@@ -70815,7 +71008,7 @@ gn:Syrymbe
 gu:મૃદુકાય સમુદાય
 he:רכיכות
 hi:मोलस्का
-hr:Mekušci
+hr:mekušaca, mekušci
 hu:puhatestűek
 hy:փափկամարմիններ
 ia:Mollusca
@@ -72349,6 +72542,7 @@ gu:કરચલો
 gv:કરચલો
 he:סרטנים קצרי בטן
 hi:केकड़ा
+hr:rakova
 ht:Krab
 hu:Rövidfarkú rákok
 hy:խաչափառներ
@@ -73060,6 +73254,7 @@ de:Weißbeingarnele, Litopenaeus vannamei
 es:camarón, Litopenaeus vannamei
 fi:valkokatkarapu, Litopenaeus vannamei
 fr:Crevette à pattes blanches, Litopenaeus vannamei
+hr:kozice, penaeus vannamei
 la:Litopenaeus vannamei, Penaeus vannamei, Litopenaus vanamei
 pl:krewetka białonoga, Litopenaeus vannamei
 pt:camarão-de-patas-brancas, Litopenaeus vannamei
@@ -74357,7 +74552,7 @@ fi:Sulfiitti, sulfiitit
 fr:sulfite, sulfites, sulphites, sulphite, bisulfite, metabisulfite, metabisulphite, disulfites
 ga:suilfítí
 he:סולפיט
-hr:sulfit, sulfite
+hr:sulfit, sulfiti, sulfite
 hu:szulfit
 hy:Սուլֆիտներ
 it:solfito, solfiti
@@ -77167,7 +77362,7 @@ ga:buíocán
 gd:buidheagan
 he:חלמון
 hi:अंडे की ज़र्दी
-hr:žumanjak
+hr:žumanjak, žumanjak jaja
 hu:tojássárgája
 hy:Ռեբու
 id:kuning telur
@@ -77690,7 +77885,7 @@ fi:inuliini, inuliinikuitu
 fr:inuline
 gl:Inulina
 he:אינולין
-hr:inulin
+hr:inulin, prehrambena vlakna Beneo, inulin od cikorije
 hu:Inulin
 hy:Ինուլին
 id:Inulin
@@ -77758,6 +77953,8 @@ pl:Błonnik roślinny
 pt:fibra vegetal
 ro:fibre vegetale
 ru:растительное волокно
+sl:rastlinske vlaknine
+sr:biljna vlakna
 sv:vegetabilisk fiber, vegetabilisk fibrer, växtfiber, växtfibrer
 # pt-br:fibra vegetal
 vegan:en:yes
@@ -77995,7 +78192,7 @@ fi:täyte
 fr:garniture, fourrage, nappage, farce, fourrage blanc, remplissage
 gl:Recheo
 he:מלית
-hr:punjenje, punilo
+hr:punjenje, punjenje od, punilo
 hu:töltelék
 id:Isian
 io:Farso
@@ -78059,6 +78256,7 @@ bg:малинов пълнеж
 de:Himbeerfüllung
 fi:vadelmatäyte
 fr:garniture aux framboises
+hr:punjenje od malina
 sv:hallonfyllning
 # usage:en:raspberry filling (raspberries, water, granulated sugar, pectin, and citric acid)
 # mainIngredient:en:raspberry
@@ -79871,6 +80069,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Speculaas
 en:coating, seasoning
 bg:Покритие
 bs:smjesa za paniranje
+cs:ochucující
 de:Beschichtung
 es:envolviendo, sobrimiento,sazonador
 et:kate
@@ -79959,6 +80158,7 @@ pl:bułka tarta, bułki tartej
 pt:pão ralado
 ru:Панировочные сухари
 sk:Strúhanka
+sl:krušne drobtine
 sv:panering, ströbröd, paneringsmjöl, brödsmulor, skorpmjöl, kryddpanering
 uk:Паніровка
 vi:Vụn bánh mì
@@ -81046,6 +81246,7 @@ ciqual_food_name:fr:Fond de volaille pour sauces et cuisson, déshydraté
 <en:chickens
 en:chicken broth, chicken stock
 bg:пилешки бульон
+bs:kokošja supa
 ca:brou de pollastre
 da:Kyllingebouillon
 de:Hühnerbrühe
@@ -82098,6 +82299,7 @@ de:Marinade
 es:marinado
 fi:marinadi
 fr:marinade
+hr:marinada
 hu:marinálás
 it:marinata
 lt:marinatas

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -32,6 +32,7 @@ el:ακατέργαστο
 es:crudo, cruda, crudos, crudas
 fi:raaka
 fr:cru, crue, crus, crues, brut, non raffiné
+hr:nerafinirani
 hu:nyers, nyersen
 nl:rauw, rauwe
 pl:surowy, surowa, surowe
@@ -71,6 +72,7 @@ ca:pura, pur
 de:Purer
 es:pura, puro
 fr:pur
+hr:pasirana, pureće
 it:puro, puri, pura, pure
 
 en:selected
@@ -102,6 +104,7 @@ el:σπόροι
 es:semilla, semillas
 fi:siemen, konsiemenet
 fr:graine, graines
+hr:u zrnu, sjeme
 is:fræ
 it:semi, grani
 ja:の実
@@ -111,6 +114,7 @@ nb:frø
 nl:zaad, zaden
 pl:ziarna, pestki
 pt:sementes
+sl:zrna
 sv:frön
 zh:籽
 
@@ -119,6 +123,7 @@ zh:籽
 #de:filet
 #fi:filee
 #fr:filet de
+#hr:fileti
 #it:filetti di
 #nl:filet
 #pl:filet
@@ -313,6 +318,7 @@ de:granulat, granuliert, granulierte, granulierter, granuliertes
 es:granulado,granulada,granulados,granuladas
 fi:rae
 fr:en granules, granules de, granules d'
+hr:u granulama
 hu:granulátum, granulált
 it:granulare, in granuli
 pl:granulat, granulat z, granulowany, granulowana, granulowane
@@ -332,7 +338,7 @@ de:gemahlen, gemahlene, gemahlener, gemahlenes
 es:molido, molidos, molida, molidas
 fi:jauhettu, jauhetut
 fr:moulu, moulue, moulus, moulues
-hr:mljeveni
+hr:mljeveni, mljevene
 hu:őrölt, őrölve, darált, darálva
 is:muldar
 nl:gemalen
@@ -371,6 +377,7 @@ fr:en purée, purée de, purée d'
 hr:kaša, kaša od
 hu:püré, pürésített
 it:purea di
+mk:каша од
 nb:puré
 nl:puree
 pl:przecier, przeciery, przecier z, przeciery z, piure z, przetarty, przetarta, przetarte
@@ -399,6 +406,7 @@ de:ganz, ganze, ganzer, ganzes
 es:entero, entera, enteros, enteras
 fi:kokonainen, kokonaiset
 fr:entier, entière, entiers, entières
+hr:cijele
 hu:egész, egészben
 it:intero, intera, interi, intere
 pl:całe, w całości
@@ -425,7 +433,7 @@ af:stukkies
 de:stücke, stücken, stückchen, gestückelt, stück
 es:trozo, troza, trozos, trozas, guarnición
 fr:morceaux, pièces de, en morceaux, morceaux de, morceaux d'
-hr:komadići, komadići od, hrskavi komadići, hrskavi komadići od
+hr:komadići, komadići od, hrskavi komadići, hrskavi komadići od, komata
 hu:darabok, darabolt, darab, darabka
 it:pezzi, in pezzi, a pezzi, pezzi di, pezzi d'
 nl:stukjes
@@ -449,6 +457,7 @@ de:Flocken
 es:escamas de
 fi:hiutaleet, hiutale
 fr:flocons de
+hr:pahuljice od
 it:fiocchi di, fiocchi d'
 nl:vlokken
 pl:płatki, grys, wiórki
@@ -482,6 +491,7 @@ ar:مسحوق
 be:парашок
 bg:Прах, на прах
 bn:গুড়া
+bs:u prahu
 ca:en pols, polvo de, pols de, pols d'
 cs:prášek
 cy:powdwr
@@ -496,7 +506,7 @@ fi:jauhe
 fr:en poudre, poudre de, poudre d'
 he:אבקה
 hi:चूर्ण, पाउडर
-hr:prah, u prahu
+hr:prah, praha, u prahu
 ht:Poud
 hu:porított, por
 id:Bubuk
@@ -593,11 +603,15 @@ bg:обезкостен, обезкостено, обезкостена, обе�
 ca:desossat, desossats, desossada, desossades, sense os
 es:deshuesado, deshuesada, deshuesados, deshuesadas, sin hueso
 fr:désossé, désossée, désossés, désossées, sans os
-hr:iskošteno
+hr:iskošteno, bez kosti
 hu:csontozott, kicsontozott
 it:disossato, disossata, disossati, disossate
 pl:bez kości
 pt:desensoçado, desossado, sem osso
+
+<en:boned
+en:boned and skinned
+hr:bez kosti i kože
 
 <en:boned
 en:machine boned
@@ -606,6 +620,7 @@ hr:strojno otkošteno
 #en:description:To remove the outer covering or shell of something
 en:shelled
 ca:sense closca, pelat, pelats, pelada, pelades
+cs:loupaná
 es:sin cascara, pelada, pelado, peladas, pelados
 fr:décortiqué, décortiquée, décortiqués, décortiquées, décoquillé, décoquillée, décoquillés, décoquillées, émondé, émondée, émondés, émondées
 hr:oljušteni
@@ -641,6 +656,7 @@ de:entsteint, entsteinte, entsteinter, entsteintes, entkernt, entkernte, entkern
 #es:sin hueso
 fi:kivetön, kivettömät
 fr:dénoyauté, dénoyautée, dénoyautés, dénoyautées
+hr:bez koštice, bez sjemenki
 hu:magozott, kimagozott, magtalanított
 it:denocciolato, denocciolati, denocciolata, denocciolate
 nl:ontpit, ontpitte
@@ -761,7 +777,7 @@ es:jugo, jugo de
 fi:mehu
 fr:jus de, jus d'
 #en:comment:au jus (tomates pelees concassees au jus) is an exception, jus de cuisson, jus cuisiné, jus de poisson, jus de moules
-hr:sok, sok od
+hr:sok, sok od, voćni sok od, od soka
 hu:leve, lé
 it:succo, succo di, succo d', succhi, succhi di, succhi d'
 nb:juice
@@ -834,10 +850,11 @@ es:concentrado, concentrada, concentrados, concentradas
 fa:کنسانتره
 fi:tiivistetty, tiiviste, tiivisteitä
 fr:concentré, concentrée, concentrés, concentrées, concentré de
-hr:koncentrirani, koncentrat
+hr:koncentriran, koncentrirani, koncentrani, koncentrat, koncentrat za
 hu:sűrítmény, sűrített, koncentrátum
 it:concentrato, concentrato di, concentrato d', concentrati, concentrata, concentrate
 ko:농축물
+mk:концентриран, концентрирана
 nl:concentraten, concentraat, geconcentreerd, geconcentreerde
 pl:koncentrat, koncentraty, koncentrat z, skoncentrowany, skoncentrowana, skoncentrowane, zagęszczony, zagęszczone, zagęszczona, zagęszczonych, zagęszczonego, zagęszczonej
 pt:concentrado, concentrada, concentrados, concentradas, concentrado de, concentrados de, concentratos
@@ -889,7 +906,7 @@ de:aus Konzentrat, aus Konzentraten
 es:a base de concentrado, a base de concentrada, a partir de concentrado, a partir de concentrada
 fi:tiivisteestä, tiivisteestä valmistettu
 fr:à base de concentré, à partir de concentré
-hr:na koncentrat, od koncentriranog soka škrob, od koncentriranog soka
+hr:koncentrirane, na koncentrat, od koncentriranog soka škrob, od koncentriranog soka, od koncentrirane kaše
 hu:sűrítményből, koncentrátumból, sűrítményekből, koncentrátumokból
 it:da concentrato
 lt:iš koncentrąto
@@ -905,7 +922,7 @@ ar:مجف
 bg:изсушен, изсушено, изсушена, изсушени, сушен, сушено, сушена, сушени
 ca:dessecat, dessecade, dessecades, dessecats
 co:secchi
-cs:sušené, sušená, sušenná
+cs:sušené, sušená, sušenná, sušený, suseny
 da:tørret, tørrede
 de:getrocknet, getrocknete, getrockneter, getrocknetes, in getrockneter form, Trocken
 es:seco, seca, secos, secas, secados, secadas, desecado, desecada, desecados, desecadas
@@ -913,7 +930,7 @@ et:kuivatatud
 fi:kuivattu, kuivatut
 fr:séché, séchée, séchés, séchées, sèches
 he:מיובשים, מיובש
-hr:sušeni, sušena, sušeno, sušene, suho, suhi
+hr:sušeni, sušena, sušeno, sušene, suha, suhe, suho, suhi
 hu:szárított
 it:secco, secca, secchi, secche, essiccato, essiccati, essiccata, essiccate
 ja:ドライ
@@ -927,6 +944,7 @@ pt:seco, seca, secos, secas
 ro:uscate
 ru:сушеный, Сушеное, сушёная, сушёный
 sk:sušené
+sr:sušeno
 sv:torkad, torkade
 th:ตาก, ออบแห้ง
 uk:сушена
@@ -944,7 +962,7 @@ en:freeze dried
 de:gefriergetrocknet, gefriergetrocknete, gefriergetrockneter, gefriergetrocknetes
 fi:pakkaskuivattu, pakkaskuivatut, pakastekuivattu
 fr:lyophilisé, lyophilisée, lyophilisés, lyophilisées
-hr:liofilizirane
+hr:liofilizirane, liofiliziran, liofilizirana
 hu:fagyasztva szárított
 nb:frysetørkede
 nl:gevriesdroogde
@@ -1026,6 +1044,7 @@ ca:rehidratat, rehidratada
 es:rehidritado, rehidritada, rehidritados, rehidritadas
 de:rehydriert, rehydrierte, rehydrierter, rehydriertes
 fr:réhydraté, réhydratée, réhydratés, réhydratées
+hr:rehidrirana, rehidrirani
 hu:rehidratált
 it:reidratato, reidratata, reidratati, reidratate
 pt:reidratado, reidratada, reidratados, reidratadas
@@ -1059,6 +1078,7 @@ pt:parcialmente reconstituído, parcialmente reconstituída, parcialmente recons
 en:extract, extracts, extracted, extract of, extracts of, extractive, extractives, extractives of
 bg:екстракт, екстракт от
 ca:extracte
+cs:extrakt
 da:ekstrakt
 de:extrakt, extrakte, extrakt aus, extrakte aus
 es:extracto, extracto de, extractos
@@ -1211,6 +1231,7 @@ pl:pasteryzowana, pasteryzowane, pasteryzowany
 pt:pasteurizado, pasteurizados, pasteurizada, pasteurizadas
 ro:pasteurizat, pasteurizata
 ru:пастеризованные
+sr:pasterizovana
 sv:pastöriserad
 
 fr:thermisé
@@ -1257,6 +1278,9 @@ it:sbollentato, sbollentata, sbollentati, sbollentate
 nl:geblancheerd
 pl:blanszowany, blanszowana, blanszowane, blanszowanych, blanszowanego, blanszowanej
 
+en:thermally processed
+hr:termički obrađena
+
 en:cooked, boiled
 bg:сготвено, сготвена, сготвен, сготвени, варено, варена, варен, варени
 cs:vařená
@@ -1265,6 +1289,7 @@ de:gekocht, gekochte, gekochter, gekochtes
 es:cocido, cocida, cocidos, cocidas
 fi:paistettu, keitetty, kypsennetty, kypsennetyt
 fr:cuit, cuite, cuits, cuites, cuit au naturel, cuite au naturel, cuits au naturel, cuites au naturel, cuisiné, cuisinée, cuisinés, cuisinées
+hr:kuhani
 hu:főtt, főzött
 id:rebus
 it:cotto, cotta, cotti, cotte, cotto al naturale, cotta al naturale, cotti al naturale, cotte al naturale, cucinato, cucinata, cucinati, cucinate
@@ -1275,6 +1300,10 @@ pl:gotowana, gotowany, gotowane, gotowanej, gotowanego, gotowanych
 pt:cozido, cozida, cozidos, cozidas
 ro:fiert
 sv:kokt, kokta
+
+en:distilled
+hr:destilat
+wikidata:en:Q101017
 
 #<en:cooked
 de:gegart, gegarte, gegarter, gegartes, vorgegarte
@@ -1294,6 +1323,7 @@ de:dampfgegart, dampfgegarte, dampfgegarter
 
 en:caramelized, caramelised
 bg:карамелизиран, карамелизирана, карамелизирано, карамелизирани
+bs:karamelizovani
 ca:caramel-litzat
 hr:karamelizirani
 hu:karamellizált
@@ -1341,6 +1371,7 @@ de:gebraten, gebratene, gebratener, gebratenes
 es:asado, asada, asados, asadas
 et:röstitud
 fr:rôti, rôtie, rôtis, rôties, torréfié, torréfiée, torréfiés, torréfiées
+hr:pržene
 hu:pörkölt
 it:arrostito, arrostita, arrostiti, arrostite
 nl:gebraden
@@ -1381,7 +1412,7 @@ de:gegrillt, gegrillte, gegrillter, gegrilltes
 es:a la parrila, a la brasa
 fi:grillattu
 fr:grillé, grillée, grillés, grillées
-hr:pečeni
+hr:pečena, pečeni
 hu:grillezett
 it:grigliato, grigliata, grigliati, grigliate
 nl:gegrild, gegrilde
@@ -1413,6 +1444,7 @@ de:angereichert
 es:enriquecida
 #de:comment:Can also appear in combinations: de:Eiweißangereichertes
 fr:enrichi, enrichie, enrichis
+hr:obogačena
 nl:verrijkt
 pl:wzbogacany, wzbogacana, wzbogacane, wzbogacanej, wzbogacanego, wzbogacanych, fortyfikowany, fortyfikowana, fortyfikowane
 pt:enriquecido, enriquecida, enriquecidos, enriquecidas, enriquecido com, enriquecida com, enriquecidos com, enriquecidas com, enriquecido em, enriquecida em, enriquecidos em, enriquecidas em
@@ -1436,6 +1468,7 @@ pt:coberto, coberta, cobertos, cobertas, cobertura, coberturas, coberto com, cob
 en:mixture
 ca:barreja, barreja de
 es:mezcla, mezcla de
+hr:mješavina
 
 #en:comment:salt has been added to the ingredient
 #<en:added
@@ -1533,6 +1566,7 @@ da:kandiserede
 de:kandiert, kandierte, kandierten, kandierter
 es:confitado,confitada,confitados,confitadas
 fr:confit,confite,confits,confites,confit de,confit d'
+hr:kandirana
 hu:kandírozott, konfitált
 it:candito, candita, canditi, candite
 nl:gekonfijt, gekonfijte
@@ -1654,6 +1688,7 @@ en:fermented
 bg:ферментирало, ферментирал, ферментирала, ферментирали
 ca:fermentat
 es:fermentado
+hr:fermentirano
 hu:fermentált
 it:fermentato, fermentata, fermentati, fermentate
 pl:fermentowany, fermentowana, fermentowane, kiszony, kiszona, kiszone, kiszonych, kiszonego, kiszonej
@@ -1881,7 +1916,7 @@ de::ganz gehärtetes, vollständig hydriertes
 es:totalmente hidrogenado, totalmente hidrogenada
 fr:totalement hydrogénée
 fi:kokonaan kovetettu
-hr:potpuno hidrogenirana
+hr:potpuno hidrogenirana, potpuno hidrogenirano
 nb:fullherdet
 pl:całkowicie uwodorniony, całkowicie uwodorniona, całkowicie uwodornione
 sv:fullhärdad

--- a/taxonomies/minerals.txt
+++ b/taxonomies/minerals.txt
@@ -4911,7 +4911,7 @@ gu:સોડિયમ
 gv:Sodjum
 he:נתרן
 hi:सोडियम
-hr:Natrij
+hr:natrij, natrijev
 ht:Sodyòm
 hu:Nátrium
 hy:նատրիում

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -312,7 +312,7 @@ ca:Ergocalciferol, vitamina D2, D2
 bg:Ергокалциферол
 cs:ergokalciferol, Vitamín D2
 cy:ergocalcifferol
-de:Ergocalciferol, Vitamin D2
+de:Ergocalciferol, Vitamin D2, vitamine D2
 el:εργοκαλσιφερόλη
 eo:Ergokalciferolo
 es:ergocalciferol, vitamina D2, D2
@@ -1120,7 +1120,7 @@ es:Niacina, Vitamina B3
 et:Niatsiin
 fi:Niasiini
 fr:Niacine, Vitamine B3, Vitamine PP
-hr:niacin, Vitamin B3
+hr:niacin, Vitamin B3, nijacin
 hu:Niacin, B3-vitamin, PP-vitamin
 it:Niacina
 ja:ナイアシン
@@ -1181,12 +1181,13 @@ sv:nikotinamid
 
 en:Vitamin B6, Pyridoxin
 bg:Витамин B6
-de:de:Vitamin B6, Pyridoxin
+de:Vitamin B6, Pyridoxin
 el:Βιταμίνη B6
 es:Vitamina B6
 et:B6-vitamiin
 fi:B6-vitamiini
 fr:Vitamine B6, Pyridoxine
+hr:vitamin B6
 hu:B6-vitamin, piridoxin
 it:Vitamina B6, piridoxina
 lt:Vitaminas B6
@@ -1400,7 +1401,7 @@ ca:cobalamina, vitamina B12, B12
 cs:kobalamin, vitamín B12
 cy:cobalamin, Fitamin B12
 da:Vitamin B12
-de:Cobalamine, Vitamin B12
+de:Cobalamine, Vitamin B12, vitamine B12
 dv:ވިޓަމިން ބީ12
 el:Βιταμίνη B12
 eo:Kobalamino, Vitamino B12


### PR DESCRIPTION
updated taxonomies for products found in Croatia (include Serbian, Bosnian, Slovenian, German, etc. languages)