### PR TITLE
fix: removed underline of links in attribute cards

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -927,11 +927,11 @@ html[dir="rtl"] {
 
 a.attribute_card {
   color: $body-font-color;
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 a.attribute_card:hover {
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 // Knowledge panels


### PR DESCRIPTION
small fix to remove underline on links in attributes

![image](https://user-images.githubusercontent.com/8158668/222199106-96f77204-f0d6-4b37-937c-8702e16f5e49.png)
