### PR TITLE
taxonomy: add packaging material code in canonical name

### DIFF
--- a/taxonomies/packaging_materials.txt
+++ b/taxonomies/packaging_materials.txt
@@ -109,16 +109,16 @@ en:Mixed plastics
 fr:Plastiques mixtes
 
 <en:Plastic
-en:PET - Polyethylene terephthalate, Polyethylene terephthalate
+en:PET - 1 - Polyethylene terephthalate, PET - Polyethylene terephthalate, Polyethylene terephthalate
 xx:PET, PET(E), PETE, PET 1, PET 01, 1 PET, 01 PET, ♳
-bg:PET - Полиетилентерефталат, Полиетилен терефталат
-de:PET - Polyethylenterephtalat, Polyethylenterephtalat
-fr:PET - Polytéréphtalate d'éthylène, Polytéréphtalate d'éthylène, polyéthylène téréphtalate
-hr:PET - polietilen tereftalat
-hu:PET - Polietilén-tereftalát, Polietilén-tereftalát
-it:PET - Polietilene tereftalato, Polietilene tereftalato, Polietilentereftalato
-nl:PET - Polyethyleentereftalaat, Polyethyleentereftalaat
-pt:PET - Tereftalato de polietileno, Tereftalato de polietileno
+bg:PET - 1 - Полиетилентерефталат, PET - Полиетилентерефталат, Полиетилен терефталат
+de:PET - 1 - Polyethylenterephtalat, PET - Polyethylenterephtalat, Polyethylenterephtalat
+fr:PET - 1 - Polytéréphtalate d'éthylène, PET - Polytéréphtalate d'éthylène, Polytéréphtalate d'éthylène, polyéthylène téréphtalate
+hr:PET - 1 - polietilen tereftalat, PET - polietilen tereftalat, olietilen tereftalat
+hu:PET - 1 - Polietilén-tereftalát, PET - Polietilén-tereftalát, Polietilén-tereftalát
+it:PET - 1 - Polietilene tereftalato, PET - Polietilene tereftalato, Polietilene tereftalato, Polietilentereftalato
+nl:PET - 1 - Polyethyleentereftalaat, PET - Polyethyleentereftalaat, Polyethyleentereftalaat
+pt:PET - 1 - Tereftalato de polietileno, PET - Tereftalato de polietileno, Tereftalato de polietileno
 ru:PET - Полиэтилентерефталат, Полиэтилентерефталат
 wikidata:en:Q145863
 recycling_code:en:1


### PR DESCRIPTION
I'm proposing to add the packaging material code in the main names of packaging material entries, so that it is easier to identify them.

This is useful in particular when entering materials for a product. The user sees a 1 or 01 in a triangle, he or she can type it, get suggestions for "PET - 1 - Polyethylene terephthalate" and validate it. We could make suggestions work differently (by matching on the xx: entries and synonyms, which we should also do), but if we just suggest "PET - Polyethylene terephthalate", the user cannot get a sense of whether it is a correct entry or not.

Note that this change will change the canonical entry for packagings. It also makes us repeat the local name 3 times in each language:

[abbrevation] - [number] - [name], [abbrevation] - [name], [name]