### PR TITLE
ci: fix build taxonomy in ci

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,6 +48,12 @@ jobs:
       uses: ishworkh/docker-image-artifact-upload@v1
       with:
         image: "openfoodfacts-server/backend:dev"
+    - name: rebuild taxonomies
+      # here we first restore dates from git for taxonomies to avoid build them all
+      # see https://stackoverflow.com/a/60984318/2886726
+      run: |
+        git ls-files taxonomies/ | xargs -I{} git log -1 --date=format:%Y%m%d%H%M.%S --format='touch -t %ad "{}"' "{}" | bash
+        make build_taxonomies GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
 
   check_perl:
     name: Check perl
@@ -82,22 +88,21 @@ jobs:
       uses: ishworkh/docker-image-artifact-download@v1
       with:
         image: "openfoodfacts-server/backend:dev"
-    - name: rebuild taxonomies
-      # here we first restore dates from git for taxonomies to avoid build them all
-      # see https://stackoverflow.com/a/60984318/2886726
-      run: |
-        git ls-files taxonomies/ | xargs -I{} git log -1 --date=format:%Y%m%d%H%M.%S --format='touch -t %ad "{}"' "{}" | bash
-        make build_taxonomies GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
     - name: test
       run: make tests
 
   tests_dev:
     name: Test make dev
+    needs: build_backend  # only to avoid building taxonomies
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 50
+    - name: Download backend image from artifacts
+      uses: ishworkh/docker-image-artifact-download@v1
+      with:
+        image: "openfoodfacts-server/backend:dev"
     - name: Test make dev
       run: |
         make dev

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,6 +69,8 @@ jobs:
         image: "openfoodfacts-server/backend:dev"
     - name: ensure branch origin/main is fetched
       run: git fetch --no-tags --prune --progress --no-recurse-submodules --depth=5 origin  main
+    - name: build taxonomies (should use cache)
+      run: make build_taxonomies
     - name: check perltidy
       run: make check_perltidy
     - name: check perlcritic


### PR DESCRIPTION
We have more than one step depending on it, so add it to the build step. 

Should fix Check perl failing.

