### PR TITLE
fix: remove css rule hiding legit content on pages

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -1067,10 +1067,6 @@ a.grade_e:hover {
 
 #main_column {
   padding-bottom: 2rem;
-  > h1,
-  > p {
-    display: none;
-  }
 }
 
 @import "cards";


### PR DESCRIPTION
Remove CSS rule that has no obvious intent, and that hides legit content on pages like "NOVA" explanation.

fixes:
- #8188