### PR TITLE
fix: responsive-scroll-bar

### DIFF
--- a/scss/_product-page.scss
+++ b/scss/_product-page.scss
@@ -48,6 +48,10 @@ $decalTop:48px;
         display:flex;
     }
     padding:0;
+   
+    @media (max-width:1024px){
+        margin-bottom:50px;
+    }
 }
 #attributes_grid {
     


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
In edit mode, the scroll to top button is overlapping with the changes summary textbox when the width of device is below 1024px. So, I have added media queries specifying the max-width to 1024px where the bottom margin of the button is set to 50px to prevent overlapping:)
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
![Screenshot 2023-03-14 023630](https://user-images.githubusercontent.com/99353300/224840922-9dab63a9-bf7b-4a45-83cc-1917f5c3789c.png)

### Related issue(s) and discussion

- It fixes #7494

