### PR TITLE
fix: underline links in panel text

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -1425,6 +1425,12 @@ a.panel_title {
 .accordion-navigation a {
   text-decoration:none !important;
 }
+.panel_title a {
+  text-decoration:none !important;
+}
+.panel_text a {
+  text-decoration:underline !important;
+}
 .pagination a {
   text-decoration:none !important;
 }


### PR DESCRIPTION
Links were almost invisible in the text of panels, this PR adds an underline. (related: #8216)

I believe links in general should be more obvious (e.g. with a blue color), but that's for another PR.

![image](https://user-images.githubusercontent.com/8158668/225634295-7ac2b17d-8cf0-438d-a51b-8b7453e8f1b7.png)
