### PR TITLE
fix: remove extra barcode in product edit form

### DIFF
--- a/templates/web/pages/product_edit/product_edit_form.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form.tt.html
@@ -1,9 +1,5 @@
 <!-- start templates/[% template.name %] -->
 
-<p id="barcode_paragraph"> [% lang("barcode") %]:
-	<span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">[% code %]</span>
-</p>
-
 [% IF type == "search_or_add" %]
 
     [% IF code.defined %]

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -56,7 +56,9 @@
 
         <section id="misc" class="card fieldset">
             <div class="card-section">
-                <p>[% lang("barcode") %]: [% code %]</p>
+                <p id="barcode_paragraph"> [% lang("barcode") %][% sep %]:
+                    <span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">[% code %]</span>
+                </p>
 
         [% IF moderator %]
             <label for="new_code" id="label_new_code">[% label_new_code %]</label>


### PR DESCRIPTION
Removes the barcode at the top (which was previously hidden with a display:none css rule that we removed)

![image](https://user-images.githubusercontent.com/8158668/225856227-31cc9b9c-c248-4601-86b5-a6a7852c2807.png)
