### PR TITLE
fix: open in Gitpod and mongo shell docs links should point to right resources

### DIFF
--- a/docs/dev/how-to-develop-using-docker.md
+++ b/docs/dev/how-to-develop-using-docker.md
@@ -166,7 +166,7 @@ db.products.find({_id: "5053990155354"})
 db.products.deleteOne({_id: "5053990155354"})
 ```
 
-See the [`mongo` shell docs](https://docs.mongodb.com/manual/reference/mongo-shell/) for more commands.
+See the [`mongo` shell docs](https://www.mongodb.com/products/shell) for more commands.
 
 ## Adding environment variables
 

--- a/docs/dev/how-to-use-gitpod.md
+++ b/docs/dev/how-to-use-gitpod.md
@@ -27,7 +27,7 @@ On the Gitpod side, you can also update what Gitpod is allowed to do with your G
 
 ## Get Started
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/https://github.com/openfoodfacts/openfoodfacts-server/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/openfoodfacts/openfoodfacts-server/)
 > Gitpod will automatically clone and open the repository for you in VSCode by default. It will also automatically build
 > the project for you on opening and comes with Docker and other tools pre-installed making it one of the fastest ways
 > to spin up an environment for `openfoodfacts-server`.


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
just simply made sure that docs reference to correct resources 
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

