### PR TITLE
fix: Hide all nutritional related info if no nutritional info on the box is selected

### DIFF
--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -156,57 +156,58 @@
         <!--nutrient fieldset-->
         <section class="card fieldset" id="nutrition">
             <div class="card-section">
-            <legend>[% lang('nutrition_data') %]</legend>
-            <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-            <input type="hidden" name="no_nutrition_data_displayed" value="1" />
-            <input type="checkbox" id="no_nutrition_data" name="no_nutrition_data" [% nutrition_checked %] />
-            <label for="no_nutrition_data" class="checkbox_label">[% lang('no_nutrition_data') %]</label><br/>
-            [% display_tab_nutrition_image %]
-            [% display_field_serving_size %]
-
-            [% FOREACH nutrient IN nutrition_products %]
+                <legend>[% lang('nutrition_data') %]</legend>
                 <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
-                <input type="hidden" name="[% nutrient.nutrition_data %]_displayed" value="1" />
-                <input type="checkbox" id="[% nutrient.nutrition_data %]" name="[% nutrient.nutrition_data %]" [% nutrient.checked %] />
-                <label for="[% nutrient.nutrition_data %]" class="checkbox_label">[% nutrient.nutrition_data_exists %]</label> &nbsp;
-                <input type="radio" id="[% nutrient.nutrition_data_per %]_100g" value="100g" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_100g %] />
-                <label for="[% nutrient.nutrition_data_per %]_100g">[% lang('nutrition_data_per_100g') %]</label>
-                <input type="radio" id="[% nutrient.nutrition_data_per %]_serving" value="serving" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_serving %] />
-                <label for="[%nutrient. nutrition_data_per %]_serving">[% lang('nutrition_data_per_serving') %]</label><br/>
+                <input type="hidden" name="no_nutrition_data_displayed" value="1" />
+                <input type="checkbox" id="no_nutrition_data" name="no_nutrition_data" [% nutrition_checked %] />
+                <label for="no_nutrition_data" class="checkbox_label">[% lang('no_nutrition_data') %]</label><br/>
+                <div id="nutrition_data_div">
+                    [% display_tab_nutrition_image %]
+                    [% display_field_serving_size %]
 
-                [% IF nutrition_data_instructions_check && nutrition_data_instructions_check != '' %]
-                    <p id="[% nutrient.nutrition_data_instructions %]" [% nutrient.hidden %]>[% lang(nutrient.nutrition_data_instructions) %]</p>
-                [% END %]
-            [% END %]
+                    [% FOREACH nutrient IN nutrition_products %]
+                        <!-- extra field suffixed with _displayed to allow detecting when a box is unchecked -->
+                        <input type="hidden" name="[% nutrient.nutrition_data %]_displayed" value="1" />
+                        <input type="checkbox" id="[% nutrient.nutrition_data %]" name="[% nutrient.nutrition_data %]" [% nutrient.checked %] />
+                        <label for="[% nutrient.nutrition_data %]" class="checkbox_label">[% nutrient.nutrition_data_exists %]</label> &nbsp;
+                        <input type="radio" id="[% nutrient.nutrition_data_per %]_100g" value="100g" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_100g %] />
+                        <label for="[% nutrient.nutrition_data_per %]_100g">[% lang('nutrition_data_per_100g') %]</label>
+                        <input type="radio" id="[% nutrient.nutrition_data_per %]_serving" value="serving" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_serving %] />
+                        <label for="[%nutrient. nutrition_data_per %]_serving">[% lang('nutrition_data_per_serving') %]</label><br/>
 
-            <div style="position:relative">
+                        [% IF nutrition_data_instructions_check && nutrition_data_instructions_check != '' %]
+                            <p id="[% nutrient.nutrition_data_instructions %]" [% nutrient.hidden %]>[% lang(nutrient.nutrition_data_instructions) %]</p>
+                        [% END %]
+                    [% END %]
 
-                <table id="nutrition_data_table" class="data_table" style="[% tablestyle %]" aria-label="nutrition table">
-                    <thead class="nutriment_header">
-                        <th id="col_1">
-                            [% lang('nutrition_data_table') %]
-                        </th>
-                        <th id="col_2" class="nutriment_col" [% column_display_style_nutrition_data %]>
-                            [% lang('product_as_sold') %]<br/>
-                            <span id="nutrition_data_100g" [% nutrition_data_100g_style %]>[% lang('nutrition_data_per_100g') %]</span>
-                            <span id="nutrition_data_serving" [% nutrition_data_serving_style %]>[% lang('nutrition_data_per_serving') %]</span>
-                        </th>
-                        <th id="col_3" class="nutriment_col_prepared" [% column_display_style_nutrition_data_prepared %]>
-                            [% lang('prepared_product') %]<br/>
-                            <span id="nutrition_data_prepared_100g" [% nutrition_data_prepared_100g_style %]>[% lang('nutrition_data_per_100g') %]</span>
-                            <span id="nutrition_data_prepared_serving" [% nutrition_data_prepared_serving_style %]>[% lang('nutrition_data_per_serving') %]</span>
-                        </th>
-                        <th id="col_4">
-                            [% lang('unit') %]
-                        </th>
-                    </thead>
+                    <div style="position:relative">
 
-                    <tbody>
+                        <table id="nutrition_data_table" class="data_table" style="[% tablestyle %]" aria-label="nutrition table">
+                            <thead class="nutriment_header">
+                                <th id="col_1">
+                                    [% lang('nutrition_data_table') %]
+                                </th>
+                                <th id="col_2" class="nutriment_col" [% column_display_style_nutrition_data %]>
+                                    [% lang('product_as_sold') %]<br/>
+                                    <span id="nutrition_data_100g" [% nutrition_data_100g_style %]>[% lang('nutrition_data_per_100g') %]</span>
+                                    <span id="nutrition_data_serving" [% nutrition_data_serving_style %]>[% lang('nutrition_data_per_serving') %]</span>
+                                </th>
+                                <th id="col_3" class="nutriment_col_prepared" [% column_display_style_nutrition_data_prepared %]>
+                                    [% lang('prepared_product') %]<br/>
+                                    <span id="nutrition_data_prepared_100g" [% nutrition_data_prepared_100g_style %]>[% lang('nutrition_data_per_100g') %]</span>
+                                    <span id="nutrition_data_prepared_serving" [% nutrition_data_prepared_serving_style %]>[% lang('nutrition_data_per_serving') %]</span>
+                                </th>
+                                <th id="col_4">
+                                    [% lang('unit') %]
+                                </th>
+                            </thead>
 
-                        [% FOREACH nutriment IN nutriments %]
+                            <tbody>
 
-                            [% IF nutriment.shown %]
-                                <tr id="nutriment_[% nutriment.enid %]_tr" class="nutriment_[% nutriment.class %]"[% nutriment.display %]>
+                                [% FOREACH nutriment IN nutriments %]
+
+                                    [% IF nutriment.shown %]
+                                        <tr id="nutriment_[% nutriment.enid %]_tr" class="nutriment_[% nutriment.class %]"[% nutriment.display %]>
 
                                     <td>
                                         <!--label starts-->
@@ -224,49 +225,50 @@
                                         <!--label ends-->
                                     </td>
 
-                                    <td class="nutriment_col" [% column_display_style_nutrition_data %]>
-                                        <input class="nutriment_value nutriment_value_as_sold" id="nutriment_[% nutriment.enid %]" name="nutriment_[% nutriment.enid %]" value="[% nutriment.value %]" [% nutriment.disabled %] autocomplete="off"/>
-                                    </td>
-                                    <td class="nutriment_col_prepared" [% column_display_style_nutrition_data_prepared %]>
-                                        <input class="nutriment_value nutriment_value_prepared" id="nutriment_[% nutriment.enidp %]" name="nutriment_[% nutriment.enidp %]" value="[% nutriment.valuep %]" [% nutriment.disabled %] autocomplete="off"/>
-                                    </td>
-
-                                    [% IF nutriment.nid == 'alcohol' || nutriment.nid == 'energy-kj' || nutriment.nid == 'energy-kcal' %]
-                                        <td>
-                                            <span class="nutriment_unit">[% nutriment.nutriment_unit %]</span>
-
-                                    [% ELSE %]
-                                        <td>
-                                            <span class="nutriment_unit_percent" id="nutriment_[% nutriment.enid %]_unit_percent"[% nutriment.hide_percent %]>%</span>
-                                            <select class="nutriment_unit" id="nutriment_[% nutriment.enid %]_unit" name="nutriment_[% nutriment.enid %]_unit"[% nutriment.hide_select %] [% nutriment.nutriment_unit_disabled %]>
-                                                [% FOREACH unit IN nutriment.units_arr %]
-                                                    <option value="[% unit.u %]" [% unit.selected %]>[% unit.label %]</option>
-                                                [% END %]
-                                                </select>
-                                    [% END %]
+                                            <td class="nutriment_col" [% column_display_style_nutrition_data %]>
+                                                <input class="nutriment_value nutriment_value_as_sold" id="nutriment_[% nutriment.enid %]" name="nutriment_[% nutriment.enid %]" value="[% nutriment.value %]" [% nutriment.disabled %] autocomplete="off"/>
                                             </td>
-                                    </tr>
+                                            <td class="nutriment_col_prepared" [% column_display_style_nutrition_data_prepared %]>
+                                                <input class="nutriment_value nutriment_value_prepared" id="nutriment_[% nutriment.enidp %]" name="nutriment_[% nutriment.enidp %]" value="[% nutriment.valuep %]" [% nutriment.disabled %] autocomplete="off"/>
+                                            </td>
 
-                            [% END %]
+                                            [% IF nutriment.nid == 'alcohol' || nutriment.nid == 'energy-kj' || nutriment.nid == 'energy-kcal' %]
+                                                <td>
+                                                    <span class="nutriment_unit">[% nutriment.nutriment_unit %]</span>
 
-                        [% END %]
+                                            [% ELSE %]
+                                                <td>
+                                                    <span class="nutriment_unit_percent" id="nutriment_[% nutriment.enid %]_unit_percent"[% nutriment.hide_percent %]>%</span>
+                                                    <select class="nutriment_unit" id="nutriment_[% nutriment.enid %]_unit" name="nutriment_[% nutriment.enid %]_unit"[% nutriment.hide_select %] [% nutriment.nutriment_unit_disabled %]>
+                                                        [% FOREACH unit IN nutriment.units_arr %]
+                                                            <option value="[% unit.u %]" [% unit.selected %]>[% unit.label %]</option>
+                                                        [% END %]
+                                                        </select>
+                                            [% END %]
+                                                    </td>
+                                            </tr>
 
-                    </tbody>
-                </table>
+                                    [% END %]
 
-                <input type="hidden" name="new_max" id="new_max" value="1" />
-                <div id="nutrition_image_copy" style="position:absolute;bottom:0"></div>
+                                [% END %]
+
+                            </tbody>
+                        </table>
+
+                        <input type="hidden" name="new_max" id="new_max" value="1" />
+                        <div id="nutrition_image_copy" style="position:absolute;bottom:0"></div>
+                    </div>
+
+                [% IF moderator %]
+                    <div><a class="small button" onclick="\$('.nutriment_value').val('')">[% lang('remove_all_nutrient_values') %]</a></div>
+                [% END %]
+
+                <p class="asterisk">&rarr;*[% sep %]:[% lang('nutrition_data_table_asterisk') %]</p>
+                <p class="note">&rarr; [% lang('nutrition_data_table_note') %]</p>
+                </div>
+                
             </div>
-
-            [% IF moderator %]
-                <div><a class="small button" onclick="\$('.nutriment_value').val('')">[% lang('remove_all_nutrient_values') %]</a></div>
-            [% END %]
-           
-            <p class="asterisk">&rarr;*[% sep %]:[% lang('nutrition_data_table_asterisk') %]</p>
-            <p class="note">&rarr; [% lang('nutrition_data_table_note') %]</p>
-
-            </div>
-        </section><!--nutrient field set-->
+    </section><!--nutrient field set-->
 
         <!--packaging field-->
         <section id="packaging_section" class="card fieldset">

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.js
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.js
@@ -26,3 +26,11 @@
 	});
 
 [% END %]
+
+\$('#no_nutrition_data').change(function() {
+	if (\$(this).prop('checked')) {
+		\$('#nutrition_data_div').hide();
+	} else {
+		\$('#nutrition_data_div').show();
+	}
+});


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

This misunderstanding happens because while the checkbox saying "Nutrition facts are not specified on the product.", we hide some nutrional info form elements but we still display others.


<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot

https://user-images.githubusercontent.com/58003327/226318904-f02b9292-aee3-4c2e-bfc6-4501b5c1f394.mov

cc @yuktea @stephanegigandet @alexgarel 

<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #6729

