### PR TITLE
fix: Do not show the lilo prompt in countries where it's unsupported

### DIFF
--- a/templates/web/pages/session/signed_in.tt.html
+++ b/templates/web/pages/session/signed_in.tt.html
@@ -4,7 +4,9 @@
 
 [% IF !server_options_producers_platform %]
     <h3>[% lang('you_can_also_help_us') %]</h3>
-    <p>[% lang('bottom_content') %]</p>
+    [% IF lc == "en" or lc == "fr" %]
+        <p>[% lang('bottom_content') %]</p>
+    [% END %]
 [% ELSE %]
 
     <h3>[% lang("resources") %]</h3>

--- a/templates/web/pages/session/signed_in.tt.html
+++ b/templates/web/pages/session/signed_in.tt.html
@@ -3,8 +3,8 @@
 <p>[% lang('hello')%] [% user_name %]!</p>
 
 [% IF !server_options_producers_platform %]
-    <h3>[% lang('you_can_also_help_us') %]</h3>
     [% IF lc == "en" or lc == "fr" %]
+        <h3>[% lang('you_can_also_help_us') %]</h3>
         <p>[% lang('bottom_content') %]</p>
     [% END %]
 [% ELSE %]

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -206,7 +206,9 @@
 
         [% IF !(server_options_producers_platform) %]
             <h3>[% lang("you_can_also_help_us") %]</h3>
-            <p>[% lang("bottom_content") %]</p>
+            [% IF lc == "en" or lc == "fr" %]
+                <p>[% lang("bottom_content") %]</p>
+            [% END %]
         [% END %]
 
     [% END %]

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -205,8 +205,8 @@
         <!-- Do not display donate link on producers platform -->
 
         [% IF !(server_options_producers_platform) %]
-            <h3>[% lang("you_can_also_help_us") %]</h3>
             [% IF lc == "en" or lc == "fr" %]
+                <h3>[% lang("you_can_also_help_us") %]</h3>
                 <p>[% lang("bottom_content") %]</p>
             [% END %]
         [% END %]


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Do not show the lilo prompt in countries where it's unsupported
https://www.lilo.org/fr/open-food-facts/

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot

https://user-images.githubusercontent.com/58003327/226471635-4f615e76-1a19-40cf-88e8-1d5c64baf575.mov

cc @yuktea @stephanegigandet @alexgarel 

<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[7905]

