### PR TITLE
fix: re-canonicalize packaging component properties

### DIFF
--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -706,6 +706,27 @@ sub migrate_old_number_and_quantity_fields_202211 ($product_ref) {
 	return;
 }
 
+=head2 canonicalize_packaging_components_properties ($product_ref) {
+
+Re-canonicalize the shape, material and recycling properties of packaging components.
+This is useful in particular if the corresponding taxonomies have changed.
+
+=cut
+
+sub canonicalize_packaging_components_properties ($product_ref) {
+
+	foreach my $packaging_ref (@{$product_ref->{packagings}}) {
+		foreach my $property ("shape", "material", "recycling") {
+			if (defined $packaging_ref->{$property}) {
+				my $tagtype = $packaging_taxonomies{$property};
+				$packaging_ref->{$property}
+					= canonicalize_taxonomy_tag($product_ref->{lc}, $tagtype, $packaging_ref->{$property});
+			}
+		}
+	}
+	return;
+}
+
 =head2 set_packaging_misc_tags($product_ref)
 
 Set some tags in the /misc/ facet so that we can track the products that have 
@@ -866,6 +887,9 @@ sub analyze_and_combine_packaging_data ($product_ref, $response_ref) {
 
 	# TODO: remove once all products have been migrated
 	migrate_old_number_and_quantity_fields_202211($product_ref);
+
+	# Re-canonicalize the packaging components properties, in case the corresponding taxonomies have changed
+	canonicalize_packaging_components_properties($product_ref);
 
 	# The packaging text field (populated by OCR of the packaging image and/or contributors or producers)
 	# is used as input only if the packagings structure is empty

--- a/tests/unit/packaging.t
+++ b/tests/unit/packaging.t
@@ -592,6 +592,30 @@ foreach my $test_ref (@tests) {
 	}
 }
 
+my $product_ref = {
+	lc => "fr",
+	packagings => [
+		{
+			shape => 'fr:bouteille',
+			material => 'en:pet',
+			recycling => 'à jeter'
+		},
+	],
+};
+
+ProductOpener::Packaging::canonicalize_packaging_components_properties($product_ref);
+
+is_deeply(
+	$product_ref->{packagings},
+	[
+		{
+			'material' => 'en:pet-1-polyethylene-terephthalate',
+			'recycling' => 'en:discard',
+			'shape' => 'en:bottle'
+		},
+	]
+) or diag explain $product_ref->{packagings};
+
 #
 
 done_testing();


### PR DESCRIPTION
This is needed because we have changed the canonical names for packaging entries like PET.