### PR TITLE
fix: docker YAML key mapping duplication 

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -33,12 +33,10 @@ services:
     profiles: ["off"]
     <<: *minion-db-network
   backend:
-    <<: *backend-conf
-    <<: *minion-db-network
+    <<: [*backend-conf, *minion-db-network] 
   incron: *backend-conf
   minion:
-    <<: *backend-conf
-    <<: *minion-db-network
+    <<: [*backend-conf, *minion-db-network]
   # in dev we want to use watch assets and recompile on the fly
   # also we want to build at start time in case some files changed, as we want to avoid recreating volumes
   dynamicfront:


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [ ] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
I experienced an error with make dev  or docker compose up  or any command that requires docker.
```
docker-compose --env-file=.env build 2>&1
yaml: unmarshal errors:
  line 37: mapping key "<<" already defined at line 36
  line 41: mapping key "<<" already defined at line 40
make: *** [Makefile:93: build] Error 15
```
There was need to merge https://github.com/openfoodfacts/openfoodfacts-server/blob/d9072f92ac0d0c0b8cbd6f7e478b3e0cba6a8700/docker/dev.yml#L36-L40  

Thanks to @alexgarel who suggested the idea 

cc @stephanegigandet @yuktea 


<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

