### PR TITLE
build: fix docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,4 +29,4 @@ packager-codes/*.csv
 packager-codes/*.tsv
 packager-codes/*.py
 packager-codes/*.json
-taxonomies*/**/*.txt
+taxonomies*/**/*.sto

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -152,6 +152,7 @@ jobs:
           echo "INFLUXDB_HOST=${{ env.INFLUXDB_HOST }}" >> .env
           echo "LOG_LEVEL_ROOT=ERROR" >> .env
           echo "LOG_LEVEL_MONGODB=ERROR" >> .env
+          echo "BUILD_CACHE_REPO=openfoodfacts/openfoodfacts-build-cache" >> .env
 
           # Override domain name in nginx.conf
           sed -i.bak "s/productopener.localhost/${{ env.PRODUCT_OPENER_DOMAIN }}/g" ./conf/nginx.conf

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -180,6 +180,7 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        command_timeout: 25m
         script_stop: false
         script: |
           cd ${{ matrix.env }} && \
@@ -194,6 +195,7 @@ jobs:
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        command_timeout: 15m
         script_stop: false
         script: |
           cd ${{ matrix.env }} && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,12 @@ x-backend-conf: &backend-conf
     - products:/mnt/podata/products # .sto
     - product_images:/opt/product-opener/html/images/products # .jpg
     - orgs:/mnt/podata/orgs # .sto
+    # build-cache
+    - build_cache:/mnt/podata/build-cache
+
     # all the rest
     - podata:/mnt/podata
+
 
     # Logs
     - ./logs/apache2:/var/log/apache2

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -105,6 +105,7 @@ volumes:
   podata:  # we also need to share it because users_emails and orgs... are not separated yet
     name: ${PO_COMMON_PREFIX:-}po_podata
   dbdata:
+  build_cache:
 
 networks:
   # this is a specific network to enable pro platform to join the postgres db

--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -37,6 +37,8 @@ volumes:
     external: true
   podata:
     external: true
+  # not external, for wiping it will avoid keeping too much cached data
+  build_cache:
 
 networks:
   webnet:


### PR DESCRIPTION
1. We need taxonomy txt files in images as we build sto from them
2. We also need to have BUILD_CACHE_REPO set on the deployment to use cache
3. Use a volume for local build cache.
