### PR TITLE
fix: loosing the second facet at the end of the url on redirection

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -3060,6 +3060,7 @@ sub display_tag ($request_ref) {
 	}
 
 	if (defined $request_ref->{groupby_tagtype}) {
+		$request_ref->{current_link} .= "/" . $tag_type_plural{$request_ref->{groupby_tagtype}}{$lc};
 		$request_ref->{world_current_link} .= "/" . $tag_type_plural{$request_ref->{groupby_tagtype}}{$lc};
 	}
 

--- a/tests/unit/display.t
+++ b/tests/unit/display.t
@@ -153,9 +153,9 @@ like(display_field($product_ref, 'states'), qr/$expected/);
 
 # should not loose the second facet at the end of the url on redirection
 my $facets_ref = {
-	'current_link' => 'category/en:lemonades/data-quality',
+	'tagtype' => 'categories',
 	'groupby_tagtype' => 'data_quality',
-	'tagid' => 'en:lemonade'
+	'tagid' => 'en:bread'
 };
 
 my $apache_util_module = Test::MockModule->new('Apache2::RequestUtil');
@@ -203,7 +203,7 @@ $display_module->mock(
 
 display_tag($facets_ref);
 
-unlike($facets_ref->{'current_link'}, qr/en:lemonades\/data\-quality/);    # verify that link has been processed
-like($facets_ref->{'redirect'}, qr/lemonade\/data\-quality/);
+is($facets_ref->{'current_link'}, '/category/breads/data-quality');
+is($facets_ref->{'redirect'}, '/category/breads/data-quality');
 
 done_testing();

--- a/tests/unit/display.t
+++ b/tests/unit/display.t
@@ -4,6 +4,7 @@ use Modern::Perl '2017';
 use utf8;
 
 use Test::More;
+use Test::MockModule;
 use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Display qw/:all/;
@@ -149,5 +150,60 @@ $product_ref = {
 };
 $expected = lang('to_do_status') . separator_before_colon($lc) . q{:};
 like(display_field($product_ref, 'states'), qr/$expected/);
+
+# should not loose the second facet at the end of the url on redirection
+my $facets_ref = {
+	'current_link' => 'category/en:lemonades/data-quality',
+	'groupby_tagtype' => 'data_quality',
+	'tagid' => 'en:lemonade'
+};
+
+my $apache_util_module = Test::MockModule->new('Apache2::RequestUtil');
+$apache_util_module->mock(
+	'request',
+	sub {
+		# Return a mock Apache request object
+		my $r = {};
+		bless $r, 'Apache2::RequestRec';
+
+		return $r;
+	}
+);
+
+my $request_rec_module = Test::MockModule->new('Apache2::RequestRec');
+$request_rec_module->mock(
+	'rflush',
+	sub {
+		# Do nothing, am just mocking the method
+	}
+);
+
+$request_rec_module->mock(
+	'status',
+	sub {
+		# Do nothing, am just mocking the method
+	}
+);
+
+$request_rec_module->mock(
+	'headers_out',
+	sub {
+		# Do nothing, am just mocking the method
+
+	}
+);
+
+my $display_module = Test::MockModule->new('ProductOpener::Display');
+$display_module->mock(
+	'redirect_to_url',
+	sub {
+		# Do nothing, am just mocking the method
+	}
+);
+
+display_tag($facets_ref);
+
+unlike($facets_ref->{'current_link'}, qr/en:lemonades\/data\-quality/);    # verify that link has been processed
+like($facets_ref->{'redirect'}, qr/lemonade\/data\-quality/);
 
 done_testing();


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
I have appended `$request_ref->{groupby_tagtype}` to  the `$request_ref->{current_link}` so that there is no truncation in redirection.
I have also added tests to verify that, 
1. request is processed 
2. the second facet exists in the redirection link

cc @yuktea @alexgarel @stephanegigandet 
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

https://user-images.githubusercontent.com/58003327/230877303-f4caf75a-4257-4580-9fdb-93911b339b79.mov

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #7979

