### PR TITLE
chore: cleaning up the potatoes category

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -90390,7 +90390,7 @@ nl:Pepers in blik/pot
 
 
 <en:Canned plant-based foods
-<en:Potatoes
+<en:Potato preparations
 en:Canned potatoes, Canned potatoes
 bg:Картофи от консерва
 es:Patatas en conserva
@@ -92753,12 +92753,12 @@ agribalyse_proxy_food_code:en:4008
 agribalyse_proxy_food_name:en:Potato, peeled, raw
 agribalyse_proxy_food_name:fr:Pomme de terre, sans peau, crue
 
-<en:Potatoes
+<en:Potato preparations
 en:Precooked potatoes
 fr:Pommes de terres précuites
 nl:Voorgekookte aardappelen
 
-<en:Potatoes
+<en:Potato preparations
 <en:Cooked vegetables
 en:Cooked potatoes
 fr:Pommes de terre cuites
@@ -92894,13 +92894,14 @@ ciqual_food_code:en:4028
 ciqual_food_name:en:Ware potato, boiled/cooked in water, peeled
 ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à l'eau
 
-<en:Potato preparations
-en:Peeled boiled early potato, Peeled early potato cooked in water
-fr:Pommes de terre primeur sans peau bouillies, Pommes de terre primeur sans peau cuites à l'eau
-agribalyse_food_code:en:4029
-ciqual_food_code:en:4029
-ciqual_food_name:en:Early potato, boiled/cooked in water, peeled
-ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
+#<en:Potato preparations
+#en:Peeled boiled early potato, Peeled early potato cooked in water
+#fr:Pommes de terre primeur sans peau bouillies, Pommes de terre primeur sans peau cuites à l'eau
+#agribalyse_food_code:en:4029
+#ciqual_food_code:en:4029
+#ciqual_food_name:en:Early potato, boiled/cooked in water, peeled
+#ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
+#no products on 15-4-23
 
 <en:Potatoes
 en:Peeled potatoes
@@ -92953,7 +92954,7 @@ ciqual_food_name:fr:Pomme de terre sautée/poêlée à la graisse de canard
 en:Potatoes for steaming
 fr:Pommes de terre spéciales vapeur
 
-<en:Potatoes
+<en:Potato preparations
 en:Vacuum-packed steamed potatoes
 fr:Pommes de terre vapeur sous vide
 agribalyse_food_code:en:4014

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92758,17 +92758,14 @@ agribalyse_proxy_food_name:fr:Pomme de terre, sans peau, crue
 #################### Potato harvest ####################
 
 <en:Potatoes
-en:Fresh potatoes, New potatoes
+en:New potatoes
 fi:Tuoreet perunat
-fr:Pommes de terre nouvelles, Pommes de terre fraîches
+fr:Pommes de terre nouvelles, Pommes de terre fraîches, Pommes de terre primeurs, Pommes de terre de primeur
 nl:Nieuwe oogst aardappelen
 agribalyse_food_code:en:4023
 ciqual_food_code:en:4023
 ciqual_food_name:en:New potato, raw
 ciqual_food_name:fr:Pomme de terre nouvelle, crue
-
-<en:Potatoes
-fr:Pommes de terre primeurs, Pommes de terre de primeur
 
 #################### Potato minimal processing ####################
 
@@ -92825,6 +92822,8 @@ nl:Lady Christl aardappelen
 
 <en:Potatoes
 en:Potatoes for steaming
+de:Speisekartoffeln
+es:Patatas para cocinar al vapor
 fr:Pommes de terre spéciales vapeur
 
 

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92768,9 +92768,14 @@ ciqual_food_name:en:Potato, cooked (average food)
 ciqual_food_name:fr:Pomme de terre, cuite (aliment moyen)
 
 <en:Potatoes
-en:Fresh potatoes
+en:Fresh potatoes, New potatoes
 fi:Tuoreet perunat
-fr:Pommes de terre fraîches
+fr:Pommes de terre nouvelles, Pommes de terre fraîches
+nl:Nieuwe oogst aardappelen
+agribalyse_food_code:en:4023
+ciqual_food_code:en:4023
+ciqual_food_name:en:New potato, raw
+ciqual_food_name:fr:Pomme de terre nouvelle, crue
 
 <en:Potatoes
 fr:Pommes de terre primeurs, Pommes de terre de primeur
@@ -92792,24 +92797,34 @@ wikidata:en:Q373973
 fr:Pommes de terre Béa
 wikidata:en:Q2929373
 
-<en:Potatoes
-fi:Lapin Puikula
-fr:Pommes de terre de Laponie
-nl:Aardappelen uit lapland Finland
-protected_name_file_number:en: PDO-FI-1390
-protected_name_type:en: pdo
-origins:en: en:Finland
+#<en:Potatoes
+#en:Potatoes from Lapin Puikula
+#fi:Lapin Puikula
+#fr:Pommes de terre de Laponie
+#nl:Aardappelen uit lapland Finland
+#protected_name_file_number:en: PDO-FI-1390
+#protected_name_type:en: pdo
+#origins:en: en:Finland
 #wikidata:en:
+#no products @2023-04-15
 
 <en:Potatoes
-en:Potatoes from Fucino Italy
+en:Potatoes from Italy
+fr:Pommes de terre d'Italie
+nl:Aardappelen uit Italië
+origins:en: en:France
+#wikidata:en:
+#add the origin France if you want to specify this category
+
+<en:Potatoes from Italy
+en:Potatoes from Fucino 
 it:Patata del Fucino
 protected_name_file_number:en: PGI-IT-01217-AM01, en: PGI-IT-01217
 protected_name_type:en: pgi
 origins:en: en:Italy
 wikidata:en:Q3368654
 
-#<en:Potatoes
+#<en:Potatoes from Italy
 #it:Patata novella di Galatina
 #protected_name_file_number:en: PDO-IT-1148
 #protected_name_type:en: pdo
@@ -92817,7 +92832,7 @@ wikidata:en:Q3368654
 #wikidata:en:Q3368641
 #no products on 14/04/23
 
-#<en:Potatoes
+#<en:Potatoes from Italy
 #it:Patata Rossa di Colfiorito
 #protected_name_file_number:en: PGI-IT-1236
 #protected_name_type:en: pgi
@@ -92825,8 +92840,8 @@ wikidata:en:Q3368654
 #wikidata:en:Q3368646
 #no products on 14/04/23
 
-#<en:Potatoes
-#en:Potatoes from Bologna Italy
+#<en:Potatoes from Italy
+#en:Potatoes from Bologna 
 #it:Patata di Bologna
 #protected_name_file_number:en: PDO-IT-0349
 #protected_name_type:en: pdo
@@ -92834,8 +92849,8 @@ wikidata:en:Q3368654
 #wikidata:en:Q3368638
 #no products on 14/04/23
 
-<en:Potatoes
-en:Potatoes from Sila Italy
+<en:Potatoes from Italy
+en:Potatoes from Sila 
 it:Patata della Sila
 protected_name_file_number:en: PGI-IT-0643
 protected_name_type:en: pgi
@@ -92858,14 +92873,15 @@ fr:Pommes de terre Charlotte
 nl:Charlotte aardappel
 wikidata:en:Q1067085
 
-#<en:Potatoes
-#en:French potatoes
-#fr:Pommes de terre françaises
-#origins:en: en:France
+<en:Potatoes
+en:French potatoes
+fr:Pommes de terre françaises
+origins:en: en:France
 #wikidata:en:
 #add the origin France if you want to specify this category
 
 <en:French potatoes
+en:Potatoes from Île de Ré
 fr:Pommes de terre de l'île de Ré, Pomme de terre de l'île de Ré
 protected_name_file_number:en: PDO-FR-0065
 protected_name_type:en: pdo
@@ -92873,6 +92889,7 @@ origins:en: en:France, fr:île de Ré
 wikidata:en:Q3395977
 
 <en:French potatoes
+en:Potatoes from Noirmoutier
 fr:Pomme de terre de Noirmoutier
 protected_name_type:en: pdo
 origins:en: en:France, fr:Noirmoutier
@@ -92880,6 +92897,7 @@ protected_name_file_number:en: PGI-FR-02434
 protected_name_type:en: pgi
 
 <en:French potatoes
+en:Potatoes from Merville
 fr:Pommes de terre de Merville
 protected_name_file_number:en: PGI-FR-0197
 protected_name_type:en: pgi
@@ -92970,16 +92988,9 @@ ciqual_food_code:en:4014
 ciqual_food_name:en:Potato, steamed, vacuum-packed
 ciqual_food_name:fr:Pomme de terre vapeur, sous vide
 
-<en:Potatoes
-en:New potatoes
-fr:Pommes de terre nouvelles
-agribalyse_food_code:en:4023
-ciqual_food_code:en:4023
-ciqual_food_name:en:New potato, raw
-ciqual_food_name:fr:Pomme de terre nouvelle, crue
 
 <en:Potatoes
-enPotatoes from Alto Viterbese Italy
+en:Potatoes from Alto Viterbese
 it:Patata dell'Alto Viterbese
 protected_name_file_number:en: PGI-IT-1038
 protected_name_type:en: pgi

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92733,6 +92733,8 @@ fr:Poivrons grillés
 nl:Geroosterde paprikas
 wikidata:en:Q28843386
 
+#################### Potatoes ####################
+
 <en:Cereals and potatoes
 en:Potatoes
 bg:Картофи
@@ -92753,19 +92755,7 @@ agribalyse_proxy_food_code:en:4008
 agribalyse_proxy_food_name:en:Potato, peeled, raw
 agribalyse_proxy_food_name:fr:Pomme de terre, sans peau, crue
 
-<en:Potato preparations
-en:Precooked potatoes
-fr:Pommes de terres précuites
-nl:Voorgekookte aardappelen
-
-<en:Potato preparations
-<en:Cooked vegetables
-en:Cooked potatoes
-fr:Pommes de terre cuites
-nl:Gekookte aardappelen
-ciqual_food_code:en:4048
-ciqual_food_name:en:Potato, cooked (average food)
-ciqual_food_name:fr:Pomme de terre, cuite (aliment moyen)
+#################### Potato harvest ####################
 
 <en:Potatoes
 en:Fresh potatoes, New potatoes
@@ -92780,6 +92770,44 @@ ciqual_food_name:fr:Pomme de terre nouvelle, crue
 <en:Potatoes
 fr:Pommes de terre primeurs, Pommes de terre de primeur
 
+#################### Potato minimal processing ####################
+
+<en:Potatoes
+en:Peeled potatoes
+fr:Pommes de terre sans peau
+agribalyse_food_code:en:4008
+ciqual_food_code:en:4008
+ciqual_food_name:en:Potato, peeled, raw
+ciqual_food_name:fr:Pomme de terre, sans peau, crue
+
+#################### Potato varieties ####################
+
+<en:Potatoes
+en:Agata potatoes
+de:Agata Kartoffeln
+fr:Pommes de terre Agata
+nl:Agata aardappelen
+wikidata:en:Q373973
+
+<en:Potatoes
+en:Béa potatoes
+de:Béa Kortoffeln
+fr:Pommes de terre Béa
+nl:Béa aardappelen
+wikidata:en:Q2929373
+
+<en:Potatoes
+en:Charlotte potatoes
+fr:Pommes de terre Charlotte
+nl:Charlotte aardappel
+wikidata:en:Q1067085
+
+<en:Potatoes
+en:Bintje potatoes
+de:Bintje Kartoffeln
+fr:Pomme de terre Bintje
+nl:Bintje aardappelen
+
 <en:Potatoes
 en:Jersey Royal potatoes
 protected_name_file_number:en: PDO-GB-0027
@@ -92788,16 +92816,24 @@ origins:en: en:United Kingdom
 wikidata:en:Q3177530
 
 <en:Potatoes
-en:Agata potatoes
-fr:Pommes de terre Agata
-nl:Agata aardappelen
-wikidata:en:Q373973
+en:Lady Christl potatoes
+de:Lady Christl Kartoffeln
+fr:Pomme de terre Lady Christl
+nl:Lady Christl aardappelen
 
 <en:Potatoes
-fr:Pommes de terre Béa
-wikidata:en:Q2929373
+en:Potatoes for steaming
+fr:Pommes de terre spéciales vapeur
+
+
+#################### Potatoes with an origin ####################
 
 #<en:Potatoes
+#en:Potatoes from Finland, Finnish potatoes
+#nl:Aardappelen uit Finland, Finse aardappelen
+#origins:en: en:Finland
+
+#<en:Potatoes from Finland
 #en:Potatoes from Lapin Puikula
 #fi:Lapin Puikula
 #fr:Pommes de terre de Laponie
@@ -92809,12 +92845,12 @@ wikidata:en:Q2929373
 #no products @2023-04-15
 
 <en:Potatoes
-en:Potatoes from Italy
+en:Potatoes from Italy, Italian potatoes
+de:Kartoffeln aus Italien
 fr:Pommes de terre d'Italie
 nl:Aardappelen uit Italië
 origins:en: en:France
 #wikidata:en:
-#add the origin France if you want to specify this category
 
 <en:Potatoes from Italy
 en:Potatoes from Fucino 
@@ -92857,30 +92893,45 @@ protected_name_type:en: pgi
 origins:en: en:Italy
 wikidata:en:Q647212
 
-<fr:Pommes de terre Béa
-fr:Béa du Roussillon, pomme de terre primeur du Roussillon
-protected_name_file_number:en: PDO-FR-0548
-protected_name_type:en: pdo
-origins:en: en:France
-wikidata:en:Q2929377
+<en:Potatoes from Italy
+en:Potatoes from Alto Viterbese
+it:Patata dell'Alto Viterbese
+protected_name_file_number:en: PGI-IT-1038
+protected_name_type:en: pgi
+origins:en: en:Italy
+wikidata:en:Q3368640
+
+#<en:Potatoes
+#en:Potatoes from the United Kingdom
+#nl:Aardappelen uit het Verenigd Koninkrijk
+#origins:en: en:United Kingdom
+
+#<en:Potatoes from the United Kingdom
+#en:New Season Comber Potatoes, Comber Earlies
+#protected_name_file_number:en: PGI-GB-0810
+#protected_name_type:en: pgi
+#origins:en: en:United Kingdom
+#wikidata:en:
+#no products on 14-04-2023
+
+#<en:Potatoes from the United Kingdom
+#en:Ayrshire New Potatoes, Ayrshire Earlies
+#protected_name_file_number:en: PGI-GB-02286
+#protected_name_type:en: pgi
+#origins:en: en:United Kingdom
+#wikidata:en:
+#no products on 14-04-2023
 
 <en:Potatoes
-fr:Pommes de terre catégorie 1, Pommes de terre Cat. 1
-
-<en:Potatoes
-en:Charlotte potatoes
-fr:Pommes de terre Charlotte
-nl:Charlotte aardappel
-wikidata:en:Q1067085
-
-<en:Potatoes
-en:French potatoes
+en:Potatoes from France, French potatoes
+de:Kartoffeln aus Frankreich
 fr:Pommes de terre françaises
+nl:Aardappelen uit Frankrijk, Franse aardappen
 origins:en: en:France
 #wikidata:en:
 #add the origin France if you want to specify this category
 
-<en:French potatoes
+<en:Potatoes from France
 en:Potatoes from Île de Ré
 fr:Pommes de terre de l'île de Ré, Pomme de terre de l'île de Ré
 protected_name_file_number:en: PDO-FR-0065
@@ -92888,7 +92939,7 @@ protected_name_type:en: pdo
 origins:en: en:France, fr:île de Ré
 wikidata:en:Q3395977
 
-<en:French potatoes
+<en:Potatoes from France
 en:Potatoes from Noirmoutier
 fr:Pomme de terre de Noirmoutier
 protected_name_type:en: pdo
@@ -92896,13 +92947,42 @@ origins:en: en:France, fr:Noirmoutier
 protected_name_file_number:en: PGI-FR-02434
 protected_name_type:en: pgi
 
-<en:French potatoes
+<en:Potatoes from France
 en:Potatoes from Merville
 fr:Pommes de terre de Merville
 protected_name_file_number:en: PGI-FR-0197
 protected_name_type:en: pgi
 origins:en: en:France
 wikidata:en:Q3395971
+
+<en:Potatoes from France
+fr:Béa du Roussillon, pomme de terre primeur du Roussillon
+protected_name_file_number:en: PDO-FR-0548
+protected_name_type:en: pdo
+origins:en: en:France
+wikidata:en:Q2929377
+
+################### misc potatoes ###################
+
+<en:Potatoes
+fr:Pommes de terre catégorie 1, Pommes de terre Cat. 1
+
+
+
+
+<en:Potato preparations
+en:Precooked potatoes
+fr:Pommes de terres précuites
+nl:Voorgekookte aardappelen
+
+<en:Potato preparations
+<en:Cooked vegetables
+en:Cooked potatoes
+fr:Pommes de terre cuites
+nl:Gekookte aardappelen
+ciqual_food_code:en:4048
+ciqual_food_name:en:Potato, cooked (average food)
+ciqual_food_name:fr:Pomme de terre, cuite (aliment moyen)
 
 <en:Potato preparations
 en:Boiled potatoes, Potatoes cooked in water
@@ -92928,14 +93008,6 @@ ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à
 #ciqual_food_name:en:Early potato, boiled/cooked in water, peeled
 #ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
 #no products on 15-4-23
-
-<en:Potatoes
-en:Peeled potatoes
-fr:Pommes de terre sans peau
-agribalyse_food_code:en:4008
-ciqual_food_code:en:4008
-ciqual_food_name:en:Potato, peeled, raw
-ciqual_food_name:fr:Pomme de terre, sans peau, crue
 
 <en:Potato preparations
 en:Baked peeled potatoes
@@ -92976,9 +93048,6 @@ ciqual_food_code:en:4036
 ciqual_food_name:en:Potato, sautéed/pan-fried, with goose fat
 ciqual_food_name:fr:Pomme de terre sautée/poêlée à la graisse de canard
 
-<en:Potatoes
-en:Potatoes for steaming
-fr:Pommes de terre spéciales vapeur
 
 <en:Potato preparations
 en:Vacuum-packed steamed potatoes
@@ -92987,31 +93056,6 @@ agribalyse_food_code:en:4014
 ciqual_food_code:en:4014
 ciqual_food_name:en:Potato, steamed, vacuum-packed
 ciqual_food_name:fr:Pomme de terre vapeur, sous vide
-
-
-<en:Potatoes
-en:Potatoes from Alto Viterbese
-it:Patata dell'Alto Viterbese
-protected_name_file_number:en: PGI-IT-1038
-protected_name_type:en: pgi
-origins:en: en:Italy
-wikidata:en:Q3368640
-
-#<en:Potatoes
-#en:New Season Comber Potatoes, Comber Earlies
-#protected_name_file_number:en: PGI-GB-0810
-#protected_name_type:en: pgi
-#origins:en: en:United Kingdom
-#wikidata:en:
-#no products on 14-04-2023
-
-#<en:Potatoes
-#en:Ayrshire New Potatoes, Ayrshire Earlies
-#protected_name_file_number:en: PGI-GB-02286
-#protected_name_type:en: pgi
-#origins:en: en:United Kingdom
-#wikidata:en:
-#no products on 14-04-2023
 
 <en:Pumpkins and their products
 en:Pumpkins, Squashes

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92806,6 +92806,12 @@ fr:Pomme de terre Bintje
 nl:Bintje aardappelen
 
 <en:Potatoes
+en:Grenaille potatoes
+de:Grenaille Kartoffeln
+fr:Pomme de terre Grenaille
+nl:Grenaille aardappelen
+
+<en:Potatoes
 en:Jersey Royal potatoes
 protected_name_file_number:en: PDO-GB-0027
 protected_name_type:en: pdo
@@ -92822,10 +92828,27 @@ nl:Lady Christl aardappelen
 
 <en:Potatoes
 en:Potatoes for steaming
-de:Speisekartoffeln
 es:Patatas para cocinar al vapor
-fr:Pommes de terre spéciales vapeur
+fr:Pommes de terre vapeur, Pommes de terre spéciales vapeur
 
+<en:Potatoes
+en:Potatoes for gratin
+fr:Pomme de terre gratin
+
+<en:Potatoes
+en:Potatoes for hash browns
+fr:Pommes de terre rissolées
+
+<en:Potatoes
+en:Potatoes for raclette
+fr:Pommes de terre raclette
+
+<en:Potatoes
+fr:Pommes de terre farineuses
+nl:Kruimige aardappelen
+
+<en:Potatoes
+de:Speisekartoffeln
 
 #################### Potatoes with an origin ####################
 
@@ -92901,6 +92924,20 @@ protected_name_file_number:en: PGI-IT-1038
 protected_name_type:en: pgi
 origins:en: en:Italy
 wikidata:en:Q3368640
+
+<en:Potatoes
+en:Potatoes from Spain, Spanish potatoes
+de:Kartoffeln aus Spanien
+fr:Pommes de terre d'Espagne
+nl:Aardappelen uit Spanje
+origins:en: en:Spain
+#wikidata:en:
+
+<en:Potatoes from Spain
+en:Potatoes from Val de Picones
+de:Kartoffeln aus Val de Picones
+fr:Pommes de terre de Val de Picones
+nl:Aardappelen ui Val de Picones
 
 #<en:Potatoes
 #en:Potatoes from the United Kingdom

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92878,7 +92878,7 @@ protected_name_type:en: pgi
 origins:en: en:France
 wikidata:en:Q3395971
 
-<en:Potatoes
+<en:Potato preparations
 en:Boiled potatoes, Potatoes cooked in water
 fr:Pommes de terre bouillies, Pommes de terre cuites à l'eau
 agribalyse_food_code:en:4003
@@ -92886,7 +92886,7 @@ ciqual_food_code:en:4003
 ciqual_food_name:en:Potato, boiled/cooked in water
 ciqual_food_name:fr:Pomme de terre, bouillie/cuite à l'eau
 
-<en:Potatoes
+<en:Potato preparations
 en:Boiled peeled ware potatoes, Peeled ware potatoes cooked in water
 fr:Pommes de terre de conservation sans peau bouillies, Pommes de terre de conservation sans peau cuites à l'eau
 agribalyse_food_code:en:4028
@@ -92894,7 +92894,7 @@ ciqual_food_code:en:4028
 ciqual_food_name:en:Ware potato, boiled/cooked in water, peeled
 ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à l'eau
 
-<en:Potatoes
+<en:Potato preparations
 en:Peeled boiled early potato, Peeled early potato cooked in water
 fr:Pommes de terre primeur sans peau bouillies, Pommes de terre primeur sans peau cuites à l'eau
 agribalyse_food_code:en:4029
@@ -92910,7 +92910,7 @@ ciqual_food_code:en:4008
 ciqual_food_name:en:Potato, peeled, raw
 ciqual_food_name:fr:Pomme de terre, sans peau, crue
 
-<en:Peeled potatoes
+<en:Potato preparations
 en:Baked peeled potatoes
 fr:Pommes de terre sans peau cuites au four
 agribalyse_food_code:en:4002
@@ -92918,7 +92918,7 @@ ciqual_food_code:en:4002
 ciqual_food_name:en:Potato, peeled, baked
 ciqual_food_name:fr:Pomme de terre, sans peau, cuite au four
 
-<en:Potatoes
+<en:Potato preparations
 en:Roasted potatoes, Baked potatoes
 fr:Pommes de terre rôties, Pommes de terre cuites au four
 agribalyse_food_code:en:4026
@@ -92926,7 +92926,7 @@ ciqual_food_code:en:4026
 ciqual_food_name:en:Potato, roasted/baked
 ciqual_food_name:fr:Pomme de terre, rôtie/cuite au four
 
-<en:Potatoes
+<en:Potato preparations
 en:Sautéed Potatoes, Pan-fried potatoes
 fr:Pommes de terre sautées, Pommes de terre poêlées
 agribalyse_food_code:en:4015
@@ -92934,7 +92934,7 @@ ciqual_food_code:en:4015
 ciqual_food_name:en:Potato, sautéed/pan-fried
 ciqual_food_name:fr:Pomme de terre, sautée/poêlée
 
-<en:Potatoes
+<en:Potato preparations
 en:Fried potato cubes
 fr:Pommes de terre rissolées
 agribalyse_proxy_food_code:en:4043

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92795,40 +92795,47 @@ wikidata:en:Q2929373
 <en:Potatoes
 fi:Lapin Puikula
 fr:Pommes de terre de Laponie
+nl:Aardappelen uit lapland Finland
 protected_name_file_number:en: PDO-FI-1390
 protected_name_type:en: pdo
 origins:en: en:Finland
 #wikidata:en:
 
 <en:Potatoes
+en:Potatoes from Fucino Italy
 it:Patata del Fucino
 protected_name_file_number:en: PGI-IT-01217-AM01, en: PGI-IT-01217
 protected_name_type:en: pgi
 origins:en: en:Italy
 wikidata:en:Q3368654
 
-<en:Potatoes
-it:Patata novella di Galatina
-protected_name_file_number:en: PDO-IT-1148
-protected_name_type:en: pdo
-origins:en: en:Italy
-wikidata:en:Q3368641
+#<en:Potatoes
+#it:Patata novella di Galatina
+#protected_name_file_number:en: PDO-IT-1148
+#protected_name_type:en: pdo
+#origins:en: en:Italy
+#wikidata:en:Q3368641
+#no products on 14/04/23
+
+#<en:Potatoes
+#it:Patata Rossa di Colfiorito
+#protected_name_file_number:en: PGI-IT-1236
+#protected_name_type:en: pgi
+#origins:en: en:Italy
+#wikidata:en:Q3368646
+#no products on 14/04/23
+
+#<en:Potatoes
+#en:Potatoes from Bologna Italy
+#it:Patata di Bologna
+#protected_name_file_number:en: PDO-IT-0349
+#protected_name_type:en: pdo
+#origins:en: en:Italy
+#wikidata:en:Q3368638
+#no products on 14/04/23
 
 <en:Potatoes
-it:Patata Rossa di Colfiorito
-protected_name_file_number:en: PGI-IT-1236
-protected_name_type:en: pgi
-origins:en: en:Italy
-wikidata:en:Q3368646
-
-<en:Potatoes
-it:Patata di Bologna
-protected_name_file_number:en: PDO-IT-0349
-protected_name_type:en: pdo
-origins:en: en:Italy
-wikidata:en:Q3368638
-
-<en:Potatoes
+en:Potatoes from Sila Italy
 it:Patata della Sila
 protected_name_file_number:en: PGI-IT-0643
 protected_name_type:en: pgi
@@ -92851,11 +92858,12 @@ fr:Pommes de terre Charlotte
 nl:Charlotte aardappel
 wikidata:en:Q1067085
 
-<en:Potatoes
-en:French potatoes
-fr:Pommes de terre françaises
-origins:en: en:France
+#<en:Potatoes
+#en:French potatoes
+#fr:Pommes de terre françaises
+#origins:en: en:France
 #wikidata:en:
+#add the origin France if you want to specify this category
 
 <en:French potatoes
 fr:Pommes de terre de l'île de Ré, Pomme de terre de l'île de Ré
@@ -92971,25 +92979,28 @@ ciqual_food_name:en:New potato, raw
 ciqual_food_name:fr:Pomme de terre nouvelle, crue
 
 <en:Potatoes
+enPotatoes from Alto Viterbese Italy
 it:Patata dell'Alto Viterbese
 protected_name_file_number:en: PGI-IT-1038
 protected_name_type:en: pgi
 origins:en: en:Italy
 wikidata:en:Q3368640
 
-<en:Potatoes
-en:New Season Comber Potatoes, Comber Earlies
-protected_name_file_number:en: PGI-GB-0810
-protected_name_type:en: pgi
-origins:en: en:United Kingdom
+#<en:Potatoes
+#en:New Season Comber Potatoes, Comber Earlies
+#protected_name_file_number:en: PGI-GB-0810
+#protected_name_type:en: pgi
+#origins:en: en:United Kingdom
 #wikidata:en:
+#no products on 14-04-2023
 
-<en:Potatoes
-en:Ayrshire New Potatoes, Ayrshire Earlies
-protected_name_file_number:en: PGI-GB-02286
-protected_name_type:en: pgi
-origins:en: en:United Kingdom
+#<en:Potatoes
+#en:Ayrshire New Potatoes, Ayrshire Earlies
+#protected_name_file_number:en: PGI-GB-02286
+#protected_name_type:en: pgi
+#origins:en: en:United Kingdom
 #wikidata:en:
+#no products on 14-04-2023
 
 <en:Pumpkins and their products
 en:Pumpkins, Squashes

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92821,6 +92821,8 @@ de:Lady Christl Kartoffeln
 fr:Pomme de terre Lady Christl
 nl:Lady Christl aardappelen
 
+#################### Potatoes with a usage ####################
+
 <en:Potatoes
 en:Potatoes for steaming
 fr:Pommes de terre spéciales vapeur
@@ -92970,92 +92972,6 @@ fr:Pommes de terre catégorie 1, Pommes de terre Cat. 1
 
 
 
-<en:Potato preparations
-en:Precooked potatoes
-fr:Pommes de terres précuites
-nl:Voorgekookte aardappelen
-
-<en:Potato preparations
-<en:Cooked vegetables
-en:Cooked potatoes
-fr:Pommes de terre cuites
-nl:Gekookte aardappelen
-ciqual_food_code:en:4048
-ciqual_food_name:en:Potato, cooked (average food)
-ciqual_food_name:fr:Pomme de terre, cuite (aliment moyen)
-
-<en:Potato preparations
-en:Boiled potatoes, Potatoes cooked in water
-fr:Pommes de terre bouillies, Pommes de terre cuites à l'eau
-agribalyse_food_code:en:4003
-ciqual_food_code:en:4003
-ciqual_food_name:en:Potato, boiled/cooked in water
-ciqual_food_name:fr:Pomme de terre, bouillie/cuite à l'eau
-
-<en:Potato preparations
-en:Boiled peeled ware potatoes, Peeled ware potatoes cooked in water
-fr:Pommes de terre de conservation sans peau bouillies, Pommes de terre de conservation sans peau cuites à l'eau
-agribalyse_food_code:en:4028
-ciqual_food_code:en:4028
-ciqual_food_name:en:Ware potato, boiled/cooked in water, peeled
-ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à l'eau
-
-#<en:Potato preparations
-#en:Peeled boiled early potato, Peeled early potato cooked in water
-#fr:Pommes de terre primeur sans peau bouillies, Pommes de terre primeur sans peau cuites à l'eau
-#agribalyse_food_code:en:4029
-#ciqual_food_code:en:4029
-#ciqual_food_name:en:Early potato, boiled/cooked in water, peeled
-#ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
-#no products on 15-4-23
-
-<en:Potato preparations
-en:Baked peeled potatoes
-fr:Pommes de terre sans peau cuites au four
-agribalyse_food_code:en:4002
-ciqual_food_code:en:4002
-ciqual_food_name:en:Potato, peeled, baked
-ciqual_food_name:fr:Pomme de terre, sans peau, cuite au four
-
-<en:Potato preparations
-en:Roasted potatoes, Baked potatoes
-fr:Pommes de terre rôties, Pommes de terre cuites au four
-agribalyse_food_code:en:4026
-ciqual_food_code:en:4026
-ciqual_food_name:en:Potato, roasted/baked
-ciqual_food_name:fr:Pomme de terre, rôtie/cuite au four
-
-<en:Potato preparations
-en:Sautéed Potatoes, Pan-fried potatoes
-fr:Pommes de terre sautées, Pommes de terre poêlées
-agribalyse_food_code:en:4015
-ciqual_food_code:en:4015
-ciqual_food_name:en:Potato, sautéed/pan-fried
-ciqual_food_name:fr:Pomme de terre, sautée/poêlée
-
-<en:Potato preparations
-en:Fried potato cubes
-fr:Pommes de terre rissolées
-agribalyse_proxy_food_code:en:4043
-agribalyse_proxy_food_name:en:Potato, pre-fried into cubes, frozen, raw
-agribalyse_proxy_food_name:fr:Pomme de terre rissolée, surgelée, crue
-
-<en:Sautéed Potatoes
-en:Sautéed potato with goose fat, Pan-fried potato with goose fat
-fr:Pommes de terre sautées à la graisse de canard, Pommes de terre poêlées à la graisse de canard
-agribalyse_food_code:en:4036
-ciqual_food_code:en:4036
-ciqual_food_name:en:Potato, sautéed/pan-fried, with goose fat
-ciqual_food_name:fr:Pomme de terre sautée/poêlée à la graisse de canard
-
-
-<en:Potato preparations
-en:Vacuum-packed steamed potatoes
-fr:Pommes de terre vapeur sous vide
-agribalyse_food_code:en:4014
-ciqual_food_code:en:4014
-ciqual_food_name:en:Potato, steamed, vacuum-packed
-ciqual_food_name:fr:Pomme de terre vapeur, sous vide
 
 <en:Pumpkins and their products
 en:Pumpkins, Squashes
@@ -100353,6 +100269,92 @@ de:Kartoffelzubereitungen
 fi:Perunavalmisteet
 fr:Préparations à base de pommes de terre
 nl:Aardappelbereidingen
+
+<en:Potato preparations
+en:Precooked potatoes
+fr:Pommes de terres précuites
+nl:Voorgekookte aardappelen
+
+<en:Potato preparations
+<en:Cooked vegetables
+en:Cooked potatoes
+fr:Pommes de terre cuites
+nl:Gekookte aardappelen
+ciqual_food_code:en:4048
+ciqual_food_name:en:Potato, cooked (average food)
+ciqual_food_name:fr:Pomme de terre, cuite (aliment moyen)
+
+<en:Potato preparations
+en:Boiled potatoes, Potatoes cooked in water
+fr:Pommes de terre bouillies, Pommes de terre cuites à l'eau
+agribalyse_food_code:en:4003
+ciqual_food_code:en:4003
+ciqual_food_name:en:Potato, boiled/cooked in water
+ciqual_food_name:fr:Pomme de terre, bouillie/cuite à l'eau
+
+<en:Potato preparations
+en:Boiled peeled ware potatoes, Peeled ware potatoes cooked in water
+fr:Pommes de terre de conservation sans peau bouillies, Pommes de terre de conservation sans peau cuites à l'eau
+agribalyse_food_code:en:4028
+ciqual_food_code:en:4028
+ciqual_food_name:en:Ware potato, boiled/cooked in water, peeled
+ciqual_food_name:fr:Pomme de terre de conservation, sans peau, bouillie/cuite à l'eau
+
+#<en:Potato preparations
+#en:Peeled boiled early potato, Peeled early potato cooked in water
+#fr:Pommes de terre primeur sans peau bouillies, Pommes de terre primeur sans peau cuites à l'eau
+#agribalyse_food_code:en:4029
+#ciqual_food_code:en:4029
+#ciqual_food_name:en:Early potato, boiled/cooked in water, peeled
+#ciqual_food_name:fr:Pomme de terre primeur, sans peau, bouillie/cuite à l'eau
+#no products on 15-4-23
+
+<en:Potato preparations
+en:Baked peeled potatoes
+fr:Pommes de terre sans peau cuites au four
+agribalyse_food_code:en:4002
+ciqual_food_code:en:4002
+ciqual_food_name:en:Potato, peeled, baked
+ciqual_food_name:fr:Pomme de terre, sans peau, cuite au four
+
+<en:Potato preparations
+en:Roasted potatoes, Baked potatoes
+fr:Pommes de terre rôties, Pommes de terre cuites au four
+agribalyse_food_code:en:4026
+ciqual_food_code:en:4026
+ciqual_food_name:en:Potato, roasted/baked
+ciqual_food_name:fr:Pomme de terre, rôtie/cuite au four
+
+<en:Potato preparations
+en:Sautéed Potatoes, Pan-fried potatoes
+fr:Pommes de terre sautées, Pommes de terre poêlées
+agribalyse_food_code:en:4015
+ciqual_food_code:en:4015
+ciqual_food_name:en:Potato, sautéed/pan-fried
+ciqual_food_name:fr:Pomme de terre, sautée/poêlée
+
+<en:Potato preparations
+en:Fried potato cubes
+fr:Pommes de terre rissolées
+agribalyse_proxy_food_code:en:4043
+agribalyse_proxy_food_name:en:Potato, pre-fried into cubes, frozen, raw
+agribalyse_proxy_food_name:fr:Pomme de terre rissolée, surgelée, crue
+
+<en:Sautéed Potatoes
+en:Sautéed potato with goose fat, Pan-fried potato with goose fat
+fr:Pommes de terre sautées à la graisse de canard, Pommes de terre poêlées à la graisse de canard
+agribalyse_food_code:en:4036
+ciqual_food_code:en:4036
+ciqual_food_name:en:Potato, sautéed/pan-fried, with goose fat
+ciqual_food_name:fr:Pomme de terre sautée/poêlée à la graisse de canard
+
+<en:Potato preparations
+en:Vacuum-packed steamed potatoes
+fr:Pommes de terre vapeur sous vide
+agribalyse_food_code:en:4014
+ciqual_food_code:en:4014
+ciqual_food_name:en:Potato, steamed, vacuum-packed
+ciqual_food_name:fr:Pomme de terre vapeur, sous vide
 
 <en:Potato preparations
 en:Rostis, Potatoes cakes, Potato cakes


### PR DESCRIPTION
### What
The potatoes category will be cleanup and reorganised such that it contains only products with a single ingredient (potato) and reflects the NOVA 1 status of this category.