### PR TITLE
fix: escape issue in additives knowledge panel - remove latex formulas

### DIFF
--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -216,11 +216,13 @@ The function converts the multiline string into a single line string.
 
 sub convert_multiline_string_to_singleline ($line) {
 
-	# \R will match all Unicode newline sequence
-	$line =~ s/\R/\\n/sg;
 	# Escape " and \ unless they have been escaped already
 	# negative look behind to not convert \n to \\n or \" to \\" or \\ to \\\\
-	$line =~ s/(?<!\\)(n|"|\\)/\\$1/g;
+	$line =~ s/(?<!\\)("|\\)/\\$1/g;
+
+	# \R will match all Unicode newline sequence
+	$line =~ s/\R/\\n/sg;
+
 	return '"' . $line . '"';
 }
 

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -219,8 +219,8 @@ sub convert_multiline_string_to_singleline ($line) {
 	# \R will match all Unicode newline sequence
 	$line =~ s/\R/\\n/sg;
 	# Escape " and \ unless they have been escaped already
-	# negative look behind to not convert \" to \\" or \\ to \\\\
-	$line =~ s/(?<!\\)("|\\)/\\$1/g;
+	# negative look behind to not convert \n to \\n or \" to \\" or \\ to \\\\
+	$line =~ s/(?<!\\)(n|"|\\)/\\$1/g;
 	return '"' . $line . '"';
 }
 

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -218,11 +218,9 @@ sub convert_multiline_string_to_singleline ($line) {
 
 	# \R will match all Unicode newline sequence
 	$line =~ s/\R/\\n/sg;
-	# Escape quotes unless they have been escaped already
-	# negative look behind to not convert \" to \\"
-	$line =~ s/(?<!\\)"/\\"/g;
-	# Escape \ to \\
-	$line =~ s/(?<!\\)\\/\\\\/g;
+	# Escape " and \ unless they have been escaped already
+	# negative look behind to not convert \" to \\" or \\ to \\\\
+	$line =~ s/(?<!\\)("|\\)/\\$1/g;
 	return '"' . $line . '"';
 }
 

--- a/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
+++ b/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
@@ -29,7 +29,7 @@
                 "type": "summary",
                 "html": `
                     <p>[% lang('source_ademe_agribalyse_for_category') %] 
-                    <a href=\"https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]\">[% panel.agribalyse_category_name.dquote %]</a>
+                    <a href="https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]">[% panel.agribalyse_category_name.dquote %]</a>
                     ([% lang('source_ademe_agribalyse') %])
                     </p>
                     `

--- a/templates/api/knowledge-panels/environment/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/agribalyse.tt.json
@@ -16,7 +16,7 @@
                 "type": "summary",
                 "html": `
                     <p>[% lang('categories_s') FILTER ucfirst %][% sep %]: 
-                    <a href=\"https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]\">[% panel.agribalyse_category_name %]</a>
+                    <a href="https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]">[% panel.agribalyse_category_name %]</a>
                     </p>
                     <ul>
                         <li>

--- a/tests/unit/knowledge_panels.t
+++ b/tests/unit/knowledge_panels.t
@@ -1,0 +1,22 @@
+#!/usr/bin/perl -w
+
+use Modern::Perl '2017';
+use utf8;
+
+use Test::More;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::KnowledgePanels qw/:all/;
+
+is(ProductOpener::KnowledgePanels::convert_multiline_string_to_singleline('
+test
+muti-line string
+a slash A / B and anti-slash \
+HTML <a href="https://url.com">test</a>
+'),
+'"\ntest\nmuti-line string\na slash A / B and anti-slash \\\nHTML <a href=\"https://url.com\">test</a>\n"');
+
+is(ProductOpener::KnowledgePanels::convert_multiline_string_to_singleline('<a href="https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]">'),
+'"<a href=\"https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]\">"');
+
+done_testing();

--- a/tests/unit/knowledge_panels.t
+++ b/tests/unit/knowledge_panels.t
@@ -8,15 +8,20 @@ use Log::Any::Adapter 'TAP';
 
 use ProductOpener::KnowledgePanels qw/:all/;
 
-is(ProductOpener::KnowledgePanels::convert_multiline_string_to_singleline('
+is(
+	ProductOpener::KnowledgePanels::convert_multiline_string_to_singleline('
 test
 muti-line string
 a slash A / B and anti-slash \
 HTML <a href="https://url.com">test</a>
 '),
-'"\ntest\nmuti-line string\na slash A / B and anti-slash \\\nHTML <a href=\"https://url.com\">test</a>\n"');
+	'"\ntest\nmuti-line string\na slash A / B and anti-slash \\\nHTML <a href=\"https://url.com\">test</a>\n"'
+);
 
-is(ProductOpener::KnowledgePanels::convert_multiline_string_to_singleline('<a href="https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]">'),
-'"<a href=\"https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]\">"');
+is(
+	ProductOpener::KnowledgePanels::convert_multiline_string_to_singleline(
+		'<a href="https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]">'),
+	'"<a href=\"https://agribalyse.ademe.fr/app/aliments/[% product.ecoscore_data.agribalyse.code %]\">"'
+);
 
 done_testing();

--- a/tests/unit/knowledge_panels.t
+++ b/tests/unit/knowledge_panels.t
@@ -15,7 +15,7 @@ muti-line string
 a slash A / B and anti-slash \
 HTML <a href="https://url.com">test</a>
 '),
-	'"\ntest\nmuti-line string\na slash A / B and anti-slash \\\nHTML <a href=\"https://url.com\">test</a>\n"'
+	'"\ntest\nmuti-line string\na slash A / B and anti-slash \\\\\nHTML <a href=\"https://url.com\">test</a>\n"'
 );
 
 is(


### PR DESCRIPTION

### What
- fixes #8339 (see screenshots in issue)

![image](https://user-images.githubusercontent.com/8158668/233453143-a83b6127-e008-44b9-a57a-c782e343c8db.png)

this particular wikipedia abstract is really not relevant to OFF, I would be very much in favor to creating our own additives descriptions.

### Part of
- #5493 