### PR TITLE
taxonomy: reapply changes from previous PR

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -42,6 +42,7 @@ synonyms:es:OGMs, Organismos genéticamente modificados, transgénicos, OGM
 synonyms:en:Rich in, High in
 synonyms:es:Rico en, Alto contenido de, Alto contenido en
 synonyms:fi:runsaasti, paljon
+synonyms:fr:Riche en, Fort en
 synonyms:it:Ricco in, Alto contenuto di, Ricchi in
 synonyms:pt:Rico em, Alto conteúdo de
 synonyms:ru:Обогащено
@@ -101,6 +102,7 @@ synonyms:fr:fabrique, fabriqué
 synonyms:ru:изготовление, производство
 synonyms:es:fabricación, producción, elaborado
 
+synonyms:en:fats, fat
 synonyms:fr:matières grasses, MG, gras
 synonyms:ru:жир
 


### PR DESCRIPTION
These are changes brought by @alexouille123 in this previous PR: https://github.com/openfoodfacts/openfoodfacts-server/pull/3739/


If you approve and merge this present PR, please invalidate https://github.com/openfoodfacts/openfoodfacts-server/pull/3739/ 

The following contributions have been skipped: 
- synonyms: fr:OGM, Organismes Génétiquement Modifiés
already in main currently: synonyms: fr:OGMs, Organismes génétiquement modifiés, OGM

- synonyms:en:natural, of natural origin
ignored because there are n occurrence of "of natural origin" in the taxonomy and there are no occurrence in https://uk.openfoodfacts.org/labels nor https://us.openfoodfacts.org/labels

- synonyms:en:from the end, after
ignored because there are no occurrence of "from the end" in the taxonomy and there are no occurrence in https://uk.openfoodfacts.org/labels nor https://us.openfoodfacts.org/labels

- synonyms:en:first, 1st
ignored because there are no occurrence of "first" in the taxonomy and there are no occurrence in https://uk.openfoodfacts.org/labels nor https://us.openfoodfacts.org/labels