### PR TITLE
fix: make CORS work on dev server and API v3

### DIFF
--- a/lib/ProductOpener/API.pm
+++ b/lib/ProductOpener/API.pm
@@ -374,10 +374,13 @@ sub process_api_request ($request_ref) {
 		# Product read or write
 		if ($request_ref->{api_action} eq "product") {
 
-			if ($request_ref->{api_method} eq "PATCH") {
+			if ($request_ref->{api_method} eq "OPTIONS") {
+				# Just return CORS headers
+			}
+			elsif ($request_ref->{api_method} eq "PATCH") {
 				write_product_api($request_ref);
 			}
-			elsif ($request_ref->{api_method} =~ /^(GET|HEAD|OPTIONS)$/) {
+			elsif ($request_ref->{api_method} =~ /^(GET|HEAD)$/) {
 				read_product_api($request_ref);
 			}
 			else {

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -460,7 +460,8 @@ sub execute_api_tests ($file, $tests_ref, $ua = undef) {
 			$response = $test_ua->delete(
 				$url,
 				Content => encode_utf8($test_ref->{body}),
-				"Content-Type" => "application/json; charset=utf-8" % $headers_in,
+				"Content-Type" => "application/json; charset=utf-8",
+				%$headers_in,
 			);
 		}
 		elsif ($method eq 'PATCH') {

--- a/lib/ProductOpener/HTTP.pm
+++ b/lib/ProductOpener/HTTP.pm
@@ -30,7 +30,7 @@ C<ProductOpener::Web> consists of functions used only in OpenFoodFacts website f
 
 The module implements http utilities to use in different part of the code.
 
-FIXME: a lot of fuctions in Display.pm should be moved here.
+FIXME: a lot of functions in Display.pm should be moved here.
 
 =cut
 
@@ -61,7 +61,7 @@ use ProductOpener::Config qw/:all/;
 
 =head2 get_cors_headers($allow_credentials = 0, $sub_domain_only = 0)
 
-We handle CORS headers from perl code, NGINX should not interfere.
+We handle CORS headers from Perl code, NGINX should not interfere.
 So this is the central place for it.
 
 Some parts needs to be more strict than others (eg. auth).

--- a/lib/ProductOpener/HTTP.pm
+++ b/lib/ProductOpener/HTTP.pm
@@ -129,7 +129,7 @@ sub get_cors_headers ($allow_credentials = 0, $sub_domain_only = 0) {
 	# be generous on methods and headers, it does not hurt
 	$headers_ref->{"Access-Control-Allow-Methods"} = "HEAD, GET, PATCH, POST, PUT, OPTIONS";
 	$headers_ref->{"Access-Control-Allow-Headers"}
-		= "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match";
+		= "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match,Authorization";
 	$headers_ref->{"Access-Control-Expose-Headers"} = "Content-Length,Content-Range";
 
 	return $headers_ref;

--- a/stop_words.txt
+++ b/stop_words.txt
@@ -133,6 +133,7 @@ NaN
 naturel
 nd
 NGO
+NGINX
 nodejs
 nutri
 Nutri

--- a/stop_words.txt
+++ b/stop_words.txt
@@ -18,6 +18,7 @@ APIProductWrite
 appid
 aromatisées
 arôme
+auth
 autocomplete
 backend
 backticks
@@ -44,6 +45,7 @@ CodeOnline
 colza
 Config
 contenant
+CORS
 couvercle
 Crowdin
 csv
@@ -66,6 +68,7 @@ EXIF
 Fabriqué
 filehandle
 FILEHANDLE
+FIXME
 flavour
 flavouring
 flavourings
@@ -146,6 +149,7 @@ packagings
 param
 Pâtes
 pectine
+Perl
 png
 PNG
 PNNS
@@ -189,6 +193,7 @@ tagtype
 taxonomize
 taxonomized
 tesseract
+tld
 TODO
 TSV
 ua

--- a/tests/integration/api_v3_product_write.t
+++ b/tests/integration/api_v3_product_write.t
@@ -594,6 +594,12 @@ my $tests_ref = [
 		body => '{"product": { "ingredients_text_en": "milk 80%, sugar, cocoa powder"}}',
 	},
 	{
+		test_case => 'patch-code-test',
+		method => 'OPTIONS',
+		path => '/api/v3/product/test',
+		body => '{"product": { "ingredients_text_en": "milk 80%, sugar, cocoa powder"}}',
+	},
+	{
 		test_case => 'patch-unrecognized-field',
 		method => 'PATCH',
 		path => '/api/v3/product/test',

--- a/tests/integration/api_v3_product_write.t
+++ b/tests/integration/api_v3_product_write.t
@@ -594,10 +594,15 @@ my $tests_ref = [
 		body => '{"product": { "ingredients_text_en": "milk 80%, sugar, cocoa powder"}}',
 	},
 	{
-		test_case => 'patch-code-test',
+		test_case => 'options-code-test',
 		method => 'OPTIONS',
 		path => '/api/v3/product/test',
 		body => '{"product": { "ingredients_text_en": "milk 80%, sugar, cocoa powder"}}',
+		headers => {
+			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+		},
+		expected_type => "html",		
 	},
 	{
 		test_case => 'patch-unrecognized-field',

--- a/tests/integration/api_v3_product_write.t
+++ b/tests/integration/api_v3_product_write.t
@@ -602,7 +602,7 @@ my $tests_ref = [
 			"Access-Control-Allow-Origin" => "*",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
 		},
-		expected_type => "html",		
+		expected_type => "html",
 	},
 	{
 		test_case => 'patch-unrecognized-field',

--- a/tests/integration/cors.t
+++ b/tests/integration/cors.t
@@ -60,11 +60,23 @@ my $tests_ref = [
 		},
 		expected_type => "html",
 	},
+	# Note: in API v3, we return a 200 status code for OPTIONS, even if the product does not exist
 	{
 		test_case => 'options-api-v3',
 		method => 'OPTIONS',
 		path => '/api/v3/product/0000002',
-		expected_status_code => 404,
+		expected_status_code => 200,
+		headers => {
+			"Access-Control-Allow-Origin" => "*",
+			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
+		},
+		expected_type => "html",
+	},
+	{
+		test_case => 'options-api-v3-test-product',
+		method => 'OPTIONS',
+		path => '/api/v3/product/test',
+		expected_status_code => 200,
 		headers => {
 			"Access-Control-Allow-Origin" => "*",
 			"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-code-test.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-code-test.json
@@ -1,25 +1,5 @@
 {
    "errors" : [],
-   "product" : {
-      "ingredients_text_en" : "milk 80%, sugar, cocoa powder"
-   },
-   "status" : "success_with_warnings",
-   "warnings" : [
-      {
-         "field" : {
-            "default_value" : "en",
-            "id" : "tags_lc"
-         },
-         "impact" : {
-            "id" : "warning",
-            "lc_name" : "Warning",
-            "name" : "Warning"
-         },
-         "message" : {
-            "id" : "missing_field",
-            "lc_name" : "Missing field",
-            "name" : "Missing field"
-         }
-      }
-   ]
+   "status" : "success",
+   "warnings" : []
 }

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-code-test.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-code-test.json
@@ -1,5 +1,25 @@
 {
    "errors" : [],
-   "status" : "success",
-   "warnings" : []
+   "product" : {
+      "ingredients_text_en" : "milk 80%, sugar, cocoa powder"
+   },
+   "status" : "success_with_warnings",
+   "warnings" : [
+      {
+         "field" : {
+            "default_value" : "en",
+            "id" : "tags_lc"
+         },
+         "impact" : {
+            "id" : "warning",
+            "lc_name" : "Warning",
+            "name" : "Warning"
+         },
+         "message" : {
+            "id" : "missing_field",
+            "lc_name" : "Missing field",
+            "name" : "Missing field"
+         }
+      }
+   ]
 }

--- a/tests/unit/http.t
+++ b/tests/unit/http.t
@@ -34,7 +34,7 @@ sub fake_headers_in ($fake_arg) {
 	my $expected_base_ref = {
 		"Access-Control-Allow-Methods" => "HEAD, GET, PATCH, POST, PUT, OPTIONS",
 		"Access-Control-Allow-Headers" =>
-			"DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match",
+			"DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match,Authorization",
 		"Access-Control-Expose-Headers" => "Content-Length,Content-Range",
 	};
 


### PR DESCRIPTION
- add the Authorization header (needed on .dev and .net)
- return a 200 response instead of 404 when we have an OPTIONS request for a product that does not exist: we don't execute the request, we just validate that the browser can make it
- added some tests