### PR TITLE
fix: nutrition edit warnings

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6652,3 +6652,15 @@ msgstr "Pro platform user guide"
 msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
+
+msgctxt "product_js_enter_value_between_0_and_100"
+msgid "Please enter a value between 0 and 100."
+msgstr "Please enter a value between 0 and 100."
+
+msgctxt "product_js_sugars_warning"
+msgid "Sugars should not be higher than carbohydrates."
+msgstr "Sugars should not be higher than carbohydrates."
+
+msgctxt "product_js_saturated_fat_warning"
+msgid "Saturated fat should not be higher than fat."
+msgstr "Saturated fat should not be higher than fat."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6662,3 +6662,15 @@ msgstr "Pro platform user guide"
 msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
+
+msgctxt "product_js_enter_value_between_0_and_100"
+msgid "Please enter a value between 0 and 100."
+msgstr "Please enter a value between 0 and 100."
+
+msgctxt "product_js_sugars_warning"
+msgid "Sugars should not be higher than carbohydrates."
+msgstr "Sugars should not be higher than carbohydrates."
+
+msgctxt "product_js_saturated_fat_warning"
+msgid "Saturated fat should not be higher than fat."
+msgstr "Saturated fat should not be higher than fat."

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.js
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.js
@@ -40,61 +40,44 @@ function show_warning(should_show, nutrient_id, warning_message){
 		\$('#nutriment_'+nutrient_id).css("background-color", "rgb(255 237 235)");
 		\$('#nutriment_question_mark_'+nutrient_id).css("display", "inline-table");
 		\$('#nutriment_sugars_warning_'+nutrient_id).text(warning_message);
-	}else {
-		\$('#nutriment_'+nutrient_id).css("background-color", "white");
-		\$('#nutriment_question_mark_'+nutrient_id).css("display", "none");
+	} else {
+		// clear the warning only if the warning message we don't show is the same as the existing warning
+		// so that we don't remove a warning on sugars > 100g if we change carbohydrates
+		if (warning_message == \$('#nutriment_sugars_warning_'+nutrient_id).text()) {
+			\$('#nutriment_'+nutrient_id).css("background-color", "white");
+			\$('#nutriment_question_mark_'+nutrient_id).css("display", "none");
+		}
 	}
 }
-
-var sugars_value;
-var carbohydrates_value;
-var saturated_fats_value;
-var fat_value;
 
 var required_nutrients_id = ['energy-kj', 'energy-kcal', 'fat', 'saturated-fat', 'sugars', 'carbohydrates', 'fiber', 'proteins', 'salt', 'sodium', 'alcohol'];
 
 required_nutrients_id.forEach(nutrient_id => {
 	\$('#nutriment_' + nutrient_id).on('input', function() {
-		var nutrient_value = \$(this).val();
-		var is_above_or_below_100 = isNaN(nutrient_value) || nutrient_value < 0 || nutrient_value > 100;
-		show_warning(is_above_or_below_100, nutrient_id, "Please enter a value between 0 and 100");
 
-		var crutial_nutrients = ['fat', 'saturated-fat', 'sugars', 'carbohydrates'];
+		// check the changed nutrient value
+		var nutrient_value = \$(this).val().replace(',','.');
+		var is_above_or_below_100 = (isNaN(nutrient_value) && nutrient_value != '-') || nutrient_value < 0 || nutrient_value > 100;
+		// if the nutrition facts are indicated per serving, the value can be above 100
+		if ((nutrient_value > 100) && (\$('#nutrition_data_per_serving').is(':checked'))) {
+			is_above_or_below_100 = false;
+		}
+		show_warning(is_above_or_below_100, nutrient_id, lang().product_js_enter_value_between_0_and_100);
 
-		if (crutial_nutrients.includes(nutrient_id)) {
-			switch(nutrient_id) {
-				case "saturated-fat":
-					saturated_fats_value = nutrient_value;
-					break;
-				case "sugars":
-					sugars_value = nutrient_value;
-					break;
-				case "carbohydrates":
-					carbohydrates_value = nutrient_value;
-					break;
-				case "fat":
-					fat_value = nutrient_value;
-					break;
-			}
+		// check that nutrients are sound (e.g. sugars is not above carbohydrates)
+		// but only if the changed nutrient does not have a warning
+		// otherwise we may clear the sugars or saturated-fat warning
+		if (! is_above_or_below_100) {
+			var fat_value = \$('#nutriment_fat').val().replace(',','.');
+			var carbohydrates_value = \$('#nutriment_carbohydrates').val().replace(',','.');
+			var sugars_value = \$('#nutriment_sugars').val().replace(',','.');
+			var saturated_fats_value = \$('#nutriment_saturated-fat').val().replace(',','.');
+		
+			var is_sugars_above_carbohydrates = parseFloat(carbohydrates_value) < parseFloat(sugars_value);
+			show_warning(is_sugars_above_carbohydrates, 'sugars', lang().product_js_sugars_warning);
 			
-			if(!fat_value) {
-				fat_value = \$('#nutriment_fat').val();
-			}
-			if(!carbohydrates_value){
-				carbohydrates_value = \$('#nutriment_carbohydrates').val();
-			}
-			if(!sugars_value) {
-				sugars_value = \$('#nutriment_sugars').val();
-			}
-			if(!saturated_fats_value) {
-				saturated_fats_value = \$('#nutriment_saturated-fat').val();
-			}
-
-			var is_sugars_above_carbohydrates = carbohydrates_value < sugars_value;
-			show_warning(is_sugars_above_carbohydrates, 'sugars', 'Sugars should not be higher than carbohydrates');
-
-			var is_fat_above_saturated_fats = fat_value < saturated_fats_value;
-			show_warning(is_fat_above_saturated_fats, 'saturated-fat', 'Saturated fats should not be higher than fat');
+			var is_fat_above_saturated_fats = parseFloat(fat_value) < parseFloat(saturated_fats_value);
+			show_warning(is_fat_above_saturated_fats, 'saturated-fat', lang().product_js_saturated_fat_warning);
 		}
 	});
 });


### PR DESCRIPTION
This PR builds upon the work of @jnsereko : https://github.com/openfoodfacts/openfoodfacts-server/pull/8258
It fixes some issues with the original PR, that were found when doing more testing before pushing to production.

- We need to use parseFloat() on input values, otherwise "47" < "8"

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/66ca4a76-a171-4ca6-a040-29d3fe1434cb)

- Commas are replaced by dots, so that French numbers like 4,7 are converted to 4.7
- Re-ordered the logic so that some warnings like the sugars > 100g warning is not cleared if carbohydrates are then modified (and are above sugars). In practice the "Please enter a value between 0 and 100" now takes priority over the other.
- Added translations in .po files.
- Allow values > 100g if nutrients are per serving and not per 100g
