### PR TITLE
feat: added nitrate sulfate as suggestions in table

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -396,7 +396,8 @@ sub assign_nid_modifier_value_and_unit ($product_ref, $nid, $modifier, $value, $
 			'glycemic-index-', 'water-hardness-',
 			'choline-', 'phylloquinone-',
 			'beta-glucan-', 'inositol-',
-			'carnitine-',
+			'carnitine-', 'sulphate-',
+			'nitrate-',
 		)
 	],
 	ca => [
@@ -458,6 +459,7 @@ sub assign_nid_modifier_value_and_unit ($product_ref, $nid, $modifier, $value, $
 			'water-hardness-', 'choline-',
 			'phylloquinone-', 'beta-glucan-',
 			'inositol-', 'carnitine-',
+			'sulphate-', 'nitrate-',
 		)
 	],
 	ru => [
@@ -519,6 +521,7 @@ sub assign_nid_modifier_value_and_unit ($product_ref, $nid, $modifier, $value, $
 			'water-hardness-', 'choline-',
 			'phylloquinone-', 'beta-glucan-',
 			'inositol-', 'carnitine-',
+			'sulphate-', 'nitrate-',
 		)
 	],
 	us => [
@@ -578,6 +581,7 @@ sub assign_nid_modifier_value_and_unit ($product_ref, $nid, $modifier, $value, $
 			'carbon-footprint-', 'carbon-footprint-from-meat-or-fish-',
 			'nutrition-score-fr-', 'nutrition-score-uk-',
 			'glycemic-index-', 'water-hardness-',
+			'sulfate-', 'nitrate-',
 		)
 	],
 	us_before_2017 => [
@@ -638,6 +642,7 @@ sub assign_nid_modifier_value_and_unit ($product_ref, $nid, $modifier, $value, $
 			'water-hardness-', 'choline-',
 			'phylloquinone-', 'beta-glucan-',
 			'inositol-', 'carnitine-',
+			'sulfate-', 'nitrate-',
 		)
 	],
 	hk => [
@@ -650,6 +655,7 @@ sub assign_nid_modifier_value_and_unit ($product_ref, $nid, $modifier, $value, $
 			'vitamin-pp-', 'vitamin-b6-', 'vitamin-b9-', 'folates-',
 			'vitamin-b12-', '#minerals', 'calcium', 'potassium-',
 			'phosphorus-', 'iron', 'alcohol', 'nutrition-score-fr-',
+			'sulphate-', 'nitrate-',
 		)
 	],
 );

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -4165,7 +4165,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Bicarbonate
 
 # SO4--
 zz:Sulphate
-en:Sulphate,Sulfate
+en:Sulphate, Sulfate
 xx:Sulphate
 af:Sulfaat
 ar:كبريتات
@@ -4242,12 +4242,12 @@ cv:Нитратсем
 da:Nitrat
 de:Nitrate
 eo:Nitrato
-# es:Nitrato # uncomment need to recreate expected_test_results for unit tests
+es:Nitrato
 et:Nitraadid
 eu:Nitrato
 fa:نیترات
 fi:Nitraatti
-# fr:Nitrate # uncomment need to recreate expected_test_results for unit tests
+fr:Nitrate
 fy:Nitraat
 ga:Níotráit
 gl:Nitrato


### PR DESCRIPTION
### What
1/ added both nitrate and sulfate as suggestion in the table (populate %nutriments_tables in Food.pm)
2/ added nitrate and sulfate to export csv because of 1/. In the comments in the beginning of the Export.pm file, it is written:
> Use the list of fields from C<Product::Opener::Config::options{import_export_fields_groups}>
and the list of nutrients from C<Product::Opener::Food::nutriments_tables> to list fields
that need to be exported.

### Screenshot
Depending of the country:
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/b3b9d808-b86c-4cb9-a3f0-607d26dc31d9)
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/0ad1c9e5-721b-435f-b362-f637c031a256)
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/2f2a153a-9f69-4d86-a0ca-513799719ba4)

Both are in mg:
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/b970b433-f4b4-4566-a908-447a99f2d6ec)

Both are exported:
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/1a80bf53-0b7c-4354-b6b9-64de16e92231)


### Related issue(s) and discussion
fixes #8265 

