### PR TITLE
fix: Update nova-group-unknown.svg

### DIFF
--- a/html/images/attributes/src/nova-group-unknown.svg
+++ b/html/images/attributes/src/nova-group-unknown.svg
@@ -1,95 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="68"
-   height="130"
-   viewBox="0 0 68 130"
-   id="svg4443"
-   version="1.1"
-   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)"
-   sodipodi:docname="nova-group-unknown.svg">
-  <defs
-     id="defs4445" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.979899"
-     inkscape:cx="77.552552"
-     inkscape:cy="136.14203"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="2488"
-     inkscape:window-height="1376"
-     inkscape:window-x="72"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:document-rotation="0" />
-  <metadata
-     id="metadata4448">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1">
-    <g
-       id="g1420"
-       transform="matrix(0.09138624,0,0,0.09138624,-3.3620485e-6,16.914007)">
-      <path
-         style="opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke-width:13.345"
-         d="M -3.7001955e-6,208.84668 H 744.09448 V 1193.6776 H -3.7001955e-6 Z"
-         id="rect855" />
-      <g
-         aria-label="NOVA"
-         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:267.972px;line-height:0%;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:22.331px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="text4305">
-        <path
-           d="M 53.238054,28.894823 V 137.69144 H 9.2906535 V -52.568651 H 43.591064 L 132.28978,59.175654 V -52.568651 h 43.9474 V 137.69144 h -35.3723 z"
-           style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';fill:#b3b3b3;fill-opacity:1;stroke-width:22.331px"
-           id="path970" />
-        <path
-           d="m 296.22582,139.29927 q -21.16979,0 -38.58796,-8.30713 -17.41818,-8.30713 -29.74489,-21.70573 -12.32671,-13.66657 -19.29398,-31.084747 -6.6993,-17.418177 -6.6993,-35.908242 0,-18.758037 6.96727,-36.1762138 7.23524,-17.4181772 19.82993,-30.5488032 12.86265,-13.398597 30.28083,-21.169784 17.41817,-8.039159 38.05201,-8.039159 21.16979,0 38.58796,8.307131 17.41818,8.307131 29.74489,21.9737 12.32671,13.6665699 19.02601,31.0847469 6.6993,17.4181771 6.6993,35.3722981 0,18.758037 -7.23524,36.176214 -6.96727,17.418177 -19.56196,30.816779 -12.59468,13.13062 -30.01285,21.16978 -17.41818,8.03916 -38.05202,8.03916 z M 246.65101,42.829365 q 0,10.98685 3.21566,21.437756 3.21566,10.182935 9.37902,18.222093 6.43132,8.039159 15.81034,12.862654 9.37902,4.823492 21.43776,4.823492 12.59468,0 21.9737,-5.091464 9.37902,-5.091467 15.54237,-13.130626 6.16336,-8.30713 9.11105,-18.490065 3.21566,-10.450906 3.21566,-21.169784 0,-10.98685 -3.21566,-21.169784 -3.21566,-10.450907 -9.64699,-18.2220933 -6.43133,-8.0391586 -15.81035,-12.5946818 -9.11104,-4.8234949 -21.16978,-4.8234949 -12.59468,0 -21.9737,5.0914668 -9.11105,4.8234952 -15.54237,12.8626538 -6.16336,8.0391584 -9.37902,18.4900644 -2.94769,10.182935 -2.94769,20.901813 z"
-           style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';fill:#b3b3b3;fill-opacity:1;stroke-width:22.331px"
-           id="path972" />
-        <path
-           d="m 437.27955,-52.568651 44.75132,135.057865 44.21537,-135.057865 h 46.35915 L 500.52093,137.69144 H 463.5408 L 390.65243,-52.568651 Z"
-           style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';fill:#b3b3b3;fill-opacity:1;stroke-width:22.331px"
-           id="path974" />
-        <path
-           d="m 625.73922,-52.568651 h 39.65985 L 734.80381,137.69144 H 689.78452 L 675.04606,95.083896 h -59.2218 L 601.35377,137.69144 H 556.33448 Z M 667.81082,64.803065 645.56915,-2.4578954 622.79153,64.803065 Z"
-           style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-family:Raleway;-inkscape-font-specification:'Raleway Ultra-Bold';fill:#b3b3b3;fill-opacity:1;stroke-width:22.331px"
-           id="path976" />
-      </g>
-      <text
-         xml:space="preserve"
-         style="font-size:823.675px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';fill:#ffffff;stroke-width:20.5919"
-         x="198.21645"
-         y="997.37329"
-         id="text1476"><tspan
-           sodipodi:role="line"
-           id="tspan1474"
-           x="198.21645"
-           y="997.37329"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Raleway;-inkscape-font-specification:Raleway;fill:#ffffff;stroke-width:20.5919">?</tspan></text>
-    </g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Calque_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 113.99">
+  <path d="m0,23.99h68v90H0V23.99Z" fill="#b3b3b3" />
+  <path d="m4.86,7.54v9.94H.85V.1h3.14l8.11,10.21V.1h4.02v17.39h-3.23L4.86,7.54Zm22.21,10.09c-1.29,0-2.47-.25-3.53-.76-1.06-.51-1.97-1.17-2.72-1.98-.75-.83-1.34-1.78-1.76-2.84-.41-1.06-.61-2.16-.61-3.28s.21-2.24.64-3.31c.44-1.06,1.04-1.99,1.81-2.79.78-.82,1.71-1.46,2.77-1.93,1.06-.49,2.22-.73,3.48-.73s2.47.25,3.53.76c1.06.51,1.97,1.17,2.72,2.01.75.83,1.33,1.78,1.74,2.84.41,1.06.61,2.14.61,3.23s-.22,2.24-.66,3.31c-.42,1.06-1.02,2-1.79,2.82-.77.8-1.68,1.44-2.74,1.93-1.06.49-2.22.74-3.48.73Zm-4.53-8.82c0,.67.1,1.32.29,1.96.2.62.48,1.17.86,1.66.39.49.87.88,1.44,1.18.57.29,1.22.44,1.96.44s1.44-.15,2.01-.47c.57-.31,1.04-.71,1.42-1.2.38-.51.65-1.07.83-1.69.2-.64.29-1.28.29-1.93s-.1-1.31-.29-1.93c-.2-.64-.49-1.19-.88-1.67-.39-.49-.87-.87-1.44-1.15-.56-.29-1.2-.44-1.93-.44s-1.44.16-2.01.47c-.55.29-1.03.68-1.42,1.17-.38.49-.66,1.05-.86,1.69-.18.62-.27,1.26-.27,1.91h0ZM39.96.1l4.09,12.34L48.09.1h4.24l-6.59,17.39h-3.38L35.7.1h4.26ZM57.18.1h3.62l6.34,17.39h-4.11l-1.35-3.89h-5.41l-1.32,3.89h-4.11L57.18.1Zm3.85,10.73l-2.03-6.15-2.08,6.15h4.11Z" fill="#b3b3b3" />
+  <g isolation="isolate">
+    <text transform="translate(18.12 96.05)" fill="#fff" font-family="Raleway-Bold, Raleway" font-size="75.28" font-weight="700" isolation="isolate">
+      <tspan x="0" y="0">?</tspan>
+    </text>
   </g>
 </svg>


### PR DESCRIPTION
Hi everyone!

On the mobile app, [we have some issues](https://github.com/openfoodfacts/smooth-app/issues/3990) with the current version of the Unknown group's SVG file.

After regenerating it with Illustrator, it seems to be OK on our side.

Could it be possible to use this one instead?
But please check, there is no visual regression (I don't think, but always better).
