### PR TITLE
feat: added quality facet error for reversed kcal and kj

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -701,12 +701,24 @@ sub check_nutrition_data ($product_ref) {
 			# energy in kcal greater than in kj
 			if ($product_ref->{nutriments}{"energy-kcal_value"} > $product_ref->{nutriments}{"energy-kj_value"}) {
 				push @{$product_ref->{data_quality_errors_tags}}, "en:energy-value-in-kcal-greater-than-in-kj";
+
+				# additionally check if kcal value and kj value are reversed. Exact opposite condition as next error below
+				if (
+					(
+						$product_ref->{nutriments}{"energy-kcal_value"}
+						> 3.7 * $product_ref->{nutriments}{"energy-kj_value"} - 2
+					)
+					and ($product_ref->{nutriments}{"energy-kcal_value"}
+						< 4.7 * $product_ref->{nutriments}{"energy-kj_value"} + 2)
+					)
+				{
+					push @{$product_ref->{data_quality_errors_tags}}, "en:energy-value-in-kcal-and-kj-are-reversed";
+				}
 			}
 
 			# check energy in kcal is ~ 4.2 (+/- 0.5) energy in kj
 			#   +/- 2 to avoid false positives due to rounded values below 2 Kcal.
 			#   Eg. 1.49 Kcal -> 6.26 KJ in reality, can be rounded by the producer to 1 Kcal -> 6 KJ.
-			# TODO: add tests in /tests/unit/dataqualityfood.t
 			if (
 				(
 					$product_ref->{nutriments}{"energy-kj_value"}

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -30,8 +30,12 @@ description:fr:La valeur de l'énergie en kJ doit être environ 4,2 fois plus gr
 en:Energy value in kcal greater than in kJ
 es:Valor energético en kcal mayor que en kJ
 fr:La valeur de l'énergie en kcal est plus grande qu'en kJ
-description:en:The energy value in kJ must be about 4.2 times greater than the value in kcal. The values could be inverted.
+description:en:The energy value in kJ must be about 4.2 times greater than the value in kcal. The values could be reversed.
 description:fr:La valeur de l'énergie en kJ doit être environ 4,2 fois plus grande que la valeur en kcal. Les valeurs sont peut être inversées.
+
+<en:Nutrition errors
+en:Energy value in kcal and kj are reversed
+description:en:The energy value in kJ must be about 4.2 times greater than the value in kcal. The values seems to be reversed.
 
 <en:Nutrition errors
 en:Energy value in kJ does not match value computed from other nutrients

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -744,4 +744,77 @@ $product_ref = {quantity => "300 ml e / 342 g"};
 ProductOpener::DataQuality::check_quality($product_ref);
 check_quality_and_test_product_has_quality_tag($product_ref, 'en:quantity-contains-e', 'quantity contains e', 1);
 
+# testing of ProductOpener::DataQualityFood::check_nutrition_data kJ vs kcal
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 686,
+		"energy-kcal_value" => 165,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-greater-than-in-kj',
+	'1 kcal = 4.184 kJ', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-does-not-match-value-in-kj',
+	'1 kcal = 4.184 kJ, value in kJ is between 165*3.7-2=608.5 and 165*4.7+2=777.5', 0
+);
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 100,
+		"energy-kcal_value" => 200,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-greater-than-in-kj',
+	'1 kcal = 4.184 kJ', 1
+);
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 496,
+		"energy-kcal_value" => 105,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-does-not-match-value-in-kj',
+	'1 kcal = 4.184 kJ, value in kJ is larger than 105*4.7+2=495.5', 1
+);
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 386,
+		"energy-kcal_value" => 105,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-does-not-match-value-in-kj',
+	'1 kcal = 4.184 kJ, value in kJ is lower than 105*3.7-2=495.5', 1
+);
+$product_ref = {
+	nutriments => {
+		"energy-kj_value" => 165,
+		"energy-kcal_value" => 686,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-greater-than-in-kj',
+	'1 kcal = 4.184 kJ', 1
+);
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:energy-value-in-kcal-and-kj-are-reversed',
+	'1 kcal = 4.184 kJ, value in kcal is between 165*3.7-2=608.5 and 165*4.7+2=777.5', 1
+);
+
 done_testing();


### PR DESCRIPTION
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)

### What
added data quality error for reversed kj and kcal

Instead of the formula in issue #8394, we can use the exact opposite of the formula used for "en:energy-value-in-kcal-does-not-match-value-in-kj" (reverse kcal and kj, and reversed < and >, so that any kcal that is in the window 3.7\*kj -2 and 4.7\*kj + 2 can be considered as reversed kcal and kj)

Also added tests for "en:energy-value-in-kcal-does-not-match-value-in-kj" (see: `# TODO: add tests in /tests/unit/dataqualityfood.t` ?!?)


### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/d09cfb0c-a3af-4ad7-b7b5-d30f31f03f49)



### Related issue(s) and discussion

- Fixes #8394 