### PR TITLE
fix: update vitamin b5

### DIFF
--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -3995,7 +3995,7 @@ unit:en: µg
 wikidata:en: Q181354
 wikipedia:en: https://en.wikipedia.org/wiki/Biotin
 
-zz:pantothenic-acid
+zz:Vitamin B5 (Pantothenic acid)
 en:Vitamin B5 (Pantothenic acid), Pantothenic acid, Pantothenate (Vitamin B5), Pantothenic acid, Pantothenate, Vitamin B5, B5
 xx:Vitamin B5 (Pantothenic acid), Pantothenic acid, Pantothenate (Vitamin B5), Pantothenic acid, Pantothenate, Vitamin B5, B5
 ar:فيتامين بي5


### PR DESCRIPTION
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Vitamin B5 (pantothenic acid) is displayed in the form's list of nutrients in "edit" mode.


It seems already there for French:
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/fefda96b-af2c-4649-806d-7411c1ab3e2a)

I updated the zz entry and it seems fine now for world as well:

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/6e81120e-103f-4903-807d-6ae872fe6544)


### Related issue(s) and discussion

- Fixes #8388