### PR TITLE
feat: bypass data quality error for citrus

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -594,39 +594,10 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 			# following error/warning should be ignored for some categories
 			# for example, lemon juices containing organic acid, it is forbidden to display organic acid in nutrition tables but
 			# organic acid contributes to the total energy calculation
-			my $skip_energy_error = 0;
-			if (defined $product_ref->{categories_tags}) {
-				# start from end, categories_tags has the most specific categories at the end
-				my $i = @{$product_ref->{categories_tags}} - 1;
-				while (
-					($i >= 0)
-					and (
-						not(
-							# category - or a parent - with expected tag
-							defined get_inherited_property(
-								"categories", $product_ref->{categories_tags}[$i],
-								"ignore_energy_calculated_error:en"
-							)
-							and (
-								# we expect single letter a, b, c, d, e for nutriscore grade in the taxonomy. Case insensitive (/i).
-								get_inherited_property(
-									"categories", $product_ref->{categories_tags}[$i],
-									"ignore_energy_calculated_error:en"
-								) =~ /yes$/i
-							)
-						)
-					)
-					)
-				{
-					$i--;
-				}
+			my $ignore_energy_calculated_error
+				= get_inherited_property_from_categories_tags($product_ref, "ignore_energy_calculated_error:en");
 
-				if ($i >= 0) {
-					$skip_energy_error = 1;
-				}
-			}
-
-			if (not($skip_energy_error)) {
+			if (not($ignore_energy_calculated_error)) {
 				# Compare to specified energy value with a tolerance of 30% + an additiontal tolerance of 5
 				if (   ($computed_energy < ($specified_energy * 0.7 - 5))
 					or ($computed_energy > ($specified_energy * 1.3 + 5)))

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -408,16 +408,8 @@ sub get_inherited_property_from_categories_tags ($product_ref, $property) {
 			$category_match = lc(get_inherited_property("categories", $category, $property));
 			last if $category_match;
 		}
-		if ($category_match) {
-			return $category_match;
-		}
-		else {
-			return;
-		}
 	}
-	else {
-		return;
-	}
+	return $category_match;
 }
 
 =head2 get_inherited_properties ($tagtype, $canon_tagid, $properties_names_ref, $fallback_lcs = ["xx", "en"]) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -59,6 +59,7 @@ BEGIN {
 		&get_property
 		&get_property_with_fallbacks
 		&get_inherited_property
+		&get_inherited_property_from_categories_tags
 		&get_inherited_properties
 		&get_tags_grouped_by_property
 
@@ -379,6 +380,47 @@ sub get_inherited_property ($tagtype, $canon_tagid, $property) {
 		}
 	}
 	return;
+}
+
+=head2 get_inherited_property_from_categories_tags ($product_ref, $property) {
+
+Iterating from the most specific category, try to get a property for a tag by exploring the taxonomy (using parents).
+
+=head3 Parameters
+
+=head4 $product_ref - the product reference
+=head4 $property - the property - string
+
+=head3 Return
+
+The property if found.
+
+=cut
+
+sub get_inherited_property_from_categories_tags ($product_ref, $property) {
+	# loop -> for each
+	# reduce calls to get_inherited_property
+	
+	my $category_match;
+	
+	if ((defined $product_ref->{categories_tags}) and (scalar @{$product_ref->{categories_tags}} > 0)) {
+
+		# Start with most specific category first
+		foreach my $category (reverse @{$product_ref->{categories_tags}}) {
+
+			$category_match = lc(get_inherited_property("categories", $category, $property));
+			last if $category_match;
+		}
+		if ($category_match) {
+			return $category_match;
+		}
+		else {
+			return;
+		}
+	}
+	else {
+		return;
+	}
 }
 
 =head2 get_inherited_properties ($tagtype, $canon_tagid, $properties_names_ref, $fallback_lcs = ["xx", "en"]) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -398,11 +398,8 @@ The property if found.
 =cut
 
 sub get_inherited_property_from_categories_tags ($product_ref, $property) {
-	# loop -> for each
-	# reduce calls to get_inherited_property
-	
 	my $category_match;
-	
+
 	if ((defined $product_ref->{categories_tags}) and (scalar @{$product_ref->{categories_tags}} > 0)) {
 
 		# Start with most specific category first

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -36,6 +36,13 @@ stopwords:nl:bevat,en
 stopwords:nl_be:bevat,en
 stopwords:de:und,mit,von
 
+# add following tag to ignore "Energy value in kJ does not correspond to the value calculated from the other nutrients error
+# only for categories having nutrients that are not displayed in the nutrition table and contributing to the energy
+# for example, lemon juices containing organic acid, it is forbidden to display organic acid in nutrition tables but
+# organic acid contributes to the total energy calculation. Only option is yes for this tag
+# ignore_energy_calculated_error:en:yes
+
+
 en:Artisan products
 ca:Prouctes artesans
 de:Handgefertigte Produkte, Artisanale Produkte, Handgemachte Produkte
@@ -5631,22 +5638,23 @@ agribalyse_food_code:en:13067
 agribalyse_proxy_food_name:en:Lime, pulp, raw
 agribalyse_proxy_food_name:fr:Citron vert ou Lime, pulpe, cru
 wikidata:en:Q5361217
+ignore_energy_calculated_error:en:yes
 
-#<en:Lime juice
+#<en:Lime juices
 #en:Home-made lime juice
 #fr:Jus de citron vert maison
 #ciqual_food_code:en:2030
 #ciqual_food_name:en:Lime juice, home-made
 #ciqual_food_name:fr:Jus de citron vert, maison
 
-<en:Lime juice
+<en:Lime juices
 en:Squeezed lime juices, Pure lime juices
 fr:Jus de citron vert pur jus
 ciqual_food_code:en:2031
 ciqual_food_name:en:Lime juice, pure juice
 ciqual_food_name:fr:Jus de citron vert, pur jus
 
-<en:Lime juice
+<en:Lime juices
 en:Lime juices from concentrate
 fr:Jus de citron vert à partir d'un concentré
 nl:limoensappen uit concentraat
@@ -5669,6 +5677,7 @@ pt:Sumos de limão
 ru:Лимонный сок
 zh:柠檬汁
 wikidata:en:Q1375049
+ignore_energy_calculated_error:en:yes
 
 <en:Lemon juice
 en:Home-made lemon juice

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -344,7 +344,7 @@ ok(has_tag($product_ref, 'data_quality', 'en:sum-of-ingredients-with-unspecified
 ok(has_tag($product_ref, 'data_quality', 'en:sum-of-ingredients-with-specified-percent-greater-than-100'))
 	or diag explain $product_ref;
 
-# energy matches nutrients
+# energy does not match nutrients
 $product_ref = {
 	nutriments => {
 		"energy-kj_value" => 5,
@@ -360,7 +360,25 @@ ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-v
 	'energy not matching nutrients')
 	or diag explain $product_ref;
 
-# energy does not match nutrients
+# energy does not match nutrients but this alert is ignored for this category
+$product_ref = {
+	categories_tags => ['en:squeezed-lemon-juices'],
+	nutriments => {
+		"energy-kj_value" => 5,
+		"carbohydrates_value" => 10,
+		"fat_value" => 20,
+		"proteins_value" => 30,
+		"fiber_value" => 2,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+is($product_ref->{nutriments}{"energy-kj_value_computed"}, 1436);
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrients but category possesses ignore_energy_calculated_error:en:yes tag'
+) or diag explain $product_ref;
+
+# energy matches nutrients
 $product_ref = {
 	nutriments => {
 		"energy-kj_value" => 1435,


### PR DESCRIPTION
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)

### What
Added feature to bypass "Energy value in kJ does not correspond to the value calculated from the other nutrients"

### Screenshot
Not sure what to screenshot because there is no error anymore :-D

### Related issue(s) and discussion
- Fixes #8425 

