### PR TITLE
taxonomy: e-243 additive exposure

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -5137,9 +5137,9 @@ efsa:en:http://www.efsa.europa.eu/en/efsajournal/doc/3294.pdf
 efsa_evaluation_url:en:https://efsa.onlinelibrary.wiley.com/doi/10.2903/j.efsa.2019.5621
 efsa_evaluation_date:en:2019/03/08
 efsa_evaluation:en:Safety of ethyl lauroyl arginate (E 243) as a food additive in the light of the new information provided and the proposed extension of use
-efsa_evaluation_overexposure_risk:en: en:high
-efsa_evaluation_exposure_mean_greater_than_adi:en:en:children, en:toddlers
-efsa_evaluation_exposure_95th_greater_than_adi:en:en:adults, en:elderly, en:adolescents, en:children, en:toddlers, en:infants
+efsa_evaluation_overexposure_risk:en: en:moderate
+efsa_evaluation_exposure_mean_greater_than_adi:en:en:no-group
+efsa_evaluation_exposure_95th_greater_than_adi:en:en:children, en:toddlers
 additives_classes:en:en:preservative
 vegan:en:yes
 vegetarian:en:yes


### PR DESCRIPTION
EFSA conclusion in https://efsa.onlinelibrary.wiley.com/doi/10.2903/j.efsa.2019.5621

"Based on the above, the Panel concluded that the current ADI of 0.5 mg/kg bw would be reached in toddlers and children at the 95th percentile already for exposure estimates calculated using the currently permitted ML for ethyl lauroyl arginate (E 243)."