### PR TITLE
chore: migrate from snyk protect to @snyk/protect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "win32"
       ],
       "dependencies": {
+        "@snyk/protect": "^1.1163.0",
         "@webcomponents/webcomponentsjs": "2.6.0",
         "@yaireo/tagify": ">=4.12.0 <4.13.0",
         "blueimp-file-upload": "^10.31.0",
@@ -30,7 +31,6 @@
         "osmtogeojson": "^3.0.0-beta.4",
         "papaparse": "^5.3.2",
         "select2": "~4.0",
-        "snyk": "^1.907.0",
         "xml2json": "^0.12.0"
       },
       "devDependencies": {
@@ -696,6 +696,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@snyk/protect": {
+      "version": "1.1163.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1163.0.tgz",
+      "integrity": "sha512-pwUwun+dukyPZFgglH7w13laMrtddL306HzxXNDKX9o3j8ay16blAKau/iI/asiL9czAaTbibxbS9KSZSxryng==",
+      "bin": {
+        "snyk-protect": "bin/snyk-protect"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@stylelint/postcss-css-in-js": {
@@ -7906,17 +7917,6 @@
         "urix": "^0.1.0"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.1060.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1060.0.tgz",
-      "integrity": "sha512-WAYComfIYczRf/BnXNOTnmboGuyX6zkYznqJReKxb+h6AbG6IzC5O9qOWe6ws3v3BXDpfi4AjcaaBeo4WHOxMw==",
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10268,6 +10268,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@snyk/protect": {
+      "version": "1.1163.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1163.0.tgz",
+      "integrity": "sha512-pwUwun+dukyPZFgglH7w13laMrtddL306HzxXNDKX9o3j8ay16blAKau/iI/asiL9czAaTbibxbS9KSZSxryng=="
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.3",
@@ -15858,11 +15863,6 @@
           }
         }
       }
-    },
-    "snyk": {
-      "version": "1.1060.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1060.0.tgz",
-      "integrity": "sha512-WAYComfIYczRf/BnXNOTnmboGuyX6zkYznqJReKxb+h6AbG6IzC5O9qOWe6ws3v3BXDpfi4AjcaaBeo4WHOxMw=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "",
   "private": true,
   "browserslist": [
-    ">0.05%", "defaults"
+    ">0.05%",
+    "defaults"
   ],
   "scripts": {
     "build": "gulp",
@@ -25,7 +26,7 @@
     "perlc:startup": "perl -c -CS -Ilib lib/startup_apache2.pl",
     "perlc:cgi": "node scripts/check_perl.js cgi/*.pl",
     "perlc:scripts": "node scripts/check_perl.js scripts/*.pl",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect"
   },
   "repository": {
@@ -44,6 +45,7 @@
     "win32"
   ],
   "dependencies": {
+    "@snyk/protect": "^1.1163.0",
     "@webcomponents/webcomponentsjs": "2.6.0",
     "@yaireo/tagify": ">=4.12.0 <4.13.0",
     "blueimp-file-upload": "^10.31.0",
@@ -59,9 +61,8 @@
     "leaflet.markercluster": "1.5.3",
     "osmtogeojson": "^3.0.0-beta.4",
     "papaparse": "^5.3.2",
-    "snyk": "^1.907.0",
-    "xml2json": "^0.12.0",
-    "select2": "~4.0"
+    "select2": "~4.0",
+    "xml2json": "^0.12.0"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
### What

`snyk protect` is deprecated

https://github.com/snyk/cli/tree/master/packages/snyk-protect#migrating-from-snyk-protect-to-snykprotect
