### PR TITLE
fix: on the fly nutrition edit checks #8420

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6657,9 +6657,10 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
 
-msgctxt "product_js_enter_value_between_0_and_100"
-msgid "Please enter a value between 0 and 100."
-msgstr "Please enter a value between 0 and 100."
+# variable names between { } must not be translated
+msgctxt "product_js_enter_value_between_0_and_max"
+msgid "Please enter a value between 0 and {max}."
+msgstr "Please enter a value between 0 and {max}."
 
 msgctxt "product_js_sugars_warning"
 msgid "Sugars should not be higher than carbohydrates."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6667,9 +6667,10 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
 
-msgctxt "product_js_enter_value_between_0_and_100"
-msgid "Please enter a value between 0 and 100."
-msgstr "Please enter a value between 0 and 100."
+# variable names between { } must not be translated
+msgctxt "product_js_enter_value_between_0_and_max"
+msgid "Please enter a value between 0 and {max}."
+msgstr "Please enter a value between 0 and {max}."
 
 msgctxt "product_js_sugars_warning"
 msgid "Sugars should not be higher than carbohydrates."

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.js
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.js
@@ -15,10 +15,10 @@
 
 	\$('input[name=[% nutrition.nutrition_data_per %]]').change(function() {
 		if (\$('input[name=[% nutrition.nutrition_data_per %]]:checked').val() == '100g') {
-			\$('#[% nutrition.nutrition_data %]_100g').show();
+			\$('#[% nutrition.nutrition_data %]_maxg').show();
 			\$('#[% nutrition.nutrition_data %]_serving').hide();
 		} else {
-			\$('#[% nutrition.nutrition_data %]_100g').hide();
+			\$('#[% nutrition.nutrition_data %]_maxg').hide();
 			\$('#[% nutrition.nutrition_data %]_serving').show();
 		}
 		update_nutrition_image_copy();
@@ -50,34 +50,67 @@ function show_warning(should_show, nutrient_id, warning_message){
 	}
 }
 
+function check_nutrient(nutrient_id) {
+	// check the changed nutrient value
+	var nutrient_value = \$('#nutriment_' + nutrient_id).val().replace(',','.').replace(/^<|>|~/, '');
+	var nutrient_unit = \$('#nutriment_' + nutrient_id + '_unit').val()
+
+	// define the max valid value
+	var max;
+	var percent;
+
+	if (nutrient_id == 'energy-kj') {
+		max = 3800;
+	}
+	else if (nutrient_id == 'energy-kcal') {
+		max = 900;
+	}
+	else if (nutrient_id == 'alcohol') {
+		max = 100;
+		percent = true;
+	}	
+	else if (nutrient_unit == 'g') {
+		max = 100;
+	}
+	else if (nutrient_unit == 'mg') {
+		max = 100 * 1000;
+	}
+	else if (nutrient_unit == 'µg') {
+		max = 100 * 1000 * 1000;
+	}	
+	
+	var is_above_or_below_max;
+	if (max) {
+		is_above_or_below_max = (isNaN(nutrient_value) && nutrient_value != '-') || nutrient_value < 0 || nutrient_value > max;
+		// if the nutrition facts are indicated per serving, the value can be above 100
+		if ((nutrient_value > max) && (\$('#nutrition_data_per_serving').is(':checked')) && !percent) {
+			is_above_or_below_max = false;
+		}
+		show_warning(is_above_or_below_max, nutrient_id, lang().product_js_enter_value_between_0_and_max.replace('{max}', max));
+	}
+
+	// check that nutrients are sound (e.g. sugars is not above carbohydrates)
+	// but only if the changed nutrient does not have a warning
+	// otherwise we may clear the sugars or saturated-fat warning
+	if (! is_above_or_below_max) {
+		var fat_value = \$('#nutriment_fat').val().replace(',','.');
+		var carbohydrates_value = \$('#nutriment_carbohydrates').val().replace(',','.');
+		var sugars_value = \$('#nutriment_sugars').val().replace(',','.');
+		var saturated_fats_value = \$('#nutriment_saturated-fat').val().replace(',','.');
+	
+		var is_sugars_above_carbohydrates = parseFloat(carbohydrates_value) < parseFloat(sugars_value);
+		show_warning(is_sugars_above_carbohydrates, 'sugars', lang().product_js_sugars_warning);
+		
+		var is_fat_above_saturated_fats = parseFloat(fat_value) < parseFloat(saturated_fats_value);
+		show_warning(is_fat_above_saturated_fats, 'saturated-fat', lang().product_js_saturated_fat_warning);
+	}
+}
+
 var required_nutrients_id = ['energy-kj', 'energy-kcal', 'fat', 'saturated-fat', 'sugars', 'carbohydrates', 'fiber', 'proteins', 'salt', 'sodium', 'alcohol'];
 
 required_nutrients_id.forEach(nutrient_id => {
 	\$('#nutriment_' + nutrient_id).on('input', function() {
-
-		// check the changed nutrient value
-		var nutrient_value = \$(this).val().replace(',','.');
-		var is_above_or_below_100 = (isNaN(nutrient_value) && nutrient_value != '-') || nutrient_value < 0 || nutrient_value > 100;
-		// if the nutrition facts are indicated per serving, the value can be above 100
-		if ((nutrient_value > 100) && (\$('#nutrition_data_per_serving').is(':checked'))) {
-			is_above_or_below_100 = false;
-		}
-		show_warning(is_above_or_below_100, nutrient_id, lang().product_js_enter_value_between_0_and_100);
-
-		// check that nutrients are sound (e.g. sugars is not above carbohydrates)
-		// but only if the changed nutrient does not have a warning
-		// otherwise we may clear the sugars or saturated-fat warning
-		if (! is_above_or_below_100) {
-			var fat_value = \$('#nutriment_fat').val().replace(',','.');
-			var carbohydrates_value = \$('#nutriment_carbohydrates').val().replace(',','.');
-			var sugars_value = \$('#nutriment_sugars').val().replace(',','.');
-			var saturated_fats_value = \$('#nutriment_saturated-fat').val().replace(',','.');
-		
-			var is_sugars_above_carbohydrates = parseFloat(carbohydrates_value) < parseFloat(sugars_value);
-			show_warning(is_sugars_above_carbohydrates, 'sugars', lang().product_js_sugars_warning);
-			
-			var is_fat_above_saturated_fats = parseFloat(fat_value) < parseFloat(saturated_fats_value);
-			show_warning(is_fat_above_saturated_fats, 'saturated-fat', lang().product_js_saturated_fat_warning);
-		}
+		check_nutrient(nutrient_id);
 	});
+	check_nutrient(nutrient_id);
 });

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.js
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.js
@@ -15,10 +15,10 @@
 
 	\$('input[name=[% nutrition.nutrition_data_per %]]').change(function() {
 		if (\$('input[name=[% nutrition.nutrition_data_per %]]:checked').val() == '100g') {
-			\$('#[% nutrition.nutrition_data %]_maxg').show();
+			\$('#[% nutrition.nutrition_data %]_100g').show();
 			\$('#[% nutrition.nutrition_data %]_serving').hide();
 		} else {
-			\$('#[% nutrition.nutrition_data %]_maxg').hide();
+			\$('#[% nutrition.nutrition_data %]_100g').hide();
 			\$('#[% nutrition.nutrition_data %]_serving').show();
 		}
 		update_nutrition_image_copy();


### PR DESCRIPTION
Solves most of the issues reported by @CharlesNepote and @benbenben2 in https://github.com/openfoodfacts/openfoodfacts-server/issues/8420

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/cbca9132-ef8c-475d-b6f3-f6c8e934d42e)

Does not address the tooltip below the image issue.
