### PR TITLE
taxonomy: Added German variant of inositol

### DIFF
--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -6415,7 +6415,7 @@ bg:Инозитол
 ca:inositol
 cs:inositol
 da:inositol
-de:Inositol, Inosit
+de:Inosit, Inositol
 el:Ινοσιτόλη
 es:inositol
 et:Inositool

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -6415,7 +6415,7 @@ bg:Инозитол
 ca:inositol
 cs:inositol
 da:inositol
-de:Inositol
+de:Inositol, Inosit
 el:Ινοσιτόλη
 es:inositol
 et:Inositool

--- a/taxonomies/other_nutritional_substances.txt
+++ b/taxonomies/other_nutritional_substances.txt
@@ -374,7 +374,7 @@ ar:إينوزيتول
 ca:inositol
 cs:inositol
 da:inositol
-de:Inositol
+de:Inositol, Inosit
 el:Ινοσιτόλη
 es:inositol
 et:Inositool

--- a/taxonomies/other_nutritional_substances.txt
+++ b/taxonomies/other_nutritional_substances.txt
@@ -374,7 +374,7 @@ ar:إينوزيتول
 ca:inositol
 cs:inositol
 da:inositol
-de:Inositol, Inosit
+de:Inosit, Inositol
 el:Ινοσιτόλη
 es:inositol
 et:Inositool


### PR DESCRIPTION
### What

Added the German variant "Inosit" to inositol, which is often contained in beverages like energy drinks. In German, the word "Inosit" is more common than "Inositol".