### PR TITLE
taxonomy: Add Spanish/Catalan sugars for creatine products

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -90638,6 +90638,8 @@ wikidata:en:Q914538
 <en:Sugars
 en:Dextrose
 xx:Dextrose
+ca:Dextrosa
+es:Dextrosa
 nl:Dextrose, Druivensuiker
 
 <en:Sugars
@@ -90807,8 +90809,9 @@ ciqual_food_name:fr:Fructose
 
 <en:Natural sugar substitutes
 en:Glucose
+es:Glucosa
 bg:Глюкоза
-es:Glucosa, Dextrosa
+es:Glucosa
 fr:Glucose
 nl:Glucose
 pl:Glukoza
@@ -102167,8 +102170,10 @@ nl:Vertakte keten aminozuren
 wikidata:en:Q420726
 
 <en:Bodybuilding supplements
-en:Glutamine
+en:Glutamine, L-Glutamine
+ca:Glutamina, L-Glutamina
 de:Glutamin, L-Glutamin, 2-Amino-4-carbamoylbutansäure, 2-Amino-4-carbamoylbuttersäure, Glutaminsäure-5-amid
+es:Glutamina, L-Glutamina
 fr:Glutamine
 pl:Glutamina
 wikidata:en:Q181619
@@ -102184,9 +102189,11 @@ de:Prohormone
 wikidata:en:Q419119
 
 <en:Bodybuilding supplements
-en:Creatine, Creatine supplements
+en:Creatine, Creatine supplements, Creatine monohydrate
+ca:Creatina, Monohidrat de creatina
 bg:Креатин
 de:Kreatin, N-Amidinosarkosin, N-(Aminoiminomethyl)-N-methyl-glycin, α-Methylguanidinoessigsäure
+es:Creatina, Monohidrato de creatina
 fi:Kreatiini, Kreatiinilisäravinteet
 wikidata:en:Q1058872
 

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -1931,11 +1931,12 @@ en:Carbohydrates, carbohydrate
 xx:Carbohydrates, carbohydrate
 ar:الكاربوهايدريد
 bg:Въглехидрати
+ca:Hidrats de carboni, Glúcids, Carbohidrats
 cs:Sacharidy
 da:Kulhydrat
 de:Kohlenhydrate
 el:Υδατάνθρακες
-es:Hidratos de carbono, Glúcidos
+es:Hidratos de carbono, Glúcidos, Carbohidratos
 et:Süsivesikud
 fa:کربوهیدرات ها
 fi:Hiilihydraatit, hiilihydraatti
@@ -1985,7 +1986,7 @@ bh:चीनी
 bn:চিনি
 br:Sukr
 bs:Šećer
-ca:Sucre
+ca:Sucre, Sucres
 ce:Шекар
 cs:Cukry, Cukr
 cv:Сахăр
@@ -2179,7 +2180,7 @@ wikidata:en: Q4027534
 wikipedia:en: https://en.wikipedia.org/wiki/Sucrose
 
 zz:glucose
-en:Glucose
+en:Glucose, Dextrose
 xx:Glucose
 af:Glukose
 ar:جلوكوز
@@ -2189,13 +2190,13 @@ be:Глюкоза
 bg:Глюкоза
 bn:গ্লুকোজ
 bs:Glukoza
-ca:Glucosa
+ca:Glucosa, Dextrosa
 cs:Glukóza
 da:glukose
 de:Traubenzucker, Glukose
 el:Γλυκόζη
 eo:Glukozo
-es:Glucosa
+es:Glucosa, Dextrosa
 et:glükoos
 eu:Glukosa
 fa:گلوکز
@@ -2342,6 +2343,16 @@ zh_TW:果糖
 unit:en: g
 wikidata:en: Q122043
 wikipedia:en: https://en.wikipedia.org/wiki/Fructose
+
+zz:oligosaccharide
+en:Oligosaccharide, oligosaccharides
+xx:Oligosaccharide, oligosaccharides
+ca:Oligosacàrids
+es:Oligosacáridos
+unit:en: g
+wikidata:en: Q320607
+wikipedia:en: https://en.wikipedia.org/wiki/Oligosaccharide
+description:en: a saccharide polymer containing a small number (typically two to ten) of simple sugars (monosaccharides)
 
 zz:lactose
 en:Lactose
@@ -5955,6 +5966,8 @@ zh_tw:牛磺酸
 unit:en: g
 zh_hans:en: 牛磺酸
 zh_hant:en: 牛磺酸
+wikidata:en: Q207051
+wikipedia:en: https://en.wikipedia.org/wiki/Taurine
 
 zz:ph
 en:pH
@@ -6534,5 +6547,7 @@ description:en:Spermidine is a polyamine compound (C7H19N3) found in ribosomes a
 
 zz:water
 en:Water
+ca:Aigua
+es:Agua
 fr:Eau
 unit:en: g


### PR DESCRIPTION
From [product 8424644002497](https://es.openfoodfacts.org/producto/8424644002497) , there is no nutrition table, but instead a list of components weight.
Adding few translations for sugars in Spanish and Catalan, and a bit of some additional info.