### PR TITLE
fix: Hide the Classic Packaging Field in Edit Mode

### DIFF
--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -993,7 +993,7 @@ CSS
 
 	my @display_fields_arr;
 	foreach my $field (@fields) {
-		next if $field eq "origins";    # now displayed below allergens and traces in the ingredients section
+		next if $field eq "origins" || $field eq "packaging";    # hide packaging field & origins are now displayed below allergens and traces in the ingredients section
 		$log->debug("display_field", {field_name => $field, field_value => $product_ref->{$field}}) if $log->is_debug();
 		my $display_field = display_input_field($product_ref, $field, undef);
 		push(@display_fields_arr, $display_field);

--- a/cgi/product_multilingual.pl
+++ b/cgi/product_multilingual.pl
@@ -993,7 +993,8 @@ CSS
 
 	my @display_fields_arr;
 	foreach my $field (@fields) {
-		next if $field eq "origins" || $field eq "packaging";    # hide packaging field & origins are now displayed below allergens and traces in the ingredients section
+		# hide packaging field & origins are now displayed below allergens and traces in the ingredients section
+		next if $field eq "origins" || $field eq "packaging";
 		$log->debug("display_field", {field_name => $field, field_value => $product_ref->{$field}}) if $log->is_debug();
 		my $display_field = display_input_field($product_ref, $field, undef);
 		push(@display_fields_arr, $display_field);


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Added the packaging field too in cgi/product_multilingual.pm so that this field is not displayed for the tab "product characteristics" in templates/web/pages/product_edit/product_edit_form_display.tt.html !

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/99353300/c2909c2f-7a36-40bd-91dc-d47e959e2c47)

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #7804

