### PR TITLE
feat: Run user deletion as a background task

### DIFF
--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -2008,4 +2008,8 @@ sub update_export_status_for_csv_file_task ($job, $args_ref) {
 	return;
 }
 
+sub queue_job { ## no critic (Subroutines::RequireArgUnpacking)
+	return $minion->enqueue(@_);
+}
+
 1;

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -82,9 +82,11 @@ use ProductOpener::Display qw/:all/;
 use ProductOpener::Orgs qw/:all/;
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Text qw/:all/;
+use ProductOpener::Producers qw/:all/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use Encode;
+use JSON::PP;
 
 use Email::Valid;
 use Crypt::PasswdMD5 qw(unix_md5_crypt);
@@ -180,10 +182,9 @@ sub check_password_hash ($password, $hash) {
 
 # we use user_init() now and not create_user()
 
-=head2 delete_user ($password, $hash)
+=head2 delete_user ($user_ref)
 
-C<delete_user()> This function is used for deleting a user and uses the user_ref as a parameter. 
-This function removes the user files, the email and re-assigns product edits to openfoodfacts-contributors-[random number]
+C<delete_user()> Creates a background job to delete the user
 
 =head3 Arguments
 
@@ -192,8 +193,40 @@ Takes in the $user_ref of the user to be deleted
 =cut
 
 sub delete_user ($user_ref) {
+	my $args_ref = {
+		userid => get_string_id_for_lang("no_language", $user_ref->{userid}),
+		email => $user_ref->{email},
+	};
 
-	my $userid = get_string_id_for_lang("no_language", $user_ref->{userid});
+	$minion->enqueue(delete_user => [$args_ref] => {queue => $server_options{minion_local_queue}});
+
+	return;
+}
+
+=head2 delete_user_task ($job, $args_ref)
+
+C<delete_user_task()> Background task that deletes a user. 
+This function removes the user files, the email and re-assigns product edits to openfoodfacts-contributors-[random number]
+
+=head3 Arguments
+
+Minion job arguments. $args_ref contains the userid and email
+
+=cut
+
+sub delete_user_task ($job, $args_ref) {
+	return if not defined $job;
+
+	my $job_id = $job->{id};
+
+	my $log_message = "delete_user_task - job: $job_id started - args: " . encode_json($args_ref) . "\n";
+	open(my $minion_log, ">>", "$data_root/logs/minion.log");
+	print $minion_log $log_message;
+	close($minion_log);
+
+	print STDERR $log_message;
+
+	my $userid = $args_ref->{userid};
 	# Suffix is a combination of seconds since epoch plus a 16 bit random number
 	my $new_userid = "anonymous-" . lc(encode_base32(pack('LS', time(), rand(65536))));
 
@@ -204,7 +237,7 @@ sub delete_user ($user_ref) {
 
 	# Remove the e-mail
 	my $emails_ref = retrieve("$data_root/users/users_emails.sto");
-	my $email = $user_ref->{email};
+	my $email = $args_ref->{email};
 
 	if ((defined $email) and ($email =~ /\@/)) {
 
@@ -214,8 +247,11 @@ sub delete_user ($user_ref) {
 		}
 	}
 
-	#  re-assign product edits to openfoodfacts-contributors-[random number]
+	#  re-assign product edits to anonymous-[random number]
 	find_and_replace_user_id_in_products($userid, $new_userid);
+
+	$job->finish("done");
+
 	return;
 }
 

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -82,7 +82,6 @@ use ProductOpener::Display qw/:all/;
 use ProductOpener::Orgs qw/:all/;
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Text qw/:all/;
-use ProductOpener::Producers qw/:all/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use Encode;
@@ -198,7 +197,8 @@ sub delete_user ($user_ref) {
 		email => $user_ref->{email},
 	};
 
-	$minion->enqueue(delete_user => [$args_ref] => {queue => $server_options{minion_local_queue}});
+	require ProductOpener::Producers;
+	ProductOpener::Producers::queue_job(delete_user => [$args_ref] => {queue => $server_options{minion_local_queue}});
 
 	return;
 }

--- a/po/common/aa.po
+++ b/po/common/aa.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ach.po
+++ b/po/common/ach.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/af.po
+++ b/po/common/af.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ak.po
+++ b/po/common/ak.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/am.po
+++ b/po/common/am.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -5276,7 +5276,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/as.po
+++ b/po/common/as.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ast.po
+++ b/po/common/ast.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/az.po
+++ b/po/common/az.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/be.po
+++ b/po/common/be.po
@@ -5264,7 +5264,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ber.po
+++ b/po/common/ber.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -5280,7 +5280,7 @@ msgid "Remove all nutrient values"
 msgstr "Премахнете всички хранителни стойности"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Изтрит потребител."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/bm.po
+++ b/po/common/bm.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -5256,7 +5256,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/bo.po
+++ b/po/common/bo.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -5260,7 +5260,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/bs.po
+++ b/po/common/bs.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -5278,7 +5278,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "S'ha suprimit l'usuari."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ce.po
+++ b/po/common/ce.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/chr.po
+++ b/po/common/chr.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/co.po
+++ b/po/common/co.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5408,8 +5408,8 @@ msgid "Remove all nutrient values"
 msgstr "Remove all nutrient values"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
-msgstr "User deleted."
+msgid "User is being deleted. This may take a few minutes."
+msgstr "User is being deleted. This may take a few minutes."
 
 msgctxt "attribute_ecoscore_not_applicable_title"
 msgid "Eco-Score not yet applicable"

--- a/po/common/crs.po
+++ b/po/common/crs.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -5273,7 +5273,7 @@ msgid "Remove all nutrient values"
 msgstr "Odstranit všechny nutriční hodnoty"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Uživatel byl smazán."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/cv.po
+++ b/po/common/cv.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/cy.po
+++ b/po/common/cy.po
@@ -5247,7 +5247,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -5278,7 +5278,7 @@ msgid "Remove all nutrient values"
 msgstr "Fjern alle næringsværdier"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Bruger slettet."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -5278,7 +5278,7 @@ msgid "Remove all nutrient values"
 msgstr "Alle Nährwertwerte entfernen"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Benutzer gelöscht."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -5252,7 +5252,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5445,8 +5445,8 @@ msgid "Remove all nutrient values"
 msgstr "Remove all nutrient values"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
-msgstr "User deleted."
+msgid "User is being deleted. This may take a few minutes."
+msgstr "User is being deleted. This may take a few minutes."
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -5178,7 +5178,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -5264,8 +5264,8 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
-msgstr "User deleted."
+msgid "User is being deleted. This may take a few minutes."
+msgstr "User is being deleted. This may take a few minutes."
 
 msgctxt "attribute_ecoscore_not_applicable_title"
 msgid "Eco-Score not yet applicable"

--- a/po/common/eo.po
+++ b/po/common/eo.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -5277,7 +5277,7 @@ msgid "Remove all nutrient values"
 msgstr "Eliminar todos los valores de nutrientes"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Usuario eliminado."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/et.po
+++ b/po/common/et.po
@@ -5248,7 +5248,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -5261,7 +5261,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -5275,7 +5275,7 @@ msgid "Remove all nutrient values"
 msgstr "Poista kaikki ravintoarvot"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Käyttäjä poistettu."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/fil.po
+++ b/po/common/fil.po
@@ -5269,7 +5269,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/fo.po
+++ b/po/common/fo.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5282,7 +5282,7 @@ msgid "Remove all nutrient values"
 msgstr "Supprimer toutes les valeurs nutritives"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Utilisateur supprimé."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ga.po
+++ b/po/common/ga.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/gd.po
+++ b/po/common/gd.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/gl.po
+++ b/po/common/gl.po
@@ -5248,7 +5248,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/gu.po
+++ b/po/common/gu.po
@@ -5263,7 +5263,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ha.po
+++ b/po/common/ha.po
@@ -5259,7 +5259,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -5278,7 +5278,7 @@ msgid "Remove all nutrient values"
 msgstr "הסרת כל ערכי ההזנה"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "המשתמש נמחק."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/hi.po
+++ b/po/common/hi.po
@@ -5261,7 +5261,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/hr.po
+++ b/po/common/hr.po
@@ -5263,7 +5263,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ht.po
+++ b/po/common/ht.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -5273,7 +5273,7 @@ msgid "Remove all nutrient values"
 msgstr "Távolítson el minden tápanyagértéket"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Felhasználó törölve."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/hy.po
+++ b/po/common/hy.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/id.po
+++ b/po/common/id.po
@@ -5275,7 +5275,7 @@ msgid "Remove all nutrient values"
 msgstr "Hapus semua nilai makanan bergizi"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Pengguna dihapus."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ii.po
+++ b/po/common/ii.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/is.po
+++ b/po/common/is.po
@@ -5260,7 +5260,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -5280,7 +5280,7 @@ msgid "Remove all nutrient values"
 msgstr "Rimuovi tutti i valori nutrizionali"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Utente rimosso."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/iu.po
+++ b/po/common/iu.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -5279,7 +5279,7 @@ msgid "Remove all nutrient values"
 msgstr "すべての栄養価を削除"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "ユーザが削除されました。"
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/jv.po
+++ b/po/common/jv.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ka.po
+++ b/po/common/ka.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/kab.po
+++ b/po/common/kab.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/kk.po
+++ b/po/common/kk.po
@@ -5261,7 +5261,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/km.po
+++ b/po/common/km.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/kmr.po
+++ b/po/common/kmr.po
@@ -5145,7 +5145,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/kmr_TR.po
+++ b/po/common/kmr_TR.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/kn.po
+++ b/po/common/kn.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -5277,7 +5277,7 @@ msgid "Remove all nutrient values"
 msgstr "모든 영양소 값 제거"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "사용자 삭제됨"
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ku.po
+++ b/po/common/ku.po
@@ -5145,7 +5145,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/kw.po
+++ b/po/common/kw.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ky.po
+++ b/po/common/ky.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/la.po
+++ b/po/common/la.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/lb.po
+++ b/po/common/lb.po
@@ -5262,7 +5262,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/lol.po
+++ b/po/common/lol.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr "crwdns203716:0crwdne203716:0"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "crwdns203718:0crwdne203718:0"
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/lt.po
+++ b/po/common/lt.po
@@ -5274,7 +5274,7 @@ msgid "Remove all nutrient values"
 msgstr "Pašalinkite visas maistinių medžiagų vertes"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Vartotojas ištrintas."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/lv.po
+++ b/po/common/lv.po
@@ -5264,7 +5264,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/me.po
+++ b/po/common/me.po
@@ -5147,7 +5147,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/mg.po
+++ b/po/common/mg.po
@@ -5261,7 +5261,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/mi.po
+++ b/po/common/mi.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ml.po
+++ b/po/common/ml.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/mn.po
+++ b/po/common/mn.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/mr.po
+++ b/po/common/mr.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -5278,7 +5278,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/mt.po
+++ b/po/common/mt.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/my.po
+++ b/po/common/my.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/nb.po
+++ b/po/common/nb.po
@@ -5263,7 +5263,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ne.po
+++ b/po/common/ne.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -5277,7 +5277,7 @@ msgid "Remove all nutrient values"
 msgstr "Verwijder alle voedingswaarden"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Gebruiker verwijderd."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -5231,7 +5231,7 @@ msgid "Remove all nutrient values"
 msgstr "Verwijder alle voedingswaarden"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Gebruiker verwijderd."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/nn.po
+++ b/po/common/nn.po
@@ -5247,7 +5247,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/no.po
+++ b/po/common/no.po
@@ -5247,7 +5247,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/nr.po
+++ b/po/common/nr.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/oc.po
+++ b/po/common/oc.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/pa.po
+++ b/po/common/pa.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -5277,7 +5277,7 @@ msgid "Remove all nutrient values"
 msgstr "Usuń wszystkie wartości odżywcze"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Użytkownik usunięty."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -5277,7 +5277,7 @@ msgid "Remove all nutrient values"
 msgstr "Remover todos os valores nutricionais"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Utilizador eliminado."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -5230,7 +5230,7 @@ msgid "Remove all nutrient values"
 msgstr "Remover todos os valores nutricionais"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Utilizador eliminado."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/qu.po
+++ b/po/common/qu.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/rm.po
+++ b/po/common/rm.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -5274,7 +5274,7 @@ msgid "Remove all nutrient values"
 msgstr "Eliminați toate valorile nutritive"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Utilizatorul a fost șters."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -5279,7 +5279,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Пользователь удалён."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ry.po
+++ b/po/common/ry.po
@@ -5147,7 +5147,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/sa.po
+++ b/po/common/sa.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sat.po
+++ b/po/common/sat.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sc.po
+++ b/po/common/sc.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sco.po
+++ b/po/common/sco.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sd.po
+++ b/po/common/sd.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sg.po
+++ b/po/common/sg.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sh.po
+++ b/po/common/sh.po
@@ -5147,7 +5147,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/si.po
+++ b/po/common/si.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -5247,7 +5247,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -5275,7 +5275,7 @@ msgid "Remove all nutrient values"
 msgstr "Odstrani vse hranilne vrednosti"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Uporabnik zbrisan."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sma.po
+++ b/po/common/sma.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sn.po
+++ b/po/common/sn.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/so.po
+++ b/po/common/so.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/son.po
+++ b/po/common/son.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sq.po
+++ b/po/common/sq.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sr.po
+++ b/po/common/sr.po
@@ -5247,7 +5247,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sr_CS.po
+++ b/po/common/sr_CS.po
@@ -5147,7 +5147,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/sr_RS.po
+++ b/po/common/sr_RS.po
@@ -5173,7 +5173,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/ss.po
+++ b/po/common/ss.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/st.po
+++ b/po/common/st.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -5277,7 +5277,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Användare borttagen."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/sw.po
+++ b/po/common/sw.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ta.po
+++ b/po/common/ta.po
@@ -5262,7 +5262,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/te.po
+++ b/po/common/te.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tg.po
+++ b/po/common/tg.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -5260,7 +5260,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ti.po
+++ b/po/common/ti.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tl.po
+++ b/po/common/tl.po
@@ -5269,7 +5269,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tn.po
+++ b/po/common/tn.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -5274,7 +5274,7 @@ msgid "Remove all nutrient values"
 msgstr "Bütün besin değerlerini kaldır"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Kullanıcı silindi."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ts.po
+++ b/po/common/ts.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tt.po
+++ b/po/common/tt.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tw.po
+++ b/po/common/tw.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ty.po
+++ b/po/common/ty.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/tzl.po
+++ b/po/common/tzl.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ug.po
+++ b/po/common/ug.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -5279,7 +5279,7 @@ msgid "Remove all nutrient values"
 msgstr "Видалити всі значення поживних речовин"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Користувач видалений."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ur.po
+++ b/po/common/ur.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -5261,7 +5261,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/val.po
+++ b/po/common/val.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/ve.po
+++ b/po/common/ve.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/vec.po
+++ b/po/common/vec.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -5279,7 +5279,7 @@ msgid "Remove all nutrient values"
 msgstr "Loại bỏ tất cả các giá trị dinh dưỡng"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "Người dùng đã bị xóa."
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/vls.po
+++ b/po/common/vls.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/wa.po
+++ b/po/common/wa.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/wo.po
+++ b/po/common/wo.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/xh.po
+++ b/po/common/xh.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/yi.po
+++ b/po/common/yi.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/yo.po
+++ b/po/common/yo.po
@@ -5261,7 +5261,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/zea.po
+++ b/po/common/zea.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -5225,7 +5225,7 @@ msgid "Remove all nutrient values"
 msgstr "删除所有营养值"
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "用户已删除"
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -5269,7 +5269,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -5188,7 +5188,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr "使用者已刪除"
 
 msgctxt "attribute_ecoscore_unknown_title"

--- a/po/common/zu.po
+++ b/po/common/zu.po
@@ -5246,7 +5246,7 @@ msgid "Remove all nutrient values"
 msgstr ""
 
 msgctxt "delete_user_process"
-msgid "User deleted."
+msgid "User is being deleted. This may take a few minutes."
 msgstr ""
 
 msgctxt "attribute_ecoscore_not_applicable_title"

--- a/scripts/minion_producers.pl
+++ b/scripts/minion_producers.pl
@@ -68,6 +68,8 @@ app->minion->add_task(
 app->minion->add_task(
 	import_products_categories_from_public_database => \&import_products_categories_from_public_database_task);
 
+app->minion->add_task(delete_user => \&ProductOpener::Users::delete_user_task);
+
 app->config(
 	hypnotoad => {
 		listen => [$server_options{minion_daemon_server_and_port}],


### PR DESCRIPTION
### What

User deletion is run as a minion job rather than synchronously

### Related issue(s) and discussion

- Fixes #8270
