### PR TITLE
chore: export recent changes collection

### DIFF
--- a/scripts/mongodb_dump.sh
+++ b/scripts/mongodb_dump.sh
@@ -46,5 +46,9 @@ ls -tp products_*.json.gz | grep -v '/$' | tail -n +14 | xargs -I {} rm -- {}
 echo $NEWTS > $TSFILE
 ls -tp products_*.json.gz > index.txt
 
+# Export recent changes collection
+# Export all fields but `ip` (contributor ip address)
+mongoexport --collection recent_changes --host $HOST --db $DB --fields=_id,comment,code,userid,rev,countries_tags,t,diffs | gzip -9 > "data/${PREFIX}_recent_changes.jsonl.gz"
+
 popd > /dev/null # data/delta
 popd > /dev/null # data


### PR DESCRIPTION
We've never exported the recent_changes collection, which includes the history of all changes performed on OFF DB since the 11th of September, 2018.

It's the most interesting data source to analyze contributor/apps impacts.

This commit adds the automatic export of this collection as a JSONL gzipped file.