### PR TITLE
fix: adapt Makefile to work on pro platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,15 @@ ifneq (,$(wildcard ./${ENV_FILE}))
     export
 endif
 
+ifneq (${EXTRA_ENV_FILE},'')
+    -include ${EXTRA_ENV_FILE}
+    export
+endif
+
 
 HOSTS=127.0.0.1 world.productopener.localhost fr.productopener.localhost static.productopener.localhost ssl-api.productopener.localhost fr-en.productopener.localhost
 # commands aliases
-DOCKER_COMPOSE=docker-compose --env-file=${ENV_FILE}
+DOCKER_COMPOSE=docker-compose --env-file=${ENV_FILE} ${LOAD_EXTRA_ENV_FILE}
 # we run tests in a specific project name to be separated from dev instances
 # we also publish mongodb on a separate port to avoid conflicts
 # we also enable the possibility to fake services in po_test_runner

--- a/env.pro
+++ b/env.pro
@@ -1,0 +1,17 @@
+# NOTE: this is an addition to .env file, not a standalone file !
+COMPOSE_PROJECT_NAME=po_pro
+# we do not want postgres on the pro side, we use the one from off
+COMPOSE_PROFILES=
+# Expose mongo on a different port to avoid conflict with public platform
+MONGO_EXPOSE_PORT=27018
+# Tweak config for producer platform
+PRODUCERS_PLATFORM=1
+MINION_QUEUE=pro.openfoodfacts.localhost
+# use a different port for minion admin
+# Note: we do not change PRODUCT_OPENER_DOMAIN for Config2.pm will handle this
+# neither do we change PRODUCT_OPENER_FLAVOR, as off-pro use same contents as off
+
+# Set a variable that we use in Makefile to add an extra env file 
+# in addition to .env when we run docker-compose
+EXTRA_ENV_FILE=env.pro
+LOAD_EXTRA_ENV_FILE=--env-file=env.pro

--- a/scripts/build_lang.pl
+++ b/scripts/build_lang.pl
@@ -31,7 +31,7 @@ use ProductOpener::Store qw/:all/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Food qw/:all/;
 
-print STDERR "Build \%Lang - data_root: $data_root\n";
+print STDERR "Build \%Lang - data_root: $data_root - server_domain: $server_domain\n";
 
 # This script is used a stored Lang.sto file with %Lang that contains:
 # - strings from the .po files (loaded by Lang.pm and I18N.pm - Lang::build_lang())

--- a/setenv-pro.sh
+++ b/setenv-pro.sh
@@ -1,16 +1,5 @@
 # source it before launching platform
-# NOTE: this is an addition to .env file, not a standalone file !
-export COMPOSE_PROJECT_NAME=po_pro
-# we do not want postgres on the pro side, we use the one from off
-export COMPOSE_PROFILES=
-# Expose mongo on a different port to avoid conflict with public platform
-export MONGO_EXPOSE_PORT=27018
-# Tweak config for producer platform
-export PRODUCERS_PLATFORM=1
-export MINION_QUEUE=pro.openfoodfacts.localhost
-# use a different port for minion admin
-# Note: we do not change PRODUCT_OPENER_DOMAIN for Config2.pm will handle this
-# neither do we change PRODUCT_OPENER_FLAVOR, as off-pro use same contents as off
+set -o allexport; source env.pro; set +o allexport
 
 set_ps1 () {
     export PS1=${PS1:-}"(pro) "


### PR DESCRIPTION
I tried to make "make build_lang" build the pro platform lang file when we have run source set-env.pro.sh, by loading an extra env.pro environment file (otherwise the env variables set by set-env.pro.sh are overloaded by .env when running the make script I believe).

But it fails later on.

Anyone can help?

`stephane@stephane-jaguar-NS50-70MU:~/openfoodfacts-server$ (pro) (pro) (pro) (pro) (pro) make build_lang
🥫 Rebuild language
docker-compose --env-file=.env --env-file=env.pro run --rm -e GITHUB_TOKEN= backend perl -I/opt/product-opener/lib -I/opt/perl/local/lib/perl5 /opt/product-opener/scripts/build_lang.pl
WARN[0000] volume "po_podata" already exists but was not created for project "po". Use `external: true` to use an existing volume 
WARN[0000] volume "po_orgs" already exists but was not created for project "po". Use `external: true` to use an existing volume 
WARN[0000] volume "po_users" already exists but was not created for project "po". Use `external: true` to use an existing volume 
[+] Running 1/0
 ⠿ Container po_pro-memcached-1  Running                                                           0.0s
[+] Running 1/2
 ⠦ Container po_pro-dynamicfront-1  Starting                                                       0.7s
 ⠿ Container po_pro-minion-1        Started                                                        0.7s
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/stephane/openfoodfacts-server/gulpfile.js" to rootfs at "/opt/product-opener/gulpfile.js": mount /home/stephane/openfoodfacts-server/gulpfile.js:/opt/product-opener/gulpfile.js (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
make: *** [Makefile:171 : build_lang] Erreur 1
`