### PR TITLE
fix: remove warning in get_inherited_property_from_categories_tags

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -597,7 +597,7 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 			my $ignore_energy_calculated_error
 				= get_inherited_property_from_categories_tags($product_ref, "ignore_energy_calculated_error:en");
 
-			if (not ((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))) {
+			if (not((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))) {
 				# Compare to specified energy value with a tolerance of 30% + an additiontal tolerance of 5
 				if (   ($computed_energy < ($specified_energy * 0.7 - 5))
 					or ($computed_energy > ($specified_energy * 1.3 + 5)))

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -597,7 +597,7 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 			my $ignore_energy_calculated_error
 				= get_inherited_property_from_categories_tags($product_ref, "ignore_energy_calculated_error:en");
 
-			if (not($ignore_energy_calculated_error)) {
+			if (not ((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))) {
 				# Compare to specified energy value with a tolerance of 30% + an additiontal tolerance of 5
 				if (   ($computed_energy < ($specified_energy * 0.7 - 5))
 					or ($computed_energy > ($specified_energy * 1.3 + 5)))

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -405,7 +405,7 @@ sub get_inherited_property_from_categories_tags ($product_ref, $property) {
 		# Start with most specific category first
 		foreach my $category (reverse @{$product_ref->{categories_tags}}) {
 
-			$category_match = lc(get_inherited_property("categories", $category, $property));
+			$category_match = get_inherited_property("categories", $category, $property);
 			last if $category_match;
 		}
 	}


### PR DESCRIPTION
This removes a warning caused by calling lc() on something that can be undefined.