### PR TITLE
fix: Restore Search Bar in Producers Platform

### DIFF
--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -190,8 +190,8 @@
 						</li>
 					</ul>
 
-					[%# Don't show the search bar on the producers platform %]
-					[% IF !(server_options_producers_platform) %]
+					[%# Show the search bar on the producers platform only when the producer is logged in %]
+					[% IF !(server_options_producers_platform) || (user_id.defined) %]
 					<section class="top-bar-section">
 					
 						<ul class="left small-4" style="margin-right:2rem;">


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Search bar is shown only when the producer is logged in or it's user id is defined. 
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/99353300/3a2cf7ec-f81c-4393-bd59-420125239792)


### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #8413 

