### PR TITLE
taxonomy: add fi translation for Crossed Grain Trademark

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1146,6 +1146,7 @@ wikidata:en:Q101542317
 
 <en:No gluten
 en:Crossed Grain Trademark, CGT, Crossed Grain Symbol, Crossed Grain
+fi:Gluteenittoman tuotteen merkki
 fr:épi barré
 hr:Znak precrtane pšenice
 xx:Crossed Grain Trademark, CGT, Crossed Grain Symbol, Crossed Grain


### PR DESCRIPTION
### What

Added Finnish translation for 'Crossed Grain Trademark' label. This name is used by the Finnish Coeliac Society, who issues the label for Finland: https://www.keliakialiitto.fi/kuluttajat/reseptit-ja-tuotteet/gluteenittoman-tuotteen-merkki/


