### PR TITLE
fix: Build Taxonomies does not cache the full json files

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -965,6 +965,9 @@ sub get_from_cache ($tagtype, @files) {
 		$got_from_cache = get_file_from_cache("$cache_prefix.json", "$tag_www_root.json");
 	}
 	if ($got_from_cache) {
+		$got_from_cache = get_file_from_cache("$cache_prefix.full.json", "$tag_www_root.full.json");
+	}
+	if ($got_from_cache) {
 		print "obtained taxonomy for $tagtype from " . ('', 'local', 'GitHub')[$got_from_cache] . " cache.\n";
 		$cache_prefix = '';
 	}
@@ -1011,6 +1014,7 @@ sub put_to_cache ($tagtype, $cache_prefix) {
 	my $tag_www_root = "$www_root/data/taxonomies/$tagtype";
 
 	put_file_to_cache("$tag_www_root.json", "$cache_prefix.json");
+	put_file_to_cache("$tag_www_root.full.json", "$cache_prefix.full.json");
 	put_file_to_cache("$tag_data_root.result.txt", "$cache_prefix.result.txt");
 	put_file_to_cache("$tag_data_root.result.sto", "$cache_prefix.result.sto");
 


### PR DESCRIPTION
### What

Also cache full.json files

### Related issue(s) and discussion
- Fixes #8556

