### PR TITLE
feat: allow admins to specify a timeout for MongoDB queries

### DIFF
--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -139,7 +139,7 @@ A reference to a parameters object that can be passed to get_products_collection
 
 sub get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {} ) {
 
-	my $parameters_ref = {}
+	my $parameters_ref = {};
 
 	# If the request is for obsolete products, we will select a specific products collection
 	# for obsolete products
@@ -198,7 +198,7 @@ Returns a mongoDB collection object.
 =cut
 
 sub get_products_collection ($parameters_ref = {}) {
-	my $database = $options_ref->{database} // $mongodb;
+	my $database = $parameters_ref->{database} // $mongodb;
 	my $collection = 'products';
 	if ($parameters_ref->{obsolete}) {
 		$collection .= '_obsolete';
@@ -208,7 +208,7 @@ sub get_products_collection ($parameters_ref = {}) {
 	elsif ($parameters_ref->{tags}) {
 		$collection .= '_tags';
 	}
-	return get_collection($database, $collection, $options_ref->{timeout});
+	return get_collection($database, $collection, $parameters_ref->{timeout});
 }
 
 sub get_emb_codes_collection ($timeout = undef) {

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -54,7 +54,6 @@ BEGIN {
 		&execute_query
 		&get_database
 		&get_collection
-		&get_products_collection_request_parameters
 		&get_products_collection
 		&get_emb_codes_collection
 		&get_recent_changes_collection
@@ -115,47 +114,6 @@ sub execute_query ($sub) {
 			# Do not retry the query, as it will make things worse
 		strategy => {Fibonacci => {max_retries_number => 0,}},
 	)->run();
-}
-
-=head2 get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {} )
-
-This function looks at the request object to set parameters to pass to the get_products_collection() function.
-
-=head3 Arguments
-
-=head4 $request_ref request object
-
-=head4 $additional_parameters_ref
-
-An optional reference to a hash of parameters that should be added to the parameters extracted from the request object.
-This is useful in particular to request the query to be executed on the smaller products_tags category, by passing
-{ tags = 1 }
-
-=head3 Return value
-
-A reference to a parameters object that can be passed to get_products_collection()
-
-=cut
-
-sub get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {} ) {
-
-	my $parameters_ref = {};
-
-	# If the request is for obsolete products, we will select a specific products collection
-	# for obsolete products
-	$parameters_ref->{obsolete} = request_param($request_ref, "obsolete");
-
-	# Admin users can request a specific query_timeout for MongoDB queries
-	if ($request_ref->{admin}) {
-		$parameters_ref->{timeout} = request_param($request_ref, "timeout");
-	}
-
-	# Add / overwrite request parameters with additional parameters passed as arguments
-	foreach my $parameter (keys %$additional_parameters_ref) {
-		$parameters_ref->{$parameter} = $additional_parameters_ref->{$parameter};
-	}
-
-	return $parameters_ref;
 }
 
 =head2 get_products_collection( $parameters_ref )

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1444,7 +1444,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					if $log->is_debug();
 				$results = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters())
+						return get_products_collection(get_products_collection_request_parameters($request_ref))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -1458,7 +1458,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					if $log->is_debug();
 				$results = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters({tags => 1}))
+						return get_products_collection(get_products_collection_request_parameters($request_ref, {tags => 1}))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -1526,7 +1526,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 						if $log->is_debug();
 					$count_results = execute_query(
 						sub {
-							return get_products_collection(get_products_collection_request_parameters())
+							return get_products_collection(get_products_collection_request_parameters($request_ref))
 								->aggregate($aggregate_count_parameters, {allowDiskUse => 1});
 						}
 					);
@@ -1540,7 +1540,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					$count_results = execute_query(
 						sub {
 							return get_products_collection(
-								get_products_collection_request_parameters({tags => 1}))
+								get_products_collection_request_parameters($request_ref, {tags => 1}))
 								->aggregate($aggregate_count_parameters, {allowDiskUse => 1});
 						}
 					);
@@ -4400,6 +4400,47 @@ sub count_products ($request_ref, $query_ref, $obsolete = 0) {
 	return $count;
 }
 
+=head2 get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {} )
+
+This function looks at the request object to set parameters to pass to the get_products_collection() function.
+
+=head3 Arguments
+
+=head4 $request_ref request object
+
+=head4 $additional_parameters_ref
+
+An optional reference to a hash of parameters that should be added to the parameters extracted from the request object.
+This is useful in particular to request the query to be executed on the smaller products_tags category, by passing
+{ tags = 1 }
+
+=head3 Return value
+
+A reference to a parameters object that can be passed to get_products_collection()
+
+=cut
+
+sub get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {} ) {
+
+	my $parameters_ref = {};
+
+	# If the request is for obsolete products, we will select a specific products collection
+	# for obsolete products
+	$parameters_ref->{obsolete} = request_param($request_ref, "obsolete");
+
+	# Admin users can request a specific query_timeout for MongoDB queries
+	if ($request_ref->{admin}) {
+		$parameters_ref->{timeout} = request_param($request_ref, "timeout");
+	}
+
+	# Add / overwrite request parameters with additional parameters passed as arguments
+	foreach my $parameter (keys %$additional_parameters_ref) {
+		$parameters_ref->{$parameter} = $additional_parameters_ref->{$parameter};
+	}
+
+	return $parameters_ref;
+}
+
 =head2 add_params_to_query ( $request_ref, $query_ref )
 
 This function is used to parse search query parameters that are passed
@@ -4911,7 +4952,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				$log->debug("Counting MongoDB documents for query", {query => $query_ref}) if $log->is_debug();
 				$count = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters({tags => 1}))
+						return get_products_collection(get_products_collection_request_parameters($request_ref, {tags => 1}))
 							->count_documents($query_ref);
 					}
 				);
@@ -4922,7 +4963,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				$log->debug("Executing MongoDB query", {query => $aggregate_parameters}) if $log->is_debug();
 				$cursor = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters({tags => 1}))
+						return get_products_collection(get_products_collection_request_parameters($request_ref, {tags => 1}))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -4974,7 +5015,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 										{key => $key_count})
 										if $log->is_debug();
 									return get_products_collection(
-										get_products_collection_request_parameters({tags => 1}))
+										get_products_collection_request_parameters($request_ref, {tags => 1}))
 										->count_documents($query_ref);
 								}
 							);
@@ -4987,7 +5028,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 									$log->debug("count_documents on complete products collection", {key => $key_count})
 										if $log->is_debug();
 									return get_products_collection(
-										get_products_collection_request_parameters())
+										get_products_collection_request_parameters($request_ref))
 										->count_documents($query_ref);
 								}
 							);
@@ -5014,7 +5055,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 						sub {
 							$log->debug("empty query_ref, use estimated_document_count fot better performance", {})
 								if $log->is_debug();
-							return get_products_collection(get_products_collection_request_parameters())
+							return get_products_collection(get_products_collection_request_parameters($request_ref))
 								->estimated_document_count();
 						}
 					);
@@ -5026,7 +5067,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 					if $log->is_debug();
 				$cursor = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters())
+						return get_products_collection(get_products_collection_request_parameters($request_ref))
 							->query($query_ref)->fields($fields_ref)->sort($sort_ref)->limit($limit)->skip($skip);
 					}
 				);
@@ -6388,7 +6429,7 @@ sub search_and_graph_products ($request_ref, $query_ref, $graph_ref) {
 	eval {
 		$cursor = execute_query(
 			sub {
-				return get_products_collection(get_products_collection_request_parameters())
+				return get_products_collection(get_products_collection_request_parameters($request_ref))
 					->query($query_ref)->fields($fields_ref);
 			}
 		);
@@ -6521,7 +6562,7 @@ sub search_and_map_products ($request_ref, $query_ref, $graph_ref) {
 	eval {
 		$cursor = execute_query(
 			sub {
-				return get_products_collection(get_products_collection_request_parameters())
+				return get_products_collection(get_products_collection_request_parameters($request_ref))
 					->query($query_ref)->fields(
 					{
 						code => 1,
@@ -10997,7 +11038,7 @@ sub search_and_analyze_recipes ($request_ref, $query_ref) {
 	eval {
 		$cursor = execute_query(
 			sub {
-				return get_products_collection(get_products_collection_request_parameters())
+				return get_products_collection(get_products_collection_request_parameters($request_ref))
 					->query($query_ref)->fields($fields_ref);
 			}
 		);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -793,6 +793,8 @@ sub init_request ($request_ref = {}) {
 	if (is_admin_user($User_id)) {
 		$admin = 1;
 	}
+	$request_ref->{admin} = $admin;
+	# TODO: remove the $admin global variable, and use $request_ref->{admin} instead.
 
 	# Producers platform: not logged in users, or users with no permission to add products
 
@@ -1442,7 +1444,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					if $log->is_debug();
 				$results = execute_query(
 					sub {
-						return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+						return get_products_collection(get_products_collection_request_parameters())
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -1456,7 +1458,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					if $log->is_debug();
 				$results = execute_query(
 					sub {
-						return get_products_collection({obsolete => request_param($request_ref, "obsolete"), tags => 1})
+						return get_products_collection(get_products_collection_request_parameters({tags => 1}))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -1524,7 +1526,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 						if $log->is_debug();
 					$count_results = execute_query(
 						sub {
-							return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+							return get_products_collection(get_products_collection_request_parameters())
 								->aggregate($aggregate_count_parameters, {allowDiskUse => 1});
 						}
 					);
@@ -1538,7 +1540,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					$count_results = execute_query(
 						sub {
 							return get_products_collection(
-								{obsolete => request_param($request_ref, "obsolete"), tags => 1})
+								get_products_collection_request_parameters({tags => 1}))
 								->aggregate($aggregate_count_parameters, {allowDiskUse => 1});
 						}
 					);
@@ -4909,7 +4911,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				$log->debug("Counting MongoDB documents for query", {query => $query_ref}) if $log->is_debug();
 				$count = execute_query(
 					sub {
-						return get_products_collection({obsolete => request_param($request_ref, "obsolete"), tags => 1})
+						return get_products_collection(get_products_collection_request_parameters({tags => 1}))
 							->count_documents($query_ref);
 					}
 				);
@@ -4920,7 +4922,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				$log->debug("Executing MongoDB query", {query => $aggregate_parameters}) if $log->is_debug();
 				$cursor = execute_query(
 					sub {
-						return get_products_collection({obsolete => request_param($request_ref, "obsolete"), tags => 1})
+						return get_products_collection(get_products_collection_request_parameters({tags => 1}))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -4972,7 +4974,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 										{key => $key_count})
 										if $log->is_debug();
 									return get_products_collection(
-										{obsolete => request_param($request_ref, "obsolete"), tags => 1})
+										get_products_collection_request_parameters({tags => 1}))
 										->count_documents($query_ref);
 								}
 							);
@@ -4985,7 +4987,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 									$log->debug("count_documents on complete products collection", {key => $key_count})
 										if $log->is_debug();
 									return get_products_collection(
-										{obsolete => request_param($request_ref, "obsolete")})
+										get_products_collection_request_parameters())
 										->count_documents($query_ref);
 								}
 							);
@@ -5012,7 +5014,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 						sub {
 							$log->debug("empty query_ref, use estimated_document_count fot better performance", {})
 								if $log->is_debug();
-							return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+							return get_products_collection(get_products_collection_request_parameters())
 								->estimated_document_count();
 						}
 					);
@@ -5024,7 +5026,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 					if $log->is_debug();
 				$cursor = execute_query(
 					sub {
-						return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+						return get_products_collection(get_products_collection_request_parameters())
 							->query($query_ref)->fields($fields_ref)->sort($sort_ref)->limit($limit)->skip($skip);
 					}
 				);
@@ -6386,7 +6388,7 @@ sub search_and_graph_products ($request_ref, $query_ref, $graph_ref) {
 	eval {
 		$cursor = execute_query(
 			sub {
-				return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+				return get_products_collection(get_products_collection_request_parameters())
 					->query($query_ref)->fields($fields_ref);
 			}
 		);
@@ -6519,7 +6521,7 @@ sub search_and_map_products ($request_ref, $query_ref, $graph_ref) {
 	eval {
 		$cursor = execute_query(
 			sub {
-				return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+				return get_products_collection(get_products_collection_request_parameters())
 					->query($query_ref)->fields(
 					{
 						code => 1,
@@ -10995,7 +10997,7 @@ sub search_and_analyze_recipes ($request_ref, $query_ref) {
 	eval {
 		$cursor = execute_query(
 			sub {
-				return get_products_collection({obsolete => request_param($request_ref, "obsolete")})
+				return get_products_collection(get_products_collection_request_parameters())
 					->query($query_ref)->fields($fields_ref);
 			}
 		);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1458,7 +1458,8 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 					if $log->is_debug();
 				$results = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters($request_ref, {tags => 1}))
+						return get_products_collection(
+							get_products_collection_request_parameters($request_ref, {tags => 1}))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);
@@ -4420,7 +4421,7 @@ A reference to a parameters object that can be passed to get_products_collection
 
 =cut
 
-sub get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {} ) {
+sub get_products_collection_request_parameters ($request_ref, $additional_parameters_ref = {}) {
 
 	my $parameters_ref = {};
 
@@ -4952,7 +4953,8 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				$log->debug("Counting MongoDB documents for query", {query => $query_ref}) if $log->is_debug();
 				$count = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters($request_ref, {tags => 1}))
+						return get_products_collection(
+							get_products_collection_request_parameters($request_ref, {tags => 1}))
 							->count_documents($query_ref);
 					}
 				);
@@ -4963,7 +4965,8 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 				$log->debug("Executing MongoDB query", {query => $aggregate_parameters}) if $log->is_debug();
 				$cursor = execute_query(
 					sub {
-						return get_products_collection(get_products_collection_request_parameters($request_ref, {tags => 1}))
+						return get_products_collection(
+							get_products_collection_request_parameters($request_ref, {tags => 1}))
 							->aggregate($aggregate_parameters, {allowDiskUse => 1});
 					}
 				);


### PR DESCRIPTION
This PR adds a &timeout=[number of ms] parameter that can be used by admins in order to override the default timeout (currently 50s in production), in order to be able to run queries that run longer. This could be useful for instance for monitoring queries (e.g. getting stats on recognized ingredients).

Note that the proxy timeout in nginx is currently not set (except on the pro platform where we can have big uploads), and the default is 60 sec. So in order for the timeout to have a real effect, we would also need to change the nginx config to include something like:

```
        proxy_connect_timeout       1200;
        proxy_send_timeout          1200;
        proxy_read_timeout          1200;
        send_timeout                1200;
```
