### PR TITLE
fix: add LCA icon in Eco-Score panel

### DIFF
--- a/templates/api/knowledge-panels/environment/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/agribalyse.tt.json
@@ -4,6 +4,9 @@
         "environment"
     ],
     "title_element": {
+        "icon_url": "[% static_subdomain %]/images/icons/dist/lca.svg",
+        "icon_color_from_evaluation": true,
+        "icon_size": "small",
         "title": "[% lang('average_impact_of_the_category') %][% sep %]: [% panel.agribalyse_grade FILTER upper %] (Score: [% panel.agribalyse_score %]/100)",
         "subtitle": "[% lang('categories_s') FILTER ucfirst %][% sep %]: [% panel.agribalyse_category_name.dquote %]",
         "type": "grade",

--- a/templates/api/knowledge-panels/environment/ecoscore/total.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/total.tt.json
@@ -9,6 +9,7 @@
         "subtitle": "[% lang("front_alt") %][% sep %]: [% product_name_brand_quantity(product) %]",
         "type": "grade",
         "grade": "[% panel.grade %]",
+        "icon_url": "[% static_subdomain %]/images/attributes/ecoscore-[% panel.grade %].svg",
     },
     "elements": [
         {

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -46,6 +46,8 @@
                         class="filter-grey"
                     [% ELSIF panel.evaluation == "unknown" %]
                         class="filter-grey"
+                    [% ELSE %]
+                        class="filter-grey"
                     [% END %]
                 [% END %]
             >


### PR DESCRIPTION
Add an icon in the Eco-Score subpanel for LCA.

Note that the LCA icon is always grey, as we currently have a mechanism only to change the color according to a good/average/bad evaluation, but not to a A to E grade color.

Fixes #8563

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/efdc7b6c-be71-4854-9fd3-d42a124c0116)
