### PR TITLE
fix: remove source files in agena3000 sftp

### DIFF
--- a/scripts/agena3000/run_agena3000_import.sh
+++ b/scripts/agena3000/run_agena3000_import.sh
@@ -2,7 +2,7 @@
 
 # Mirror data from Agena3000's server
 # access needs to be configured in ~/.netrc
-lftp -c "set cmd:default-protocol sftp; open sftp-a3dm.agena3000.com:2222; mirror / /home/sftp/agena3000/"
+lftp -c "set cmd:default-protocol sftp; open sftp-a3dm.agena3000.com:2222; mirror --Remove-source-files /PROD/Fiches/ /home/sftp/agena3000/PROD/Fiches/"
 
 cd /srv/off-pro/scripts
 
@@ -28,4 +28,4 @@ export PERL5LIB="/srv/off-pro/lib:${PERL5LIB}"
 /srv/off-pro/scripts/import_csv_file.pl --user_id agena3000 --org_id agena3000 --source_id agena3000 --source_name Agena3000 --source_url https://agena3000.com/ --manufacturer 1 --comment "Import from Agena3000" --define lc=fr --images_download_dir /srv2/off-pro/agena3000-images-tmp --csv_file /srv2/off-pro/agena3000-data-tmp/agena3000-data.tsv
 
 # Send confirmation messages to Agena3000
-lftp -c "set cmd:default-protocol sftp; open sftp-a3dm.agena3000.com:2222; mirror -R /srv2/off-pro/agena3000-data-tmp/Ack/ /PROD/Ack/"
+lftp -c "set cmd:default-protocol sftp; open sftp-a3dm.agena3000.com:2222; mirror -R --Remove-source-files /srv2/off-pro/agena3000-data-tmp/Ack/ /PROD/Ack/"


### PR DESCRIPTION
There is a quota on the sftp account Agena3000 created for us. This is to remove the files that we have already received.