### PR TITLE
fix: "make import_prod_data" incorrect mapping on data folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ import_prod_data:
 	cd ./html/data && sha256sum --check gz-sha256sum
 	@echo "🥫 Restoring the MongoDB dump …"
 	${DOCKER_COMPOSE} exec -T mongodb //bin/sh -c "cd /data/db && mongorestore --quiet --drop --gzip --archive=/import/openfoodfacts-mongodbdump.gz"
-	rm html/data/openfoodfacts-mongodbdump.tar.gz && rm html/data/gz-sha256sum
+	rm html/data/openfoodfacts-mongodbdump.gz && rm html/data/gz-sha256sum
 
 #--------#
 # Checks #

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -91,6 +91,7 @@ services:
     command: mongod --wiredTigerCacheSizeGB ${MONGODB_CACHE_SIZE}
     volumes:
       - dbdata:/data/db
+      - ./html/data:/import
     ports:
       - "127.0.0.1:${MONGO_EXPOSE_PORT:-27017}:27017"
 volumes:


### PR DESCRIPTION
### Related issue(s) and discussion
- Fixes "make import_prod_data" error "Failed: stat /import/openfoodfacts-mongodbdump.gz: no such file or directory"
- Was raised by me in slack channel #api in June 22.06.2023

