### PR TITLE
fix: Add back the "Remember me" checkbox

### DIFF
--- a/templates/web/pages/session/sign_in_form.tt.html
+++ b/templates/web/pages/session/sign_in_form.tt.html
@@ -22,6 +22,15 @@
     </div>
 
     <div class="row">
+      <div class="large-12 columns">
+        <label for="remember_me">
+          <input type="checkbox" name="remember_me" id="remember_me" value="on" />
+          [% lang('remember_me') %]
+        </label>
+      </div>
+    </div>
+
+    <div class="row">
         <div class="large-12 columns">
             <label for="submit">
                 <input type="submit" name="submit" class="button" id="submit" value="[% lang('sign_in') %]" />


### PR DESCRIPTION
### What
Added back the checkbox on the main sign-in form. It was still on the product edit sign-in form, but had been dropped from the main form at some point during the redesign.

### Related issue(s) and discussion

- Resolves #7915

