### PR TITLE
fix: do not display empty packagings materials panel

### DIFF
--- a/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
@@ -56,12 +56,14 @@
                     "panel_id": "packaging_components",
             },
         },
+        [% IF (product.packagings_materials AND product.packagings_materials.size) %]
         {
             "element_type": "panel",
             "panel_element": {
                 "panel_id": "packaging_materials",
             },
-        },       
+        },
+        [% END %]
     ]
 [% END %]
 }


### PR DESCRIPTION
Small fix to avoid an empty panel if we have not reprocessed packagings yet.

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/624b20fc-8efb-4246-9bbc-bbb5a1d16411)
