### PR TITLE
ci: Reduce the volumetry of unecessary builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,12 @@ name: Pull Requests
 
 on:
   pull_request:
-
+    paths-ignore:
+      - "**.md"
+      - ".github/CODEOWNERS"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".editorconfig"
+  
 jobs:
 
   # those are just until we de-activate their mandatory


### PR DESCRIPTION
### What
- We run the full CI suite on minor changes not related to perl
- use paths-ignore to not run the CI in specific files and reduce the volumetry of unecessary builds

### Ask 
- Please add paths that should not trigger a build

