### PR TITLE
ci: revert path-ignore on required actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,11 +2,13 @@ name: Pull Requests
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - ".github/CODEOWNERS"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
-      - ".editorconfig"
+    # we can't do that, because status are required
+    # see https://stackoverflow.com/questions/66751567/return-passing-status-on-github-workflow-when-using-paths-ignore
+    # paths-ignore:
+    #   - "**.md"
+    #   - ".github/CODEOWNERS"
+    #   - ".github/PULL_REQUEST_TEMPLATE.md"
+    #   - ".editorconfig"
   
 jobs:
 


### PR DESCRIPTION
revert the change we introduced in
d782f0a586d42d050af430bd5483607b521b187e … because we skip check that
are required.
This is discussed in
https://stackoverflow.com/questions/66751567/return-passing-status-on-github-workflow-when-using-paths-ignore
