### PR TITLE
test: adding a synonym test for the suggestion feature

### DIFF
--- a/tests/integration/api_cgi_suggest.t
+++ b/tests/integration/api_cgi_suggest.t
@@ -83,6 +83,12 @@ my $tests_ref = [
 		path => '/cgi/suggest.pl?tagtype=categories&string=Café&lc=fr',
 		expected_status_code => 200,
 	},
+	{
+		test_case => 'synonym-string-fr-dairy-drinks',
+		method => 'GET',
+		path => '/cgi/suggest.pl?tagtype=categories&string=jus de fruits au lait&lc=fr',
+		expected_status_code => 200,
+	},
 ];
 
 execute_api_tests(__FILE__, $tests_ref);


### PR DESCRIPTION
Adding a synonym test for the suggestion feature in my case I am using "jus de fruits au lait", which is a synonym of dairy drinks in French, and the suggestion feature should suggest me "Boissons au fruit et au lait" which is the first French translation in the categories.txt
