### PR TITLE
test: adding a synonym test for the suggestion feature

### DIFF
--- a/tests/integration/api_cgi_suggest.t
+++ b/tests/integration/api_cgi_suggest.t
@@ -83,6 +83,12 @@ my $tests_ref = [
 		path => '/cgi/suggest.pl?tagtype=categories&string=Café&lc=fr',
 		expected_status_code => 200,
 	},
+	{
+		test_case => 'synonym-string-fr-dairy-drinks',
+		method => 'GET',
+		path => '/cgi/suggest.pl?tagtype=categories&string=jus de fruits au lait&lc=fr',
+		expected_status_code => 200,
+	},
 ];
 
 execute_api_tests(__FILE__, $tests_ref);

--- a/tests/integration/expected_test_results/api_cgi_suggest/synonym-string-fr-dairy-drinks.json
+++ b/tests/integration/expected_test_results/api_cgi_suggest/synonym-string-fr-dairy-drinks.json
@@ -1,0 +1,3 @@
+[
+   "Boissons au fruit et au lait"
+]


### PR DESCRIPTION
adding a synonym test for the suggestion feature, in my case i used the product "Dairy Drink" in French. The input "jus de fruits au lait" should give "Boissons au fruit et au lait" as a result which is the first word in the taxonomy matching "Dairy Drink" in French.