### PR TITLE
fix: Add missing string to common.pot

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -3251,6 +3251,10 @@ msgctxt "correctors_without_products"
 msgid "Products not corrected by %s"
 msgstr ""
 
+msgctxt "contributors_products"
+msgid "Products added by %s"
+msgstr ""
+
 msgctxt "editors_products"
 msgid "Products edited by %s"
 msgstr ""


### PR DESCRIPTION
contributors_products was in en.po but not common.pot

fixes: #8636
