### PR TITLE
feat: updated test for serving_size for nutrition table

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -668,6 +668,7 @@ sub check_nutrition_data ($product_ref) {
 			}
 		}
 
+		# catch serving_size = "serving", regardless of setting (per 100g or per serving)
 		if (    (defined $product_ref->{serving_size})
 			and ($product_ref->{serving_size} ne "")
 			and ($product_ref->{serving_size} !~ /\d/))
@@ -678,13 +679,15 @@ sub check_nutrition_data ($product_ref) {
 			and (defined $product_ref->{nutrition_data_per})
 			and ($product_ref->{nutrition_data_per} eq 'serving'))
 		{
-
 			if ((not defined $product_ref->{serving_size}) or ($product_ref->{serving_size} eq '')) {
-				push @{$product_ref->{data_quality_warnings_tags}},
-					"en:nutrition-data-per-serving-missing-serving-size";
+				push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-data-per-serving-missing-serving-size";
+			}
+			elsif ($product_ref->{serving_quantity} eq "0") {
+				push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-data-per-serving-serving-quantity-is-0";
 			}
 			elsif ($product_ref->{serving_quantity} == 0) {
-				push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-data-per-serving-serving-quantity-is-0";
+				push @{$product_ref->{data_quality_errors_tags}},
+					"en:nutrition-data-per-serving-serving-quantity-is-not-recognized";
 			}
 		}
 	}

--- a/lib/ProductOpener/Units.pm
+++ b/lib/ProductOpener/Units.pm
@@ -307,7 +307,7 @@ sub normalize_serving_size ($serving) {
 	}
 
 	#$log->trace("serving size normalized", { serving => $serving, q => $q, u => $u }) if $log->is_trace();
-	return 0;
+	return;
 }
 
 # @todo we should have equivalences for more units if we are supporting this

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -58,6 +58,14 @@ description:en:Saturated Fat is a sub-section of Fat on the nutrition labels, as
 description:fr:Les acides gras saturés sont contenus dans les matières grasses. En conséquence, ils ne doivent jamais être plus élévés que ces dernières.
 
 <en:Nutrition errors
+en:Nutrition data per serving - Missing serving size, serving quantity is unknown
+description:en:"Nutrition facts are specified for the product as sold." is checked. "per serving" is selected. But the serving size is missing.
+
+<en:Nutrition errors
+en:Nutrition data per serving - Serving quantity is not recognized
+description:en: although serving size is given, it cannot be parsed (digit or unit may be missing or unknown)
+
+<en:Nutrition errors
 en:Nutrition data per serving - Serving quantity is 0
 fr:Données nutritionnelles par portion - portion nulle
 description:en:Serving quantity is 0 or is not recognized while nutrition data is per portion.
@@ -2687,10 +2695,6 @@ description:en: We have nutrition data for prepared product
 
 <en:Nutrition warnings
 en:Nutrition data - Prepared without category dried products to be rehydrated
-#description:en:
-
-<en:Nutrition warnings
-en:Nutrition data per serving - Missing serving size
 #description:en:
 
 <en:Nutri-Score warnings

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -521,6 +521,92 @@ check_quality_and_test_product_has_quality_tag(
 	'serving size should contains digits', 0
 );
 
+# serving size is missing
+$product_ref = {
+	nutrition_data => "on",
+	nutrition_data_per => "serving"
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-missing-serving-size',
+	'serving size should be provided if "per serving" is selected', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-0',
+	'serving size equal to 0 is unexpected', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-not-recognized',
+	'serving size cannot be parsed', 0
+);
+# serving size equal to 0
+$product_ref = {
+	nutrition_data => "on",
+	nutrition_data_per => "serving",
+	serving_quantity => "0",
+	serving_size => "0g"
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-missing-serving-size',
+	'serving size should be provided if "per serving" is selected', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-0',
+	'serving size equal to 0 is unexpected', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-not-recognized',
+	'serving size cannot be parsed', 0
+);
+# serving size cannot be parsed
+$product_ref = {
+	nutrition_data => "on",
+	nutrition_data_per => "serving",
+	serving_size => "1 container"
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-missing-serving-size',
+	'serving size should be provided if "per serving" is selected', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-0',
+	'serving size equal to 0 is unexpected', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-not-recognized',
+	'serving size cannot be parsed', 1
+);
+# last 3 tests should not appears when expected serving size is provided
+$product_ref = {
+	nutrition_data => "on",
+	nutrition_data_per => "serving",
+	serving_quantity => "50",
+	serving_size => "50 mL"
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-missing-serving-size',
+	'serving size should be provided if "per serving" is selected', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-0',
+	'serving size equal to 0 is unexpected', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-not-recognized',
+	'serving size cannot be parsed', 0
+);
+
 # percentage for ingredient is higher than 100% in extracted ingredients from the picture
 $product_ref = {
 	ingredients => [


### PR DESCRIPTION

- Fixes #3029 


**Reminder:** serving_size is the input from the contributor, serving_quantity is the extracted quantity from the serving_size


1) Nutrition data per serving - Serving quantity is unknown
2) Nutrition data per serving - Serving quantity is not recognized
3) Nutrition data per serving - Serving quantity is 0 --> only when we actually get "0 g" or similar


1) would be exact same as: en:nutrition-data-per-serving-missing-serving-size
previously it was a warning
updated to be an error


**Remark about 2 & 3)**  
>    input "une crepe 25 grammes" -> output serving_quantity=25 (special case, supposedly due to unit_equivalences_list in Units.pm)
>     input "100 milliliter" -> output serving_quantity not in result
>     input "3 pcs" -> output serving_quantity not in result
>     2 comprimés -> missing
>     1 container -> missing 
>     serving -> 0
>     input "1/4 cup" -> output serving_quantity=0

**Reason** is that normalize_serving_size subroutine in Units.pm returns 0 if it cannot extract the serving otherwise it returns the result of the subroutine unit_to_g, and this latter return either something or nothing (i.e., not 0)

2) (new) en:nutrition-data-per-serving-serving-quantity-is-not-recognized
This covers both cases:
2)a) Serving quantity is not recognized - but regex did work) and 
2)b) Serving quantity is not recognized - and regex to extract "quantity" and "unit" does not work
This should never be 0

3) en:nutrition-data-per-serving-serving-quantity-is-0
For "0 g" or "0 mL"

4) (from #8057) en:Nutrition data per serving - Serving size is missing digits


tested locally:
input - result
10 ml - ok
empty - 1
serving - 2 and 4
0g - 3 
0 mL - 3

