### PR TITLE
taxonomy: added Croatian ingredients in taxonomies

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -187,7 +187,8 @@ my %may_contain_regexps = (
 		"saattaa sisältää pienehköjä määriä muita|saattaa sisältää pieniä määriä muita|saattaa sisältää pienehköjä määriä|saattaa sisältää pieniä määriä|voi sisältää vähäisiä määriä|saattaa sisältää hivenen|saattaa sisältää pieniä|saattaa sisältää jäämiä|sisältää pienen määrän|jossa käsitellään myös|saattaa sisältää myös|joka käsittelee myös|jossa käsitellään|saattaa sisältää",
 	fr =>
 		"peut également contenir|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace",
-	hr => "Mogući sadržaj|može sadržavati|može sadržavati tragove|može sadržati|proizvod može sadržavati|sadrži",
+	hr =>
+		"Mogući sadržaj|može sadržavati|može sadržavati tragove|može sadržavati u tragovima|može sadržati|proizvod može sadržavati|sadrži|sadržaj",
 	is => "getur innihaldið leifar|gæti innihaldið snefil|getur innihaldið",
 	it =>
 		"Pu[òo] contenere tracce di|pu[òo] contenere|che utilizza anche|possibili tracce|eventuali tracce|possibile traccia|eventuale traccia|tracce|traccia",
@@ -2062,6 +2063,7 @@ sub parse_ingredients_text ($product_ref) {
 								'savjet kod alergije',    # allergy advice
 								'uključujući žitarice koje sadrže gluten',    # including grains containing gluten
 								'za alergene',    # for allergens
+								'u promjenjivim udjelima'    # in variable proportions
 							],
 
 							'it' => ['^in proporzion[ei] variabil[ei]$',],

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -1280,7 +1280,7 @@ es:E141, Complejos cúpricos de clorofilas y clorofilinas
 et:E141, E141 food additive
 fi:E141, Klorofylliinikuparikompleksit ja Klorofylli-kuparikompleksi, Klorofylli-kuparikompleksia ja Klorofylliinikuparikomplekseja
 fr:E141, Complexe cuivrique des chlorophylles et des chlorophyllines
-hr:E141  bojilo bakreni kompleksi klorofila i klorofilina, bakreni kompleksi klorofila i klorofilina
+hr:E141  bojilo bakreni kompleksi klorofila i klorofilina, bakreni kompleksi klorofila i klorofilina, klorofili i bakreni kompleksi klorofilina
 hu:E141, Klorofillok és klorofillinek rézkomplexei
 it:E141, Complessi rameici delle clorofille e delle clorofilline, Complessi rameici della clorofilla e delle clorofilline
 lt:E141, E141 food additive
@@ -6446,6 +6446,7 @@ es:E297, Ácido fumárico, Ácido trans-butenodioico
 et:E297, Fumaarhape, trans-buteendihape
 fi:E297, Fumaarihappo, trans-Buteenidikarbonihappo, Fumaarihappoa, trans-Buteenidikarbonihappoa
 fr:E297, Acide fumarique, Acide trans-butène-dioïque
+hr:E297, fumarna kiselina
 hu:E297, Fumársav, transz-Buténdisav
 it:E297, Acido fumarico, Acido trans-butenedioico
 lt:E297, Fumaro rūgštis, Transbuteno dirūgštis
@@ -8531,6 +8532,7 @@ es:E338, Ácido fosfórico, Ácido ortofosfórico, Ortofosforico, Fosfato monoam
 et:E338, Fosforhape, Ortofosforhape
 fi:E338, Fosforihappo, Ortofosforihappo, Divetyfosfaatti, Vetyfosfaatti, H3PO4, Fosforihappoa, Ortofosforihappoa, Divetyfosfaattia, Vetyfosfaattia
 fr:E338, Acide orthophosphorique, acide phosphorique, Sels de potassium de l'acide phosphorique, sels de potassium de E338, Phosphate d'hydrogène, Acide monophosphorique, Dihydrogénophosphate, Acide phophorique, Hydrogénophosphate
+hr:E338, fosforna kiselina
 hu:E338, Foszforsav, Ortofoszforsav
 it:E338, Acido fosforico, Acido ortofosforico, Acido tetraossofosforico(V), H3PO4
 lt:E338, Fosforo rūgštis, Ortofosforo rūgštis
@@ -9909,7 +9911,7 @@ es:E385, Ácido etilendiaminotetraacético, EDTA, AEDT, Etilendiamino-tetracetat
 et:E385, Kaltsiumdinaatriumetüleendiamiintetraatsetaat, Kaltsiumdinaatrium-EDTA
 fi:E385, Kalsiumdinatriumetyleenidiamiinitetra-asetaatti, Kalsiumdinatrium EDTA, Kalsiumdinatriumetyleenidiamiinitetra-asetaattia
 fr:E385, Éthylène diamine tétra-acétate de calcium disodium, calcium disodium EDTA, CAS 662-33-9,  EDTA calcio-disodique, Ethylène-diamine-tétra-acètate calcio-disodique, CAS 60-00-4, acide éthylene diamine tétra acétique, EDTA de calcium disodique, EDTA  , Éthylènediaminetétraacétate de calcium et de disodium
-hr:E385
+hr:E385, kalcijev dinatrijev EDTA
 hu:E385, Kalcium-dinátrium-etilén-diamin-tetraacetát, Kalcium-dinátrium-EDTA
 it:E385, Etilendiamminotetraacetato di calcio disodico, Calcio disodico EDTA
 lt:E385, Kalcio dinatrio etilendiaminotetraacetatas, Kalcio dinatrio EDTA
@@ -10639,7 +10641,7 @@ eu:E410, algarrobo-goma
 fi:E410, Karobikumi, Karobikumia
 fr:E410, gomme de caroube
 he:E410, מסטיק שעועית חרוב
-hr:E410
+hr:E410, karuba guma
 hu:E410, Szentjánoskenyér-gumi, Szentjánoskenyérfa-gumi
 it:E410, Farina di carrube, Gomma di carrube
 ja:E410, ローカストビーンガム
@@ -10787,7 +10789,7 @@ es:E414, Goma arábiga
 et:E414, Kummiaraabik
 fi:E414, Arabikumi, Arabikumia
 fr:E414, Gomme d'acacia, gomme arabique
-hr:E414
+hr:E414, guma arabika
 hu:E414, Gumiarábikum, Akácmézga
 it:E414, Gomma d'acacia, Gomma arabica
 lt:E414, Akacijų derva (gumiarabikas), Gumiarabikas
@@ -10956,7 +10958,7 @@ es:E418, Goma gellan, E 418
 et:E418, Gellankummi
 fi:E418, Gellaanikumi, Gellaanikumia
 fr:E418, Gomme gellane, Gomme de gellane, gellan gum, E-418, 71010-52-1
-hr:E418, gelan guma
+hr:E418, gelan guma, gellan guma
 hu:E418, Gellángumi
 it:E418, Gomma di gellano, gomma gellano
 lt:E418, Gelano derva
@@ -11182,7 +11184,7 @@ gl:E422, Glicerol
 gv:E422, glisreen
 he:E422, גליצרול
 hi:E422, ग्लीसरीन
-hr:E422, Glicerol
+hr:E422, Glicerol, glicerin
 hu:E422, Glicerin, Glycerol
 hy:E422, Գլիցերին
 id:E422, Gliserol
@@ -11310,6 +11312,7 @@ es:E425(i), Goma konjac
 et:E425(i), Rivieri titaanjuure kummi
 fi:E425(i), Konjak-hartsi, Konjak-hartsia, Konjakkikumi
 fr:E425(i), Gomme de konjac
+hr:E425(i), konjak guma
 hu:E425(i), Konjakgyanta
 it:E425(i), Gomma di konjac
 lt:E425(i), Konjako derva
@@ -11363,6 +11366,7 @@ es:E426, Hemicelulosa de soja
 et:E426, Soja hemitselluloos
 fi:E426, Soijapapuhemiselluloosa, Soijapapuhemiselluloosaa
 fr:E426, Hémicellulose de soja
+hr:E246: hemiceluloza
 hu:E426, Szója-hemicellulóz
 it:E426, Emicellulosa di soia
 lt:E426, Sojų hemiceliuliozė
@@ -13446,6 +13450,7 @@ et:E464, Hüdroksüpropüülmetüültselluloos
 fa:E464, اشک مصنوعی
 fi:E464, Hydroksipropyylimetyyliselluloosa, Hydroksipropyylimetyyliselluloosaa
 fr:E464, Hydroxypropylméthylcellulose, Hypromellose, Hydroxypropyl methyl cellulose, Hydroxypropyl methylcellulose, HPMC, Cellulose hydroxypropyl methyl ether, Methylhydroxypropylcellulosum
+hr:E464, hidroksipropil metil celuloza, hidroksipropilmetilirana celuloza
 hu:E464, Hidroxi-propil-metil-cellulóz, Hidroxipropil-metilcellulóz
 id:E464, Hydroxypropyl methylcellulose
 it:E464, Idrossipropilmetilcellulosa
@@ -16566,6 +16571,7 @@ fr:E525, Hydroxyde de potassium
 gl:E525, Hidróxido de potasio
 he:E525, אשלגן הידרוקסידי
 hi:E525, पोटासियम हाइड्राक्साइड
+hr:E525, kalijev hidroksid
 hu:E525, Kálium-hidroxid
 hy:E525, Կալիումի հիդրօքսիդ
 id:E525, kalium hidroksida
@@ -17643,6 +17649,7 @@ fa:E575, گلوکونو دلتا-لاکتون
 fi:E575, Glukono-delta-laktoni, Glukonolaktoni, GDL, D-glukonihappo-delta-laktoni, Glukono-delta-laktonia, Glukonolaktonia, D-glukonihappo-delta-laktonia
 fr:E575, Glucono-delta-lactone, Gluconodeltalactone, Gluconolactone, GDL, Delta-gluconolactone
 ga:E575, glúcón-deilte-lachtón
+hr:E575, glukono-delta-lakton
 hu:E575, Glükono-delta-lakton, Glükono-lakton, GDL, D-Glükonsav-delta-lakton
 it:E575, Gluconedeltalattone
 ja:E575, グルコノラクトン
@@ -19095,6 +19102,7 @@ fi:E903, Karnaubavaha, Karnaubavahaa
 fr:E903, Cire de carnauba
 he:E903, ווקס קרנובה
 hi:E903, कार्नायूबावैक्स
+hr:E903, karnuba vosak
 hu:E903, Karnaubaviasz
 it:E903, Cera carnauba, Cera di carnauba, Carnauba, agenti di rivestimento cera di carnauba
 lt:E903, Karnaubo vaškas
@@ -19945,7 +19953,7 @@ et:E917, kaaliumjodaat
 fa:E917, پتاسیم یدات
 fi:E917, Kaliumjodaatti, Kaliumjodaattia
 fr:E917, Iodate de potassium
-hr:E917, kalijev jodat, KIO3
+hr:E917, kalijev jodat, KIO3, kalij jodat
 hu:E917, Kálium-jodát
 id:E917, Kalium iodat
 it:E917, Iodato di potassio
@@ -21613,7 +21621,7 @@ es:E960, Glucósidos de esteviol, Glicósidos de esteviol, estevia, extracto de 
 et:E960, Steviooglükosiidid
 fi:E960, Stevioliglykosidit, Stevioliglykosidejä, Steviaglykosidit, stevia rebaudiana -uute
 fr:E960, Glucosides de stéviol, stévioside, rébaudioside A, extrait de stévia, glycosides de stéviol, Stévioside, extrait de feuille de Stévia, Stévia, extrait de stevia rebaudiana
-hr:E960, steviol glikozidi, stevia list
+hr:E960, steviol glikozidi, stevia list, steviol glikozidi iz stevije
 hu:E960, Szteviol-glikozidok szinonimák
 it:E960, Glicosidi dello steviolo, glicosidi steviolici, Estratto di stevia
 lt:E960, Steviolio glikozidai
@@ -22133,6 +22141,7 @@ es:E1001, E1001 food additive
 et:E1001, E1001 food additive
 fi:E1001, Koliinin suolat ja esterit, Koliinin suoloja ja estereitä
 fr:E1001, Sels et esters de choline, Acétate de choline, Carbonate de choline, chlorure de choline, Citrate de choline, Tartrate de choline, Lactate de choline
+hr:E1001, kolin bitartarat
 hu:E1001, Kolin-só
 it:E1001, E1001 food additive
 lt:E1001, E1001 food additive
@@ -23690,6 +23699,7 @@ wikidata:en:Q28487684
 
 en:potassium iodide
 es:yoduro potásico
+hr:kalijev jodid
 hu:kálium-jodid
 wikipedia:en:https://en.wikipedia.org/wiki/Potassium_iodide
 wikidata:en:Q121874

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -19,7 +19,7 @@ fi: Happo, Happoa, Hapot, Happoja
 fr: Acidifiant, acide alimentaire, acide, acidulants, acide alimentaire
 ga: Aigéad
 he:חומצה
-hr: kiselina, kiseline, sredstva kiselosti
+hr: kiselina, kiseline, sredstva kiselosti, kiseli
 hu: Étkezési sav
 it: Acidificante, acidificanti
 ja: 酸味料
@@ -360,7 +360,7 @@ fi: Väri, Väriä, Värit, Värejä, Väriaine, Väriainetta, Väriaineet, Vär
 fr: Colorant, colorant de surface, pigment décoratif, pigment colorant, colorants, colorant alimentaire, colorants alimentaires
 ga:Dath
 he:צבע
-hr: boja, bojila, bojilo, bojenje, namirnice za bojanje 
+hr: boja, bojila, bojilo, bojenje, namirnice za bojanje, hrana za bojenje
 hu: Színezék, mesterséges színezék, színezőanyag, színezékek, színezőanyagok, színező anyag
 is: Litarefni
 it: Colorante, coloranti, alimento colorante

--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -102,7 +102,7 @@ fi:munat, muna, munaa, munasta, munia, munista, kananmuna, kananmunan, kananmuna
 fr:œufs, œuf, oeufs, oeuf, blanc d'oeuf, jaune d'oeuf, blanc d'œuf, jaune d'œuf, blanc d'œufs, jaune d'œufs, oeuf frais, œuf frais, œufs frais, oeufs frais
 ga:uibheacha, ubh
 he:ביצים, ביצה, חלמון, חלבון, הלבן של הביצה, הצהוב של הביצה
-hr:jaja, bjelanjak, bjelanjka jajeta, žumanjak
+hr:jaja, bjelanjak, bjelanjka jajeta, žumanjak, iz jaja
 hu:tojás, tojássárgája, tojásfehérje, tojáspor, tyúktojás, tojássárgájapor, tojáslé
 it:uova, uovo
 jp:卵
@@ -278,7 +278,7 @@ fi:pähkinät, pähkinä, pähkinää, pähkinästä, pähkinöitä, pähkinöis
 fr:fruits à coque, amandes, noisettes, noix, noix de cajou, noix de pécan, noix du Brésil, pistaches, noix de Macadamia, noix du Queensland, fruits secs, autres fruits secs, autres fruits à coque, fruits secs à coque, fruits à coque dure
 ga:cnónna,  almóinní, cnónna coill, gallchnónna, cnónna caisiú, cnónna peagáin, cnónna Brasaíleacha, cnónna pistéise, cnónna macadaíme, cnónna Thír na Banríona
 he:אגוזים, שקדים, פקאן, אגוז ברזיל, אגוז מלך, פיסטוק, קשיו, ערמונים,מקדמיה
-hr:orašaste plodove, orašastih plodova, orašasto voće, orašastog voća, ostalih orašastih plodova, ostalog orašastog voća, drugo orašasto voće, drugog orašastog voća, badem, badema, bademe, bademi, lješnjak, lješnjaka, lješnjake, lješnjaci, pistacije, drugih orašastih plodova
+hr:orašaste plodove, orašastih plodova, orašasto voće, orašastog voća, ostalih orašastih plodova, ostalo orašasto voće, ostalog orašastog voća, drugo orašasto voće, drugog orašastog voća, badem, badema, bademe, bademi, lješnjak, lješnjaka, lješnjake, lješnjaci, pistacije, drugih orašastih plodova, druge orašaste plodove
 hu:diófélék, mandula, mogyoró, dió, kesudió, pekándió, brazil dió, pisztácia, makadámia, queenslandi dió, dióféléket
 is:hnetur
 it:frutta a guscio, mandorle, nocciole, noci, noci di acagiù, noci di pecan,  noci del Brasile, pistacchi, noci macadamia, noci del Queensland

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -44,7 +44,7 @@ stopwords:en:contains, contain, from, with, produced with, with added, minimum,i
 stopwords:es:contiene,de,del,la,el,las,los,con,y,e,en,minimo,maximo,puede,contener,por,categoria,calibre,minimo,min,vereidad,de cultivo,origen,nota,produccion,controlada
 stopwords:fi:sisältää,muun muassa,valio, koskenlaskija, snellmanin, jossa, noin, käymisen aikana muodostuva
 stopwords:fr:aux,au,de,le,du,la,a,et,avec,ou,en,proportion,variable, contient, élaboré avec, papier traité, minimum, filets tournants et filets, pour souleves,dont,avec,autres,d'autres,d', avec ajout, sachet, marquants, demeter
-stopwords:hr:i, iz, min, od, sadrže, sastojci, sastav, u promjenjivim omjerima, u promjenjivim udjelima, u različitim omjerima
+stopwords:hr:i, ili, iz, min, od, sadrže, sastojci, sastav, u promjenjivim omjerima, u promjenjivim udjelima, u različitim omjerima
 stopwords:hu:tartalmaz, változó arányban, min, zsírtartalom, összetevő, összetétel, amelyből, amiből
 stopwords:id:mengandung
 stopwords:is:úr
@@ -105,7 +105,7 @@ de:Karamellsirup, Caramelsirup
 es:jarabe de caramelo, sirope de caramelo
 fi:Karamellisiirappi
 fr:sirop de caramel, sirop caramel
-hr:karamel sirup, karamelizirani sirup
+hr:karamel sirup, karamelizirani sirup, karamelov sirup
 hu:karamellszirup, karamell szirup, karamell-szirup, karamella szirup
 it:sciroppo di caramello
 ja:キャラメルシロップ
@@ -152,12 +152,17 @@ bg:карамел на прах
 fr:caramel en poudre
 de:Karamell-Pulver, Caramelpulver, Karamellpulver
 fi:karamellijauhe
+# hr:karamel prahu # see ingredients_processings.txt
 hu:karamellpor
 it:caramello in polvere
 nl:karamelpoeder
 pl:proszek karmelowy
 pt:caramelo em pó
 # ingredient/fr:caramel-en-poudre has 69 products in 5 languages @2019-03-09
+
+<en:E150
+en:caramel chocolate preparation
+hr:karamelno čokoladni pripravak
 
 # <en:compound
 en:salted butter caramel
@@ -812,7 +817,7 @@ el:λυσοζύμη από το ΑΥΓΟ
 es:lisozima de huevo
 fi:lysotsyymi kananmunasta
 fr:lysozyme d'œuf, lysozyme d'oeuf, lysozyme issu de protéine d'oeufs
-hr:jajčani lizozim, lizozim iz jaja, lisozim iz jaja, lizozim (iz jaja)
+hr:jajčani lizozim, lizozim iz jaja, lisozim iz jaja
 it:lisozima da uovo, lisozima d'uovo
 nl:lysozym uit ei, lysozym van ei
 pl:lizozym z jaj
@@ -1010,7 +1015,7 @@ es:fermentos lácticos, fermentos lácteos, cultivos lácticos, ferments del yog
 et:juuretis
 fi:maitohappokäyte, maitohappokannat, maitohappoviljelmä, elävä jogurttiviljelmä, elävä jogurttibakteeriviljelmä, elävät jogurttibakteeriviljelmät, maitohappobakteeriviljelmä, maitohappobakteeriviljelmät, maitohappobakteerit, maitohappobakteerikanta, maitohappobakteerikannat, juustoviljelmä, juustoviljelmät, hapankulttuuri, jogurttihapate, maitohappobakteeri, käynnistin kulttuuri
 fr:ferment lactique, ferments lactique, ferments lactiques, ferment lactiques, culture de bactéries lactiques, cultures lactiques, ferment lactique du yaourt, ferments lactiques du yaourt, ferments vivants du yaourt
-hr:jogurtna kultura, jogurtne kulture, mljekarska kultura, mljekarske kulture, mlijekarske kulture, sirna kultura, starter kultura, baktrije mliječnog vrenja, bakterije mliječne kiseline, kultura plemenitih plijesni, sirište mljekarske kulture
+hr:jogurtna kultura, jogurtne kulture, mljekarska kultura, mljekarske kulture, mlijekarske kulture, sirna kultura, starter kultura, baktrije mliječnog vrenja, bakterije mliječne kiseline, kultura plemenitih plijesni, sirište mljekarske kulture, mliječnokiselinske kulture, kultura mliječnih bakterija
 hu:tejsavbaktériumok, tejsavbaktérium, starterkultúra, starter kultúra, tejsavbaktérium-tenyészet, tejsavbaktérium kultúra, joghurtkultúra, joghurtkultúrák, sajtkultúra, sajtkultúrák
 it:fermenti lattici, coltura di batteri acidolattici, fermenti lattici vivi, fermenti latici vivi, fermenti lattici dello yogurt
 lt:jogurtinės bakterijos
@@ -1180,6 +1185,7 @@ fr:ferments lactiques dont bifidobacterium
 en:kefir ferments, kefir cultures, live kefir cultures, active kefir cultures, kefir grains microflora
 es:fermentos de kéfir, cultivos microbianos de kéfir, levaduras de kéfir, fermentos propios del kéfir
 fr:ferments du kéfir, culture de kéfir, cultures de kéfir
+hr:kefirna kultura
 hu:kefirkultúra
 pl:kultury kefirowe, żywe kultury bakterii kefirowych
 
@@ -1273,6 +1279,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_delbrueckii_subsp._bulg
 en:lactobacillus casei, L. casei
 xx:lactobacillus casei, L. casei
 ar:ملبنة مجبنة
+hr:kultura lactobacillus casei
 ko:락토바실러스 카제이
 zh:乾酪乳酸桿菌
 wikidata:en:Q139777
@@ -1280,6 +1287,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_casei
 # ingredient/lactobacillus-casei has 77 products in 6 languages @2019-07-08
 
 <en:lactobacillus casei
+hr:L.casei 431
 it:L.casei 431
 
 # description:en:LACTOBACILLUS HELVETICUS is a lactic-acid producing, rod-shaped bacterium of the genus Lactobacillus. It is most commonly used in the production of American Swiss cheese and Emmental cheese, but is also sometimes used in making other styles of cheese, such as Cheddar, Parmesan, Romano, provolone, and mozzarella.
@@ -1323,6 +1331,7 @@ wikidata:en:Q597078
 
 <en:Lactobacillus
 en:Lactobacillus rhamnosus
+hr:kultura lactobacillus rhamnosus
 ja:ラクトバチルスラムノーザス
 ko:락토바실러스
 xx:Lactobacillus rhamnosus
@@ -1332,7 +1341,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Lactobacillus_rhamnosus
 <en:Lactobacillus rhamnosus
 en:Lactobacillus rhamnosus GG
 xx:Lactobacillus rhamnosus GG, LGG
-hr:kultura Lactobacillus rhamnosus, kultura Lactobacillus rhamnosus (LGG)
+hr:kultura Lactobacillus rhamnosus, kultura Lactobacillus rhamnosus, LGG
 # ingredient/fi:Lactobacillus-rhamnosus-GG has 1 product in 2 languages @2020-06-08
 
 # description:en:BACILLUS COAGULANS is a lactic acid-forming bacterial species. B. coagulans is often marketed as Lactobacillus sporogenes or a 'sporeforming lactic acid bacterium' probiotic, but this is an outdated name due to taxonomic changes in 1939.
@@ -1379,6 +1388,7 @@ ru:закваска на кефирных грибках
 
 <en:ferment
 fr:ferments de maturation
+hr:kulture za zrenje
 # ingredient/fr:ferments-de-maturation has 88 products in french @2019-07-08
 
 <en:ferment
@@ -2768,7 +2778,7 @@ de:teilentrahmte milch
 es:leche parcialmente desnatada, leche semidesnatada, Leche semidescremada, leche parcialmente descremada
 fi:kevytmaito
 fr:lait demi-écrémé, lait partiellement écrémé, Lait à 15.5 g/l de matière grasse
-hr:djelomično obrano mlijeko, djelomično obrano mlijeko s 1,5% mliječne masti bez laktoze, djelomično obrano mlijeko s 1,5% mliječne masti bez laktoze (<0,1 g/100 g), djelomično obrano mlijeko s 1.5% mliječne masti, djelimično obrano mlijeko
+hr:djelomično obrano mlijeko, djelimično obrano mlijeko
 hu:zsírszegény tej, félzsíros tej
 is:léttmjólk
 it:latte parzialmente scremato
@@ -2882,6 +2892,15 @@ fr:Lait frais demi-écrémé microfiltré issu de l'agriculture biologique
 <en:fresh milk
 de:Frische fettarme Milch
 
+<en:semi-skimmed milk
+en:semi-skimmed milk with 1.5% milk fat
+hr:djelomično obrano mlijeko s 1.5% mliječne masti
+
+<en:lactose-free milk
+<en:semi-skimmed milk
+en:semi-skimmed milk with 1.5% lactose-free milk fat
+hr:djelomično obrano mlijeko s 1,5% mliječne masti bez laktoze, djelomično obrano mlijeko s 1,5% mliječne masti bez laktoze (<0,1 g/100 g)
+
 ################################## FULL FAT MILKS ##############################
 
 # description:fr:WHOLE MILK (around 3.5–4% fat), dans l'Union européenne, le lait entier doit contenir au minimum 3,50 % en masse de matière grasse.
@@ -2897,7 +2916,7 @@ de:Vollmilch
 es:leche entera
 fi:täysmaito
 fr:lait entier
-hr:mlijeko trajno, mlijeko trajno s 2.8% mliječne masti, mlijeko s 2.8% mliječne masti, mlijeko 3,2 % m.m., punomasno mlijeko
+hr:mlijeko trajno, punomasno mlijeko
 hu:teljes tej
 is:nýmjólk
 it:latte intero
@@ -3012,6 +3031,14 @@ ciqual_food_name:fr:Lait entier, pasteurisé
 
 <en:whole milk
 fr:lait entier standardisé
+
+<en:whole milk
+en:whole milk with 2.8% milk fat
+hr:mlijeko trajno s 2.8% mliječne masti, mlijeko s 2.8% mliječne masti
+
+<en:whole milk
+en:whole milk with 3.2% milk fat
+hr:mlijeko 3,2 % m.m.
 
 ################################## RAW MILKS ###################################
 
@@ -3190,6 +3217,14 @@ ca:llet fresca desnatada pasteuritzada de vaca
 de:pasteurisierte entrahmte Kuhmilch
 es:leche de vaca desnatada pasterizada
 th:น้ำนมโคขาดมันเนย
+
+<en:cow's milk
+en:homogenized milk with 2 8 milk fats
+hr:homogenizirano mlijeko s 2 8 mliječne masti
+
+<en:cow's milk
+en:homogenized milk with 3 2 milk fats
+hr:homogenizirano mlijeko s 3 2 mliječne masti
 
 ################################# GOAT MILKS ###################################
 
@@ -3582,7 +3617,7 @@ es:leche condensada azucarada, leche azucarada condensada
 et:magustatud kondenspiim
 fi:makeutettu kondensoitu maito, makeutettu maitotiiviste, sokeroitu maitotiiviste, sokeroitua maitotiivistettä
 fr:lait concentré sucré, lait condensé sucré
-hr:ugušćeno zaslađeno mlijeko
+hr:ugušćeno zaslađeno mlijeko, kondenzirano zaslađeno mlijeko
 hu:édesített sűrített tej, cukrozott sűrített tej
 it:latte concentrato zuccherato
 lt:saldintas kondensuotas pienas
@@ -3996,7 +4031,7 @@ fa:ایزومالتیوس
 fi:isomaltuloosi
 fr:Isomaltulose
 he:איזומלטולוז
-hr:izomaltuloza, isomaltulose-palatinose
+hr:izomaltuloza, isomaltulose-palatinose, izomaltuloza-palatinoza
 hu:izomaltulóz
 id:Isomaltulosa
 it:isomaltulosio
@@ -4203,9 +4238,17 @@ ca:iogurt de llet pasteuritzada
 de:Joghurt aus pasteurisierter MIlch
 es:yogur de leche pasteurizada
 
-<en:yogurt
+<en:pasteurized milk yogurt
+en:yogurt from pasteurized milk with milk fat
+hr:jogurt od pasteriziranog mlijeka s mliječne masti
+
+<en:yogurt from pasteurized milk with milk fat
 en:solid yogurt made from pasteurized milk with 3.2% milk fat
 hr:čvrsti jogurt od pasterizi̇ranog mlijeka s 3,2% mlijećne masti
+
+<en:yogurt from pasteurized milk with milk fat
+en:yogurt from pasteurized milk with 3 5 milk fat
+hr:jogurt od pasteriziranog mlijeka s 3 5 mliječne masti
 
 <en:yogurt
 fr:yogourt partiellement écrémé
@@ -5671,6 +5714,10 @@ ca:formatge de llet de vaca crua
 es:queso de leche de vaca cruda
 # ingredient/fr:fromage-au-lait-cru-de-vache has 15 products in french @2019-05-24
 
+<en:cow cheese
+en:cow's cheese with chives
+hr:kravlji sir s vlascom
+
 # description:en:GOAT CHEESE, goats' cheese, or chèvre, is cheese made from goat's milk.
 
 <en:cheese
@@ -6769,6 +6816,7 @@ es:queso blanco fresco
 
 <en:Cheese
 en:cream cheese
+hr:krem sir
 
 <en:cheese
 en:Quark
@@ -9644,6 +9692,7 @@ de:Himalayasalz
 el:αλάτι Ιμαλάιων
 es:Sal del Himalaya
 fr:Sel de l'Himalaya
+hr:himalajska sol
 it:Sale dell'Himalaya
 pl:Sól himalajska, soli himalajskiej
 
@@ -9988,7 +10037,7 @@ es:Sal yodada
 fa:نمک یددار
 fi:jodioitu suola, jodia sisältävä suola, jodisuola
 fr:Sel iodé, sel de cuisine iodé
-hr:jodirana sol, jodirona kuhinjska sol, kuhinjska sol jodirana
+hr:jodirana sol, jodirona kuhinjska sol, kuhinjska sol jodirana, jodirana kuhinjska sol
 hu:jódozott só
 id:Garam beryodium
 it:Sale iodato
@@ -10049,7 +10098,7 @@ de:jodiertes Meersalz
 es:sal marina yodada, sal de mar yodada
 fi:jodioitu merisuola
 fr:sel marin iodé
-hr:morska sol jodirana, sitna jodirana morska sol, krupna jodirana morska sol
+hr:morska sol jodirana, jodirana morska sol, sitna jodirana morska sol, krupna jodirana morska sol
 hu:jódozott tengeri só
 it:sale marino iodato
 pl:sól morska jodowana, jodowana sól morska
@@ -10224,6 +10273,10 @@ fr:boulettes de poulet
 # usage:en:chicken meatballs (organic chicken, water, organic almond flour, organic garlic, organic crushed red pepper, organic oregano)
 # mainIngredient:en:chicken meat
 # ingredient/en:chicken-meatballs has 4 products in 1 language @2020-12-21
+
+<en:meatball
+en:beef meatball
+hr:goveđe okruglice
 
 <en:animal
 en:offal
@@ -10441,6 +10494,10 @@ ciqual_food_name:en:Tongue, calf, cooked
 ciqual_food_name:fr:Langue, veau, cuite
 
 <en:beef meat
+en:beef knuckle
+hr:juneći but
+
+<en:beef knuckle
 en:Boiled beef knuckle, Beef knuckle cooked in water
 fr:Jarret de boeuf bouilli, Jarret de boeuf cuit à l'eau
 ciqual_food_code:en:6151
@@ -13117,7 +13174,7 @@ ga:Collaiginí
 gl:Coláxeno
 he:קולגן
 hi:कोलेजन
-hr:Kolagen
+hr:Kolagen, kolagena
 hu:Kollagén
 hy:Կոլագեն
 id:Kolagen
@@ -13165,6 +13222,7 @@ ar:كولاجين متحلل
 bg:хидролизиран колаген
 de:kollagen-hydrolysat
 es:colágeno hidrolizado
+hr:hidrolizat kolagena
 sv:kollagenpeptider
 vi:collagen peptide
 wikidata:en:Q1779264
@@ -14349,6 +14407,7 @@ de:Rinderfett
 es:Grasa de vacuno, grasa bovina, grasa vacuna
 fi:naudanrasva
 fr:gras de bœuf, graisse de bœuf, gras de bovin, bovin
+hr:goveđi loja
 hu:marhazsír
 it:grasso di manzo
 nl:rundvet, rundervet
@@ -15148,7 +15207,7 @@ eu:Palmiste olio
 fa:روغن هسته پالم
 fi:palmuydinöljy, palmunydinöljy, palmuydin, palmunydin, palmunsiemenöljy
 fr:huile de palmiste, huile végétale de palmiste, palmiste
-hr:ulje palminih koštica, palmine koštice
+hr:ulje palminih koštica, palmine koštice, ulja palminih koštica
 hu:pálmamagolaj, pálmamag
 id:Minyak inti kelapa sawit
 is:pálmakjarmaolía
@@ -16472,6 +16531,11 @@ de:Natives Haselnussöl
 fr:huile vierge de noisette
 # ingredient/fr:huile-vierge-de-noisette has 9 products @2019-06-02
 from_palm_oil:en:no
+
+<en:vegetable oil
+<en:hemp
+en:cold pressed hemp oil
+hr:hladno prešano konopljino ulje
 
 <en:vegetable oil
 # <en:nut
@@ -19186,6 +19250,9 @@ en:amontillado sherry
 de:Amontillado-Sherry
 fr:xérès amontillado
 
+<en:wine
+en:blackberry wine
+hr:kupinovo vino
 
 # description:en:BRANDY is a spirit produced by distilling wine. Brandy generally contains 35–60% alcohol by volume (70–120 US proof) and is typically consumed as an after-dinner digestif.
 
@@ -21596,6 +21663,11 @@ en:hydrolysed cereal, hydrolysed cereals
 fr:céréales hydrolysées
 nova:en:4
 
+<en:cereal
+<en:cocoa
+en:cereal with cocoa
+hr:žitarica s kakaom
+
 ##################################################################################
 #
 #                        Sorghum
@@ -22774,7 +22846,7 @@ gl:cebada
 gv:oarn
 he:שעורה תרבותית
 hi:जौ
-hr:ječam, ječmene
+hr:ječam, ječmene, ječmena trava
 ht:òj
 hu:árpa
 hy:սովորական գարի
@@ -22998,6 +23070,10 @@ es:extracto de cebada
 en:natural barley extract
 de:natürlicher Gerstenextrakt
 es:extracto natural de cebada
+
+<en:barley
+en:barley syrup
+hr:ječmeni sirup
 
 ##################################################################################
 #
@@ -23452,6 +23528,7 @@ fa:کاشا
 fi:kasha
 fr:kasha, Kacha
 he:קאשה
+hr:heljdina prekrupa
 hu:hajdinakása
 hy:Հնդկացորենի շիլա
 it:kaša
@@ -23748,7 +23825,7 @@ gd:coirce
 gl:avea
 he:שיבולת
 hi:जई
-hr:zob, zobene
+hr:zob, zobd, zobene
 ht:avwàn
 hu:zab
 id:haver
@@ -24145,7 +24222,7 @@ fr:quinoa
 ga:cuineo
 he:קינואה
 hi:क्विन्वा
-hr:kvinoja
+hr:kvinoja, kvinojine
 hu:kinoa, quinoa, rizsparéj
 hy:uագախոտ
 id:kinoa
@@ -24570,7 +24647,7 @@ fr:épeautre
 ga:speilt
 gl:espelta
 he:כוסמין
-hr:pravi pir, pirovo
+hr:pravi pir, pirovo, pira
 hu:tönkölybúza, tönköly
 io:spelto
 is:spelt
@@ -25249,7 +25326,7 @@ es:harina de trigo integral, harina integral de trigo
 et:täistera nisujahu, täisteranisujahu
 fi:täysjyvävehnäjauho
 fr:farine de blé complète, farine de blé complet, farine complète de blé, farine intégrale de blé, farine complète de froment
-hr:integralno pšenično brašno, pšenično brašno od cjelovitog zrna, pšenično brašno iz cijelog zrna, brašno cijelog zrna pšenice, brašno od cjelovitog zrna pšenice, cjelovito pšenično brašno
+hr:integralno pšenično brašno, pšenično brašno od cjelovitog zrna, pšenično brašno iz cijelog zrna, brašno cijelog zrna pšenice, brašno od cjelovitog zrna pšenice, cjelovito pšenično brašno, integralno i namjensko pšenično brašno
 hu:teljes kiőrlésű búzaliszt
 it:farina integrale di frumento, farina di frumento integrale
 ja:小麦全粒粉
@@ -25378,7 +25455,7 @@ de:Gerstenvollkornmehl, Gersten-Vollkornmehl
 es:harina de cebada integral, harina integral de cebada
 fi:täysjyväohrajauho
 fr:farine complète d’orge, farine d'orge complète
-hr:integralno ječmeno brašno, ječmeno brašno iz cijelog zrna, brašno cijelog zrna ječma, brašno od cjelovitog zrna ječma, brašno iz cijelog zrna ječma
+hr:integralno ječmeno brašno, ječmeno brašno iz cijelog zrna, brašno cijelog zrna ječma, brašno od cjelovitog zrna ječma, brašno iz cijelog zrna ječma, ječmeno brašno od cjelovitog zrna
 hu:teljes kiőrlésű árpaliszt
 it:Farina integrale d'orzo
 nl:volkoren gerstemeel
@@ -25859,7 +25936,7 @@ es:harina de coco
 et:kookosjahu
 fi:kookosjauho
 fr:farine de noix de coco, farine de coco
-hr:kokosovo brašno
+hr:kokosovo brašno, kokos brašno
 pl:mąka kokosowa, mąka z kokosa
 sv:kokosmjöl
 # ingredient/fr:farine-de-noix-de-coco has 24 products in 2 languages @2020-06-08
@@ -25918,7 +25995,7 @@ gu:મકાઈ
 ha:masara
 he:תירס
 hi:मक्का
-hr:kukuruz, kukuruzno
+hr:kukuruz, kukuruzno, iz kukuruza
 ht:mayi
 hu:kukorica, tengeri, törökbúza, málé
 hy:եգիպտացորեն
@@ -26112,6 +26189,7 @@ de:Süßmais, Süssmais, Zuckermais
 es:maíz dulce, maiz dulce
 fi:sokerimaissi
 fr:maïs doux, mais doux
+hr:kukuruz šećerac
 hu:csemegekukorica
 it:mais dolce
 ja:スイートコーン, スィートコーン
@@ -27922,6 +28000,7 @@ de:Invertzucker
 es:azúcar invertido,azucar liquido invertido
 fi:inverttisokeri
 fr:sucre inverti
+hr:invertni šećer
 hu:invertcukor
 it:zucchero invertito
 nl:Invertsuiker
@@ -27947,7 +28026,7 @@ es:azúcar caramelizado
 et:karamelliseeritud suhkur
 fi:karamellisoitu sokeri, karamellisoitua sokeria, karamellisokeri
 fr:sucre brun, sucre caramel, sucre caramélisé
-hr:karamelizirani šećer
+hr:karamelizirani šećer, karameliziran šećer
 hu:karamellizált cukor
 it:zucchero caramellato
 nl:gekarameliseerde suiker, gebrande suiker
@@ -30089,6 +30168,11 @@ hr:suncokretovih bjelančevina, suncokretove bjelančevine
 pl:białko słonecznika, białko słonecznikowe, białka słonecznika
 ro:proteină de floarea-soarelui
 
+<en:sunflower protein
+<en:rice protein
+en:sunflower and rice proteins
+hr:suncokretovih bjelančevina i riže
+
 <en:plant protein
 en:potato protein
 bg:картофен протеин
@@ -30111,7 +30195,7 @@ de:hydrolysiertes Pflanzenprotein, aufgeschlossenes Pflanzeneiweiß, aufgeschlos
 es:Proteina vegetal hidrolizada, hidrolizado de proteína vegetal
 fi:hydrolysoitu kasviproteiini, kasviproteiinihydrosylaatti
 fr:protéine végétale hydrolysée, protéines végétales hydrolysées
-hr:hidrolizirane biljne bjelančevine
+hr:hidrolizirane biljne bjelančevine, hidrolizirane bjelančevine povrća
 hu:hidrolizált növényi fehérjék, hidolizált növényi fehérje
 it:Proteine vegetali idrolisse
 nb:hydrolysert vegetabilsk protein
@@ -30143,7 +30227,7 @@ et:sojavalk
 fi:soijaproteiini, soijaproteiinivalmiste
 fr:protéine de soja, protéines de soja
 hu:szójafehérje
-hr:bjelančevine soje, hidrolizat sojinih bjelančevina, sojine bjelančevine
+hr:bjelančevine soje, hidrolizat sojinih bjelančevina, sojine bjelančevine, bjelančevina soje
 it:proteine di soia
 nl:soja-eiwit, sojaeiwitten
 pl:Białko sojowe, hydrolizat białka sojowego, białko soi, białko z soi, białka sojowego
@@ -30212,6 +30296,7 @@ de:Sojaproteinisolat, Sojaeiweißisolat
 es:Aislado de proteína de soja
 fi:soijaproteiini-isolaatti
 fr:isolat de protéine de soja
+hr:izolat proteina soje, izolat sojinih bjelančevina
 it:Proteine isolate della soia
 pl:izolowane białko sojowe, izolat białka sojowego
 ru:изолированный белок сои
@@ -30223,6 +30308,7 @@ de:Sojaproteinhydrolysat
 es:proteína de soja hidrolizada
 fi:soijaproteiinihydrolysaatti
 fr:protéine de soja hydrolysée, protéines de soja hydrolysées
+hr:hidrolizirani sojini proteini
 hu:hidrolizált szójafehérje
 it:proteine di soia idrolizzate
 nl:gehydroliseerd soja-eiwit, gehydrolyseerd soja-eiwit
@@ -30296,6 +30382,7 @@ de:Maisproteinhydrolysat
 es:proteína de maíz hidrolizada
 fi:hydrolysoitu maissiproteiini, maissiproteiinihydrosylaatti
 fr:protéine de maïs hydrolysée
+hr:hidrolizirane bjelančevine kukuruza
 hu:hidrolizált kukoricafehérje
 it:Proteine di mais idrolizzate
 nl:gehydroliseerd maïseiwit, gehydrolyseerd mais-eiwit, gehydrolyseerd maïseiwit
@@ -30419,6 +30506,7 @@ allergens:en: en:milk
 en:milk protein isolate
 de:Milcheiweißisolat
 fr:isolat de protéines du lait
+hr:izolat mliječnih proteina
 it:Proteine isolate del latte
 
 <en:milk proteins
@@ -30478,6 +30566,7 @@ fa:پروتیین وی
 fi:heraproteiini
 fr:protéine de lactosérum
 hi:मट्ठा प्रोटीन
+hr:proteina sirutke
 hu:savófehérje, tejsavófehérje, savófehérjék, tejsavófehérjék
 id:Protein susu
 it:Proteine del siero del latte, WP
@@ -30668,7 +30757,7 @@ fr:cacao
 ga:cócó
 he:קקאו
 hi:कोको
-hr:kakao, theobroma cacao L, kakaovca
+hr:kakao, kakaov, theobroma cacao L, kakaovca
 hu:kakaó
 id:Kakao
 it:cacao
@@ -30920,7 +31009,7 @@ fa:پودر کاکائو
 fi:kaakaojauhe, kaakaojauhetta
 fr:poudre de cacao, cacao en poudre
 he:אבקת קקאו
-hr:kakao prah, kakaov prah
+# hr:kakao prah, kakaov prah # see ingredients_processing.txt
 hu:kakaópor
 id:Kakao padat
 #it:cacao in polvere
@@ -30965,7 +31054,7 @@ es:cacao magro en polvo, cacao desgrasado en polvo, cacao en polvo desgrasado, c
 et:lahja kakaopulber, vähendatud rasvasisaldusega kakaopulber
 fi:vähärasvainen kaakaojauhe, vähärasvaista kaakaojauhetta
 fr:poudre de cacao maigre, poudre de cacao dégraissé, cacao dégraissé en poudre, cacao en poudre dégraissé, cacao maigre en poudre, cacao sec dégraissé, poudre de cacao à teneur réduite en matières grasses, poudre de cacao allegee
-hr:kakao u prahu smanjene masnoce, nemasni kakao prah, nemasni kakao u prahu, kakao prah smanjene masti, kakaov prah smanjene masti, kakao smanjene masnoće u prahu, kakaov prahu smanjene mast, kakao prah sa reduciranim sadržajem kakao maslaca
+hr:kakao u prahu smanjene masnoce, nemasni kakao prah, nemasni kakao u prahu, kakao prah smanjene masti, kakaov prahu smanjene masti, kakaov prah smanjene masti, kakao smanjene masnoće u prahu, kakaov prahu smanjene mast, kakao prah sa reduciranim sadržajem kakao maslaca, kakaov prah smanje masti, kakaov prah smanjene masti min, kakaov prah smanjenje masti
 hu:zsírszegény kakaópor
 it:cacao magro in polvere, cacao scremato in polvere
 lt:liesi kakavos milteliai
@@ -30980,9 +31069,9 @@ sk:kakaový prášok so zníženým množstvom tuku
 sv:fettreducerat kakaopulver, fettreducerad kakaopulver, skummet kakaopulver, fettreduserat kakaopulver, avfettat kakaopulver, fettfattigt kakaopulver
 # ingredient/fr:poudre-de-cacao-maigre has 843 products in 8 languages @2019-05-25
 
-<en:cocoa powder
-<en:fat reduced cocoa
-en:fat reduced cocoa powder, low-fat cocoa powder, low fat cocoa powder
+#<en:cocoa powder
+#<en:fat reduced cocoa
+#en:fat reduced cocoa powder, low-fat cocoa powder, low fat cocoa powder
 #en:processing:en:powder
 #bg:обеэмаслено какао на прах
 #ca:cacau desgreixat en pols
@@ -31024,6 +31113,7 @@ ru:обезжиренный какаопорошок, сухой обезжир�
 <en:cocoa
 en:cocoa solids
 fr:cacao sec
+hr:kakaovi dijelovi, kakaovih dijelova
 
 wikipedia:en:https://en.wikipedia.org/wiki/Cocoa_solids
 
@@ -31062,7 +31152,7 @@ es:Cacao en grano
 et:kakaooad, kakaopuu seemned
 fi:kaakaopapu, kaakaopavut
 fr:fèves de cacao, grains de cacao, cacao en grains
-hr:kakaovog zrna
+hr:kakaovog zrna, kakaa u zrnu
 hu:kakaóbab
 id:Biji kakao
 it:fave di cacao, semi di cacao, granelli di cacao
@@ -31121,6 +31211,14 @@ nl:gekaramelliseerde schilfers van cacaobonen
 # ingredient/fr:éclats-de-fèves-de-cacao-caramélisés has 35 products @2019-05-25
 # usage:es:pepitas de cacao caramelizadas (cacao, azúcar)
 
+<en:cocoa
+en:cocoa bar
+hr:kakaova ploča
+
+<en:cocoa
+en:cocoa fiber
+hr:kakaova vlakna
+
 # description:en:CHOCOLATE is a usually sweet, brown food preparation of roasted and ground cacao seeds that is made in the form of a liquid, paste, or in a block, or used as a flavoring ingredient in other foods.
 
 # <en:compound
@@ -31164,7 +31262,7 @@ gu:ચોકલિટ્
 gv:shocklaid
 he:שוקולד
 hi:चॉकलेट
-hr:Čokolada, čokoladni
+hr:Čokolada, čokoladni, čokolade
 ht:chokola
 hu:csokoládé
 hy:Շոկոլադ
@@ -31351,7 +31449,7 @@ es:copos de chocolate, pepitas de chocolate,gotas de chocolate,chips de chocolat
 fi:suklaapalat, suklaarouhe
 fr:morceaux de chocolat, pépites de chocolat, copeaux de chocolat
 he:שברי שוקולד, נטיפי שוקולד, שוקולד צ׳יפס, שוקולד צ'יפס, חתיכות שוקולד
-hr:komadići čokolade, čokoladni komadići, čokoladni posip
+# hr:komadići čokolade, čokoladni komadići, čokoladni posip # see ingredients_processings.txt
 it:pezzi di cioccolato, gocce di cioccolato
 nl:Chocostukjes
 pl:Kawałki czekolady
@@ -31371,7 +31469,7 @@ de:Milchschokoladenstücke
 es:pepitas de chocolate con leche
 fi:maitosuklaapalat
 fr:Flocons de chocolat au lait
-hr:komadići mliječne čokolade
+# hr:komadići mliječne čokolade # ingredients_processings.txt
 nb:melkesjokoladedråper
 sv:mjölkchokladdroppar
 allergens:en: en:milk
@@ -31482,6 +31580,10 @@ pl:kawalki czekolday deserowej
 # ingredient/fr:morceaux-de-chocolat-noir has 66 products in 5 languages @2019-03-29
 # usage:it: pezzetti di cioccolato fondente (zucchero, pasta di cacao, burro di cacao, emulsionante: lecitina di soia: aroma naturale di vaniglia)
 
+<en:dark chocolate chunks
+en:sugar free dark chocolate chunks
+hr:kapljice tamne čokolade bez šećera
+
 <en:dark chocolate
 en:organic dark chocolate
 de:dunkle Bio-Schokolade
@@ -31492,6 +31594,10 @@ nl:biologische pure chocola
 
 <en:chocolate
 de:Halbbitterschokolade
+
+<en:chocolate
+en:chocolate bar
+hr:kakao pločice
 
 description:en:MILK CHOCOLATE is solid chocolate made with milk added in the form of powdered milk, liquid milk, or condensed milk.
 # <en:contains:en:sugar
@@ -31515,7 +31621,7 @@ fi:maitosuklaa
 fr:chocolat au lait, Chocolat au lait extra fin, Chocolat au lait en tablette
 gl:Chocolate con leite
 he:שוקולד חלב
-hr:mliječna čokolada
+hr:mliječna čokolada, mliječne čokolade
 hu:tejcsokoládé
 it:cioccolato al latte
 ja:ミルクチョコレート
@@ -31654,6 +31760,10 @@ ciqual_food_name:fr:Chocolat blanc, tablette
 # ingredient/white-chocolate has 1212 products in 8 languages @2019-05-25
 # category/white-chocolates has 444 products @2018-05-25
 # usage:fr:Chocolat blanc (beurre de cacao, sucre, lait écrémé en poudre, beurre concentré, émulsifiants:lécithines [soja], arômes)
+
+<en:white chocolate
+en:chocolate and white chocolate
+hr:čokolade i bijele čokolade
 
 <en:chocolate
 en:white chocolate powder
@@ -32393,7 +32503,7 @@ ga:soighe
 gl:Soia
 gn:Sóha
 he:סויה
-hr:soja, soje, soju, sojino, sojina
+hr:soja, soje, soju, sojino, sojina, iz soje
 hu:szója, szójatej, szójaliszt, szójából, szóját
 ia:soya
 id:Kedelai
@@ -32662,7 +32772,7 @@ fi:gluteeni
 fr:gluten
 ga:glútan
 he:גלוטן
-hr:gluten
+hr:gluten, glutena
 hu:glutén, Glutent
 it:glutine
 ja:グルテン
@@ -33129,6 +33239,9 @@ la:Cyberlindnera jadinii, Candida utilis
 wikidata:en:Q1527729
 wikipedia:en:https://en.wikipedia.org/wiki/Torula
 
+<en:yeast
+en:hops yeast
+hr:hmelj kvasac
 
 # description:en:YEAST EXTRACT is the common name for yeast products made by extracting the cell contents
 
@@ -33203,6 +33316,7 @@ fa:نان خمیر ترش
 fi:taikinajuuri, taikinanjuuri, hapantaikina, hapanjuuri
 fr:levain, levain naturel, levain panaire
 he:מחמצת שאור
+hr:kiselo tijesto
 hu:Kovász
 id:Adonan asam
 is:Súrdeig
@@ -33253,6 +33367,7 @@ de:Weizensauerteig
 es:masa madre de trigo, masa madre natural de trigo
 fi:vehnätaikinanjuuri, vehnähapantaikina
 fr:levain de blé, levain panaire de blé
+hr:pšenično kiselo tijesto
 it:lievito madre di frumento
 lt:kviečių raugas
 nb:surdeig av hvete
@@ -33266,7 +33381,7 @@ en:dried wheat sourdough, dehydrated wheat sourdough
 es:masa madre deshidratada de trigo
 fi:kuivattu vehnätaikinanjuuri
 fr:levain de blé déshydraté
-hr:osušeno pšenično kiselo tijesto
+# hr:osušeno pšenično kiselo tijesto # see ingredients_processings.txt
 lt:sausas kviečių raugas
 nl:gedroogde tarwezuurdesem
 
@@ -34457,7 +34572,7 @@ fr:fruit
 gl:Froita
 he:פרי
 hi:फल
-hr:voće, voćni
+hr:voće, voćni, voćna
 hu:gyümölcs
 hy:միրգ
 ia:fructo
@@ -34947,7 +35062,7 @@ gl:Albaricoque
 gv:apricoc
 he:מִשְׁמֵשׁ
 hi:खुबानी
-hr:marelica, marelice
+hr:marelica, marelice, od marelice
 ht:zabriko
 hu:sárgabarack
 hy:ծիրան
@@ -35208,7 +35323,7 @@ gu:કેળાં
 gv:Bananey
 he:בננה
 hi:केला
-hr:banana, banane
+hr:banana, banane, od banane
 ht:Bannann
 hu:Banán
 hy:Բանան
@@ -35698,7 +35813,7 @@ fr:mangue, mangues
 ga:Mangó
 gl:Manga
 hi:आम
-hr:mango, manga
+hr:mango, manga, od manga
 ht:Mango
 hu:Mangó
 id:Mangga
@@ -36593,7 +36708,7 @@ gu:સફરજન
 gv:Ooyl
 he:תפוח
 hi:सेब
-hr:jabuka, jabuke, jabuka plod, plod jabuke
+hr:jabuka, jabuke, jabuka plod, plod jabuke, od jabuke
 ht:Pòm
 hu:alma
 hy:խնձոր
@@ -37463,7 +37578,7 @@ ga:seadóg
 gl:pomelo
 he:אשכולית
 hi:अंगूरफल
-hr:grejp
+hr:grejp, grejpa
 hu:grépfrút
 hy:թուրինջ
 id:limau gedang
@@ -38931,6 +39046,7 @@ de:kandierte Orangenschalen, Orangeat, Orangenschalen confiert
 es:corteza de naranja confitada
 fi:kandeerattu appelsiininkuori
 fr:écorces d'orange confites, écorces d'oranges confites, orangeat
+# hr:kandirana narančina korica # see ingredients_processing.txt
 it:scorze d'arancia candite, cubetti di scorza di limone
 nl:gekonfijte sinaasappelschillen
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:écorces-d'orange-confites/
@@ -39390,6 +39506,10 @@ nl:zwarte bessensap op basis van concentraat
 # nl:cassis likeur
 # de:Cassis-Likör
 
+<en:blackcurrant
+en:pieces and juice of blackcurrant
+hr:komadi i sok crnog ribiza
+
 ###################################################################################################
 #
 #                                Blueberry
@@ -39413,7 +39533,7 @@ et:mustikas
 fa:بیل‌بری
 fi:puolukat
 fr:myrtille
-hr:borovnica, borovnice
+hr:borovnica, borovnice, od borovnica, od borovnice
 hu:áfonya
 is:bláber
 it:mirtillo, mirtilli, mirtilli neri
@@ -39942,7 +40062,7 @@ de:Sauerkirsch, Sauerkirsche, Sauerkirschen
 es:Cereza agria
 fi:hapankirsikka, hapankirsikat
 fr:griotte, griottes, cerises griottes
-hr:višnja, višnje
+hr:višnja, višnje, od višnje
 it:amarene
 nl:morellen, kriek, krieken, zure kers
 pl:wiśnia, wiśnie, wiśniowy, wiśniowe, wiśniowa, wiśniowego, wiśniowych, wiśniowej
@@ -40214,7 +40334,7 @@ fi:kookos, kookospähkinä
 fr:noix de coco, coco
 gl:Coco
 he:קוקוס
-hr:kokos, kokosova, kokosov orah
+hr:kokos, kokosa, kokosova, kokosove, kokosovo, kokosov orah
 hu:kókuszdió, kókusz
 it:cocco, noce di cocco
 ja:ココナッツ
@@ -40993,6 +41113,7 @@ gl:goiaba
 gn:arasa
 gu:જમરૂખ
 ha:gweba
+hr:guava
 ht:gwayav
 ia:guayaba
 it:guaiave, guava
@@ -41089,7 +41210,7 @@ ga:cíobhaí, planda cíobhaíonna
 gl:kiwi
 he:קיווי
 hi:कीवी फल
-hr:aktinidija
+hr:kiwi, kiwana, aktinidija
 ht:kiwi
 hu:kivi
 hy:կիվի
@@ -42478,7 +42599,7 @@ fr:framboise
 ga:Sú craobh
 gd:Sùbh-craoibh
 hi:रसभरी
-hr:malina, maline, plod maline
+hr:malina, maline, od malina, plod maline
 ht:Franbwaz
 hu:málna
 hy:Ազնվամորի
@@ -42649,7 +42770,7 @@ de:Himbeeren gefriergetrockent
 es:frambuesas liofilizadas
 fi:pakkaskuivattu vadelma, pakastekuivattu vadelma
 fr:framboises lyophilisées
-hr:komadići liofiliziranih malina
+# hr:komadići liofiliziranih malina # see ingredients_processings.txt
 it:lamponi liofilizzati
 sv:frystorkade hallon
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:framboises-lyophilisées
@@ -42833,7 +42954,7 @@ gn:Yvapytã
 gu:સ્ટ્રોબેરી
 he:תות, תותים
 hi:स्ट्रॉबेरी
-hr:jagoda, jagode
+hr:jagoda, jagode, od jagode
 hu:Eper
 hy:Ելակ
 id:Stroberi kebun
@@ -43172,7 +43293,7 @@ gu:દ્રાક્ષ
 gv:smeyr-feeyney
 he:ענב
 hi:अंगूर
-hr:grožđe
+hr:grožđe, grožđa
 ht:rezen
 hu:szőlő
 hy:Խաղող
@@ -43780,7 +43901,7 @@ de:Traubenmost
 es:Mosto de uva
 fi:puristemehu, rypäleen puristemehu
 fr:moût de raisin
-hr:mošt grožđa, grožđanog mošta
+hr:mošt grožđa, grožđanog mošta, groždani mošt
 it:mosto d'uva
 nl:druivenmost
 ro:must de struguri
@@ -44833,84 +44954,6 @@ fr:Jus de Grenade issu de l'agriculture biologique
 <en:pomegranate
 fr:écorces de grenade
 
-# Aronia is a genus of deciduous shrubs, the chokeberries, in the family Rosaceae native to eastern North America
-
-<en:fruit
-en:chokeberry
-ar:أرونية
-az:Aroniya
-bg:Арония
-ca:Aronia
-cs:temnoplodec
-cy:Llwyn aeron tagu coch
-da:Surbær
-de:Aronia, Apfelbeer, Apfelbeeren
-el:Αρώνια
-eo:aronio
-es:Aronia
-eu:Aronia
-fa:انگورک گلوگیر
-fi:marja-aronia
-fr:aronie, aronia
-he:ארוניה
-hr:Aronija
-hy:արոնիա
-it:aronia
-ja:アロニア属
-kk:Қара жемісті итжүзім
-ko:아로니아
-la:Aronia
-lt:Aronija
-lv:Aronijas
-mk:Аронија
-nl:appelbes
-pl:aronia
-pt:aronia
-ro:Aronia
-ru:Арония
-sh:Aronija
-sk:Arónia
-sl:Aronija
-sq:aronia
-sr:Аронија
-sv:Aroniasläktet
-tr:Aronia
-uk:Aronia
-vi:Aronia
-zh:野櫻莓
-# de-ch:Apfelbeeren
-# en-ca:Aronia
-# en-gb:Aronia
-# hsb:Aronija
-# kk-arab:قارا جەمىستى ٴىيتجۇزىم
-# kk-cn:قارا جەمىستى ٴىيتجۇزىم
-# kk-cyrl:Қара жемісті итжүзім
-# kk-kz:Қара жемісті итжүзім
-# kk-latn:Qara jemisti ïtjüzim
-# kk-kz:Qara jemisti ïtjüzim
-# nah:Capolin
-# pt-br:aronia
-# sr-ec:Аронија
-# sr-el:Aronija
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:aronia
-# 163 products in 5 languages @2018-10-03
-
-<en:chokeberry
-<en:fruit juice
-en:chokeberry juice
-de:Aroniasaft
-fi:marja-aroniamehu
-fr:jus d'aronia
-it:succo d'aronia
-# openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:jus-d'aronia
-# 20 products in 3 languages @2018-10-03
-
-<en:chokeberry juice
-en:concentrated chokeberry juice
-de:Aroniasaft-Konzentrat, Aroniasaft Konzentrat
-fi:marja-aroniamehutiiviste
-fr:Jus concentré d'aronia
-
 <en:fruit
 en:acerola
 de:Acerolakirschen
@@ -45451,7 +45494,7 @@ es:verduras, hortaliza,hortalizas, vegetal,vegetales
 fi:vihannes, kasvis, kasvikset
 fr:légume, légumes
 he:ירק
-hr:povrće, biljno, biljni
+hr:povrće, povrća, biljno, biljni
 hu:zöldség, zöldségek
 it:vegetale, ortaggi, verdure
 ja:野菜
@@ -47415,7 +47458,7 @@ es:remolacha, betarraga
 fi:punajuuri
 fr:betterave, betteraves
 he:סלק
-hr:cikla
+hr:cikla, cikle
 hu:cékla
 it:barbabietola
 ja:ビーツ
@@ -48482,7 +48525,7 @@ gn:sanaória
 gv:carradje
 he:גזר
 hi:गाजर
-hr:mrkva
+hr:mrkva, mrkve, od mrkve
 ht:karòt
 hu:sárgarépa
 hy:Գազար
@@ -48760,7 +48803,7 @@ de:schwarze Karotte
 es:Zanahorias negras
 fi:Musta porkkana, mustaporkkana, mustaporkkanaa
 fr:carotte noire
-hr:crna mrkva
+hr:crna mrkva, crne mrkve
 it:carote nere
 nb:sort gulrot
 nl:zwarte wortel
@@ -51137,7 +51180,7 @@ gn:Jety
 gu:શક્કરીયાં
 he:בטטה
 hi:शकरकन्द
-hr:Batat
+hr:Batat, krumpir batat
 ht:Patat
 hu:Édesburgonya
 hy:բաթաթ
@@ -51656,6 +51699,7 @@ fi:perunasose, perunamuusi
 fr:purée de pomme de terre, purée de pommes de terre
 ga:brúitín
 he:מחית תפוחי אדמה
+hr:pire krumpir
 id:kentang tumbuk
 it:purea di patate
 ja:マッシュポテト
@@ -51681,6 +51725,10 @@ wikipedia:en:https://en.wikipedia.org/wiki/Mashed_potato
 # wuu:土豆泥
 # zh_yue:薯茸
 # fr:purée-de-pomme-de-terre has 152 products in 1 language @2018-10-15
+
+<en:mashed potato
+en:instant mashed potatoes
+hr:instant pire krumpir
 
 <en:potato
 en:potato flakes
@@ -51721,6 +51769,7 @@ de:Kartoffelfasern, Kartoffelfaser, Kartoffelballaststoffe
 es:fibra de patata, fibra vegetal de patata
 fi:perunakuitu
 fr:fibres de pomme de terre, fibre de pomme de terre, fibres de pommes de terre
+hr:krumpirova vlakna
 nb:potetfiber
 nl:aardappelvezel, aardappelvezels
 no:potetfiber, potetfibre
@@ -52236,6 +52285,7 @@ fi:jalapeño, jalapeno, jalapenot
 fr:piments jalapeño, piment jalapeño
 gl:pemento xalapeño
 he:חלפניו
+hr:jalapeno papričica
 hu:jalapeno paprika, jalapeno
 hy:հալապենո
 id:jalapeño
@@ -52543,7 +52593,7 @@ fr:tomate, tomates
 gl:tomate
 gu:tomate
 he:עגבנייה
-hr:rajčica, rajčice
+hr:rajčica, rajčice, od rajčice
 ht:Tomat
 hu:paradicsom
 ia:Tomato
@@ -52890,7 +52940,7 @@ et:tomatipüree
 fi:tomaattipyree, tomaattipyre, tomaattitiiviste, tomaattisose
 fr:purée de tomate, purée de tomates, puree de tomate
 he:מחית עגבניות
-hr:pire od rajčice, kaša od rajčice
+# hr:pire od rajčice, kaša od rajčice # see ingredients_processing.txt
 hu:paradicsompüré
 is:tómatpúrra
 ja:トマトピューレ
@@ -52944,7 +52994,8 @@ et:tomatipasta
 fi:tomaattitahna
 fr:concentré de tomate, concentré de tomates, pâte de tomate, concentre de tomate
 hu:Paradicsom sűrítmény
-hr:koncentrat rajčice
+# hr:koncentrat rajčice # see ingredients_processing.txt
+hr:rajčice od koncentrirane kaše rajčice
 it:concentrato di pomodoro
 ja:トマトペースト
 lt:pomidorų pasta
@@ -52988,7 +53039,7 @@ de:Tomatenkonzentrat zweifach konzentriert, Tomatenmark doppelt konzentriert
 es:tomate doble concentrado, concentrado doble de tomate
 fi:tuplatiivistetty tomaattipyree
 fr:double concentré de tomate, purée de tomates double concentré, purée de tomate double concentrée
-hr:dvostruki koncentrat rajčice
+# hr:dvostruki koncentrat rajčice # see ingredients_processings.txt
 it:doppio concentrato di pomodoro
 nl:Dubbel geconcentreerde tomatenpuree
 # ingredient/fr:double-concentré-de-tomate has 520 products in 8 languages @2018-12-26
@@ -53004,7 +53055,7 @@ ciqual_food_name:fr:Tomate, double concentré, appertisé
 <en:tomato purée
 fr:purée de tomates reconstituée, purée de tomates à base de concentré, purée de tomate à base de concentré
 de:Tomatenpüree aus Konzentrat, Tomatenmark aus Konzentrat
-hr:pire rajčice iz koncentrata
+# hr:pire rajčice iz koncentrata
 # ingredient/fr:puree-de-tomates-reconstituee has 127 products in french @2018-12-26
 # ingredient/fr:purée-de-tomates-à-base-de-concentré has 94 products in 2 languages @2018-12-26
 
@@ -55899,7 +55950,7 @@ fy:Mangel
 ga:almóinní
 gl:Améndoa
 he:שקד
-hr:badem, bademi
+hr:badem, bademi, badema
 hu:mandula
 ia:amandola
 it:mandorla, mandorle
@@ -56049,6 +56100,7 @@ bg:бадемово брашно
 de:Mandelmehl
 es:harina de almendra
 fr:farine d'amandes
+hr:bademovo brašno
 it:Farina di mandorle
 nl:Amandelbloem
 pl:mąka midgałowa
@@ -56059,6 +56111,7 @@ en:organic almond flour
 da:økologisk mandelmel
 de:Bio-Mandelmehl
 fi:luomu mantelijauho
+hr:bademovo brašno iz kontroliranog organskog uzgoja
 it:farina di mandorle bio
 nb:økologisk mandelmel
 pt:farinha de amêndoa biológica, farinha de amêndoas biológicas
@@ -56092,7 +56145,7 @@ de:Mandelstückchen, Mandelstücke, Zerkleinerte Mandeln
 es:trozos de almendras, almendras en trozos
 fi:mantelipala, mantelipalat
 fr:éclats d'amandes
-hr:komadići badema
+# hr:komadići badema # see ingredients_processings.txt
 it:mandorle spezzate
 nl:amandelstukjes
 pl:kawałki migdałów
@@ -56471,7 +56524,7 @@ fr:noisette, noisettes
 ga:cnónna coill
 gl:Abelá
 he:אגוז לוז
-hr:lješnjak, lješnjaci
+hr:lješnjak, lješnjaka, lješnjaci
 ht:Nwazèt
 hu:mogyoró
 id:Kacang hazel
@@ -56599,6 +56652,7 @@ en:ground hazelnuts
 <en:hazelnut
 fr:éclats de noisettes
 de:Haselnusssplitter, Haselnussstücke
+# hr:komadić lješnjaka # see ingredients_processings.txt
 it:nocciole a scaglie
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:éclats-de-noisettes
 # 145 products in 4 languages @2018-10-06
@@ -56621,7 +56675,7 @@ de:Haselnüsspaste, Haselnusspaste, Haselnussmasse, Haselnussmark
 es:pasta de avellana, pasta de avellanas
 fi:hasselpähkinätahna, hasselpähkinämassa
 fr:pâte de noisette, purée de noisettes
-hr:pasta lješnjaka, pasta od lješnjaka
+hr:pasta lješnjaka, pasta od lješnjaka, krema od lješnjaka
 hu:mogyoromassza
 it:pasta di nocciole
 nb:hasselnøttpasta, hasselnøtmasse
@@ -56738,7 +56792,7 @@ ga:Cnó talún, piseanna
 gu:મગફળી
 ha:Gyaɗa
 he:בוטן, בוטנים, חמאת בוטנים
-hr:kikiriki
+hr:kikiriki, kikirikija
 hu:földimogyoró
 ia:cacahuete
 it:arachide, arachidi
@@ -56876,6 +56930,7 @@ bg:фъстъчено масло, фъстъчена паста
 de:Erdnussbutter
 es:crema de cacahuete
 fr:beurre d'arachide, beurre de cacahuète, beurre de cacahouète, pâte d'arachide
+hr:kikiriki maslac
 it:Burro di arachidi
 ja:ピーナッツバーター
 nb:peanøttssmör
@@ -57156,7 +57211,7 @@ de:Walnusskerne, Walnusskern
 es:nuez mondada
 fi:kuoreton saksanpähkinä, kuorettomat saksanpähkinät
 fr:cerneaux de noix
-hr:orah jezgra
+hr:orah jezgra, jezgra oraha
 it:gherigli di noci, noci comuni
 nb:Valnøttkjerner
 nl:Gepelde walnoot, walnootpitten
@@ -59125,7 +59180,7 @@ fi:cayennepippuri, cayenne
 fr:piment de cayenne, cayenne, poivre de cayenne
 gl:pementa de caiena
 he:פלפל קאיין
-hr:kajenski papar, kajenska paprika
+hr:kajenski papar, kajenska paprika, kajenska papričica
 hu:cayennebors
 hy:Կայենեյան պղպեղ
 id:cabai cayenne
@@ -59877,7 +59932,7 @@ el:κιννάμωμον η κασσία
 et:hiina kaneelipuu
 fi:kassiakaneli
 fr:cannelle de chine
-hr:kora kineskog cimeta, cinnamomum aromaticum
+hr:kineskog cimeta, cinnamomum aromaticum
 id:kayu manis cina
 it:cassia
 ja:シナニッケイ
@@ -59959,7 +60014,7 @@ gl:craveiro da india
 gu:લવિંગ
 he:ציפורן
 hi:लौंग
-hr:klinčić, cvjetne palice klinčića, syzygium aromaticum
+hr:klinčić, klinčići, klinčić cijeli, cvjetne palice klinčića, syzygium aromaticum
 ht:jiwòf
 hu:szegfűszeg
 id:cengkih
@@ -60456,6 +60511,11 @@ fr:extrait de gingembre, l'extrait de gingembre
 <en:ginger
 en:ginger syrup
 nl:gembersiroop
+
+
+en:griffonia, griffonia simplicifolia
+hr:griffonia, griffonia simplicifolia
+wikidata:en:Q1941426
 
 #category/mustards
 <en:spice
@@ -62065,6 +62125,7 @@ en:parsley root
 de:Petersilienwurzel
 es:raices de peregril
 fr:racine de persil
+hr:korijen peršina
 it:radice di prezzemolo
 la:Petroselinum crispum var. tuberosum
 nl:peterseliewortel
@@ -63621,7 +63682,7 @@ fi:humala
 fr:houblon
 ga:Leannlus
 he:כשות
-hr:hmelj, hmeljevi
+hr:hmelj, hmelji, hmeljevi
 hu:komló, komlo
 id:hopio:Lupulo
 is:Humall
@@ -65559,7 +65620,7 @@ fa:گل‌آفتاب‌گردانیان
 fi:auringonkukka
 fr:tournesol
 he:חמנית
-hr:suncokret, suncokreta, suncokretov, suncokretova, suncokretovo
+hr:suncokret, suncokreta, suncokretov, suncokretova, suncokretovo, iz suncokreta
 hu:napraforgó
 hy:արևածաղիկ
 is:Sólblóm
@@ -66145,6 +66206,11 @@ de:Entkoffeinierter Grüntee
 fr:thé vert décaféiné
 it:te verde decaffeinato, tè verde decaffeinato
 pt:Chá verde descafeinado
+
+<en:green tea
+en:gunpowder tea
+hr:gunpowder
+wikidata:en:Q1079875
 
 <en:black tea
 en:decaffeinated black tea
@@ -66803,7 +66869,7 @@ fr:chlorella, chlorelle
 ga:Clóireile
 gl:Chlorella
 he:כלורלה
-hr:Chlorella
+hr:Chlorella, klorela alge
 hy:քլորելա
 ia:Chlorella
 id:Chlorella
@@ -68926,7 +68992,7 @@ gv:Eeast
 ha:kifi
 he:דג
 hi:मछली
-hr:Ribe
+hr:Ribe, ribu
 ht:Pwason
 hu:halak, hal
 hy:Ձկնամիս, ձկներ
@@ -69552,6 +69618,7 @@ de:Sardellenfilets
 es:filetes de anchoas
 fi:anjovisfilee
 fr:filets d'anchois
+hr:filet inćuna, fileti inćuna
 it:Filetti d'acciuga
 # ingredient/fr:filets-d'anchois has 36 products in 4 languages @2019-01-06
 
@@ -69564,6 +69631,9 @@ it:Filetti d'acciuga
 #it:filetti di acciughe salate
 # 50 in 4 @2021-09-12
 
+<en:anchovy filets
+en:marinated anchovy fillets
+hr:fileti mariniranih incuna
 
 description:en:The European anchovy (Engraulis encrasicolus) is a forage fish somewhat related to the herring.
 <en:anchovy
@@ -69868,6 +69938,7 @@ fa:خردماهی
 fi:Villakuore
 fr:capelan
 he:טרוטנית
+hr:kapelin, kapelinova ikra
 hu:Csuklyás hal
 id:Capelin
 is:Loðna
@@ -75184,6 +75255,9 @@ wikidata:en:Q752188
 wikipedia:en:https://en.wikipedia.org/wiki/Cancer_pagurus
 # ingredient/fr:cancer-pagurus has 12 products @2019-01-14
 
+<en:crab
+en:crab substitute
+hr:imitacija rakovice
 
 description:en:CRAYFISH, also known as crawfish, crawdads, crawlfish,[1] crawldads,[2] freshwater lobsters, mountain lobsters, mudbugs, or yabbies, are freshwater crustaceans resembling small lobsters
 <en:crustacean
@@ -78351,7 +78425,7 @@ de:Pouletfleisch, Hühnerfleisch, Hühnchenfleisch
 es:Carne de pollo
 fi:kananliha
 fr:viande de poulet, viande de poule
-hr:pileće meso
+hr:pileće meso, pilećeg mesa
 hu:csirkehús
 it:carne di pollo
 ja:鶏肉
@@ -78535,6 +78609,10 @@ nl:verhitte gepekelde kipfilet
 
 <fr:filet de poulet traité en salaison cuit
 fr:préparation à base de filets de poulet traités en salaison
+
+<en:chicken fillet
+en:chicken thigh fillet 
+hr:file pilećeg zabatka
 
 <en:chicken meat
 de:Hühnerfleischpulver
@@ -78983,7 +79061,7 @@ carbon_footprint_fr_foodges_value:fr:6.6
 en:turkey thigh meat
 de:putenoberkeulenfleisch
 fr:viande de cuisse de dinde
-de:putenoberkeulenfleisch
+hr:meso purećeg zabatka
 # ingredient/fr:viande-de-cuisse-de-dinde has 58 products in french @2019-04-16
 
 <en:turkey
@@ -79012,10 +79090,6 @@ fr:jambon de dinde cuit standard goût fumé
 <en:turkey
 en:roasted turkey including natural turkey juices
 de:Gebratener Truthahn mit natürlichen Truthahnsäften
-
-<en:turkey
-en:turkey gizzard meat
-hr:meso purećeg zabatka
 
 <en:poultry
 en:quail
@@ -79135,7 +79209,7 @@ gl:ovo
 gv:Ooh
 he:ביצה
 hi:अण्डा
-hr:jaja
+hr:jaja, iz jaja
 hu:tojás
 hy:Ձու
 id:telur
@@ -79419,6 +79493,7 @@ de:Hühnereier aus Freilandhaltung
 es:huevos de gallinas camperas
 fi:ulkokanan munat, ulkokanan munia, ulkokanojen munia
 fr:œuf de poules élevées en plein air, œufs de poules élevées en plein air, oeuf de poules élevées en plein air, oeufs de poules élevées en plein air
+hr:jaja iz podnog uzgoja
 nl:ei van hennen met vrije uitloop, scharrelkipheelei, scharrelkippenei
 
 # ingredient/fr:oeufs-de-poules-elevees-en-plein-air has 242 products in 5 languages @2018-12-18
@@ -80263,7 +80338,7 @@ de:Gemüseextrakte
 es:Extrato vegetal, extratos vegetales
 fi:kasvisuute, kasvisuutteet
 fr:extraits végétaux
-hr:biljni ekstrakt
+hr:biljni ekstrakt, biljni ekstrakti sa svojstvom
 it:estratto vegetale, estratti vegetali
 nl:plantaardig extract, plantaardige extracten
 pt:Extrato de vegetais
@@ -82346,7 +82421,7 @@ fa:وافل
 fi:vohveli
 fr:gaufre
 he:ופל
-hr:Vafel proizvod
+hr:Vafel, Vafel proizvod, vafla
 hu:gofri
 hy:Վաֆլի
 id:Wafel
@@ -82556,7 +82631,7 @@ ga:Briosca
 gd:Briosgaid
 gl:Galleta
 he:ביסקוויט
-hr:biskvit, čajno pecivo
+hr:biskvit, čajno pecivo, keks, čajnog peciva i čokolade, digestive keksa, 
 hu:Kekszek, Keksz
 hy:բիսկվիտ
 id:Biskuit
@@ -82691,6 +82766,16 @@ likely_allergens:en: en:gluten
 wikidata:en:Q6591
 wikipedia:en:https://en.wikipedia.org/wiki/Speculaas
 
+<en:biscuit
+<en:cocoa
+en:cocoa biscuit
+hr:keks od kakaa, kakov keksa
+
+<en:biscuit
+<en:chocolate
+en:biscuit and chocolate
+hr:keksa i čokolade
+
 # <en:compound
 en:coating, seasoning
 bg:Покритие
@@ -82721,7 +82806,7 @@ vegetarian:en:ignore
 
 <en:coating
 en:cocoa coating
-hr:kakao preljev
+hr:kakao preljev, kakaov preljev, kakaovog preljeva
 
 <en:coating
 fr:décor au cacao maigre, decor au cacao maigre, enrobage au cacao maigre
@@ -82730,7 +82815,7 @@ fr:décor au cacao maigre, decor au cacao maigre, enrobage au cacao maigre
 fr:chocolat de couverture
 ca:cobertura de xocolata, cobertura de cacau
 es:cobertura de chocolate
-hr:čokoladna kuvertura, čokoladni preljev
+hr:čokoladna kuvertura, čokoladni preljev, preljev od čokolade
 pt:chocolate de cobertura
 
 <en:coating
@@ -82757,6 +82842,12 @@ hr:bijeli čokoladni preljev
 # comment:en:The inside part of an ice cream cone
 
 fr:intérieur cône
+
+<en:coating
+<en:beef
+<en:collagen
+en:edible coating originating from bovine collagen
+hr:jestivi ovitak podrijetlom od goveđeg kolagena
 
 # description:en:BREAD CRUMBS are sliced residue of dry bread, used for breading or crumbing foods, topping casseroles, stuffing poultry, thickening stews, adding inexpensive bulk to soups, meatloaves and similar foods, and making a crisp and crunchy covering for fried foods, especially breaded cutlets like tonkatsu and schnitzel.
 # This is a compound ingredient, e.g.:chapelure (farine de blé, levure, sel)
@@ -82867,7 +82958,7 @@ ga:Císte
 gl:Pastel
 he:עוגה
 hi:केक
-hr:Pita
+hr:Pita, kolač, kolača
 ht:Gato
 hu:Sütemények, sütemény
 hy:տորթ
@@ -83578,7 +83669,7 @@ fi:kuorrute
 fr:glaçage
 he:זיגוג
 hi:चमक
-hr:bijela-glazura
+hr:glazura, bijela-glazura
 it:glassa
 ja:グレーズ
 ko:글레이즈
@@ -83610,6 +83701,10 @@ ru:шоколадная глазурь
 sv:chokladglasyr, kakaoglasyr
 # usage:en:chocolate glaze (sugar, soybean oil, cocoa powder processed with alkali, palm oil, soy lecithin, vanilla)
 # ingredient/en:chocolate-glaze has 4 products in 1 language @2020-06-13
+
+<en:glaze
+en:cacao glaze
+hr:kakao glazura, kakaova glazura
 
 # mainIngredient:en:cacao
 # <en:compound

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -3219,12 +3219,12 @@ es:leche de vaca desnatada pasterizada
 th:น้ำนมโคขาดมันเนย
 
 <en:cow's milk
-en:homogenized milk with 2 8 milk fats
-hr:homogenizirano mlijeko s 2 8 mliječne masti
+en:homogenized milk with 2.8% milk fats
+hr:homogenizirano mlijeko s 2.8% mliječne masti
 
 <en:cow's milk
-en:homogenized milk with 3 2 milk fats
-hr:homogenizirano mlijeko s 3 2 mliječne masti
+en:homogenized milk with 3.2% milk fats
+hr:homogenizirano mlijeko s 3.2% mliječne masti
 
 ################################# GOAT MILKS ###################################
 

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -143,7 +143,7 @@ de:blatt, blätter
 es:hojas de, hoja de
 fi:lehti, lehdet
 fr:feuille de, feuille d'
-hr:list
+hr:list, folium
 hu:levél
 it:foglie, in foglie
 ja:の葉
@@ -191,6 +191,7 @@ de:mittelfein geschnittenen
 <en:cut
 en:finely cut
 es:cortado fino, cortada fina,cortados finos, cortadas finas
+hr:fino sjeckana
 hu:vékonyan vágott, vékony vágás
 pt:cortado fino, cortada fina, cortados finos, cortadas finas
 
@@ -370,7 +371,9 @@ hr:fino mljeveno
 hu:finomra őrölt
 
 # <en:ground
+en:coarsely ground
 de:grob gemahlen, grob gemahlene, grob gemahlener, grob gemahlenes
+hr:grublje mljeveno, grubo mljeveni
 hu:durvára őrölt
 
 # <en:ground
@@ -405,6 +408,11 @@ sv:puré
 # nb:parsing:$puré
 # sv:parsing:$puré
 
+# <en:concentrated
+# <en:pureed
+en:concentrated puree
+hr:od koncentrirane kaše, koncentrirana kaša od, koncentrirane kaše
+
 
 hu:lapított
 
@@ -434,6 +442,7 @@ en:halved, halves
 bg:наполовина
 de:halbiert, halbierte, halbierter, halbiertes, halbe
 fr:demi
+hr:polovice
 pl:połówki
 pt:metade, metades
 # de:false-positives:Halbbitterschokolade, halbfettstufe, halbgetrocknete, halbfester, halberstädter, halbbitter, Halbrahm
@@ -449,7 +458,7 @@ af:stukkies
 de:stücke, stücken, stückchen, gestückelt, stück
 es:trozo, troza, trozos, trozas, guarnición
 fr:morceaux, pièces de, en morceaux, morceaux de, morceaux d'
-hr:komadići, komadići od, hrskavi komadići, hrskavi komadići od, komata
+hr:komadići, komadići od, hrskavi komadići, hrskavi komadići od, komadić, komata, posip
 hu:darabok, darabolt, darab, darabka
 it:pezzi, in pezzi, a pezzi, pezzi di, pezzi d'
 nl:stukjes
@@ -473,7 +482,7 @@ de:Flocken
 es:escamas de
 fi:hiutaleet, hiutale
 fr:flocons de, en flocons
-hr:pahuljice od
+hr:pahuljice, pahuljice od
 it:fiocchi di, fiocchi d'
 ja:フレーク
 nl:vlokken
@@ -693,6 +702,7 @@ es:piel de, corteza de
 #es:false:cáscaras
 fi:kuori, kuoret, kuorta
 fr:écorce de, écorces de, écorces d'
+hr:kora, korica, kora od 
 hu:héj, héja
 it:scorza di, scorze di, scorza d', scorze d'
 nl:schil, schillen
@@ -815,7 +825,7 @@ sv:juice, saft
 #<en:concentrated
 #en:concentrated juice of
 #fr:jus concentré de, jus concentré d'
-#hr:koncentrirani sok od
+hr:koncentrirani sok, koncentrirani sok od, koncentriran sok od, koncentrani sok od, koncentrat soka, koncentriran sok, koncentrirani sokovi, od koncentriranog soka
 
 # fr:pur jus
 
@@ -871,7 +881,7 @@ es:concentrado, concentrada, concentrados, concentradas
 fa:کنسانتره
 fi:tiivistetty, tiiviste, tiivisteitä
 fr:concentré, concentrée, concentrés, concentrées, concentré de
-hr:koncentriran, koncentrirani, koncentrani, koncentrat, koncentrat za, koncentrati
+hr:koncentriran, koncentrirani, koncentrani, koncentrat, koncentrat za, koncentrati, iz koncentrata, od koncentrata, konc.
 hu:sűrítmény, sűrített, koncentrátum
 it:concentrato, concentrato di, concentrato d', concentrati, concentrata, concentrate
 ja:濃縮
@@ -891,6 +901,7 @@ wikidata:en:Q1355665
 en:double concentrated
 de:zweifach konzentriert, zweifach konzentrierte, zweifach konzentrierter, zweifach konzentriertes, 2 fach konzentriert, 2 fach konzentrierte, 2 fach konzentrierter, 2 fach konzentriertes, doppelt konzentriert, doppelt konzentrierte, doppelt konzentrierter, doppelt konzentriertes, 2-fach konzentriert, 2-fach konzentrierte, 2-fach konzentrierter, 2-fach konzentriertes
 es:doble concentrado,doble concentrada
+hr:dvostruki koncentrat
 it:doppio concentrato, doppio concentrato di, doppio concentrato d'
 pl:podwójnie skoncentrowany
 
@@ -901,6 +912,12 @@ de:dreifach konzentriert
 de:200fach konzentriertes
 
 #en:not from concentrate
+
+# <en:concentrated
+# <en:extract
+en:concentrated extract
+hr:koncentrirani ekstrakt
+
 
 # there is a problem with en:cocoa paste
 #en:paste
@@ -929,7 +946,7 @@ de:aus Konzentrat, aus Konzentraten
 es:a base de concentrado, a base de concentrada, a partir de concentrado, a partir de concentrada
 fi:tiivisteestä, tiivisteestä valmistettu
 fr:à base de concentré, à partir de concentré
-hr:koncentrirane, na koncentrat, od koncentriranog soka škrob, od koncentriranog soka, od koncentrirane kaše
+hr:koncentrirane, koncentrirano, na koncentrat
 hu:sűrítményből, koncentrátumból, sűrítményekből, koncentrátumokból
 it:da concentrato
 ja:濃縮還元
@@ -986,7 +1003,7 @@ en:freeze dried
 de:gefriergetrocknet, gefriergetrocknete, gefriergetrockneter, gefriergetrocknetes
 fi:pakkaskuivattu, pakkaskuivatut, pakastekuivattu
 fr:lyophilisé, lyophilisée, lyophilisés, lyophilisées
-hr:liofilizirane, liofiliziran, liofilizirana
+hr:liofilizirane, liofiliziran, liofilizirana, liofiliziranih
 hu:fagyasztva szárított
 nb:frysetørkede
 nl:gevriesdroogde
@@ -1052,7 +1069,7 @@ bg:дехидратиран, дехидратирано, дехидратира�
 ca:deshidratat, deshidratada
 es:deshidratado, deshidratada, deshidratados, deshidratadas
 fr:déshydraté, déshydratée, déshydratés, déshydratées
-hr:dehidrirani
+hr:dehidrirani, osušeno
 hu:dehidratált, liofilizált
 it:disidratato, disidratata, disidratati, disidratate
 nl:gedehydrateerde
@@ -1364,7 +1381,7 @@ da:puffede
 de:gepufft, gepuffte, gepuffter, gepufftes, gepoppt, gepoppte, gepoppter
 es:hinchado,hinchada,hinchados,hinchadas
 fr:soufflé, soufflée, soufflés, soufflées
-hr:ekspandirana, ekspandirani
+hr:ekspandirana, ekspandirani, ekspandiranih
 hu:puffasztott, felfújt
 it:soffiato, soffiati, soffiata, soffiate
 nl:gepoft, gepofte
@@ -1598,7 +1615,7 @@ da:kandiserede
 de:kandiert, kandierte, kandierten, kandierter
 es:confitado,confitada,confitados,confitadas
 fr:confit,confite,confits,confites,confit de,confit d'
-hr:kandirana
+hr:kandirana, kandirane
 hu:kandírozott, konfitált
 it:candito, candita, canditi, candite
 nl:gekonfijt, gekonfijte
@@ -1720,7 +1737,7 @@ en:fermented
 bg:ферментирало, ферментирал, ферментирала, ферментирали
 ca:fermentat
 es:fermentado
-hr:fermentirano
+hr:fermentirano, fermentirana
 hu:fermentált
 it:fermentato, fermentata, fermentati, fermentate
 ja:発酵
@@ -1928,6 +1945,7 @@ sv:ohärdad
 
 #en:hydrolysed, hydrolized
 #fr:Hydrolisé, hydrolisée
+#hr:hidrolizat, hidrolizirane
 #nl:gehydrolyseerd, gehydrolyseerde
 
 en:hydrogenated

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1327,6 +1327,9 @@ en:First grade TIS 3-1983, Thai Industrial Standard Institute
 ca:Primer grau TIS 3-1983, Institut d'Estandaritzacions Industrials Thai
 wikidata:en:Q15613582
 
+en:isomaltulose is a source of glucose and fructose
+hr:izomaltuloza je izvor glukoze i fruktoze
+
 en:source of fibre
 bg:източник на влакнини
 da:Fiberkilde
@@ -4369,7 +4372,7 @@ es:Ecológico, ecológica, Producto ecológico, Biológico, Producto biológico,
 fi:Luomu, luomutuotanto, luomutuotantoa, luomuraaka-aine, luonnonmukainen tuotanto, luonnonmukaisesti
 fr:Bio, agriculture biologique, biologique, organic, organique, issu de l'agriculture biologique, issus de l'agriculture biologique, issue de l'agriculture biologique, issues de l'agriculture biologique, ingrédient issu de l'agriculture biologique, ingrédients issus de l'agriculture biologique, Les-ingredients-sont-issus-d-une-agriculture-biologique, ingrédients agricoles issus de l'agriculture biologique, produits issus de l'agriculture biologique, produit issu de l'agriculture biologique, ingrédient agricole issu de l'agriculture biologique, tous les ingrédients agricoles sont issus de l'agriculture biologique, les ingrédients agricoles sont issus de l'agriculture biologique, tous les ingrédients sont issus de l'agriculture biologique, ingrédients bio, ingrédients biologiques, ingrédient bio, ingrédient biologique, issue de l'agriculture biologique controlee
 he:אורגני
-hr:ekološki uzgoj, iz ekološkog uzgoja, iz kontroliranog ekološkog uzgoja
+hr:ekološki uzgoj, iz ekološkog uzgoja, iz kontroliranog ekološkog uzgoja, iz kontrolirane ekološke proizvodnje, iz kontroliranog biološkog uzgoja
 hu:Bio, Öko, Organikus, biogazdálkodásból, ellenőrzött ökológiai gazdálkodásból
 it:Biologico, biologici, da agricoltura biologica
 ko:유기농
@@ -21391,7 +21394,7 @@ de:Enthält eine Phenylalaninquelle, Das produkt enthält eine Phenylalaninquell
 es:contiene una fuente de fenilalanina
 fi:Sisältää fenyylialaniinin lähteen
 fr:Contient une source de phénylalanine
-hr:sadrži izvor fenilalanina
+hr:sadrži izvor fenilalanina, izvor fenilalanina
 hu:fenilalanin-forrást tartalmaz
 it:Contiene una fonte di fenilalanina
 nb:Inneholder en fenylalaninkilde

--- a/taxonomies/other_nutritional_substances.txt
+++ b/taxonomies/other_nutritional_substances.txt
@@ -385,6 +385,7 @@ fr:inositol
 ga:Ionóisíotól
 gl:Inositol
 hi:इनोसिटॉल
+hr:inositol
 hu:Inozitol
 hy:Ինոզիտ
 id:Inositol

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -189,7 +189,7 @@ de:Provitamin A
 es:provitamina A
 fi:provitamiini A, A-vitamiinin provitamiini
 fr:pro-vitamine A, provitamine A
-hr:provitamina A
+hr:provitamina A, iz provitamina A
 hu:A-provitamin
 it:provitamina A
 nl:provitamine A

--- a/tests/unit/ingredients_processing.t
+++ b/tests/unit/ingredients_processing.t
@@ -1130,7 +1130,7 @@ my @tests = (
 			},
 			{
 				'id' => 'en:spinach',
-				'processing' => 'de:grob-gemahlen',
+				'processing' => 'en:coarsely-ground',
 				'text' => 'spinat'
 			},
 			{


### PR DESCRIPTION
### What

added Croatian ingredients into the taxonomies.


(remark: big block "en:chokeberry" has been deleted because it was duplicated in the taxonomy)