### PR TITLE
fix: remove forgotten JS marker in nutrition_facts_table.tt.html

### DIFF
--- a/templates/web/pages/product/includes/nutrition_facts_table.tt.html
+++ b/templates/web/pages/product/includes/nutrition_facts_table.tt.html
@@ -98,8 +98,6 @@ else {
 }
 );
 
-JS
-;	
 </initjs>	
 
 [% END %]


### PR DESCRIPTION
When we copy code from perl to the template we forgot to remove the end of content marker (JS).