### PR TITLE
docs: fix api ref url

### DIFF
--- a/docs/assets/api-rapidoc.html
+++ b/docs/assets/api-rapidoc.html
@@ -31,7 +31,7 @@
 </head>
 <body>
   <rapi-doc
-    spec-url="/docs/api/ref/api.yml"
+    spec-url="https://raw.githubusercontent.com/openfoodfacts/openfoodfacts-server/main/docs/api/ref/api.yml"
     render-style="focus"
     schema-expand-level="5"
     default-schema-tab="schema"


### PR DESCRIPTION
I did broke the API documentation because I changed the url to test it was working ok but did not restore URL afterwards...