### PR TITLE
ci: remove cron for Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - crowdin-trigger
-  schedule:
-  - cron: "0 2 * * *"
   
 jobs:         
   synchronize-with-crowdin:
-    name: Synchronize with crowdin
+    name: Synchronize with Crowdin
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
### What
ci: remove cron for Crowdin. The sync is now handled by Crowdin. CRON readds files at the root of crowdin in addition to the more organized sync made by crowdin