### PR TITLE
ci: concurrency on translation check workflow

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,9 +1,13 @@
 # .github/workflows/auto-author-assign.yml
-name: 'Auto Author Assign'
+name: 'Assign the author of a PR automatically'
 
 on:
   pull_request_target:
     types: [opened, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,9 @@
 name: Unit Test Coverage
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push]
 jobs:
   coverage:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 23 * * 4'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
     name: "CodeQL Analysis"

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -7,6 +7,10 @@ on:
       - deploy-*
     tags: 
       - v*.*.*
+      
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -5,9 +5,13 @@
 # file with configuration.  For more information, see:
 # https://github.com/actions/labeler
 
-name: Labeler
+name: Pull Request Labeler
 on:
 - pull_request_target
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   label:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,10 @@ on:
     #   - ".github/CODEOWNERS"
     #   - ".github/PULL_REQUEST_TEMPLATE.md"
     #   - ".editorconfig"
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
   
 jobs:
 

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths: ["**.po", "**.pot", ".github/workflows/translation-check.yml"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate translation files


### PR DESCRIPTION
### What
- ci: concurrency on translation check workflow
- What do we put concurrency on ? Everything ?
- Caveat: if you do a string of commits without waiting, you can't see where your code started failing.
- Note: When concurrency is specified at the job level, order is not guaranteed for jobs or runs that queue within 5 minutes of each other.
- See #8733 