### PR TITLE
fix: disable facets knowledge panels for crawlers

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4240,6 +4240,9 @@ HTML
 	}
 	# Rendering Page tags
 	my $tag_html;
+	# TODO: is_crawl_bot should be added directly by process_template(),
+	# but we would need to add a new $request_ref parameter to process_template(), will do later
+	$tag_template_data_ref->{is_crawl_bot} = $request_ref->{is_crawl_bot};
 	process_template('web/pages/tag/tag.tt.html', $tag_template_data_ref, \$tag_html)
 		or $tag_html = "<p>tag.tt.html template error: " . $tt->error() . "</p>";
 

--- a/templates/web/pages/tag/tag.tt.html
+++ b/templates/web/pages/tag/tag.tt.html
@@ -71,13 +71,14 @@
     
         <div class="large-6 column">
             [% IF tagid.defined %]
+                is_crawl_bot: [% is_crawl_bot %] --
+                [% IF facets_kp_url.defined && ! is_crawl_bot %]
                 <!-- injecting facet-knowledge-panel -->
                 <div id="facet-knowledge-panel" style="margin-left: 70px;">
                     <h2 id="facet_panels_title"></h2>
                     <div id="facet_panels_content"></div>
                 </div>
-                <!-- Fetching facet knowledge panel -->
-                [% IF facets_kp_url.defined %]
+                <!-- Fetching facet knowledge panel -->                
                 <script>
                         let facet_kp = "[% facets_kp_url %]";
                         let params = "?facet_tag=[% tagtype %]&value_tag=[% canon_tagid %]";

--- a/templates/web/pages/tag/tag.tt.html
+++ b/templates/web/pages/tag/tag.tt.html
@@ -71,7 +71,6 @@
     
         <div class="large-6 column">
             [% IF tagid.defined %]
-                is_crawl_bot: [% is_crawl_bot %] --
                 [% IF facets_kp_url.defined && ! is_crawl_bot %]
                 <!-- injecting facet-knowledge-panel -->
                 <div id="facet-knowledge-panel" style="margin-left: 70px;">

--- a/tests/integration/facet_page_crawler.t
+++ b/tests/integration/facet_page_crawler.t
@@ -29,6 +29,7 @@ my %product_form = (
 	(
 		code => '0200000000235',
 		product_name => "Only-Product",
+		categories => "cakes",
 	)
 );
 
@@ -40,7 +41,7 @@ my $tests_ref = [
 		test_case => 'normal-user-access-product-page',
 		method => 'GET',
 		path => '/product/0200000000235/only-product',
-		headers_in => {'User-Agent' => $CRAWLING_BOT_USER_AGENT},
+		headers_in => {'User-Agent' => $NORMAL_USER_USER_AGENT},
 		expected_status_code => 200,
 		expected_type => 'html',
 		response_content_must_match => '<title>Only-Product - 100 g</title>'
@@ -50,7 +51,7 @@ my $tests_ref = [
 		test_case => 'crawler-access-product-page',
 		method => 'GET',
 		path => '/product/0200000000235/only-product',
-		headers_in => {'User-Agent' => $NORMAL_USER_USER_AGENT},
+		headers_in => {'User-Agent' => $CRAWLING_BOT_USER_AGENT},
 		expected_status_code => 200,
 		expected_type => 'html',
 		response_content_must_match => '<title>Only-Product - 100 g</title>'
@@ -114,6 +115,26 @@ my $tests_ref = [
 		expected_status_code => 200,
 		expected_type => 'html',
 		response_content_must_match => 'Unknown user.'
+	},
+	# Normal user should get facet knowledge panels
+	{
+		test_case => 'normal-user-get-facet-knowledge-panels',
+		method => 'GET',
+		path => '/category/cakes',
+		headers_in => {'User-Agent' => $NORMAL_USER_USER_AGENT},
+		expected_status_code => 200,
+		expected_type => 'html',
+		response_content_must_match => 'Fetching facet knowledge panel'
+	},
+	# Crawling bot should have access to product page
+	{
+		test_case => 'crawler-does-not-get-facet-knowledge-panels',
+		method => 'GET',
+		path => '/category/cakes',
+		headers_in => {'User-Agent' => $CRAWLING_BOT_USER_AGENT},
+		expected_status_code => 200,
+		expected_type => 'html',
+		response_content_must_not_match => 'Fetching facet knowledge panel'
 	},
 ];
 


### PR DESCRIPTION
Related to https://github.com/openfoodfacts/facets-knowledge-panels/pull/123 : we don't want to load facets knowledge panels for crawlers.

In the future, we might want to disable other things for crawlers, this PR makes is_crawl_bot available to the template engine (only for tags right now, it should be added for all templates later)