### PR TITLE
fix: redirect for donner-a-open-food-facts

### DIFF
--- a/conf/nginx/snippets/off.locations-redirects.include
+++ b/conf/nginx/snippets/off.locations-redirects.include
@@ -8,6 +8,10 @@ location = /faire-un-don-a-open-food-facts {
 	try_files /donate/fr.helloasso.html =404;
 }
 
+location = /donner-a-open-food-facts {
+        try_files /donate/fr.helloasso.html =404;
+}
+
 # bg: даряване-на-openfoodfacts
 # ca: dona a openfoodfacts
 location = /darujte-openfoodfacts {


### PR DESCRIPTION
added a redirect for an url that is in the signup e-mail (and maybe elsewhere, not sure where it comes from)