### PR TITLE
feat: Timeout before calling autocomplete

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
 # For reference, please look at https://github.com/actions/labeler
 
+javascript:
+- '**/*.js'
+
 github_actions:
 - .github/**/*
 
@@ -743,6 +746,7 @@ unit tests:
 multilingual products:
 - cgi/product_jqm_multilingual.pl
 - cgi/product_multilingual.pl
+- html/js/product-multilingual.js
 
 file import:
 - cgi/import_file_process.pl

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -545,7 +545,7 @@ function initializeTagifyInput(el) {
 
     let abortController;
     let debounceTimer;
-    let timeoutWait = 300;
+    const timeoutWait = 300;
 
     input.on("input", function(event) {
         const value = event.detail.value;

--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -544,26 +544,33 @@ function initializeTagifyInput(el) {
     });
 
     let abortController;
+    let debounceTimer;
+    let timeoutWait = 300;
+
     input.on("input", function(event) {
         const value = event.detail.value;
         input.whitelist = null; // reset the whitelist
 
         if (el.dataset.autocomplete && el.dataset.autocomplete !== "") {
-            // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
-            if (abortController) {
-                abortController.abort();
-            }
+            clearTimeout(debounceTimer);
 
-            abortController = new AbortController();
+            debounceTimer = setTimeout(function(){
+                // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+                if (abortController) {
+                    abortController.abort();
+                }
 
-            fetch(el.dataset.autocomplete + "&string=" + value, {
-                signal: abortController.signal
-            }).
-            then((RES) => RES.json()).
-            then(function(json) {
-                input.whitelist = json.suggestions;
-                input.dropdown.show(value); // render the suggestions dropdown
-            });
+                abortController = new AbortController();
+
+                fetch(el.dataset.autocomplete + "&string=" + value, {
+                    signal: abortController.signal
+                }).
+                then((RES) => RES.json()).
+                then(function(json) {
+                    input.whitelist = json.suggestions;
+                    input.dropdown.show(value); // render the suggestions dropdown
+                });
+            }, timeoutWait);
         }
     });
 


### PR DESCRIPTION
### What

As users are writing into Tagified content that performs autocompletion, each letter typed will result in an immediate call to API.

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/1145001/c4ba362e-b30d-4ea4-b40e-f2b709a7b17d)

This amounts of requests and cancellations may overload the API service, which in turn cause that lookup takes long (+5 seconds to get response).

In order to improve this situation:
- Whenever the user types any letter, a `timeout` starts.
- If the user continues to write, the `timeout` will restart from beginning.
- If the `timeout` completes, the REST API call will be executed.

---

**NOTE:** This code is not tested. Feel free to make any additional changes required.

### Part of
- #8764 

