### PR TITLE
taxonomy: Add Japanese form variants for vitamins and additives

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -297,7 +297,7 @@ hr:E102, Tartrazin
 hu:E102, Tartrazin
 id:E102, Tartrazina
 it:E102, Tartrazina
-ja:E102, :タートラジン
+ja:E102, タートラジン
 ko:E102, 타트라진
 lt:E102, Tartrazinas
 lv:E102, Tartrazīns
@@ -3184,7 +3184,7 @@ hy:E170(i), Կալցիումի կարբոնատ
 id:E170(i), calsium carbonat
 is:E170(i), Kalsíumkarbónat
 it:E170(i), Carbonato di calcio, CI pigmento bianco 18
-ja:E170(i), 炭酸カルシウム
+ja:E170(i), 炭酸カルシウム, 炭酸Ca, 炭酸Ｃａ
 ko:E170(i), 탄산 칼슘
 ky:E170(i), Кальций карбонаты
 la:E170(i), Carbonatum calcii
@@ -3789,7 +3789,7 @@ hr:E202, kalijev sorbat
 hu:E202, Kálium-szorbát
 is:E202, Kalíumsorbat
 it:E202, Sorbato di potassio, potassio sorbato
-ja:E202, ソルビン酸カリウム
+ja:E202, ソルビン酸カリウム, ソルビン酸K, ソルビン酸Ｋ
 lt:E202, Kalio sorbatas
 lv:E202, Kālija sorbāts
 mt:E202, Sorbat tal-potassju
@@ -3859,7 +3859,7 @@ fi:E203, Kalsiumsorbaatti, Kalsiumsorbaattia
 fr:E203, Sorbate de calcium
 hu:E203, Kalcium-szorbát
 it:E203, Sorbato di calcio
-ja:E203, ソルビン酸カルシウム
+ja:E203, ソルビン酸カルシウム, ソルビン酸Ca, ソルビン酸Ｃａ
 lt:E203, Kalcio sorbatas
 lv:E203, Kalcija sorbāts
 mt:E203, Sorbat tal-kalċju
@@ -4361,7 +4361,7 @@ fr:E221, Sulfite de sodium, Sulfite de soude
 hu:E221, Nátrium-szulfit
 hy:E221, Նատրիումի սուլֆիտ
 it:E221, Solfito di sodio, Solfito sodico
-ja:E221, 亜硫酸ナトリウム
+ja:E221, 亜硫酸ナトリウム, 亜硫酸Na, 亜硫酸Ｎａ
 ky:E221, Натрий сульфити
 lt:E221, Natrio sulfitas
 lv:E221, Nātrija sulfīts
@@ -4484,7 +4484,7 @@ hu:E223, Nátrium-metabiszulfit, Piroszulfit
 hy:E223, Նատրիումի պիրոսուլֆիտ
 id:E223, Natrium metabisulfit
 it:E223, Metabisolfito di sodio, Pirosolfito
-ja:E223, ピロ亜硫酸ナトリウム
+ja:E223, ピロ亜硫酸ナトリウム, ピロ亜硫酸Na, ピロ亜硫酸Ｎａ
 lt:E223, Natrio metabisulfitas, Pirosulfitas
 lv:E223, Nātrija metabisulfīts, Pirosulfīts
 mt:E223, Metabisulfit tas-sodju, Pirosulfit
@@ -4538,7 +4538,7 @@ fr:E224, Disulfite de potassium, Métabisulfite de potassium, Pyrosulfite de pot
 hr:E224, kalijev metabisulfit
 hu:E224, Kálium-metabiszulfit
 it:E224, Metabisolfito di potassio, Pirosolfito di potassio, Disolfito di potassio, Potassio metabisolfito
-ja:E224, ピロ亜硫酸カリウム
+ja:E224, ピロ亜硫酸カリウム, 亜硫酸カリウム, 亜硫酸K, 亜硫酸Ｋ, 重亜硫酸カリウム, 重亜硫酸K, 重亜硫酸Ｋ
 lt:E224, Kalio metabisulfitas
 lv:E224, Kālija metabisulfīts
 mt:E224, Metabisulfit tal-potassju
@@ -5223,7 +5223,7 @@ hr:E250, natrijev nitrit, nitritna sol za salamurenje
 hu:E250, Nátrium-nitrit
 id:E250, natrium nitrit
 it:E250, Nitrito di sodio
-ja:E250, 亜硝酸ナトリウム, 亜硝酸Na
+ja:E250, 亜硝酸ナトリウム, 亜硝酸Na, 亜硝酸Ｎａ
 ko:E250, 아질산 나트륨
 ky:E250, Натрий нитрити
 lt:E250, Natrio nitritas
@@ -5306,7 +5306,7 @@ hu:E251, Nátrium-nitrát
 hy:E251, Նատրիումի նիտրատ
 id:E251, Natrium nitrat
 it:E251, Nitrato di sodio, Nitrato del Cile
-ja:E251, 硝酸ナトリウム
+ja:E251, 硝酸ナトリウム, 硝酸Na, 硝酸Ｎａ
 kk:E251, Натрий нитраты
 ko:E251, 질산 나트륨
 ky:E251, Натрий нитраты
@@ -5398,7 +5398,7 @@ id:E252, Kalium nitrat
 io:E252, Salpetro
 is:E252, Saltpétur
 it:E252, Nitrato di potassio, Salnitro, KNO3
-ja:E252, 硝酸カリウム
+ja:E252, 硝酸カリウム, 硝酸K, 硝酸Ｋ
 kk:E252, Калий селитрасы
 ko:E252, 질산 칼륨
 ky:E252, Калий нитраты
@@ -5631,7 +5631,7 @@ fr:E262, Acétates de sodium
 hr:E262, natrijevi acetati
 hu:E262, Nátrium-acetátok
 it:E262, acetati di sodio
-ja:E262, 酢酸ナトリウム, 酢酸Na
+ja:E262, 酢酸ナトリウム, 酢酸Na, 酢酸Ｎａ
 lt:E262, E262 food additive
 lv:E262, E262 food additive
 mt:E262, E262 food additive
@@ -5673,7 +5673,7 @@ hr:E262(i),Natrijev acetat
 hu:E262(i), Nátrium-acetát
 id:E262(i),Natrium asetat
 it:E262(i), Acetato di sodio
-ja:E262(i),酢酸ナトリウム
+ja:E262(i), 酢酸ナトリウム, 酢酸Na, 酢酸Ｎａ
 lt:E262(i), Natrio acetatas
 lv:E262(i), Nātrija acetāts
 mt:E262(i), Aċetat tas-sodju
@@ -5724,7 +5724,7 @@ fi:E262(ii), Natriumvetyasetaatti, Natriumvetyasetaattia
 fr:E262(ii), Diacétate de sodium
 hu:E262(ii), Nátrium-diacetát
 it:E262(ii), Diacetato di sodio
-ja:E262(ii),二酢酸ナトリウム
+ja:E262(ii), 二酢酸ナトリウム
 lt:E262(ii), Natrio diacetatas
 lv:E262(ii), Nātrija diacetāts
 mt:E262(ii), Diaċetat tas-sodju
@@ -5772,7 +5772,7 @@ hr:E263, kalcijev acetat
 hu:E263, Kalcium-acetát
 id:E263,Kalsium asetat
 it:E263, Acetato di calcio, (CH3COO)2Ca
-ja:E263,酢酸カルシウム
+ja:E263, 酢酸カルシウム, 酢酸Ca, 酢酸Ｃａ
 lt:E263, Kalcio acetatas
 lv:E263, Kalcija acetāts
 mt:E263, Aċetat tal-kalċju
@@ -6033,7 +6033,7 @@ hr:E281
 hu:E281, Nátrium-propionát
 hy:E281, Նատրիումի պրոպիոնատ
 it:E281, Propionato di sodio, Propionato di sodio
-ja:E281, プロピオン酸ナトリウム
+ja:E281, プロピオン酸ナトリウム, プロピオン酸Na, プロピオン酸Ｎａ
 lt:E281, Natrio propionatas, Natrio propionatas
 lv:E281, Nātrija propionāts, Nātrija propionāts
 mt:E281, Propjonat tas-sodju, Propjonat tas-sodju
@@ -7203,7 +7203,7 @@ fr:E316, érythorbate de sodium, isoascorbate de sodium
 hr:E316, natrijev izoaskorbat
 hu:E316, Nátrium-eritroaszkorbát
 it:E316, eritorbato di sodio
-ja:E316, エリソルビン酸ナトリウム
+ja:E316, エリソルビン酸ナトリウム, エリソルビン酸Na, エリソルビン酸Ｎａ, イソアスコルビン酸ナトリウム, イソアスコルビン酸Na, イソアスコルビン酸Ｎａ
 lt:E316, Natrio eritorbatas
 lv:E316, Nātrija eritorbāts
 mt:E316, Eritorbat tas-sodju
@@ -7587,7 +7587,7 @@ ga:E325, lachtaláit sóidiam
 hr:E325, natrijev laktilat, natrijev laktat
 hu:E325, Nátrium-laktát
 it:E325, lattato di sodio
-ja:E325, 乳酸ナトリウム, 乳酸Na
+ja:E325, 乳酸ナトリウム, 乳酸Na, 乳酸Ｎａ
 lt:E325, Natrio laktatas
 lv:E325, Nātrija laktāts
 mt:E325, Lattat tas-sodju
@@ -7641,7 +7641,7 @@ fr:E326, lactate de potassium
 hr:E326, kalijev laktat
 hu:E326, Kálium-laktát
 it:E326, lattato di potassio
-ja:E326, 乳酸カリウム
+ja:E326, 乳酸カリウム, 乳酸K, 乳酸Ｋ
 lt:E326, kalio laktatas
 lv:E326, kālija laktāts
 mt:E326, Lattat tal-potassju
@@ -7686,7 +7686,7 @@ fr:E327, lactate de calcium
 hr:E327, kalcijev laktat
 hu:E327, Kalcium-laktát
 it:E327, lattato di calcio
-ja:E327, 乳酸カルシウム
+ja:E327, 乳酸カルシウム, 乳酸Ca, 乳酸Ｃａ
 lt:E327, kalcio laktatas
 lv:E327, kalcija laktāts
 mt:E327, Lattat tal-kalċju
@@ -7993,7 +7993,7 @@ fr:E331(iii), Citrate trisodique
 hr:E331(iii), trinatrijev citrat
 hu:E331(iii), Trinátrium-citrát
 it:E331(iii), Citrato trisodico, citrato di trisodio
-ja:E331(iii), クエン酸三ナトリウム, クエン酸ナトリウム, クエン酸Na
+ja:E331(iii), クエン酸三ナトリウム, クエン酸ナトリウム, クエン酸Na, クエン酸Ｎａ
 nb:E331(iii), Trinatriumsitrat
 nl:E331(iii), trinatriumcitraat
 pl:E331(iii), Cytrynian trisodowy
@@ -8089,7 +8089,7 @@ fi:E332(ii), Trikaliumsitraatti, Trikaliumsitraattia, kaliumsitraatti
 fr:E332(ii), Citrate tripotassique, citratex de potassium
 hu:E332(ii), Trikálium-citrát, kálium-citrát
 it:E332(ii), Citrato tripotassico, citrato di potassio
-ja:E332(ii), クエン酸カリウム
+ja:E332(ii), クエン酸カリウム, クエン酸K, クエン酸Ｋ
 lt:E332(ii), Trikalio citratas, kalio citratas
 lv:E332(ii), Trikālija citrāts, kālija citrāts
 mt:E332(ii), Ċitrat tripotassiku, ċitrat tal-potassju
@@ -8487,7 +8487,7 @@ fi:E336(ii), Dikaliumtartraatti, Dikaliumtartraattia
 fr:E336(ii), Tartrate dipotassique
 hu:E336(ii), Dikálium-tartarát
 it:E336(ii), Tartrato dipotassico
-ja:E336(ii), 酒石酸カリウム
+ja:E336(ii), 酒石酸カリウム, 酒石酸K, 酒石酸Ｋ
 lt:E336(ii), Dikalio tartratas
 lv:E336(ii), Dikālija tartrāts
 mt:E336(ii), Tartrat dipotassiku
@@ -10226,7 +10226,7 @@ fr:E401, alginate de sodium
 hr:E401
 hu:E401, Nátrium-alginát
 it:E401, alginato di sodio, sodio alginato
-ja:E401, アルギン酸ナトリウム, アルギニン酸na
+ja:E401, アルギン酸ナトリウム, アルギン酸Na, アルギン酸Ｎａ
 lt:E401, Natrio alginatas
 lv:E401, Nātrija algināts
 mt:E401, Alġinat tas-sodju
@@ -12600,7 +12600,7 @@ fr:E450(i), Pyrophosphate de sodium acide, Pyrophosphate acide de sodium, Diphos
 hr:E450(i), E450i, dinatrijev difosfat
 hu:E450(i), Dinátrium-difoszfát
 it:E450(i), Difosfato disodico
-ja:E450(i), ピロリン酸ナトリウム
+ja:E450(i), ピロリン酸ナトリウム, ピロリン酸Na, ピロリン酸Ｎａ
 lt:E450(i), Dinatrio difosfatas
 lv:E450(i), Dinātrija difosfāts
 mt:E450(i), Difosfat disodiku, Difosfat didroġenat disodiku, Pirofosfat didroġenat disodiku, Pirofosfat tal-aċidu tas-sodju
@@ -14430,7 +14430,7 @@ ga:E481, lachtaláit stéiril sóidiam
 hr:E481, natrijev stearoil-2-laktilat
 hu:E481, Nátrium-sztearoil-2-laktilát, Nátrium-sztearoil-laktilát
 it:E481, Stearoil-2-lattilato di sodio, Stearoil-lattilato di sodio
-ja:E481, ステアロイル乳酸ナトリウム
+ja:E481, ステアロイル乳酸ナトリウム, ステアロイル乳酸Na, ステアロイル乳酸Ｎａ, ステアリル乳酸ナトリウム, ステアリル乳酸Na, ステアリル乳酸Ｎａ
 lt:E481, Natrio stearoil-2-laktilatas, Natrio stearoil-laktilatas
 lv:E481, Nātrija stearoil-2-laktilāts, Nātrija stearoillaktilāts
 mt:E481, Stearojl-2-lattilat tas-sodju, Lattilat stearojliku tas-sodju
@@ -15019,7 +15019,7 @@ hr:E500(i), Natrijev karbonat
 hu:E500(i), Nátrium-karbonát, szóda, sziksó, mosószóda, kalcinált szóda
 id:E500(i), Natrium karbonat
 it:E500(i), Carbonato di sodio, Carbonato di disodio, Carbonato sodico, Soda, Soda Solvay
-ja:E500(i), 炭酸ナトリウム
+ja:E500(i), 炭酸ナトリウム, 炭酸Na, 炭酸Ｎａ
 ko:E500(i), 탄산 나트륨
 lt:E500(i), Natrio karbonatas, Kalcinuota soda
 lv:E500(i), Nātrija karbonāts
@@ -15108,7 +15108,7 @@ ia:E500(ii), Bicarbonato de Sodium
 id:E500(ii), Natrium bikarbonat
 is:E500(ii), Matarsódi
 it:E500(ii), Carbonato acido di sodio, Bicarbonato di sodio, carbonato acido di sodio
-ja:E500(ii), 炭酸水素ナトリウム, 重曹
+ja:E500(ii), 炭酸水素ナトリウム, 炭酸水素Na, 炭酸水素Ｎａ, 重炭酸ナトリウム, 重炭酸Na, 重炭酸Ｎａ, 重曹
 kk:E500(ii), Ас содасы
 kn:E500(ii), ಸೋಡಿಯಂ ಬೈ ಕಾರ್ಬೋನೇಟ್
 ko:E500(ii), 탄산 수소 나트륨
@@ -15273,7 +15273,7 @@ id:E501(i), Potasium karbonat
 io:E501(i), Potaso
 is:E501(i), Pottaska
 it:E501(i), Carbonato di potassio, Potassa
-ja:E501(i), 炭酸カリウム
+ja:E501(i), 炭酸カリウム, 炭酸K, 炭酸Ｋ
 kk:E501(i), Сақар
 ko:E501(i), 탄산 칼륨
 ky:E501(i), Калий карбонаты
@@ -15606,7 +15606,7 @@ hi:E504(i), मैग्निसियम कार्बोनेट
 hr:E504(i), magnezijev karbonat
 hu:E504(i), Magnézium-karbonát
 it:E504(i), Carbonato di magnesio
-ja:E504(i), 炭酸マグネシウム
+ja:E504(i), 炭酸マグネシウム, 炭酸Mg, 炭酸Ｍｇ
 ky:E504(i), Магний карбонаты
 lt:E504(i), Magnio karbonatas
 lv:E504(i), Magnija karbonāts
@@ -15798,7 +15798,7 @@ hu:E509, Kalcium-klorid
 hy:E509, Կալցիումի քլորիդ
 id:E509, Kalsium klorida
 it:E509, Cloruro di calcio, CaCl2, Dicloruro di calcio, Calcio cloruro
-ja:E509, 塩化カルシウム, 塩化Ca
+ja:E509, 塩化カルシウム, 塩化Ca, 塩化Ｃａ
 ko:E509, 염화 칼슘
 ky:E509, Кальций хлориди
 lt:E509, Kalcio chloridas
@@ -16218,7 +16218,7 @@ hu:E516, Kalcium-szulfát, Gipsz, Szelenit
 hy:E516, Կալցիումի սուլֆատ
 id:E516, Kalsium sulfat
 it:E516, Solfato di calcio, Gesso, selenite, Gesso di Parigi, CaSO4
-ja:E516, 硫酸カルシウム
+ja:E516, 硫酸カルシウム, 硫酸Ca, 硫酸Ｃａ
 kk:E516, Кальций сульфаты
 ko:E516, 황산 칼슘
 ky:E516, Кальций сульфаты
@@ -16596,7 +16596,7 @@ hu:E525, Kálium-hidroxid
 hy:E525, Կալիումի հիդրօքսիդ
 id:E525, kalium hidroksida
 it:E525, Idrossido di potassio, potassa caustica
-ja:E525, 水酸化カリウム
+ja:E525, 水酸化カリウム, 水酸化K, 水酸化Ｋ
 ka:E525, კალიუმის ჰიდროქსიდი
 ko:E525, 수산화 칼륨
 ky:E525, Калий гидроксиди
@@ -16756,7 +16756,7 @@ hu:E529, Kalcium-oxid
 hy:E529, Կալցիումի օքսիդ
 id:E529, Kapur tohor
 it:E529, Ossido di calcio
-ja:E529, 酸化カルシウム
+ja:E529, 酸化カルシウム, 酸化Ca, 酸化Ｃａ
 kk:E529, Сөндірілмеген әк
 ko:E529, 생석회
 ky:E529, Кальций оксиди
@@ -16836,7 +16836,7 @@ hu:E530, Magnézium-oxid
 hy:E530, Մագնեզիումի օքսիդ
 id:E530, Magnesium oksida
 it:E530, Ossido di magnesio, magnesia
-ja:E530, 酸化マグネシウム
+ja:E530, 酸化マグネシウム, 酸化Mg, 酸化Ｍｇ
 ko:E530, 산화 마그네슘
 ky:E530, Магний оксиди
 lt:E530, Magnio oksidas
@@ -17778,7 +17778,7 @@ fi:E578, Kalsiumglukonaatti, Kalsiumglukonaattia
 fr:E578, Gluconate de calcium, Pentahydroxyéthanoate de calcium, Gluconate calcique
 hu:E578, kalcium-glükonát
 it:E578, gluconato di calcio
-ja:E578, グルコン酸カルシウム, グルコン酸ｃａ
+ja:E578, グルコン酸カルシウム, グルコン酸Ca, グルコン酸Ｃａ
 lt:E578, kalcio gliukonatas
 lv:E578, kalcija glikonāts
 mt:E578, glukonat tal-kalċju
@@ -18005,7 +18005,7 @@ hu:E621, Mononátrium-glutamát, Nátrium-glutamát
 id:E621, Mononatrium glutamat
 is:E621, MSG
 it:E621, Glutammato di monosodio, Glutammato di sodio, Glutammato monosodico, NaC5NO4H8
-ja:E621, グルタミン酸ナトリウム
+ja:E621, L-グルタミン酸ナトリウム, L-グルタミン酸Na, Ｌーグルタミン酸Ｎａ, グルタミン酸ナトリウム, グルタミン酸Na, グルタミン酸Ｎａ
 ko:E621, 글루탐산 나트륨
 lt:E621, Mononatrio glutamatas, Natrio glutamatas
 lv:E621, Mononātrija glutamāts, Nātrija glutamāts
@@ -18509,7 +18509,7 @@ fr:E635, 5'-ribonucléotide disodique, 5'-ribonucléotides disodiques, 5'-ribonu
 hr:E635, dinatrij 5'-ribonukleotidi, dinatrijevi 5'-ribonukleotidi
 hu:E635, Dinátrium-5'-ribonukleotid, dinátrium-5-ribonukleotid, dinátrium-5-ribonukleotidok
 it:E635, 5'ribonucleotide di disodio, disodio 5'-ribonucleotidi
-ja:E635, 5'-リボヌクレオチド二ナトリウム
+ja:E635, 5'-リボヌクレオチド二ナトリウム, リボヌクレオチドナトリウム, リボヌクレオチドNa, リボヌクレオチドＮａ, リボヌクレオタイドナトリウム, リボヌクレオタイドNa, リボヌクレオタイドＮａ
 lt:E635, Dinatrio 5'-ribonukleotidas
 lv:E635, Dinātrija 5'-ribonukleotīds
 mt:E635, 5'-ribonukleotid disodiku
@@ -21193,7 +21193,7 @@ hr:E950, acesulfam-K
 hu:E950, Aceszulfám k, Aceszulfám-kálium
 id:E950, Asesulfam
 it:E950, Acesulfame K, acesulfame potassico
-ja:E950, アセスルファムK
+ja:E950, アセスルファムカリウム, アセスルファムK, アセスルファムＫ
 lt:E950, Acesulfamas k, Acesulfamo kalis
 lv:E950, Acesulfāms k, Acesulfamkālijs
 mt:E950, Aċesulfam k, Aċesulfam tal-potassju

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -76,7 +76,7 @@ hu: Savanyúságot szabályozó anyag, Savanyúságot szabályozó anyagok, Sava
 id: pengatur keasaman
 is: Sýrustillir, Sýrustillar
 it: correttore di acidità, correttori di acidità, regolatore di acidità, regolatori di acidità, correttore d'acidità
-ja: pH調整剤, ｐｈ調整剤
+ja: pH調整剤, ｐＨ調整剤
 lt: Rūgštingumą reguliuojanti medžiaga
 lv: Skābuma regulētājs
 mt: Regolatur tal-Aċidità

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -23,7 +23,7 @@ fr:Vitamine A, vitamine Pro-A
 he:ויטמין A, רטינול
 hu:A-vitamin
 it:Vitamina A
-ja:ビタミン A, v-a
+ja:ビタミンA, ビタミンＡ, ビタミン A, ビタミン Ａ, V.A, Ｖ．Ａ, V-A, ＶーＡ
 lt:Vitaminas A
 lv:A vitamīns
 mt:Vitamina A
@@ -239,7 +239,7 @@ hy:Վիտամին D
 id:Vitamin D
 is:D-vítamín
 it:vitamina D
-ja:ビタミンD, ｖ．ｄ, v-d, ビタミン D
+ja:ビタミンD, ビタミンＤ, ビタミン D, ビタミン Ｄ, V.D, Ｖ．Ｄ, V-D, ＶーＤ
 ka:ვიტამინი D
 ko:비타민 D
 ky:Кальциферол
@@ -323,7 +323,7 @@ fr:ergocalciférol, vitamine D2
 hi:एर्गोकैल्सिफेरॉल
 hu:D2-vitamin, Ergokalciferol, D2
 it:Ergocalciferolo, Vitamina D2
-ja:エルゴカルシフェロール
+ja:エルゴカルシフェロール, ビタミンD2, ビタミンＤ２, ビタミン D2, ビタミン Ｄ２, V.D2, Ｖ．Ｄ２, V.D₂, V-D2, ＶーＤ２, V-D₂
 lt:ergokalciferolis
 lv:ergokalciferols
 mt:ergokalċiferol
@@ -381,7 +381,7 @@ hi:कॉलेकैल्सिफेरॉल
 hr:Vitamin D3, kolekalciferol
 hu:D3-vitamin, Kolekalciferol, D3
 it:Colecalciferolo, Vitamina D3
-ja:ビタミンD3
+ja:ビタミンD3, ビタミンＤ３, ビタミン D3, ビタミン Ｄ３, V.D3, Ｖ．Ｄ３, V.D₃, V-D3, ＶーＤ３, V-D₃
 ka:ვიტამინი D3
 ko:비타민 D3
 lt:Vitaminas D3, cholekalciferolis
@@ -463,7 +463,7 @@ hu:E-vitamin, Tokoferol
 hy:Վիտամին E
 id:Vitamin E
 it:Vitamina E
-ja:ビタミン E, ビタミンE, ビタミンｅ, ビタミンe, v-e
+ja:ビタミンE, ビタミンＥ, ビタミン E, ビタミン Ｅ, V.E, Ｖ．Ｅ, V-E, ＶーＥ
 jv:Vitamin E
 ka:ვიტამინი E
 kk:Е дәрумені
@@ -644,7 +644,7 @@ fi:K-vitamiini
 fr:Vitamine K
 hu:K-vitamin
 it:Vitamina K
-ja:ビタミン K
+ja:ビタミンK, ビタミンＫ, ビタミン K, ビタミン Ｋ, V.K, Ｖ．Ｋ, V-K, ＶーＫ
 lt:Vitaminas K
 lv:K vitamīns
 mt:Vitamina K
@@ -671,7 +671,7 @@ fi:fyllokinoni, fytomenadioni, K1-vitamiini
 fr:phylloquinone, phytoménadione, phytonadione, Vitamine K1, K1
 hu:fillokinon, fitomenadion, K1-vitamin
 it:fillochinone, fitomenadione, vitamina K1
-ja:フィロキノン
+ja:フィロキノン, ビタミンK1, ビタミンＫ１, ビタミン K1, ビタミン Ｋ１, V.K1, Ｖ．Ｋ１, V.K₁, V-K1, ＶーＫ１, V-K₁
 ko:필로퀴논
 ky:Филлохинон
 lt:filochinonas, fitomenadionas
@@ -708,6 +708,7 @@ fi:menakinoni
 fr:ménaquinone, Vitamine K2
 hu:menakinon
 it:menachinone
+ja:ビタミンK2, ビタミンＫ２, ビタミン K2, ビタミン Ｋ２, V.K2, Ｖ．Ｋ２, V.K₂, V-K2, ＶーＫ２, V-K₂
 lt:menachinonas
 lv:menahinons
 mt:menakinona
@@ -732,7 +733,7 @@ ga:Vitimín K3
 he:ויטמין K3, מנדיון
 hu:K3-vitamin
 it:Vitamina K3
-ja:ビタミン K3
+ja:ビタミンK3, ビタミンＫ３, ビタミン K3, ビタミン Ｋ３, V.K3, Ｖ．Ｋ３, V.K₃, V-K3, ＶーＫ３, V-K₃
 lt:Vitaminas K3
 lv:K3 vitamīns
 mt:Vitamina K3
@@ -776,7 +777,7 @@ hy:Վիտամին C
 id:Vitamin C
 is:C-vítamín
 it:vitamina C
-ja:ビタミンC, ｖ．ｃ, v-c, ビタミンｃ
+ja:ビタミンC, ビタミンＣ, ビタミン C, ビタミン Ｃ, V.C, Ｖ．Ｃ, V-C, ＶーＣ
 jv:Vitamin C
 ka:vitamine c
 kn:C ಜೀವ ಸತ್ವ
@@ -853,6 +854,7 @@ gl:Ácido ascórbico
 hr:L-askorbinska kiselina, askorbinska kiselina
 hu:L-aszkorbinsav, aszkorbinsav
 it:acido L-Ascorbico, acido Ascorbico
+ja:L-アスコルビン酸, アスコルビン酸
 lt:L–askorbo rūgštis, askorbo rūgštis
 lv:L-askorbīnskābe, askorbīnskābe
 mt:L-aċidu askorbiku, aċidu askorbiku
@@ -995,7 +997,7 @@ hy:Թիամին, Վիտամին B1
 id:Tiamina, Vitamin B1
 is:Þíamín, B1-vítamín
 it:tiamina, vitamina B1
-ja:チアミン, ビタミンB1, ビタミン B1, V.B1, ｖ．ｂ１, v-b₁, ビタミンｂ１
+ja:チアミン, ビタミンB1, ビタミンＢ１, ビタミン B1, ビタミン Ｂ１, V.B1, Ｖ．Ｂ１, V.B₁, V-B1, ＶーＢ１, V-B₁
 ko:티아민, 바이타민 B1
 ky:Витамин В1
 lb:Thiamin, Vitamin B1
@@ -1105,7 +1107,7 @@ fi:Riboflaviini
 fr:Riboflavine, Vitamine B2
 hu:Riboflavin, B2-vitamin
 it:Riboflavina
-ja:リボフラビン, ビタミンB2, V.B2, v-b₂, ビタミンｂ２
+ja:リボフラビン, ビタミンB2, ビタミンＢ２, ビタミン B2, ビタミン Ｂ２, V.B2, Ｖ．Ｂ２, V.B₂, V-B2, ＶーＢ２, V-B₂
 lt:Riboflavinas
 lv:Riboflavīns
 nl:Riboflavine
@@ -1123,7 +1125,7 @@ fr:Niacine, Vitamine B3, Vitamine PP
 hr:niacin, Vitamin B3, nijacin
 hu:Niacin, B3-vitamin, PP-vitamin
 it:Niacina
-ja:ナイアシン
+ja:ナイアシン, ビタミンB3, ビタミンＢ３, ビタミン B3, ビタミン Ｂ３, V.B3, Ｖ．Ｂ３, V.B₃, V-B3, ＶーＢ３, V-B₃
 lt:Niacinas
 lv:Niacīns
 mt:Niaċina
@@ -1190,7 +1192,7 @@ fr:Vitamine B6, Pyridoxine
 hr:vitamin B6, B6
 hu:B6-vitamin, piridoxin
 it:Vitamina B6, piridoxina
-ja:ｖ．ｂ６, v-b6, v-b₆
+ja:ビタミンB6, ビタミンＢ６, ビタミン B6, ビタミン Ｂ６, V.B6, Ｖ．Ｂ６, V.B₆, V-B6, ＶーＢ６, V-B₆
 lt:Vitaminas B6
 lv:B6 vitamīns
 mt:Vitamina B6
@@ -1308,7 +1310,7 @@ hy:Վիտամին B9
 id:Asam folat
 is:Fólínsýra
 it:acido folico, acido pteroil-monoglutammico, Vitamina B9
-ja:葉酸, B9
+ja:葉酸, ビタミンB9, ビタミンＢ９, ビタミン B9, ビタミン Ｂ９, V.B9, Ｖ．Ｂ９, V.B₉, V-B9, ＶーＢ９, V-B₉
 kk:Птероилглютамин
 ko:엽산
 ky:Фоли кычкылы
@@ -1420,7 +1422,7 @@ hy:Վիտամին B12
 id:Vitamin B12
 is:B12-vítamín
 it:Cobalamina, vitamina B12
-ja:シアノコバラミン, ビタミン B12, v-b12, v-b₁₂, ビタミンb12
+ja:シアノコバラミン, ビタミンB12, ビタミンＢ１２, ビタミン B12, ビタミン Ｂ１２, V.B12, Ｖ．Ｂ１２, V.B₁₂, V-B12, ＶーＢ１２, V-B₁₂
 jv:Vitamin b12
 kk:Кобаламин
 ko:비타민 B12
@@ -1552,6 +1554,7 @@ fi:B8-vitamiini, B8
 fr:vitamine b8, b8
 hu:B8-vitamin, B8
 it:vitamina b8, B8
+ja:ビタミンＢ８, ビタミン B8, ビタミン Ｂ８, V.B8, Ｖ．Ｂ８, V.B₈, V-B8, ＶーＢ８, V-B₈
 nl:vitamine b8, B8
 pl:witamina B8, B8
 # ingredient/vitamin-b8 has 35 products in 3 languages @2018-11-24
@@ -1569,6 +1572,7 @@ fr:Acide pantothénique, Vitamine B5
 hr:vitamin B5
 hu:Panoténsav, B5-vitamin
 it:Acido pantotenico
+ja:パントテン酸, ビタミンＢ５, ビタミン B5, ビタミン Ｂ５, V.B5, Ｖ．Ｂ５, V.B₅, V-B5, ＶーＢ５, V-B₅
 lt:Pantoteno rūgštis
 lv:Pantotēn-skābe
 mt:Aċidu Pantoteniku


### PR DESCRIPTION
### What

#8752 added variants of Japanese translations of vitamins and additives, mainly with short forms and full/half-width variations. This PR expands on that.

Used [this document](https://www.hokeniryo.metro.tokyo.lg.jp/shokuhin//hyouji/files/tsuuchi-additives.pdf) as a reference to decide which ones to expand and by how.