### PR TITLE
fix: don't save object in memcached above allowed size 

### DIFF
--- a/lib/ProductOpener/Cache.pm
+++ b/lib/ProductOpener/Cache.pm
@@ -27,6 +27,7 @@ BEGIN {
 	use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
 		$memd
+		$max_memcached_object_size
 		&generate_cache_key
 	);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
@@ -52,6 +53,9 @@ $memd = Cache::Memcached::Fast->new(
 	}
 );
 
+# Maximum object size that we can store in memcached
+$max_memcached_object_size = 1048576;
+
 my $json = JSON->new->utf8->allow_nonref->canonical;
 
 =head1 FUNCTIONS
@@ -59,7 +63,7 @@ my $json = JSON->new->utf8->allow_nonref->canonical;
 =head2  generate_cache_key($name, $context_ref)
 
 Generate a key to use for caching, that depends on the content of the $context_ref object.
-The key is prependend by the name of the variable we want to store, so that we can set multiple variables for the same context
+The key is prepended by the name of the variable we want to store, so that we can set multiple variables for the same context
 (e.g. a count of search results + the search results themselves)
 
 =head3 Arguments

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1177,17 +1177,6 @@ sub display_text ($request_ref) {
 		return $html;
 	};
 
-	my $replace_query = sub ($query) {
-
-		my $query_ref = decode_json($query);
-		my $sort_by = undef;
-		if (defined $query_ref->{sort_by}) {
-			$sort_by = $query_ref->{sort_by};
-			delete $query_ref->{sort_by};
-		}
-		return search_and_display_products({}, $query_ref, $sort_by, undef, undef);
-	};
-
 	if ($file =~ /\/index-pro/) {
 		# On the producers platform, display products only if the owner is logged in
 		# and has an associated org or is a moderator
@@ -1200,8 +1189,6 @@ sub display_text ($request_ref) {
 		# Display all products
 		$html .= search_and_display_products($request_ref, {}, "last_modified_t_complete_first", undef, undef);
 	}
-
-	$html =~ s/\[\[query:(.*?)\]\]/$replace_query->($1)/eg;
 
 	# Replace included texts
 	$html =~ s/\[\[(.*?)\]\]/$replace_file->($1)/eg;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1374,8 +1374,8 @@ sub set_cache_results ($key, $results) {
 	$log->debug("Setting value for MongoDB query key", {key => $key}) if $log->is_debug();
 	my $result_size = total_size($results);
 
-	# memcached max object size is 1 048 576 bytes
-	if ($result_size >= 1048576) {
+	# $max_memcached_object_size is defined is Cache.pm
+	if ($result_size >= $max_memcached_object_size) {
 		$mongodb_log->info(
 			"set_cache_results - skipping - setting value - key: $key (total_size: $result_size > max size)");
 		return;

--- a/stop_words.txt
+++ b/stop_words.txt
@@ -223,5 +223,6 @@ weighers
 www
 xml
 gzipped
+webpage
 webpages
 bing


### PR DESCRIPTION
First PR to fix memcached caching error investigated in #8792. It doesn't solve the caching issue, but at least we're not trying to save a 30MB blob in memcached anymore.
It turns out this saving attempt was very costly, with this PR the main webpage loads in 600-1000ms (instead of 1500-2000s), it's deployed and can be tried on https://openfoodfacts.net.