### PR TITLE
fix: link to register for the OFF days

### DIFF
--- a/templates/web/common/includes/offdays_banner.tt.html
+++ b/templates/web/common/includes/offdays_banner.tt.html
@@ -22,10 +22,10 @@
     <p class="offdays-banner__content-paragraphs--text">
         [% IF lc == "fr" %]
             Les <b>Journées Open Food Facts 2023</b>, auront lieu en octobre à Paris !
-            On vous y attend, <a href="https://blog.openfoodfacts.org/fr/news/rendez-vous-en-octobre-pour-les-journees-open-food-facts">INSCRIVEZ-VOUS ICI</a>
+            On vous y attend, <a href="https://connect.openfoodfacts.org/fr/event/les-journees-open-food-facts-2023-9/register">INSCRIVEZ-VOUS ICI</a>
         [% ELSE %]
             Our annual community event <b>Open Food Facts Days 2023</b> will take place this October in Paris!
-            To be a part of it, <a href=""https://blog.openfoodfacts.org/en/news/open-food-facts-days-are-back-%f0%9f%8e%89-2023-edition">REGISTER HERE</a>            
+            To be a part of it, <a href="https://connect.openfoodfacts.org/event/open-food-fact-days-2023-9/register">REGISTER HERE</a>            
         [% END %]
     </p>
   </div>


### PR DESCRIPTION
Have the button link to the register form instead of the blog post