### PR TITLE
fix: fix and speed up CSV export

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -161,6 +161,10 @@ BEGIN {
 
 		&cmp_taxonomy_tags_alphabetically
 
+		&cached_display_taxonomy_tag
+		$cached_display_taxonomy_tag_calls
+		$cached_display_taxonomy_tag_misses
+
 	);    # symbols to export on request
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
@@ -3850,6 +3854,45 @@ sub exists_taxonomy_tag ($tagtype, $tagid) {
 			and (exists $translations_from{$tagtype}{$tagid})
 			and not((exists $just_synonyms{$tagtype}) and (exists $just_synonyms{$tagtype}{$tagid})));
 }
+
+
+=head2 cached_display_taxonomy_tag ( $target_lc, $tagtype, $canon_tagid )
+
+Return the name of a tag for displaying it to the user.
+This function builds a cache of the resulting names, in order to reduce execution time.
+The cache is an evergrowing hash of input parameters.
+This function should only be used in batch scripts, and not in code called from the Apache mod_perl processes.
+
+=head3 Arguments
+
+=head4 $target_lc - target language code
+
+=head4 $tagtype
+
+=head4 $canon_tagid
+
+=head3 Return values
+
+The tag translation if it exists in target language,
+otherwise, the tag id.
+
+=cut
+
+my %cached_display_taxonomy_tags = ();
+$cached_display_taxonomy_tag_calls = 0;
+$cached_display_taxonomy_tag_misses = 0;
+
+sub cached_display_taxonomy_tag ($target_lc, $tagtype, $tag) {
+	$cached_display_taxonomy_tag_calls++;
+	my $key = $target_lc . ':' . $tagtype . ':' . $tag;
+	return $cached_display_taxonomy_tags{$key} if exists $cached_display_taxonomy_tags{$key};
+
+	$cached_display_taxonomy_tag_misses++;
+	my $value = display_taxonomy_tag($target_lc, $tagtype, $tag);
+	$cached_display_taxonomy_tags{$key} = $value;
+	return $value;
+}
+
 
 =head2 display_taxonomy_tag ( $target_lc, $tagtype, $canon_tagid )
 

--- a/scripts/export_database.pl
+++ b/scripts/export_database.pl
@@ -124,6 +124,7 @@ foreach my $field (@export_fields) {
 	}
 }
 
+$fields_ref->{empty} = 1;
 $fields_ref->{nutriments} = 1;
 $fields_ref->{ingredients} = 1;
 $fields_ref->{images} = 1;
@@ -280,16 +281,18 @@ XML
 
 		# 300 000 ms timeout so that we can export the whole database
 		# 5mins is not enough, 50k docs were exported
-		my $cursor = $collection->query(
-			{
-				'code' => {"\$ne" => ""},
-				'empty' => {"\$ne" => 1}
-			}
-		)->fields($fields_ref)->sort({code => 1});
+		# Removed sort({code => 1} in order to speed up the MongoDB query and not run into the error
+		# "MongoDB::DatabaseError: Executor error during find command :: caused by :: Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting."
+		my $cursor = $collection->query()->fields($fields_ref);
 
 		$cursor->immortal(1);
 
 		while (my $product_ref = $cursor->next) {
+
+			# Skip empty products and products without code
+			# We filter them here instead of in the query
+			next if not $product_ref->{code};
+			next if $product_ref->{empty};
 
 			my $csv = '';
 			my $url = "http://world-$lc.$server_domain" . product_url($product_ref);
@@ -374,7 +377,7 @@ XML
 					if (defined $product_ref->{$field . '_tags'}) {
 						$csv
 							.= join(',',
-							map {display_taxonomy_tag($lc, $field, $_)} @{$product_ref->{$field . '_tags'}})
+							map {cached_display_taxonomy_tag($lc, $field, $_)} @{$product_ref->{$field . '_tags'}})
 							. "\t";
 					}
 					else {
@@ -412,7 +415,7 @@ XML
 				$main_cid = $product_ref->{categories_tags}[(scalar @{$product_ref->{categories_tags}}) - 1];
 
 				$main_cid = canonicalize_tag2("categories", $main_cid);
-				$main_cid_lc = display_taxonomy_tag($lc, 'categories', $main_cid);
+				$main_cid_lc = cached_display_taxonomy_tag($lc, 'categories', $main_cid);
 			}
 
 			$csv .= $main_cid . "\t";
@@ -518,14 +521,17 @@ XML
 
 	# only overwrite previous dump if the new one is bigger, to reduce failed runs breaking the dump.
 	my $csv_size_old = (-s $csv_filename) // 0;
-	my $csv_size_new = (-s "$csv_filename.temp") // 0;
+	# Sort lines by code, except header line
+	system("(head -1 $csv_filename.temp && tail -n +2 $csv_filename.temp | sort) > $csv_filename.temp2");
+	unlink "$csv_filename.temp";
+	my $csv_size_new = (-s "$csv_filename.temp2") // 0;
 	if ($csv_size_new >= $csv_size_old * 0.99) {
 		unlink $csv_filename;
-		rename "$csv_filename.temp", $csv_filename;
+		rename "$csv_filename.temp2", $csv_filename;
 	}
 	else {
 		print STDERR "Not overwriting previous CSV. Old size = $csv_size_old, new size = $csv_size_new.\n";
-		unlink "$csv_filename.temp";
+		unlink "$csv_filename.temp2";
 	}
 
 	my %links = ();
@@ -586,5 +592,8 @@ XML
 	}
 
 }
+
+print "cached_display_taxonomy_tag_calls: $cached_display_taxonomy_tag_calls\n";
+print "cached_display_taxonomy_tag_misses: $cached_display_taxonomy_tag_misses\n";
 
 exit(0);


### PR DESCRIPTION
- Removed the MongoDB sort, to avoid running into the https://github.com/openfoodfacts/openfoodfacts-infrastructure/issues/246 issue: "MongoDB::DatabaseError: Executor error during find command :: caused by :: Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting."

The sort is now done after the CSV file is generated.

- Profiled export_database.pl to try to speed it up. The largest amount if time was spent in get_string_id_for_lang() (mostly called by display_taxonomy_tag) :

(all numbers below on a small database of 12K products)



Calls | P | F | ExclusiveTime | InclusiveTime | Subroutine
-- | -- | -- | -- | -- | --
892196 | 19 | 9 | 7.51s | 9.86s | ProductOpener::Store::get_string_id_for_lang
745106 | 3 | 2 | 5.28s | 13.7s | ProductOpener::Tags::display_taxonomy_tag
250 | 1 | 1 | 4.99s | 4.99s | BSON::XS::_decode_bson (xsub)
4607286 | 7 | 1 | 2.77s | 2.77s | main::CORE:match (opcode)
24692 | 1 | 1 | 1.92s | 1.92s | ProductOpener::Tags::get_all_taxonomy_entries

The display_taxonomy_tag() calls are used to translates values of fields like categories_tags in their English and French names. There are lots of repeated values, so we can try caching them.

Added a cached_display_taxonomy_tag() function in Tags.pm to keep a cache (simple hash).

After:

Calls | P | F | ExclusiveTime | InclusiveTime | Subroutine
-- | -- | -- | -- | -- | --
249 | 1 | 1 | 5.22s | 5.22s | BSON::XS::_decode_bson (xsub)
4607286 | 7 | 1 | 2.73s | 2.73s | main::CORE:match (opcode)
24692 | 1 | 1 | 1.80s | 1.80s | ProductOpener::Tags::get_all_taxonomy_entries
164748 | 19 | 9 | 1.52s | 2.13s | ProductOpener::Store::get_string_id_for_lang

Typical runs:

Before:

--- not cached:

real	0m30.468s
user	0m28.947s
sys	0m1.093s

real	0m31.633s
user	0m30.102s
sys	0m1.101s

real	0m32.819s
user	0m31.207s
sys	0m1.173s

After:

--- cached:

cached_display_taxonomy_tag_calls: 742838
cached_display_taxonomy_tag_misses: 15390

real	0m26.765s
user	0m25.185s
sys	0m1.158s

real	0m28.247s
user	0m26.808s
sys	0m1.012s

real	0m25.590s
user	0m24.114s
sys	0m1.068s
