### PR TITLE
feat: parsing of ingredients with quantity in various units

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2720,8 +2720,6 @@ sub init_percent_values ($total_min, $total_max, $ingredients_ref) {
 
 	# Determine if percent listed are absolute (default) or relative to a parent ingredient
 
-	
-
 	# Check if all ingredients have a set quantity
 	# and compute the sum of all percents and quantities
 
@@ -2755,15 +2753,15 @@ sub init_percent_values ($total_min, $total_max, $ingredients_ref) {
 
 	if (($total_min == $total_max) and $all_ingredients_have_a_set_percent) {
 		$percent_mode = "scale_percents";
-	}	
+	}
 	elsif (($total_min == $total_max) and $all_ingredients_have_a_set_quantity) {
 		$percent_mode = "scale_grams";
 	}
 	elsif ($percent_sum > $total_max) {
-		$percent_mode = "relative";	# percents are relative to the parent ingredient
+		$percent_mode = "relative";    # percents are relative to the parent ingredient
 	}
 	else {
-		$percent_mode = "absolute";	# percents are absolute (relative to the whole product)
+		$percent_mode = "absolute";    # percents are absolute (relative to the whole product)
 	}
 
 	$log->debug(
@@ -2783,7 +2781,9 @@ sub init_percent_values ($total_min, $total_max, $ingredients_ref) {
 	# Go through each ingredient to set percent_min, percent_max, and if we can an absolute percent
 
 	foreach my $ingredient_ref (@{$ingredients_ref}) {
-		if (((defined $ingredient_ref->{percent}) and ($ingredient_ref->{percent} > 0)) or ($percent_mode eq "scale_grams")) {
+		if (   ((defined $ingredient_ref->{percent}) and ($ingredient_ref->{percent} > 0))
+			or ($percent_mode eq "scale_grams"))
+		{
 			# There is a specified percent for the ingredient (or we can derive it from grams)
 
 			if ($percent_mode eq "scale_percents") {

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-ingredients-categories-to-get-nutriscore.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-ingredients-categories-to-get-nutriscore.json
@@ -39,6 +39,8 @@
             "percent_estimate" : 75,
             "percent_max" : 75,
             "percent_min" : 75,
+            "quantity" : "300 g",
+            "quantity_g" : 300,
             "text" : "Sucre",
             "vegan" : "yes",
             "vegetarian" : "yes"
@@ -50,6 +52,8 @@
             "percent_estimate" : 25,
             "percent_max" : 25,
             "percent_min" : 25,
+            "quantity" : "100 g",
+            "quantity_g" : 100,
             "text" : "pommes",
             "vegan" : "yes",
             "vegetarian" : "yes"

--- a/tests/unit/expected_test_results/ingredients/en-specific-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/en-specific-ingredients.json
@@ -93,7 +93,8 @@
       {
          "id" : "en:milk",
          "ingredient" : "milk",
-         "percent" : 75.2,
+         "quantity" : "75.2 g",
+         "quantity_g" : 75.2,
          "text" : "Total milk content: 75.2g"
       }
    ],

--- a/tests/unit/expected_test_results/ingredients/fr-specific-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/fr-specific-ingredients.json
@@ -121,7 +121,8 @@
       {
          "id" : "en:fruit",
          "ingredient" : "fruits",
-         "percent" : 50,
+         "quantity" : "50 g",
+         "quantity_g" : 50,
          "text" : "Préparée avec 50 g de fruits pour 100g de produit fini."
       },
       {
@@ -145,7 +146,8 @@
       {
          "id" : "en:sugar",
          "ingredient" : "sucres",
-         "percent" : 60,
+         "quantity" : "60 g",
+         "quantity_g" : 60,
          "text" : "Teneur totale en sucres : 60 g pour 100 g de produit fini."
       },
       {
@@ -157,7 +159,8 @@
       {
          "id" : "en:fruit-juice",
          "ingredient" : "jus de fruits",
-         "percent" : 35,
+         "quantity" : "35 g",
+         "quantity_g" : 35,
          "text" : "Teneur minimum en jus de fruits 35 g pour 100 g de produit fini."
       },
       {

--- a/tests/unit/expected_test_results/ingredients_percent/2-ingredients-with-max-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/2-ingredients-with-max-percent.json
@@ -1,0 +1,23 @@
+[
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 95,
+      "percent_max" : 100,
+      "percent_min" : 90,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:lemon-flavouring",
+      "percent_estimate" : 2.5,
+      "percent_max" : "5",
+      "percent_min" : 0,
+      "text" : "lemon flavouring"
+   },
+   {
+      "id" : "en:orange-flavouring",
+      "percent_estimate" : 2.5,
+      "percent_max" : "5",
+      "percent_min" : 0,
+      "text" : "orange flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/absolute-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/absolute-percent.json
@@ -1,0 +1,49 @@
+[
+   {
+      "id" : "en:fruit",
+      "ingredients" : [
+         {
+            "id" : "en:apple",
+            "percent" : 20,
+            "percent_estimate" : 20,
+            "percent_max" : 20,
+            "percent_min" : 20,
+            "text" : "apple"
+         },
+         {
+            "id" : "en:pear",
+            "percent" : 15,
+            "percent_estimate" : 15,
+            "percent_max" : 15,
+            "percent_min" : 15,
+            "text" : "pear"
+         },
+         {
+            "id" : "en:cranberry",
+            "percent_estimate" : 11.25,
+            "percent_max" : 15,
+            "percent_min" : 7.5,
+            "text" : "cranberry"
+         },
+         {
+            "id" : "en:lemon",
+            "percent_estimate" : 3.75,
+            "percent_max" : 7.5,
+            "percent_min" : 0,
+            "text" : "lemon"
+         }
+      ],
+      "percent" : 50,
+      "percent_estimate" : 50,
+      "percent_max" : 50,
+      "percent_min" : 50,
+      "text" : "fruits"
+   },
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 50,
+      "percent_max" : 50,
+      "percent_min" : 50,
+      "text" : "sugar"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/chocolate-1-sub-ingredient.json
+++ b/tests/unit/expected_test_results/ingredients_percent/chocolate-1-sub-ingredient.json
@@ -1,0 +1,18 @@
+[
+   {
+      "id" : "en:chocolate",
+      "ingredients" : [
+         {
+            "id" : "en:cocoa",
+            "percent_estimate" : 100,
+            "percent_max" : 100,
+            "percent_min" : 100,
+            "text" : "cocoa"
+         }
+      ],
+      "percent_estimate" : 100,
+      "percent_max" : 100,
+      "percent_min" : 100,
+      "text" : "chocolate"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/chocolate-2-sub-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients_percent/chocolate-2-sub-ingredients.json
@@ -1,0 +1,32 @@
+[
+   {
+      "id" : "en:chocolate",
+      "ingredients" : [
+         {
+            "id" : "en:cocoa",
+            "percent_estimate" : 50,
+            "percent_max" : 100,
+            "percent_min" : 25,
+            "text" : "cocoa"
+         },
+         {
+            "id" : "en:sugar",
+            "percent_estimate" : 25,
+            "percent_max" : 50,
+            "percent_min" : 0,
+            "text" : "sugar"
+         }
+      ],
+      "percent_estimate" : 75,
+      "percent_max" : 100,
+      "percent_min" : 50,
+      "text" : "chocolate"
+   },
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 25,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "text" : "milk"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/chocolate-sub-sub-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients_percent/chocolate-sub-sub-ingredients.json
@@ -1,0 +1,42 @@
+[
+   {
+      "id" : "en:chocolate",
+      "ingredients" : [
+         {
+            "id" : "en:cocoa",
+            "ingredients" : [
+               {
+                  "id" : "en:cocoa-paste",
+                  "percent" : 70,
+                  "percent_estimate" : 70,
+                  "percent_max" : 70,
+                  "percent_min" : 70,
+                  "text" : "cocoa paste"
+               },
+               {
+                  "id" : "en:cocoa-butter",
+                  "percent_estimate" : 15,
+                  "percent_max" : 30,
+                  "percent_min" : 0,
+                  "text" : "cocoa butter"
+               }
+            ],
+            "percent_estimate" : 85,
+            "percent_max" : 100,
+            "percent_min" : 70,
+            "text" : "cocoa"
+         },
+         {
+            "id" : "en:sugar",
+            "percent_estimate" : 15,
+            "percent_max" : 30,
+            "percent_min" : 0,
+            "text" : "sugar"
+         }
+      ],
+      "percent_estimate" : 100,
+      "percent_max" : 100,
+      "percent_min" : 100,
+      "text" : "chocolate"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/flour-chocolate-egg.json
+++ b/tests/unit/expected_test_results/ingredients_percent/flour-chocolate-egg.json
@@ -1,0 +1,46 @@
+[
+   {
+      "id" : "en:flour",
+      "percent_estimate" : 66.6666666666667,
+      "percent_max" : 100,
+      "percent_min" : 33.3333333333333,
+      "text" : "Flour"
+   },
+   {
+      "id" : "en:chocolate",
+      "ingredients" : [
+         {
+            "id" : "en:cocoa",
+            "percent_estimate" : 8.33333333333333,
+            "percent_max" : 50,
+            "percent_min" : 0,
+            "text" : "cocoa"
+         },
+         {
+            "id" : "en:sugar",
+            "percent_estimate" : 4.16666666666667,
+            "percent_max" : 25,
+            "percent_min" : 0,
+            "text" : "sugar"
+         },
+         {
+            "id" : "en:soya-lecithin",
+            "percent_estimate" : 4.16666666666667,
+            "percent_max" : 16.6666666666667,
+            "percent_min" : 0,
+            "text" : "soy lecithin"
+         }
+      ],
+      "percent_estimate" : 16.6666666666667,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "text" : "chocolate"
+   },
+   {
+      "id" : "en:egg",
+      "percent_estimate" : 16.6666666666667,
+      "percent_max" : 33.3333333333333,
+      "percent_min" : 0,
+      "text" : "egg"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/illegal-division-by-zero-bug-0-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/illegal-division-by-zero-bug-0-percent.json
@@ -1,0 +1,33 @@
+[
+   {
+      "id" : "en:vegetable",
+      "ingredients" : [
+         {
+            "id" : "en:herbs-and-spices",
+            "ingredients" : [
+               {
+                  "id" : "en:onion",
+                  "percent_estimate" : 25,
+                  "text" : "contient oignon"
+               },
+               {
+                  "id" : "en:e164",
+                  "percent" : 0.1,
+                  "percent_estimate" : 25,
+                  "text" : "safran"
+               }
+            ],
+            "percent_estimate" : 50,
+            "text" : "épices et aromates"
+         },
+         {
+            "id" : "en:salt",
+            "percent_estimate" : 50,
+            "text" : "sel"
+         }
+      ],
+      "percent" : 0,
+      "percent_estimate" : 100,
+      "text" : "légumes"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/impossible-values-infinte-loop-bug.json
+++ b/tests/unit/expected_test_results/ingredients_percent/impossible-values-infinte-loop-bug.json
@@ -1,0 +1,25 @@
+[
+   {
+      "id" : "en:cocoa-butter",
+      "percent" : 15,
+      "percent_estimate" : 15,
+      "text" : "beurre de cacao"
+   },
+   {
+      "id" : "en:sugar",
+      "percent" : 10,
+      "percent_estimate" : 10,
+      "text" : "sucre"
+   },
+   {
+      "id" : "en:milk-proteins",
+      "percent_estimate" : 37.5,
+      "text" : "protéines de lait"
+   },
+   {
+      "id" : "en:egg",
+      "percent" : 1,
+      "percent_estimate" : 37.5,
+      "text" : "oeuf"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/impossible-values-sub-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients_percent/impossible-values-sub-ingredients.json
@@ -1,0 +1,38 @@
+[
+   {
+      "id" : "en:flour",
+      "percent" : 12,
+      "percent_estimate" : 12,
+      "text" : "farine"
+   },
+   {
+      "id" : "en:chocolate",
+      "ingredients" : [
+         {
+            "id" : "en:cocoa-butter",
+            "percent" : 15,
+            "percent_estimate" : 15,
+            "text" : "beurre de cacao"
+         },
+         {
+            "id" : "en:sugar",
+            "percent" : 10,
+            "percent_estimate" : 10,
+            "text" : "sucre"
+         },
+         {
+            "id" : "en:milk-proteins",
+            "percent_estimate" : 31.5,
+            "text" : "protéines de lait"
+         },
+         {
+            "id" : "en:egg",
+            "percent" : 1,
+            "percent_estimate" : 31.5,
+            "text" : "oeuf"
+         }
+      ],
+      "percent_estimate" : 88,
+      "text" : "chocolat"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-but-lower-than-later-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-but-lower-than-later-ingredients.json
@@ -1,0 +1,24 @@
+[
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 62.5,
+      "percent_max" : 80,
+      "percent_min" : 45,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:flavouring",
+      "percent_estimate" : 23.75,
+      "percent_max" : 45,
+      "percent_min" : 10,
+      "text" : "flavouring"
+   },
+   {
+      "id" : "en:sugar",
+      "percent" : 10,
+      "percent_estimate" : 13.75,
+      "percent_max" : 10,
+      "percent_min" : 10,
+      "text" : "sugar"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-but-sum-less-than-100-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-but-sum-less-than-100-percent.json
@@ -1,0 +1,17 @@
+[
+   {
+      "id" : "en:milk",
+      "percent" : 80,
+      "percent_estimate" : 80,
+      "percent_max" : 80,
+      "percent_min" : 80,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:flavouring",
+      "percent_estimate" : 20,
+      "percent_max" : 20,
+      "percent_min" : 20,
+      "text" : "flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-from-parent-ingredient.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-from-parent-ingredient.json
@@ -1,0 +1,16 @@
+[
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 97.5,
+      "percent_max" : 100,
+      "percent_min" : 95,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:natural-flavouring",
+      "percent_estimate" : 2.5,
+      "percent_max" : "5",
+      "percent_min" : 0,
+      "text" : "natural flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-is-first-ingredient.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent-is-first-ingredient.json
@@ -1,0 +1,16 @@
+[
+   {
+      "id" : "en:flavouring",
+      "percent_estimate" : 75,
+      "percent_max" : 100,
+      "percent_min" : 50,
+      "text" : "flavouring"
+   },
+   {
+      "id" : "en:lemon-flavouring",
+      "percent_estimate" : 25,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "text" : "lemon flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-with-max-percent.json
@@ -1,0 +1,16 @@
+[
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 97.5,
+      "percent_max" : 100,
+      "percent_min" : 95,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:flavouring",
+      "percent_estimate" : 2.5,
+      "percent_max" : "5",
+      "percent_min" : 0,
+      "text" : "flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-different-quantities.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-different-quantities.json
@@ -1,0 +1,34 @@
+[
+   {
+      "id" : "en:lemon-juice",
+      "percent" : 5,
+      "percent_estimate" : 5,
+      "text" : "lemon juice"
+   },
+   {
+      "id" : "en:orange-juice-10cl",
+      "percent_estimate" : 47.5,
+      "text" : "orange juice 10cl"
+   },
+   {
+      "id" : "en:sugar",
+      "percent" : 5,
+      "percent_estimate" : 5,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:salt-0-5mg",
+      "percent_estimate" : 21.25,
+      "text" : "salt 0.5mg"
+   },
+   {
+      "id" : "en:apple-juice-1l",
+      "percent_estimate" : 10.625,
+      "text" : "apple juice 1L"
+   },
+   {
+      "id" : "en:ice-cream-100ml",
+      "percent_estimate" : 10.625,
+      "text" : "ice cream 100ml"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-different-quantities.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-different-quantities.json
@@ -1,34 +1,50 @@
 [
    {
-      "id" : "en:lemon-juice",
-      "percent" : 5,
-      "percent_estimate" : 5,
-      "text" : "lemon juice"
+      "id" : "en:lemon",
+      "percent" : 45.3514636391239,
+      "percent_estimate" : 45.3514636391239,
+      "quantity" : "1 KG",
+      "quantity_g" : 1000,
+      "text" : "lemon"
    },
    {
-      "id" : "en:orange-juice-10cl",
-      "percent_estimate" : 47.5,
-      "text" : "orange juice 10cl"
+      "id" : "en:orange-juice",
+      "percent" : 4.53514636391239,
+      "percent_estimate" : 4.53514636391239,
+      "quantity" : "10 cl",
+      "quantity_g" : 100,
+      "text" : "orange juice"
    },
    {
       "id" : "en:sugar",
-      "percent" : 5,
-      "percent_estimate" : 5,
+      "percent" : 0.226757318195619,
+      "percent_estimate" : 0.226757318195619,
+      "quantity" : "5 g",
+      "quantity_g" : 5,
       "text" : "sugar"
    },
    {
-      "id" : "en:salt-0-5mg",
-      "percent_estimate" : 21.25,
-      "text" : "salt 0.5mg"
+      "id" : "en:salt",
+      "percent" : 2.26757318195619e-05,
+      "percent_estimate" : 2.26757318195619e-05,
+      "quantity" : "0.5 mg",
+      "quantity_g" : 0.0005,
+      "text" : "salt"
    },
    {
-      "id" : "en:apple-juice-1l",
-      "percent_estimate" : 10.625,
-      "text" : "apple juice 1L"
+      "id" : "en:apple-juice",
+      "percent" : 45.3514636391239,
+      "percent_estimate" : 45.3514636391239,
+      "quantity" : "1 L",
+      "quantity_g" : 1000,
+      "text" : "apple juice"
    },
    {
-      "id" : "en:ice-cream-100ml",
-      "percent_estimate" : 10.625,
-      "text" : "ice cream 100ml"
+      "id" : "en:ice-cream",
+      "percent" : 4.53514636391239,
+      "percent_estimate" : 4.53514636391239,
+      "quantity" : "100 ml",
+      "quantity_g" : 100,
+      "text" : "ice cream"
    }
 ]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-1-ingredient-missing-a-quantity.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-1-ingredient-missing-a-quantity.json
@@ -1,23 +1,25 @@
 [
    {
       "id" : "en:milk",
-      "percent" : 160,
-      "percent_estimate" : 100,
-      "percent_max" : 70,
-      "percent_min" : 160,
+      "percent_estimate" : 72.5,
+      "percent_max" : 100,
+      "percent_min" : 45,
+      "quantity" : "160 g",
+      "quantity_g" : 160,
       "text" : "milk"
    },
    {
       "id" : "en:sugar",
-      "percent" : 30,
-      "percent_estimate" : 0,
-      "percent_max" : 30,
-      "percent_min" : 30,
+      "percent_estimate" : 13.75,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "quantity" : "30 g",
+      "quantity_g" : 30,
       "text" : "sugar"
    },
    {
       "id" : "en:lemon-flavouring",
-      "percent_estimate" : 0,
+      "percent_estimate" : 13.75,
       "percent_max" : "5",
       "percent_min" : 0,
       "text" : "lemon flavouring"

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-1-ingredient-missing-a-quantity.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-1-ingredient-missing-a-quantity.json
@@ -1,0 +1,25 @@
+[
+   {
+      "id" : "en:milk",
+      "percent" : 160,
+      "percent_estimate" : 100,
+      "percent_max" : 70,
+      "percent_min" : 160,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:sugar",
+      "percent" : 30,
+      "percent_estimate" : 0,
+      "percent_max" : 30,
+      "percent_min" : 30,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:lemon-flavouring",
+      "percent_estimate" : 0,
+      "percent_max" : "5",
+      "percent_min" : 0,
+      "text" : "lemon flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-greater-than-100.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-greater-than-100.json
@@ -1,0 +1,26 @@
+[
+   {
+      "id" : "en:milk",
+      "percent" : 80,
+      "percent_estimate" : 80,
+      "percent_max" : 80,
+      "percent_min" : 80,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:sugar",
+      "percent" : 15,
+      "percent_estimate" : 15,
+      "percent_max" : 15,
+      "percent_min" : 15,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:lemon-flavouring",
+      "percent" : 5,
+      "percent_estimate" : 5,
+      "percent_max" : 5,
+      "percent_min" : 5,
+      "text" : "lemon flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-greater-than-100.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-greater-than-100.json
@@ -5,6 +5,8 @@
       "percent_estimate" : 80,
       "percent_max" : 80,
       "percent_min" : 80,
+      "quantity" : "160 g",
+      "quantity_g" : 160,
       "text" : "milk"
    },
    {
@@ -13,6 +15,8 @@
       "percent_estimate" : 15,
       "percent_max" : 15,
       "percent_min" : 15,
+      "quantity" : "30 g",
+      "quantity_g" : 30,
       "text" : "sugar"
    },
    {
@@ -21,6 +25,8 @@
       "percent_estimate" : 5,
       "percent_max" : 5,
       "percent_min" : 5,
+      "quantity" : "10 g",
+      "quantity_g" : 10,
       "text" : "lemon flavouring"
    }
 ]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-lesser-than-100-not-in-quantity-order.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-lesser-than-100-not-in-quantity-order.json
@@ -3,6 +3,8 @@
       "id" : "en:milk",
       "percent" : 20,
       "percent_estimate" : 20,
+      "quantity" : "10 g",
+      "quantity_g" : 10,
       "text" : "milk"
    },
    {
@@ -21,12 +23,16 @@
       ],
       "percent" : 60,
       "percent_estimate" : 60,
+      "quantity" : "30 g",
+      "quantity_g" : 30,
       "text" : "fruits"
    },
    {
       "id" : "en:lemon-flavouring",
       "percent" : 20,
       "percent_estimate" : 20,
+      "quantity" : "10 g",
+      "quantity_g" : 10,
       "text" : "lemon flavouring"
    }
 ]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-lesser-than-100-not-in-quantity-order.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredients-in-grams-with-sum-lesser-than-100-not-in-quantity-order.json
@@ -1,0 +1,32 @@
+[
+   {
+      "id" : "en:milk",
+      "percent" : 20,
+      "percent_estimate" : 20,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:fruit",
+      "ingredients" : [
+         {
+            "id" : "en:apple",
+            "percent_estimate" : 30,
+            "text" : "apples"
+         },
+         {
+            "id" : "en:pear",
+            "percent_estimate" : 30,
+            "text" : "pears"
+         }
+      ],
+      "percent" : 60,
+      "percent_estimate" : 60,
+      "text" : "fruits"
+   },
+   {
+      "id" : "en:lemon-flavouring",
+      "percent" : 20,
+      "percent_estimate" : 20,
+      "text" : "lemon flavouring"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/min-in-cumin-bug.json
+++ b/tests/unit/expected_test_results/ingredients_percent/min-in-cumin-bug.json
@@ -1,0 +1,42 @@
+[
+   {
+      "id" : "en:salt",
+      "percent" : 56.3380281690141,
+      "percent_estimate" : 56.3380281690141,
+      "percent_max" : 56.3380281690141,
+      "percent_min" : 56.3380281690141,
+      "text" : "sel"
+   },
+   {
+      "id" : "en:pepper",
+      "percent" : 28.169014084507,
+      "percent_estimate" : 28.169014084507,
+      "percent_max" : 28.169014084507,
+      "percent_min" : 28.169014084507,
+      "text" : "poivre"
+   },
+   {
+      "id" : "en:chili-pepper",
+      "percent" : 14.0845070422535,
+      "percent_estimate" : 14.0845070422535,
+      "percent_max" : 14.0845070422535,
+      "percent_min" : 14.0845070422535,
+      "text" : "piment"
+   },
+   {
+      "id" : "en:cumin",
+      "percent" : 1.12676056338028,
+      "percent_estimate" : 1.12676056338028,
+      "percent_max" : 1.12676056338027,
+      "percent_min" : 1.12676056338028,
+      "text" : "cumin"
+   },
+   {
+      "id" : "en:garlic",
+      "percent" : 0.28169014084507,
+      "percent_estimate" : 0.281690140845058,
+      "percent_max" : 0.281690140845058,
+      "percent_min" : 0.28169014084507,
+      "text" : "ail"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/minimum-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/minimum-percent.json
@@ -1,0 +1,17 @@
+[
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 73,
+      "percent_max" : 73,
+      "percent_min" : 73,
+      "text" : "Leche"
+   },
+   {
+      "id" : "en:cocoa",
+      "percent" : 27,
+      "percent_estimate" : 27,
+      "percent_max" : 27,
+      "percent_min" : 27,
+      "text" : "Cacao"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/missing-percent-not-first-or-last.json
+++ b/tests/unit/expected_test_results/ingredients_percent/missing-percent-not-first-or-last.json
@@ -1,0 +1,26 @@
+[
+   {
+      "id" : "en:apple-juice",
+      "percent" : 57.3,
+      "percent_estimate" : 57.3,
+      "percent_max" : 57.3,
+      "percent_min" : 57.3,
+      "text" : "Jus de pomme"
+   },
+   {
+      "id" : "en:carrot-juice",
+      "percent_estimate" : 40.2,
+      "percent_max" : 40.2,
+      "percent_min" : 40.2,
+      "text" : "jus de carotte"
+   },
+   {
+      "id" : "en:ginger",
+      "percent" : 2.5,
+      "percent_estimate" : 2.5,
+      "percent_max" : 2.5,
+      "percent_min" : 2.5,
+      "processing" : "en:juice",
+      "text" : "gingembre"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/propagate-max-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/propagate-max-percent.json
@@ -1,0 +1,53 @@
+[
+   {
+      "id" : "en:beans",
+      "percent" : 52,
+      "percent_estimate" : 52,
+      "percent_max" : 52,
+      "percent_min" : 52,
+      "text" : "Beans"
+   },
+   {
+      "id" : "en:tomato",
+      "percent" : 33,
+      "percent_estimate" : 33,
+      "percent_max" : 33,
+      "percent_min" : 33,
+      "text" : "Tomatoes"
+   },
+   {
+      "id" : "en:water",
+      "percent_estimate" : 9,
+      "percent_max" : 15,
+      "percent_min" : 3,
+      "text" : "Water"
+   },
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 3,
+      "percent_max" : 7.5,
+      "percent_min" : 0,
+      "text" : "Sugar"
+   },
+   {
+      "id" : "en:corn-flour",
+      "percent_estimate" : 1.5,
+      "percent_max" : 5,
+      "percent_min" : 0,
+      "text" : "Cornflour"
+   },
+   {
+      "id" : "en:salt",
+      "percent_estimate" : 0.75,
+      "percent_max" : 3.75,
+      "percent_min" : 0,
+      "text" : "Salt"
+   },
+   {
+      "id" : "en:spirit-vinegar",
+      "percent_estimate" : 0.75,
+      "percent_max" : 3,
+      "percent_min" : 0,
+      "text" : "Spirit Vinegar"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/relative-percent-with-different-percent-min-and-percent-max-on-parent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/relative-percent-with-different-percent-min-and-percent-max-on-parent.json
@@ -1,0 +1,47 @@
+[
+   {
+      "id" : "en:water",
+      "percent" : 60,
+      "percent_estimate" : 60,
+      "percent_max" : 60,
+      "percent_min" : 60,
+      "text" : "water"
+   },
+   {
+      "id" : "en:fruit-concentrate",
+      "ingredients" : [
+         {
+            "id" : "en:apple",
+            "percent_estimate" : 12,
+            "percent_max" : 16,
+            "percent_min" : 8,
+            "text" : "apple"
+         },
+         {
+            "id" : "en:mango",
+            "percent_estimate" : 9,
+            "percent_max" : 12,
+            "percent_min" : 6,
+            "text" : "mango"
+         },
+         {
+            "id" : "en:citrus-fruit",
+            "percent_estimate" : 9,
+            "percent_max" : 12,
+            "percent_min" : 0,
+            "text" : "citrus"
+         }
+      ],
+      "percent_estimate" : 30,
+      "percent_max" : 40,
+      "percent_min" : 20,
+      "text" : "fruit concentrate"
+   },
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 10,
+      "percent_max" : 20,
+      "percent_min" : 0,
+      "text" : "sugar"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/relative-percent-with-no-percent-on-parent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/relative-percent-with-no-percent-on-parent.json
@@ -1,0 +1,42 @@
+[
+   {
+      "id" : "en:water",
+      "percent" : 60,
+      "percent_estimate" : 60,
+      "percent_max" : 60,
+      "percent_min" : 60,
+      "text" : "water"
+   },
+   {
+      "id" : "en:fruit-concentrate",
+      "ingredients" : [
+         {
+            "id" : "en:apple",
+            "percent" : 16,
+            "percent_estimate" : 16,
+            "percent_max" : 16,
+            "percent_min" : 16,
+            "text" : "apple"
+         },
+         {
+            "id" : "en:mango",
+            "percent" : 12,
+            "percent_estimate" : 12,
+            "percent_max" : 12,
+            "percent_min" : 12,
+            "text" : "mango"
+         },
+         {
+            "id" : "en:citrus-fruit",
+            "percent_estimate" : 12,
+            "percent_max" : 12,
+            "percent_min" : 12,
+            "text" : "citrus"
+         }
+      ],
+      "percent_estimate" : 40,
+      "percent_max" : 40,
+      "percent_min" : 40,
+      "text" : "fruit concentrate"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/relative-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/relative-percent.json
@@ -1,0 +1,49 @@
+[
+   {
+      "id" : "en:fruit",
+      "ingredients" : [
+         {
+            "id" : "en:apple",
+            "percent" : 20,
+            "percent_estimate" : 20,
+            "percent_max" : 20,
+            "percent_min" : 20,
+            "text" : "apple"
+         },
+         {
+            "id" : "en:pear",
+            "percent" : 15,
+            "percent_estimate" : 15,
+            "percent_max" : 15,
+            "percent_min" : 15,
+            "text" : "pear"
+         },
+         {
+            "id" : "en:cranberry",
+            "percent_estimate" : 11.25,
+            "percent_max" : 15,
+            "percent_min" : 7.5,
+            "text" : "cranberry"
+         },
+         {
+            "id" : "en:lemon",
+            "percent_estimate" : 3.75,
+            "percent_max" : 7.5,
+            "percent_min" : 0,
+            "text" : "lemon"
+         }
+      ],
+      "percent" : 50,
+      "percent_estimate" : 50,
+      "percent_max" : 50,
+      "percent_min" : 50,
+      "text" : "fruits"
+   },
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 50,
+      "percent_max" : 50,
+      "percent_min" : 50,
+      "text" : "sugar"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/scale-percents-when-sum-greater-than-100.json
+++ b/tests/unit/expected_test_results/ingredients_percent/scale-percents-when-sum-greater-than-100.json
@@ -1,0 +1,26 @@
+[
+   {
+      "id" : "en:milk",
+      "percent" : 61,
+      "percent_estimate" : 61,
+      "percent_max" : 61,
+      "percent_min" : 61,
+      "text" : "Leche"
+   },
+   {
+      "id" : "en:cocoa",
+      "percent" : 35,
+      "percent_estimate" : 35,
+      "percent_max" : 35,
+      "percent_min" : 35,
+      "text" : "Cacao"
+   },
+   {
+      "id" : "en:hazelnut",
+      "percent" : 4,
+      "percent_estimate" : 4,
+      "percent_max" : 4,
+      "percent_min" : 4,
+      "text" : "Avellanas"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar-90-percent-milk.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar-90-percent-milk.json
@@ -1,0 +1,17 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent" : 90,
+      "percent_estimate" : 90,
+      "percent_max" : 90,
+      "percent_min" : 90,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 10,
+      "percent_max" : 10,
+      "percent_min" : 10,
+      "text" : "milk"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar-milk-10-percent-water.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar-milk-10-percent-water.json
@@ -1,0 +1,24 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 85,
+      "percent_max" : 90,
+      "percent_min" : 80,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:milk",
+      "percent" : 10,
+      "percent_estimate" : 10,
+      "percent_max" : 10,
+      "percent_min" : 10,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:water",
+      "percent_estimate" : 5,
+      "percent_max" : 10,
+      "percent_min" : 0,
+      "text" : "water"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar-milk-10-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar-milk-10-percent.json
@@ -1,0 +1,17 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 90,
+      "percent_max" : 90,
+      "percent_min" : 90,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:milk",
+      "percent" : 10,
+      "percent_estimate" : 10,
+      "percent_max" : 10,
+      "percent_min" : 10,
+      "text" : "milk"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar-milk-water.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar-milk-water.json
@@ -1,0 +1,23 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 66.6666666666667,
+      "percent_max" : 100,
+      "percent_min" : 33.3333333333333,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 16.6666666666667,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "text" : "milk"
+   },
+   {
+      "id" : "en:water",
+      "percent_estimate" : 16.6666666666667,
+      "percent_max" : 33.3333333333333,
+      "percent_min" : 0,
+      "text" : "water"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar-milk.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar-milk.json
@@ -1,0 +1,16 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 75,
+      "percent_max" : 100,
+      "percent_min" : 50,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:milk",
+      "percent_estimate" : 25,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "text" : "milk"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar-water-milk-10-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar-water-milk-10-percent.json
@@ -1,0 +1,24 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 62.5,
+      "percent_max" : 80,
+      "percent_min" : 45,
+      "text" : "sugar"
+   },
+   {
+      "id" : "en:water",
+      "percent_estimate" : 23.75,
+      "percent_max" : 45,
+      "percent_min" : 10,
+      "text" : "water"
+   },
+   {
+      "id" : "en:milk",
+      "percent" : 10,
+      "percent_estimate" : 13.75,
+      "percent_max" : 10,
+      "percent_min" : 10,
+      "text" : "milk"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/sugar.json
+++ b/tests/unit/expected_test_results/ingredients_percent/sugar.json
@@ -1,0 +1,9 @@
+[
+   {
+      "id" : "en:sugar",
+      "percent_estimate" : 100,
+      "percent_max" : 100,
+      "percent_min" : 100,
+      "text" : "sugar"
+   }
+]

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -549,8 +549,6 @@ Origin of peaches: Spain. Origin of some unknown ingredient: France. origin of A
 	],
 );
 
-my $json = JSON->new->allow_nonref->canonical;
-
 foreach my $test_ref (@tests) {
 
 	my $testid = $test_ref->[0];

--- a/tests/unit/ingredients_percent.t
+++ b/tests/unit/ingredients_percent.t
@@ -14,6 +14,9 @@ use ProductOpener::TagsEntries qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Test qw/:all/;
 
+
+
+
 my ($test_id, $test_dir, $expected_result_dir, $update_expected_results) = (init_expected_results(__FILE__));
 
 my @tests = (
@@ -228,7 +231,7 @@ my @tests = (
 		'ingredients-in-different-quantities',
 		{
 			lc => 'en',
-			ingredients_text => "lemon juice 5%, orange juice 10cl, sugar 5g, salt 0.5mg, apple juice 1L, ice cream 100ml",
+			ingredients_text => "lemon 1 KG, orange juice 10cl, sugar 5g, salt 0.5mg, apple juice 1L, ice cream 100ml",
 		}
 	],
 );

--- a/tests/unit/ingredients_percent.t
+++ b/tests/unit/ingredients_percent.t
@@ -14,59 +14,29 @@ use ProductOpener::TagsEntries qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
 use ProductOpener::Test qw/:all/;
 
-
-
-
 my ($test_id, $test_dir, $expected_result_dir, $update_expected_results) = (init_expected_results(__FILE__));
 
 my @tests = (
 
-	[
-		'sugar',
-		{lc => "en", ingredients_text => "sugar"},
-	],
+	['sugar', {lc => "en", ingredients_text => "sugar"},],
 
-	[
-		'sugar-milk',
-		{lc => "en", ingredients_text => "sugar, milk"},
-	],
+	['sugar-milk', {lc => "en", ingredients_text => "sugar, milk"},],
 
-	[
-		'sugar-milk-water',
-		{lc => "en", ingredients_text => "sugar, milk, water"},
-	],
+	['sugar-milk-water', {lc => "en", ingredients_text => "sugar, milk, water"},],
 
-	[
-		'sugar-90-percent-milk',
-		{lc => "en", ingredients_text => "sugar 90%, milk"},
-	],
+	['sugar-90-percent-milk', {lc => "en", ingredients_text => "sugar 90%, milk"},],
 
-	[
-		'sugar-milk-10-percent',
-		{lc => "en", ingredients_text => "sugar, milk 10%"},
-	],
+	['sugar-milk-10-percent', {lc => "en", ingredients_text => "sugar, milk 10%"},],
 
-	[
-		'sugar-milk-10-percent-water',
-		{lc => "en", ingredients_text => "sugar, milk 10%, water"},
-	],
+	['sugar-milk-10-percent-water', {lc => "en", ingredients_text => "sugar, milk 10%, water"},],
 
-	[
-		'sugar-water-milk-10-percent',
-		{lc => "en", ingredients_text => "sugar, water, milk 10%"},
-	],
+	['sugar-water-milk-10-percent', {lc => "en", ingredients_text => "sugar, water, milk 10%"},],
 
 	# Ingredients with sub-ingredients
 
-	[
-		'chocolate-1-sub-ingredient',
-		{lc => "en", ingredients_text => "chocolate (cocoa)"},
-	],
+	['chocolate-1-sub-ingredient', {lc => "en", ingredients_text => "chocolate (cocoa)"},],
 
-	[
-		'chocolate-2-sub-ingredients',
-		{lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"},
-	],
+	['chocolate-2-sub-ingredients', {lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"},],
 
 	[
 		'chocolate-sub-sub-ingredients',
@@ -92,10 +62,7 @@ my @tests = (
 		},
 	],
 
-	[
-		'flour-chocolate-egg',
-		{lc => "en", ingredients_text => "Flour, chocolate (cocoa, sugar, soy lecithin), egg"},
-	],
+	['flour-chocolate-egg', {lc => "en", ingredients_text => "Flour, chocolate (cocoa, sugar, soy lecithin), egg"},],
 
 	# For lists like  "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"
 	# we can set a maximum on Sugar, Cornflour etc. that takes into account that all ingredients
@@ -109,10 +76,7 @@ my @tests = (
 		{lc => "en", ingredients_text => "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"},
 	],
 
-	[
-		'minimum-percent',
-		{lc => "es", ingredients_text => "Leche. Cacao: 27% mínimo"},
-	],
+	['minimum-percent', {lc => "es", ingredients_text => "Leche. Cacao: 27% mínimo"},],
 
 	# All ingredients have % specified, but the total is not 100%
 	# We now scale them to 100%.
@@ -163,10 +127,7 @@ my @tests = (
 
 	# Where flavourings or other ingredients with a maximum percentage are not the first ingredient then
 	# use their maximum percentage
-	[
-		'ingredient-with-max-percent',
-		{lc => "en", ingredients_text => "milk, flavouring"},
-	],
+	['ingredient-with-max-percent', {lc => "en", ingredients_text => "milk, flavouring"},],
 
 	# Can get percent_max from parent ingredient
 	[
@@ -193,10 +154,7 @@ my @tests = (
 	],
 
 	# Where two ingredients have a maximum then apply it
-	[
-		'2-ingredients-with-max-percent',
-		{lc => "en", ingredients_text => "milk, lemon flavouring, orange flavouring"},
-	],
+	['2-ingredients-with-max-percent', {lc => "en", ingredients_text => "milk, lemon flavouring, orange flavouring"},],
 
 	# Ingredients indicated in grams, with a sum different than 100 (here 200)
 	# The percents need to be scaled to take into account the actual sum
@@ -249,7 +207,11 @@ foreach my $test_ref (@tests) {
 
 	compute_ingredients_percent_estimates(100, $product_ref->{ingredients});
 
-	compare_to_expected_results($product_ref->{ingredients}, "$expected_result_dir/$testid.json", $update_expected_results);
+	compare_to_expected_results(
+		$product_ref->{ingredients},
+		"$expected_result_dir/$testid.json",
+		$update_expected_results
+	);
 }
 
 done_testing();

--- a/tests/unit/ingredients_percent.t
+++ b/tests/unit/ingredients_percent.t
@@ -12,273 +12,62 @@ use Log::Any::Adapter 'TAP', filter => "none";
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::TagsEntries qw/:all/;
 use ProductOpener::Ingredients qw/:all/;
+use ProductOpener::Test qw/:all/;
 
-# dummy product for testing
+my ($test_id, $test_dir, $expected_result_dir, $update_expected_results) = (init_expected_results(__FILE__));
 
 my @tests = (
 
 	[
+		'sugar',
 		{lc => "en", ingredients_text => "sugar"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 100,
-				'percent_max' => 100,
-				'percent_min' => 100,
-				'text' => 'sugar'
-			}
-		]
 	],
 
 	[
+		'sugar-milk',
 		{lc => "en", ingredients_text => "sugar, milk"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 75,
-				'percent_max' => 100,
-				'percent_min' => 50,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 25,
-				'percent_max' => 50,
-				'percent_min' => 0,
-				'text' => 'milk'
-			}
-		]
 	],
 
 	[
+		'sugar-milk-water',
 		{lc => "en", ingredients_text => "sugar, milk, water"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => '66.6666666666667',
-				'percent_max' => 100,
-				'percent_min' => '33.3333333333333',
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => '16.6666666666667',
-				'percent_max' => 50,
-				'percent_min' => 0,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:water',
-				'percent_estimate' => '16.6666666666667',
-				'percent_max' => '33.3333333333333',
-				'percent_min' => 0,
-				'text' => 'water'
-			}
-		]
 	],
 
 	[
+		'sugar-90-percent-milk',
 		{lc => "en", ingredients_text => "sugar 90%, milk"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 90,
-				'percent' => '90',
-				'percent_max' => 90,
-				'percent_min' => 90,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 10,
-				'percent_max' => 10,
-				'percent_min' => 10,
-				'text' => 'milk'
-			}
-		]
 	],
 
 	[
+		'sugar-milk-10-percent',
 		{lc => "en", ingredients_text => "sugar, milk 10%"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 90,
-				'percent_max' => 90,
-				'percent_min' => 90,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:milk',
-				'percent' => '10',
-				'percent_estimate' => 10,
-				'percent_max' => 10,
-				'percent_min' => 10,
-				'text' => 'milk'
-			}
-		]
 	],
 
 	[
+		'sugar-milk-10-percent-water',
 		{lc => "en", ingredients_text => "sugar, milk 10%, water"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 85,
-				'percent_max' => 90,
-				'percent_min' => 80,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:milk',
-				'percent' => '10',
-				'percent_estimate' => 10,
-				'percent_max' => 10,
-				'percent_min' => 10,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:water',
-				'percent_estimate' => 5,
-				'percent_max' => 10,
-				'percent_min' => 0,
-				'text' => 'water'
-			}
-		]
 	],
 
 	[
+		'sugar-water-milk-10-percent',
 		{lc => "en", ingredients_text => "sugar, water, milk 10%"},
-		[
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => '62.5',
-				'percent_max' => 80,
-				'percent_min' => 45,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:water',
-				'percent_estimate' => '23.75',
-				'percent_max' => 45,
-				'percent_min' => 10,
-				'text' => 'water'
-			},
-			{
-				'id' => 'en:milk',
-				'percent' => '10',
-				'percent_estimate' => '13.75',
-				'percent_max' => 10,
-				'percent_min' => 10,
-				'text' => 'milk'
-			}
-		]
 	],
 
 	# Ingredients with sub-ingredients
 
 	[
+		'chocolate-1-sub-ingredient',
 		{lc => "en", ingredients_text => "chocolate (cocoa)"},
-		[
-			{
-				'id' => 'en:chocolate',
-				'ingredients' => [
-					{
-						'id' => 'en:cocoa',
-						'percent_estimate' => 100,
-						'percent_max' => 100,
-						'percent_min' => 100,
-						'text' => 'cocoa'
-					}
-				],
-				'percent_estimate' => 100,
-				'percent_max' => 100,
-				'percent_min' => 100,
-				'text' => 'chocolate'
-			}
-		]
 	],
 
 	[
+		'chocolate-2-sub-ingredients',
 		{lc => "en", ingredients_text => "chocolate (cocoa, sugar), milk"},
-		[
-			{
-				'id' => 'en:chocolate',
-				'ingredients' => [
-					{
-						'id' => 'en:cocoa',
-						'percent_estimate' => 50,
-						'percent_max' => 100,
-						'percent_min' => 25,
-						'text' => 'cocoa'
-					},
-					{
-						'id' => 'en:sugar',
-						'percent_estimate' => 25,
-						'percent_max' => 50,
-						'percent_min' => 0,
-						'text' => 'sugar'
-					}
-				],
-				'percent_estimate' => 75,
-				'percent_max' => 100,
-				'percent_min' => 50,
-				'text' => 'chocolate'
-			},
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 25,
-				'percent_max' => 50,
-				'percent_min' => 0,
-				'text' => 'milk'
-			}
-		]
 	],
 
 	[
+		'chocolate-sub-sub-ingredients',
 		{lc => "en", ingredients_text => "chocolate (cocoa [cocoa paste 70%, cocoa butter], sugar)"},
-		[
-			{
-				'id' => 'en:chocolate',
-				'ingredients' => [
-					{
-						'id' => 'en:cocoa',
-						'ingredients' => [
-							{
-								'id' => 'en:cocoa-paste',
-								'percent' => '70',
-								'percent_estimate' => 70,
-								'percent_max' => 70,
-								'percent_min' => 70,
-								'text' => 'cocoa paste'
-							},
-							{
-								'id' => 'en:cocoa-butter',
-								'percent_estimate' => 15,
-								'percent_max' => 30,
-								'percent_min' => 0,
-								'text' => 'cocoa butter'
-							}
-						],
-						'percent_estimate' => 85,
-						'percent_max' => 100,
-						'percent_min' => 70,
-						'text' => 'cocoa'
-					},
-					{
-						'id' => 'en:sugar',
-						'percent_estimate' => 15,
-						'percent_max' => 30,
-						'percent_min' => 0,
-						'text' => 'sugar'
-					}
-				],
-				'percent_estimate' => 100,
-				'percent_max' => 100,
-				'percent_min' => 100,
-				'text' => 'chocolate'
-			}
-		]
 	],
 
 	# Make sure we can handle impossible values gracefully
@@ -287,128 +76,22 @@ my @tests = (
 	#  "farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%) - émulsifiants : E463, E432 et E472 - correcteurs d'acidité : E322/E333 E474-E475, acidifiant (acide citrique, acide phosphorique) - sel"
 
 	[
+		'impossible-values-infinte-loop-bug',
 		{lc => "fr", ingredients_text => "beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%"},
-		[
-			{
-				'id' => 'en:cocoa-butter',
-				'percent' => '15',
-				'percent_estimate' => 15,
-				'text' => 'beurre de cacao'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent' => '10',
-				'percent_estimate' => 10,
-				'text' => 'sucre'
-			},
-			{
-				'id' => 'en:milk-proteins',
-				'percent_estimate' => '37.5',
-				'text' => "prot\x{e9}ines de lait"
-			},
-			{
-				'id' => 'en:egg',
-				'percent' => '1',
-				'percent_estimate' => '37.5',
-				'text' => 'oeuf'
-			}
-		]
 	],
 
 	[
+		'impossible-values-sub-ingredients',
 		{
 			lc => "fr",
 			ingredients_text =>
 				"farine (12%), chocolat (beurre de cacao (15%), sucre [10%], protéines de lait, oeuf 1%)"
 		},
-		[
-			{
-				'id' => 'en:flour',
-				'percent' => '12',
-				'percent_estimate' => 12,
-				'text' => 'farine'
-			},
-			{
-				'id' => 'en:chocolate',
-				'ingredients' => [
-					{
-						'id' => 'en:cocoa-butter',
-						'percent' => '15',
-						'percent_estimate' => 15,
-						'text' => 'beurre de cacao'
-					},
-					{
-						'id' => 'en:sugar',
-						'percent' => '10',
-						'percent_estimate' => 10,
-						'text' => 'sucre'
-					},
-					{
-						'id' => 'en:milk-proteins',
-						'percent_estimate' => '31.5',
-						'text' => "prot\x{e9}ines de lait"
-					},
-					{
-						'id' => 'en:egg',
-						'percent' => '1',
-						'percent_estimate' => '31.5',
-						'text' => 'oeuf'
-					}
-				],
-				'percent_estimate' => 88,
-				'text' => 'chocolat'
-			}
-		]
 	],
 
 	[
+		'flour-chocolate-egg',
 		{lc => "en", ingredients_text => "Flour, chocolate (cocoa, sugar, soy lecithin), egg"},
-		[
-			{
-				'id' => 'en:flour',
-				'percent_estimate' => '66.6666666666667',
-				'percent_max' => 100,
-				'percent_min' => '33.3333333333333',
-				'text' => 'Flour'
-			},
-			{
-				'id' => 'en:chocolate',
-				'ingredients' => [
-					{
-						'id' => 'en:cocoa',
-						'percent_estimate' => '8.33333333333333',
-						'percent_max' => 50,
-						'percent_min' => 0,
-						'text' => 'cocoa'
-					},
-					{
-						'id' => 'en:sugar',
-						'percent_estimate' => '4.16666666666667',
-						'percent_max' => 25,
-						'percent_min' => 0,
-						'text' => 'sugar'
-					},
-					{
-						'id' => 'en:soya-lecithin',
-						'percent_estimate' => '4.16666666666667',
-						'percent_max' => '16.6666666666667',
-						'percent_min' => 0,
-						'text' => 'soy lecithin'
-					}
-				],
-				'percent_estimate' => '16.6666666666667',
-				'percent_max' => 50,
-				'percent_min' => 0,
-				'text' => 'chocolate'
-			},
-			{
-				'id' => 'en:egg',
-				'percent_estimate' => '16.6666666666667',
-				'percent_max' => '33.3333333333333',
-				'percent_min' => 0,
-				'text' => 'egg'
-			}
-		]
 	],
 
 	# For lists like  "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"
@@ -419,701 +102,141 @@ my @tests = (
 	# the max of cornflour to be set to 15 / 3 etc.
 
 	[
+		'propagate-max-percent',
 		{lc => "en", ingredients_text => "Beans (52%), Tomatoes (33%), Water, Sugar, Cornflour, Salt, Spirit Vinegar"},
-		[
-			{
-				'id' => 'en:beans',
-				'percent' => '52',
-				'percent_estimate' => 52,
-				'percent_max' => 52,
-				'percent_min' => 52,
-				'text' => 'Beans'
-			},
-			{
-				'id' => 'en:tomato',
-				'percent' => '33',
-				'percent_estimate' => 33,
-				'percent_max' => 33,
-				'percent_min' => 33,
-				'text' => 'Tomatoes'
-			},
-			{
-				'id' => 'en:water',
-				'percent_estimate' => 9,
-				'percent_max' => 15,
-				'percent_min' => 3,
-				'text' => 'Water'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 3,
-				'percent_max' => '7.5',
-				'percent_min' => 0,
-				'text' => 'Sugar'
-			},
-			{
-				'id' => 'en:corn-flour',
-				'percent_estimate' => '1.5',
-				'percent_max' => 5,
-				'percent_min' => 0,
-				'text' => 'Cornflour'
-			},
-			{
-				'id' => 'en:salt',
-				'percent_estimate' => '0.75',
-				'percent_max' => '3.75',
-				'percent_min' => 0,
-				'text' => 'Salt'
-			},
-			{
-				'id' => 'en:spirit-vinegar',
-				'percent_estimate' => '0.75',
-				'percent_max' => 3,
-				'percent_min' => 0,
-				'text' => 'Spirit Vinegar'
-			}
-		]
 	],
 
 	[
+		'minimum-percent',
 		{lc => "es", ingredients_text => "Leche. Cacao: 27% mínimo"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 73,
-				'percent_max' => 73,
-				'percent_min' => 73,
-				'text' => 'Leche'
-			},
-			{
-				'id' => 'en:cocoa',
-				'percent' => '27',
-				'percent_estimate' => 27,
-				'percent_max' => 27,
-				'percent_min' => 27,
-				'text' => 'Cacao'
-			}
-		]
 	],
 
 	# All ingredients have % specified, but the total is not 100%
 	# We now scale them to 100%.
 	# Note: currently the min part is ignored, we set percent instead of percent_min
 	[
+		'scale-percents-when-sum-greater-than-100',
 		{lc => "es", ingredients_text => "Leche min 12.2%, Cacao: min 7%, Avellanas (mínimo 0,8%)"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent' => 61,
-				'percent_estimate' => 61,
-				'percent_max' => 61,
-				'percent_min' => 61,
-				'text' => 'Leche'
-			},
-			{
-				'id' => 'en:cocoa',
-				'percent' => 35,
-				'percent_estimate' => 35,
-				'percent_max' => 35,
-				'percent_min' => 35,
-				'text' => 'Cacao'
-			},
-			{
-				'id' => 'en:hazelnut',
-				'percent' => '4',
-				'percent_estimate' => 4,
-				'percent_max' => 4,
-				'percent_min' => 4,
-				'text' => 'Avellanas'
-			}
-		]
-
 	],
 
 	# bug #3762 "min" in "cumin"
 	# bug #3762 "min" in "cumin"
 	[
+		'min-in-cumin-bug',
 		{lc => "fr", ingredients_text => "sel (min 20%), poivre (min. 10%), piment (min : 5%), cumin 0,4%, ail : 0.1%"},
-		[
-			{
-				'id' => 'en:salt',
-				'percent' => '56.3380281690141',
-				'percent_estimate' => '56.3380281690141',
-				'percent_max' => '56.3380281690141',
-				'percent_min' => '56.3380281690141',
-				'text' => 'sel'
-			},
-			{
-				'id' => 'en:pepper',
-				'percent' => '28.169014084507',
-				'percent_estimate' => '28.169014084507',
-				'percent_max' => '28.169014084507',
-				'percent_min' => '28.169014084507',
-				'text' => 'poivre'
-			},
-			{
-				'id' => 'en:chili-pepper',
-				'percent' => '14.0845070422535',
-				'percent_estimate' => '14.0845070422535',
-				'percent_max' => '14.0845070422535',
-				'percent_min' => '14.0845070422535',
-				'text' => 'piment'
-			},
-			{
-				'id' => 'en:cumin',
-				'percent' => '1.12676056338028',
-				'percent_estimate' => '1.12676056338028',
-				'percent_max' => '1.12676056338027',
-				'percent_min' => '1.12676056338028',
-				'text' => 'cumin'
-			},
-			{
-				'id' => 'en:garlic',
-				'percent' => '0.28169014084507',
-				'percent_estimate' => '0.281690140845058',
-				'percent_max' => '0.281690140845058',
-				'percent_min' => '0.28169014084507',
-				'text' => 'ail'
-			}
-		]
 	],
 
 	# Relative percent
 
 	[
+		'relative-percent',
 		{lc => "en", ingredients_text => "fruits 50% (apple 40%, pear 30%, cranberry, lemon), sugar"},
-		[
-			{
-				'id' => 'en:fruit',
-				'ingredients' => [
-					{
-						'id' => 'en:apple',
-						'percent' => 20,
-						'percent_estimate' => 20,
-						'percent_max' => 20,
-						'percent_min' => 20,
-						'text' => 'apple'
-					},
-					{
-						'id' => 'en:pear',
-						'percent' => 15,
-						'percent_estimate' => 15,
-						'percent_max' => 15,
-						'percent_min' => 15,
-						'text' => 'pear'
-					},
-					{
-						'id' => 'en:cranberry',
-						'percent_estimate' => '11.25',
-						'percent_max' => 15,
-						'percent_min' => '7.5',
-						'text' => 'cranberry'
-					},
-					{
-						'id' => 'en:lemon',
-						'percent_estimate' => '3.75',
-						'percent_max' => '7.5',
-						'percent_min' => 0,
-						'text' => 'lemon'
-					}
-				],
-				'percent' => 50,
-				'percent_estimate' => 50,
-				'percent_max' => 50,
-				'percent_min' => 50,
-				'text' => 'fruits'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 50,
-				'percent_max' => 50,
-				'percent_min' => 50,
-				'text' => 'sugar'
-			}
-		]
 	],
 
 	# Absolute percent
 
 	[
+		'absolute-percent',
 		{lc => "en", ingredients_text => "fruits 50% (apple 20%, pear 15%, cranberry, lemon), sugar"},
-		[
-			{
-				'id' => 'en:fruit',
-				'ingredients' => [
-					{
-						'id' => 'en:apple',
-						'percent' => 20,
-						'percent_estimate' => 20,
-						'percent_max' => 20,
-						'percent_min' => 20,
-						'text' => 'apple'
-					},
-					{
-						'id' => 'en:pear',
-						'percent' => 15,
-						'percent_estimate' => 15,
-						'percent_max' => 15,
-						'percent_min' => 15,
-						'text' => 'pear'
-					},
-					{
-						'id' => 'en:cranberry',
-						'percent_estimate' => '11.25',
-						'percent_max' => 15,
-						'percent_min' => '7.5',
-						'text' => 'cranberry'
-					},
-					{
-						'id' => 'en:lemon',
-						'percent_estimate' => '3.75',
-						'percent_max' => '7.5',
-						'percent_min' => 0,
-						'text' => 'lemon'
-					}
-				],
-				'percent' => 50,
-				'percent_estimate' => 50,
-				'percent_max' => 50,
-				'percent_min' => 50,
-				'text' => 'fruits'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 50,
-				'percent_max' => 50,
-				'percent_min' => 50,
-				'text' => 'sugar'
-			}
-		]
 	],
 
 	# Relative percent with no indicated percent on the parent ingredient, but with a percent min = percent max on the parent ingredient
 	[
+		'relative-percent-with-no-percent-on-parent',
 		{lc => "en", ingredients_text => "water (60%), fruit concentrate (apple 40%, mango 30%, citrus)"},
-		[
-			{
-				'id' => 'en:water',
-				'percent' => 60,
-				'percent_estimate' => 60,
-				'percent_max' => 60,
-				'percent_min' => 60,
-				'text' => 'water'
-			},
-			{
-				'id' => 'en:fruit-concentrate',
-				'ingredients' => [
-					{
-						'id' => 'en:apple',
-						'percent' => 16,
-						'percent_estimate' => 16,
-						'percent_max' => 16,
-						'percent_min' => 16,
-						'text' => 'apple'
-					},
-					{
-						'id' => 'en:mango',
-						'percent' => 12,
-						'percent_estimate' => 12,
-						'percent_max' => 12,
-						'percent_min' => 12,
-						'text' => 'mango'
-					},
-					{
-						'id' => 'en:citrus-fruit',
-						'percent_estimate' => 12,
-						'percent_max' => 12,
-						'percent_min' => 12,
-						'text' => 'citrus'
-					}
-				],
-				'percent_estimate' => 40,
-				'percent_max' => 40,
-				'percent_min' => 40,
-				'text' => 'fruit concentrate'
-			}
-		]
 	],
 
 	# Relative percent with a different percent min and percent max on the parent ingredient
 	[
+		'relative-percent-with-different-percent-min-and-percent-max-on-parent',
 		{lc => "en", ingredients_text => "water (60%), fruit concentrate (apple 40%, mango 30%, citrus), sugar"},
-		[
-			{
-				'id' => 'en:water',
-				'percent' => 60,
-				'percent_estimate' => 60,
-				'percent_max' => 60,
-				'percent_min' => 60,
-				'text' => 'water'
-			},
-			{
-				'id' => 'en:fruit-concentrate',
-				'ingredients' => [
-					{
-						'id' => 'en:apple',
-						'percent_estimate' => 12,
-						'percent_max' => 16,
-						'percent_min' => 8,
-						'text' => 'apple'
-					},
-					{
-						'id' => 'en:mango',
-						'percent_estimate' => 9,
-						'percent_max' => 12,
-						'percent_min' => 6,
-						'text' => 'mango'
-					},
-					{
-						'id' => 'en:citrus-fruit',
-						'percent_estimate' => 9,
-						'percent_max' => 12,
-						'percent_min' => 0,
-						'text' => 'citrus'
-					}
-				],
-				'percent_estimate' => 30,
-				'percent_max' => 40,
-				'percent_min' => 20,
-				'text' => 'fruit concentrate'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent_estimate' => 10,
-				'percent_max' => 20,
-				'percent_min' => 0,
-				'text' => 'sugar'
-			}
-		]
-
 	],
 
 	# Missing % that is not the first or the last
 	[
+		'missing-percent-not-first-or-last',
 		{lc => "fr", ingredients_text => "Jus de pomme (57,3%), jus de carotte, jus de gingembre (2,5%)."},
-		[
-			{
-				'id' => 'en:apple-juice',
-				'percent' => '57.3',
-				'percent_estimate' => '57.3',
-				'percent_max' => '57.3',
-				'percent_min' => '57.3',
-				'text' => 'Jus de pomme'
-			},
-			{
-				'id' => 'en:carrot-juice',
-				'percent_estimate' => '40.2',
-				'percent_max' => '40.2',
-				'percent_min' => '40.2',
-				'text' => 'jus de carotte'
-			},
-			{
-				'id' => 'en:ginger',
-				'percent' => '2.5',
-				'percent_estimate' => '2.5',
-				'percent_max' => '2.5',
-				'percent_min' => '2.5',
-				'processing' => 'en:juice',
-				'text' => 'gingembre'
-			}
-		]
 	],
 
 	# Where flavourings or other ingredients with a maximum percentage are not the first ingredient then
 	# use their maximum percentage
 	[
+		'ingredient-with-max-percent',
 		{lc => "en", ingredients_text => "milk, flavouring"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 97.5,
-				'percent_max' => 100,
-				'percent_min' => 95,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:flavouring',
-				'percent_estimate' => 2.5,
-				'percent_max' => 5,
-				'percent_min' => 0,
-				'text' => 'flavouring'
-			}
-		]
 	],
 
 	# Can get percent_max from parent ingredient
 	[
+		'ingredient-with-max-percent-from-parent-ingredient',
 		{lc => "en", ingredients_text => "milk, natural flavouring"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 97.5,
-				'percent_max' => 100,
-				'percent_min' => 95,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:natural-flavouring',
-				'percent_estimate' => 2.5,
-				'percent_max' => 5,
-				'percent_min' => 0,
-				'text' => 'natural flavouring'
-			}
-		]
 	],
 
 	# Where flavourings are the first ingredient then ignore maximum percentages
 	[
+		'ingredient-with-max-percent-is-first-ingredient',
 		{lc => "en", ingredients_text => "flavouring, lemon flavouring"},
-		[
-			{
-				'id' => 'en:flavouring',
-				'percent_estimate' => 75,
-				'percent_max' => 100,
-				'percent_min' => 50,
-				'text' => 'flavouring'
-			},
-			{
-				'id' => 'en:lemon-flavouring',
-				'percent_estimate' => 25,
-				'percent_max' => 50,
-				'percent_min' => 0,
-				'text' => 'lemon flavouring'
-			}
-		]
 	],
 
 	# Where maximum would prevent ingredients from adding up to 100% then ignore it
 	[
+		'ingredient-with-max-percent-but-sum-less-than-100-percent',
 		{lc => "en", ingredients_text => "milk 80%, flavouring"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent' => 80,
-				'percent_estimate' => 80,
-				'percent_max' => 80,
-				'percent_min' => 80,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:flavouring',
-				'percent_estimate' => 20,
-				'percent_max' => 20,
-				'percent_min' => 20,
-				'text' => 'flavouring'
-			}
-		]
 	],
 
 	# Where maximum is lower than later ingredients then ignore it
 	[
+		'ingredient-with-max-percent-but-lower-than-later-ingredients',
 		{lc => "en", ingredients_text => "milk, flavouring, sugar 10%"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 62.5,
-				'percent_max' => 80,
-				'percent_min' => 45,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:flavouring',
-				'percent_estimate' => 23.75,
-				'percent_max' => 45,
-				'percent_min' => 10,
-				'text' => 'flavouring'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent' => 10,
-				'percent_estimate' => 13.75,
-				'percent_max' => 10,
-				'percent_min' => 10,
-				'text' => 'sugar'
-			}
-		]
 	],
 
 	# Where two ingredients have a maximum then apply it
 	[
+		'2-ingredients-with-max-percent',
 		{lc => "en", ingredients_text => "milk, lemon flavouring, orange flavouring"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent_estimate' => 95,
-				'percent_max' => 100,
-				'percent_min' => 90,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:lemon-flavouring',
-				'percent_estimate' => 2.5,
-				'percent_max' => 5,
-				'percent_min' => 0,
-				'text' => 'lemon flavouring'
-			},
-			{
-				'id' => 'en:orange-flavouring',
-				'percent_estimate' => 2.5,
-				'percent_max' => 5,
-				'percent_min' => 0,
-				'text' => 'orange flavouring'
-			}
-		]
 	],
 
 	# Ingredients indicated in grams, with a sum different than 100 (here 200)
 	# The percents need to be scaled to take into account the actual sum
 	# This works only if we have actual percent values for all ingredients
 	[
+		'ingredients-in-grams-with-sum-greater-than-100',
 		{lc => "en", ingredients_text => "milk (160g), sugar (30g), lemon flavouring (10g)"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent' => 80,
-				'percent_estimate' => 80,
-				'percent_max' => 80,
-				'percent_min' => 80,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent' => 15,
-				'percent_estimate' => 15,
-				'percent_max' => 15,
-				'percent_min' => 15,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:lemon-flavouring',
-				'percent' => '5',
-				'percent_estimate' => 5,
-				'percent_max' => 5,
-				'percent_min' => 5,
-				'text' => 'lemon flavouring'
-			}
-		]
-
 	],
 	# smaller sum than 100, sub ingredients, ingredients not in quantity order (as in a recipe)
 	[
+		'ingredients-in-grams-with-sum-lesser-than-100-not-in-quantity-order',
 		{lc => "en", ingredients_text => "milk (10g), fruits 30g (apples, pears), lemon flavouring (10g)"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent' => 20,
-				'percent_estimate' => 20,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:fruit',
-				'ingredients' => [
-					{
-						'id' => 'en:apple',
-						'percent_estimate' => 30,
-						'text' => 'apples'
-					},
-					{
-						'id' => 'en:pear',
-						'percent_estimate' => 30,
-						'text' => 'pears'
-					}
-				],
-				'percent' => 60,
-				'percent_estimate' => 60,
-				'text' => 'fruits'
-			},
-			{
-				'id' => 'en:lemon-flavouring',
-				'percent' => '20',
-				'percent_estimate' => 20,
-				'text' => 'lemon flavouring'
-			}
-		]
-
 	],
 	# This test currently does not give very good results, as we have one ingredient without quantity,
 	# so we can't do much about it
 	[
+		'ingredients-in-grams-with-1-ingredient-missing-a-quantity',
 		{lc => "en", ingredients_text => "milk (160g), sugar (30g), lemon flavouring"},
-		[
-			{
-				'id' => 'en:milk',
-				'percent' => 160,
-				'percent_estimate' => 100,
-				'percent_max' => 70,
-				'percent_min' => 160,
-				'text' => 'milk'
-			},
-			{
-				'id' => 'en:sugar',
-				'percent' => 30,
-				'percent_estimate' => 0,
-				'percent_max' => 30,
-				'percent_min' => 30,
-				'text' => 'sugar'
-			},
-			{
-				'id' => 'en:lemon-flavouring',
-				'percent_estimate' => 0,
-				'percent_max' => 5,
-				'percent_min' => 0,
-				'text' => 'lemon flavouring'
-			}
-		]
-
 	],
 
 	# Trigger illegal division by zero - https://github.com/openfoodfacts/openfoodfacts-server/issues/8782
 	[
+		'illegal-division-by-zero-bug-0-percent',
 		{
 			lc => "fr",
 			ingredients_text => 'légumes 0% (épices et aromates (contient oignon et safran &lt;0.1%), sel)',
 		},
-		[
-			{
-				'id' => 'en:vegetable',
-				'ingredients' => [
-					{
-						'id' => 'en:herbs-and-spices',
-						'ingredients' => [
-							{
-								'id' => 'en:onion',
-								'percent_estimate' => 25,
-								'text' => 'contient oignon'
-							},
-							{
-								'id' => 'en:e164',
-								'percent' => '0.1',
-								'percent_estimate' => 25,
-								'text' => 'safran'
-							}
-						],
-						'percent_estimate' => 50,
-						'text' => "\x{e9}pices et aromates"
-					},
-					{
-						'id' => 'en:salt',
-						'percent_estimate' => 50,
-						'text' => 'sel'
-					}
-				],
-				'percent' => 0,
-				'percent_estimate' => 100,
-				'text' => "l\x{e9}gumes"
-			}
-		]
+	],
 
-	]
-
+	# Ingredients in other quantities than grams
+	[
+		'ingredients-in-different-quantities',
+		{
+			lc => 'en',
+			ingredients_text => "lemon juice 5%, orange juice 10cl, sugar 5g, salt 0.5mg, apple juice 1L, ice cream 100ml",
+		}
+	],
 );
 
 foreach my $test_ref (@tests) {
 
-	my $product_ref = $test_ref->[0];
-	my $expected_ingredients_ref = $test_ref->[1];
-
-	print STDERR "ingredients_text: " . $product_ref->{ingredients_text} . "\n";
+	my $testid = $test_ref->[0];
+	my $product_ref = $test_ref->[1];
 
 	parse_ingredients_text($product_ref);
 	if (compute_ingredients_percent_values(100, 100, $product_ref->{ingredients}) < 0) {
@@ -1123,13 +246,7 @@ foreach my $test_ref (@tests) {
 
 	compute_ingredients_percent_estimates(100, $product_ref->{ingredients});
 
-	is_deeply($product_ref->{ingredients}, $expected_ingredients_ref)
-		# using print + join instead of diag so that we don't have
-		# hashtags. It makes copy/pasting the resulting structure
-		# inside the test file much easier when tests results need
-		# to be updated. Caveat is that it might interfere with
-		# test output.
-		or print STDERR join("\n", explain $product_ref->{ingredients});
+	compare_to_expected_results($product_ref->{ingredients}, "$expected_result_dir/$testid.json", $update_expected_results);
 }
 
 done_testing();


### PR DESCRIPTION
This PR makes it possible to analyze ingredients lists like "lemon  juice 10cl, sugar 5g, mint 1kg, rum 5L". It is needed in particular for the ratemyrecipe project, but is also useful for some rare product ingredients lists.

In addition we now clearly differentiate percent and quantity in the ingredients structure.

Also includes some refactoring of ingredients_percent.t tests to make it easier to compare diffs and update results.