### PR TITLE
taxonomy: adding some german translation for ingredients of More Protein Brownie

### DIFF
--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -15541,7 +15541,7 @@ fr:huile de noix de cajou
 en:pumpkin seed oil
 bg:олио от тиквени семки
 da:græskarkerneolie
-de:Kürbiskern-Öl
+de:Kürbiskern-Öl, Kürbiskernöl
 fi:kurpitsansiemenöljy
 fr:Huile de pépins de courge
 hu:tökmagolaj
@@ -24450,6 +24450,7 @@ sv:fullkornshavremjöl
 
 <en:oat flour
 en:gluten free oat flour
+de: glutenfreies Hafermehl
 es:harina de avena libre de gluten, harina de avena sin gluten
 fr:farine d'avoine sans gluten
 


### PR DESCRIPTION
added some german translation for ingredients of More Protein Brownie (some still missing, because I could not find an english equivalent) and a second translation for pumpin seed oil, because it was still missing