### PR TITLE
fix: parse origins (ingredient from origin) in German, Italian and Spanish

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -382,7 +382,10 @@ my %of = (
 
 my %from = (
 	en => " from ",
+	de => " aus ",
+	es => " de ",
 	fr => " de la | de | du | des | d'",
+	it => " dal | della | dalla | dagli | dall'",
 	pl => " z | ze ",
 );
 

--- a/tests/unit/match_ingredient_origin.t
+++ b/tests/unit/match_ingredient_origin.t
@@ -92,6 +92,23 @@ my @tests = (
 			}
 		],
 	},
+	{
+		desc => 'German ingredient aus origin',
+		lc => 'de',
+		text => 'Zucker aus Deutschland, Bio natives Olivenöl extra aus Spanien',
+		expected => [
+			{
+				'ingredient' => 'Zucker',
+				'matched_text' => 'Zucker aus Deutschland,',
+				'origins' => 'Deutschland'
+			},
+			{
+				'ingredient' => 'Bio natives Olivenöl extra',
+				'matched_text' => '  Bio natives Olivenöl extra aus Spanien',
+				'origins' => 'Spanien'
+			}
+		]
+	}
 );
 
 init_origins_regexps();


### PR DESCRIPTION
fixes #8936