### PR TITLE
fix: improve ingredients extraction

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3955,7 +3955,9 @@ my %phrases_after_ingredients_list = (
 	],
 
 	en => [
+		'adds a trivial amount',    # e.g. adds a trivial amount of added sugars per serving
 		'after opening',
+		#'Best before',
 		'nutrition(al)? (as sold|facts|information|typical|value[s]?)',
 		# "nutrition advice" seems to appear before ingredients rather than after.
 		# "nutritional" on its own would match the ingredient "nutritional yeast" etc.
@@ -3966,8 +3968,8 @@ my %phrases_after_ingredients_list = (
 		'once opened[,]? (consume|keep|refrigerate|store|use)',
 		'(Storage( instructions)?[: ]+)?Store in a cool[,]? dry place',
 		'(dist(\.)?|distributed|sold)(\&|and|sold| )* (by|exclusively)',
-		#'Best before',
 		#'See bottom of tin',
+		'spices and or vegetable powder as last ingredient',
 	],
 
 	es => [
@@ -4216,7 +4218,7 @@ my %ignore_phrases = (
 		'\d\d?\s?%\sFett\si(\.|,)\s?Tr(\.|,)?',    # 45 % Fett i.Tr.
 		"inklusive",
 	],
-	en => ["na|n/a|not applicable",],
+	en => ["na|n/a|not applicable", "Contains 2% and less of",],    # Contains 2% and less of (Xanthan Gum)
 	fr => ["non applicable|non concerné",],
 
 );

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -16566,6 +16566,9 @@ ciqual_food_name:fr:Huile de soja
 # ingredient/soya-oil has 41836 products 1in 28 languages @2021-08-16
 
 <en:soya oil
+en:non-gmo soybean oil
+
+<en:soya oil
 en:refined soya oil
 pl:rafinowany olej sojowy
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -4376,7 +4376,7 @@ nl:Niet geschikt voor kinderen onder 1 jaar
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #en:description:Labels used for identifying products (and ingredients) that have been grown organically.
 
-en:Organic, organically grown, organically produced, ingredient produced organically, from organic farming, From Organic Agriculture
+en:Organic, organically grown, organically produced, ingredient produced organically, from organic farming, From Organic Agriculture, organic ingredients
 bg:Био, биологично земеделие, биологично
 ca:Orgànic,de cultiu ecologic
 cs:Bio


### PR DESCRIPTION
### What
0850003875088
 - Lngredietns, correct typo,     ok
 - *Organic ingredients, upd taxonomy,     ok

0099482485375
 - text considered ingredients, add to phrases_after_ingredients_list (this same text appears in 272 products), 

0856500004013, 0856500004037, 0029737700144
 - wrong extraction, reeaxtracted, ok


0029737700144
 - non-gmo soybean oil is unknown, added in taxonomy, ok

0029737210070
0073872746109
8006013990644
0008005958876
0008005985179
0008005958043
0008005959101
- contributors question, folksonomy engine. key: ingredient_list:multiple, value: 'nb of ingredients list'

2252559300126
 - *SPICES AND OR VEGETABLE POWDER as last ingredient when that flavor, added to phrases_after_ingredients_list (this text appears in this single product only), ok 

### Question
Is there a way to test the image extraction locally?
![Screenshot_20230903_110511](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/3ade0b0d-927a-4c57-a35b-db006e3b9776)


### Related issue(s) and discussion
- Fixes #3030



### Comment
Thanks @bredowmax to have collected so many examples. That is of great help.