### PR TITLE
fix: delete fields after removing ingredients

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2470,7 +2470,8 @@ sub compute_ingredients_tags ($product_ref) {
 	remove_fields(
 		$product_ref,
 		[
-			"ingredients_tags, ingredients_original_tags", "ingredients_n",
+			"ingredients_hierarchy", "ingredients_tags",
+			"ingredients_original_tags", "ingredients_n",
 			"known_ingredients_n", "unknown_ingredients_n",
 			"ingredients_n_tags", "ingredients_with_specified_percent_n",
 			"ingredients_with_unspecified_percent_n", "ingredients_with_specified_percent_sum",
@@ -2628,6 +2629,27 @@ sub extract_ingredients_from_text ($product_ref) {
 
 		estimate_nutriscore_fruits_vegetables_nuts_value_from_ingredients($product_ref);
 
+	}
+	else {
+		remove_fields(
+			$product_ref,
+			[
+				"ingredients_without_ciqual_codes", # assign_ciqual_codes - may have been introduced in previous version
+				"ingredients_without_ciqual_codes_n"
+				,    # assign_ciqual_codes - may have been introduced in previous version
+				"specific_ingredients"
+				, # estimate_nutriscore_fruits_vegetables_nuts_value_from_ingredients - may have been introduced in previous version
+			]
+		);
+		remove_fields(
+			$product_ref->{nutriments},
+			[
+				"fruits-vegetables-nuts-estimate-from-ingredients_100g"
+				, # estimate_nutriscore_fruits_vegetables_nuts_value_from_ingredients - may have been introduced in previous version
+				"fruits-vegetables-nuts-estimate-from-ingredients_serving"
+				, # estimate_nutriscore_fruits_vegetables_nuts_value_from_ingredients - may have been introduced in previous version
+			]
+		);
 	}
 
 	# Keep the nested list of sub-ingredients, but also copy the sub-ingredients at the end for apps


### PR DESCRIPTION
### What
For https://world.openfoodfacts.org/product/07562174/salade-3-fromages-u.

Percentage  236.5% was introduced in https://world.openfoodfacts.org/product/07562174/salade-3-fromages-u?rev=11 (December 3, 2021 at 12:37:05 PM CET)

Current version has the same percentage.

Not easy to reproduce the quality error (above 105) locally, but, locally create a product with same ingredients and nutrition data as https://world.openfoodfacts.org/product/07562174/salade-3-fromages-u?rev=11, leads to fruits-vegetables-nuts-estimate-from-ingredients_100g of 11.5 (not sure to understand why it is not 236.5%, maybe calculation method has changed since 2021).
Deleting ingredient leave it as it is.

Fix: estimate_nutriscore_fruits_vegetables_nuts_value_from_ingredients($product_ref); was called inside a condition: "if (defined $product_ref->{ingredients})" this does not handle the case when there was an ingredient list and it has been removed. Suggestion solution, add a "else" and delete fields that may have been created in the past. 

Also found big typo when handling previous bug: "ingredients_tags, ingredients_original_tags" -> "ingredients_tags", "ingredients_original_tags".  Added "ingredients_hierarchy" on the same list.

### Screenshot
Before - after
![Screenshot_20230903_145949](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/13fb84a2-27eb-4169-bf72-74b62a32140e)

### Related issue(s) and discussion
- Fixes  #8589

This removes some fields when ingredients are removed. 
Not sure for the data quality, but I assume that it is checked AFTER Ingredients.pm and that it will be updated accordingly. But this has to be checked and as described before, I could not get the data quality warning locally with the example of the issue.

### Comment
Allergen and traces remain after deleting ingredients. There are 2 fields: 
- allergens_from_ingredients is "" 
- allergens_from_user that is populated 
Note however that locally, I DID NOT enter allergens and traces by myself, they were added from the ingredients list. 
=> In any cases, explicitly remove allergen in edit mode. This will remove them totally from the api results

