### PR TITLE
ci: wait docker images to avoid failing in container deploy

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -175,6 +175,36 @@ jobs:
           make create_external_volumes && \
           make create_external_networks
 
+    - name: wait docker images
+      # we sometimes have the images not ready immediately after build, so we prefer to wait for it
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ env.SSH_HOST }}
+        username: ${{ env.SSH_USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_host: ${{ env.SSH_PROXY_HOST }}
+        proxy_username: ${{ env.SSH_USERNAME }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        command_timeout: 25m
+        script_stop: false
+        script: |
+          waited=0
+          for IMAGE_TYPE in frontend backend
+          do
+            image_name=ghcr.io/${{ github.repository }}/$IMAGE_TYPE:${{ env.TAG_NAME }}
+            # pull image, eventually waiting for it to be available in ghcr.io
+            while ! (docker pull $image_name); do
+              sleep 30
+              waited=$((waited+30))
+              # timeout after 6 minutes (gloablly)
+              if [[ $waited -gt 360 ]]; then
+                echo "Timeout waiting for image $image_name"
+                # Abort the job
+                exit 1
+              fi
+            done
+          done
+
     - name: init backend
       uses: appleboy/ssh-action@master
       with:

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -205,7 +205,7 @@ jobs:
             done
           done
 
-    - name: init backend
+    - name: initialize the backend
       uses: appleboy/ssh-action@master
       with:
         host: ${{ env.SSH_HOST }}

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -175,7 +175,7 @@ jobs:
           make create_external_volumes && \
           make create_external_networks
 
-    - name: wait docker images
+    - name: wait for docker images to be available
       # we sometimes have the images not ready immediately after build, so we prefer to wait for it
       uses: appleboy/ssh-action@master
       with:


### PR DESCRIPTION
It happens we fail because the container image is not immediately accessible in ghcr.io. ([like this morning](https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/6081527840/job/16497359812).
Add a step to wait for images availability.