### PR TITLE
feat: add support for product quantity and packaging weights in search graphs

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -322,16 +322,29 @@ if ($action eq 'display') {
 		$axis_labels{$nid} = display_taxonomy_tag($lc, "nutrients", "zz:$nid");
 		$log->debug("nutriments", {nid => $nid, value => $axis_labels{$nid}}) if $log->is_debug();
 	}
-	push @axis_values, "additives_n", "ingredients_n", "known_ingredients_n", "unknown_ingredients_n";
-	push @axis_values, "fruits-vegetables-nuts-estimate-from-ingredients";
-	push @axis_values, "forest_footprint";
-	$axis_labels{additives_n} = lang("number_of_additives");
-	$axis_labels{ingredients_n} = lang("ingredients_n_s");
-	$axis_labels{known_ingredients_n} = lang("known_ingredients_n_s");
-	$axis_labels{unknown_ingredients_n} = lang("unknown_ingredients_n_s");
+
+	my @other_search_fields = (
+		"additives_n", "ingredients_n",
+		"known_ingredients_n", "unknown_ingredients_n",
+		"fruits-vegetables-nuts-estimate-from-ingredients", "forest_footprint",
+		"product_quantity",
+	);
+
+	# Add the fields related to packaging
+	foreach my $material ("all", "en:plastic", "en:glass", "en:metal", "en:paper-or-cardboard", "en:unknown") {
+		foreach my $subfield ("weight", "weight_100g", "weight_percent") {
+			push @other_search_fields, "packagings_materials.$material.$subfield";
+		}
+	}
+
 	$axis_labels{search_nutriment} = lang("search_nutriment");
 	$axis_labels{products_n} = lang("number_of_products");
-	$axis_labels{forest_footprint} = lang("forest_footprint");
+
+	foreach my $field (@other_search_fields) {
+		my ($title, $unit, $unit2, $allow_decimals) = get_search_field_title_and_details($field);
+		push @axis_values, $field;
+		$axis_labels{$field} = $title;
+	}
 
 	my @sorted_axis_values = ("", sort({lc($axis_labels{$a}) cmp lc($axis_labels{$b})} @axis_values));
 

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -94,7 +94,8 @@ if ((defined single_param('json')) or (defined single_param('jsonp')) or (define
 }
 
 my @search_fields
-	= qw(brands categories packaging labels origins manufacturing_places emb_codes purchase_places stores countries ingredients additives allergens traces nutrition_grades nova_groups languages creator editors states);
+	= qw(brands categories packaging labels origins manufacturing_places emb_codes purchase_places stores countries
+	ingredients additives allergens traces nutrition_grades nova_groups ecoscore languages creator editors states);
 
 $admin and push @search_fields, "lang";
 
@@ -109,6 +110,8 @@ my %search_tags_fields = (
 	allergens => 1,
 	traces => 1,
 	nutrition_grades => 1,
+	nova_groups => 1,
+	eco_score => 1,
 	purchase_places => 1,
 	stores => 1,
 	countries => 1,
@@ -324,10 +327,9 @@ if ($action eq 'display') {
 	}
 
 	my @other_search_fields = (
-		"additives_n", "ingredients_n",
-		"known_ingredients_n", "unknown_ingredients_n",
-		"fruits-vegetables-nuts-estimate-from-ingredients", "forest_footprint",
-		"product_quantity",
+		"additives_n", "ingredients_n", "known_ingredients_n", "unknown_ingredients_n",
+		"fruits-vegetables-nuts-estimate-from-ingredients",
+		"forest_footprint", "product_quantity", "nova_group", 'ecoscore_score',
 	);
 
 	# Add the fields related to packaging

--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -738,13 +738,13 @@ HTML
 
 		# We want existing values for axis fields
 		foreach my $axis ('x', 'y') {
-			if (    ($graph_ref->{"axis_$axis"} ne "")
-				and ($graph_ref->{"axis_$axis"} ne "forest_footprint")
-				and ($graph_ref->{"axis_$axis"} !~ /_n$/))
-			{
-				(defined $query_ref->{"nutriments." . $graph_ref->{"axis_$axis"} . "_100g"})
-					or $query_ref->{"nutriments." . $graph_ref->{"axis_$axis"} . "_100g"} = {};
-				$query_ref->{"nutriments." . $graph_ref->{"axis_$axis"} . "_100g"}{'$exists'} = 1;
+
+			if ($graph_ref->{"axis_$axis"} ne "") {
+				my $field = $graph_ref->{"axis_$axis"};
+				# Get the field path components
+				my @fields = get_search_field_path_components($field);
+				# Convert to dot notation to get the MongoDB field
+				$query_ref->{join(".", @fields)} = {'$exists' => 1};
 			}
 		}
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5815,7 +5815,8 @@ my %nutrition_grades_colors = (
 sub get_search_field_path_components ($field) {
 	my @fields;
 	# direct fields
-	if (($field =~ /_n$/) or ($field eq "product_quantity")) {
+	if (($field =~ /_n$/) or ($field eq "product_quantity") or ($field eq "nova_group") or ($field eq "ecoscore_score"))
+	{
 		@fields = ($field);
 	}
 	# indirect fields separated with the . character
@@ -5854,6 +5855,14 @@ sub get_search_field_title_and_details ($field) {
 		$title = escape_single_quote(lang("quantity"));
 		$unit = ' (g)';
 		$unit2 = 'g';
+	}
+	elsif ($field eq "nova_group") {
+		$allow_decimals = "allowDecimals:false,\n";
+		$title = escape_single_quote(lang("nova_groups_s"));
+	}
+	elsif ($field eq "ecoscore_score") {
+		$allow_decimals = "allowDecimals:false,\n";
+		$title = escape_single_quote(lang("ecoscore_score"));
 	}
 	elsif ($field =~ /^packagings_materials\.([^\.]+)\.([^\.]+)$/) {
 		my $material = $1;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5901,6 +5901,22 @@ sub get_search_field_title_and_details ($field) {
 	return ($title, $unit, $unit2, $allow_decimals);
 }
 
+=head2 display_scatter_plot ($graph_ref, $products_ref)
+
+Called by search_and_graph_products() to display a scatter plot of products on 2 axis
+
+=head3 Arguments
+
+=head4 $graph_ref
+
+Options for the graph, set by /cgi/search.pl
+
+=head4 $products_ref
+
+List of search results from search_and_graph_products()
+
+=cut
+
 sub display_scatter_plot ($graph_ref, $products_ref) {
 
 	my @products = @{$products_ref};
@@ -5978,8 +5994,8 @@ sub display_scatter_plot ($graph_ref, $products_ref) {
 
 		# Identify the series id
 		my $seriesid = 0;
-        # series value, we start high for first series
-        # and second series value will have s / 10, etc.
+		# series value, we start high for first series
+		# and second series value will have s / 10, etc.
 		my $s = 1000000;
 
 		# default, organic, fairtrade, with_sweeteners
@@ -6026,10 +6042,10 @@ sub display_scatter_plot ($graph_ref, $products_ref) {
 		$data{url} = $formatted_subdomain . product_url($product_ref->{code});
 		$data{img} = display_image_thumb($product_ref, 'front');
 
-        # create data entry for series
+		# create data entry for series
 		defined $series{$seriesid} or $series{$seriesid} = '';
 		$series{$seriesid} .= JSON::PP->new->encode(\%data) . ',';
-        # count entries / series
+		# count entries / series
 		defined $series_n{$seriesid} or $series_n{$seriesid} = 0;
 		$series_n{$seriesid}++;
 		$i++;
@@ -6240,6 +6256,22 @@ HTML
 	return $html;
 
 }
+
+=head2 display_histogram ($graph_ref, $products_ref)
+
+Called by search_and_graph_products() to display an histogram of products on 1 axis
+
+=head3 Arguments
+
+=head4 $graph_ref
+
+Options for the graph, set by /cgi/search.pl
+
+=head4 $products_ref
+
+List of search results from search_and_graph_products()
+
+=cut
 
 sub display_histogram ($graph_ref, $products_ref) {
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5864,7 +5864,7 @@ sub get_search_field_title_and_details ($field) {
 		$allow_decimals = "allowDecimals:false,\n";
 		$title = escape_single_quote(lang("ecoscore_score"));
 	}
-	elsif ($field =~ /^packagings_materials\.([^\.]+)\.([^\.]+)$/) {
+	elsif ($field =~ /^packagings_materials\.([^.]+)\.([^.]+)$/) {
 		my $material = $1;
 		my $subfield = $2;
 		$title = lang("packaging") . " - ";
@@ -5904,7 +5904,7 @@ sub get_search_field_title_and_details ($field) {
 sub display_scatter_plot ($graph_ref, $products_ref) {
 
 	my @products = @{$products_ref};
-	my $count = @products;
+	my $count = scalar @products;
 
 	my $html = '';
 
@@ -6018,14 +6018,16 @@ sub display_scatter_plot ($graph_ref, $products_ref) {
 			}
 		}
 
-		defined $series{$seriesid} or $series{$seriesid} = '';
+		$series{$seriesid} = $series{$seriesid} // '';
 
 		$data{product_name} = $product_ref->{product_name};
 		$data{url} = $formatted_subdomain . product_url($product_ref->{code});
 		$data{img} = display_image_thumb($product_ref, 'front');
 
+        # create data entry for series
 		defined $series{$seriesid} or $series{$seriesid} = '';
 		$series{$seriesid} .= JSON::PP->new->encode(\%data) . ',';
+        # count entries / series
 		defined $series_n{$seriesid} or $series_n{$seriesid} = 0;
 		$series_n{$seriesid}++;
 		$i++;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5849,7 +5849,15 @@ sub get_search_field_title_and_details ($field) {
 		$title = escape_single_quote(lang($field . "_s"));
 	}
 	elsif ($field =~ /^packagings_materials\.([^\.]+)\.([^\.]+)$/) {
-		$title = lang("packaging") . " - " . display_taxonomy_tag($lc, "packagings_materials", "zz:$1") . ' - ' . $2;
+		$title = lang("packaging") . " - ";
+		if ($1 eq "all") {
+			$title .= lang("packagings_materials_all");
+		}
+		else {
+			$title .= display_taxonomy_tag($lc, "packagings_materials", "zz:$1");
+		}
+		$title .= ' - ' . lang($2);
+		display_taxonomy_tag($lc, "packagings_materials", "zz:$1") . ' - ' . $2;
 	}
 	else {
 		$title = display_taxonomy_tag($lc, "nutrients", "zz:" . $field);

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -76,6 +76,7 @@ BEGIN {
 		&display_product_history
 		&display_preferences_api
 		&display_attribute_groups_api
+		&get_search_field_path_components
 		&search_and_display_products
 		&search_and_export_products
 		&search_and_graph_products
@@ -6614,8 +6615,9 @@ sub search_and_graph_products ($request_ref, $query_ref, $graph_ref) {
 		}
 	}
 
+	# Add fields for the axis
 	foreach my $axis ('x', 'y') {
-		my @field = $graph_ref->{"axis_$axis"};
+		my $field = $graph_ref->{"axis_$axis"};
 		# Get the field path components
 		my @fields = get_search_field_path_components($field);
 		# Convert to dot notation to get the MongoDB field

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5978,6 +5978,8 @@ sub display_scatter_plot ($graph_ref, $products_ref) {
 
 		# Identify the series id
 		my $seriesid = 0;
+        # series value, we start high for first series
+        # and second series value will have s / 10, etc.
 		my $s = 1000000;
 
 		# default, organic, fairtrade, with_sweeteners

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6602,3 +6602,15 @@ msgstr "Number of packaging components"
 msgctxt "packagings_materials_all"
 msgid "All materials"
 msgstr "All materials"
+
+msgctxt "weight"
+msgid "Weight"
+msgstr "Weight"
+
+msgctxt "weight_100g"
+msgid "Weight per 100g of product"
+msgstr "Weight per 100g of product"
+
+msgctxt "weight_percent"
+msgid "Weight percent"
+msgstr "Weight percent"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6591,3 +6591,14 @@ msgctxt "relative_to_all_products"
 msgid "relative to all products"
 msgstr "relative to all products"
 
+msgctxt "packagings_n_p"
+msgid "Numbers of packaging components"
+msgstr "Numbers of packaging components"
+
+msgctxt "packagings_n_s"
+msgid "Number of packaging components"
+msgstr "Number of packaging components"
+
+msgctxt "packagings_materials_all"
+msgid "All materials"
+msgstr "All materials"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6626,3 +6626,15 @@ msgstr "Number of packaging components"
 msgctxt "packagings_materials_all"
 msgid "All materials"
 msgstr "All materials"
+
+msgctxt "weight"
+msgid "Weight"
+msgstr "Weight"
+
+msgctxt "weight_100g"
+msgid "Weight per 100g of product"
+msgstr "Weight per 100g of product"
+
+msgctxt "weight_percent"
+msgid "Weight percent"
+msgstr "Weight percent"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6615,3 +6615,14 @@ msgctxt "relative_to_all_products"
 msgid "relative to all products"
 msgstr "relative to all products"
 
+msgctxt "packagings_n_p"
+msgid "Numbers of packaging components"
+msgstr "Numbers of packaging components"
+
+msgctxt "packagings_n_s"
+msgid "Number of packaging components"
+msgstr "Number of packaging components"
+
+msgctxt "packagings_materials_all"
+msgid "All materials"
+msgstr "All materials"


### PR DESCRIPTION
Discussed in last packagings call: now that we have packaging weights, we could create graphs (histograms or scatter plots) using the packaging weights, so that it's easy to see distributions and view the corresponding products.

- Added product_quantity + packaging weights fields (for main materials: all, glass, paper, plastics, metals etc. with for each either the total packaging weight, the weight per 100g, or the weight % compared to the other materials)
- Small refactor of search graphs in order to remove duplicate code (and avoid adding more)

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/c0e50e81-6201-4682-bd12-a07b3518d2b6)
### Part of
- #5751 