### PR TITLE
fix: remove empty env.TAG_NAME (breaks deployments to .net)

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -191,7 +191,7 @@ jobs:
           waited=0
           for IMAGE_TYPE in frontend backend
           do
-            image_name=ghcr.io/${{ github.repository }}/$IMAGE_TYPE:${{ env.TAG_NAME }}
+            image_name=ghcr.io/${{ github.repository }}/$IMAGE_TYPE
             # pull image, eventually waiting for it to be available in ghcr.io
             while ! (docker pull $image_name); do
               sleep 30


### PR DESCRIPTION
try to fix an issue introduced by https://github.com/openfoodfacts/openfoodfacts-server/pull/8951/files : env.TAG_NAME is not set, so we get this error:

https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/6107869077/job/16575737773

```
======CMD======
waited=0
for IMAGE_TYPE in frontend backend
do
  image_name=ghcr.io/openfoodfacts/openfoodfacts-server/$IMAGE_TYPE:
  # pull image, eventually waiting for it to be available in ghcr.io
  while ! (docker pull $image_name); do
    sleep 30
    waited=$((waited+30))
    # timeout after 6 minutes (gloablly)
    if [[ $waited -gt 360 ]]; then
      echo "Timeout waiting for image $image_name"
      # Abort the job
      exit 1
    fi
  done
done

======END======
err: invalid reference format
err: invalid reference format
```