### PR TITLE
fix: fix export excel with leading zero

### DIFF
--- a/lib/ProductOpener/Export.pm
+++ b/lib/ProductOpener/Export.pm
@@ -454,6 +454,8 @@ sub export_csv ($args_ref) {
 		$worksheet = $workbook->add_worksheet();
 		my $workbook_format = $workbook->add_format();
 		$workbook_format->set_bold();
+		$worksheet->keep_leading_zeros();
+
 		$worksheet->write_row(0, 0, \@sorted_populated_fields, $workbook_format);
 
 		# Set the width of the columns


### PR DESCRIPTION
### What

Exported Excels do not contain leading zeros for the barcode.

Adding "$worksheet->keep_leading_zeros();" seems to solve the issue.

See: https://metacpan.org/pod/Spreadsheet::WriteExcel#keep_leading_zeros()

CSV seems not having this issue:
![Screenshot_20230917_121541](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/8c204db3-475c-4ca0-bc8c-ac08db3f6108)

### Screenshot
Result locally:
![Screenshot_20230917_115311](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/914d28dc-b22f-469f-8833-c6022d588388)

### Related issue(s) and discussion
- Fixes #6782