### PR TITLE
fix: limit the number of fields fetched from MongoDB

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -31,6 +31,10 @@ the same structured format for all attributes.
 
 See https://wiki.openfoodfacts.org/Product_Attributes
 
+If new attributes are added, make sure *to update the list of fields* fetched from MongoDB
+in Display.pm (in search_and_display_products subroutine).
+
+
 =cut
 
 package ProductOpener::Attributes;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5111,8 +5111,42 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 	}
 	# - if we use user preferences, we need a lot of fields to compute product attributes: load them all
 	elsif ($request_ref->{user_preferences}) {
-		# when product attributes become more stable, we could try to restrict the fields
-		$fields_ref = {};
+		# we restrict the fields that are queried to MongoDB, and use the basic ones and those necessary
+		# by Attributes.pm to compute attributes.
+		# This list should be updated if new attributes are added.
+		$fields_ref = {
+			# generic fields
+			"lc" => 1,
+			"code" => 1,
+			"product_name" => 1,
+			"product_name_$lc" => 1,
+			"generic_name" => 1,
+			"generic_name_$lc" => 1,
+			"abbreviated_product_name" => 1,
+			"abbreviated_product_name_$lc" => 1,
+			"brands" => 1,
+			"images" => 1,
+			"quantity" => 1,
+			# fields necessary for personal search
+			"additives_n" => 1,
+			"allergens_tags" => 1,
+			"categories_tags" => 1,
+			"ecoscore_data" => 1,
+			"ecoscore_grade" => 1,
+			"ecoscore_score" => 1,
+			"forest_footprint_data" => 1,
+			"ingredients_analysis_tags" => 1,
+			"ingredients_n" => 1,
+			"labels_tags" => 1,
+			"nova_group" => 1,
+			"nutrient_levels" => 1,
+			"nutriments" => 1,
+			"nutriscore_data" => 1,
+			"nutriscore_grade" => 1,
+			"nutrition_grades" => 1,
+			"traces_tags" => 1,
+			"unknown_ingredients_n" => 1
+		};
 	}
 	else {
 		#for HTML, limit the fields we retrieve from MongoDB


### PR DESCRIPTION
It does not solve issue #8792 as we're still over Memcached limit for main page, but it should still be faster (payload went from 30MB to 3MB). Without images, the payload is 2.3MB, so even while rearranging images we potentially need to increase memcached limit.
Furthermore, knowing which fields to fetched to compute attributes will be necessary once search-a-licious project is deployed, as data will be fetched from Elasticsearch (and not MongoDB).

It was tested locally, all attributes work as expected (a double check should be done once merged in staging).