### PR TITLE
fix: Mark script/css as base layout

### DIFF
--- a/html/js/display-product.js
+++ b/html/js/display-product.js
@@ -109,7 +109,7 @@ class RobotoffAsker extends HTMLElement {
     this.question = this.questions ? this.questions.pop() : null;
     if (!this.question) {
       const serverDomain = getServerDomain();
-      const response = await fetch(`${this.url}/api/v1/questions/${this.code}?lang=${this.lang}&server_domain=${serverDomain}`, { credentials: 'include' });
+      const response = await fetch(`${this.url}/api/v1/questions/${encodeURIComponent(this.code)}?lang=${encodeURIComponent(this.lang)}&server_domain=${encodeURIComponent(serverDomain)}`, { credentials: 'include' });
       const json = await response.json();
       if (!json || json.status !== 'found') {
         this.style.display = 'none';
@@ -172,13 +172,13 @@ class RobotoffAsker extends HTMLElement {
     const shadowRoot = this.attachShadow({mode: 'open'});
     const content = RobotoffAsker.template.content.cloneNode(true);
 
-    const styles = document.querySelectorAll('link[rel="stylesheet"]');
+    const styles = document.querySelectorAll('link[rel="stylesheet"][data-base-layout="true"]');
     for (let i = 0; i < styles.length; ++i) {
       const style = styles[i];
       content.appendChild(style.cloneNode(true));
     }
 
-    const scripts = document.querySelectorAll('script');
+    const scripts = document.querySelectorAll('script[data-base-layout="true"]');
     for (let i = 0; i < scripts.length; ++i) {
       const script = scripts[i];
       content.appendChild(script.cloneNode(true));

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -16,8 +16,8 @@
     <meta property="og:description" content="[% canon_description %]">
     [% options_favicons %]
     <link rel="canonical" href="[% canon_url %]">
-    <link rel="stylesheet" href="[% static_subdomain %]/css/dist/app-[% lang('text_direction') %].css?v=[% css_timestamp %]">
-    <link rel="stylesheet" href="[% static_subdomain %]/css/dist/jqueryui/themes/base/jquery-ui.css">
+    <link rel="stylesheet" href="[% static_subdomain %]/css/dist/app-[% lang('text_direction') %].css?v=[% css_timestamp %]" data-base-layout="true">
+    <link rel="stylesheet" href="[% static_subdomain %]/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
     <link rel="stylesheet" href="[% static_subdomain %]/css/dist/select2.min.css">
     <link rel="search" href="[% formatted_subdomain %]/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="[% lang('site_name') %]">
 	[% header %]
@@ -404,9 +404,9 @@
 
 	</div>
 
-<script src="[% static_subdomain %]/js/dist/modernizr.js"></script>
-<script src="[% static_subdomain %]/js/dist/jquery.js"></script>
-<script src="[% static_subdomain %]/js/dist/jquery-ui.js"></script>
+<script src="[% static_subdomain %]/js/dist/modernizr.js" data-base-layout="true"></script>
+<script src="[% static_subdomain %]/js/dist/jquery.js" data-base-layout="true"></script>
+<script src="[% static_subdomain %]/js/dist/jquery-ui.js" data-base-layout="true"></script>
 <script src="[% static_subdomain %]/js/dist/hc-sticky.js"></script>
 <script src="[% static_subdomain %]/js/dist/display.js"></script>
 <script src="[% static_subdomain %]/js/dist/stikelem.js"></script>
@@ -430,7 +430,7 @@
 <script src="https://support.openfoodfacts.org/assets/chat/chat.min.js"></script>
 [% END %]
 
-<script src="[% static_subdomain %]/js/dist/foundation.js"></script>
+<script src="[% static_subdomain %]/js/dist/foundation.js" data-base-layout="true"></script>
 <script src="[% static_subdomain %]/js/dist/jquery.cookie.js"></script>
 <script src="[% static_subdomain %]/js/dist/select2.min.js"></script>
 [% scripts %]


### PR DESCRIPTION
### What

Add a `data-`-attribute to some `script` and `link` tags, so that `robotoff-asker` can reduce the amount of JS/CSS run.

### Related issue(s) and discussion

- Fixes #8799

