### PR TITLE
fix: updated ingredients_categories_and_types

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1345,7 +1345,7 @@ Nested structure of ingredients and sub-ingredients
 
 sub parse_ingredients_text ($product_ref) {
 
-	my $debug_ingredients = 1;
+	my $debug_ingredients = 0;
 
 	delete $product_ref->{ingredients};
 

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -4796,7 +4796,6 @@ sub develop_ingredients_categories_and_types ($ingredients_lc, $text) {
 
 	if (defined $ingredients_categories_and_types{$ingredients_lc}) {
 
-		# my $categories_and_types_ref_index = 0;
 		foreach my $categories_and_types_ref (@{$ingredients_categories_and_types{$ingredients_lc}}) {
 
 			my $category_regexp = "";

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -4891,7 +4891,6 @@ sub develop_ingredients_categories_and_types ($ingredients_lc, $text) {
 				$text
 					=~ s/($category_regexp)\s?(?::)\s?($type_regexp)(?=$separators|$)/normalize_enumeration($ingredients_lc,$1,$2,$of_bool)/ieg;
 			}
-			# $categories_and_types_ref_index += 1;
 		}
 
 		# Some additives have "et" in their name: need to recombine them

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -4722,7 +4722,7 @@ my %ingredients_categories_and_types = (
 			]
 		],
 		# peppers
-		[["piment",], ["vert", "jaune", "rouge",], 0,],
+		[["piment", "poivron"], ["vert", "jaune", "rouge",], 0,],
 	],
 
 	pl => [

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -53522,7 +53522,7 @@ da:Grøn peber
 de:grüne Peperoni
 es:pimiento verde, pimientos verdes, pimiento verde dulce, pimientos verdes dulces
 fi:vihreä paprika
-fr:poivron vert, poivrons verts
+fr:poivron vert, poivrons verts, poivrons vert
 it:peperoni verdi
 nl:groene paprika
 pl:zielona papryka, papryka zielona, zielonej papryki

--- a/tests/unit/ingredients_parsing.t
+++ b/tests/unit/ingredients_parsing.t
@@ -15,13 +15,13 @@ use ProductOpener::Ingredients qw/:all/;
 
 #use Log::Any::Adapter 'TAP', filter => "none";
 
-is(normalize_a_of_b("en", "oil", "olive"), "olive oil");
-is(normalize_a_of_b("es", "aceta", "oliva"), "aceta de oliva");
-is(normalize_a_of_b("fr", "huile végétale", "olive"), "huile végétale d'olive");
+is(normalize_a_of_b("en", "oil", "olive", 1), "olive oil");
+is(normalize_a_of_b("es", "aceta", "oliva", 1), "aceta de oliva");
+is(normalize_a_of_b("fr", "huile végétale", "olive", 1), "huile végétale d'olive");
 
-is(normalize_enumeration("en", "phosphates", "calcium and sodium"), "calcium phosphates, sodium phosphates");
-is(normalize_enumeration("en", "vegetal oil", "sunflower, palm"), "sunflower vegetal oil, palm vegetal oil");
-is(normalize_enumeration("fr", "huile", "colza, tournesol et olive"),
+is(normalize_enumeration("en", "phosphates", "calcium and sodium", 1), "calcium phosphates, sodium phosphates");
+is(normalize_enumeration("en", "vegetal oil", "sunflower, palm", 1), "sunflower vegetal oil, palm vegetal oil");
+is(normalize_enumeration("fr", "huile", "colza, tournesol et olive", 1),
 	"huile de colza, huile de tournesol, huile d'olive");
 
 is(separate_additive_class("fr", "colorant", " ", "", "naturel"), "colorant ");
@@ -625,7 +625,9 @@ my @lists = (
 	],
 	["it", "formaggio, E 472 e, E470a.", "formaggio, e472 e, e470a."],
 	["it", "formaggio, E 472 e E470a.", "formaggio, e472, e470a."],
-	["sk", "syr, E470 a E470a, mlieko.", "syr, e470, e470a, mlieko."]
+	["sk", "syr, E470 a E470a, mlieko.", "syr, e470, e470a, mlieko."],
+	# Piments (vert, rouge, jaune) -> Piments vert, Piments rouge, Piments jaune
+	["fr", "Piments (vert, rouge, jaune)", "Piments vert, Piments rouge, Piments jaune"],
 );
 
 foreach my $test_ref (@lists) {


### PR DESCRIPTION
### What
Added piment in %ingredients_categories_and_types in Ingredients.pm.
Because it resulted to "piments de vert, piments de rouge, piments de jaune", a new variable (boolean) was added that can be set to 0 to indicate that there is no additional word ("de" or "d' ") between the categories (piment, for example) and the type (vert, for example).

### Screenshot
![Screenshot_20230919_195258](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/515e83b7-66c2-42da-be3f-d053fbcc0133)



### Related issue(s) and discussion
- Fixes #8890

