### PR TITLE
feat: Use 'GS1 Barcode Syntax Engine' to normalize product codes

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -89,6 +89,9 @@ requires 'Action::Retry'; # deps: libmath-fibonacci-perl
 requires 'AnyEvent';
 requires 'AnyEvent::Inotify::Simple';
 
+# GS1 Encoder
+requires 'GS1::SyntaxEngine::FFI';
+
 on 'test' => sub {
   requires 'Test::More', '>= 1.302186, < 2.0';
   requires 'Test::MockModule';

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -340,7 +340,7 @@ sub scan_code ($file) {
 				$log->debug("barcode found", {code => $code, type => $type}) if $log->is_debug();
 				print STDERR "scan_code code found: $code\n";
 
-				if (($code !~ /^[0-9]+$/) or ($type eq 'QR-Code')) {
+				if (($code !~ /^\d+|(?:[\^(\N{U+001D}\N{U+241D}]|https?:\/\/).+$/)) {
 					$code = undef;
 					next;
 				}

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -357,7 +357,11 @@ sub scan_code ($file) {
 
 		}
 	}
-	print STDERR "scan_code return code: $code\n";
+
+	if (defined $code) {
+		$code = normalize_code($code);
+		print STDERR "scan_code return code: $code\n";
+	}
 
 	return $code;
 }

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -344,7 +344,7 @@ sub _try_normalize_code_gs1 ($code) {
 		}
 	}
 
-	return undef;
+	return;
 }
 
 # - When products are public, the _id is the code, and the path is of the form 123/456/789/0123

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -311,37 +311,41 @@ sub normalize_code ($code) {
 }
 
 sub _try_normalize_code_gs1 ($code) {
-	$code =~ s/[\N{U+001D}\N{U+241D}]/^/g; # Replace FNC1/<GS1> with ^ for the GS1Encoder to work
-	my $parsed_as_gs1 = 0;
-	if ($code =~ /^\(.+/) {
-		# Code could be a GS1 bracketed AI element string
-		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
-		if ($encoder->ai_data_str($code)) {
-			my $ai_data_str = $encoder->ai_data_str();
-			if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
-				return $1;
+	eval {
+		my $parsed_as_gs1 = 0;
+		if ($code =~ /^\(.+/) {
+			# Code could be a GS1 bracketed AI element string
+			my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
+			if ($encoder->ai_data_str($code)) {
+				my $ai_data_str = $encoder->ai_data_str();
+				if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
+					return $1;
+				}
 			}
 		}
-	}
-	elsif ($code =~ /^\^.+/) {
-		# Code could be a GS1 unbracketed AI element string
-		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
-		if ($encoder->data_str($code)) {
-			my $ai_data_str = $encoder->ai_data_str();
-			if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
-				return $1;
+		elsif ($code =~ /^\^.+/) {
+			# Code could be a GS1 unbracketed AI element string
+			my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
+			if ($encoder->data_str($code)) {
+				my $ai_data_str = $encoder->ai_data_str();
+				if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
+					return $1;
+				}
 			}
 		}
-	}
-	elsif ($code =~ /^http?s:\/\/.+/) {
-		# Code could be a GS1 unbracketed AI element string
-		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
-		if ($encoder->data_str($code)) {
-			my $ai_data_str = $encoder->ai_data_str();
-			if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
-				return $1;
+		elsif ($code =~ /^http?s:\/\/.+/) {
+			# Code could be a GS1 unbracketed AI element string
+			my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
+			if ($encoder->data_str($code)) {
+				my $ai_data_str = $encoder->ai_data_str();
+				if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
+					return $1;
+				}
 			}
 		}
+	};
+	if ($@) {
+		$log->warn("GS1Parser error", {error => $@}) if $log->is_warn();
 	}
 
 	return;

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -281,7 +281,7 @@ sub normalize_code ($code) {
 	if (defined $code) {
 		my $gs1_code = _try_normalize_code_gs1($code);
 		if ($gs1_code) {
-			return $$gs1_code;
+			return $gs1_code;
 		}
 
 		# Keep only digits, remove spaces, dashes and everything else
@@ -316,20 +316,19 @@ sub _try_normalize_code_gs1 ($code) {
 	if ($code =~ /^\(.+/) {
 		# Code could be a GS1 bracketed AI element string
 		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
-		my $ai_data_str;
 		if ($encoder->ai_data_str($code)) {
-			$ai_data_str = $encoder->ai_data_str();
-			if ($ai_data_str =~ /^\(01\)(\d{1,14})$/) {
+			my $ai_data_str = $encoder->ai_data_str();
+			if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
 				return $1;
 			}
 		}
 	}
-	elsif ($code =~ /^\[.+/) {
+	elsif ($code =~ /^\^.+/) {
 		# Code could be a GS1 unbracketed AI element string
 		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
 		if ($encoder->data_str($code)) {
-			$ai_data_str = $encoder->ai_data_str();
-			if ($ai_data_str =~ /^\(01\)(\d{1,14})$/) {
+			my $ai_data_str = $encoder->ai_data_str();
+			if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
 				return $1;
 			}
 		}
@@ -338,8 +337,8 @@ sub _try_normalize_code_gs1 ($code) {
 		# Code could be a GS1 unbracketed AI element string
 		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
 		if ($encoder->data_str($code)) {
-			$ai_data_str = $encoder->ai_data_str();
-			if ($ai_data_str =~ /^\(01\)(\d{1,14})$/) {
+			my $ai_data_str = $encoder->ai_data_str();
+			if ($ai_data_str =~ /^\(01\)(\d{1,14})/) {
 				return $1;
 			}
 		}

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -281,7 +281,7 @@ sub normalize_code ($code) {
 	if (defined $code) {
 		my $gs1_code = _try_normalize_code_gs1($code);
 		if ($gs1_code) {
-			return $gs1_code;
+			$code = $gs1_code;
 		}
 
 		# Keep only digits, remove spaces, dashes and everything else

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -263,8 +263,9 @@ sub assign_new_code() {
 =head2 normalize_code()
 
 C<normalize_code()> this function normalizes the product code by:
-- Keeps only digits and removes spaces/dashes etc.
-- Normalizes the length by adding leading zeroes or removing the leading zero (in case of 14 digit codes)
+- running the given code through normalization method provided by GS1 to format a GS1 data string, or data URL to a GTIN,
+- keeping only digits and removing spaces/dashes etc.,
+- normalizing the length by adding leading zeroes or removing the leading zero (in case of 14 digit codes)
 
 =head3 Arguments
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -167,6 +167,8 @@ my $ean_check = CheckDigits('ean');
 
 use Scalar::Util qw(looks_like_number);
 
+use GS1::SyntaxEngine::FFI::GS1Encoder;
+
 =head1 FUNCTIONS
 
 =head2 make_sure_numbers_are_stored_as_numbers ( PRODUCT_REF )
@@ -277,6 +279,10 @@ Normalized version of the code
 sub normalize_code ($code) {
 
 	if (defined $code) {
+		my $gs1_code = _try_normalize_code_gs1($code);
+		if ($gs1_code) {
+			return $$gs1_code;
+		}
 
 		# Keep only digits, remove spaces, dashes and everything else
 		$code =~ s/\D//g;
@@ -302,6 +308,44 @@ sub normalize_code ($code) {
 		}
 	}
 	return $code;
+}
+
+sub _try_normalize_code_gs1 ($code) {
+	$code =~ s/[\N{U+001D}\N{U+241D}]/^/g; # Replace FNC1/<GS1> with ^ for the GS1Encoder to work
+	my $parsed_as_gs1 = 0;
+	if ($code =~ /^\(.+/) {
+		# Code could be a GS1 bracketed AI element string
+		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
+		my $ai_data_str;
+		if ($encoder->ai_data_str($code)) {
+			$ai_data_str = $encoder->ai_data_str();
+			if ($ai_data_str =~ /^\(01\)(\d{1,14})$/) {
+				return $1;
+			}
+		}
+	}
+	elsif ($code =~ /^\[.+/) {
+		# Code could be a GS1 unbracketed AI element string
+		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
+		if ($encoder->data_str($code)) {
+			$ai_data_str = $encoder->ai_data_str();
+			if ($ai_data_str =~ /^\(01\)(\d{1,14})$/) {
+				return $1;
+			}
+		}
+	}
+	elsif ($code =~ /^http?s:\/\/.+/) {
+		# Code could be a GS1 unbracketed AI element string
+		my $encoder = GS1::SyntaxEngine::FFI::GS1Encoder->new();
+		if ($encoder->data_str($code)) {
+			$ai_data_str = $encoder->ai_data_str();
+			if ($ai_data_str =~ /^\(01\)(\d{1,14})$/) {
+				return $1;
+			}
+		}
+	}
+
+	return undef;
 }
 
 # - When products are public, the _id is the code, and the path is of the form 123/456/789/0123
@@ -358,7 +402,7 @@ e.g. off:[code]
 
 =head4 Owner id
 
-=head4 Code 
+=head4 Code
 
 Product barcode
 
@@ -625,7 +669,7 @@ sub get_owner_id ($userid, $orgid, $ownerid) {
 
 =head2 init_product ( $userid, $orgid, $code, $countryid )
 
-Initializes and return a $product_ref structure for a new product. 
+Initializes and return a $product_ref structure for a new product.
 If $countryid is defined and is not "en:world", then assign this country for the countries field.
 Otherwise, use the country associated with the ip address of the user.
 
@@ -1709,7 +1753,7 @@ to determine if the change was done through an app, the OFF userid, or an app sp
 
 =head3 Parameters
 
-=head4 $change_ref 
+=head4 $change_ref
 reference to a change record
 
 =head3 Return value
@@ -3360,7 +3404,7 @@ e.g. official producer data that should not be changed by anonymous users throug
 Product data is protected if it has an owner and if the corresponding organization has
 the "protect data" checkbox checked.
 
-=head3 Parameters 
+=head3 Parameters
 
 =head4 $product_ref
 

--- a/stop_words.txt
+++ b/stop_words.txt
@@ -217,6 +217,7 @@ uncharacterized
 undef
 ur
 url
+uri
 userid
 UTF
 utilisant

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -20,16 +20,16 @@ is(normalize_code(' just a simple test 036000291452 here we go '),
 	'0036000291452', 'should add leading 0 to cleaned valid UPC12');
 is(normalize_code(' just a simple test 036000291455 here we go '),
 	'036000291455', 'should not add leading 0 to cleaned invalid UPC12');
-is(normalize_code('0100012345000058'), '00012345000058', 'should reduce GS1 AI unbracketed string to GTIN');
-is(normalize_code('(01)00012345000058(17)270101'), '00012345000058', 'should reduce GS1 AI bracketed string to GTIN');
-is(normalize_code('^00012345000058270101'),
-	'00012345000058', 'should reduce GS1 AI unbracketed string with ^ as FNC1 to GTIN');
-is(normalize_code("\x{001d}00012345000058270101"),
-	'00012345000058', 'should reduce GS1 AI unbracketed string with original FNC1 to GTIN');
-is(normalize_code("\x{241d}00012345000058270101"),
-	'00012345000058', 'should reduce GS1 AI unbracketed string with GS as FNC1 to GTIN');
-is(normalize_code('https://id.gs1.org/01/09506000140445/22/2A'),
-	'09506000140445', 'should reduce GS1 Digital Link URI string with ^ as FNC1 to GTIN');
+is(normalize_code('0104044782317112'), '4044782317112', 'should reduce GS1 AI unbracketed string to GTIN');
+is(normalize_code('(01)04044782317112(17)270101'), '4044782317112', 'should reduce GS1 AI bracketed string to GTIN');
+is(normalize_code('^010404478231711217270101'),
+	'4044782317112', 'should reduce GS1 AI unbracketed string with ^ as FNC1 to GTIN');
+is(normalize_code("\x{001d}010404478231711217270101"),
+	'4044782317112', 'should reduce GS1 AI unbracketed string with original FNC1 to GTIN');
+is(normalize_code("\x{241d}010404478231711217270101"),
+	'4044782317112', 'should reduce GS1 AI unbracketed string with GS as FNC1 to GTIN');
+is(normalize_code('https://id.gs1.org/01/04044782317112/22/2A'),
+	'4044782317112', 'should reduce GS1 Digital Link URI string with ^ as FNC1 to GTIN');
 
 # product storage path
 is(product_path_from_id('not a real code'), 'invalid', 'non digit code should return "invalid"');

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -21,10 +21,14 @@ is(normalize_code(' just a simple test 036000291452 here we go '),
 is(normalize_code(' just a simple test 036000291455 here we go '),
 	'036000291455', 'should not add leading 0 to cleaned invalid UPC12');
 is(normalize_code('(01)00012345000058(17)270101'), '00012345000058', 'should reduce GS1 AI bracketed string to GTIN');
-is(normalize_code('^00012345000058270101'), '00012345000058', 'should reduce GS1 AI unbracketed string with ^ as FNC1 to GTIN');
-is(normalize_code("\x{001d}00012345000058270101"), '00012345000058', 'should reduce GS1 AI unbracketed string with original FNC1 to GTIN');
-is(normalize_code("\x{241d}00012345000058270101"), '00012345000058', 'should reduce GS1 AI unbracketed string with GS as FNC1 to GTIN');
-is(normalize_code('https://id.gs1.org/01/09506000140445/22/2A'), '09506000140445', 'should reduce GS1 Digital Link URI string with ^ as FNC1 to GTIN');
+is(normalize_code('^00012345000058270101'),
+	'00012345000058', 'should reduce GS1 AI unbracketed string with ^ as FNC1 to GTIN');
+is(normalize_code("\x{001d}00012345000058270101"),
+	'00012345000058', 'should reduce GS1 AI unbracketed string with original FNC1 to GTIN');
+is(normalize_code("\x{241d}00012345000058270101"),
+	'00012345000058', 'should reduce GS1 AI unbracketed string with GS as FNC1 to GTIN');
+is(normalize_code('https://id.gs1.org/01/09506000140445/22/2A'),
+	'09506000140445', 'should reduce GS1 Digital Link URI string with ^ as FNC1 to GTIN');
 
 # product storage path
 is(product_path_from_id('not a real code'), 'invalid', 'non digit code should return "invalid"');

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -20,6 +20,7 @@ is(normalize_code(' just a simple test 036000291452 here we go '),
 	'0036000291452', 'should add leading 0 to cleaned valid UPC12');
 is(normalize_code(' just a simple test 036000291455 here we go '),
 	'036000291455', 'should not add leading 0 to cleaned invalid UPC12');
+is(normalize_code('0100012345000058'), '00012345000058', 'should reduce GS1 AI unbracketed string to GTIN');
 is(normalize_code('(01)00012345000058(17)270101'), '00012345000058', 'should reduce GS1 AI bracketed string to GTIN');
 is(normalize_code('^00012345000058270101'),
 	'00012345000058', 'should reduce GS1 AI unbracketed string with ^ as FNC1 to GTIN');

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -20,6 +20,11 @@ is(normalize_code(' just a simple test 036000291452 here we go '),
 	'0036000291452', 'should add leading 0 to cleaned valid UPC12');
 is(normalize_code(' just a simple test 036000291455 here we go '),
 	'036000291455', 'should not add leading 0 to cleaned invalid UPC12');
+is(normalize_code('(01)00012345000058(17)270101'), '00012345000058', 'should reduce GS1 AI bracketed string to GTIN');
+is(normalize_code('^00012345000058270101'), '00012345000058', 'should reduce GS1 AI unbracketed string with ^ as FNC1 to GTIN');
+is(normalize_code("\x{001d}00012345000058270101"), '00012345000058', 'should reduce GS1 AI unbracketed string with original FNC1 to GTIN');
+is(normalize_code("\x{241d}00012345000058270101"), '00012345000058', 'should reduce GS1 AI unbracketed string with GS as FNC1 to GTIN');
+is(normalize_code('https://id.gs1.org/01/09506000140445/22/2A'), '09506000140445', 'should reduce GS1 Digital Link URI string with ^ as FNC1 to GTIN');
 
 # product storage path
 is(product_path_from_id('not a real code'), 'invalid', 'non digit code should return "invalid"');

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -30,6 +30,12 @@ is(normalize_code("\x{241d}010404478231711217270101"),
 	'4044782317112', 'should reduce GS1 AI unbracketed string with GS as FNC1 to GTIN');
 is(normalize_code('https://id.gs1.org/01/04044782317112/22/2A'),
 	'4044782317112', 'should reduce GS1 Digital Link URI string with ^ as FNC1 to GTIN');
+is(normalize_code('https://dalgiardino.com/01/09506000134376/10/ABC/21/123456?17=211200'),
+	'9506000134376', 'should reduce GS1 Digital Link URI to GTIN');
+is(normalize_code('https://example.com/01/00012345000058?17=271200'),
+	'0012345000058', 'should reduce GS1 Digital Link URI to GTIN');
+is(normalize_code('https://world.openfoodfacts.org/'), '', 'non-GS1 URIs should return an empty string');
+is(normalize_code('http://spam.zip/'), '', 'non-GS1 URIs should return an empty string');
 
 # product storage path
 is(product_path_from_id('not a real code'), 'invalid', 'non digit code should return "invalid"');


### PR DESCRIPTION
### What

Use Perl module `GS1::SyntaxEngine::FFI` to normalize barcodes. This allows more GS1 strings to be used with search.

### Related issue(s) and discussion

- Fixes #9013

