### PR TITLE
fix: error and warning for vegan label with non-vegan ingredients

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1384,36 +1384,6 @@ Vegetarian label: check that there is no non-vegetarian ingredient.
 =cut
 
 sub check_labels ($product_ref) {
-	# if (defined $product_ref->{labels_tags} && has_tag($product_ref, "labels", "en:vegan")) {
-	# 	if (defined $product_ref->{ingredients}) {
-	# 		my @ingredients = @{$product_ref->{ingredients}};
-
-	# 		while (@ingredients) {
-
-	# 			# Remove and process the first ingredient
-	# 			my $ingredient_ref = shift @ingredients;
-	# 			my $ingredientid = $ingredient_ref->{id};
-
-	# 			# Add sub-ingredients at the beginning of the ingredients array
-	# 			if (defined $ingredient_ref->{ingredients}) {
-
-	# 				unshift @ingredients, @{$ingredient_ref->{ingredients}};
-	# 			}
-
-	# 			if (defined $ingredient_ref->{"vegan"}) {
-	# 				if ($ingredient_ref->{"vegan"} eq 'no') {
-	# 					push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
-	# 				}
-	# 				# else 'yes', 'maybe'
-	# 			}
-	# 			else {
-	# 				push @{$product_ref->{data_quality_warnings_tags}},
-	# 					"en:vegan-label-but-could-not-confirm-for-all-ingredients";
-	# 			}
-	# 		}
-	# 	}
-	# }
-
 	# this also include en:vegan that is a child of en:vegetarian
 	if (defined $product_ref->{labels_tags} && has_tag($product_ref, "labels", "en:vegetarian")) {
 		if (defined $product_ref->{ingredients}) {

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1402,7 +1402,7 @@ sub check_labels ($product_ref) {
 				}
 
 				# some additives_classes (like thickener, for example) do not have the key-value vegan and vegetarian
-				# it it can be additives_classes that contain only vegan/vegetarian additives.
+				# it can be additives_classes that contain only vegan/vegetarian additives.
 				# to avoid false-positive - instead of raising a warning (else below) we ignore additives_classes
 				if (!exists_taxonomy_tag("additives_classes", $ingredientid)) {
 					if (has_tag($product_ref, "labels", "en:vegan")) {

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1399,7 +1399,7 @@ sub check_labels ($product_ref) {
 
 	# 				unshift @ingredients, @{$ingredient_ref->{ingredients}};
 	# 			}
-				
+
 	# 			if (defined $ingredient_ref->{"vegan"}) {
 	# 				if ($ingredient_ref->{"vegan"} eq 'no') {
 	# 					push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
@@ -1432,7 +1432,7 @@ sub check_labels ($product_ref) {
 				}
 
 				# some additives_classes (like thickener, for example) do not have the key-value vegan and vegetarian
-				# it it can be additives_classes that contain only vegan/vegetarian additives. 
+				# it it can be additives_classes that contain only vegan/vegetarian additives.
 				# to avoid false-positive - instead of raising a warning (else below) we ignore additives_classes
 				if (!exists_taxonomy_tag("additives_classes", $ingredientid)) {
 					# vegan

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1373,6 +1373,69 @@ sub check_categories ($product_ref) {
 	return;
 }
 
+=head2 check_labels( PRODUCT_REF )
+
+Checks related to specific product labels.
+
+Vegan label: check that there is no non-vegan ingredient.
+
+Vegetarian label: check that there is no non-vegetarian ingredient.
+
+=cut
+
+sub check_labels ($product_ref) {
+	if (defined $product_ref->{labels_tags} && has_tag($product_ref, "labels", "en:vegan")) {
+		if (defined $product_ref->{ingredients}) {
+			# my $has_non_vegan_ingredient = 0;
+			# foreach my $ingredient ()
+
+			# my $product_ref_ingredients = ($product_ref->{ingredients});
+			# my @all_ingredients = ($product_ref_ingredients);
+			my @ingredients = @{$product_ref->{ingredients}};
+
+			while (@ingredients) {
+
+				# Remove and process the first ingredient
+				my $ingredient_ref = shift @ingredients;
+				my $ingredientid = $ingredient_ref->{id};
+
+				# Add sub-ingredients at the beginning of the ingredients array
+				if (defined $ingredient_ref->{ingredients}) {
+
+					unshift @ingredients, @{$ingredient_ref->{ingredients}};
+				}
+
+				# vegan
+				if (defined $ingredient_ref->{"vegan"}) {
+					if ($ingredient_ref->{"vegan"} eq 'no') {
+						push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
+					}
+					# else 'yes', 'maybe'
+				}
+				else {
+					push @{$product_ref->{data_quality_warnings_tags}},
+						"en:vegan-label-but-could-not-confirm-for-all-ingredients";
+				}
+
+				# vegetarian
+				if (defined $ingredient_ref->{"vegetarian"}) {
+					if ($ingredient_ref->{"vegetarian"} eq 'no') {
+						push @{$product_ref->{data_quality_errors_tags}},
+							"en:vegetarian-label-but-non-vegetarian-ingredient";
+					}
+					# else 'yes', 'maybe'
+				}
+				else {
+					push @{$product_ref->{data_quality_warnings_tags}},
+						"en:vegetarian-label-but-could-not-confirm-for-all-ingredients";
+				}
+			}
+		}
+	}
+
+	return;
+}
+
 sub compare_nutriscore_with_value_from_producer ($product_ref) {
 
 	if (
@@ -1572,6 +1635,7 @@ sub check_quality_food ($product_ref) {
 	check_quantity($product_ref);
 	detect_categories($product_ref);
 	check_categories($product_ref);
+	check_labels($product_ref);
 	compare_nutriscore_with_value_from_producer($product_ref);
 	check_ecoscore_data($product_ref);
 	check_food_groups($product_ref);

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1384,13 +1384,39 @@ Vegetarian label: check that there is no non-vegetarian ingredient.
 =cut
 
 sub check_labels ($product_ref) {
-	if (defined $product_ref->{labels_tags} && has_tag($product_ref, "labels", "en:vegan")) {
-		if (defined $product_ref->{ingredients}) {
-			# my $has_non_vegan_ingredient = 0;
-			# foreach my $ingredient ()
+	# if (defined $product_ref->{labels_tags} && has_tag($product_ref, "labels", "en:vegan")) {
+	# 	if (defined $product_ref->{ingredients}) {
+	# 		my @ingredients = @{$product_ref->{ingredients}};
 
-			# my $product_ref_ingredients = ($product_ref->{ingredients});
-			# my @all_ingredients = ($product_ref_ingredients);
+	# 		while (@ingredients) {
+
+	# 			# Remove and process the first ingredient
+	# 			my $ingredient_ref = shift @ingredients;
+	# 			my $ingredientid = $ingredient_ref->{id};
+
+	# 			# Add sub-ingredients at the beginning of the ingredients array
+	# 			if (defined $ingredient_ref->{ingredients}) {
+
+	# 				unshift @ingredients, @{$ingredient_ref->{ingredients}};
+	# 			}
+				
+	# 			if (defined $ingredient_ref->{"vegan"}) {
+	# 				if ($ingredient_ref->{"vegan"} eq 'no') {
+	# 					push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
+	# 				}
+	# 				# else 'yes', 'maybe'
+	# 			}
+	# 			else {
+	# 				push @{$product_ref->{data_quality_warnings_tags}},
+	# 					"en:vegan-label-but-could-not-confirm-for-all-ingredients";
+	# 			}
+	# 		}
+	# 	}
+	# }
+
+	# this also include en:vegan that is a child of en:vegetarian
+	if (defined $product_ref->{labels_tags} && has_tag($product_ref, "labels", "en:vegetarian")) {
+		if (defined $product_ref->{ingredients}) {
 			my @ingredients = @{$product_ref->{ingredients}};
 
 			while (@ingredients) {
@@ -1405,29 +1431,34 @@ sub check_labels ($product_ref) {
 					unshift @ingredients, @{$ingredient_ref->{ingredients}};
 				}
 
-				# vegan
-				if (defined $ingredient_ref->{"vegan"}) {
-					if ($ingredient_ref->{"vegan"} eq 'no') {
-						push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
+				# some additives_classes (like thickener, for example) do not have the key-value vegan and vegetarian
+				# it it can be additives_classes that contain only vegan/vegetarian additives. 
+				# to avoid false-positive - instead of raising a warning (else below) we ignore additives_classes
+				if (!exists_taxonomy_tag("additives_classes", $ingredientid)) {
+					# vegan
+					if (defined $ingredient_ref->{"vegan"}) {
+						if ($ingredient_ref->{"vegan"} eq 'no') {
+							push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
+						}
+						# else 'yes', 'maybe'
 					}
-					# else 'yes', 'maybe'
-				}
-				else {
-					push @{$product_ref->{data_quality_warnings_tags}},
-						"en:vegan-label-but-could-not-confirm-for-all-ingredients";
-				}
+					else {
+						push @{$product_ref->{data_quality_warnings_tags}},
+							"en:vegan-label-but-could-not-confirm-for-all-ingredients";
+					}
 
-				# vegetarian
-				if (defined $ingredient_ref->{"vegetarian"}) {
-					if ($ingredient_ref->{"vegetarian"} eq 'no') {
-						push @{$product_ref->{data_quality_errors_tags}},
-							"en:vegetarian-label-but-non-vegetarian-ingredient";
+					# vegetarian
+					if (defined $ingredient_ref->{"vegetarian"}) {
+						if ($ingredient_ref->{"vegetarian"} eq 'no') {
+							push @{$product_ref->{data_quality_errors_tags}},
+								"en:vegetarian-label-but-non-vegetarian-ingredient";
+						}
+						# else 'yes', 'maybe'
 					}
-					# else 'yes', 'maybe'
-				}
-				else {
-					push @{$product_ref->{data_quality_warnings_tags}},
-						"en:vegetarian-label-but-could-not-confirm-for-all-ingredients";
+					else {
+						push @{$product_ref->{data_quality_warnings_tags}},
+							"en:vegetarian-label-but-could-not-confirm-for-all-ingredients";
+					}
 				}
 			}
 		}

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1435,16 +1435,19 @@ sub check_labels ($product_ref) {
 				# it it can be additives_classes that contain only vegan/vegetarian additives.
 				# to avoid false-positive - instead of raising a warning (else below) we ignore additives_classes
 				if (!exists_taxonomy_tag("additives_classes", $ingredientid)) {
-					# vegan
-					if (defined $ingredient_ref->{"vegan"}) {
-						if ($ingredient_ref->{"vegan"} eq 'no') {
-							push @{$product_ref->{data_quality_errors_tags}}, "en:vegan-label-but-non-vegan-ingredient";
+					if (has_tag($product_ref, "labels", "en:vegan")) {
+						# vegan
+						if (defined $ingredient_ref->{"vegan"}) {
+							if ($ingredient_ref->{"vegan"} eq 'no') {
+								push @{$product_ref->{data_quality_errors_tags}},
+									"en:vegan-label-but-non-vegan-ingredient";
+							}
+							# else 'yes', 'maybe'
 						}
-						# else 'yes', 'maybe'
-					}
-					else {
-						push @{$product_ref->{data_quality_warnings_tags}},
-							"en:vegan-label-but-could-not-confirm-for-all-ingredients";
+						else {
+							push @{$product_ref->{data_quality_warnings_tags}},
+								"en:vegan-label-but-could-not-confirm-for-all-ingredients";
+						}
 					}
 
 					# vegetarian

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -2857,3 +2857,23 @@ en:Carbon footprint from known ingredients less than from meat or fish
 <en:Carbon footprint warnings
 en:Carbon footprint from known ingredients more than from meat or fish
 #description:en:
+
+
+
+### Labels
+
+<en:Data quality errors
+en:vegan-label-but-non-vegan-ingredient
+description:en:This product has a vegan label but contains non-vegan ingredients.
+
+<en:Data quality errors
+en:vegetarian-label-but-non-vegetarian-ingredient
+description:en:This product has a vegetarian label but contains non-vegetarian ingredients.
+
+<en:Data quality warnings
+en:vegan-label-but-could-not-confirm-for-all-ingredients 
+description:en:This product has a vegan label, however some ingredients are not known as non-vegan in the taxonomy (could be unknown ingredients or missing vegan true/false in the taxonomy).
+
+<en:Data quality warnings
+en:vegetarian-label-but-could-not-confirm-for-all-ingredients 
+description:en:This product has a vegetarian label, however some ingredients are not known as non-vegetarian in the taxonomy (could be unknown ingredients or missing vegetarian true/false in the taxonomy).

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1094,5 +1094,128 @@ check_quality_and_test_product_has_quality_tag(
 	'en:ingredients-single-ingredient-from-category-does-not-match-actual-ingredients',
 	'We expect the ingredient given in the taxonomy for this product', 0
 );
-
+# vegan label but non-vegan ingredients
+# unknown ingredient -> warnings
+$product_ref = {
+	labels_tags => ["en:vegetarian", "en:vegan",],
+	ingredients => [
+		{
+			id => "en:lentils",
+			vegan => "yes",
+			vegetarian => "yes"
+		},
+		{
+			id => "en:green-bell-pepper",
+			vegan => "yes",
+			vegetarian => "yes"
+		},
+		{
+			id => "en:totoro",
+		}
+	],
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegan-label-but-non-vegan-ingredient',
+	'raise error only when vegan is no and label is vegan', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegetarian-label-but-non-vegetarian-ingredient',
+	'raise error only when vegetarian is no and label is vegan', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegan-label-but-could-not-confirm-for-all-ingredients',
+	'raise warning because vegan or non-vegan is unknown for an ingredient', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegetarian-label-but-could-not-confirm-for-all-ingredients',
+	'raise warning because vegetarian or non-vegetarian is unknown for an ingredient', 1
+);
+# non-vegan/non-vegetarian ingredient -> error
+$product_ref = {
+	labels_tags => ["en:vegetarian", "en:vegan",],
+	ingredients => [
+		{
+			id => "en:lentils",
+			vegan => "yes",
+			vegetarian => "yes"
+		},
+		{
+			id => "en:green-bell-pepper",
+			vegan => "yes",
+			vegetarian => "yes"
+		},
+		{
+			id => "en:chicken",
+			vegan => "no",
+			vegetarian => "no"
+		}
+	],
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegan-label-but-non-vegan-ingredient',
+	'raise error only when vegan is no and label is vegan', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegetarian-label-but-non-vegetarian-ingredient',
+	'raise error only when vegetarian is no and label is vegan', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegan-label-but-could-not-confirm-for-all-ingredients',
+	'raise warning because vegan or non-vegan is unknown for an ingredient', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegetarian-label-but-could-not-confirm-for-all-ingredients',
+	'raise warning because vegetarian or non-vegetarian is unknown for an ingredient', 0
+);
+# non-vegan/vegatarian ingredient -> error
+$product_ref = {
+	labels_tags => ["en:vegetarian", "en:vegan",],
+	ingredients => [
+		{
+			id => "en:lentils",
+			vegan => "yes",
+			vegetarian => "yes"
+		},
+		{
+			id => "en:green-bell-pepper",
+			vegan => "yes",
+			vegetarian => "yes"
+		},
+		{
+			id => "en:honey",
+			vegan => "no",
+			vegetarian => "yes"
+		}
+	],
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegan-label-but-non-vegan-ingredient',
+	'raise error only when vegan is no and label is vegan', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegetarian-label-but-non-vegetarian-ingredient',
+	'raise error only when vegetarian is no and label is vegan', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegan-label-but-could-not-confirm-for-all-ingredients',
+	'raise warning because vegan or non-vegan is unknown for an ingredient', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vegetarian-label-but-could-not-confirm-for-all-ingredients',
+	'raise warning because vegetarian or non-vegetarian is unknown for an ingredient', 0
+);
 done_testing();


### PR DESCRIPTION
### What
Added data quality errors:
- vegan label but non-vegan ingredients
- vegetarian label but non-vegetarian ingredients

Added warning:
- vegan label but could not confirm for some ingredients
- vegetarian label but could not confirm for some ingredients

### Discussion
Question mark about the warning, because of these 2 cases:
- some ingredients (like thickener, for example) do not have the key-value vegan and vegetarian) -> but it can be additives classes that could contain only vegan/vegetarian additives. false-positive in this case (example: https://world.openfoodfacts.org/api/v2/product/3263859506216.json)
- key-value vegan and vegetarian can be yes, no or maybe. For this latter, we could also generate a warning.

These two would need further investigations. Maybe, we can start with this error and the warning as it is now, and come back to it in the future.

### Screenshot
![Screenshot_20230923_230032](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/16f004d5-c348-4d48-aceb-9b505bb6833c)

### Related issue(s) and discussion
- Fixes #5249
