### PR TITLE
fix: parse 'some ingredient (some quantity per 100g of finished product)'

### DIFF
--- a/stop_words.txt
+++ b/stop_words.txt
@@ -8,6 +8,7 @@ acidifiant
 Agribalyse
 AgriBalyse
 AGS
+Alimentarius
 Allergènes
 Anses
 ANSES
@@ -104,6 +105,7 @@ hashmaps
 hashref
 hashrefs
 heic
+hinnies
 http
 https
 incrontab
@@ -153,6 +155,7 @@ Nutriscore
 ok
 obf
 off
+Offals
 openfoodfacts
 OpenFoodFacts
 Origine

--- a/tests/unit/expected_test_results/ingredients/en-quantity-per-100g.json
+++ b/tests/unit/expected_test_results/ingredients/en-quantity-per-100g.json
@@ -1,0 +1,118 @@
+{
+   "ingredients" : [
+      {
+         "id" : "en:tomato",
+         "ingredients" : [
+            {
+               "id" : "en:per",
+               "percent_estimate" : 75,
+               "percent_max" : 100,
+               "percent_min" : 50,
+               "quantity" : "148 g",
+               "quantity_g" : 148,
+               "text" : "per"
+            }
+         ],
+         "percent_estimate" : 75,
+         "percent_max" : 100,
+         "percent_min" : 50,
+         "text" : "tomatoes",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:pork",
+         "ingredients" : [
+            {
+               "id" : "en:per-100-g-of-finished-product",
+               "percent_estimate" : 25,
+               "percent_max" : 50,
+               "percent_min" : 0,
+               "quantity" : "200 g",
+               "quantity_g" : 200,
+               "text" : "per 100 g of finished product"
+            }
+         ],
+         "percent_estimate" : 25,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "pork",
+         "vegan" : "no",
+         "vegetarian" : "no"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:non-vegan" : [
+         "en:pork"
+      ],
+      "en:non-vegetarian" : [
+         "en:pork"
+      ],
+      "en:palm-oil-content-unknown" : [
+         "en:per",
+         "en:per-100-g-of-finished-product"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:per",
+         "en:per-100-g-of-finished-product"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:per",
+         "en:per-100-g-of-finished-product"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:non-vegan",
+      "en:non-vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:tomato",
+      "en:vegetable",
+      "en:fruit-vegetable",
+      "en:pork",
+      "en:animal",
+      "en:per",
+      "en:per-100-g-of-finished-product"
+   ],
+   "ingredients_n" : 4,
+   "ingredients_n_tags" : [
+      "4",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:tomato",
+      "en:pork",
+      "en:per",
+      "en:per-100-g-of-finished-product"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:tomato",
+      "en:vegetable",
+      "en:fruit-vegetable",
+      "en:pork",
+      "en:animal",
+      "en:per",
+      "en:per-100-g-of-finished-product"
+   ],
+   "ingredients_text" : "tomatoes (148 g per 100g), pork (200 g per 100 g of finished product)",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 2,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:per",
+      "en:per-100-g-of-finished-product"
+   ],
+   "ingredients_without_ciqual_codes_n" : 2,
+   "known_ingredients_n" : 5,
+   "lc" : "en",
+   "nutriments" : {
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 75,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 75,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 75,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 75
+   },
+   "unknown_ingredients_n" : 2
+}

--- a/tests/unit/expected_test_results/ingredients/fr-quantity-per-100g.json
+++ b/tests/unit/expected_test_results/ingredients/fr-quantity-per-100g.json
@@ -1,0 +1,80 @@
+{
+   "ingredients" : [
+      {
+         "ciqual_food_code" : "20047",
+         "id" : "en:tomato",
+         "percent" : 42.5287356321839,
+         "percent_estimate" : 42.5287356321839,
+         "quantity" : "148 g",
+         "quantity_g" : 148,
+         "text" : "tomates",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:pork",
+         "percent" : 57.4712643678161,
+         "percent_estimate" : 57.4712643678161,
+         "quantity" : "200 g",
+         "quantity_g" : 200,
+         "text" : "porc",
+         "vegan" : "no",
+         "vegetarian" : "no"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:non-vegan" : [
+         "en:pork"
+      ],
+      "en:non-vegetarian" : [
+         "en:pork"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:non-vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:tomato",
+      "en:vegetable",
+      "en:fruit-vegetable",
+      "en:pork",
+      "en:animal"
+   ],
+   "ingredients_n" : 2,
+   "ingredients_n_tags" : [
+      "2",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:tomato",
+      "en:pork"
+   ],
+   "ingredients_percent_analysis" : -1,
+   "ingredients_tags" : [
+      "en:tomato",
+      "en:vegetable",
+      "en:fruit-vegetable",
+      "en:pork",
+      "en:animal"
+   ],
+   "ingredients_text" : "tomates (148 g par 100g), porc (200 gr par 100 g de produit fini)",
+   "ingredients_with_specified_percent_n" : 2,
+   "ingredients_with_specified_percent_sum" : 100,
+   "ingredients_with_unspecified_percent_n" : 0,
+   "ingredients_with_unspecified_percent_sum" : 0,
+   "ingredients_without_ciqual_codes" : [
+      "en:pork"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
+   "known_ingredients_n" : 5,
+   "lc" : "fr",
+   "nutriments" : {
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 42.5287356321839,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 42.5287356321839,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 42.5287356321839,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 42.5287356321839
+   },
+   "unknown_ingredients_n" : 0
+}

--- a/tests/unit/expected_test_results/ingredients/fr-specific-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/fr-specific-ingredients.json
@@ -37,12 +37,19 @@
          "ingredients" : [
             {
                "id" : "en:fruit-pectin",
-               "percent_estimate" : 9.375,
+               "percent_estimate" : 4.6875,
                "percent_max" : 25,
                "percent_min" : 0,
                "text" : "pectines de fruits",
                "vegan" : "yes",
                "vegetarian" : "yes"
+            },
+            {
+               "id" : "fr:teneur-totale-en-sucres",
+               "percent_estimate" : 4.6875,
+               "percent_max" : 12.5,
+               "percent_min" : 0,
+               "text" : "Teneur totale en sucres"
             }
          ],
          "percent_estimate" : 9.375,
@@ -51,11 +58,21 @@
          "text" : "gélifiant"
       }
    ],
-   "ingredients_analysis" : {},
+   "ingredients_analysis" : {
+      "en:palm-oil-content-unknown" : [
+         "fr:teneur-totale-en-sucres"
+      ],
+      "en:vegan-status-unknown" : [
+         "fr:teneur-totale-en-sucres"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "fr:teneur-totale-en-sucres"
+      ]
+   },
    "ingredients_analysis_tags" : [
       "en:palm-oil-free",
-      "en:vegan",
-      "en:vegetarian"
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
    ],
    "ingredients_hierarchy" : [
       "en:cane-sugar",
@@ -71,11 +88,12 @@
       "en:lemon-juice",
       "en:gelling-agent",
       "en:fruit-pectin",
-      "en:e440a"
+      "en:e440a",
+      "fr:teneur-totale-en-sucres"
    ],
-   "ingredients_n" : 5,
+   "ingredients_n" : 6,
    "ingredients_n_tags" : [
-      "5",
+      "6",
       "1-10"
    ],
    "ingredients_original_tags" : [
@@ -83,7 +101,8 @@
       "en:apricot",
       "en:concentrated-lemon-juice",
       "en:gelling-agent",
-      "en:fruit-pectin"
+      "en:fruit-pectin",
+      "fr:teneur-totale-en-sucres"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
@@ -100,31 +119,33 @@
       "en:lemon-juice",
       "en:gelling-agent",
       "en:fruit-pectin",
-      "en:e440a"
+      "en:e440a",
+      "fr:teneur-totale-en-sucres"
    ],
    "ingredients_text" : "Sucre de canne*, abricots*, jus de citrons concentré*, gélifiant : pectines de fruits. *biologique.\nPréparée avec 50 grammes de fruits pour 100gr de produit fini.\nPréparé avec 32,5 % de légumes -\nPréparés avec 25,2g de tomates.\nPREPARE AVEC 30% DE TRUC INCONNU.\nTeneur totale en sucres : 60 g pour 100 g de produit fini.\nTeneur en lait: minimum 40%.\nTeneur minimum en jus de fruits 35 grammes pour 100 grammes de produit fini.\nPrésence exceptionnelle possible de noyaux ou de morceaux de noyaux.\nOrigine des abricots: Provence.\nTeneur en citron de 5,5%",
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
-   "ingredients_with_unspecified_percent_n" : 4,
+   "ingredients_with_unspecified_percent_n" : 5,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:apricot",
       "en:cane-sugar",
-      "en:fruit-pectin"
+      "en:fruit-pectin",
+      "fr:teneur-totale-en-sucres"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 4,
    "known_ingredients_n" : 14,
    "lc" : "fr",
    "nutriments" : {
-      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 115.7,
-      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 115.7,
-      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 148.2,
-      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 148.2
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 30.7,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 30.7,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 63.2,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 63.2
    },
    "specific_ingredients" : [
       {
-         "id" : "en:fruit",
-         "ingredient" : "fruits",
+         "id" : "fr:fruits-pour-100g-de-produit-fini",
+         "ingredient" : "fruits pour 100g de produit fini",
          "quantity" : "50 g",
          "quantity_g" : 50,
          "text" : "Préparée avec 50 g de fruits pour 100g de produit fini."
@@ -148,24 +169,10 @@
          "text" : "PREPARE AVEC 30% DE TRUC INCONNU."
       },
       {
-         "id" : "en:sugar",
-         "ingredient" : "sucres",
-         "quantity" : "60 g",
-         "quantity_g" : 60,
-         "text" : "Teneur totale en sucres : 60 g pour 100 g de produit fini."
-      },
-      {
          "id" : "en:milk",
          "ingredient" : "lait",
          "percent" : 40,
          "text" : "Teneur en lait: minimum 40%."
-      },
-      {
-         "id" : "en:fruit-juice",
-         "ingredient" : "jus de fruits",
-         "quantity" : "35 g",
-         "quantity_g" : 35,
-         "text" : "Teneur minimum en jus de fruits 35 g pour 100 g de produit fini."
       },
       {
          "id" : "en:lemon",
@@ -180,5 +187,5 @@
          "text" : "Origine des abricots: Provence."
       }
    ],
-   "unknown_ingredients_n" : 0
+   "unknown_ingredients_n" : 1
 }

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -562,6 +562,22 @@ Origin of peaches: Spain. Origin of some unknown ingredient: France. origin of A
 			ingredients_text => "each capsule contains: paracetamol 500 m 5 060198 790 0 mg.",
 		}
 	],
+
+	# 148g per 100g
+	[
+		"en-quantity-per-100g",
+		{
+			lc => "en",
+			ingredients_text => "tomatoes (148 g per 100g), pork (200 g per 100 g of finished product)",
+		},
+	],
+	[
+		"fr-quantity-per-100g",
+		{
+			lc => "fr",
+			ingredients_text => "tomates (148 g par 100g), porc (200 gr par 100 g de produit fini)",
+		}
+	],
 );
 
 foreach my $test_ref (@tests) {

--- a/tests/unit/ingredients_parsing.t
+++ b/tests/unit/ingredients_parsing.t
@@ -628,6 +628,10 @@ my @lists = (
 	["sk", "syr, E470 a E470a, mlieko.", "syr, e470, e470a, mlieko."],
 	# Piments (vert, rouge, jaune) -> Piments vert, Piments rouge, Piments jaune
 	["fr", "Piments (vert, rouge, jaune)", "Piments vert, Piments rouge, Piments jaune"],
+
+	# 148 per 100g
+	["en", "tomatoes (148g per 100g), pork (200 g per 100 g of finished product) "],
+	["fr", "tomates (148 g par 100g), pork (200 gr per 100 g de produit fini)"],
 );
 
 foreach my $test_ref (@lists) {

--- a/tests/unit/ingredients_parsing.t
+++ b/tests/unit/ingredients_parsing.t
@@ -628,10 +628,6 @@ my @lists = (
 	["sk", "syr, E470 a E470a, mlieko.", "syr, e470, e470a, mlieko."],
 	# Piments (vert, rouge, jaune) -> Piments vert, Piments rouge, Piments jaune
 	["fr", "Piments (vert, rouge, jaune)", "Piments vert, Piments rouge, Piments jaune"],
-
-	# 148 per 100g
-	["en", "tomatoes (148g per 100g), pork (200 g per 100 g of finished product) "],
-	["fr", "tomates (148 g par 100g), pork (200 gr per 100 g de produit fini)"],
 );
 
 foreach my $test_ref (@lists) {


### PR DESCRIPTION
Related to #9060

This adds support for parsing " tomatoes (148g per 100g)".

Also a small refactor to create $per_100g_regexp in different languages.