### PR TITLE
taxonomy: add proxy for Tête de Moine as it's similar to Abondance

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -41605,6 +41605,7 @@ de:Tête de Moine
 wikidata:en:Q687579
 agribalyse_proxy_food_code:en:12112
 agribalyse_proxy_food_name:fr:Abondance
+agribalyse_proxy_food_name:en:Abondance cheese, from cow's milk
 
 <en:French cheeses
 <en:Cooked pressed cheeses
@@ -102341,6 +102342,9 @@ de:Entenstopflebern am Stück, Ganze Entenstopflebern
 fi:Kokonaiset ankan rasvamaksat
 fr:Foies gras de canard entiers, Foie gras de canard entier
 it:Foie gras di anatra intero
+agribalyse_proxy_food_code:en:40121
+agribalyse_proxy_food_name:en:Liver, duck, raw
+agribalyse_proxy_food_name:fr:Foie, canard, cru
 
 <en:Foies gras from ducks
 <en:Whole foies gras

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -41603,6 +41603,8 @@ fr:Vacherin Mont-d'Or suisse
 fr:Têtes de Moine, Tête de Moine
 de:Tête de Moine
 wikidata:en:Q687579
+agribalyse_proxy_food_code:en:12112
+agribalyse_proxy_food_name:fr:Abondance
 
 <en:French cheeses
 <en:Cooked pressed cheeses


### PR DESCRIPTION
taxonomy updates for categories:
- add proxy for Tête de Moine as it's similar to Abondance type of cheese
- proxy whole duck foie gras to duck raw liver
- english translation