### PR TITLE
fix: add padding between tabs

### DIFF
--- a/scss/_product-page.scss
+++ b/scss/_product-page.scss
@@ -161,6 +161,9 @@ $decalTop:48px;
 
 
 #navbar {
+li.product-section-button {
+    margin-bottom: .5rem;
+}
 a.active {
     background-color:#000;
     color:white;

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -82,11 +82,11 @@
             <div class="large-12">
                <nav id="navbar" class="navbar h-space-tiny">
                     <ul class="inline-list">
-                        <li><a class="nav-link scrollto button small round white-button" href="#product"><span>[% lang("product") %]</span></a></li>
-                        <li><a class="nav-link scrollto button small round white-button" href="#match"><span>[% lang("your_criteria") %]</span></a></li>
-                        <li><a class="nav-link scrollto button small round white-button" href="#health"><span>[% lang("health") %]</span></a></li>
-                        <li><a class="nav-link scrollto button small round white-button" href="#environment"><span>[% lang("environment") %]</span></a></li>
-                        <li><a class="nav-link scrollto button small round white-button" href="#contribution"><span>[% lang("contribution_navigation") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#product"><span>[% lang("product") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#match"><span>[% lang("your_criteria") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#health"><span>[% lang("health") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#environment"><span>[% lang("environment") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#contribution"><span>[% lang("contribution_navigation") %]</span></a></li>
                     </ul>
                 </nav><!-- .navbar -->
             </div> 


### PR DESCRIPTION
### What
Add 1rem of "margin bottom" to fix the responsive issue

### Screenshot
**Before :** 
![before_mobile](https://github.com/openfoodfacts/openfoodfacts-server/assets/112864841/6de31b05-aa18-4cb1-8d41-076a3cc2fc40)
![before_laptop](https://github.com/openfoodfacts/openfoodfacts-server/assets/112864841/172756d1-df89-4d1d-a59b-05a275f2020b)
**After :**
![after_mobile](https://github.com/openfoodfacts/openfoodfacts-server/assets/112864841/58b72446-e051-4dae-9051-8adbc37b9f10)
![after_laptop](https://github.com/openfoodfacts/openfoodfacts-server/assets/112864841/0e82199d-0cd4-4c48-9cb5-4b059355103a)


- Fixes #7495

@raphael0202 
