### PR TITLE
feat: add knowledge content to additive knowledge panels

### DIFF
--- a/lang-default/fr/knowledge_panels/additives/en_e100_world.html
+++ b/lang-default/fr/knowledge_panels/additives/en_e100_world.html
@@ -1,0 +1,1 @@
+<p>La curcumine ne présente pas de risques connus pour la santé.</p>

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -1227,7 +1227,7 @@ sub create_additives_panel ($product_ref, $target_lc, $target_cc, $options_ref) 
 			my $additive_description = get_knowledge_content("additives", $additive, $target_lc, $target_cc);
 
 			if (defined $additive_description) {
-				$additive_panel_data_ref->{additive_description} = $additive_description;	
+				$additive_panel_data_ref->{additive_description} = $additive_description;
 			}
 
 			create_panel_from_json_template($additive_panel_id,

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -1222,6 +1222,14 @@ sub create_additives_panel ($product_ref, $target_lc, $target_cc, $options_ref) 
 				["wikipedia_url", "wikipedia_title", "wikipedia_abstract"],
 				$target_lcs_ref);
 
+			# We check if the knowledge content for this additive (and language/country) is available.
+			# If it is it will be displayed instead of the wikipedia extract
+			my $additive_description = get_knowledge_content("additives", $additive, $target_lc, $target_cc);
+
+			if (defined $additive_description) {
+				$additive_panel_data_ref->{additive_description} = $additive_description;	
+			}
+
 			create_panel_from_json_template($additive_panel_id,
 				"api/knowledge-panels/health/ingredients/additive.tt.json",
 				$additive_panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref);

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -4991,6 +4991,7 @@ sub get_knowledge_content ($tagtype, $tagid, $target_lc, $target_cc) {
 			return $text;
 		}
 	}
+	return;
 }
 
 $log->info("Tags.pm loaded") if $log->is_info();

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -4937,53 +4937,51 @@ sub cmp_taxonomy_tags_alphabetically ($tagtype, $target_lc, $a, $b) {
 		cmp($translations_to{$tagtype}{$b}{$target_lc} || $translations_to{$tagtype}{$b}{"xx"} || $b);
 }
 
-
-=head2 get_knowledge_content ($tag_type, $tag, $lang_id, $country_code)
+=head2 get_knowledge_content ($tagtype, $tagid, $target_lc, $target_cc)
 
 Fetch knowledge content as HTML about additive, categories,...
 
 This content is used in knowledge panels.
 
-Content is stored as HTML files in `${lang_dir}/${lang_id}/knowledge_panels/${tag_type}`.
-We first check the existence of a file specific to the country specified by `${country_code}`,
+Content is stored as HTML files in `${lang_dir}/${target_lc}/knowledge_panels/${tagtype}`.
+We first check the existence of a file specific to the country specified by `${target_cc}`,
 with a fallback on `world` otherwise. This is useful to have a more specific description for some
 countries compared to the `world` base content.
 
 =head3 Arguments
 
-=head4 $tag_type
+=head4 $tagtype
 
 The type of the tag (e.g. categories, labels, allergens)
 
-=head4 $tag
+=head4 $tagid
 
 The tag we want to match, with language prefix (ex: `en:e255`).
 
-=head4 $lang_id
+=head4 $target_lc
 
 The user language as a 2-letters code (fr, it,...)
 
-=head4 $country_code
+=head4 $target_cc
 
 The user country as a 2-letters code (fr, it, ch) or `world`
 
 =head3 Return value
 
-If a content exists for the tag type, tag value, language ID and country code, return the HTML text,
+If a content exists for the tag type, tag value, language code and country code, return the HTML text,
 return undef otherwise. 
 
 =cut
 
-sub get_knowledge_content ($tag_type, $tag, $lang_id, $country_code) {
+sub get_knowledge_content ($tagtype, $tagid, $target_lc, $target_cc) {
 	# tag value is normalized:
 	# en:250 -> en_250
-	$tag =~ s/:/_/g;
+	$tagid =~ s/:/_/g;
 
-	my $base_dir = "$lang_dir/$lang_id/knowledge_panels/$tag_type";
-	my $file_path = undef;
+	my $base_dir = "$lang_dir/$target_lc/knowledge_panels/$tagtype";
 
-	foreach my $target_country_code ($country_code, "world") {
-		$file_path = "$base_dir/$tag" . "_" . "$target_country_code.html";
+	foreach my $cc ($target_cc, "world") {
+		my $file_path = "$base_dir/$tagid" . "_" . "$cc.html";
 		$log->debug("get_knowledge_content - checking $file_path") if $log->is_debug();
 		if (-e $file_path) {
 			$log->debug("get_knowledge_content - Match on $file_path!") if $log->is_debug();
@@ -4993,9 +4991,7 @@ sub get_knowledge_content ($tag_type, $tag, $lang_id, $country_code) {
 			return $text;
 		}
 	}
-	return undef;
 }
-
 
 $log->info("Tags.pm loaded") if $log->is_info();
 

--- a/templates/api/knowledge-panels/health/ingredients/additive.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/additive.tt.json
@@ -5,10 +5,17 @@
     ],
     "size": "small",
     "title_element": {
-        "title": `[% display_taxonomy_tag_name("additives", panel.additive) %]`,
+        "title": `[% display_taxonomy_tag_name("additives", panel.additive) %]`
     },        
     "elements": [
-        [% IF panel.wikipedia_abstract %]
+        [% IF panel.additive_description -%]
+        {
+            "element_type": "text",
+            "text_element": {
+                "html": `[% panel.additive_description %]`
+            }
+        }
+        [% ELSIF panel.wikipedia_abstract -%]
         {
             "element_type": "text",
             "text_element": {
@@ -18,7 +25,7 @@
                 "source_lc": "[% panel.wikipedia_url_lc %]",
                 "source_language": "[% panel.wikipedia_url_language %]"
             }
-        },
+        }
         [% END %]
     ]
 }

--- a/tests/unit/tags.t
+++ b/tests/unit/tags.t
@@ -843,4 +843,23 @@ is(
 	"no"
 );
 
+
+# Test get_knowledge_content subroutine
+
+# a match is expected here, as lang-default/fr/knowledge_panels/en_e100_world.html exists
+is(
+	get_knowledge_content("additives", "en:e100", "fr", "world"),
+	"<p>La curcumine ne présente pas de risques connus pour la santé.</p>"
+);
+# no content exists for fr country, but we should fallback on world
+is(
+	get_knowledge_content("additives", "en:e100", "fr", "fr"),
+	"<p>La curcumine ne présente pas de risques connus pour la santé.</p>"
+);
+# No content exists for en language, undef is expected
+is(
+	get_knowledge_content("additives", "en:e100", "en", "world"),
+	undef
+);
+
 done_testing();

--- a/tests/unit/tags.t
+++ b/tests/unit/tags.t
@@ -843,10 +843,9 @@ is(
 	"no"
 );
 
-
 # Test get_knowledge_content subroutine
 
-# a match is expected here, as lang-default/fr/knowledge_panels/en_e100_world.html exists
+# a match is expected here, as lang-default/fr/knowledge_panels/additives/en_e100_world.html exists
 is(
 	get_knowledge_content("additives", "en:e100", "fr", "world"),
 	"<p>La curcumine ne présente pas de risques connus pour la santé.</p>"
@@ -857,9 +856,6 @@ is(
 	"<p>La curcumine ne présente pas de risques connus pour la santé.</p>"
 );
 # No content exists for en language, undef is expected
-is(
-	get_knowledge_content("additives", "en:e100", "en", "world"),
-	undef
-);
+is(get_knowledge_content("additives", "en:e100", "en", "world"), undef);
 
 done_testing();


### PR DESCRIPTION
Allow to easily change the knowledge content for additive knowledge panels. Content is stored in openfoodfacts-web.

Before:
![Capture d’écran du 2023-10-02 17-21-25](https://github.com/openfoodfacts/openfoodfacts-server/assets/9609923/ceff15b9-ef67-45d7-8d8b-362e2f7f09f6)

After:
![Capture d’écran du 2023-10-02 17-22-28](https://github.com/openfoodfacts/openfoodfacts-server/assets/9609923/584b3144-5ba8-4635-b616-ad6cb2097a3c)

