### PR TITLE
fix: add ingredients-original facet, start to split tagtype and taxonomy

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1514,6 +1514,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 	add_country_and_owner_filters_to_query($request_ref, $query_ref);
 
 	my $groupby_tagtype = $request_ref->{groupby_tagtype};
+
 	my $page = $request_ref->{page};
 	# Flag that indicates whether we cache MongoDB results in Memcached
 	# Caching is disabled for crawling bots, as they tend to explore

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2421,7 +2421,7 @@ sub generate_tags_taxonomy_extract ($tagtype, $tags_ref, $options_ref, $lcs_ref)
 
 sub retrieve_tags_taxonomy ($tagtype) {
 
-	$taxonomy_fields{$tagtype} = 1;
+	$taxonomy_fields{$tagtype} = $tagtype;
 	$tags_fields{$tagtype} = 1;
 
 	my $file = $tagtype;
@@ -2550,6 +2550,8 @@ foreach my $taxonomyid (@ProductOpener::Config::taxonomy_fields) {
 	$log->info("loading taxonomy $taxonomyid");
 	retrieve_tags_taxonomy($taxonomyid);
 }
+# ingredients_original uses the ingredients taxonomy
+$taxonomy_fields{"ingredients_original"} = "ingredients";
 
 # Build map of language codes and names
 
@@ -2850,8 +2852,10 @@ sub canonicalize_taxonomy_tag_link ($target_lc, $tagtype, $tag) {
 
 sub display_taxonomy_tag_link ($target_lc, $tagtype, $tag) {
 
+	my $taxonomy = $taxonomy_fields{$tagtype};
+
 	$target_lc =~ s/_.*//;
-	$tag = display_taxonomy_tag($target_lc, $tagtype, $tag);
+	$tag = display_taxonomy_tag($target_lc, $taxonomy, $tag);
 	my $tagid = get_taxonomyid($target_lc, $tag);
 	my $tagurl = get_taxonomyurl($target_lc, $tagid);
 
@@ -2895,6 +2899,8 @@ sub display_taxonomy_tag_link ($target_lc, $tagtype, $tag) {
 
 sub get_taxonomy_tag_and_link_for_lang ($target_lc, $tagtype, $tagid) {
 
+	my $taxonomy = $taxonomy_fields{$tagtype};
+
 	my $tag_lc;
 
 	if ($tagid =~ /^(\w\w):/) {
@@ -2905,27 +2911,27 @@ sub get_taxonomy_tag_and_link_for_lang ($target_lc, $tagtype, $tagid) {
 	my $display_lc = "en";    # Default to English
 	my $exists_in_taxonomy = 0;
 
-	if (    (defined $translations_to{$tagtype})
-		and (defined $translations_to{$tagtype}{$tagid})
-		and (defined $translations_to{$tagtype}{$tagid}{$target_lc}))
+	if (    (defined $translations_to{$taxonomy})
+		and (defined $translations_to{$taxonomy}{$tagid})
+		and (defined $translations_to{$taxonomy}{$tagid}{$target_lc}))
 	{
 		# we have a translation for the target language
-		# print STDERR "display_taxonomy_tag - translation for the target language - translations_to{$tagtype}{$tagid}{$target_lc} : $translations_to{$tagtype}{$tagid}{$target_lc}\n";
-		$display = $translations_to{$tagtype}{$tagid}{$target_lc};
+		# print STDERR "display_taxonomy_tag - translation for the target language - translations_to{$taxonomy}{$tagid}{$target_lc} : $translations_to{$taxonomy}{$tagid}{$target_lc}\n";
+		$display = $translations_to{$taxonomy}{$tagid}{$target_lc};
 		$display_lc = $target_lc;
 		$exists_in_taxonomy = 1;
 	}
 	else {
 		# use tag language
-		if (    (defined $translations_to{$tagtype})
-			and (defined $translations_to{$tagtype}{$tagid})
+		if (    (defined $translations_to{$taxonomy})
+			and (defined $translations_to{$taxonomy}{$tagid})
 			and (defined $tag_lc)
-			and (defined $translations_to{$tagtype}{$tagid}{$tag_lc}))
+			and (defined $translations_to{$taxonomy}{$tagid}{$tag_lc}))
 		{
 			# we have a translation for the tag language
-			# print STDERR "display_taxonomy_tag - translation for the tag language - translations_to{$tagtype}{$tagid}{$tag_lc} : $translations_to{$tagtype}{$tagid}{$tag_lc}\n";
+			# print STDERR "display_taxonomy_tag - translation for the tag language - translations_to{$taxonomy}{$tagid}{$tag_lc} : $translations_to{$taxonomy}{$tagid}{$tag_lc}\n";
 
-			$display = "$tag_lc:" . $translations_to{$tagtype}{$tagid}{$tag_lc};
+			$display = "$tag_lc:" . $translations_to{$taxonomy}{$tagid}{$tag_lc};
 
 			$exists_in_taxonomy = 1;
 		}
@@ -2938,18 +2944,18 @@ sub get_taxonomy_tag_and_link_for_lang ($target_lc, $tagtype, $tagid) {
 			if ($target_lc eq $tag_lc) {
 				$display =~ s/^(\w\w)://;
 			}
-			# print STDERR "display_taxonomy_tag - no translation available for $tagtype $tagid in target language $lc or tag language $tag_lc - result: $display\n";
+			# print STDERR "display_taxonomy_tag - no translation available for $taxonomy $tagid in target language $lc or tag language $tag_lc - result: $display\n";
 		}
 	}
 
 	# for additives, add the first synonym
-	if ($tagtype =~ /^additives(|_prev|_next|_debug)$/) {
+	if ($taxonomy =~ /^additives(|_prev|_next|_debug)$/) {
 		$tagid =~ s/.*://;
-		if (    (defined $synonyms_for{$tagtype}{$target_lc})
-			and (defined $synonyms_for{$tagtype}{$target_lc}{$tagid})
-			and (defined $synonyms_for{$tagtype}{$target_lc}{$tagid}[1]))
+		if (    (defined $synonyms_for{$taxonomy}{$target_lc})
+			and (defined $synonyms_for{$taxonomy}{$target_lc}{$tagid})
+			and (defined $synonyms_for{$taxonomy}{$target_lc}{$tagid}[1]))
 		{
-			$display .= " - " . ucfirst($synonyms_for{$tagtype}{$target_lc}{$tagid}[1]);
+			$display .= " - " . ucfirst($synonyms_for{$taxonomy}{$target_lc}{$tagid}[1]);
 		}
 	}
 
@@ -3444,6 +3450,8 @@ Otherwise, we return the string prefixed with the language code (e.g. en:An unkn
 
 sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref = undef) {
 
+	my $taxonomy = $taxonomy_fields{$tagtype};
+
 	if (not defined $tag) {
 		if (defined $exists_in_taxonomy_ref) {
 			$$exists_in_taxonomy_ref = 0;
@@ -3455,12 +3463,12 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 	$tag =~ s/^ //g;
 	$tag =~ s/ $//g;
 
-	my $linked_data_tag = canonicalize_taxonomy_tag_linkeddata($tagtype, $tag);
+	my $linked_data_tag = canonicalize_taxonomy_tag_linkeddata($taxonomy, $tag);
 	if ($linked_data_tag) {
 		return $linked_data_tag;
 	}
 
-	my $weblink_tag = canonicalize_taxonomy_tag_weblink($tagtype, $tag);
+	my $weblink_tag = canonicalize_taxonomy_tag_weblink($taxonomy, $tag);
 	if ($weblink_tag) {
 		return $weblink_tag;
 	}
@@ -3475,13 +3483,13 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 	$tag = normalize_percentages($tag, $tag_lc);
 	my $tagid = get_string_id_for_lang($tag_lc, $tag);
 
-	if ($tagtype =~ /^additives/) {
+	if ($taxonomy =~ /^additives/) {
 		# convert the E-number + name into just E-number (we get those in urls like /additives/e330-citric-acid)
 		# check E + 1 digit in order to not convert Erythorbate-de-sodium to Erythorbate
 		$tagid =~ s/^e(\d.*?)-(.*)$/e$1/i;
 	}
 
-	if (($tagtype eq "ingredients") or ($tagtype eq "packaging") or ($tagtype =~ /^additives/)) {
+	if (($taxonomy eq "ingredients") or ($taxonomy eq "packaging") or ($taxonomy =~ /^additives/)) {
 		# convert E-number + name to E-number only if the number match the name
 		my $additive_tagid;
 		my $name;
@@ -3504,16 +3512,16 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 
 	my $found = 0;
 
-	if (    (defined $synonyms{$tagtype})
-		and (defined $synonyms{$tagtype}{$tag_lc})
-		and (defined $synonyms{$tagtype}{$tag_lc}{$tagid}))
+	if (    (defined $synonyms{$taxonomy})
+		and (defined $synonyms{$taxonomy}{$tag_lc})
+		and (defined $synonyms{$taxonomy}{$tag_lc}{$tagid}))
 	{
-		$tagid = $synonyms{$tagtype}{$tag_lc}{$tagid};
+		$tagid = $synonyms{$taxonomy}{$tag_lc}{$tagid};
 		$found = 1;
 	}
 	else {
 		# try removing stopwords and plurals
-		my $tagid2 = remove_stopwords($tagtype, $tag_lc, $tagid);
+		my $tagid2 = remove_stopwords($taxonomy, $tag_lc, $tagid);
 		$tagid2 = remove_plurals($tag_lc, $tagid2);
 
 		# try to add / remove hyphens (e.g. antioxydant / anti-oxydant)
@@ -3522,25 +3530,25 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 		$tagid3 =~ s/(anti)(-| )/$1/;
 		$tagid4 =~ s/(anti)([a-z])/$1-$2/;
 
-		if (    (defined $synonyms{$tagtype})
-			and (defined $synonyms{$tagtype}{$tag_lc})
-			and (defined $synonyms{$tagtype}{$tag_lc}{$tagid2}))
+		if (    (defined $synonyms{$taxonomy})
+			and (defined $synonyms{$taxonomy}{$tag_lc})
+			and (defined $synonyms{$taxonomy}{$tag_lc}{$tagid2}))
 		{
-			$tagid = $synonyms{$tagtype}{$tag_lc}{$tagid2};
+			$tagid = $synonyms{$taxonomy}{$tag_lc}{$tagid2};
 			$found = 1;
 		}
-		elsif ( (defined $synonyms{$tagtype})
-			and (defined $synonyms{$tagtype}{$tag_lc})
-			and (defined $synonyms{$tagtype}{$tag_lc}{$tagid3}))
+		elsif ( (defined $synonyms{$taxonomy})
+			and (defined $synonyms{$taxonomy}{$tag_lc})
+			and (defined $synonyms{$taxonomy}{$tag_lc}{$tagid3}))
 		{
-			$tagid = $synonyms{$tagtype}{$tag_lc}{$tagid3};
+			$tagid = $synonyms{$taxonomy}{$tag_lc}{$tagid3};
 			$found = 1;
 		}
-		elsif ( (defined $synonyms{$tagtype})
-			and (defined $synonyms{$tagtype}{$tag_lc})
-			and (defined $synonyms{$tagtype}{$tag_lc}{$tagid4}))
+		elsif ( (defined $synonyms{$taxonomy})
+			and (defined $synonyms{$taxonomy}{$tag_lc})
+			and (defined $synonyms{$taxonomy}{$tag_lc}{$tagid4}))
 		{
-			$tagid = $synonyms{$tagtype}{$tag_lc}{$tagid4};
+			$tagid = $synonyms{$taxonomy}{$tag_lc}{$tagid4};
 			$found = 1;
 		}
 		else {
@@ -3555,14 +3563,14 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 				if ($options{product_type} eq "food") {
 
 					# Latin animal species (e.g. for fish)
-					if ($tagtype eq "ingredients") {
+					if ($taxonomy eq "ingredients") {
 						@test_languages = ("xx", "la");
 					}
 				}
 				elsif ($options{product_type} eq "beauty") {
 
 					# Beauty products ingredients are often in English or Latin
-					if ($tagtype eq "ingredients") {
+					if ($taxonomy eq "ingredients") {
 						@test_languages = ("xx", "en", "la");
 					}
 				}
@@ -3575,24 +3583,24 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 				# get a tagid with the unaccenting rules for the language we are trying to match
 				my $test_lc_tagid = get_string_id_for_lang($test_lc, $tag);
 
-				if (    (defined $synonyms{$tagtype})
-					and (defined $synonyms{$tagtype}{$test_lc})
-					and (defined $synonyms{$tagtype}{$test_lc}{$test_lc_tagid}))
+				if (    (defined $synonyms{$taxonomy})
+					and (defined $synonyms{$taxonomy}{$test_lc})
+					and (defined $synonyms{$taxonomy}{$test_lc}{$test_lc_tagid}))
 				{
-					$tagid = $synonyms{$tagtype}{$test_lc}{$test_lc_tagid};
+					$tagid = $synonyms{$taxonomy}{$test_lc}{$test_lc_tagid};
 					$tag_lc = $test_lc;
 					$found = 1;
 				}
 				else {
 
 					# try removing stopwords and plurals
-					my $tagid2 = remove_stopwords($tagtype, $test_lc, $test_lc_tagid);
+					my $tagid2 = remove_stopwords($taxonomy, $test_lc, $test_lc_tagid);
 					$tagid2 = remove_plurals($test_lc, $tagid2);
-					if (    (defined $synonyms{$tagtype})
-						and (defined $synonyms{$tagtype}{$test_lc})
-						and (defined $synonyms{$tagtype}{$test_lc}{$tagid2}))
+					if (    (defined $synonyms{$taxonomy})
+						and (defined $synonyms{$taxonomy}{$test_lc})
+						and (defined $synonyms{$taxonomy}{$test_lc}{$tagid2}))
 					{
-						$tagid = $synonyms{$tagtype}{$test_lc}{$tagid2};
+						$tagid = $synonyms{$taxonomy}{$test_lc}{$tagid2};
 						$tag_lc = $test_lc;
 						$found = 1;
 						last;
@@ -3611,8 +3619,8 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 			my $tag2 = $';
 			my $exists_tag1;
 			my $exists_tag2;
-			my $tagid1 = canonicalize_taxonomy_tag($tag_lc, $tagtype, $tag1, \$exists_tag1);
-			my $tagid2 = canonicalize_taxonomy_tag($tag_lc, $tagtype, $tag2, \$exists_tag2);
+			my $tagid1 = canonicalize_taxonomy_tag($tag_lc, $taxonomy, $tag1, \$exists_tag1);
+			my $tagid2 = canonicalize_taxonomy_tag($tag_lc, $taxonomy, $tag2, \$exists_tag2);
 
 			$log->debug(
 				"Checking for multiple tags separated by a slash",
@@ -3634,11 +3642,11 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 					$tagid = $tagid1;
 				}
 				# "Parent / Child"
-				elsif (is_a($tagtype, $tagid2, $tagid1)) {
+				elsif (is_a($taxonomy, $tagid2, $tagid1)) {
 					$tagid = $tagid2;
 				}
 				# "Child / Parent"
-				elsif (is_a($tagtype, $tagid1, $tagid2)) {
+				elsif (is_a($taxonomy, $tagid1, $tagid2)) {
 					$tagid = $tagid1;
 				}
 			}
@@ -3652,11 +3660,11 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 
 	my $exists_in_taxonomy = 0;
 
-	if (    (defined $translations_from{$tagtype})
-		and (defined $translations_from{$tagtype}{$tagid})
-		and not((exists $just_synonyms{$tagtype}) and (exists $just_synonyms{$tagtype}{$tagid})))
+	if (    (defined $translations_from{$taxonomy})
+		and (defined $translations_from{$taxonomy}{$tagid})
+		and not((exists $just_synonyms{$taxonomy}) and (exists $just_synonyms{$taxonomy}{$tagid})))
 	{
-		$tagid = $translations_from{$tagtype}{$tagid};
+		$tagid = $translations_from{$taxonomy}{$tagid};
 		$exists_in_taxonomy = 1;
 	}
 	elsif (defined $tag) {
@@ -4002,6 +4010,7 @@ otherwise, the tag id.
 =cut
 
 sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
+
 	$target_lc =~ s/_.*//;
 
 	if (not defined $tag) {
@@ -4012,7 +4021,9 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 	$tag =~ s/^ //g;
 	$tag =~ s/ $//g;
 
-	if (not defined $taxonomy_fields{$tagtype}) {
+	my $taxonomy = $taxonomy_fields{$tagtype};
+
+	if (not defined $taxonomy) {
 
 		return canonicalize_tag2($tagtype, $tag);
 	}
@@ -4033,19 +4044,19 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 
 	my $display = '';
 
-	if (    (defined $translations_to{$tagtype})
-		and (defined $translations_to{$tagtype}{$tagid})
-		and (defined $translations_to{$tagtype}{$tagid}{$target_lc}))
+	if (    (defined $translations_to{$taxonomy})
+		and (defined $translations_to{$taxonomy}{$tagid})
+		and (defined $translations_to{$taxonomy}{$tagid}{$target_lc}))
 	{
 		# we have a translation for the target language
-		$display = $translations_to{$tagtype}{$tagid}{$target_lc};
+		$display = $translations_to{$taxonomy}{$tagid}{$target_lc};
 	}
-	elsif ( (defined $translations_to{$tagtype})
-		and (defined $translations_to{$tagtype}{$tagid})
-		and (defined $translations_to{$tagtype}{$tagid}{xx}))
+	elsif ( (defined $translations_to{$taxonomy})
+		and (defined $translations_to{$taxonomy}{$tagid})
+		and (defined $translations_to{$taxonomy}{$tagid}{xx}))
 	{
 		# we have a translation for the default xx language
-		$display = $translations_to{$tagtype}{$tagid}{xx};
+		$display = $translations_to{$taxonomy}{$tagid}{xx};
 	}
 	else {
 		# We may have changed a canonical en: entry into an language-less xx: entry,
@@ -4056,46 +4067,46 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 
 		# if we didn't find a language specific entry but there is a corresponding xx: synonym for it,
 		# assume the language specific entry was changed to a language-less xx: entry
-		if (    (defined $synonyms{$tagtype})
-			and (defined $synonyms{$tagtype}{xx})
-			and (defined $synonyms{$tagtype}{xx}{$tagid_no_lc}))
+		if (    (defined $synonyms{$taxonomy})
+			and (defined $synonyms{$taxonomy}{xx})
+			and (defined $synonyms{$taxonomy}{xx}{$tagid_no_lc}))
 		{
-			$tagid = "xx:" . $synonyms{$tagtype}{xx}{$tagid_no_lc};
-			$tagid = $translations_from{$tagtype}{$tagid};
+			$tagid = "xx:" . $synonyms{$taxonomy}{xx}{$tagid_no_lc};
+			$tagid = $translations_from{$taxonomy}{$tagid};
 		}
 
-		if (    (defined $translations_to{$tagtype})
-			and (defined $translations_to{$tagtype}{$tagid})
-			and (defined $translations_to{$tagtype}{$tagid}{$target_lc}))
+		if (    (defined $translations_to{$taxonomy})
+			and (defined $translations_to{$taxonomy}{$tagid})
+			and (defined $translations_to{$taxonomy}{$tagid}{$target_lc}))
 		{
 			# we have a translation for the target language
-			$display = $translations_to{$tagtype}{$tagid}{$target_lc};
+			$display = $translations_to{$taxonomy}{$tagid}{$target_lc};
 		}
-		elsif ( (defined $translations_to{$tagtype})
-			and (defined $translations_to{$tagtype}{$tagid})
-			and (defined $translations_to{$tagtype}{$tagid}{xx}))
+		elsif ( (defined $translations_to{$taxonomy})
+			and (defined $translations_to{$taxonomy}{$tagid})
+			and (defined $translations_to{$taxonomy}{$tagid}{xx}))
 		{
 			# we have a translation for the default xx language
-			$display = $translations_to{$tagtype}{$tagid}{xx};
+			$display = $translations_to{$taxonomy}{$tagid}{xx};
 		}
 
-		elsif ( (defined $translations_to{$tagtype})
-			and (defined $translations_to{$tagtype}{$xx_tagid})
-			and (defined $translations_to{$tagtype}{$xx_tagid}{xx}))
+		elsif ( (defined $translations_to{$taxonomy})
+			and (defined $translations_to{$taxonomy}{$xx_tagid})
+			and (defined $translations_to{$taxonomy}{$xx_tagid}{xx}))
 		{
 			# we have a translation for the default xx language
-			$display = $translations_to{$tagtype}{$xx_tagid}{xx};
+			$display = $translations_to{$taxonomy}{$xx_tagid}{xx};
 		}
 
 		# use tag language
-		elsif ( (defined $translations_to{$tagtype})
-			and (defined $translations_to{$tagtype}{$tagid})
-			and (defined $translations_to{$tagtype}{$tagid}{$tag_lc}))
+		elsif ( (defined $translations_to{$taxonomy})
+			and (defined $translations_to{$taxonomy}{$tagid})
+			and (defined $translations_to{$taxonomy}{$tagid}{$tag_lc}))
 		{
 			# we have a translation for the tag language
-			# print STDERR "display_taxonomy_tag - translation for the tag language - translations_to{$tagtype}{$tagid}{$tag_lc} : $translations_to{$tagtype}{$tagid}{$tag_lc}\n";
+			# print STDERR "display_taxonomy_tag - translation for the tag language - translations_to{$taxonomy}{$tagid}{$tag_lc} : $translations_to{$taxonomy}{$tagid}{$tag_lc}\n";
 
-			$display = "$tag_lc:" . $translations_to{$tagtype}{$tagid}{$tag_lc};
+			$display = "$tag_lc:" . $translations_to{$taxonomy}{$tagid}{$tag_lc};
 		}
 		else {
 			$display = $tag;
@@ -4106,18 +4117,18 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 			else {
 				$display = ucfirst($display);
 			}
-			# print STDERR "display_taxonomy_tag - no translation available for $tagtype $tagid in target language $lc or tag language $tag_lc - result: $display\n";
+			# print STDERR "display_taxonomy_tag - no translation available for $taxonomy $tagid in target language $lc or tag language $tag_lc - result: $display\n";
 		}
 	}
 
 	# for additives, add the first synonym
-	if ($tagtype =~ /^additives(|_prev|_next|_debug)$/) {
+	if ($taxonomy =~ /^additives(|_prev|_next|_debug)$/) {
 		$tagid =~ s/.*://;
-		if (    (defined $synonyms_for{$tagtype}{$target_lc})
-			and (defined $synonyms_for{$tagtype}{$target_lc}{$tagid})
-			and (defined $synonyms_for{$tagtype}{$target_lc}{$tagid}[1]))
+		if (    (defined $synonyms_for{$taxonomy}{$target_lc})
+			and (defined $synonyms_for{$taxonomy}{$target_lc}{$tagid})
+			and (defined $synonyms_for{$taxonomy}{$target_lc}{$tagid}[1]))
 		{
-			$display .= " - " . ucfirst($synonyms_for{$tagtype}{$target_lc}{$tagid}[1]);
+			$display .= " - " . ucfirst($synonyms_for{$taxonomy}{$target_lc}{$tagid}[1]);
 		}
 	}
 

--- a/po/tags/en.po
+++ b/po/tags/en.po
@@ -134,6 +134,14 @@ msgctxt "ingredients:singular"
 msgid "ingredient"
 msgstr "ingredient"
 
+msgctxt "ingredients_original:plural"
+msgid "ingredients-original"
+msgstr "ingredients-original"
+
+msgctxt "ingredients_original:singular"
+msgid "ingredient-original"
+msgstr "ingredient-original"
+
 msgctxt "ingredients_from_palm_oil:plural"
 msgid "ingredients-from-palm-oil"
 msgstr "ingredients-from-palm-oil"

--- a/po/tags/tags.pot
+++ b/po/tags/tags.pot
@@ -159,6 +159,16 @@ msgctxt "ingredients:singular"
 msgid   "ingredient"
 msgstr  ""
 
+#. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
+msgctxt "ingredients_original:plural"
+msgid "ingredients-original"
+msgstr "ingredients-original"
+
+#. part of an url, put here the singular in your language, without caps, and by using hyphens instead of spaces
+msgctxt "ingredients_original:singular"
+msgid "ingredient-original"
+msgstr "ingredient-original"
+
 #. part of an url, put here the plural in your language, without caps, and by using hyphens instead of spaces
 msgctxt "ingredients_from_palm_oil:plural"
 msgid   "ingredients-from-palm-oil"

--- a/tests/integration/expected_test_results/page_crawler/get-robots-txt-ch-it.txt
+++ b/tests/integration/expected_test_results/page_crawler/get-robots-txt-ch-it.txt
@@ -63,6 +63,8 @@ Disallow: /ingredients-analysis
 Disallow: /ingredients-from-palm-oil
 Disallow: /number-of-ingredients
 Disallow: /numbers-of-ingredients
+Disallow: /ingredient-original
+Disallow: /ingredients-original
 Disallow: /ingredients-that-may-be-from-palm-oil
 Disallow: /known-nutrient
 Disallow: /known-nutrients

--- a/tests/integration/expected_test_results/page_crawler/get-robots-txt-fr-pro-platform.txt
+++ b/tests/integration/expected_test_results/page_crawler/get-robots-txt-fr-pro-platform.txt
@@ -107,6 +107,8 @@ Disallow: /number-of-ingredients
 Disallow: /numbers-of-ingredients
 Disallow: /nombre-d-ingredients
 Disallow: /nombres-d-ingredients
+Disallow: /ingredient-original
+Disallow: /ingredients-original
 Disallow: /ingredients-that-may-be-from-palm-oil
 Disallow: /ingredients-pouvant-etre-issus-de-l-huile-de-palme
 Disallow: /known-nutrient

--- a/tests/integration/expected_test_results/page_crawler/get-robots-txt-fr.txt
+++ b/tests/integration/expected_test_results/page_crawler/get-robots-txt-fr.txt
@@ -107,6 +107,8 @@ Disallow: /number-of-ingredients
 Disallow: /numbers-of-ingredients
 Disallow: /nombre-d-ingredients
 Disallow: /nombres-d-ingredients
+Disallow: /ingredient-original
+Disallow: /ingredients-original
 Disallow: /ingredients-that-may-be-from-palm-oil
 Disallow: /ingredients-pouvant-etre-issus-de-l-huile-de-palme
 Disallow: /known-nutrient

--- a/tests/integration/expected_test_results/page_crawler/get-robots-txt-world-pro-platform.txt
+++ b/tests/integration/expected_test_results/page_crawler/get-robots-txt-world-pro-platform.txt
@@ -63,6 +63,8 @@ Disallow: /ingredients-analysis
 Disallow: /ingredients-from-palm-oil
 Disallow: /number-of-ingredients
 Disallow: /numbers-of-ingredients
+Disallow: /ingredient-original
+Disallow: /ingredients-original
 Disallow: /ingredients-that-may-be-from-palm-oil
 Disallow: /known-nutrient
 Disallow: /known-nutrients

--- a/tests/integration/expected_test_results/page_crawler/get-robots-txt-world.txt
+++ b/tests/integration/expected_test_results/page_crawler/get-robots-txt-world.txt
@@ -63,6 +63,8 @@ Disallow: /ingredients-analysis
 Disallow: /ingredients-from-palm-oil
 Disallow: /number-of-ingredients
 Disallow: /numbers-of-ingredients
+Disallow: /ingredient-original
+Disallow: /ingredients-original
 Disallow: /ingredients-that-may-be-from-palm-oil
 Disallow: /known-nutrient
 Disallow: /known-nutrients


### PR DESCRIPTION
In addition to ingredients_tags, we also have ingredients_original_tags which contains the ingredients actually listed in the ingredients text, and not their parents.

This PR adds a facet /ingredients-original that allows us to list those. It will be very useful in particular to see which ingredients are the most popular.

As ingredients_original uses the ingredients taxonomy, this PR starts to differentiate the tag type (ingredients or ingredients_original from the taxonomy : ingredients). We could continue down this path to have traces use the allergens taxonomy without copying it as we do today (same for the data quality facets)