### PR TITLE
fix: exists_taxonomy_tag for ingredients_original tag type

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3948,9 +3948,11 @@ sub get_taxonomy_tag_synonyms ($target_lc, $tagtype, $tagid) {
 
 sub exists_taxonomy_tag ($tagtype, $tagid) {
 
-	return (    (exists $translations_from{$tagtype})
-			and (exists $translations_from{$tagtype}{$tagid})
-			and not((exists $just_synonyms{$tagtype}) and (exists $just_synonyms{$tagtype}{$tagid})));
+	my $taxonomy = $taxonomy_fields{$tagtype};
+
+	return (    (exists $translations_from{$taxonomy})
+			and (exists $translations_from{$taxonomy}{$tagid})
+			and not((exists $just_synonyms{$taxonomy}) and (exists $just_synonyms{$taxonomy}{$tagid})));
 }
 
 =head2 cached_display_taxonomy_tag ( $target_lc, $tagtype, $canon_tagid )


### PR DESCRIPTION
continuation of https://github.com/openfoodfacts/openfoodfacts-server/pull/9127 so that https://world.openfoodfacts.org/popularity/top-1000-scans-2022/ingredients-original?stats=1 can work correctly.