### PR TITLE
taxonomy: Add all prefectures of Japan

### DIFF
--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -151,7 +151,7 @@ hu:Csiba prefektúra
 hy:Թիբա (պրեֆեկտուրա)
 id:Prefektur Chiba
 it:prefettura di Chiba
-ja:千葉県
+ja:千葉県, 千葉
 jv:Prefektur Chiba
 ka:ტიბის პრეფექტურა
 km:ខេត្តឈីបា
@@ -228,7 +228,7 @@ hu:Jamagata prefektúra
 hy:Յամագաթա (պրեֆեկտուրա)
 id:Prefektur Yamagata
 it:prefettura di Yamagata
-ja:山形県
+ja:山形県, 山形
 ka:იამაგატის პრეფექტურა
 km:ខេត្តយ៉ាម៉ាកាតា
 kn:ಯಮಗಾಟಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -303,7 +303,7 @@ hu:Kumamoto prefektúra
 hy:Կումամոտո (պրեֆեկտուրա)
 id:Prefektur Kumamoto
 it:prefettura di Kumamoto
-ja:熊本県
+ja:熊本県, 熊本
 ka:კუმამოტოს პრეფექტურა
 km:ខេត្តឃឹម៉ាម៉ុតុ
 kn:ಕುಮಾಮೊಟೊ ಪ್ರಿಫೆಕ್ಚರ್
@@ -375,7 +375,7 @@ hu:Siga prefektúra
 hy:Սիգա (պրեֆեկտուրա)
 id:Prefektur Shiga
 it:prefettura di Shiga
-ja:滋賀県
+ja:滋賀県, 滋賀
 jv:Prefektur Shiga
 ka:სიგის პრეფექტურა
 kn:ಶಿಗಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -449,7 +449,7 @@ hu:Jamanasi prefektúra
 hy:Յամանասի (պրեֆեկտուրա)
 id:Prefektur Yamanashi
 it:prefettura di Yamanashi
-ja:山梨県
+ja:山梨県, 山梨
 ka:იამანასის პრეფექტურა
 km:ខេត្តយ៉ាម៉ាណាស៊ី
 kn:ಯಮನಶಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -565,7 +565,7 @@ hu:Ibaraki prefektúra
 hy:Իբարակի (պրեֆեկտուրա)
 id:Prefektur Ibaraki
 it:prefettura di Ibaraki
-ja:茨城県
+ja:茨城県, 茨城
 jv:Prefektur Ibaraki
 ka:იბარაკის პრეფექტურა
 km:ខេត្តអ៊ីបារ៉ាគិ
@@ -643,7 +643,7 @@ hu:Aicsi prefektúra
 hy:Այչի
 id:Prefektur Aichi
 it:prefettura di Aichi
-ja:愛知県
+ja:愛知県, 愛知
 jv:Prefektur Aichi
 ka:აიტის პრეფექტურა
 km:ខេត្តអៃឈិ
@@ -720,7 +720,7 @@ hu:Oszaka prefektúra
 hy:Օսակայի պրեֆեկտուրա
 id:Prefektur Osaka
 it:prefettura di Osaka
-ja:大阪府
+ja:大阪府, 大阪
 jv:Prefektur Osaka
 ka:ოსაკის პრეფექტურა
 km:អាណាខេត្តអូសាកា
@@ -794,7 +794,7 @@ hu:Tottori prefektúra
 hy:Տոթթորի
 id:Prefektur Tottori
 it:prefettura di Tottori
-ja:鳥取県
+ja:鳥取県, 鳥取
 jv:Prefektur Tottori
 ka:ტოტორის პრეფექტურა
 kn:ಟೊಟ್ಟೊರಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -866,7 +866,7 @@ hu:Simane prefektúra
 hy:Սիմանե (պրեֆեկտուրա)
 id:Prefektur Shimane
 it:prefettura di Shimane
-ja:島根県
+ja:島根県, 島根
 ka:სიმანეს პრეფექტურა
 km:ខេត្តស៊ីម៉ាណិ
 kn:ಶಿಮಾನ್ ಪ್ರಿಫೆಕ್ಚರ್
@@ -938,7 +938,7 @@ hu:Tojama prefektúra
 hy:Տոյամա
 id:Prefektur Toyama
 it:prefettura di Toyama
-ja:富山県
+ja:富山県, 富山
 ka:ტოიამის პრეფექტურა
 km:ខេត្តតុយ៉ាម៉ា
 kn:ಟೊಯಾಮಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1010,7 +1010,7 @@ hu:Okajama prefektúra
 hy:Օկայամա (պրեֆեկտուրա)
 id:Prefektur Okayama
 it:prefettura di Okayama
-ja:岡山県
+ja:岡山県, 岡山
 jv:Prefektur Okayama
 ka:ოკაიამის პრეფექტურა
 km:ខេត្តអូកាយ៉ាម៉ា
@@ -1083,7 +1083,7 @@ hu:Vakajama prefektúra
 hy:Վակայամա
 id:Prefektur Wakayama
 it:prefettura di Wakayama
-ja:和歌山県
+ja:和歌山県, 和歌山
 jv:Prefektur Wakayama
 ka:ვაკაიამის პრეფექტურა
 kn:ವಕಾಯಾಮಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1158,7 +1158,7 @@ hu:Niigata prefektúra
 hy:Նիիգատա
 id:Prefektur Niigata
 it:prefettura di Niigata
-ja:新潟県
+ja:新潟県, 新潟
 jv:Prefektur Niigata
 ka:ნიიგატის პრეფექტურა
 km:ខេត្តនីហ្គាតាក់
@@ -1232,7 +1232,7 @@ hu:Hirosima prefektúra
 hy:Հերոսիմա (պրեֆեկտուրա)
 id:Prefektur Hiroshima
 it:prefettura di Hiroshima
-ja:広島県
+ja:広島県, 広島
 ka:ჰიროსიმის პრეფექტურა
 km:ខេត្តហ៊ីរ៉ូស៊ីម៉ា
 kn:ಹಿರೋಷಿಮಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1305,7 +1305,7 @@ hu:Kiotó prefektúra
 hy:Կիոտո (պրեֆեկտուրա)
 id:Prefektur Kyoto
 it:prefettura di Kyoto
-ja:京都府
+ja:京都府, 京都
 ka:კიოტოს პრეფექტურა
 km:ខេត្តក្យូតុ
 kn:ಕ್ಯೋಟೋ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1378,7 +1378,7 @@ hu:Kanagava prefektúra
 hy:Կանագավա
 id:Prefektur Kanagawa
 it:prefettura di Kanagawa
-ja:神奈川県
+ja:神奈川県, 神奈川
 ka:კანაგავის პრეფექტურა
 km:ខេត្តខាន់ណាហ្គាវ៉ា
 kn:ಕನಗಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1452,7 +1452,7 @@ hu:Gifu prefektúra
 hy:Գիֆու (պրեֆեկտուրա)
 id:Prefektur Gifu
 it:prefettura di Gifu
-ja:岐阜県
+ja:岐阜県, 岐阜
 jv:Prefektur Gifu
 ka:გიფუს პრეფექტურა
 kn:ಜಿಫು ಪ್ರಿಫೆಕ್ಚರ್
@@ -1525,7 +1525,7 @@ hu:Kócsi prefektúra
 hy:Կոտի (պրեֆեկտուրա)
 id:Prefektur Kōchi
 it:prefettura di Kōchi
-ja:高知県
+ja:高知県, 高知
 ka:კოტის პრეფექტურა
 km:ខេត្តខូឈិ
 kn:ಕೊಚಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1598,7 +1598,7 @@ hu:Fukusima prefektúra
 hy:Ֆուկուսիմա
 id:Prefektur Fukushima
 it:prefettura di Fukushima
-ja:福島県
+ja:福島県, 福島
 jv:Prefektur Fukushima
 ka:ფუკუსიმის პრეფექტურა
 km:ខេត្តហ្វូគូស៊ីម៉ា
@@ -1674,7 +1674,7 @@ hu:Fukuoka prefektúra
 hy:Ֆուկուոկա
 id:Prefektur Fukuoka
 it:prefettura di Fukuoka
-ja:福岡県
+ja:福岡県, 福岡
 jv:Prefektur Fukuoka
 ka:ფუკუოკის პრეფექტურა
 kn:ಫುಕುಕಾಕಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1748,7 +1748,7 @@ hu:Gunma prefektúra
 hy:Գումմա
 id:Prefektur Gunma
 it:prefettura di Gunma
-ja:群馬県
+ja:群馬県, 群馬
 jv:Prefektur Gunma
 ka:გუმის პრეფექტურა
 km:ខេត្តហ្គឺនម៉ា
@@ -1821,7 +1821,7 @@ hu:Mijazaki prefektúra
 hy:Միյաձակի
 id:Prefektur Miyazaki
 it:prefettura di Miyazaki
-ja:宮崎県
+ja:宮崎県, 宮崎
 ka:მიაძაკის პრეფექტურა
 km:ខេត្តមីយ៉ាសាគី
 kn:ಮಿಯಾಜಾಕಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1892,7 +1892,7 @@ hu:Tokusima prefektúra
 hy:Տոկուսիմա (պրեֆեկտուրա)
 id:Prefektur Tokushima
 it:prefettura di Tokushima
-ja:徳島県
+ja:徳島県, 徳島
 jv:Prefektur Tokushima
 ka:ტოკუსიმის პრეფექტურა
 kn:ಟೋಕುಶಿಮಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -1965,7 +1965,7 @@ hu:Akita prefektúra
 hy:Ակիտա
 id:Prefektur Akita
 it:prefettura di Akita
-ja:秋田県
+ja:秋田県, 秋田
 jv:Prefektur Akita
 ka:აკიტის პრეფექტურა
 km:ខេត្តអាគីតា
@@ -2042,7 +2042,7 @@ hu:Ehime prefektúra
 hy:Էհիմե (պրեֆեկտուրա)
 id:Prefektur Ehime
 it:prefettura di Ehime
-ja:愛媛県
+ja:愛媛県, 愛媛
 jv:Prefektur Ehime
 ka:ეჰიმეს პრეფექტურა
 km:ខេត្តអិហ៊ីមិ
@@ -2115,7 +2115,7 @@ hu:Óita prefektúra
 hy:Օիտա (պրեֆեկտուրա)
 id:Prefektur Oita
 it:prefettura di Ōita
-ja:大分県
+ja:大分県, 大分
 ka:ოიტის პრეფექტურა
 km:ខេត្តអយតាក់
 kn:ಒಐಟಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2188,7 +2188,7 @@ hu:Szaitama prefektúra
 hy:Սայտամա
 id:Prefektur Saitama
 it:prefettura di Saitama
-ja:埼玉県
+ja:埼玉県, 埼玉
 ka:საიტამის პრეფექტურა
 km:ខេត្តសៃតាម៉ា
 kn:ಸೈತಮಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2265,7 +2265,7 @@ hy:Սիձուոկա (պրեֆեկտուրա)
 id:Prefektur Shizuoka
 is:Shizuoka-umdæmi
 it:prefettura di Shizuoka
-ja:静岡県
+ja:静岡県, 静岡
 jv:Prefektur Shizuoka
 ka:სიძუოკის პრეფექტურა
 kn:ಶಿಝುವೊಕಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2337,7 +2337,7 @@ hu:Fukui prefektúra
 hy:Ֆուկուի (պրեֆեկտուրա)
 id:Prefektur Fukui
 it:prefettura di Fukui
-ja:福井県
+ja:福井県, 福井
 jv:Prefektur Fukui
 ka:ფუკუის პრეფექტურა
 kn:ಫುಕುಯಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2410,7 +2410,7 @@ hu:Kagava prefektúra
 hy:Կագավա (պրեֆեկտուրա)
 id:Prefektur Kagawa
 it:prefettura di Kagawa
-ja:香川県
+ja:香川県, 香川
 ka:კაგავის პრეფექტურა
 km:ខេត្តកាហ្គាវ៉ា
 kn:ಕಾಗಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2482,7 +2482,7 @@ hu:Nagaszaki prefektúra
 hy:Նագասակի
 id:Prefektur Nagasaki
 it:prefettura di Nagasaki
-ja:長崎県
+ja:長崎県, 長崎
 ka:ნაგასაკის პრეფექტურა
 km:ខេត្តណាហ្គាសាគី
 kn:ನಾಗಸಾಕಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2555,7 +2555,7 @@ hu:Nara prefektúra
 hy:Նարա պրեֆեկտուրա
 id:Prefektur Nara
 it:prefettura di Nara
-ja:奈良県
+ja:奈良県, 奈良
 jv:Prefektur Nara
 ka:ნარის პრეფექტურა
 km:អាណាខេត្តណារ៉ា
@@ -2628,7 +2628,7 @@ hu:Okinava prefektúra
 hy:Օկինավա
 id:Prefektur Okinawa
 it:prefettura di Okinawa
-ja:沖縄県
+ja:沖縄県, 沖縄
 jv:Prefektur Okinawa
 km:ខេត្តអូគីណាវ៉ា
 kn:ಒಕಿನಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2703,7 +2703,7 @@ hu:Aomori prefektúra
 hy:Աոմորի
 id:Prefektur Aomori
 it:prefettura di Aomori
-ja:青森県
+ja:青森県, 青森
 jv:Prefektur Aomori
 ka:აომორის პრეფექტურა
 km:ខេត្តអាអូម៉ូរី
@@ -2779,7 +2779,7 @@ hy:Յամագուտի
 ia:Prefectura de Yamaguchi
 id:Prefektur Yamaguchi
 it:prefettura di Yamaguchi
-ja:山口県
+ja:山口県, 山口
 ka:იამაგუტის პრეფექტურა
 km:ខេត្តយ៉ាម៉ាហ្គឹឈិ
 kn:ಯಮಗುಚಿ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2850,7 +2850,7 @@ hu:Szaga prefektúra
 hy:Սագա (պրեֆեկտուրա)
 id:Prefektur Saga
 it:prefettura di Saga
-ja:佐賀県
+ja:佐賀県, 佐賀
 ka:საგის პრეფექტურა
 kn:ಸಾಗಾ ಪ್ರಿಫೆಕ್ಚರ್
 ko:사가현
@@ -2922,7 +2922,7 @@ hy:Հյոգո (պրեֆեկտուրա)
 id:Prefektur Hyogo
 is:Hyogo-hérað
 it:prefettura di Hyōgo
-ja:兵庫県
+ja:兵庫県, 兵庫
 jv:Prefektur Hyogo
 ka:ჰიოგოს პრეფექტურა
 kn:ಹೈಗೊ ಪ್ರಿಫೆಕ್ಚರ್
@@ -2993,7 +2993,7 @@ hu:Tocsigi prefektúra
 hy:Տոտիգի (պրեֆեկտուրա)
 id:Prefektur Tochigi
 it:prefettura di Tochigi
-ja:栃木県
+ja:栃木県, 栃木
 ka:ტოტიგის პრეფექტურა
 kn:ತೋಚಿಗಿ ಪ್ರಿಫೆಕ್ಚರ್
 ko:도치기현
@@ -3066,7 +3066,7 @@ hu:Ivate prefektúra
 hy:Իվատե
 id:Prefektur Iwate
 it:prefettura di Iwate
-ja:岩手県
+ja:岩手県, 岩手
 jv:Prefektur Iwate
 ka:ივატეს პრეფექტურა
 km:ខេត្តអ៊ីវ៉ាតិ
@@ -3141,7 +3141,7 @@ hu:Nagano prefektúra
 hy:Նագանո (պրեֆեկտուրա)
 id:Prefektur Nagano
 it:prefettura di Nagano
-ja:長野県
+ja:長野県, 長野
 ka:ნაგანო
 km:ខេត្តណាហ្គាណុ
 kn:ನ್ಯಾಗೊನೋ ಪ್ರಿಫೆಕ್ಚರ್
@@ -3215,7 +3215,7 @@ hu:Isikava prefektúra
 hy:Իսիկավա (պրեֆեկտուրա)
 id:Prefektur Ishikawa
 it:prefettura di Ishikawa
-ja:石川県
+ja:石川県, 石川
 ka:ისიკავის პრეფექტურა
 kn:ಇಶಿಕಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
 ko:이시카와현
@@ -3286,7 +3286,7 @@ hu:Mie prefektúra
 hy:Միե
 id:Prefektur Mie
 it:prefettura di Mie
-ja:三重県
+ja:三重県, 三重
 ka:მიეს პრეფექტურა
 km:ខេត្តមីអិ
 kn:ಮೀ ಪ್ರಿಫೆಕ್ಚರ್
@@ -3393,7 +3393,7 @@ io:Tokyo
 is:Tókýó
 it:Tokyo
 iu:ᑑᑭᐅ
-ja:東京都
+ja:東京都, 東京
 jv:Tokyo
 ka:ტოკიო
 ki:Tokyo
@@ -3518,7 +3518,7 @@ hu:Kagosima prefektúra
 hy:Կոգոշիմա
 id:Prefektur Kagoshima
 it:prefettura di Kagoshima
-ja:鹿児島県
+ja:鹿児島県, 鹿児島
 jv:Prefektur Kagoshima
 ka:კაგოსიმის პრეფექტურა
 km:ខេត្តខាហ្គុស៊ីម៉ា
@@ -3594,7 +3594,7 @@ hu:Mijagi prefektúra
 hy:Միյագի
 id:Prefektur Miyagi
 it:prefettura di Miyagi
-ja:宮城県
+ja:宮城県, 宮城
 ka:მიაგის პრეფექტურა
 km:ខេត្តមីយ៉ាហ្គិ
 kn:ಮಿಯಾಗಿ ಪ್ರಿಫೆಕ್ಚರ್

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -119,103 +119,3524 @@ pt:Ásia
 tr:Asya
 
 <en:Japan
+en:Chiba Prefecture
+af:Chiba Prefektuur
+ar:تشيبا
+az:Çiba prefekturası
+ba:Тиба (префектура)
+be:прэфектура Тыба
+bg:Чиба
+bn:চিবা প্রশাসনিক অঞ্চল
+ca:prefectura de Chiba
+ce:Тиба (префектура)
+cs:Prefektura Čiba
+cy:Chiba
+da:Chiba-præfekturet
+de:Präfektur Chiba
+el:Τσίμπα
+eo:Gubernio Ĉiba
+es:Prefectura de Chiba
+et:Chiba prefektuur
+eu:Chiba
+fa:استان چیبا
+fi:Chiban prefektuuri
+fr:préfecture de Chiba
+ga:Maoracht Chiba
+gl:Prefectura de Chiba
+gu:ચિબા પ્રીફેકચર
+he:צ'יבה
+hi:शिबा प्रीफेक्चर
+hr:Chiba
+hu:Csiba prefektúra
+hy:Թիբա (պրեֆեկտուրա)
+id:Prefektur Chiba
+it:prefettura di Chiba
+ja:千葉県
+jv:Prefektur Chiba
+ka:ტიბის პრეფექტურა
+km:ខេត្តឈីបា
+kn:ಚಿಬಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:지바현
+la:Tiba
+lt:Čibos prefektūra
+lv:Čibas prefektūra
+mk:Чиба
+mn:Чиба-кэн
+mr:चिबा
+ms:Wilayah Chiba
+nb:Chiba prefektur
+nl:Chiba
+nn:Chiba prefektur
+oc:Prefectura de Chiba
+pl:Prefektura Chiba
+pt:Chiba
+ro:Prefectura Chiba
+ru:Тиба
+se:Chiba prefektuvra
+sh:Prefektura Čiba
+si:චිබා ප්‍රාන්තය
+sk:Čiba
+sl:prefektura Čiba
+sr:Чиба
+su:Préféktur Chiba
+sv:Chiba prefektur
+sw:Mkoa wa Chiba
+ta:சீபா ப்ரீபெக்ட்டுர்
+te:చిబా ప్రిఫెక్చర్
+tg:Префектураи Чиба
+th:จังหวัดชิบะ
+tl:Prepektura ng Chiba
+tr:Chiba ili
+tt:Тиба (префектура)
+ug:چىبا ناھىيەسى
+uk:Префектура Чіба
+ur:چیبا پریفیکچر
+vi:Chiba
+zh:千葉縣
+wikidata:en:Q80011
+
+<en:Japan
+en:Yamagata Prefecture
+af:Yamagata Prefektuur
+ar:ياماغاتا
+az:Yamaqata
+ba:Ямагата (префектура)
+be:прэфектура Ямагата
+bg:Ямагата
+bn:ইয়ামাগাতা প্রশাসনিক অঞ্চল
+ca:prefectura de Yamagata
+ce:Ямагата (префектура)
+cs:prefektura Jamagata
+cy:Yamagata
+da:Yamagata-præfekturet
+de:Präfektur Yamagata
+el:Νομός Γιαμάγκατα
+eo:Gubernio Jamagata
+es:Prefectura de Yamagata
+et:Yamagata prefektuur
+eu:Yamagata
+fa:استان یاماگاتا
+fi:Yamagatan prefektuuri
+fr:préfecture de Yamagata
+ga:Maoracht Yamagata
+gl:Prefectura de Yamagata
+gu:યમાગાતા પ્રીફેકચર
+he:יאמאגטה
+hi:यामागाटा प्रीफेक्चर
+hr:Yamagata
+hu:Jamagata prefektúra
+hy:Յամագաթա (պրեֆեկտուրա)
+id:Prefektur Yamagata
+it:prefettura di Yamagata
+ja:山形県
+ka:იამაგატის პრეფექტურა
+km:ខេត្តយ៉ាម៉ាកាតា
+kn:ಯಮಗಾಟಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:야마가타현
+lt:Jamagatos prefektūra
+lv:Jamagatas prefektūra
+mk:Јамагата
+mn:Ямагата-кэн
+mr:यामागाता
+ms:Wilayah Yamagata
+nb:Yamagata prefektur
+nl:Yamagata
+nn:Yamagata prefektur
+pl:Prefektura Yamagata
+pt:Yamagata
+ro:Prefectura Yamagata
+ru:Ямагата
+se:Yamagata prefektuvra
+sh:Prefektura Jamagata
+si:යමගාටා ප්‍රාන්තය
+sk:Jamagata
+sl:Jamagata
+sr:Јамагата
+su:Yamagata Prefecture
+sv:Yamagata prefektur
+sw:Mkoa wa Yamagata
+ta:யமாட்டா ப்ரீபெக்ட்டுறே
+te:యమగాతా ప్రిఫెక్చర్
+tg:Префектураи Ямагата
+th:จังหวัดยามางาตะ
+tl:Prepektura ng Yamagata
+tr:Yamagata
+tt:Ямагата (префектура)
+ug:ياماگاتا ناھىيىسى
+uk:Префектура Ямаґата
+ur:یاماگاتا پرفکترے
+uz:Yamagata
+vi:Yamagata
+zh:山形縣
+wikidata:en:Q125863
+
+<en:Japan
+en:Kumamoto Prefecture
+af:Kumamoto Prefektuur
+ar:كوماموتو
+az:Kumamoto
+ba:Кумамото (префектура)
+be:прэфектура Кумамота
+bg:Кумамото
+bn:কুমামোতো প্রশাসনিক অঞ্চল
+ca:prefectura de Kumamoto
+ce:Кумамото (префектура)
+cs:Prefektura Kumamoto
+cy:Kumamoto
+da:Kumamoto-præfekturet
+de:Präfektur Kumamoto
+el:Κουμαμότο
+eo:Gubernio Kumamoto
+es:prefectura de Kumamoto
+et:Kumamoto prefektuur
+eu:Kumamoto
+fa:استان کوماموتو
+fi:Kumamoton prefektuuri
+fr:préfecture de Kumamoto
+ga:Maoracht Kumamoto
+gl:Prefectura de Kumamoto
+gu:કુમામોટો પ્રીફેકચર
+he:קוממוטו
+hi:कुमामोटो प्रान्त
+hr:Kumamoto
+hu:Kumamoto prefektúra
+hy:Կումամոտո (պրեֆեկտուրա)
+id:Prefektur Kumamoto
+it:prefettura di Kumamoto
+ja:熊本県
+ka:კუმამოტოს პრეფექტურა
+km:ខេត្តឃឹម៉ាម៉ុតុ
+kn:ಕುಮಾಮೊಟೊ ಪ್ರಿಫೆಕ್ಚರ್
+ko:구마모토현
+lt:Kumamoto prefektūra
+lv:Kumamoto prefektūra
+mk:Кумамото
+mr:कुमामोतो
+ms:Wilayah Kumamoto
+nb:Kumamoto prefektur
+nl:Kumamoto
+nn:Kumamoto prefektur
+pl:Prefektura Kumamoto
+pt:Kumamoto
+ro:Prefectura Kumamoto
+ru:Кумамото
+se:Kumamoto prefektuvra
+sh:Prefektura Kumamoto
+si:කුමමොටෝ ප්‍රාන්තය
+sk:Kumamoto
+sl:prefektura Kumamoto
+sr:Кумамото
+su:Kumamoto Prefecture
+sv:Kumamoto prefektur
+sw:Mkoa wa Kumamoto
+ta:குமமோடோ ப்ரீபெக்ட்டுர்
+te:కుమామోటో ప్రిఫెక్చర్
+tg:Префектураи Кумамото
+th:จังหวัดคูมาโมโตะ
+tl:Prepektura ng Kumamoto
+tr:Kumamoto
+tt:Кумамото (префектура)
+uk:Префектура Кумамото
+ur:کوماموتو پریفیکچر
+vi:Kumamoto
+zh:熊本縣
+wikidata:en:Q130308
+
+<en:Japan
+en:Shiga Prefecture
+af:Shiga Prefektuur
+ar:شيغا
+az:Şiqa
+ba:Сига
+be:прэфектура Сіга
+bg:Шига
+bn:শিগা প্রশাসনিক অঞ্চল
+ca:prefectura de Shiga
+ce:Сига (префектура)
+cs:Prefektura Šiga
+cy:Shiga
+da:Shiga-præfekturet
+de:Präfektur Shiga
+el:Σίγκα
+eo:Gubernio Ŝiga
+es:Prefectura de Shiga
+et:Shiga prefektuur
+eu:Shiga
+fa:استان شیگا
+fi:Shigan prefektuuri
+fr:Préfecture de Shiga
+ga:Maoracht Shiga
+gl:Prefectura de Shiga
+gu:શિગા પ્રીફેકચર
+he:שיגה
+hi:शिगा प्रीफेक्चर
+hr:Shiga
+hu:Siga prefektúra
+hy:Սիգա (պրեֆեկտուրա)
+id:Prefektur Shiga
+it:prefettura di Shiga
+ja:滋賀県
+jv:Prefektur Shiga
+ka:სიგის პრეფექტურა
+kn:ಶಿಗಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:시가현
+la:Siga
+lt:Šigos prefektūra
+lv:Sigas prefektūra
+mk:Шига
+mn:Шига
+mr:शिगा
+ms:Wilayah Shiga
+my:ရှိဂါ့စီရင်စု
+nb:Shiga prefektur
+nl:Shiga
+nn:Shiga prefektur
+pl:Prefektura Shiga
+pt:Shiga
+ro:Prefectura Shiga
+ru:Сига
+se:Shiga prefektuvra
+sh:Prefektura Šiga
+si:ශිගා ප්‍රාන්තය
+sk:Šiga
+sl:prefektura Šiga
+sr:Шига
+su:Préféktur Shiga
+sv:Shiga prefektur
+sw:Mkoa wa Shiga
+ta:ஷிகா ப்ரீபெக்ட்டுறே
+te:షిగా ప్రిఫెక్చర్
+tg:Префектураи Сига
+th:จังหวัดชิงะ
+tl:Prepektura ng Shiga
+tr:Shiga
+tt:Сига (префектура)
+uk:Префектура Шіґа
+ur:شیگا پریفیکچر
+vi:Shiga
+zh:滋賀縣
+wikidata:en:Q131358
+
+<en:Japan
+en:Yamanashi Prefecture
+af:Yamanashi Prefektuur
+ar:ياماناشي
+az:Yamanaşi
+be:прэфектура Яманасі
+bg:Яманаши
+bn:ইয়ামানাশি প্রশাসনিক অঞ্চল
+ca:prefectura de Yamanashi
+ce:Яманаси (префектура)
+cs:Prefektura Jamanaši
+cy:Yamanashi
+da:Yamanashi-præfekturet
+de:Präfektur Yamanashi
+el:Γιαμανάσι
+eo:Gubernio Jamanaŝi
+es:Prefectura de Yamanashi
+et:Yamanashi prefektuur
+eu:Yamanashi
+fa:استان یاماناشی
+fi:Yamanashin prefektuuri
+fr:Préfecture de Yamanashi
+ga:Maoracht Yamanashi
+gl:Prefectura de Yamanashi
+gu:યમાનાશી પ્રીફેકચર
+he:יאמאנאשי
+hi:यामानाशी प्रीफेक्चर
+hr:Yamanashi
+hu:Jamanasi prefektúra
+hy:Յամանասի (պրեֆեկտուրա)
+id:Prefektur Yamanashi
+it:prefettura di Yamanashi
+ja:山梨県
+ka:იამანასის პრეფექტურა
+km:ខេត្តយ៉ាម៉ាណាស៊ី
+kn:ಯಮನಶಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:야마나시현
+lt:Jamanašio prefektūra
+lv:Jamanasi prefektūra
+mk:Јаманаши
+mr:यामानाशी
+ms:Wilayah Yamanashi
+nb:Yamanashi prefektur
+nl:Yamanashi
+nn:Yamanashi prefektur
+pl:Prefektura Yamanashi
+pt:Yamanashi
+ro:Prefectura Yamanashi
+ru:Яманаси
+se:Yamanashi prefektuvra
+sh:Prefektura Jamanaši
+si:යමනාශි ප්‍රාන්තය
+sk:Jamanaši
+sl:Prefektura Jamanaši
+sr:Јаманаши
+su:Préféktur Yamanashi
+sv:Yamanashi prefektur
+sw:Mkoa wa Yamanashi
+ta:யமானஷி ப்ரீபெக்ட்டுறே
+te:యమనాషి ప్రిఫెక్చర్
+tg:Префектураи Яманаши
+th:จังหวัดยามานาชิ
+tl:Prepektura ng Yamanashi
+tr:Yamanashi
+tt:Яманаси (префектура)
+uk:Префектура Яманаші
+ur:یماناشی پرفکترے
+vi:Yamanashi
+zh:山梨縣
+wikidata:en:Q132720
+
+<en:Japan
 en:Hokkaido
-af:Hokkaido
-am:ሆካይዶ
 ar:هوكايدو
-as:হোক্কাইডো
-az:Hokkaydo
-ba:Хоккайдо
-be:Хакайда
-bg:Хокайдо
-bn:হোক্কাইদো
-bo:ཧོ་ཁའི་དོ།
-br:Hokkaido
-bs:Hokkaido
-ca:Hokkaido
-cs:Hokkaidó
-cu:Хоккаидо
-cy:Hokkaidō
-da:Hokkaido
+az:Hokkaydo prefekturası
+be:прэфектура Хакайда
+ca:prefectura de Hokkaidō
+cs:prefektura Hokkaidó
+da:Hokkaido prefektur
 de:Hokkaidō
 el:Χοκκάιντο
-eo:Hokajdo
-es:Hokkaidō
-et:Hokkaidō
-eu:Hokkaido
-fa:هوکایدو
-fi:Hokkaidō
-fo:Hokkaido
-fr:Hokkaidō
-fy:Hokkaido
-ga:Hokkaidō
-gd:Hokkaidō
-gl:Hokkaido
-ha:Hokkaido
+eo:Gubernio Hokajdo
+es:Prefectura de Hokkaido
+et:Hokkaidō prefektuur
+fr:Préfecture de Hokkaidō
+fy:Prefektuer Hokkaido
+ga:Maoracht Hokkaido
 he:הוקאידו
-hi:होक्काइदो
-hr:Hokkaido
-hu:Hokkaidó
+hr:Hokkaido, prefektura
+hu:Hokkaidó prefektúra
 hy:Հոկայդո
-ia:Hokkaido
 id:Prefektur Hokkaido
-ie:Hokkaidō
-io:Hokkaido
-is:Hokkaidō
-it:Hokkaidō
+it:prefettura di Hokkaidō
 ja:北海道
 jv:Hokkaido
-ka:ჰოკაიდო
-kk:Хоккайдо
-km:ហុកកៃដូ
 ko:홋카이도
-ku:Hokkaidō
-ky:Хоккайдо
-la:Esonia
-lt:Hokaidas
-lv:Hokaido
-mk:Хокаидо
-ml:ഹൊക്കൈഡൊ
-mn:Хоккайдо
-mr:होक्काइदो
-ms:Hokkaidō
-my:ဟော့ကိုင်းဒိုးကျွန်း
-nl:Hokkaido
-nn:Hokkaido
-no:Hokkaido
-oc:Hokkaidō
-or:ହୋକାଇଦୋ
-os:Хоккайдо
-pa:ਹੋੱਕਾਇਦੋ ਟਾਪੂ
-pl:Hokkaido
-pt:Hokkaido
-qu:Hokkaido
-rm:Hokkaidō
-ro:Insula Hokkaidō
+lv:Hokaido prefektūra
+nb:Hokkaido prefektur
+nl:Prefectuur Hokkaido
+nn:Hokkaido prefektur
+os:Хоккайдо (префектурæ)
+pl:prefektura Hokkaido
+ro:Prefectura Hokkaidō
 ru:Хоккайдо
-sh:Hokkaidō
-si:හොක්කයිදෝ
-sk:Hokkaido
+se:Hokkaidō prefektuvra
 sl:Hokaido
-sq:Hokaido
 sr:Хокаидо
-su:Hokkaido
-sv:Hokkaido
-sw:Mkoa wa Hokkaidō
-ta:ஹொக்கைடோ
-tg:Хоккайдо
-th:จังหวัดฮกไกโด
-tl:Hokkaidō
-tr:Hokkaidō
-tt:Хоккайдо
-ug:خوككايدو ئارىلى
-uk:Хоккайдо
-ur:ہوکائیدو
-uz:Xokkaydo
-vi:Hokkaidō
-yi:האקיידא
-zh:北海道 
-wikidata:en:Q35581
+sv:Hokkaido prefektur
+tg:Префектураи Ҳоккайдо
+th:ฮกไกโด
+tt:Хоккайдо (префектура)
+uk:Префектура Хоккайдо
+zh:北海道
+wikidata:en:Q1037393
+
+<en:Japan
+en:Ibaraki Prefecture
+af:Ibaraki Prefektuur
+ar:إيباراكي
+az:İbaraki prefekturası
+ba:Ибараки
+be:прэфектура Ібаракі
+bg:Ибараки
+bn:ইবারাকি প্রশাসনিক অঞ্চল
+ca:prefectura d'Ibaraki
+ce:Ибараки (префектура)
+cs:Prefektura Ibaraki
+cy:Ibaraki
+da:Ibaraki-præfekturet
+de:Präfektur Ibaraki
+el:Επαρχία Ιμπαράκι
+eo:Gubernio Ibaraki
+es:Prefectura de Ibaraki
+et:Ibaraki prefektuur
+eu:Ibaraki
+fa:استان ایباراکی
+fi:Ibarakin prefektuuri
+fr:préfecture d'Ibaraki
+ga:Maoracht Ibaraki
+gl:Prefectura de Ibaraki
+gu:ઇબારાકી પ્રીફેકચર
+he:איבראקי
+hi:आईबराकी प्रीफेक्चर
+hr:Ibaraki
+hu:Ibaraki prefektúra
+hy:Իբարակի (պրեֆեկտուրա)
+id:Prefektur Ibaraki
+it:prefettura di Ibaraki
+ja:茨城県
+jv:Prefektur Ibaraki
+ka:იბარაკის პრეფექტურა
+km:ខេត្តអ៊ីបារ៉ាគិ
+kn:ಐಬರಾಕಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:이바라키현
+lt:Ibarakio prefektūra
+lv:Ibaraki prefektūra
+mk:Ибараки
+mn:Ибараки
+mr:इबाराकी
+ms:Wilayah Ibaraki
+nb:Ibaraki prefektur
+nl:Ibaraki
+nn:Ibaraki prefektur
+oc:Prefectura d'Ibaraki
+pl:Prefektura Ibaraki
+pt:Ibaraki
+ro:Prefectura Ibaraki
+ru:Ибараки
+se:Ibaraki prefektuvra
+sh:Prefektura Ibaraki
+si:ඉබරකි ප්‍රාන්තය
+sk:Ibaraki
+sl:prefektura Ibaraki
+sr:Ибараки
+su:Ibaraki Prefecture
+sv:Ibaraki prefektur
+sw:Mkoa wa Ibaraki
+ta:இபராக்கி பிரேபிக்டூர்
+te:ఇబరాకి ప్రిఫెక్చర్
+tg:Префектураи Ибараки
+th:จังหวัดอิบารากิ
+tl:Prepektura ng Ibaraki
+tr:Ibaraki
+tt:Ибараки (префектура)
+ug:ئىباراكى ناھىيىسى
+uk:Префектура Ібаракі
+ur:ایباراکی پریفیکچر
+uz:Ibaraki prefekturasi
+vi:Ibaraki
+zh:茨城縣
+wikidata:en:Q83273
+
+<en:Japan
+en:Aichi Prefecture
+af:Aichi Prefektuur
+ar:آيتشي
+az:Ayçi prefekturası
+ba:Айти
+be:прэфектура Айты
+bg:Айчи
+bn:আইচি প্রশাসনিক অঞ্চল
+bo:ཨའི་ཆི་ཞེས་པའི་སྲིད་འཛིན་ས་ཁུལ།
+ca:prefectura d'Aichi
+ce:Айти (префектура)
+cs:Prefektura Aiči
+cy:Aichi
+da:Aichi-præfekturet
+de:Präfektur Aichi
+el:Άιτσι
+eo:Gubernio Aiĉi
+es:Prefectura de Aichi
+et:Aichi prefektuur
+eu:Aichi
+fa:استان آیچی
+fi:Aichin prefektuuri
+fr:Préfecture d'Aichi
+ga:Maoracht Aichi
+gl:Prefectura de Aichi
+gu:એચી પ્રીફેકચર
+he:אאיצ'י
+hi:आइची प्रीफ़ेक्चर
+hr:Aichi
+hu:Aicsi prefektúra
+hy:Այչի
+id:Prefektur Aichi
+it:prefettura di Aichi
+ja:愛知県
+jv:Prefektur Aichi
+ka:აიტის პრეფექტურა
+km:ខេត្តអៃឈិ
+kn:ಐಚಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:아이치현
+lt:Aičio prefektūra
+lv:Aiči
+mk:Ајчи
+mn:Айчи
+mr:ऐची
+ms:Wilayah Aichi
+nb:Aichi prefektur
+nl:Aichi
+nn:Aichi prefektur
+or:ଆଇଚି ରାଜ୍ଯ
+os:Айти (префектурæ)
+pa:ਆਇਚੀ ਪ੍ਰੀਫ਼ੈਕਚਰ
+pl:Prefektura Aichi
+pt:Aichi
+ro:Prefectura Aichi
+ru:Айти
+se:Aichi prefektuvra
+sh:Prefektura Aiči
+si:අයිචි ප්‍රාන්තය
+sk:Aiči
+sl:prefektura Aiči
+sr:Аичи
+su:Préféktur Aichi
+sv:Aichi prefektur
+sw:Mkoa wa Aichi
+ta:ஆட்சி பிரேபிக்ச்சர்
+te:అయిచి ప్రిఫెక్చర్
+tg:Префектураи Айчи
+th:จังหวัดไอจิ
+tl:Prepektura ng Aichi
+tr:Aichi
+tt:Айти (префектура)
+uk:Префектура Айчі
+ur:ایچی پریفیکچر
+vi:Aichi
+zh:愛知縣
+wikidata:en:Q80434
+
+<en:Japan
+en:Osaka Prefecture
+af:Osaka Prefektuur
+ar:أوساكا
+az:Osaka prefekturası
+ba:Осака (префектура)
+be:прэфектура Осака
+bg:Осака
+bn:ওসাকা প্রশাসনিক অঞ্চল
+ca:prefectura d'Ōsaka
+ce:Осака (префектура)
+cs:Prefektura Ósaka
+cy:Osaka
+da:Osaka-præfekturet
+de:Präfektur Osaka
+el:Οσάκα
+eo:Gubernio Osaka
+es:Prefectura de Osaka
+et:Ōsaka prefektuur
+eu:Osaka prefektura
+fa:استان اوساکا
+fi:Osakan prefektuuri
+fr:préfecture d'Osaka
+ga:Maoracht Osaka
+gl:Prefectura de Ōsaka
+gu:ઓસાકા પ્રીફેકચર
+he:מחוז אוסקה
+hi:ओसाका प्रीफेक्चर
+hr:Ōsaka
+hu:Oszaka prefektúra
+hy:Օսակայի պրեֆեկտուրա
+id:Prefektur Osaka
+it:prefettura di Osaka
+ja:大阪府
+jv:Prefektur Osaka
+ka:ოსაკის პრეფექტურა
+km:អាណាខេត្តអូសាកា
+kn:ಒಸಾಕಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:오사카부
+la:Osaka (praefectura)
+lt:Osakos prefektūra
+lv:Osakas prefektūra
+mk:Осака
+mr:ओसाका
+ms:Wilayah Osaka
+nb:Osaka prefektur
+nl:Osaka
+nn:Osaka prefektur
+os:Осакæ
+pl:Prefektura Osaka
+pt:Osaka
+ro:Prefectura Osaka
+ru:Осака
+se:Ōsaka prefektuvra
+sh:Prefektura Osaka
+si:ඔසාකා ප්‍රාන්තය
+sk:Prefektura Osaky
+sl:prefektura Osaka
+sr:Осака
+su:Osaka Prefecture
+sv:Osaka prefektur
+sw:Mkoa wa Osaka
+ta:ஒசாகா ப்ரீபெக்ட்டுர்
+te:ఓసాకా ప్రిఫెక్చర్
+tg:Префектураи Осака
+th:จังหวัดโอซากะ
+tl:Prepektura ng Osaka
+tr:Osaka ili
+tt:Осака (префектура)
+uk:Префектура Осака
+ur:اوساکا پریفیکچر
+vi:Ōsaka
+zh:大阪府
+wikidata:en:Q122723
+
+<en:Japan
+en:Tottori Prefecture
+af:Tottori Prefektuur
+ar:توتوري
+az:Tottori prefekturası
+be:прэфектура Таторы
+bg:Тотори
+bn:তোত্তোরি প্রশাসনিক অঞ্চল
+ca:prefectura de Tottori
+ce:Тоттори (префектура)
+cs:Prefektura Tottori
+cy:Tottori
+da:Tottori-præfekturet
+de:Präfektur Tottori
+el:Τόττορι
+eo:Gubernio Tottori
+es:Prefectura de Tottori
+et:Tottori prefektuur
+eu:Tottori
+fa:استان توتوری
+fi:Tottorin prefektuuri
+fr:Préfecture de Tottori
+ga:Maoracht Tottori
+gl:Prefectura de Tottori
+gu:ટોટ્ટોરી પ્રીફેકચર
+he:טוטורי
+hi:तोतोरी प्रान्त
+hr:Tottori
+hu:Tottori prefektúra
+hy:Տոթթորի
+id:Prefektur Tottori
+it:prefettura di Tottori
+ja:鳥取県
+jv:Prefektur Tottori
+ka:ტოტორის პრეფექტურა
+kn:ಟೊಟ್ಟೊರಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:돗토리현
+lt:Totorio prefektūra
+lv:Totori prefektūra
+mk:Тотори
+mr:तोतोरी
+ms:Wilayah Tottori
+nb:Tottori prefektur
+nl:Tottori
+nn:Tottori prefektur
+oc:prefectura de Tottori
+pl:Prefektura Tottori
+pt:Tottori
+ro:Prefectura Tottori
+ru:Тоттори
+se:Tottori prefektuvra
+sh:Prefektura Totori
+si:ටෝට්ටෝරි ප්‍රාන්තය
+sk:Tottori
+sr:Тотори
+su:Tottori Prefecture
+sv:Tottori prefektur
+sw:Mkoa wa Tottori
+ta:டோட்டோரி ப்ரீபெக்ட்டுறே
+te:టాటోరి ప్రిఫెక్చర్
+tg:Префектураи Тоттори
+th:จังหวัดทตโตริ
+tl:Prepektura ng Tottori
+tr:Tottori
+tt:Тоттори (префектура)
+uk:Префектура Тотторі
+ur:توتوری پریفیکچر
+vi:Tottori
+zh:鳥取縣
+wikidata:en:Q133935
+
+<en:Japan
+en:Shimane Prefecture
+af:Shimane Prefektuur
+ar:شيمانه
+az:Şimane prefekturası
+ba:Симанэ
+be:прэфектура Сіманэ
+bg:Шимане
+bn:শিমানে প্রশাসনিক অঞ্চল
+ca:prefectura de Shimane
+ce:Симане (префектура)
+cs:Prefektura Šimane
+cy:Shimane
+da:Shimane-præfekturet
+de:Präfektur Shimane
+el:Σιμάνε
+eo:Gubernio Ŝimane
+es:Prefectura de Shimane
+et:Shimane prefektuur
+eu:Shimane
+fa:استان شیمانه
+fi:Shimanen prefektuuri
+fr:Préfecture de Shimane
+ga:Maoracht Shimane
+gl:Prefectura de Shimane
+gu:શિમૅન પ્રીફેકચર
+he:שימאנה
+hi:शिमाने प्रीफेक्चर
+hr:Shimane
+hu:Simane prefektúra
+hy:Սիմանե (պրեֆեկտուրա)
+id:Prefektur Shimane
+it:prefettura di Shimane
+ja:島根県
+ka:სიმანეს პრეფექტურა
+km:ខេត្តស៊ីម៉ាណិ
+kn:ಶಿಮಾನ್ ಪ್ರಿಫೆಕ್ಚರ್
+ko:시마네현
+lt:Šimanės prefektūra
+lv:Simanes prefektūra
+mk:Шимане
+mr:शिमाने
+ms:Wilayah Shimane
+nb:Shimane prefektur
+nl:Shimane
+nn:Shimane prefektur
+pl:Prefektura Shimane
+ps:شیمانه
+pt:Shimane
+ro:Prefectura Shimane
+ru:Симане
+se:Shimane prefektuvra
+sh:Prefektura Šimane
+si:ශිමානේ ප්‍රාන්තය
+sk:Šimane
+sl:prefektura Šimane
+sr:Шимане
+su:Shimane Prefecture
+sv:Shimane prefektur
+sw:Mkoa wa Shimane
+ta:ஷிம்மனே ப்ரீபெக்ட்டுறே
+te:షిమేన్ ప్రిఫెక్చర్
+tg:Префектураи Симанэ
+th:จังหวัดชิมาเนะ
+tl:Prepektura ng Shimane
+tr:Shimane
+tt:Симане (префектура)
+uk:Префектура Шімане
+ur:شیمانے پریفیکچر
+vi:Shimane
+zh:島根縣
+wikidata:en:Q132751
+
+<en:Japan
+en:Toyama Prefecture
+af:Toyama Prefektuur
+ar:توياما
+az:Toyama prefekturası
+be:прэфектура Таяма
+bg:Тояма
+bn:তোয়্যামা প্রশাসনিক অঞ্চল
+ca:prefectura de Toyama
+ce:Тояма (префектура)
+cs:prefektura Tojama
+cy:Toyama
+da:Toyama-præfekturet
+de:Präfektur Toyama
+el:Τογιάμα
+eo:Gubernio Tojama
+es:Prefectura de Toyama
+et:Toyama prefektuur
+eu:Toyama
+fa:استان تویاما
+fi:Toyaman prefektuuri
+fr:Préfecture de Toyama
+ga:Maoracht Toyama
+gl:Prefectura de Toyama
+gu:ટોયમા પ્રીફેકચર
+he:טויאמה
+hi:तोयामा प्रभाग
+hr:Toyama
+hu:Tojama prefektúra
+hy:Տոյամա
+id:Prefektur Toyama
+it:prefettura di Toyama
+ja:富山県
+ka:ტოიამის პრეფექტურა
+km:ខេត្តតុយ៉ាម៉ា
+kn:ಟೊಯಾಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:도야마현
+lt:Tojamos prefektūra
+lv:Tojamas prefektūra
+mk:Тојама
+mr:तोयामा
+ms:Wilayah Toyama
+nb:Toyama prefektur
+nl:Toyama
+nn:Toyama prefektur
+pl:Prefektura Toyama
+pt:Toyama
+ro:Prefectura Toyama
+ru:Тояма
+se:Toyama prefektuvra
+sh:Prefektura Tojama
+si:ටෝයාමා ප්‍රාන්තය
+sk:Tojama
+sl:prefektura Tojama
+sr:Тојама
+su:Toyama Prefecture
+sv:Toyama prefektur
+sw:Mkoa wa Toyama
+ta:டோயமா ப்ரீபெக்ட்டுறே
+te:టోయామా ప్రిఫెక్చర్
+tg:Префектураи Тояма
+th:จังหวัดโทยามะ
+tl:Prepektura ng Toyama
+tr:Toyama
+tt:Тояма (префектура)
+uk:Префектура Тояма
+ur:تویاما پریفیکچر
+vi:Toyama
+zh:富山縣
+wikidata:en:Q132929
+
+<en:Japan
+en:Okayama Prefecture
+af:Okayama Prefektuur
+ar:أوكاياما
+az:Okayama prefekturası
+ba:Окаяма (префектура)
+be:прэфектура Акаяма
+bg:Окаяма
+bn:ওকায়ামা প্রশাসনিক অঞ্চল
+ca:prefectura d'Okayama
+ce:Окаяма (префектура)
+cs:prefektura Okajama
+cy:Okayama
+da:Okayama-præfekturet
+de:Präfektur Okayama
+el:Οκαγιάμα
+eo:Gubernio Okajama
+es:Prefectura de Okayama
+et:Okayama prefektuur
+eu:Okayama
+fa:استان اوکایاما
+fi:Okayaman prefektuuri
+fr:préfecture d'Okayama
+ga:Maoracht Okayama
+gl:Prefectura de Okayama
+gu:ઓકાયામા પ્રીફેકચર
+he:אוקיאמה
+hi:ओकायामा प्रान्त
+hr:Okayama
+hu:Okajama prefektúra
+hy:Օկայամա (պրեֆեկտուրա)
+id:Prefektur Okayama
+it:prefettura di Okayama
+ja:岡山県
+jv:Prefektur Okayama
+ka:ოკაიამის პრეფექტურა
+km:ខេត្តអូកាយ៉ាម៉ា
+kn:ಒಕಯಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:오카야마현
+lt:Okajamos prefektūra
+lv:Okajamas prefektūra
+mk:Окајама
+mr:ओकायामा
+ms:Wilayah Okayama
+nb:Okayama prefektur
+nl:Okayama
+nn:Okayama prefektur
+pl:Prefektura Okayama
+pt:Okayama
+ro:Prefectura Okayama
+ru:Окаяма
+se:Okayama prefektuvra
+sh:Prefektura Okajama
+si:ඔකයාමා ප්‍රාන්තය
+sk:Okajama
+sl:pefektura Okajama
+sr:Окајама
+su:Okayama Prefecture
+sv:Okayama prefektur
+sw:Mkoa wa Okayama
+ta:ஆகாயமா ப்ரீபெக்ட்டுர்
+te:ఓకయామా ప్రిఫెక్చర్
+tg:Префектураи Окаяма
+th:จังหวัดโอกายามะ
+tl:Prepektura ng Okayama
+tr:Okayama
+tt:Окаяма (префектура)
+uk:Префектура Окаяма
+ur:اوکایاما پریفیکچر
+vi:Okayama
+zh:岡山縣
+wikidata:en:Q132936
+
+<en:Japan
+en:Wakayama Prefecture
+af:Wakayama Prefektuur
+ar:واكاياما
+az:Vakayama prefekturası
+ba:Вакаяма (префектура)
+be:прэфектура Вакаяма
+bg:Вакаяма
+bn:ওয়াকায়ামা প্রশাসনিক অঞ্চল
+ca:Prefectura de Wakayama
+ce:Вакаяма (префектура)
+cs:Prefektura Wakajama
+cy:Wakayama
+da:Wakayama-præfekturet
+de:Präfektur Wakayama
+el:Γουακαγιάμα
+eo:Gubernio Ŭakajama
+es:Prefectura de Wakayama
+et:Wakayama prefektuur
+eu:Wakayama
+fa:استان واکایاما
+fi:Wakayaman prefektuuri
+fr:Préfecture de Wakayama
+ga:Maoracht Wakayama
+gl:Prefectura de Wakayama
+gu:વાકાયામા પ્રીફેકચર
+he:וקאיאמה
+hi:वकायामा प्रान्त
+hr:Wakayama
+hu:Vakajama prefektúra
+hy:Վակայամա
+id:Prefektur Wakayama
+it:prefettura di Wakayama
+ja:和歌山県
+jv:Prefektur Wakayama
+ka:ვაკაიამის პრეფექტურა
+kn:ವಕಾಯಾಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:와카야마현
+la:Vacaiama
+lt:Vakajamos prefektūra
+lv:Vakajamas prefektūra
+mk:Вакајама
+mn:Вакаяма
+mr:वाकायामा
+ms:Wilayah Wakayama
+nb:Wakayama prefektur
+nl:Wakayama
+nn:Wakayama prefektur
+pl:Prefektura Wakayama
+pt:Wakayama
+ro:Prefectura Wakayama
+ru:Вакаяма
+se:Wakayama prefektuvra
+sh:Prefektura Vakajama
+si:වකයාමා ප්‍රාන්තය
+sk:Wakajama
+sl:prefektura Wakayama
+sr:Вакајама
+su:Wakayama Prefecture
+sv:Wakayama prefektur
+sw:Mkoa wa Wakayama
+ta:வாக்கயமா ப்ரீபெக்ட்டுறே
+te:వకాయామా ప్రిఫెక్చర్
+tg:Префектураи Вакаяма
+th:จังหวัดวากายามะ
+tk:Vakaýama
+tl:Prepektura ng Wakayama
+tr:Wakayama
+tt:Вакаяма (префектура)
+uk:Префектура Вакаяма
+ur:واکایاما پریفیکچر
+vi:Wakayama
+zh:和歌山县
+wikidata:en:Q131314
+
+<en:Japan
+en:Niigata Prefecture
+af:Niigata Prefektuur
+ar:نييغاتا
+az:Niiqata prefekturası
+ba:Ниигата (префектура)
+be:прэфектура Ніігата
+bg:Ниигата
+bn:নিইগাতা প্রশাসনিক অঞ্চল
+ca:prefectura de Niigata
+ce:Ниигата (префектура)
+cs:Prefektura Niigata
+cy:Niigata
+da:Niigata-præfekturet
+de:Präfektur Niigata
+el:Νιιγκάτα
+eo:Gubernio Niigata
+es:Prefectura de Niigata
+et:Niigata prefektuur
+eu:Niigata
+fa:استان نیگاتا
+fi:Niigatan prefektuuri
+fr:préfecture de Niigata
+ga:Maoracht Niigata
+gl:Prefectura de Niigata
+gu:નીગાટા પ્રીફેકચર
+he:ניאיגטה
+hi:निगाता प्रीफेक्चर
+hr:Niigata
+hu:Niigata prefektúra
+hy:Նիիգատա
+id:Prefektur Niigata
+it:prefettura di Niigata
+ja:新潟県
+jv:Prefektur Niigata
+ka:ნიიგატის პრეფექტურა
+km:ខេត្តនីហ្គាតាក់
+kn:ನಿಗಾಟಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:니가타현
+la:Niigata
+lt:Nijigatos prefektūra
+lv:Ņiigatas prefektūra
+mk:Ниигата
+mr:निगाता
+ms:Wilayah Niigata
+nb:Niigata prefektur
+nl:Niigata
+nn:Niigata prefektur
+pl:Prefektura Niigata
+pt:Niigata
+ro:Prefectura Niigata
+ru:Ниигата
+se:Niigata prefektuvra
+sh:Prefektura Niigata
+si:නිගටා ප්‍රාන්තය
+sk:Niigata
+sl:prefektura Nigata
+sr:Ниигата
+su:Niigata Prefecture
+sv:Niigata prefektur
+sw:Mkoa wa Niigata
+ta:நீகட்ட ப்ரீபெக்ட்டுறே
+te:నీగాటా ప్రిఫెక్చర్
+tg:Префектураи Ниигата
+th:จังหวัดนีงาตะ
+tl:Prepektura ng Niigata
+tr:Niigata
+tt:Ниигата (префектура)
+uk:Префектура Ніїґата
+ur:نیگاتا پریفیکچر
+vi:Niigata
+zh:新潟縣
+wikidata:en:Q132705
+
+<en:Japan
+en:Hiroshima Prefecture
+af:Hiroshima Prefektuur
+ar:هيروشيما
+az:Hiroşima prefekturası
+ba:Хиросима (префектура)
+be:прэфектура Хірасіма
+bg:Хирошима
+bn:হিরোশিমা প্রশাসনিক অঞ্চল
+ca:prefectura de Hiroshima
+ce:Хиросима (префектура)
+cs:Prefektura Hirošima
+cy:Hiroshima
+da:Hiroshima-præfekturet
+de:Präfektur Hiroshima
+el:Χιροσίμα (νομός)
+eo:Gubernio Hiroŝima
+es:Prefectura de Hiroshima
+et:Hiroshima prefektuur
+eu:Hiroshima
+fa:استان هیروشیما
+fi:Hiroshiman prefektuuri
+fr:préfecture de Hiroshima
+ga:Maoracht Hiroshima
+gl:Prefectura de Hiroshima
+gu:હિરોશિમા પ્રીફેકચર
+he:הירושימה
+hi:हिरोशिमा प्रीफेक्चर
+hr:Hiroshima, prefektura
+hu:Hirosima prefektúra
+hy:Հերոսիմա (պրեֆեկտուրա)
+id:Prefektur Hiroshima
+it:prefettura di Hiroshima
+ja:広島県
+ka:ჰიროსიმის პრეფექტურა
+km:ខេត្តហ៊ីរ៉ូស៊ីម៉ា
+kn:ಹಿರೋಷಿಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:히로시마현
+lt:Hirosimos prefektūra
+lv:Hirosimas prefektūra
+mk:Хирошима
+mr:हिरोशिमा
+ms:Wilayah Hiroshima
+nb:Hiroshima prefektur
+nl:Hiroshima
+nn:Hiroshima prefektur
+pl:Prefektura Hiroszima
+pt:Hiroshima
+ro:Prefectura Hiroshima
+ru:Хиросима
+se:Hiroshima prefektuvra
+sh:Prefektura Hirošima
+si:හිරෝෂිමා ප්‍රාන්තය
+sk:Prefektura Hirošimy
+sl:prefektura Hirošima
+sr:Хирошима
+su:Préféktur Hiroshima
+sv:Hiroshima prefektur
+sw:Mkoa wa Hiroshima
+ta:ஹிரோஷிமா ப்ரீபெக்ட்டுறே
+te:హిరోషిమా ప్రిఫెక్చర్
+tg:Префектураи Ҳиросима
+th:จังหวัดฮิโรชิมะ
+tl:Prepektura ng Hiroshima
+tr:Hiroşima
+tt:Хиросима (префектура)
+uk:Префектура Хірошіма
+ur:ہیروشیما پریفیکچر
+vi:Hiroshima
+zh:廣島縣
+wikidata:en:Q617375
+
+<en:Japan
+en:Kyoto Prefecture
+af:Kioto Prefektuur
+ar:كيوتو
+az:Kioto prefekturası
+ba:Киото (префектура)
+be:прэфектура Кіёта
+bg:Киото
+bn:কিয়োতো প্রশাসনিক অঞ্চল
+ca:prefectura de Kyoto
+ce:Киото (префектура)
+co:prefettura di Kyōto
+cs:Prefektura Kjóto
+cy:Kyoto
+da:Kyoto-præfekturet
+de:Präfektur Kyōto
+el:Νομός Κιότο
+eo:Gubernio Kioto
+es:Prefectura de Kioto
+et:Kyōto prefektuur
+eu:Kyoto
+fa:استان کیوتو
+fi:Kioton prefektuuri
+fr:Préfecture de Kyoto
+ga:Maoracht Kyoto
+gl:Prefectura de Kyōto
+gu:ક્યોટો પ્રિફેક્ચર
+he:קיוטו
+hi:क्योटो प्रीफेक्चर
+hr:Kyōto
+hu:Kiotó prefektúra
+hy:Կիոտո (պրեֆեկտուրա)
+id:Prefektur Kyoto
+it:prefettura di Kyoto
+ja:京都府
+ka:კიოტოს პრეფექტურა
+km:ខេត្តក្យូតុ
+kn:ಕ್ಯೋಟೋ ಪ್ರಿಫೆಕ್ಚರ್
+ko:교토부
+la:Kyotum
+lt:Kioto prefektūra
+lv:Kioto prefektūra
+mk:Кјото
+mr:क्योतो
+ms:Wilayah Kyoto
+nb:Kyoto prefektur
+nl:Kioto
+nn:Kyoto prefektur
+pl:Prefektura Kioto
+pt:Quioto
+ro:Prefectura Kyoto
+ru:Киото
+se:Kyōto prefektuvra
+sh:Prefektura Kjoto
+si:ක්යෝටෝ ප්‍රාන්තය
+sk:Kjóto
+sl:prefektura Kyōto
+sr:Кјото
+su:Préféktur Kyoto
+sv:Kyoto prefektur
+sw:Mkoa wa Kyoto
+ta:கியோத்தோ நகரிய மாநிலம்
+te:క్యోటో ప్రిఫెక్చర్
+tg:Префектураи Киото
+th:จังหวัดเกียวโต
+tl:Prepektura ng Kyoto
+tr:Kyoto
+tt:Киото (префектура)
+uk:префектура Кіото
+ur:کیوٹو پریفیکچر
+vi:Kyōto
+zh:京都府
+wikidata:en:Q120730
+
+<en:Japan
+en:Kanagawa Prefecture
+af:Kanagawa Prefektuur
+ar:كاناغاوا
+az:Kanaqava prefekturası
+ba:Канагава
+be:прэфектура Канагава
+bg:Канагава
+bn:কানাগাওয়া প্রশাসনিক অঞ্চল
+ca:prefectura de Kanagawa
+ce:Канагава (префектура)
+cs:Prefektura Kanagawa
+cy:Kanagawa
+da:Kanagawa-præfekturet
+de:Präfektur Kanagawa
+el:Καναγκάβα
+eo:Gubernio Kanagaŭa
+es:prefectura de Kanagawa
+et:Kanagawa prefektuur
+eu:Kanagawa prefektura
+fa:استان کاناگاوا
+fi:Kanagawan prefektuuri
+fr:Préfecture de Kanagawa
+ga:Maoracht Kanagawa
+gl:Prefectura de Kanagawa
+gu:કનાગાવા પ્રીફેકચર
+he:קנאגאווה
+hi:कानागावा प्रीफेक्चर
+hr:Kanagawa
+hu:Kanagava prefektúra
+hy:Կանագավա
+id:Prefektur Kanagawa
+it:prefettura di Kanagawa
+ja:神奈川県
+ka:კანაგავის პრეფექტურა
+km:ខេត្តខាន់ណាហ្គាវ៉ា
+kn:ಕನಗಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:가나가와현
+lt:Kanagavos prefektūra
+lv:Kanagavas prefektūra
+mk:Канагава
+mn:Канагава
+mr:कानागावा
+ms:Wilayah Kanagawa
+nb:Kanagawa prefektur
+nl:Kanagawa
+nn:Kanagawa prefektur
+os:Канагавæ
+pl:Prefektura Kanagawa
+pt:Kanagawa
+ro:Prefectura Kanagawa
+ru:Канагава
+se:Kanagawa prefektuvra
+sh:Prefektura Kanagava
+si:කනගාවා ප්‍රාන්තය
+sk:Kanagawa
+sl:prefektura Kanagava
+sq:Kanagawa
+sr:Канагава
+su:Kanagawa Prefecture
+sv:Kanagawa prefektur
+sw:Mkoa wa Kanagawa
+ta:கனகவா ப்ரீபெக்ட்டுர்
+te:కనగావా ప్రిఫెక్చర్
+tg:Префектураи Канагава
+th:จังหวัดคานางาวะ
+tl:Prepektura ng Kanagawa
+tr:Kanagawa ili
+tt:Канагава (префектура)
+uk:Префектура Канаґава
+ur:کاناگاوا پریفیکچر
+vi:Kanagawa
+zh:神奈川縣
+wikidata:en:Q127513
+
+<en:Japan
+en:Gifu Prefecture
+af:Gifu Prefektuur
+ar:غيفو
+az:Gifu prefekturası
+be:прэфектура Гіфу
+bg:Гифу
+bn:গিফু প্রশাসনিক অঞ্চল
+ca:prefectura de Gifu
+ce:Гифу (префектура)
+cs:Prefektura Gifu
+cy:Gifu
+da:Gifu-præfekturet
+de:Präfektur Gifu
+el:Γκίφου
+eo:Gubernio Gifu
+es:Prefectura de Gifu
+et:Gifu prefektuur
+eu:Gifu
+fa:استان گیفو
+fi:Gifun prefektuuri
+fr:préfecture de Gifu
+ga:Maoracht Gifu
+gl:Prefectura de Gifu
+gu:ગીફુ પ્રીફેકચર
+he:גיפו
+hi:जिफू प्रीफेक्चर
+hr:Gifu
+hu:Gifu prefektúra
+hy:Գիֆու (պրեֆեկտուրա)
+id:Prefektur Gifu
+it:prefettura di Gifu
+ja:岐阜県
+jv:Prefektur Gifu
+ka:გიფუს პრეფექტურა
+kn:ಜಿಫು ಪ್ರಿಫೆಕ್ಚರ್
+ko:기후현
+lb:Gifu
+lt:Gifu prefektūra
+lv:Gifu prefektūra
+mk:Гифу
+mr:गिफू
+ms:Wilayah Gifu
+nb:Gifu prefektur
+nl:Gifu
+nn:Gifu prefektur
+pl:Prefektura Gifu
+pt:Gifu
+ro:Prefectura Gifu
+ru:Гифу
+se:Gifu prefektuvra
+sh:Prefektura Gifu
+si:ගීෆු පළාත
+sk:Gifu
+sl:prefektura Gifu
+sr:Гифу
+su:Préféktur Gifu
+sv:Gifu prefektur
+sw:Mkoa wa Gifu
+ta:கிபியூ ப்ரீபெக்ட்டுறே
+te:గిఫు ప్రిఫెక్చర్
+tg:Префектураи Гифу
+th:จังหวัดกิฟุ
+tl:Prepektura ng Gifu
+tr:Gifu
+tt:Гифу (префектура)
+uk:Префектура Ґіфу
+ur:گیفو پریفیکچر
+vi:Gifu
+zh:岐阜縣
+wikidata:en:Q131277
+
+<en:Japan
+en:Kōchi Prefecture
+af:Kochi Prefektuur
+ar:كوتشي
+az:Koçi prefekturası
+ba:Коти (префектура)
+be:прэфектура Коты
+bg:Кочи
+bn:কোওচি প্রশাসনিক অঞ্চল
+ca:prefectura de Kōchi
+ce:Коти (префектура)
+cs:Prefektura Kóči
+cy:Kōchi
+da:Kouchi-præfekturet
+de:Präfektur Kōchi
+el:Νομός Κότσι
+eo:Gubernio Koĉi
+es:Prefectura de Kōchi
+et:Kōchi prefektuur
+eu:Kōchi
+fa:استان کوچی
+fi:Kōchin prefektuuri
+fr:Préfecture de Kōchi
+ga:Maoracht Kōchi
+gl:Prefectura de Kōchi
+gu:કોચી પ્રીફેકચર
+he:קוצ'י
+hi:कोच्ची प्रीफेक्चर
+hr:Kōchi
+hu:Kócsi prefektúra
+hy:Կոտի (պրեֆեկտուրա)
+id:Prefektur Kōchi
+it:prefettura di Kōchi
+ja:高知県
+ka:კოტის პრეფექტურა
+km:ខេត្តខូឈិ
+kn:ಕೊಚಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:고치현
+lt:Kočio prefektūra
+lv:Koči prefektūra
+mk:Кочи
+mn:Кочи-кэн
+mr:कोची
+ms:Wilayah Kōchi
+nb:Kochi prefektur
+nl:Kochi
+nn:Kochi prefektur
+pl:Prefektura Kōchi
+pt:Kochi
+ro:Prefectura Kōchi
+ru:Коти
+se:Kōchi prefektuvra
+sh:Prefektura Koči
+si:කොචි ප්‍රාන්තය
+sk:Kóči
+sr:Кочи
+su:Préféktur Kōchi
+sv:Kochi prefektur
+sw:Mkoa wa Kochi
+ta:கொச்சி ப்ரெபெக்டர்
+te:కోచి ప్రిఫెక్చర్
+tg:Префектураи Коти
+th:จังหวัดโคจิ
+tl:Prepektura ng Kōchi
+tr:Kōchi
+tt:Коти (префектура)
+uk:Префектура Кочі
+ur:کوچی پریفیکچر
+vi:Kōchi
+zh:高知縣
+wikidata:en:Q134093
+
+<en:Japan
+en:Fukushima Prefecture
+af:Fukushima Prefektuur
+ar:فوكوشيما
+az:Fukuşima prefekturası
+ba:Фукусима
+be:прэфектура Фукусіма
+bg:Фукушима
+bn:ফুকুশিমা প্রশাসনিক অঞ্চল
+br:Prefediezh Fukushima
+ca:prefectura de Fukushima
+ce:Фукусима (префектура)
+cs:Prefektura Fukušima
+cy:Fukushima
+da:Fukushima-præfekturet
+de:Präfektur Fukushima
+el:Νομός Φουκουσίμα
+eo:Gubernio Fukuŝima
+es:Prefectura de Fukushima
+et:Fukushima prefektuur
+eu:Fukushima
+fa:استان فوکوشیما
+fi:Fukushiman prefektuuri
+fr:Préfecture de Fukushima
+ga:Maoracht Fukushima
+gl:Prefectura de Fukushima
+gu:ફૂકુશીમા પ્રીફેકચર
+he:פוקושימה
+hi:फ़ूकूशिमा प्रीफ़ेक्चर
+hr:Fukushima
+hu:Fukusima prefektúra
+hy:Ֆուկուսիմա
+id:Prefektur Fukushima
+it:prefettura di Fukushima
+ja:福島県
+jv:Prefektur Fukushima
+ka:ფუკუსიმის პრეფექტურა
+km:ខេត្តហ្វូគូស៊ីម៉ា
+kn:ಫುಕುಶಿಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:후쿠시마현
+lt:Fukušimos prefektūra
+lv:Fukusimas prefektūra
+mk:Фукушима
+mn:Фүкүшима
+mr:फुकुशिमा
+ms:Wilayah Fukushima
+nb:Fukushima prefektur
+nl:Fukushima
+nn:Fukushima prefektur
+oc:Prefectura de Fukushima
+pl:Prefektura Fukushima
+pt:Fukushima
+ro:Prefectura Fukushima
+ru:Фукусима
+se:Fukushima prefektuvra
+sh:Prefektura Fukušima
+si:ෆුකුෂිමා ප්‍රාන්තය
+sk:Fukušima
+sl:prefektura Fukušima
+sr:Фукушима
+su:Préféktur Fukushima
+sv:Fukushima prefektur
+sw:Mkoa wa Fukushima
+ta:பிக்குஷிமா ப்ரீபெக்ட்டுறே
+te:ఫుకుషిమా ప్రిఫెక్చర్
+tg:Префектураи Фукушима
+th:จังหวัดฟูกูชิมะ
+tl:Prepektura ng Fukushima
+tr:Fukuşima Prefektörlüğü
+tt:Фукусима (префектура)
+ug:فۇكۇشىما ناھىيىسى
+uk:Префектура Фукушіма
+ur:فوکوشیما پریفیکچر
+vi:Fukushima
+zh:福島縣
+wikidata:en:Q71707
+
+<en:Japan
+en:Fukuoka Prefecture
+af:Fukuoka Prefektuur
+ar:فوكوكا
+az:Fukuoka
+ba:Фукуока (префектура)
+be:прэфектура Фукуока
+bg:Фукуока
+bn:ফুকুওকা প্রশাসনিক অঞ্চল
+ca:prefectura de Fukuoka
+ce:Фукуока (префектура)
+cs:Prefektura Fukuoka
+cy:Fukuoka
+da:Fukuoka-præfekturet
+de:Präfektur Fukuoka
+el:Φουκουόκα
+eo:Gubernio Fukuoka
+es:Prefectura de Fukuoka
+et:Fukuoka prefektuur
+eu:Fukuoka
+fa:استان فوکوئوکا
+fi:Fukuokan prefektuuri
+fr:préfecture de Fukuoka
+ga:Maoracht Fukuoka
+gl:Prefectura de Fukuoka
+gu:ફુકુઓકા પ્રીફેકચર
+he:פוקואוקה
+hi:फुकुओका प्रान्त
+hr:Fukuoka
+hu:Fukuoka prefektúra
+hy:Ֆուկուոկա
+id:Prefektur Fukuoka
+it:prefettura di Fukuoka
+ja:福岡県
+jv:Prefektur Fukuoka
+ka:ფუკუოკის პრეფექტურა
+kn:ಫುಕುಕಾಕಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:후쿠오카현
+lb:Prefektur Fukuoka
+lt:Fukuokos prefektūra
+lv:Fukuokas prefektūra
+mk:Фукуока
+mr:फुकुओका
+ms:Wilayah Fukuoka
+nb:Fukuoka prefektur
+nl:Fukuoka
+nn:Fukuoka prefektur
+os:Фукуокæ (префектурæ)
+pl:Prefektura Fukuoka
+pt:Fukuoka
+ro:Prefectura Fukuoka
+ru:Фукуока
+se:Fukuoka prefektuvra
+sh:Prefektura Fukuoka
+si:ෆුකෝකා ප්‍රාන්තය
+sk:Fukuoka
+sl:prefektura Fukuoka
+sr:Фукуока
+su:Préféktur Fukuoka
+sv:Fukuoka prefektur
+sw:Mkoa wa Fukuoka
+ta:பிக்குஒக்கா ப்ரீபெக்ட்டுர்
+te:ఫుకువోకా ప్రిఫెక్చర్
+tg:Префектураи Фукуока
+th:จังหวัดฟูกูโอกะ
+tl:Prepektura ng Fukuoka
+tr:Fukuoka
+tt:Фукуока (префектура)
+uk:Префектура Фукуока
+ur:فوکوکا پریفیکچر
+vi:Fukuoka
+zh:福岡縣
+wikidata:en:Q123258
+
+<en:Japan
+en:Gunma Prefecture
+af:Gunma Prefektuur
+ar:غونما
+az:Qunma prefekturası
+ba:Гумма (префектура)
+be:прэфектура Гуму
+bg:Гунма
+bn:গুন্‌মা প্রশাসনিক অঞ্চল
+ca:prefectura de Gunma
+ce:Гумма (префектура)
+cs:Prefektura Gunma
+cy:Gunma
+da:Gunma-præfekturet
+de:Präfektur Gunma
+el:Γκούνμα
+eo:Gubernio Gunma
+es:Prefectura de Gunma
+et:Gumma prefektuur
+eu:Gunma
+fa:استان گونما
+fi:Gunman prefektuuri
+fr:Préfecture de Gunma
+ga:Maoracht Gunma
+gl:Prefectura de Gunma
+gu:ગુંમા પ્રીફેક્ચર
+he:גונמה
+hi:गुनमा प्रान्त
+hr:Gunma
+hu:Gunma prefektúra
+hy:Գումմա
+id:Prefektur Gunma
+it:prefettura di Gunma
+ja:群馬県
+jv:Prefektur Gunma
+ka:გუმის პრეფექტურა
+km:ខេត្តហ្គឺនម៉ា
+kn:ಗುನ್ಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:군마현
+lt:Gunmos prefektūra
+lv:Gummas prefektūra
+mk:Гунма
+mr:गुन्मा
+ms:Wilayah Gunma
+nb:Gunma prefektur
+nl:Gunma
+nn:Gunma prefektur
+pl:Prefektura Gunma
+pt:Gunma
+ro:Prefectura Gunma
+ru:Гумма
+se:Gunma prefektuvra
+sh:Prefektura Gunma
+si:ගුන්මා ප්‍රාන්තය
+sk:Gunma
+sl:prefektura Gunma
+sr:Гунма
+su:Préféktur Gunma
+sv:Gunma prefektur
+sw:Mkoa wa Gunma
+ta:குணமா ப்ரீபெக்ட்டுறே
+te:గన్మా ప్రిఫెక్చర్
+tg:Префектураи Гумма
+th:จังหวัดกุมมะ
+tl:Prepektura ng Gunma
+tr:Gunma
+tt:Гумма (префектура)
+uk:Префектура Ґумма
+ur:گونما پریفیکچر
+vi:Gunma
+zh:群馬縣
+wikidata:en:Q129499
+
+<en:Japan
+en:Miyazaki Prefecture
+af:Miyazaki Prefektuur
+ar:ميازاكي
+az:Miyazaki
+ba:Миядзаки (префектура)
+be:прэфектура Міядзакі
+bg:Миядзаки
+bn:মিয়াযাকি প্রশাসনিক অঞ্চল
+ca:prefectura de Miyazaki
+ce:Миядзаки (префектура)
+cs:Prefektura Mijazaki
+cy:Miyazaki
+da:Miyazaki-præfekturet
+de:Präfektur Miyazaki
+el:Μιγιαζάκι
+eo:Gubernio Mijazaki
+es:prefectura de Miyazaki
+et:Miyazaki prefektuur
+eu:Miyazaki
+fa:استان میازاکی
+fi:Miyazakin prefektuuri
+fr:préfecture de Miyazaki
+ga:Maoracht Miyazaki
+gl:Prefectura de Miyazaki
+gu:મિયાઝાકી પ્રીફેકચર
+he:מיאזאקי
+hi:मियाज़ाकि प्रीफेक्चर
+hr:Miyazaki
+hu:Mijazaki prefektúra
+hy:Միյաձակի
+id:Prefektur Miyazaki
+it:prefettura di Miyazaki
+ja:宮崎県
+ka:მიაძაკის პრეფექტურა
+km:ខេត្តមីយ៉ាសាគី
+kn:ಮಿಯಾಜಾಕಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:미야자키현
+lt:Mijadzakio prefektūra
+lv:Mijadzaki prefektūra
+mk:Мијазаки
+mr:मियाझाकी
+ms:Wilayah Miyazaki
+nb:Miyazaki prefektur
+nl:Miyazaki
+nn:Miyazaki prefektur
+pl:Prefektura Miyazaki
+pt:Miyazaki
+ro:Prefectura Miyazaki
+ru:Миядзаки
+se:Miyazaki prefektuvra
+sh:Prefektura Mijazaki
+si:මියසාකි ප්‍රාන්තය
+sk:Mijazaki
+sr:Мијазаки
+su:Miyazaki Prefecture
+sv:Miyazaki prefektur
+sw:Mkoa wa Miyazaki
+ta:மியாசாக்கி மாகாணம்
+te:మియాజాకి ప్రిఫెక్చర్
+tg:Префектураи Миядзаки
+th:จังหวัดมิยาซากิ
+tl:Prepektura ng Miyazaki
+tr:Miyazaki
+tt:Миядзаки (префектура)
+uk:Префектура Міядзакі
+ur:میازاکی پریفیکچر
+vi:Miyazaki
+zh:宮崎縣
+wikidata:en:Q130300
+
+<en:Japan
+en:Tokushima Prefecture
+af:Tokushima Prefektuur
+ar:توكوشيما
+az:Tokuşima prefekturası
+ba:Токусима (префектура)
+be:прэфектура Такусіма
+bg:Токушима
+bn:তোকুশিমা প্রশাসনিক অঞ্চল
+ca:prefectura de Tokushima
+ce:Токусима (префектура)
+cs:Prefektura Tokušima
+cy:Tokushima
+da:Tokushima-præfekturet
+de:Präfektur Tokushima
+el:Τοκουσίμα
+eo:Gubernio Tokuŝima
+es:Prefectura de Tokushima
+et:Tokushima prefektuur
+eu:Tokushima
+fa:استان توکوشیما
+fi:Tokushiman prefektuuri
+fr:Préfecture de Tokushima
+ga:Maoracht Tokushima
+gl:Prefectura de Tokushima
+gu:ટોકુશિમા પ્રીફેકચર
+he:טוקושימה
+hi:तोकुशीमा प्रीफेक्चर
+hr:Tokushima
+hu:Tokusima prefektúra
+hy:Տոկուսիմա (պրեֆեկտուրա)
+id:Prefektur Tokushima
+it:prefettura di Tokushima
+ja:徳島県
+jv:Prefektur Tokushima
+ka:ტოკუსიმის პრეფექტურა
+kn:ಟೋಕುಶಿಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:도쿠시마현
+lt:Tokušimos prefektūra
+lv:Tokusimas prefektūra
+mk:Токушима
+mr:तोकुशिमा
+ms:Wilayah Tokushima
+nb:Tokushima prefektur
+nl:Tokushima
+nn:Tokushima prefektur
+pl:Prefektura Tokushima
+pt:Tokushima
+ro:Prefectura Tokushima
+ru:Токусима
+se:Tokushima prefektuvra
+sh:Prefektura Tokušima
+si:ටෝකුශිමා ප්‍රාන්තය
+sk:Tokušima
+sl:prefektura Tokushima
+sq:Prefektura Tokushima
+sr:Токушима
+su:Tokushima Prefecture
+sv:Tokushima prefektur
+sw:Mkoa wa Tokushima
+ta:டொகுஷிமா ப்ரீபெக்ட்டுர்
+te:టొకూషిమా ప్రిఫెక్చర్
+tg:Префектураи Токусима
+th:จังหวัดโทกูชิมะ
+tl:Prepektura ng Tokushima
+tr:Tokushima
+tt:Токусима (префектура)
+uk:Префектура Токушіма
+ur:توکوشیما پریفیکچر
+vi:Tokushima
+zh:德島縣
+wikidata:en:Q160734
+
+<en:Japan
+en:Akita Prefecture
+af:Akita Prefektuur
+ar:أكيتا
+az:Akita prefekturası
+ba:Акита (префектура)
+be:прэфектура Акіта
+bg:Акита
+bn:আকিতা প্রশাসনিক অঞ্চল
+ca:prefectura d'Akita
+ce:Акита (префектура)
+cs:Prefektura Akita
+cy:Akita
+da:Akita-præfekturet
+de:Präfektur Akita
+el:Επαρχία Άκιτα
+eo:Gubernio Akita
+es:Prefectura de Akita
+et:Akita prefektuur
+eu:Akita
+fa:استان آکیتا
+fi:Akitan prefektuuri
+fr:préfecture d'Akita
+ga:Maoracht Akita
+gl:Prefectura de Akita
+gu:અકિટા પ્રીફેકચર
+he:אקיטה
+hi:अकिता प्रीफ़ेक्चर
+hr:Akita
+hu:Akita prefektúra
+hy:Ակիտա
+id:Prefektur Akita
+it:prefettura di Akita
+ja:秋田県
+jv:Prefektur Akita
+ka:აკიტის პრეფექტურა
+km:ខេត្តអាគីតា
+kn:ಅಕಿಟಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:아키타현
+lt:Akitos prefektūra
+lv:Akitas prefektūra
+mk:Акита
+mn:Акита
+mr:अकिता
+ms:Wilayah Akita
+nb:Akita prefektur
+nl:Akita
+nn:Akita prefektur
+oc:Prefectura d'Akita
+pa:ਅਕਿਤਾ ਪ੍ਰੀਫੇਕਚਰ
+pl:Prefektura Akita
+pt:Akita
+ro:Prefectura Akita
+ru:Акита
+se:Akita prefektuvra
+sh:Prefektura Akita
+si:අකිටා ප්‍රාන්තය
+sk:Akita
+sl:prefektura Akita
+sr:Акита
+su:Préféktur Akita
+sv:Akita prefektur
+sw:Mkoa wa Akita
+ta:ஆகிட்டா ப்ரீபெக்ட்டுறே
+te:అకితా ప్రిఫెక్చర్
+tg:Префектураи Акита
+th:จังหวัดอากิตะ
+tl:Prepektura ng Akita
+tr:Akita
+tt:Акита (префектура)
+ug:ئاكىتا ناھىيىسى
+uk:префектура Акіта
+ur:اکیتا پریفیکچر
+vi:Akita
+zh:秋田縣
+wikidata:en:Q81863
+
+<en:Japan
+en:Ehime Prefecture
+af:Ehime Prefektuur
+ar:إهيمه
+az:Ehime prefekturası
+ba:Эхимэ
+be:прэфектура Эхімэ
+bg:Ехиме
+bn:এহিমে প্রশাসনিক অঞ্চল
+ca:prefectura d'Ehime
+ce:Эхиме (префектура)
+cs:Prefektura Ehime
+cy:Ehime
+da:Ehime-præfekturet
+de:Präfektur Ehime
+el:Εχιμέ
+eo:Gubernio Ehime
+es:Prefectura de Ehime
+et:Ehime prefektuur
+eu:Ehime
+fa:استان اهیمه
+fi:Ehimen prefektuuri
+fr:Préfecture d'Ehime
+ga:Maoracht Ehime
+gl:Prefectura de Ehime
+gu:એહિમે પ્રીફેક્ચર
+he:אהימה
+hi:एहिम प्रीफेक्चर
+hr:Ehime
+hu:Ehime prefektúra
+hy:Էհիմե (պրեֆեկտուրա)
+id:Prefektur Ehime
+it:prefettura di Ehime
+ja:愛媛県
+jv:Prefektur Ehime
+ka:ეჰიმეს პრეფექტურა
+km:ខេត្តអិហ៊ីមិ
+kn:ಎಹಿಮ್ ಪ್ರಿಫೆಕ್ಚರ್
+ko:에히메현
+lt:Ehimės prefektūra
+lv:Ehimes prefektūra
+mk:Ехиме
+mr:एहिमे
+ms:Wilayah Ehime
+nb:Ehime prefektur
+nl:Ehime
+nn:Ehime prefektur
+pl:Prefektura Ehime
+pt:Ehime
+ro:Prefectura Ehime
+ru:Эхиме
+se:Ehime prefektuvra
+sh:Prefektura Ehime
+si:එහිමේ ප්‍රාන්තය
+sk:Ehime
+sl:prefektura Ehime
+sr:Ехиме
+su:Préféktur Ehime
+sv:Ehime prefektur
+sw:Mkoa wa Ehime
+ta:தேஹிமே ப்ரீபெக்ட்டுர்
+te:ఇహైమ్ ప్రిఫెక్చర్
+tg:Префектураи Эхимэ
+th:จังหวัดเอฮิเมะ
+tl:Prepektura ng Ehime
+tr:Ehime
+tt:Эхиме (префектура)
+uk:Префектура Ехіме
+ur:اہیمے پریفیکچر
+vi:Ehime
+zh:爱媛县
+wikidata:en:Q123376
+
+<en:Japan
+en:Oita Prefecture
+af:Oita Prefektuur
+ar:أويتا
+az:Oita
+ba:Оита
+be:прэфектура Оіта
+bg:Оита
+bn:ওওইতা প্রশাসনিক অঞ্চল
+ca:prefectura d'Ōita
+ce:Оита (префектура)
+cs:Prefektura Óita
+cy:Ōita
+da:Ooita-præfekturet
+de:Präfektur Ōita
+el:Όιτα
+eo:Gubernio Oita
+es:prefectura de Oita
+et:Ōita prefektuur
+eu:Ōita
+fa:استان اوئیتا
+fi:Ōitan prefektuuri
+fr:Préfecture d'Ōita
+ga:Maoracht Ōita
+gl:Prefectura de Ōita
+gu:ઓઈટા પ્રીફેકચર
+he:אויטה
+hi:ओइटा प्रीफेक्चर
+hr:Ōita
+hu:Óita prefektúra
+hy:Օիտա (պրեֆեկտուրա)
+id:Prefektur Oita
+it:prefettura di Ōita
+ja:大分県
+ka:ოიტის პრეფექტურა
+km:ខេត្តអយតាក់
+kn:ಒಐಟಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:오이타현
+la:Oita
+lt:Oitos prefektūra
+lv:Oitas prefektūra
+mk:Оита
+mr:ओइता
+ms:Wilayah Ōita
+nb:Oita prefektur
+nl:Oita
+nn:Oita prefektur
+pl:Prefektura Ōita
+pt:Oita
+ro:Prefectura Ōita
+ru:Оита
+se:Ōita prefektuvra
+sh:Prefektura Oita
+si:ඕයිටා ප්‍රාන්තය
+sk:Óita
+sl:prefektura Ōita
+sr:Оита
+su:Ōita Prefecture
+sv:Oita prefektur
+sw:Mkoa wa Ōita
+ta:ஓட்ட ப்ரீபெக்ட்டுறே
+te:ఓయిటా ప్రిఫెక్చర్
+tg:Префектураи Оита
+th:จังหวัดโออิตะ
+tl:Prepektura ng Ōita
+tr:Ōita
+tt:Оита (префектура)
+uk:Префектура Ойта
+ur:اوئیتا پریفیکچر
+vi:Ōita
+zh:大分县
+wikidata:en:Q133924
+
+<en:Japan
+en:Saitama Prefecture
+af:Saitama Prefektuur
+ar:سايتاما
+az:Saytama prefekturası
+ba:Сайтама (префектура)
+be:прэфектура Сайтама
+bg:Сайтама
+bn:সাইতামা প্রশাসনিক অঞ্চল
+ca:prefectura de Saitama
+ce:Сайтама (префектура)
+cs:Prefektura Saitama
+cy:Saitama
+da:Saitama-præfekturet
+de:Präfektur Saitama
+el:Σαϊτάμα
+eo:Gubernio Saitama
+es:prefectura de Saitama
+et:Saitama prefektuur
+eu:Saitama
+fa:استان سایتاما
+fi:Saitaman prefektuuri
+fr:préfecture de Saitama
+ga:Maoracht Saitama
+gl:Prefectura de Saitama
+gu:સૈતામા પ્રીફેકચર
+he:סאיטאמה
+hi:सैतामा प्रीफेक्चर
+hr:Saitama
+hu:Szaitama prefektúra
+hy:Սայտամա
+id:Prefektur Saitama
+it:prefettura di Saitama
+ja:埼玉県
+ka:საიტამის პრეფექტურა
+km:ខេត្តសៃតាម៉ា
+kn:ಸೈತಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:사이타마현
+la:Saitamaënsis
+lt:Saitamos prefektūra
+lv:Saitamas prefektūra
+mk:Сајтама
+mn:Сайтама аймаг
+mr:सैतामा
+ms:Wilayah Saitama
+nb:Saitama prefektur
+nl:Saitama
+nn:Saitama prefektur
+oc:Prefectura de Saitama
+pl:Prefektura Saitama
+pt:Saitama
+ro:Prefectura Saitama
+ru:Сайтама
+se:Saitama prefektuvra
+sh:Prefektura Saitama
+si:සයිටාමා ප්‍රාන්තය
+sk:Saitama
+sl:Prefektura Saitama
+sr:Саитама
+su:Saitama Prefecture
+sv:Saitama prefektur
+sw:Mkoa wa Saitama
+ta:சைடமா ப்ரீபெக்ட்டுறே
+te:సాయిటామా ప్రిఫెక్చర్
+tg:Префектураи Саитама
+th:จังหวัดไซตามะ
+tl:Prepektura ng Saitama
+tr:Saitama ili
+tt:Сайтама (префектура)
+uk:Префектура Сайтама
+ur:سایتاما
+uz:Saitama
+vi:Saitama
+zh:埼玉縣
+wikidata:en:Q128186
+
+<en:Japan
+en:Shizuoka Prefecture
+af:Shizuoka Prefektuur
+ar:شيزوكا
+az:Şizuoka prefekturası
+ba:Сидзуока (префектура)
+be:прэфектура Сідзуока
+bg:Шидзуока
+bn:শিযুওকা প্রশাসনিক অঞ্চল
+ca:prefectura de Shizuoka
+ce:Сидзуока (префектура)
+cs:Prefektura Šizuoka
+cy:Shizuoka
+da:Shizuoka-præfekturet
+de:Präfektur Shizuoka
+el:Σιζουόκα
+eo:Gubernio Ŝizuoka
+es:Prefectura de Shizuoka
+et:Shizuoka prefektuur
+eu:Shizuoka
+fa:استان شیزوئوکا
+fi:Shizuokan prefektuuri
+fr:Préfecture de Shizuoka
+ga:Maoracht Shizuoka
+gl:Prefectura de Shizuoka
+gu:શિઝુઓકા પ્રીફેકચર
+he:שיזואוקה
+hi:शिज़ूओका प्रांत
+hr:Shizuoka
+hu:Sizuoka prefektúra
+hy:Սիձուոկա (պրեֆեկտուրա)
+id:Prefektur Shizuoka
+is:Shizuoka-umdæmi
+it:prefettura di Shizuoka
+ja:静岡県
+jv:Prefektur Shizuoka
+ka:სიძუოკის პრეფექტურა
+kn:ಶಿಝುವೊಕಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:시즈오카현
+lt:Šidzuokos prefektūra
+lv:Sidzuokas prefektūra
+mk:Шизуока
+mr:शिझुओका
+ms:Wilayah Shizuoka
+nb:Shizuoka prefektur
+nl:Shizuoka
+nn:Shizuoka prefektur
+pl:Prefektura Shizuoka
+pt:Shizuoka
+ro:Prefectura Shizuoka
+ru:Сидзуока
+se:Shizuoka prefektuvra
+sh:Prefektura Šizuoka
+si:ශිසොකා ප්‍රාන්තය
+sk:Šizuoka
+sl:Prefektura Šizuoka
+sr:Шизуока
+su:Préféktur Shizuoka
+sv:Shizuoka prefektur
+sw:Mkoa wa Shizuoka
+ta:ஷிஸுஒக்கா ப்ரீபெக்ட்டுர்
+te:షిజువోకా ప్రిఫెక్చర్
+tg:Префектураи Шизуока
+th:จังหวัดชิซูโอกะ
+tl:Prepektura ng Shizuoka
+tr:Shizuoka
+tt:Сидзуока (префектура)
+uk:Префектура Шідзуока
+ur:شیزوکا پریفیکچر
+vi:Shizuoka
+zh:靜岡縣
+wikidata:en:Q131320
+
+<en:Japan
+en:Fukui Prefecture
+af:Fukui Prefektuur
+ar:فوكوي
+az:Fukui
+ba:Фукуи (префектура)
+be:Фукуі (прэфектура)
+bg:Фукуи
+bn:ফুকুই প্রশাসনিক অঞ্চল
+ca:prefectura de Fukui
+ce:Фукуи (префектура)
+cs:Prefektura Fukui
+cy:Fukui
+da:Fukui-præfekturet
+de:Präfektur Fukui
+el:Φουκούι
+eo:Gubernio Fukui
+es:Prefectura de Fukui
+et:Fukui prefektuur
+eu:Fukui
+fa:استان فوکوئی
+fi:Fukuin prefektuuri
+fr:Préfecture de Fukui
+ga:Maoracht Fukui
+gl:Prefectura de Fukui
+gu:ફુકુઇ પ્રીફેકચર
+he:פוקואי
+hi:फुकुई प्रीफेक्चर
+hr:Fukui
+hu:Fukui prefektúra
+hy:Ֆուկուի (պրեֆեկտուրա)
+id:Prefektur Fukui
+it:prefettura di Fukui
+ja:福井県
+jv:Prefektur Fukui
+ka:ფუკუის პრეფექტურა
+kn:ಫುಕುಯಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:후쿠이현
+la:Fukuiensis
+lt:Fukujaus prefektūra
+lv:Fukuji prefektūra
+mk:Фукуи
+mr:फुकुई
+ms:Wilayah Fukui
+nb:Fukui prefektur
+nl:Fukui
+nn:Fukui prefektur
+pl:Prefektura Fukui
+pt:Fukui
+ro:Prefectura Fukui
+ru:Фукуи
+se:Fukui prefektuvra
+sh:Prefektura Fukui
+si:ෆුකුයි ප්‍රාන්තය
+sk:Fukui
+sl:prefektura Fukui
+sr:Фукуј
+su:Préféktur Fukui
+sv:Fukui prefektur
+sw:Mkoa wa Fukui
+ta:பிக்குய் ப்ரீபெக்ட்டுர்
+te:ఫుకూయి ప్రిఫెక్చర్
+tg:Префектураи Фукуи
+th:จังหวัดฟูกูอิ
+tl:Prepektura ng Fukui
+tr:Fukui
+tt:Фукуи (префектура)
+uk:Префектура Фукуй
+ur:فوکوئی پریفیکچر
+vi:Fukui
+zh:福井縣
+wikidata:en:Q133879
+
+<en:Japan
+en:Kagawa Prefecture
+af:Kagawa Prefektuur
+ar:كاغاوا
+az:Kaqava prefekturası
+ba:Кагава
+be:прэфектура Кагава
+bg:Кагава
+bn:কাগাওয়া প্রশাসনিক অঞ্চল
+ca:prefectura de Kagawa
+ce:Кагава (префектура)
+cs:Prefektura Kagawa
+cy:Kagawa
+da:Kagawa-præfekturet
+de:Präfektur Kagawa
+el:Καγκάβα
+eo:Gubernio Kagaŭa
+es:Prefectura de Kagawa
+et:Kagawa prefektuur
+eu:Kagawa
+fa:استان کاگاوا
+fi:Kagawan prefektuuri
+fr:Préfecture de Kagawa
+ga:Maoracht Kagawa
+gl:Prefectura de Kagawa
+gu:કાગાવા પ્રીફેકચર
+he:קאגווה
+hi:कगावा प्रीफेक्चर
+hr:Kagawa
+hu:Kagava prefektúra
+hy:Կագավա (պրեֆեկտուրա)
+id:Prefektur Kagawa
+it:prefettura di Kagawa
+ja:香川県
+ka:კაგავის პრეფექტურა
+km:ខេត្តកាហ្គាវ៉ា
+kn:ಕಾಗಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:가가와현
+lt:Kagavos prefektūra
+lv:Kagavas prefektūra
+mk:Кагава
+mr:कागावा
+ms:Wilayah Kagawa
+nb:Kagawa prefektur
+nl:Kagawa
+nn:Kagawa prefektur
+pl:Prefektura Kagawa
+pt:Kagawa
+ro:Prefectura Kagawa
+ru:Кагава
+se:Kagawa prefektuvra
+sh:Prefektura Kagava
+si:කගවා ප්‍රාන්තය
+sk:Kagawa
+sl:prefektura Kagawa
+sr:Кагава
+su:Kagawa Prefecture
+sv:Kagawa prefektur
+sw:Mkoa wa Kagawa
+ta:ககவா ப்ரீபெக்ட்டுர்
+te:కగావా ప్రిఫెక్చర్
+tg:Префектураи Кагава
+th:จังหวัดคางาวะ
+tl:Prepektura ng Kagawa
+tr:Kagawa
+tt:Кагава (префектура)
+uk:Префектура Каґава
+ur:کاگاوا پریفیکچر
+vi:Kagawa
+zh:香川县
+wikidata:en:Q161454
+
+<en:Japan
+en:Nagasaki Prefecture
+af:Nagasaki Prefektuur
+ar:ناغاساكي
+az:Naqasaki prefekturası
+ba:Нагасаки
+be:прэфектура Нагасакі
+bg:Нагасаки
+bn:নাগাসাকি প্রশাসনিক অঞ্চল
+ca:prefectura de Nagasaki
+ce:Нагасаки (префектура)
+cs:Prefektura Nagasaki
+cy:Nagasaki
+da:Nagasaki-præfekturet
+de:Präfektur Nagasaki
+el:Νομαρχία Ναγκασάκι
+eo:Gubernio Nagasako
+es:prefectura de Nagasaki
+et:Nagasaki prefektuur
+eu:Nagasaki
+fa:استان ناگاساکی
+fi:Nagasakin prefektuuri
+fr:Préfecture de Nagasaki
+ga:Maoracht Nagasaki
+gl:Prefectura de Nagasaki
+gu:નાગાસાકી પ્રીફેકચર
+he:נגסאקי
+hi:नागासाकी प्रीफेक्चर
+hr:Nagasaki
+hu:Nagaszaki prefektúra
+hy:Նագասակի
+id:Prefektur Nagasaki
+it:prefettura di Nagasaki
+ja:長崎県
+ka:ნაგასაკის პრეფექტურა
+km:ខេត្តណាហ្គាសាគី
+kn:ನಾಗಸಾಕಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:나가사키현
+la:Nagasacium
+lt:Nagasakio prefektūra
+lv:Nagasaki prefektūra
+mk:Нагасаки
+mr:नागासाकी
+ms:Wilayah Nagasaki
+nb:Nagasaki prefektur
+nl:Nagasaki
+nn:Nagasaki prefektur
+pl:Prefektura Nagasaki
+pt:Nagasaki
+ro:Prefectura Nagasaki
+ru:Нагасаки
+se:Nagasaki prefektuvra
+sh:Prefektura Nagasaki
+si:නාගසාකි ප්‍රාන්තය
+sk:Nagasaki
+sl:prefektura Nagasaki
+sr:Нагасаки
+su:Préféktur Nagasaki
+sv:Nagasaki prefektur
+sw:Mkoa wa Nagasaki
+ta:நாகசாகி ப்ரீபெக்ட்டுறே
+te:నాగాసాకి ప్రిఫెక్చర్
+tg:Префектураи Нагасаки
+th:จังหวัดนางาซากิ
+tl:Prepektura ng Nagasaki
+tr:Nagasaki
+tt:Нагасаки (префектура)
+uk:Префектура Наґасакі
+ur:ناگاساکی پریفیکچر
+vi:Nagasaki
+zh:長崎縣
+wikidata:en:Q169376
+
+<en:Japan
+en:Nara Prefecture
+af:Nara Prefektuur
+ar:نارا
+az:Nara prefekturası
+ba:Нара (префектура)
+be:прэфектура Нара
+bg:Нара
+bn:নারা প্রশাসনিক অঞ্চল
+ca:prefectura de Nara
+ce:Нара (префектура)
+cs:Prefektura Nara
+cy:Nara
+da:Nara-præfekturet
+de:Präfektur Nara
+el:Νάρα
+eo:Gubernio Nara
+es:Prefectura de Nara
+et:Nara prefektuur
+eu:Nara
+fa:استان نارا
+fi:Naran prefektuuri
+fr:Préfecture de Nara
+ga:Maoracht Nara
+gl:Prefectura de Nara
+gu:નારા પ્રીફેક્ચર
+he:נארה
+hi:नारा प्रीफेक्चर
+hr:Nara
+hu:Nara prefektúra
+hy:Նարա պրեֆեկտուրա
+id:Prefektur Nara
+it:prefettura di Nara
+ja:奈良県
+jv:Prefektur Nara
+ka:ნარის პრეფექტურა
+km:អាណាខេត្តណារ៉ា
+kn:ನಾರಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:나라현
+la:Nara
+lt:Naros prefektūra
+lv:Naras prefektūra
+mk:Нара
+mr:नारा
+ms:Wilayah Nara
+nb:Nara prefektur
+nl:Nara
+nn:Nara prefektur
+pl:Prefektura Nara
+pt:Nara
+ro:Prefectura Nara
+ru:Нара
+se:Nara prefektuvra
+sh:Prefektura Nara
+si:නාරා ප්‍රාන්තය
+sk:Nara
+sl:prefektura Nara
+sr:Нара
+su:Nara Prefecture
+sv:Nara prefektur
+sw:Mkoa wa Nara
+ta:நாரா மாநிலம்
+te:నారా ప్రిఫెక్చర్
+tg:Префектураи Нара
+th:จังหวัดนาระ
+tl:Prepektura ng Nara
+tr:Nara
+tt:Нара (префектура)
+uk:Префектура Нара
+ur:نارا پریفیکچر
+vi:Nara
+zh:奈良縣
+wikidata:en:Q131287
+
+<en:Japan
+en:Okinawa Prefecture
+af:Okinawa Prefektuur
+ar:محافظة أوكيناوا
+az:Okinava prefekturası
+be:прэфектура Акінава
+bg:Окинава
+bn:ওকিনাওয়া প্রশাসনিক অঞ্চল
+ca:prefectura d'Okinawa
+ce:Окинава (префектура)
+cs:prefektura Okinawa
+cy:Okinawa
+da:Okinawa-præfekturet
+de:Präfektur Okinawa
+el:Οκινάουα
+eo:Gubernio Okinavo
+es:prefectura de Okinawa
+et:Okinawa prefektuur
+eu:Okinawa
+fa:استان اوکیناوا
+fi:Okinawan prefektuuri
+fr:Préfecture d'Okinawa
+ga:Maoracht Okinawa
+gl:Okinawa - 沖縄県
+gu:ઓકિનાવા પ્રીફેક્ચર
+he:אוקינאווה
+hi:ओकीनावा प्रीफेक्चर
+hr:Okinawa, prefektura
+hu:Okinava prefektúra
+hy:Օկինավա
+id:Prefektur Okinawa
+it:prefettura di Okinawa
+ja:沖縄県
+jv:Prefektur Okinawa
+km:ខេត្តអូគីណាវ៉ា
+kn:ಒಕಿನಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:오키나와현
+la:Okinawa
+lt:Okinavos prefektūra
+lv:Okinavas prefektūra
+mk:Окинава
+mn:Окинава
+mr:ओकिनावा
+ms:Wilayah Okinawa
+nb:Okinawa prefektur
+nl:Okinawa
+nn:Okinawa prefektur
+os:Окинавæ (префектурæ)
+pl:Prefektura Okinawa
+pt:Okinawa
+ro:Prefectura Okinawa
+ru:Окинава
+se:Okinawa prefektuvra
+sh:Prefektura Okinava
+si:ඔකිනාවා ප්‍රාන්තය
+sk:Okinawa
+sl:prefektura Okinava
+sr:Окинава
+su:Okinawa Prefecture
+sv:Okinawa prefektur
+sw:Mkoa wa Okinawa
+ta:ஓக்கினாவா மாகாணம்
+te:ఓకినావా ప్రిఫెక్చర్
+tg:Префектураи Окинава
+th:จังหวัดโอกินาวะ
+tl:Prepektura ng Okinawa
+tr:Okinawa
+tt:Окинава (префектура)
+uk:Префектура Окінава
+ur:اوکیناوا پریفیکچر
+vi:Okinawa
+zh:沖繩縣
+wikidata:en:Q766445
+
+<en:Japan
+en:Aomori Prefecture
+af:Aomori Prefektuur
+ar:محافظة آوموري
+az:Aomori
+ba:Аомори (префектура)
+be:прэфектура Аомары
+bg:Аомори
+bn:আওমোরি প্রশাসনিক অঞ্চল
+ca:prefectura d'Aomori
+ce:Аомори (префектура)
+cs:Prefektura Aomori
+cy:Aomori
+da:Aomori-præfekturet
+de:Präfektur Aomori
+el:Αομόρι
+eo:Gubernio Aomori
+es:Prefectura de Aomori
+et:Aomori prefektuur
+eu:Aomori
+fa:استان آئوموری
+fi:Aomorin prefektuuri
+fr:préfecture d'Aomori
+ga:Maoracht Aomori
+gl:Prefectura de Aomori
+gu:ઓમોરી પ્રીફેકચર
+he:אאומורי
+hi:आओमोरी प्रीफ़ेक्चर
+hr:Aomori
+hu:Aomori prefektúra
+hy:Աոմորի
+id:Prefektur Aomori
+it:prefettura di Aomori
+ja:青森県
+jv:Prefektur Aomori
+ka:აომორის პრეფექტურა
+km:ខេត្តអាអូម៉ូរី
+kn:ಅಮೊರಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:아오모리현
+lt:Aomorio prefektūra
+lv:Aomori prefektūra
+mk:Аомори
+mn:Аомори
+mr:ओमोरी
+ms:Wilayah Aomori
+my:အအိုမိုရိခရိုင်
+nb:Aomori prefektur
+nl:Aomori
+nn:Aomori prefektur
+pl:Prefektura Aomori
+pt:Aomori
+ro:Prefectura Aomori
+ru:Аомори
+se:Aomori prefektuvra
+sh:Prefektura Aomori
+si:අඔමොරි ප්‍රාන්තය
+sk:Aomori
+sl:prefektura Aomori
+sr:Аомори
+su:Préféktur Aomori
+sv:Aomori prefektur
+sw:Mkoa wa Aomori
+ta:அமரீ ப்ரீபெக்ட்டுர்
+te:ఔమోరి ప్రిఫిక్చర్
+tg:Префектураи Аомори
+th:จังหวัดอาโอโมริ
+tl:Prepektura ng Aomori
+tr:Aomori
+tt:Аомори (префектура)
+ug:ئائومورى ناھىيىسى
+uk:Префектура Аоморі
+ur:اوموری پریفیکچر
+vi:Aomori
+zh:青森縣
+wikidata:en:Q71699
+
+<en:Japan
+en:Yamaguchi Prefecture
+af:Yamaguchi Prefektuur
+ar:ياماغوتشي
+az:Yamaquçi prefekturası
+be:прэфектура Ямагуты
+bg:Ямагучи
+bn:ইয়ামাগুচি প্রশাসনিক অঞ্চল
+ca:prefectura de Yamaguchi
+ce:Ямагути (префектура)
+cs:Prefektura Jamaguči
+cy:Yamaguchi
+da:Yamaguchi-præfekturet
+de:Präfektur Yamaguchi
+el:Γιαμαγκούτσι
+eo:Gubernio Jamaguĉi
+es:prefectura de Yamaguchi
+et:Yamaguchi prefektuur
+eu:Yamaguchi prefektura
+fa:استان یاماگوچی
+fi:Yamaguchin prefektuuri
+fr:préfecture de Yamaguchi
+ga:Maoracht Yamaguchi
+gl:Prefectura de Yamaguchi
+gu:યામાગુચી પ્રીફેકચર
+he:יאמגוצ'י
+hi:यामागुची प्रीफेक्चर
+hr:Yamaguchi
+hu:Jamagucsi prefektúra
+hy:Յամագուտի
+ia:Prefectura de Yamaguchi
+id:Prefektur Yamaguchi
+it:prefettura di Yamaguchi
+ja:山口県
+ka:იამაგუტის პრეფექტურა
+km:ខេត្តយ៉ាម៉ាហ្គឹឈិ
+kn:ಯಮಗುಚಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:야마구치현
+lt:Jamagučio prefektūra
+lv:Jamaguči prefektūra
+mk:Јамагучи
+mr:यामागुची
+ms:Wilayah Yamaguchi
+nb:Yamaguchi prefektur
+nl:Yamaguchi
+nn:Yamaguchi prefektur
+pl:Prefektura Yamaguchi
+pt:Yamaguchi
+ro:Prefectura Yamaguchi
+ru:Ямагути
+se:Yamaguchi prefektuvra
+sh:Prefektura Jamaguči
+si:යමගුචි ප්‍රාන්තය
+sk:Jamaguči
+sl:prefektura Jamaguči
+sr:Јамагучи
+su:Yamaguchi Prefecture
+sv:Yamaguchi prefektur
+sw:Mkoa wa Yamaguchi
+ta:யாமாகுசி ப்ரீபெக்ட்டுறே
+te:యమగూచి ప్రిఫెక్చర్
+tg:Префектураи Ямагути
+th:จังหวัดยามางูจิ
+tl:Prepektura ng Yamaguchi
+tr:Yamaguchi Prefecture
+tt:Ямагути (префектура)
+uk:Префектура Ямаґучі
+ur:یاماگوچی پرفکترے
+vi:Yamaguchi
+zh:山口縣
+wikidata:en:Q127264
+
+<en:Japan
+en:Saga Prefecture
+af:Saga Prefektuur
+ar:ساغا
+az:Saqa prefekturası
+be:прэфектура Сага
+bg:Сага
+bn:সাগা প্রশাসনিক অঞ্চল
+ca:prefectura de Saga
+ce:Сага (префектура)
+cs:Prefektura Saga
+cy:Saga
+da:Saga-præfekturet
+de:Präfektur Saga
+el:Σάγκα
+eo:Gubernio Saga
+es:prefectura de Saga
+et:Saga prefektuur
+eu:Saga
+fa:استان ساگا
+fi:Sagan prefektuuri
+fr:Préfecture de Saga
+ga:Maoracht Saga
+gl:Prefectura de Saga
+gu:સાગા પ્રીફેક્ચર
+he:סאגה
+hi:सागा प्रान्त
+hr:Saga
+hu:Szaga prefektúra
+hy:Սագա (պրեֆեկտուրա)
+id:Prefektur Saga
+it:prefettura di Saga
+ja:佐賀県
+ka:საგის პრეფექტურა
+kn:ಸಾಗಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:사가현
+lt:Sagos prefektūra
+lv:Sagas prefektūra
+mk:Сага
+mr:सागा
+ms:Wilayah Saga
+nb:Saga prefektur
+nl:Saga
+nn:Saga prefektur
+pl:Prefektura Saga
+pt:Saga
+ro:Prefectura Saga
+ru:Сага
+se:Saga prefektuvra
+sh:Prefektura Saga
+si:සගා ප්‍රාන්තය
+sk:Saga
+sl:prefektura Saga, Japonska
+sr:Сага
+su:Préféktur Saga
+sv:Saga prefektur
+sw:Mkoa wa Saga
+ta:சகா ப்ரீபெக்ட்டுறே
+te:సాగా ప్రిఫెక్చర్
+tg:Префектураи Сага
+th:จังหวัดซางะ
+tl:Prepektura ng Saga
+tr:Saga
+tt:Сага (префектура)
+uk:Префектура Саґа
+ur:سگا پریفیکچر
+vi:Saga
+zh:佐賀縣
+wikidata:en:Q160420
+
+<en:Japan
+en:Hyogo Prefecture
+af:Hyogo Prefektuur
+ar:هيوغو
+az:Hyoqo prefekturası
+ba:Хёго
+be:прэфектура Хіёга
+bg:Хього
+bn:হিয়োগো প্রশাসনিক অঞ্চল
+ca:prefectura de Hyōgo
+ce:Хёго (префектура)
+cs:Prefektura Hjógo
+cy:Hyōgo
+da:Hyougo-præfekturet
+de:Präfektur Hyogo
+el:Χιγκόρο
+eo:Gubernio Hjogo
+es:Prefectura de Hyogo
+et:Hyōgo prefektuur
+eu:Hyōgo
+fa:استان هیوگو
+fi:Hyōgon prefektuuri
+fr:préfecture de Hyōgo
+ga:Maoracht Hyōgo
+gl:Prefectura de Hyōgo
+gu:હ્યોગો પ્રીફેકચર
+he:היוגו
+hi:ह्योगो प्रीफेक्चर
+hr:Hyōgo
+hu:Hjógo prefektúra
+hy:Հյոգո (պրեֆեկտուրա)
+id:Prefektur Hyogo
+is:Hyogo-hérað
+it:prefettura di Hyōgo
+ja:兵庫県
+jv:Prefektur Hyogo
+ka:ჰიოგოს პრეფექტურა
+kn:ಹೈಗೊ ಪ್ರಿಫೆಕ್ಚರ್
+ko:효고현
+lt:Hiogo prefektūra
+lv:Hjogo prefektūra
+mk:Хјого
+mr:ह्योगो
+ms:Wilayah Hyōgo
+nb:Hyogo prefektur
+nl:Hyogo
+nn:Hyogo prefektur
+pl:Prefektura Hyōgo
+pt:Hyōgo
+ro:Prefectura Hyōgo
+ru:Хиого
+se:Hyōgo prefektuvra
+sh:Prefektura Hjogo
+si:හයෝගෝ ප්‍රාන්තය
+sk:Hjógo
+sl:prefektura Hjogo
+sr:Хјого
+su:Préféktur Hyōgo
+sv:Hyogo prefektur
+sw:Mkoa wa Hyogo
+ta:ஹயோகோ ப்ரீபெக்ட்டுர்
+te:హయోగో ప్రిఫెక్చర్
+tg:Префектураи Ҳёго
+th:จังหวัดเฮียวโงะ
+tl:Prepektura ng Hyōgo
+tr:Hyōgo ili
+tt:Хёго (префектура)
+uk:Префектура Хіоґо
+ur:ہیوگو پریفیکچر
+vi:Hyōgo
+zh:兵庫縣
+wikidata:en:Q130290
+
+<en:Japan
+en:Tochigi Prefecture
+af:Tochigi Prefektuur
+ar:توتشيغي
+az:Totiqi
+be:прэфектура Татыгі
+bg:Точиги
+bn:তোচিগি প্রশাসনিক অঞ্চল
+ca:prefectura de Tochigi
+ce:Тотиги (префектура)
+cs:Prefektura Točigi
+cy:Tochigi
+da:Tochigi-præfekturet
+de:Präfektur Tochigi
+el:Τοτσίγκι
+eo:Gubernio Toĉigi
+es:Prefectura de Tochigi
+et:Tochigi prefektuur
+eu:Tochigi
+fa:استان توچیگی
+fi:Tochigin prefektuuri
+fr:préfecture de Tochigi
+ga:Maoracht Tochigi
+gl:Prefectura de Tochigi
+gu:ટોચીગી પ્રીફેકચર
+he:טוצ'יגי
+hi:तोशीगी प्रीफेक्चर
+hr:Tochigi
+hu:Tocsigi prefektúra
+hy:Տոտիգի (պրեֆեկտուրա)
+id:Prefektur Tochigi
+it:prefettura di Tochigi
+ja:栃木県
+ka:ტოტიგის პრეფექტურა
+kn:ತೋಚಿಗಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:도치기현
+lt:Točigio prefektūra
+lv:Točigi prefektūra
+mk:Точиги
+mr:तोचिगी
+ms:Wilayah Tochigi
+nb:Tochigi prefektur
+nl:Tochigi
+nn:Tochigi prefektur
+oc:Prefectura de Tochigi
+pl:Prefektura Tochigi
+pt:Tochigi
+ro:Prefectura Tochigi
+ru:Тотиги
+se:Tochigi prefektuvra
+sh:Prefektura Točigi
+si:ටොචිගි ප්‍රාන්තය
+sk:Točigi
+sl:prefektura Točigi
+sr:Точиги
+su:Tochigi Prefecture
+sv:Tochigi prefektur
+sw:Mkoa wa Tochigi
+ta:டோச்சிகி ப்ரீபெக்ட்டுறே
+te:టోచిగి ప్రిఫెక్చర్
+tg:Префектураи Точиги
+th:จังหวัดโทจิงิ
+tl:Prepektura ng Tochigi
+tr:Tochigi
+tt:Тотиги (префектура)
+ug:توچىگى ناھىيىسى
+uk:Префектура Точіґі
+ur:توچیگی پریفیکچر
+vi:Tochigi
+zh:栃木縣
+wikidata:en:Q44843
+
+<en:Japan
+en:Iwate Prefecture
+af:Iwate Prefektuur
+ar:إيواته
+az:İvate
+ba:Иватэ (префектура)
+be:прэфектура Іватэ
+bg:Ивате
+bn:ইওয়াতে প্রশাসনিক অঞ্চল
+ca:prefectura d'Iwate
+ce:Иватэ (префектура)
+cs:Prefektura Iwate
+cy:Iwate
+da:Iwate-præfekturet
+de:Präfektur Iwate
+el:Ιουάτε
+eo:Gubernio Iŭate
+es:Prefectura de Iwate
+et:Iwate prefektuur
+eu:Iwate
+fa:استان ایواته
+fi:Iwaten prefektuuri
+fr:Préfecture d'Iwate
+ga:Maoracht Iwate
+gl:Prefectura de Iwate
+gu:ઇવેટ પ્રીફેક્ચર
+he:איווטה
+hi:इवाते प्रीफ़ेक्चर
+hr:Iwate
+hu:Ivate prefektúra
+hy:Իվատե
+id:Prefektur Iwate
+it:prefettura di Iwate
+ja:岩手県
+jv:Prefektur Iwate
+ka:ივატეს პრეფექტურა
+km:ខេត្តអ៊ីវ៉ាតិ
+kn:ಐವೇಟ್ ಪ್ರಿಫೆಕ್ಚರ್
+ko:이와테현
+la:Iwate
+lt:Ivatės prefektūra
+lv:Ivates prefektūra
+mk:Ивате
+mn:Иватэ
+mr:इवाते
+ms:Wilayah Iwate
+nb:Iwate prefektur
+nl:Iwate
+nn:Iwate prefektur
+pl:Prefektura Iwate
+pt:Iwate
+ro:Prefectura Iwate
+ru:Иватэ
+se:Iwate prefektuvra
+sh:Prefektura Ivate
+si:අයිවටේ ප්‍රාන්තය
+sk:Iwate
+sl:prefektura Iwate
+sr:Ивате
+su:Iwate Prefecture
+sv:Iwate prefektur
+sw:Mkoa wa Iwate
+ta:இவாட்டே ப்ரீபெக்ட்டுர்
+te:ఇవాటె ప్రిఫెక్చర్
+tg:Префектураи Иватэ
+th:จังหวัดอิวาเตะ
+tl:Prepektura ng Iwate
+tr:Iwate
+tt:Иватэ (префектура)
+ug:ئىۋاتە ناھىيىسى
+uk:Префектура Івате
+ur:ایواتے پریفیکچر
+vi:Iwate
+zh:岩手縣
+wikidata:en:Q48326
+
+<en:Japan
+en:Nagano Prefecture
+af:Nagano Prefektuur
+ar:ناغانو
+az:Naqano prefekturası
+be:прэфектура Нагана
+bg:Нагано
+bn:নাগানো প্রশাসনিক অঞ্চল
+ca:prefectura de Nagano
+ce:Нагано (префектура)
+cs:Prefektura Nagano
+cy:Nagano
+da:Nagano-præfekturet
+de:Präfektur Nagano
+el:Νομός Ναγκάνο
+eo:Gubernio Nagano
+es:Prefectura de Nagano
+et:Nagano prefektuur
+eu:Nagano
+fa:استان ناگانو
+fi:Naganon prefektuuri
+fr:préfecture de Nagano
+ga:Maoracht Nagano
+gl:Prefectura de Nagano
+gu:નાગાનો પ્રીફેકચર
+he:נאגנו
+hi:नागानो प्रीफेक्चर
+hr:Nagano
+hu:Nagano prefektúra
+hy:Նագանո (պրեֆեկտուրա)
+id:Prefektur Nagano
+it:prefettura di Nagano
+ja:長野県
+ka:ნაგანო
+km:ខេត្តណាហ្គាណុ
+kn:ನ್ಯಾಗೊನೋ ಪ್ರಿಫೆಕ್ಚರ್
+ko:나가노현
+la:Naganum
+lt:Nagano prefektūra
+lv:Nagano prefektūra
+mk:Нагано
+mr:नागानो
+ms:Wilayah Nagano
+nb:Nagano prefektur
+nl:Nagano
+nn:Nagano prefektur
+os:Нагано (префектурæ)
+pl:Prefektura Nagano
+pt:Nagano
+ro:Prefectura Nagano
+ru:Нагано
+se:Nagano prefektuvra
+sh:Prefektura Nagano
+si:නගනෝ ප්‍රාන්තය
+sk:Nagano
+sl:Prefektura Nagano
+sr:Нагано
+su:Nagano Prefecture
+sv:Nagano prefektur
+sw:Mkoa wa Nagano
+ta:மகனோ ப்ரீபெக்ட்டுர்
+te:నాగానో ప్రిఫెక్చర్
+tg:Префектураи Нагано
+th:จังหวัดนางาโนะ
+tl:Prepektura ng Nagano
+tr:Nagano
+tt:Нагано (префектура)
+uk:Префектура Наґано
+ur:ناگانو پریفیکچر
+vi:Nagano
+zh:長野縣
+wikidata:en:Q127877
+
+<en:Japan
+en:Ishikawa Prefecture
+af:Ishikawa Prefektuur
+ar:إيشيكاوا
+az:İşikava
+ba:Исикава
+be:прэфектура Ісікава
+bg:Ишикава
+bn:ইশিকাওয়া প্রশাসনিক অঞ্চল
+ca:prefectura d'Ishikawa
+ce:Исикава (префектура)
+cs:Prefektura Išikawa
+cy:Ishikawa
+da:Ishikawa-præfekturet
+de:Präfektur Ishikawa
+el:Ισικάβα
+eo:Gubernio Iŝikaŭa
+es:Prefectura de Ishikawa
+et:Ishikawa prefektuur
+eu:Ishikawa
+fa:استان ایشیکاوا
+fi:Ishikawan prefektuuri
+fr:Préfecture d'Ishikawa
+ga:Maoracht Ishikawa
+gl:Prefectura de Ishikawa
+gu:ઇશિકાવા પ્રીફેકચર
+he:אישיקווה
+hi:इशिकावा प्रीफेक्चर
+hr:Ishikawa
+hu:Isikava prefektúra
+hy:Իսիկավա (պրեֆեկտուրա)
+id:Prefektur Ishikawa
+it:prefettura di Ishikawa
+ja:石川県
+ka:ისიკავის პრეფექტურა
+kn:ಇಶಿಕಾವಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:이시카와현
+lt:Išikavos prefektūra
+lv:Isikavas prefektūra
+mk:Ишикава
+mr:इशिकावा
+ms:Wilayah Ishikawa
+nb:Ishikawa prefektur
+nl:Ishikawa
+nn:Ishikawa prefektur
+pl:Prefektura Ishikawa
+pt:Ishikawa
+ro:Prefectura Ishikawa
+ru:Исикава
+se:Ishikawa prefektuvra
+sh:Išikava
+si:ඉෂිකාවා ප්‍රාන්තය
+sk:Išikawa
+sl:prefektura Išikava
+sr:Ишикава
+su:Préféktur Ishikawa
+sv:Ishikawa prefektur
+sw:Mkoa wa Ishikawa
+ta:இஷிகாவா ப்ரீபெக்ட்டுறே
+te:ఇషికావా ప్రిఫెక్చర్
+tg:Префектураи Исикава
+th:จังหวัดอิชิกาวะ
+tl:Prepektura ng Ishikawa
+tr:Ishikawa
+tt:Исикава (префектура)
+uk:Префектура Ішікава
+ur:اشیکاوا پریفیکچر
+vi:Ishikawa
+zh:石川縣
+wikidata:en:Q131281
+
+<en:Japan
+en:Mie Prefecture
+af:Mie Prefektuur
+ar:ميه
+az:Mie prefekturası
+ba:Миэ
+be:прэфектура Міэ
+bg:Мие
+bn:মিয়ে প্রশাসনিক অঞ্চল
+ca:prefectura de Mie
+ce:Ми (префектура)
+cs:Prefektura Mie
+cy:Mie
+da:Mie-præfekturet
+de:Präfektur Mie
+el:Μίε
+eo:Gubernio Mie
+es:Prefectura de Mie
+et:Mie prefektuur
+eu:Mie
+fa:استان میه
+fi:Mien prefektuuri
+fr:Préfecture de Mie
+ga:Maoracht Mie
+gl:Prefectura de Mie
+gu:મિએ ​​પ્રીફેકચર
+he:מיאה
+hi:मी प्रीफेक्चर
+hr:Mie
+hu:Mie prefektúra
+hy:Միե
+id:Prefektur Mie
+it:prefettura di Mie
+ja:三重県
+ka:მიეს პრეფექტურა
+km:ខេត្តមីអិ
+kn:ಮೀ ಪ್ರಿಫೆಕ್ಚರ್
+ko:미에현
+la:Mieum
+lt:Mijės prefektūra
+lv:Mie prefektūra
+mk:Мие
+mn:Миэ
+mr:मिई
+ms:Wilayah Mie
+nb:Mie prefektur
+nl:Mie
+nn:Mie prefektur
+os:Миэ
+pl:Prefektura Mie
+pt:Mie
+ro:Prefectura Mie
+ru:Миэ
+se:Mie prefektuvra
+sh:Prefektura Mie
+si:මයි ප්‍රාන්තය
+sk:Mie
+sl:prefektura Mie
+sr:Мије
+su:Préféktur Mie
+sv:Mie prefektur
+sw:Mkoa wa Mie
+ta:மீ ப்ரீபெக்ட்டுறே
+te:మియె ప్రిఫెక్చర్
+tg:Префектураи Миэ
+th:จังหวัดมิเอะ
+tl:Prepektura ng Mie
+tr:Mie ili
+tt:Ми (префектура)
+uk:Префектура Міє
+ur:میہ پریفیکچر
+vi:Mie
+zh:三重縣
+wikidata:en:Q128196
+
+<en:Japan
+en:Tokyo
+af:Tokio
+ak:Tokyo
+am:ቶክዮ
+an:Tokio
+ar:طوكيو
+as:টকিঅ'
+ay:Tokyo
+az:Tokio
+ba:Токио
+be:Токіа
+bg:Токио
+bi:Tokio
+bm:Tokyo
+bn:টোকিও
+bo:ཐོ་ཁེ་ཡོ།
+br:Tokyo
+bs:Tokio
+ca:Tòquio
+ce:Токио
+ch:Tokyo
+co:Tokiu
+cr:ᑐᑭᔪ
+cs:Tokio
+cu:Тѡкиѡ
+cv:Токио
+cy:Tokyo
+da:Tokyo
+de:Tokio
+dv:Tokyo
+dz:ཊོ་ཀི་ཡ
+ee:Tokyo
+el:Τόκιο
+eo:Tokio
+es:Tokio
+et:Tōkyō prefektuur
+eu:Tokio
+fa:توکیو
+fi:Tokio
+fj:Tokyo
+fo:Tokyo
+fr:Tokyo
+fy:Tokio
+ga:Tóiceo
+gd:Tokyo
+gl:Toquio
+gn:Tokio
+gu:ટોક્યો
+gv:Tokyo
+ha:Tokyo
+he:טוקיו
+hi:टोक्यो
+hr:Tokio
+ht:Tokyo
+hu:Tokió
+hy:Տոկիո
+ia:Tokyo
+id:Prefektur Tokyo
+ie:Tōkyō
+ik:Tokyo
+io:Tokyo
+is:Tókýó
+it:Tokyo
+iu:ᑑᑭᐅ
+ja:東京都
+jv:Tokyo
+ka:ტოკიო
+ki:Tokyo
+kk:Токио
+kl:Tokyo
+km:តូក្យូ
+kn:ಟೋಕ್ಯೊ
+ko:도쿄도
+ks:ٹوکیو
+ku:Tokyo
+kw:Tokyo
+ky:Токио
+la:Tokium
+lb:Tokio
+lg:Tokyo
+li:Tokio
+ln:Tokyo
+lo:ໂຕກຽວ
+lt:Tokijas
+lv:Tokija
+mg:Tokyo
+mi:Tōkio
+mk:Токио
+ml:ടോക്കിയോ
+mn:Токио
+mo:Токё
+mr:तोक्यो
+ms:Tokyo
+mt:Tokjo
+my:တိုကျိုမြို့
+na:Tokyo
+nb:Tokyo
+ne:टोकियो
+nl:Tokio
+nn:Tokyo
+nv:Táłtsʼá Hiníyíní
+ny:Tokyo
+oc:prefectura de Tòquio
+or:ଟୋକିଓ
+os:Токио
+pa:ਟੋਕੀਓ
+pl:Tokio
+ps:توکيو
+pt:Tóquio
+qu:Tokyo
+rm:Tokio
+ro:Tōkyō
+ru:Токио
+rw:Tokyo
+sa:टोक्यो
+sc:Tokio
+sd:ٽوڪيو
+se:Tokyo
+sh:Tokyo
+si:ටෝකියෝ
+sk:Tokio
+sl:Tokio
+sm:Tokyo
+sn:Tokyo
+so:Tokyo
+sq:Tokjo
+sr:Токио
+su:Tokyo
+sv:Tokyo prefektur
+sw:Tokyo
+ta:தோக்கியோ
+te:టోక్యో
+tg:Префектураи Токио
+th:โตเกียว
+tk:Tokio
+tl:Tokyo
+tn:Tokyo
+to:Tokio
+tr:Tokyo
+tt:Токио
+tw:Tokyo
+ty:Tokyo
+ug:توكيو
+uk:Токіо
+ur:توکیو
+uz:Tokio
+vi:Tokyo
+vo:Tokyo
+wo:Tokyo
+yi:טאקיא
+yo:Tokyo
+za:Dunghgingh
+zh:東京都
+zu:ITokyo
+wikidata:en:Q1490
+
+<en:Japan
+en:Kagoshima Prefecture
+af:Kagoshima Prefektuur
+ar:كاغوشيما
+az:Kaqoşima
+ba:Кагосима (префектура)
+be:прэфектура Кагосіма
+bg:Кагошима
+bn:কাগোশিমা প্রশাসনিক অঞ্চল
+ca:prefectura de Kagoshima
+ce:Кагосима (префектура)
+cs:Prefektura Kagošima
+cy:Kagoshima
+da:Kagoshima-præfekturet
+de:Präfektur Kagoshima
+el:Περιφέρεια Καγκοσίμα
+eo:Gubernio Kagoŝima
+es:prefectura de Kagoshima
+et:Kagoshima prefektuur
+eu:Kagoshima
+fa:استان کاگوشیما
+fi:Kagoshiman prefektuuri
+fr:Préfecture de Kagoshima
+ga:Maoracht Kagoshima
+gl:Prefectura de Kagoshima
+gu:કાગોશીમા પ્રીફેકચર
+he:קגושימה
+hi:कागोशिमा प्रीफेक्चर
+hr:Kagoshima
+hu:Kagosima prefektúra
+hy:Կոգոշիմա
+id:Prefektur Kagoshima
+it:prefettura di Kagoshima
+ja:鹿児島県
+jv:Prefektur Kagoshima
+ka:კაგოსიმის პრეფექტურა
+km:ខេត្តខាហ្គុស៊ីម៉ា
+kn:ಕಾಗೊಶಿಮಾ ಪ್ರಿಫೆಕ್ಚರ್
+ko:가고시마현
+ky:Кагошима
+lt:Kagošimos prefektūra
+lv:Kagosimas prefektūra
+mk:Кагошима
+mr:कागोशिमा
+ms:Wilayah Kagoshima
+nb:Kagoshima prefektur
+nl:Kagoshima
+nn:Kagoshima prefektur
+oc:Prefectura de Kagoshima
+pl:Prefektura Kagoshima
+pt:Kagoshima
+ro:Prefectura Kagoshima
+ru:Кагосима
+se:Kagoshima prefektuvra
+sh:Kagošima
+si:කගොශිමා ප්‍රාන්තය
+sk:Kagošima
+sl:Prefektura Kagošima
+sr:Кагошима
+su:Kagoshima Prefecture
+sv:Kagoshima prefektur
+sw:Mkoa wa Kagoshima
+ta:ககோஷிமா ப்ரீபெக்ட்டுறே
+te:కాగోషిమా ప్రిఫెక్చర్
+tg:Префектураи Кагосима
+th:จังหวัดคาโงชิมะ
+tl:Prepektura ng Kagoshima
+tr:Kagoşima prefektörlüğü
+tt:Кагосима (префектура)
+uk:Префектура Каґошіма
+ur:کاگوشیما پریفیکچر
+vi:Kagoshima
+zh:鹿兒島縣
+wikidata:en:Q15701
+
+<en:Japan
+en:Miyagi Prefecture
+af:Miyagi Prefektuur
+an:Prefectura de Miyagi
+ar:مياغي
+az:Miyaqi
+ba:Мияги (префектура)
+be:прэфектура Міягі
+bg:Мияги
+bn:মিয়াগি প্রশাসনিক অঞ্চল
+ca:prefectura de Miyagi
+ce:Мияги (префектура)
+cs:Prefektura Mijagi
+cy:Miyagi
+da:Miyagi-præfekturet
+de:Präfektur Miyagi
+el:Μιγιάγκι
+eo:Gubernio Mijagi
+es:Prefectura de Miyagi
+et:Miyagi prefektuur
+eu:Miyagi prefektura
+fa:استان میاگی
+fi:Miyagin prefektuuri
+fr:préfecture de Miyagi
+ga:Maoracht Miyagi
+gl:Prefectura de Miyagi
+gu:મિયાગી પ્રીફેકચર
+he:מיאגי
+hi:मियागी प्रीफेक्चर
+hr:Miyagi
+hu:Mijagi prefektúra
+hy:Միյագի
+id:Prefektur Miyagi
+it:prefettura di Miyagi
+ja:宮城県
+ka:მიაგის პრეფექტურა
+km:ខេត្តមីយ៉ាហ្គិ
+kn:ಮಿಯಾಗಿ ಪ್ರಿಫೆಕ್ಚರ್
+ko:미야기현
+lt:Mijagio prefektūra
+lv:Mijagi prefektūra
+mk:Мијаги
+mn:Мияги
+mr:मियागी
+ms:Wilayah Miyagi
+nb:Miyagi prefektur
+nl:Miyagi
+nn:Miyagi prefektur
+oc:Prefectura de Miyagi
+os:Мияги (префектурæ)
+pl:Prefektura Miyagi
+pt:Miyagi
+ro:Prefectura Miyagi
+ru:Мияги
+se:Miyagi prefektuvra
+sh:Prefektura Mijagi
+si:මියාගී ප්‍රාන්තය
+sk:Mijagi
+sl:prefektura Mijagi
+sr:Мијаги
+su:Miyagi Prefecture
+sv:Miyagi prefektur
+sw:Mkoa wa Miyagi
+ta:மியாகி ப்ரீபெக்ட்டுர்
+te:మియాగీ ప్రిఫెక్చర్
+tg:Префектураи Мияги
+th:จังหวัดมิยางิ
+tl:Prepektura ng Miyagi
+tr:Miyagi
+tt:Мияги (префектура)
+ug:مىياگى ناھىيىسى
+uk:Префектура Міяґі
+ur:میاگی پریفیکچر
+uz:Miyagi prefekturasi
+vi:Miyagi
+zh:宮城縣
+wikidata:en:Q47896
 
 <en:Japan
 en:Kyushu


### PR DESCRIPTION
Adds all 47 prefectures of Japan, as the branch contains Hokkaido. Translations were extracted from Wikidata.