### PR TITLE
fix: small refactor of processing parsing

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1325,10 +1325,10 @@ English first element for that ingredient (en:pear, for example)
 sub parse_processing_from_ingredient ($ingredients_lc, $ingredient) {
 	my $ingredient_recognized = 0;
 	my @processings = ();
-	my $debug_parse_processing_from_ingredient = 0;
+	my $debug_parse_processing_from_ingredient = 1;
 
 	# do not match anything if we don't have a translation for "and"
-	my $and = $and{$lc} || " will not match ";
+	my $and = $and{$ingredients_lc} || " will not match ";
 
 	# canonicalize_taxonomy_tag also remove stopwords, etc.
 	my $ingredient_id = canonicalize_taxonomy_tag($ingredients_lc, "ingredients", $ingredient);

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1290,10 +1290,6 @@ If it does not result in known ingredient, then it returns the same but unchange
 
 =head3 Arguments
 
-=head4 ingredients_processing_regexps
-
-list of regexps with each synonyms of all ingredients processes
-
 =head4 ingredients_lc
 
 language abbreviation (en for English, for example)
@@ -1304,7 +1300,7 @@ string ("pear", for example)
 
 =head3 Return values
 
-=head4 processing array reference
+=head4 processings_ref
 
 reference to an array of processings
 
@@ -2287,6 +2283,7 @@ sub parse_ingredients_text ($product_ref) {
 					if (defined $ingredients_processing_regexps{$ingredients_lc}) {
 						(my $new_processings_ref, $ingredient, $ingredient_id, $ingredient_recognized)
 							= parse_processing_from_ingredient($ingredients_lc, $ingredient);
+						# Add the newly extracted processings to possibly already existing processings
 						push @processings, @$new_processings_ref;
 					}
 

--- a/stop_words.txt
+++ b/stop_words.txt
@@ -176,6 +176,7 @@ Porc
 poudre
 pre
 pre-processing
+processings
 Programme
 pre
 prepend

--- a/tests/unit/expected_test_results/ingredients/fr-marmelade.json
+++ b/tests/unit/expected_test_results/ingredients/fr-marmelade.json
@@ -41,7 +41,7 @@
                "ingredients" : [],
                "percent" : 0.6,
                "percent_estimate" : 0.6,
-               "processing" : "en:pulp, en:concentrated",
+               "processing" : "en:pulp,en:concentrated",
                "text" : "orange",
                "vegan" : "yes",
                "vegetarian" : "yes"

--- a/tests/unit/expected_test_results/nutriscore/fr-ice-tea-with-sweetener.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-ice-tea-with-sweetener.json
@@ -138,7 +138,7 @@
          "percent_estimate" : 0.1,
          "percent_max" : 0.1,
          "percent_min" : 0.1,
-         "processing" : "en:from-concentrate, en:juice",
+         "processing" : "en:from-concentrate,en:juice",
          "text" : "pêche",
          "vegan" : "yes",
          "vegetarian" : "yes"

--- a/tests/unit/ingredients_nesting.t
+++ b/tests/unit/ingredients_nesting.t
@@ -298,7 +298,7 @@ my @tests = (
 			{
 				'id' => 'en:tomato',
 				'labels' => 'en:organic',
-				'processing' => 'en:cooked, en:sliced, en:cut',
+				'processing' => 'en:cooked,en:sliced,en:cut',
 				'text' => 'Tomates'
 			}
 		]

--- a/tests/unit/ingredients_processing.t
+++ b/tests/unit/ingredients_processing.t
@@ -311,12 +311,12 @@ my @tests = (
 		[
 			{
 				'id' => 'en:ham',
-				'processing' => 'en:diced, en:fried',
+				'processing' => 'en:diced,en:fried',
 				'text' => 'jambon'
 			},
 			{
 				'id' => 'en:tomato',
-				'processing' => 'en:diced, en:raw',
+				'processing' => 'en:diced,en:raw',
 				'text' => 'tomates'
 			},
 			{
@@ -343,7 +343,7 @@ my @tests = (
 		[
 			{
 				'id' => 'en:banana',
-				'processing' => 'en:cooked, en:cut',
+				'processing' => 'en:cooked,en:cut',
 				'text' => 'banane'
 			}
 		]
@@ -354,7 +354,7 @@ my @tests = (
 		[
 			{
 				'id' => 'en:banana',
-				'processing' => 'en:cooked, en:cut',
+				'processing' => 'en:cooked,en:cut',
 				'text' => 'banane'
 			}
 		]
@@ -421,7 +421,7 @@ my @tests = (
 		[
 			{
 				'id' => 'en:tomato',
-				'processing' => 'en:partially-rehydrated, en:dried',
+				'processing' => 'en:partially-rehydrated,en:dried',
 				'text' => 'tomates'
 			},
 			{
@@ -1084,17 +1084,17 @@ my @tests = (
 			# change on 17:01
 			{
 				'id' => 'en:hazelnut',
-				'processing' => 'en:toasted, en:chopped',
+				'processing' => 'en:toasted,en:chopped',
 				'text' => "haselnüsse"
 			},
 			{
 				'id' => 'en:hazelnut',
-				'processing' => 'en:chopped, en:toasted',
+				'processing' => 'en:chopped,en:toasted',
 				'text' => "haselnuss"
 			},
 			{
 				'id' => 'en:almond',
-				'processing' => 'en:sliced, en:chopped',
+				'processing' => 'en:sliced,en:chopped',
 				'text' => 'mandeln'
 			}
 		]
@@ -1338,7 +1338,7 @@ my @tests = (
 		[
 			{
 				'id' => 'en:hazelnut',
-				'processing' => 'en:toasted, en:chopped',
+				'processing' => 'en:toasted,en:chopped',
 				'text' => "haselnüsse"
 			}
 		]
@@ -1375,7 +1375,7 @@ my @tests = (
 			},
 			{
 				'id' => 'en:almond',
-				'processing' => 'en:sliced, en:chopped',
+				'processing' => 'en:sliced,en:chopped',
 				'text' => 'mandeln'
 			},
 			{
@@ -1803,7 +1803,7 @@ my @tests = (
 			},
 			{
 				'id' => 'en:butter',
-				'processing' => 'en:powder, en:roasted',
+				'processing' => 'en:powder,en:roasted',
 				'text' => "\x{30d0}\x{30bf}\x{30fc}"
 			},
 			{
@@ -1813,7 +1813,7 @@ my @tests = (
 			},
 			{
 				'id' => 'en:garlic',
-				'processing' => 'en:powder, en:fried',
+				'processing' => 'en:powder,en:fried',
 				'text' => "\x{30ac}\x{30fc}\x{30ea}\x{30c3}\x{30af}"
 			},
 			{
@@ -1910,7 +1910,7 @@ my @tests = (
 			},
 			{
 				'id' => 'en:potato',
-				'processing' => 'en:unfrozen, en:roasted',
+				'processing' => 'en:unfrozen,en:roasted',
 				'text' => 'kartofler'
 			},
 			{
@@ -2225,7 +2225,7 @@ my @tests = (
 			},
 			{
 				'id' => 'en:potato',
-				'processing' => 'en:unfrozen, en:roasted',
+				'processing' => 'en:unfrozen,en:roasted',
 				'text' => 'potatis'
 			},
 			{

--- a/tests/unit/ingredients_tags.t
+++ b/tests/unit/ingredients_tags.t
@@ -305,6 +305,7 @@ my @tests = (
 		{lc => "ru", ingredients_text => "масло растительное (подсолнечное, соевое), Масло (Пальмовое)"},
 		["en:sunflower-oil", "en:soya-oil", "en:palm-oil"]
 	],
+	[{lc => "fr", ingredients_text => "Banane coupée et cuite au naturel"}, ["en:banana"],],
 
 );
 


### PR DESCRIPTION
Small refactor of @benbenben2 's PR https://github.com/openfoodfacts/openfoodfacts-server/pull/9122

- removed most parameters to parse_processing_from_ingredient ( $ingredients_lc, $ingredient )
- internally made a @processings structure instead of the comma separated list of processings. In future versions of the API I think it would be best to return the array.