### PR TITLE
fix: avoid duplicated for data quality tags

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1408,27 +1408,60 @@ sub check_labels ($product_ref) {
 					if (has_tag($product_ref, "labels", "en:vegan")) {
 						# vegan
 						if (defined $ingredient_ref->{"vegan"}) {
-							if ($ingredient_ref->{"vegan"} eq 'no') {
+							if (
+								($ingredient_ref->{"vegan"} eq 'no')
+								&& (
+									!has_tag(
+										$product_ref, 'data_quality_errors',
+										"en:vegan-label-but-non-vegan-ingredient"
+									)
+								)
+								)
+							{
 								push @{$product_ref->{data_quality_errors_tags}},
 									"en:vegan-label-but-non-vegan-ingredient";
 							}
 							# else 'yes', 'maybe'
 						}
-						else {
+						# no tag
+						elsif (
+							!has_tag(
+								$product_ref, 'data_quality_warnings',
+								"en:vegan-label-but-could-not-confirm-for-all-ingredients"
+							)
+							)
+						{
 							push @{$product_ref->{data_quality_warnings_tags}},
 								"en:vegan-label-but-could-not-confirm-for-all-ingredients";
 						}
 					}
 
-					# vegetarian
+					# vegetarian label condition is above
 					if (defined $ingredient_ref->{"vegetarian"}) {
-						if ($ingredient_ref->{"vegetarian"} eq 'no') {
+
+						if (
+							($ingredient_ref->{"vegetarian"} eq 'no')
+							&& (
+								!has_tag(
+									$product_ref, 'data_quality_errors',
+									"en:vegetarian-label-but-non-vegetarian-ingredient"
+								)
+							)
+							)
+						{
 							push @{$product_ref->{data_quality_errors_tags}},
 								"en:vegetarian-label-but-non-vegetarian-ingredient";
 						}
 						# else 'yes', 'maybe'
 					}
-					else {
+					# no tag
+					elsif (
+						!has_tag(
+							$product_ref, 'data_quality_warnings',
+							"en:vegetarian-label-but-could-not-confirm-for-all-ingredients"
+						)
+						)
+					{
 						push @{$product_ref->{data_quality_warnings_tags}},
 							"en:vegetarian-label-but-could-not-confirm-for-all-ingredients";
 					}


### PR DESCRIPTION
### What

avoid duplicated data quality tags for vegan (vegetarian) labels having non-vegan (non-vegetarian) ingredients.



### Screenshot
Before the fix:
![Screenshot_20231015_162014](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/688f863d-74a1-49ba-bb6d-b1ce3b16eb4b)

### Related issue(s) and discussion
- Fixes #-none-