### PR TITLE
taxonomy: add "abbey beers" proxy to Trappist

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -1604,7 +1604,7 @@ de:Abteibier
 fi:luostariolut
 fr:Bières d'abbayes, Bières d'abbaye, Bières d'abbayes régionales
 hu:Apátsági sör
-it:Birre d'abbazia, Birre trappiste
+it:Birre d'abbazia
 nl:Abdijbieren
 agribalyse_food_code:en:5011
 ciqual_food_code:en:5011
@@ -1984,8 +1984,9 @@ ciqual_food_code:en:5010
 ciqual_food_name:en:Beer, special (5-6° alcohol)
 ciqual_food_name:fr:Bière spéciale (5-6° alcool)
 
-<en:Beers
+<en:Abbey ales
 en:Trappist beers, Trappist
+it:Birre trappiste
 xx:Trappist beers, Trappist
 agribalyse_proxy_food_code:en:5011
 agribalyse_proxy_food_name:en:Beer, specialty, from abbey or regional (varying alcohol content)

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -1987,6 +1987,9 @@ ciqual_food_name:fr:Bière spéciale (5-6° alcool)
 <en:Beers
 en:Trappist beers, Trappist
 xx:Trappist beers, Trappist
+agribalyse_proxy_food_code:en:5011
+agribalyse_proxy_food_name:en:Beer, specialty, from abbey or regional (varying alcohol content)
+agribalyse_proxy_food_name:fr:Bière de spécialités ou d'abbaye, régionales ou d'une brasserie (degré d'alcool variable)
 wikidata:en:Q505815
 wikipedia:en:https://en.wikipedia.org/wiki/Trappist_beer
 description:en:A type of beer that is brewed by trappist monks. There is a strict criteria managed by the International Trappist Association that grants Authentic Trappist Product label to breweries that have monks.


### PR DESCRIPTION
add "abbey beers" proxy to Trappist, since abbey beers are by definition in trappist style