### PR TITLE
fix: speed up Lang.pm initialization, save 2 seconds x 100 tests

### DIFF
--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -254,7 +254,7 @@ sub lang_in_other_lc ($target_lc, $stringid) {
 
 $log->info("initialize", {data_root => $data_root}) if $log->is_info();
 
-# Load stored %Lang from Lang.sto
+# Load stored %Lang from Lang.sto and Lang_tags.sto
 
 my $path = "$data_root/data/Lang.${server_domain}.sto";
 if (-e $path) {
@@ -275,7 +275,6 @@ if (-e $path) {
 	}
 
 	$log->info("Loaded languages", {langs => (scalar @Langs)}) if $log->is_info();
-	sleep(1) if $log->is_info();
 }
 else {
 	$log->warn("Language translation file does not exist, \%Lang will be empty. Run scripts/build_lang.pm to fix this.",
@@ -283,19 +282,42 @@ else {
 		if $log->is_warn();
 }
 
-# Tags types to path components in URLS: in ascii, lowercase, unaccented,
-# transliterated (in Roman characters)
-#
-# Note: a lot of plurals are currently missing below, commented-out are
-# the singulars that need to be changed to plurals
-my ($tag_type_singular_ref, $tag_type_plural_ref)
-	= ProductOpener::I18N::split_tags(ProductOpener::I18N::read_po_files("$data_root/po/tags/"));
-%tag_type_singular = %{$tag_type_singular_ref};
-%tag_type_plural = %{$tag_type_plural_ref};
+$path = "$data_root/data/Lang_tags.${server_domain}.sto";
+if (-e $path) {
 
+	$log->info("Loading tag types <=> singular and plural translated paths", {path => $path}) if $log->is_info();
+	my $tag_type_data_ref = retrieve($path);
+	$log->info("Loaded tag types <=> singular and plural translated paths", {path => $path}) if $log->is_info();
+
+	%tag_type_singular = %{$tag_type_data_ref->{tag_type_singular}};
+	%tag_type_plural = %{$tag_type_data_ref->{tag_type_plural}};
+	%tag_type_from_singular = %{$tag_type_data_ref->{tag_type_from_singular}};
+	%tag_type_from_plural = %{$tag_type_data_ref->{tag_type_from_plural}};
+}
+else {
+	$log->warn("Language translation file for tags does not exist. Run scripts/build_lang.pm to fix this.",
+		{path => $path})
+		if $log->is_warn();
+}
+
+# Taxonomies that can have debug, prev, and next versions
+# (older feature to generate tags using multiple versions of a taxonomy, currently not used)
 my @debug_taxonomies = ("categories", "labels", "additives");
 
-{
+# Build hashes to map a translated tag type (e.g. "catégorie") in singular or plural to the tag type (e.g. "categories")
+
+sub build_lang_tags() {
+
+	# Tags types to path components in URLS: in ascii, lowercase, unaccented,
+	# transliterated (in Roman characters)
+	#
+	# Note: a lot of plurals are currently missing below, commented-out are
+	# the singulars that need to be changed to plurals
+	my ($tag_type_singular_ref, $tag_type_plural_ref)
+		= ProductOpener::I18N::split_tags(ProductOpener::I18N::read_po_files("$data_root/po/tags/"));
+	%tag_type_singular = %{$tag_type_singular_ref};
+	%tag_type_plural = %{$tag_type_plural_ref};
+
 	foreach my $l (@Langs) {
 
 		foreach my $taxonomy (@debug_taxonomies) {
@@ -355,7 +377,14 @@ my @debug_taxonomies = ("categories", "labels", "additives");
 		}
 
 	}
-
+	return (
+		{
+			tag_type_singular => \%tag_type_singular,
+			tag_type_plural => \%tag_type_plural,
+			tag_type_from_singular => \%tag_type_from_singular,
+			tag_type_from_plural => \%tag_type_from_plural
+		}
+	);
 }
 
 # initialize languages values:

--- a/scripts/build_lang.pl
+++ b/scripts/build_lang.pl
@@ -40,6 +40,7 @@ print STDERR "Build \%Lang - data_root: $data_root - server_domain: $server_doma
 # Tags.pm builds the %Languages hash of languages from the languages taxonomy
 
 ProductOpener::Lang::build_lang(\%Languages);
+my $tags_ref = ProductOpener::Lang::build_lang_tags();
 
 # use $server_domain in part of the name so that we have different files
 # when 2 instances of Product Opener share the same $data_root
@@ -48,6 +49,7 @@ if (!-e "$data_root/data") {
 	mkdir("$data_root/data", 0755) or die("Could not create target directory $data_root/data : $!\n");
 }
 store("$data_root/data/Lang.${server_domain}.sto", \%Lang);
+store("$data_root/data/Lang_tags.${server_domain}.sto", $tags_ref);
 
 # Generate JSON files for JavaScript I18N
 ProductOpener::Lang::build_json();


### PR DESCRIPTION
This is an attempt to speed up tests. Almost all tests load Lang.pm.
- removed useless sleep()
- made parsing of the po/tags/ file saved in a file (like we do for po/common)

In profiling done with nytprof, this saves about 2 seconds per initialization. As we have 100 unit + integration tests, I'm hoping this should save 3 minutes when running all tests.