### PR TITLE
fix: don't display translation widget for non logged-in users

### DIFF
--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -473,7 +473,7 @@
 
 [% SET crowdin_languages = ["aa","ar","ber","br","co","fa","ga","hy","iu","kk","lb","me","mr","ne","no","ry","sd","sl","sq","st","tg","tr","tzl","val","wa","zea","zu","ach","as","bg","bs","crs","eo","fi","gd","hi","id","ja","km","ku","lo","mg","ms","nr","pa","qu","sa","sg","sma","sr","sv","th","ts","ug","ve","wo","zh","af","ast","bm","ca","cs","el","fil","gl","hr","ii","jv","kmr","kw","mi","mt","pl","rm","sat","sh","sn","sr_CS","sw","ti","tt","uk","vec","xh","ak","az","bn","ce","cv","et","fo","gu","ht","is","ka","kmr_TR","ky","lt","ml","my","oc","ro","sc","si","so","sr_RS","ta","tl","tw","ur","vi","yi","am","be","bo","chr","cy","eu","ha","hu","kab","kn","la","lv","mn","nb","nn","ru","sco","sk","son","ss","te","tn","ty","uz","vls","yo"] %]
 
-[% IF crowdin_languages.grep("^$lc$").size %]
+[% IF crowdin_languages.grep("^$lc$").size and user_id.defined %]
 <script
   type="text/javascript"
   src="https://crowdin.com/js/crowdjet/crowdjet.js">


### PR DESCRIPTION
Users don't understand it, and use it as a free form.