### PR TITLE
fix: add timeout to off-query

### DIFF
--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -129,6 +129,8 @@ sub execute_tags_query ($type, $query) {
 			if $log->is_debug();
 
 		my $ua = LWP::UserAgent->new();
+		# Add a timeout to the HTTP query
+		$ua->timeout(15);
 		my $resp = $ua->post(
 			$url,
 			Content => encode_json($query),


### PR DESCRIPTION
request to Open Food Facts query service didn't have any timeout.