### PR TITLE
taxonomy: put Trappist beers under Abbey ales (fix)

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -1604,8 +1604,10 @@ fr:Bières de garde
 wikidata:en:Q1168351
 
 ############ ABBEY/TRAPPIST ############
-<en:Beers
+<en:Abbey ales
 en:Trappist beers, Trappist
+it:Birre trappiste
+fr:Bières trappistes
 xx:Trappist beers, Trappist
 wikidata:en:Q505815
 wikipedia:en:https://en.wikipedia.org/wiki/Trappist_beer
@@ -1617,7 +1619,7 @@ de:Abteibier
 fi:luostariolut
 fr:Bières d'abbayes, Bières d'abbaye, Bières d'abbayes régionales
 hu:Apátsági sör
-it:Birre d'abbazia, Birre trappiste
+it:Birre d'abbazia
 nl:Abdijbieren
 agribalyse_food_code:en:5011
 ciqual_food_code:en:5011


### PR DESCRIPTION
put Trappist beers under Abbey ales (fix)
[sorry I made a mistake pushing the fix and had to close the [initial PR](https://github.com/openfoodfacts/openfoodfacts-server/pull/9198) and reopen this one]