### PR TITLE
fix: set caching headers for assetlinks.json

### DIFF
--- a/conf/nginx/sites-available/obf
+++ b/conf/nginx/sites-available/obf
@@ -101,6 +101,14 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
+        # GoogleAssociationService made 2500 requests/min to assetlinks.json
+        # and much less when caching headers are sent
+        location = /.well-known/assetlinks.json {
+                include snippets/off.cors-headers.include;
+                expires 1d;
+                try_files $uri $uri/ =404;
+        }
+
 	location / {
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -149,6 +149,14 @@ server {
 		gunzip on;
 	}
 
+        # GoogleAssociationService made 2500 requests/min to assetlinks.json
+        # and much less when caching headers are sent
+        location = /.well-known/assetlinks.json {
+                include snippets/off.cors-headers.include;
+                expires 1d;
+                try_files $uri $uri/ =404;
+        }
+
         include snippets/off.locations-redirects.include;
 
 	# Dynamically generated files and CGI scripts are passed

--- a/conf/nginx/sites-available/opf
+++ b/conf/nginx/sites-available/opf
@@ -114,13 +114,20 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
-
 	location ~ ^/(.well-known|images|fonts|css|js|rss|files|resources|foundation|bower_components)/ {
 		include snippets/off.cors-headers.include;
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;
 	}
+
+	# GoogleAssociationService made 2500 requests/min to assetlinks.json
+	# and much less when caching headers are sent
+	location = /.well-known/assetlinks.json {
+                include snippets/off.cors-headers.include;
+                expires 1d;
+                try_files $uri $uri/ =404;
+        }
 
 	location / {
 		proxy_set_header Host $host;

--- a/conf/nginx/sites-available/opff
+++ b/conf/nginx/sites-available/opff
@@ -122,6 +122,14 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
+        # GoogleAssociationService made 2500 requests/min to assetlinks.json
+        # and much less when caching headers are sent
+        location = /.well-known/assetlinks.json {
+                include snippets/off.cors-headers.include;
+                expires 1d;
+                try_files $uri $uri/ =404;
+        }
+
 	location / {
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Seems to divide by 10 the 2500 requests per minute we had on Open Pet Food Facts from GoogleAssociationService.
https://github.com/openfoodfacts/openfoodfacts-infrastructure/issues/264

before change:

```
root@opff:/var/log/nginx# tail -n 1000000 opff-access.log | grep GoogleAssociationService | grep 2023:15:00: | wc -l
2029
root@opff:/var/log/nginx# tail -n 1000000 opff-access.log | grep GoogleAssociationService | grep 2023:15:05: | wc -l
2468
root@opff:/var/log/nginx# tail -n 1000000 opff-access.log | grep GoogleAssociationService | grep 2023:15:15: | wc -l
2510
```

after change:

```
root@opff:/var/log/nginx# tail -n 1000000 opff-access.log | grep GoogleAssociationService | grep 2023:15:30: | wc -l
136
root@opff:/var/log/nginx# tail -n 1000000 opff-access.log | grep GoogleAssociationService | grep 2023:15:35: | wc -l
177
root@opff:/var/log/nginx# tail -n 1000000 opff-access.log | grep GoogleAssociationService | grep 2023:15:40: | wc -l
201
```

