### PR TITLE
chore: cache rule for assetlinks in nginx docker

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -70,6 +70,14 @@ server {
 		gunzip on;
 	}
 
+	# GoogleAssociationService made 2500 requests/min to assetlinks.json
+	# and much less when caching headers are sent
+	location = /.well-known/assetlinks.json {
+		include snippets/off.cors-headers.include;
+		expires 1d;
+		try_files $uri $uri/ =404;
+	}
+
 	location ~ /(favicon\.ico)$ {
 		include conf.d/off.cors-headers.include;
 		try_files $uri $uri/ =404;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -73,7 +73,7 @@ server {
 	# GoogleAssociationService made 2500 requests/min to assetlinks.json
 	# and much less when caching headers are sent
 	location = /.well-known/assetlinks.json {
-		include snippets/off.cors-headers.include;
+		include conf.d/off.cors-headers.include;
 		expires 1d;
 		try_files $uri $uri/ =404;
 	}


### PR DESCRIPTION
to avoid having google hammering staging environment