### PR TITLE
fix: parsing of beef meat from animals fed without GMO

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -516,6 +516,7 @@ my @labels = (
 	"en:vegetarian", "nl:beter-leven-1-ster",
 	"nl:beter-leven-2-ster", "nl:beter-leven-3-ster",
 	"en:halal", "en:kosher",
+	"en:fed-without-gmos",
 );
 my %labels_regexps = ();
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -993,11 +993,13 @@ auth_url:en: https://spp.coop/
 en:Fairtrade cocoa, fairtrade cocoa program
 xx:Fairtrade cocoa, fairtrade cocoa program
 
-en:Fed without GMOs, Fed without GMO
+# note: we need full entries like "issu d'animaux nourris sans OGM" even though we have "issu" and "d'" in stopwords
+# in order to cleanly separate ingredient and label in strings like "viande de boeuf issue d'animaux nourris sans OGM"
+en:Fed without GMOs, Fed without GMO, Animals fed without GMOs, Animals fed without GMO, from animals fed without GMOs, from animals fed without GMO
 bg:Хранене без ГМО
 ca:Alimentat sense Organismes Modificats Genèticament
 fi:Eläintä on ruokittu GMO-vapaalla rehulla, ruokittu ilman GMO:ita
-fr:Nourri sans OGM, nourris sans OGM, nourries sans OGM, Alimentation sans OGM, Animaux nourris sans OGM, élevage avec une alimentation sans ogm
+fr:Nourri sans OGM, nourris sans OGM, nourries sans OGM, Alimentation sans OGM, Animaux nourris sans OGM, élevage avec une alimentation sans ogm, issu d'animaux nourris sans OGM, issue d'animaux nourris sans OGM, issus d'animaux nourris sans OGM, issues d'animaux nourris sans OGM
 it:Alimentati senza OGM
 nl:Zonder OGM voedsel
 pt:Alimentado sem OGM, alimentado sem alimentos geneticamente modificados, alimentado sem alimentos transgênicos, alimentado sem alimentos transgénicos, alimentada sem OGM, alimentada sem alimentos geneticamente modificados, alimentada sem alimentos transgênicos, alimentada sem alimentos transgénicos, alimentados sem OGM, alimentados sem alimentos geneticamente modificados, alimentados sem alimentos transgênicos, alimentados sem alimentos transgénicos, alimentadas sem OGM, alimentadas sem alimentos geneticamente modificados, alimentadas sem alimentos transgênicos, alimentadas sem alimentos transgénicos

--- a/tests/unit/expected_test_results/ingredients/fr-viande-de-boeuf-issue-d-animaux-nourris-sans-ogm.json
+++ b/tests/unit/expected_test_results/ingredients/fr-viande-de-boeuf-issue-d-animaux-nourris-sans-ogm.json
@@ -1,0 +1,66 @@
+{
+   "ingredients" : [
+      {
+         "id" : "en:beef-meat",
+         "labels" : "en:fed-without-gmos",
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "Viande de boeuf",
+         "vegan" : "no",
+         "vegetarian" : "no"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:non-vegan" : [
+         "en:beef-meat"
+      ],
+      "en:non-vegetarian" : [
+         "en:beef-meat"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-free",
+      "en:non-vegan",
+      "en:non-vegetarian"
+   ],
+   "ingredients_hierarchy" : [
+      "en:beef-meat",
+      "en:animal",
+      "en:meat",
+      "en:beef"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:beef-meat"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:beef-meat",
+      "en:animal",
+      "en:meat",
+      "en:beef"
+   ],
+   "ingredients_text" : "Viande de boeuf issue d'animaux nourris sans OGM",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 1,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:beef-meat"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
+   "known_ingredients_n" : 4,
+   "lc" : "fr",
+   "nutriments" : {
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0
+   },
+   "unknown_ingredients_n" : 0
+}

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -703,6 +703,13 @@ puffed orange and caramelized unknown_fruit4.",
 				"fruits (apple, banana and dried cherry), vegetables (pitted avocado, peeled black radish).",
 		}
 	],
+	[
+		"fr-viande-de-boeuf-issue-d-animaux-nourris-sans-ogm",
+		{
+			lc => "fr",
+			ingredients_text => "Viande de boeuf issue d'animaux nourris sans OGM",
+		}
+	]
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
Enables to parse strings like "beef meat from animals fed without GMO" / ""Viande de boeuf issue d'animaux nourris sans OGM""