### PR TITLE
feat: add dq error for product quantity above 30kg

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1298,6 +1298,10 @@ sub check_quantity ($product_ref) {
 	if ((defined $product_ref->{product_quantity}) and ($product_ref->{product_quantity} ne "")) {
 		if ($product_ref->{product_quantity} > 10 * 1000) {
 			push @{$product_ref->{data_quality_warnings_tags}}, "en:product-quantity-over-10kg";
+
+            if ($product_ref->{product_quantity} > 30 * 1000) {
+                push @{$product_ref->{data_quality_errors_tags}}, "en:product-quantity-over-30kg";
+            }
 		}
 		if ($product_ref->{product_quantity} < 1) {
 			push @{$product_ref->{data_quality_warnings_tags}}, "en:product-quantity-under-1g";

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1299,9 +1299,9 @@ sub check_quantity ($product_ref) {
 		if ($product_ref->{product_quantity} > 10 * 1000) {
 			push @{$product_ref->{data_quality_warnings_tags}}, "en:product-quantity-over-10kg";
 
-            if ($product_ref->{product_quantity} > 30 * 1000) {
-                push @{$product_ref->{data_quality_errors_tags}}, "en:product-quantity-over-30kg";
-            }
+			if ($product_ref->{product_quantity} > 30 * 1000) {
+				push @{$product_ref->{data_quality_errors_tags}}, "en:product-quantity-over-30kg";
+			}
 		}
 		if ($product_ref->{product_quantity} < 1) {
 			push @{$product_ref->{data_quality_warnings_tags}}, "en:product-quantity-under-1g";

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -2794,6 +2794,10 @@ description:en:Compared to the category average, the Sugars value is abnormally 
 
 ### Quantity and serving
 
+<en:Quantity and serving errors
+en:Product quantity over 30kg
+description:en:Product quantity is above 30kg, which is very unlikely. 
+
 <en:Data quality warnings
 en:Quantity and serving warnings
 description:en: Potential issues on quantities or serving size
@@ -2804,7 +2808,7 @@ en:Product quantity in mg
 
 <en:Quantity and serving warnings
 en:Product quantity over 10kg
-#description:en:
+description:en:Product quantity is above 10kg, which is unlikely for most of the products
 
 <en:Quantity and serving warnings
 en:Product quantity under 1g

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -2794,6 +2794,10 @@ description:en:Compared to the category average, the Sugars value is abnormally 
 
 ### Quantity and serving
 
+<en:Data quality errors
+en:Quantity and serving errors
+description:en: Potential issues on quantities or serving size
+
 <en:Quantity and serving errors
 en:Product quantity over 30kg
 description:en:Product quantity is above 30kg, which is very unlikely. 

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1221,9 +1221,7 @@ check_quality_and_test_product_has_quality_tag(
 	'raise warning because vegetarian or non-vegetarian is unknown for an ingredient', 0
 );
 # product quantity warnings and errors
-$product_ref = {
-	product_quantity => "123456789",
-};
+$product_ref = {product_quantity => "123456789",};
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
 	'en:product-quantity-over-10kg',
@@ -1235,9 +1233,7 @@ check_quality_and_test_product_has_quality_tag(
 	'raise error because the product quantity is above 30000g', 1
 );
 # product quantity warnings and errors
-$product_ref = {
-	product_quantity => "20000",
-};
+$product_ref = {product_quantity => "20000",};
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
 	'en:product-quantity-over-10kg',
@@ -1257,10 +1253,7 @@ check_quality_and_test_product_has_quality_tag(
 	'en:product-quantity-under-1g',
 	'raise warning because the product quantity is under 1g', 1
 );
-check_quality_and_test_product_has_quality_tag(
-	$product_ref,
-	'en:product-quantity-in-mg',
-	'raise warning because the product quantity is in mg', 1
-);
+check_quality_and_test_product_has_quality_tag($product_ref, 'en:product-quantity-in-mg',
+	'raise warning because the product quantity is in mg', 1);
 
 done_testing();

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1220,4 +1220,47 @@ check_quality_and_test_product_has_quality_tag(
 	'en:vegetarian-label-but-could-not-confirm-for-all-ingredients',
 	'raise warning because vegetarian or non-vegetarian is unknown for an ingredient', 0
 );
+# product quantity warnings and errors
+$product_ref = {
+	product_quantity => "123456789",
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:product-quantity-over-10kg',
+	'raise warning because the product quantity is above 10000g', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:product-quantity-over-30kg',
+	'raise error because the product quantity is above 30000g', 1
+);
+# product quantity warnings and errors
+$product_ref = {
+	product_quantity => "20000",
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:product-quantity-over-10kg',
+	'raise warning because the product quantity is above 10000g', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:product-quantity-over-30kg',
+	'raise error because the product quantity is above 30000g', 0
+);
+$product_ref = {
+	product_quantity => "0.001",
+	quantity => "1 mg",
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:product-quantity-under-1g',
+	'raise warning because the product quantity is under 1g', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:product-quantity-in-mg',
+	'raise warning because the product quantity is in mg', 1
+);
+
 done_testing();


### PR DESCRIPTION
### What
add dq error for product quantity above 30kg
added test for it + for others quantity warning (above 10kg below 1g and in mg) 


![Screenshot_20231114_165651](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/a8bc90b8-54bd-4531-972f-4bd0ac58f70b)


### Related issue(s) and discussion
- Fixes #9217
