### PR TITLE
fix: fix_avoid_eiweiss_false_positive_for_allergens

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -6689,6 +6689,10 @@ sub detect_allergens_from_text ($product_ref) {
 			$text =~ s/\b___([^,;_\(\)\[\]]+?)___\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
 			$text =~ s/\b__([^,;_\(\)\[\]]+?)__\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
 			$text =~ s/\b_([^,;_\(\)\[\]]+?)_\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
+			# _Weizen_eiweiß is not caught in last regex because of \b (word boundary).
+			if ($language eq 'de') {
+				$text =~ s/\b_([^,;_\(\)\[\]]+?)_/replace_allergen($language,$product_ref,$1,$`)/iesg;
+			}
 
 			# allergens in all caps, with other ingredients not in all caps
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -22150,7 +22150,7 @@ cs:pšenice
 cv:тулă
 cy:gwenith
 da:hvede
-de:weizen
+de:weizen, weizen art
 dv:ގޮދަން
 el:σιτάρι
 es:trigo
@@ -30941,7 +30941,7 @@ en:wheat protein
 bg:пшеничен протеин
 ca:proteïna de blat
 cs:pšeničná bílkovina, pšeničná bilkovina
-de:Weizenprotein, Weizeneiweiß, Weizeneiweiss
+de:Weizenprotein, Weizeneiweiß, Weizeneiweiss, Weizen eiweiß
 es:Proteina de trigo
 fi:vehnäproteiini
 fr:protéine de blé, protéines de blé, protéines de froment
@@ -87042,7 +87042,7 @@ bn:সয়া সস
 ca:salsa de soia
 cs:sójová omáčka
 da:sojasovs, sojasauce
-de:Sojasauce, Sojasoße, Sojasosse, Soja Sosse, Sojasoßen, Sojasossen, Sojasaucen
+de:Sojasauce, Sojasoße, Sojasosse, Soja Sosse, Sojasoßen, Sojasossen, Sojasaucen, Soja soße
 el:Σάλτσα σόγιας
 eo:sojsaŭco
 es:salsa de soya, salsa de soja,shoyu

--- a/tests/unit/allergens.t
+++ b/tests/unit/allergens.t
@@ -518,4 +518,19 @@ detect_allergens_from_text($product_ref);
 
 is($product_ref->{ingredients_text_with_allergens_en}, "Whole Grain Oat Flakes (65.0%)");
 
+# German and underscores, see issue #8386
+$product_ref = {
+	lc => "de",
+	lang => "de",
+	ingredients_text_de =>
+		"Seitan 65% (_Weizen_eiweiß, Wasser), Rapsöl, Kidneybohnen, _Dinkel_vollkornmehl (_Weizen_art), Apfelessig, Gewürze, Tomatenmark, _Soja_soße (Wasser, _Soja_bohnen, Salz, _Weizen_mehl), Kartoffelstärke, Salz."
+};
+
+compute_languages($product_ref);
+detect_allergens_from_text($product_ref);
+
+diag explain $product_ref->{allergens_tags};
+
+is_deeply($product_ref->{allergens_tags}, ['en:gluten', 'en:soybeans',]) || diag explain $product_ref->{allergens_tags};
+
 done_testing();


### PR DESCRIPTION
### What
This is due to underscores. Replacing: "_Weizen_eiweiß" by: "Weizen eiweiß" or "Weizeneiweiß" avoids having the eggs allergen.

For other allergens, the following regex seems to work:
```
			$text
				=~ s/(^| - |_|\(|\[|\)|\]|,|$the|$and|$of|;|\.|$)((\s*)\w.+?)(?=(\s*)(^| - |_|\(|\[|\)|\]|,|$and|;|\.|\b($traces_regexp)\b|$))/replace_allergen_between_separators($language,$product_ref,$1, $2, "",$`)/iesg;
```
However, in the case of _Weizen_eiweiß it leads to 2 allergens. Hence, suggested solution is to add (for German only to minimize probability of false positive) the case when underscore after the allergen is not at the end of the word (remove \b of the previous line. This is done only for \b after the allergen, not before, again to minimize probability of false positive).

### Screenshot
![Screenshot_20231114_170812](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/44174fae-4266-4917-a086-e01f8d2b0ee9)



### Related issue(s) and discussion
- Fixes #8386

