### PR TITLE
taxonomy: insert AOP Isigny en Bresse creams under proper parent

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -45898,7 +45898,7 @@ fr:Crèmes fraîches
 nl:Cremes fraiches
 
 #AOP French cream, it contains no additives and have at least 35% fat.
-<fr:Crèmes épaisses
+<fr:Crèmes épaisses entières
 <fr:Crèmes entières
 fr:Crème Fraîche d'Isigny, Crème d'Isigny
 protected_name_file_number:en: PDO-FR-0139
@@ -45906,7 +45906,7 @@ protected_name_type:en: pdo
 origins:en: en:France
 wikidata:en:Q3006030
 
-<en:Creams
+<fr:Crèmes épaisses entières
 fr:Crème de Bresse
 protected_name_file_number:en: PDO-FR-1046
 protected_name_type:en: pdo


### PR DESCRIPTION
Insert AOP Isigny en Bresse creams under the proper Agribalyse parent : fr:Crèmes épaisses entières