### PR TITLE
feat: dq_all_val_in_nutrition_are_identical

### DIFF
--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -419,368 +419,423 @@ description:en:Docosahexaenoic acid value is over 105g per 100g, which is imposs
 en:Nutrition value over 105 - Docosahexaenoic acid dha 22 6 n 3
 description:en:Docosahexaenoic acid dha 22 6 n 3 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - EN vitamin d2
 description:en:EN vitamin d2 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Eicosapentaenoic acid
 description:en:Eicosapentaenoic acid value is over 1000g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Eicosapentaenoic acid epa 20 5 n 3
 description:en:Eicosapentaenoic acid epa 20 5 n 3 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fat
 description:en:Fat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fat prepared
 description:en:Fat prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fiber
 description:en:Fiber value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fiber prepared
 description:en:Fiber prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fluoride
 description:en:Fluoride value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Folates
 description:en:Folates value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fruits vegetables nuts and rapeseed walnut and olive oils
 description:en:Fruits vegetables nuts and rapeseed walnut and olive oils value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Fruits vegetables nuts estimate from ingredients
 description:en:Fruits vegetables nuts estimate from ingredients value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Gondoic acid
 description:en:Gondoic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Hydrogencarbonat
 description:en:Hydrogencarbonat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Iodine
 description:en:Iodine value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Iron
 description:en:Iron value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Kohlendioxid
 description:en:Kohlendioxid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Lactose
 description:en:Lactose value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Lauric acid
 description:en:Lauric acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Lignoceric acid
 description:en:Lignoceric acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Linoleic acid
 description:en:Linoleic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Magnesium
 description:en:Magnesium value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Magnesium 54 7 DE AJR
 description:en:magnesium 54 7 DE AJR is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Maltodextrins
 description:en:Maltodextrins value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Maltose
 description:en: Maltose value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Manganese
 description:en:Manganese value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Melissic acid
 description:en:Melissic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Molybdenum
 description:en:Molybdenum value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Monounsaturated fat
 description:en:Monounsaturated fat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Montanic acid
 description:en:Montanic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Myristic acid
 description:en:Myristic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - NL droogrest
 description:en:NL droogrest value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - New 1 prepared
 description:en:New 1 prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - New 2 prepared
 description:en:New 2 prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Nucleotides
 description:en:Nucleotides value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Oleic acid
 description:en:Oleic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Omega 3 fat
 description:en:Omega 3 fat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Omega 3 fat prepared
 description:en:Omega 3 fat prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Omega 6 fat
 description:en:Omega 6 fat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Omega 9 fat
 description:en:Omega-9 fats are over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Palmitic acid
 description:en:Palmitic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Pantothenic acid
 description:en:Pantothenic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Phosphorus
 description:en:Phosphorus value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Polyols
 description:en:Polyols value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Polyols prepared
 description:en:Polyols prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Polyunsaturated fat
 description:en: Polyunsaturated fat are over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Potassium
 description:en:Potassium value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Pro vitamin a
 description:en:Pro vitamin a value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Proteins
 description:en:Proteins value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Proteins prepared
 description:en:Proteins prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Residu sec
 description:en:Residu sec value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Salt
 description:en:Salt value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Salt prepared
 description:en:Salt prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Saturated fat
 description:en:Saturated fat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Saturated fat prepared
 description:en:Saturated fat prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Selenium
 description:en:Selenium value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Serum proteins
 description:en:Serum proteins value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Silica
 description:en:Silica value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Sodium
 description:en:Sodium value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Sodium prepared
 description:en:Sodium prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Starch
 description:en:Starch value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Stearic acid
 description:en:Stearic acid value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Sucrose
 description:en:Sucrose value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Sugars
 description:en:Sugars value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Sugars prepared
 description:en:Sugars prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Taurine
 description:en:Taurine value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Till 100 g färdig produkt har x g kött använts
 description:en:Till 100 g färdig produkt har x g kött använts value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Total carbohydrate
 description:en:Total carbohydrate value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Trans fat
 description:en:Trans fat value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin B1
 description:en:Vitamin B1 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin B12
 description:en:Vitamin B12 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin B2
 description:en:Vitamin B2 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin B6
 description:en:Vitamin B6 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin B9
 description:en:Vitamin B9 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin D3
 description:en:Vitamin D3 value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin PP
 description:en:Vitamin PP value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin a
 description:en:Vitamin a value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin a prepared
 description:en:Vitamin a prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin c
 description:en:Vitamin c value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin d
 description:en:Vitamin d value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin d prepared
 description:en:Vitamin d prepared value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin e
 description:en:Vitamin e value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Vitamin k
 description:en:Vitamin k value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Water hardness
 description:en:Water hardness value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 105 - Zinc
 description:en:Zinc value is over 105g per 100g, which is impossible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value over 3800 - Energy
 es:Valor nutricional superior a 3800 - Energía
 fr:Valeur nutritionnelle supérieure à 3800 - Energie
 description:en:The energy value per 100 g or 100 ml is greater than 3800 kJ, which is not possible.
 description:fr:La valeur de l'énergie pour 100 g ou 100 ml est supérieure à 3800 kJ, ce qui n'est pas possible.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value total over 1000
 es:Valor nutricional total superior a 1000
 fr:Total des valeurs nutritionnelles supérieur à 1000
 description:en:The sum of nutrient values for 100 g or 100 ml is greater than 1000 g. There is at least one value or unit error.
 description:fr:La somme des valeurs nutritionnelles pour 100 g ou 100 ml est supérieure à 1000 g. Il y a au moins une erreur de valeur ou d'unité.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Nutrition value total over 105
 es:Valor nutricional total superior a 105
 fr:Total des valeurs nutritionnelles supérieur à 105
 description:en:The sum of nutrient values for 100 g or 100 ml is greater than 100 g. It is very likely that there is at least one value or unit error.
 description:fr:La somme des valeurs nutritionnelles pour 100 g ou 100 ml est supérieure à 100 g. Il est très probable qu'il y a au moins une erreur de valeur ou d'unité.
 
-<en:Nutrition Error
+<en:Nutrition errors
 en:Serving size is missing digits
 fr:La taille de portion manque d'un nombre
 description:en:The serving size should be a size with digits. Eg. "10 g", "250 ml", "2 fl oz"...
 description:fr:La taille de portion devrait contenir un nombre. Par exemple : "10 g", "250 ml", "2 biscuits de 30 g", etc.
+
+<en:Nutrition errors
+en:Nutrition values are all identical
+description:en:Nutrition values have to be reviewed because it should not have all same values
+
+
+## Ingredients
+
+<en:Data quality errors
+en:Ingredients errors
+description:en: There might be an issue with ingredients
+show_on_producers_platform:en:yes
+marker_type:en: error
+
+<en:Ingredients errors
+en:nutri-score-grade-from-category-does-not-match-calculated-grade
+description:en: The calculated nutriscore grade is different than the one expected for this category
+fix_action:en: add_nutrition_facts
+
+<en:Ingredients errors
+en:ingredients-single-ingredient-from-category-does-not-match-actual-ingredients
+description:en: This category expect a single and specific ingredient
+fix_action:en: add_ingredients_text
+
+
+### Labels
+
+<en:Data quality errors
+en:vegan-label-but-non-vegan-ingredient
+description:en:This product has a vegan label but contains non-vegan ingredients.
+
+<en:Data quality errors
+en:vegetarian-label-but-non-vegetarian-ingredient
+description:en:This product has a vegetarian label but contains non-vegetarian ingredients.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 ## --------------- Then data quality warnings
@@ -924,22 +979,6 @@ description:en:Fibers are mentioned on nutrition photos, but are not present in 
 
 
 ## Ingredients
-
-<en:Data quality errors
-en:Ingredients errors
-description:en: There might be an issue with ingredients
-show_on_producers_platform:en:yes
-marker_type:en: error
-
-<en:Ingredients errors
-en:nutri-score-grade-from-category-does-not-match-calculated-grade
-description:en: The calculated nutriscore grade is different than the one expected for this category
-fix_action:en: add_nutrition_facts
-
-<en:Ingredients errors
-en:ingredients-single-ingredient-from-category-does-not-match-actual-ingredients
-description:en: This category expect a single and specific ingredient
-fix_action:en: add_ingredients_text
 
 <en:Data quality warnings
 en:Ingredients warnings
@@ -2861,14 +2900,6 @@ en:Carbon footprint from known ingredients more than from meat or fish
 
 
 ### Labels
-
-<en:Data quality errors
-en:vegan-label-but-non-vegan-ingredient
-description:en:This product has a vegan label but contains non-vegan ingredients.
-
-<en:Data quality errors
-en:vegetarian-label-but-non-vegetarian-ingredient
-description:en:This product has a vegetarian label but contains non-vegetarian ingredients.
 
 <en:Data quality warnings
 en:vegan-label-but-could-not-confirm-for-all-ingredients 

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -692,6 +692,45 @@ check_quality_and_test_product_has_quality_tag(
 	'en:nutrition-3-or-more-values-are-identical',
 	'3 or more identical values and above 1 in the nutrition table', 1
 );
+# en:nutrition-values-are-all-identical
+$product_ref = {
+	nutriments => {
+		"energy-kj_100g" => 0,
+		"energy-kcal_100g" => 0,
+		"fat_100g" => 0,
+		"saturated-fat_100g" => 0,
+		"carbohydrates_100g" => 0,
+		"sugars_100g" => 0,
+		"fibers_100g" => 0,
+		"proteins_100g" => 0,
+		"salt_100g" => 0,
+		"sodium_100g" => 0,
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-values-are-all-identical',
+	'all identical values and above 1 in the nutrition table', 1
+);
+$product_ref = {
+	nutriments => {
+		"energy-kj_100g" => 1,
+		"energy-kcal_100g" => 0,
+		"fat_100g" => 0,
+		"saturated-fat_100g" => 0,
+		"carbohydrates_100g" => 0,
+		"sugars_100g" => 0,
+		"fibers_100g" => 0,
+		"proteins_100g" => 0,
+		"salt_100g" => 0,
+		"sodium_100g" => 0,
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-values-are-all-identical',
+	'all identical values and above 1 in the nutrition table', 0
+);
 
 # sum of fructose plus glucose plus maltose plus lactose plus sucrose cannot be greater than sugars
 $product_ref = {nutriments => {}};


### PR DESCRIPTION
### What
New error, when all values in the nutrition table are equal.
Note that it can happen only when they are equal to 0 because otherwise salt and sodium values are automatically calculated from each other's value.

Additionally, not coherent naming in the data quality taxonomy (Error vs errrors) + noticed that the first part of the file lists errors and second part lists warnings, but some errors were listed in the second part, so I moved them up to the first part.

### Screenshot
![Screenshot_20231114_234657](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/a35515c4-b2f9-4289-b6aa-68f5d3e52ee6)



### Related issue(s) and discussion
- Fixes #1564

