### PR TITLE
fix: dq prevent split and when percent

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2101,7 +2101,7 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 		my @ingredients = ();
 
 		# 2 known ingredients separated by "and" ?
-		if ($before =~ /$and/i) {
+		if (($before =~ /$and/i) and (not defined $percent_or_quantity_value)) {
 
 			my $ingredient = $before;
 			my $ingredient1 = $`;

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-a-and-ingredient-b-and-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-a-and-ingredient-b-and-percent.json
@@ -1,0 +1,31 @@
+[
+   {
+      "id" : "fr:pulpe-de-tomates-et-purees-de-tomates",
+      "percent" : 81,
+      "percent_estimate" : 81,
+      "percent_max" : 81,
+      "percent_min" : 81,
+      "text" : "Pulpe de tomates et purées de tomates"
+   },
+   {
+      "id" : "en:water",
+      "percent_estimate" : 12.6666666666667,
+      "percent_max" : 19,
+      "percent_min" : 6.33333333333333,
+      "text" : "eau"
+   },
+   {
+      "id" : "en:salt",
+      "percent_estimate" : 3.16666666666666,
+      "percent_max" : 12.6666666666667,
+      "percent_min" : 0,
+      "text" : "sel"
+   },
+   {
+      "id" : "en:pepper",
+      "percent_estimate" : 3.16666666666666,
+      "percent_max" : 6.33333333333334,
+      "percent_min" : 0,
+      "text" : "poivre"
+   }
+]

--- a/tests/unit/expected_test_results/ingredients_percent/ingredient-a-and-ingredient-b-without-percent.json
+++ b/tests/unit/expected_test_results/ingredients_percent/ingredient-a-and-ingredient-b-without-percent.json
@@ -1,0 +1,37 @@
+[
+   {
+      "id" : "en:tomato-pulp",
+      "percent_estimate" : 60,
+      "percent_max" : 100,
+      "percent_min" : 20,
+      "text" : "Pulpe de tomates"
+   },
+   {
+      "id" : "en:tomato-puree",
+      "percent_estimate" : 20,
+      "percent_max" : 50,
+      "percent_min" : 0,
+      "text" : "purées de tomates"
+   },
+   {
+      "id" : "en:water",
+      "percent_estimate" : 10,
+      "percent_max" : 33.3333333333333,
+      "percent_min" : 0,
+      "text" : "eau"
+   },
+   {
+      "id" : "en:salt",
+      "percent_estimate" : 5,
+      "percent_max" : 25,
+      "percent_min" : 0,
+      "text" : "sel"
+   },
+   {
+      "id" : "en:pepper",
+      "percent_estimate" : 5,
+      "percent_max" : 20,
+      "percent_min" : 0,
+      "text" : "poivre"
+   }
+]

--- a/tests/unit/ingredients_percent.t
+++ b/tests/unit/ingredients_percent.t
@@ -251,6 +251,16 @@ my @tests = (
 			},
 		},
 	],
+
+	# Ingredient A and Ingredient B (81%)
+	[
+		'ingredient-a-and-ingredient-b-and-percent',
+		{lc => "fr", ingredients_text => "Pulpe de tomates et purées de tomates (81%), eau, sel et poivre."},
+	],
+	[
+		'ingredient-a-and-ingredient-b-without-percent',
+		{lc => "fr", ingredients_text => "Pulpe de tomates et purées de tomates, eau, sel et poivre."},
+	],
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
### What
do no split "Ingredient A and Ingredient B (81%)" to "Ingredient A (81%), Ingredient B (81%)"

### Screenshot
![Screenshot_20231117_175722](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/6eba42ed-4de2-442e-ba01-15af3bdf256d)


### Related issue(s) and discussion
- Fixes #7816 