### PR TITLE
feat: dq_kcal_does_not_match_exclude_more

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -597,7 +597,14 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 			my ($ignore_energy_calculated_error, $category_id)
 				= get_inherited_property_from_categories_tags($product_ref, "ignore_energy_calculated_error:en");
 
-			if (not((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))) {
+			if (
+				(
+					not((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))
+					and (  ($product_ref->{nutriments}{"energy-kj_value"} > 55)
+						or ($product_ref->{nutriments}{"energy-kcal_value"} > 13))
+				)
+				)
+			{
 				# Compare to specified energy value with a tolerance of 30% + an additiontal tolerance of 5
 				if (   ($computed_energy < ($specified_energy * 0.7 - 5))
 					or ($computed_energy > ($specified_energy * 1.3 + 5)))

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -601,8 +601,12 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 				(
 					not((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))
 					# consider only when energy is high enough to minimize false positives (issue #7789)
-					and (  ($product_ref->{nutriments}{"energy-kj_value"} > 55)
-						or ($product_ref->{nutriments}{"energy-kcal_value"} > 13))
+					# consider either computed_energy or energy input by contributor, to avoid when the energy is 5, but it should be 1500
+					and (
+						(($unit eq "kj") and (($specified_energy > 55) or ($computed_energy > 55)))
+						or (    ($unit eq "kcal")
+							and (($specified_energy > 13) or ($computed_energy > 13)))
+					)
 				)
 				)
 			{

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -600,6 +600,7 @@ sub check_nutrition_data_energy_computation ($product_ref) {
 			if (
 				(
 					not((defined $ignore_energy_calculated_error) and ($ignore_energy_calculated_error eq 'yes'))
+					# consider only when energy is high enough to minimize false positives (issue #7789)
 					and (  ($product_ref->{nutriments}{"energy-kj_value"} > 55)
 						or ($product_ref->{nutriments}{"energy-kcal_value"} > 13))
 				)

--- a/stop_words.txt
+++ b/stop_words.txt
@@ -21,6 +21,7 @@ aromatisées
 arôme
 auth
 autocomplete
+autocompletion
 backend
 backticks
 barcode
@@ -59,6 +60,7 @@ dataset
 datasets
 de
 dont
+dropdown
 ecoscore
 eg
 emb
@@ -139,6 +141,7 @@ malus
 margarines
 matche
 md
+memcached
 métal
 microservice
 microservices

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -92455,6 +92455,7 @@ th:ใช้น้ำตาลเทียม
 tr:Tatlandırıcı, Tatlandırıcılar
 zh:糖精
 wikidata:en:Q4368298
+ignore_energy_calculated_error:en:yes
 
 <en:Sweeteners
 en:Sugars

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -399,17 +399,19 @@ ok(
 $product_ref = {
 	categories_tags => ['en:sweet-spreads'],
 	nutriments => {
-		"energy-kj_value" => 5,
-		"carbohydrates_value" => 10,
-		"fat_value" => 20,
-		"proteins_value" => 30,
-		"fiber_value" => 2,
+		"energy-kj_value" => 8,
+		"fat_value" => 0.5,
+		"saturated-fat_value" => 0.1,
+		"carbohydrates_value" => 0.5,
+		"sugars_value" => 0.5,
+		"proteins_value" => 0.5,
+		"salt_value" => 0.01,
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
-	'energy not matching nutrients but energy is lower tha 55 kj'
+	'energy not matching nutrients but energy is lower than 55 kj'
 ) or diag explain $product_ref;
 
 # energy matches nutrients
@@ -441,7 +443,7 @@ $product_ref = {
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 ok(
-	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
 	'energy not matching nutrients - polyols'
 ) or diag explain $product_ref;
 
@@ -495,7 +497,7 @@ $product_ref = {
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 ok(
-	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
 	'energy not matching nutrient but lower than 55 kj'
 ) or diag explain $product_ref;
 

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -442,10 +442,9 @@ $product_ref = {
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-ok(
-	has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
-	'energy not matching nutrients - polyols'
-) or diag explain $product_ref;
+ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrients - polyols')
+	or diag explain $product_ref;
 
 # Erythritol is a polyol which does not contribute to energy
 $product_ref = {
@@ -496,10 +495,9 @@ $product_ref = {
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-ok(
-	has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
-	'energy not matching nutrient but lower than 55 kj'
-) or diag explain $product_ref;
+ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrient but lower than 55 kj')
+	or diag explain $product_ref;
 
 # Erythritol is a polyol which does not contribute to energy
 $product_ref = {

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -349,15 +349,15 @@ ok(has_tag($product_ref, 'data_quality', 'en:sum-of-ingredients-with-specified-p
 # energy does not match nutrients
 $product_ref = {
 	nutriments => {
-		"energy-kj_value" => 5,
-		"carbohydrates_value" => 10,
+		"energy-kj_value" => 56,
+		"carbohydrates_value" => 100,
 		"fat_value" => 20,
 		"proteins_value" => 30,
 		"fiber_value" => 2,
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-is($product_ref->{nutriments}{"energy-kj_value_computed"}, 1436);
+is($product_ref->{nutriments}{"energy-kj_value_computed"}, 2966);
 ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
 	'energy not matching nutrients')
 	or diag explain $product_ref;
@@ -366,7 +366,23 @@ ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-v
 $product_ref = {
 	categories_tags => ['en:squeezed-lemon-juices'],
 	nutriments => {
-		"energy-kj_value" => 5,
+		"energy-kj_value" => 550,
+		"carbohydrates_value" => 10,
+		"fat_value" => 20,
+		"proteins_value" => 30,
+		"fiber_value" => 2,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrients but category possesses ignore_energy_calculated_error:en:yes tag'
+) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:sweeteners'],
+	nutriments => {
+		"energy-kj_value" => 550,
 		"carbohydrates_value" => 10,
 		"fat_value" => 20,
 		"proteins_value" => 30,
@@ -378,6 +394,22 @@ is($product_ref->{nutriments}{"energy-kj_value_computed"}, 1436);
 ok(
 	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
 	'energy not matching nutrients but category possesses ignore_energy_calculated_error:en:yes tag'
+) or diag explain $product_ref;
+
+$product_ref = {
+	categories_tags => ['en:sweet-spreads'],
+	nutriments => {
+		"energy-kj_value" => 5,
+		"carbohydrates_value" => 10,
+		"fat_value" => 20,
+		"proteins_value" => 30,
+		"fiber_value" => 2,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrients but energy is lower tha 55 kj'
 ) or diag explain $product_ref;
 
 # energy matches nutrients
@@ -408,7 +440,7 @@ $product_ref = {
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+ok(!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
 	'energy not matching nutrients - polyols')
 	or diag explain $product_ref;
 
@@ -461,8 +493,8 @@ $product_ref = {
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
-	'energy not matching nutrient')
+ok(!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrient but lower than 55 kj')
 	or diag explain $product_ref;
 
 # Erythritol is a polyol which does not contribute to energy

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -349,7 +349,7 @@ ok(has_tag($product_ref, 'data_quality', 'en:sum-of-ingredients-with-specified-p
 # energy does not match nutrients
 $product_ref = {
 	nutriments => {
-		"energy-kj_value" => 56,
+		"energy-kj_value" => 5,
 		"carbohydrates_value" => 10,
 		"fat_value" => 20,
 		"proteins_value" => 30,
@@ -366,7 +366,7 @@ ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-v
 $product_ref = {
 	categories_tags => ['en:squeezed-lemon-juices'],
 	nutriments => {
-		"energy-kj_value" => 550,
+		"energy-kj_value" => 5,
 		"carbohydrates_value" => 10,
 		"fat_value" => 20,
 		"proteins_value" => 30,

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -350,14 +350,14 @@ ok(has_tag($product_ref, 'data_quality', 'en:sum-of-ingredients-with-specified-p
 $product_ref = {
 	nutriments => {
 		"energy-kj_value" => 56,
-		"carbohydrates_value" => 100,
+		"carbohydrates_value" => 10,
 		"fat_value" => 20,
 		"proteins_value" => 30,
 		"fiber_value" => 2,
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-is($product_ref->{nutriments}{"energy-kj_value_computed"}, 2966);
+is($product_ref->{nutriments}{"energy-kj_value_computed"}, 1436);
 ok(has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
 	'energy not matching nutrients')
 	or diag explain $product_ref;

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -440,9 +440,10 @@ $product_ref = {
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-ok(!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
-	'energy not matching nutrients - polyols')
-	or diag explain $product_ref;
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrients - polyols'
+) or diag explain $product_ref;
 
 # Erythritol is a polyol which does not contribute to energy
 $product_ref = {
@@ -493,9 +494,10 @@ $product_ref = {
 	}
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-ok(!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
-	'energy not matching nutrient but lower than 55 kj')
-	or diag explain $product_ref;
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients'),
+	'energy not matching nutrient but lower than 55 kj'
+) or diag explain $product_ref;
 
 # Erythritol is a polyol which does not contribute to energy
 $product_ref = {


### PR DESCRIPTION
### What
Need to be reviewed carefully.
- See comments in the issue
- see how tests had to be updated (for polyols and erythritol)
- note that honeys category is under sweeteners and en:energy-value-in-kj-does-not-match-value-computed-from-other-nutrients will be shutdown for those as well

### Related issue(s) and discussion
- Fixes #7789