### PR TITLE
taxonomy: fixes in category taxonomy

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -61203,8 +61203,8 @@ ciqual_food_name:en:Red berries (raspberries, strawberries, red currants, black 
 ciqual_food_name:fr:Fruits rouges, crus (framboises, fraises, groseilles, cassis)
 
 <en:Berries
+<en:blueberries
 en:Bilberries
-fr:Myrtilles, Myrtille
 nl:Bessen
 lt:Šilauogės
 wikidata:en:Q60708120
@@ -61546,7 +61546,7 @@ ro:Grepfrut, Grepfruturi
 
 <en:Grapefruits
 en:Fresh grapefruits
-fr:Pomélos frais
+fr:Pomélos frais, pomélo frais
 de:Frische Grapefruits
 lt:Švieži greipfrutai
 
@@ -61559,9 +61559,6 @@ ja:ブンタン
 la:Citrus maxima
 lt:Pomelo greipfrutai, Didieji greipfrutai Pomelo
 nl:Grapefruits
-
-<en:Pomelos
-fr:Pomélos frais, Pomelos frais
 
 <en:Fresh pomelos
 en:Corsican pomelos
@@ -96238,8 +96235,8 @@ ciqual_food_name:fr:Courge melonnette, pulpe, crue
 
 <en:Pumpkins
 en:Pattypan squash
-fr:Pâtisson, Patisson
-de:Patisson
+fr:Pâtissons, Patissons
+de:Patissons
 wikidata:en:Q876892
 agribalyse_proxy_food_code:en:20136
 agribalyse_proxy_food_name:fr:Courge melonnette, pulpe, crue
@@ -96247,7 +96244,7 @@ agribalyse_proxy_food_name:fr:Courge melonnette, pulpe, crue
 <en:Pumpkins
 <en:Cooked vegetables
 en:Cooked pumpkins
-fr:Potirons cuits
+fr:Potirons cuits, potiron cuit
 agribalyse_food_code:en:20096
 ciqual_food_code:en:20096
 ciqual_food_name:en:Pumpkin, cooked
@@ -96264,7 +96261,7 @@ ciqual_food_name:fr:Potiron, appertisé, égoutté
 <en:Pumpkins
 <en:Fresh vegetables
 en:Fresh pumpkins
-fr:Courges fraîches
+fr:Citrouilles fraîches, citrouille fraîche
 season_in_country_fr:en: 1,9,10,11,12
 
 <en:Pumpkins
@@ -96282,7 +96279,7 @@ ciqual_food_name:fr:Courge doubeurre (butternut), pulpe, crue
 <en:Pumpkins
 en:Spaghetti squashes, Spaghetti squash
 es:Calabazas espagueti, Calabazas spaghetti
-fr:Courges spaghetti
+fr:Courges spaghetti, courge spaghetti
 nl:Spaghettipompoenen
 wikidata:en:Q2142043
 

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -60185,7 +60185,7 @@ en:Belgian fruits
 fr:Fruits belges
 lt:Belgiški vaisiai
 
-<en:Fruits
+<en:Vegetables
 en:Belgian vegetables
 fr:Légumes belges
 lt:Belgiškos daržovės
@@ -60223,7 +60223,7 @@ en:Dutch fruits
 fr:Fruits néerlandais
 lt:Nyderlandiški vaisiai
 
-<en:Fruits
+<en:Vegetables
 en:Dutch vegetables
 fr:Légumes néerlandais
 lt:Nyderlandiškos daržovės
@@ -60311,6 +60311,7 @@ origins:en: en:Austria
 <en:British fruit
 <en:Apples
 en:Armagh Bramley Apples
+fr:Pommes Bramley, Bramley
 protected_name_file_number:en: PGI-GB-0792
 protected_name_type:en: pgi
 origins:en: en:United Kingdom
@@ -60318,6 +60319,7 @@ origins:en: en:United Kingdom
 
 <en:Fruits
 en:German vegetables
+fr:Fruits allemands
 lt:Vokiškos daržovės
 
 <en:German vegetables
@@ -61029,6 +61031,7 @@ ciqual_food_name:fr:Pomme Golden, pulpe et peau, crue
 
 <en:Apples
 en:Elstar apples
+fr:Pommes Elstar, Elstar
 nl:Elstar
 
 <en:Apples
@@ -61201,6 +61204,7 @@ ciqual_food_name:fr:Fruits rouges, crus (framboises, fraises, groseilles, cassis
 
 <en:Berries
 en:Bilberries
+fr:Myrtilles, Myrtille
 nl:Bessen
 lt:Šilauogės
 wikidata:en:Q60708120
@@ -61211,6 +61215,7 @@ es:Arándanos comunes
 la:Vaccinium myrtillus
 lt:Paprastosios šilauogės
 nl:Blauwe bosbessen
+xx:Vaccinium myrtillus
 
 <en:Bilberries
 en:Bog bilberries, Northern bilberries
@@ -61541,6 +61546,7 @@ ro:Grepfrut, Grepfruturi
 
 <en:Grapefruits
 en:Fresh grapefruits
+fr:Pomélos frais
 de:Frische Grapefruits
 lt:Švieži greipfrutai
 
@@ -62441,6 +62447,7 @@ wikidata:en:Q3899627
 <en:Pears
 en:Conference pears
 nl:Conference peren
+fr:Poires Conférence, Conférence
 
 <en:Pears
 <en:Fresh fruits
@@ -78886,7 +78893,7 @@ jv:Pitik
 ka:ქათამი
 kg:Nsusu
 kk:Тауық
-km:کۄکَر
+km:សាច់​មាន់
 kn:ಕೋಳಿ
 ko:닭
 ku:Mirîşk
@@ -83113,7 +83120,7 @@ nl:Gesneden oesterzwammen
 <en:Oyster mushrooms
 en:Whole oyster mushrooms
 es:Setas de ostra enteras
-fr:Pleurotes en huître entiers
+fr:Pleurotes entiers, Pleurotes en huître entiers
 nl:Hele oesterzwammen
 
 <en:Mushrooms
@@ -83324,7 +83331,7 @@ fr:Champignons nameko en conserve, Nameko en conserve, Pholiota nameko en conser
 <en:Canned mushrooms
 en:Canned oyster mushrooms, Canned Pleurotus ostreatus
 es:Setas de ostra en conserva, Setas ostra en conserva, Champiñones ostra en conserva, Gírgolas en conserva, Pleurotus ostreatus en conserva
-fr:Pleurotes en huître en conserve, Pleurotus ostreatus en conserve
+fr:Pleurotes en conserve, Pleurotes en huître en conserve, Pleurotus ostreatus en conserve
 nl:Oesterzwammen in blik/pot
 
 <en:Canned mushrooms
@@ -94231,6 +94238,7 @@ nl:Okras
 <en:Okras
 en:Okra powders
 nl:Okrapoeders
+fr:Poudres de gombo, Gombo en poudre
 
 <en:Vegetables
 en:Jackfruit
@@ -94618,6 +94626,7 @@ season_in_country_fr:en: 1,2,3,10,11,12
 <en:Leaf vegetables
 en:Collard greens, Collard
 ja:カラードグリーン
+fr:Chou cavalier
 wikidata:en:Q14879985
 
 <en:Vegetable rods
@@ -96255,7 +96264,7 @@ ciqual_food_name:fr:Potiron, appertisé, égoutté
 <en:Pumpkins
 <en:Fresh vegetables
 en:Fresh pumpkins
-en:Courges fraîches
+fr:Courges fraîches
 season_in_country_fr:en: 1,9,10,11,12
 
 <en:Pumpkins


### PR DESCRIPTION
Fixes in category taxonomy:

- wrong translation for chicken in Khmer
- add fr translations for some vegetables/fruits
- wrong parents for some categories