### PR TITLE
fix: og-url for donate page to get correct Facebook share preview, change meta title

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -529,6 +529,7 @@ Web:
 - html/donate/tt.html
 - templates/web/common/includes/donate_banner.tt.html
 - html/donate/fr.helloasso.html
+- html/donate/en.html
 
 ✏️ Editing:
 - templates/web/pages/product_edit/product_edit_form.tt.html

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -9,10 +9,10 @@
 
     <meta property="fb:app_id" content="219331381518041" />
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="Help us fund the Open Food Facts 2024 budget!" />
+    <meta property="og:title" content="Help us lead the change in the food sector!" />
     <meta
       property="og:url"
-      content="https://world.openfoodfacts.org/donate-to-openfoodfacts"
+      content="https://world.openfoodfacts.org/donate-to-open-food-facts"
     />
     <meta
       property="og:image"

--- a/html/donate/en.html
+++ b/html/donate/en.html
@@ -12,7 +12,7 @@
     <meta property="og:title" content="Help us lead the change in the food sector!" />
     <meta
       property="og:url"
-      content="https://world.openfoodfacts.org/donate-to-open-food-facts"
+      content="https://world.openfoodfacts.org/donate-to-open-food-facts?utm_source=donate-page-share&utm_campaign=donation-2024&utm_content=donate-page-share-en"
     />
     <meta
       property="og:image"


### PR DESCRIPTION
The broken og:url results in a big "Error" when sharing the donation page on Facebook.