### PR TITLE
docs: improve OpenAPI documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -188,6 +188,7 @@ footer:
 
 OpenAPI:
 - docs/assets/api-rapidoc.html
+- docs/api/ref/schemas/product_base.yaml
 
 🐋 Docker:
 - docker/**/*

--- a/docs/api/ref/schemas/product_base.yaml
+++ b/docs/api/ref/schemas/product_base.yaml
@@ -67,7 +67,7 @@ properties:
     description: |
       The name of the product can also
       be in many other languages like
-      product_name_fr (for french).
+      product_name_fr (for French).
   product_quantity:
     type: string
     description: |

--- a/docs/api/ref/schemas/product_base.yaml
+++ b/docs/api/ref/schemas/product_base.yaml
@@ -70,6 +70,10 @@ properties:
       product_name_fr (for french).
   product_quantity:
     type: string
+    description: |
+      The size in g or ml for the whole product.
+      It's a normalized version of the quantity field.
+    example: "500"
   quantity:
     type: string
     description: |

--- a/docs/api/ref/schemas/product_base.yaml
+++ b/docs/api/ref/schemas/product_base.yaml
@@ -88,4 +88,4 @@ patternProperties:
     type: string
     description: |
       This can be returned in many other languages
-      like generic_name_fr (for french).
+      like generic_name_fr (for French).


### PR DESCRIPTION
add description and example for `product_quantity` field.