### PR TITLE
fix: fix gen_feeds timers

### DIFF
--- a/conf/systemd/gen_feeds@.timer
+++ b/conf/systemd/gen_feeds@.timer
@@ -8,4 +8,4 @@ OnCalendar=0/2:35
 Unit=gen_feeds@%i.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/conf/systemd/gen_feeds_daily@.timer
+++ b/conf/systemd/gen_feeds_daily@.timer
@@ -8,4 +8,4 @@ OnCalendar=1:30
 Unit=gen_feeds_daily@%i.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target


### PR DESCRIPTION
There is a bad target for timers ! They won't run as wanted !

Before doing the change:
```bash
sudo systemctl disable gen_feeds@opff.timer gen_feeds_daily@opff.timer 
```

After the change:
```bash
sudo systemctl daemon reload
sudo systemctl enbale gen_feeds@opff.timer gen_feeds_daily@opff.timer 

# verify
sudo systemctl list-timers
```