### PR TITLE
fix: fix gen_feeds timers install target

### DIFF
--- a/conf/systemd/gen_feeds@.timer
+++ b/conf/systemd/gen_feeds@.timer
@@ -8,4 +8,4 @@ OnCalendar=0/2:35
 Unit=gen_feeds@%i.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/conf/systemd/gen_feeds_daily@.timer
+++ b/conf/systemd/gen_feeds_daily@.timer
@@ -8,4 +8,4 @@ OnCalendar=1:00
 Unit=gen_feeds_daily@%i.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target


### PR DESCRIPTION
Before doing the change:
```bash
sudo systemctl disable gen_feeds@opf.timer gen_feeds_daily@opf.timer
```

After the change:
```bash
sudo systemctl daemon reload
sudo systemctl enbale gen_feeds@opf.timer gen_feeds_daily@opf.timer

\# verify
sudo systemctl list-timers
```

<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

