### PR TITLE
fix: Fix gen_feeds timers install target

### DIFF
--- a/conf/systemd/gen_feeds@.timer
+++ b/conf/systemd/gen_feeds@.timer
@@ -8,4 +8,4 @@ OnCalendar=0/2:35
 Unit=gen_feeds@%i.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/conf/systemd/gen_feeds_daily@.timer
+++ b/conf/systemd/gen_feeds_daily@.timer
@@ -8,4 +8,4 @@ OnCalendar=2:15
 Unit=gen_feeds_daily@%i.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target


### PR DESCRIPTION
Before doing the change:
```bash
export SERVICE=off  # or off-pro
sudo systemctl disable gen_feeds@$SERVICE.timer
gen_feeds_daily@$SERVICE.timer
```

After the change:
```bash
sudo systemctl daemon reload
sudo systemctl enbale gen_feeds@$SERVICE.timer
gen_feeds_daily@$SERVICE.timer

\# verify
sudo systemctl list-timers
```
