### PR TITLE
taxonomy: pommes de terre cuites à la vapeur

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -103767,7 +103767,7 @@ ciqual_food_name:fr:Pomme de terre, bouillie/cuite à l'eau
 
 <en:Boiled or steamed potatoes
 en:Steamed potatoes, steamed cooked potatoes
-fr:Pommes de terre à la vapeur, Pommes de terre cuites à la vapeur
+fr:Pommes de terre cuites à la vapeur, Pommes de terre à la vapeur
 agribalyse_proxy_food_code:en:4003
 ciqual_proxy_food_code:en:4003
 ciqual_proxy_food_name:en:Potato, boiled/cooked in water


### PR DESCRIPTION
There's already a "pommes de terre vapeur" category for potatoes that can be steamed, so renaming the one for potatoes that are already steamed.