### PR TITLE
chore: Include some files in sonarcloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.sources=cgi,docker,lib,scripts,templates,scss,html/css,html/js
+sonar.sources=cgi,docker,lib,scripts,templates,scss,html/css,html/js,docker-compose.yml,Dockerfile,Dockerfile.frontend,gulpfile.ts,Makefile


### PR DESCRIPTION
When using the SonarLint extension locally, I noticed some warnings in Dockerfile etc. Adding those to the  `sonar.sources` to get some feedback.