### PR TITLE
refactor: extend_ingredients service + ciqual_proxy_food_code

### DIFF
--- a/lib/ProductOpener/APIProductServices.pm
+++ b/lib/ProductOpener/APIProductServices.pm
@@ -104,6 +104,7 @@ sub echo_service ($product_ref, $updated_product_fields_ref) {
 my %service_functions = (
 	echo => \&echo_service,
 	parse_ingredients_text => \&ProductOpener::Ingredients::parse_ingredients_text_service,
+	extend_ingredients => \&ProductOpener::Ingredients::extend_ingredients_service,
 	estimate_ingredients_percent => \&ProductOpener::Ingredients::estimate_ingredients_percent_service,
 	analyze_ingredients => \&ProductOpener::Ingredients::analyze_ingredients_service,
 );

--- a/tests/integration/expected_test_results/api_v2_product_write/get-product-auth-good-password.json
+++ b/tests/integration/expected_test_results/api_v2_product_write/get-product-auth-good-password.json
@@ -524,6 +524,7 @@
       ],
       "ingredients" : [
          {
+            "ciqual_proxy_food_code" : "9410",
             "id" : "en:wheat-flour",
             "percent_estimate" : 62.5,
             "percent_max" : 100,
@@ -553,6 +554,7 @@
             "vegetarian" : "yes"
          },
          {
+            "ciqual_proxy_food_code" : "31016",
             "id" : "en:sugar",
             "percent_estimate" : 9.375,
             "percent_max" : 25,
@@ -618,11 +620,8 @@
       "ingredients_with_specified_percent_sum" : 0,
       "ingredients_with_unspecified_percent_n" : 4,
       "ingredients_with_unspecified_percent_sum" : 100,
-      "ingredients_without_ciqual_codes" : [
-         "en:sugar",
-         "en:wheat-flour"
-      ],
-      "ingredients_without_ciqual_codes_n" : 2,
+      "ingredients_without_ciqual_codes" : [],
+      "ingredients_without_ciqual_codes_n" : 0,
       "interface_version_created" : "20150316.jqm2",
       "interface_version_modified" : "20150316.jqm2",
       "known_ingredients_n" : 10,

--- a/tests/integration/expected_test_results/api_v2_product_write/get-product.json
+++ b/tests/integration/expected_test_results/api_v2_product_write/get-product.json
@@ -524,6 +524,7 @@
       ],
       "ingredients" : [
          {
+            "ciqual_proxy_food_code" : "9410",
             "id" : "en:wheat-flour",
             "percent_estimate" : 62.5,
             "percent_max" : 100,
@@ -553,6 +554,7 @@
             "vegetarian" : "yes"
          },
          {
+            "ciqual_proxy_food_code" : "31016",
             "id" : "en:sugar",
             "percent_estimate" : 9.375,
             "percent_max" : 25,
@@ -618,11 +620,8 @@
       "ingredients_with_specified_percent_sum" : 0,
       "ingredients_with_unspecified_percent_n" : 4,
       "ingredients_with_unspecified_percent_sum" : 100,
-      "ingredients_without_ciqual_codes" : [
-         "en:sugar",
-         "en:wheat-flour"
-      ],
-      "ingredients_without_ciqual_codes_n" : 2,
+      "ingredients_without_ciqual_codes" : [],
+      "ingredients_without_ciqual_codes_n" : 0,
       "interface_version_created" : "20150316.jqm2",
       "interface_version_modified" : "20150316.jqm2",
       "known_ingredients_n" : 10,

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-ingredients-categories-to-get-nutriscore.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-ingredients-categories-to-get-nutriscore.json
@@ -34,6 +34,7 @@
       ],
       "ingredients" : [
          {
+            "ciqual_proxy_food_code" : "31016",
             "id" : "en:sugar",
             "percent" : 75,
             "percent_estimate" : 75,

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-language-fields.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-language-fields.json
@@ -13,6 +13,7 @@
             "vegetarian" : "yes"
          },
          {
+            "ciqual_proxy_food_code" : "31016",
             "id" : "en:sugar",
             "percent_estimate" : 15,
             "percent_max" : 20,

--- a/tests/integration/expected_test_results/search_v1/search-no-filter.json
+++ b/tests/integration/expected_test_results/search_v1/search-no-filter.json
@@ -1114,6 +1114,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "9100",
                "id" : "en:rice",
                "percent_estimate" : 25,
                "percent_max" : 50,
@@ -1163,10 +1164,9 @@
          "ingredients_with_unspecified_percent_n" : 2,
          "ingredients_with_unspecified_percent_sum" : 100,
          "ingredients_without_ciqual_codes" : [
-            "en:fruit",
-            "en:rice"
+            "en:fruit"
          ],
-         "ingredients_without_ciqual_codes_n" : 2,
+         "ingredients_without_ciqual_codes_n" : 1,
          "interface_version_created" : "20150316.jqm2",
          "interface_version_modified" : "20150316.jqm2",
          "known_ingredients_n" : 2,

--- a/tests/integration/expected_test_results/search_v1/search-without-ingredients-from-palm-oil.json
+++ b/tests/integration/expected_test_results/search_v1/search-without-ingredients-from-palm-oil.json
@@ -1114,6 +1114,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "9100",
                "id" : "en:rice",
                "percent_estimate" : 25,
                "percent_max" : 50,
@@ -1163,10 +1164,9 @@
          "ingredients_with_unspecified_percent_n" : 2,
          "ingredients_with_unspecified_percent_sum" : 100,
          "ingredients_without_ciqual_codes" : [
-            "en:fruit",
-            "en:rice"
+            "en:fruit"
          ],
-         "ingredients_without_ciqual_codes_n" : 2,
+         "ingredients_without_ciqual_codes_n" : 1,
          "interface_version_created" : "20150316.jqm2",
          "interface_version_modified" : "20150316.jqm2",
          "known_ingredients_n" : 2,

--- a/tests/unit/expected_test_results/attributes/en-attributes.json
+++ b/tests/unit/expected_test_results/attributes/en-attributes.json
@@ -849,6 +849,7 @@
    },
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "origins" : "en:united-kingdom",
          "percent_estimate" : 54.5454545454545,
@@ -859,6 +860,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "origins" : "en:paraguay",
          "percent_estimate" : 12.5,
@@ -1069,11 +1071,9 @@
       "en:e102",
       "en:e120",
       "en:milk-proteins",
-      "en:rapeseed-oil",
-      "en:sugar",
-      "en:wheat-flour"
+      "en:rapeseed-oil"
    ],
-   "ingredients_without_ciqual_codes_n" : 6,
+   "ingredients_without_ciqual_codes_n" : 4,
    "known_ingredients_n" : 30,
    "labels_tags" : [
       "en:organic",

--- a/tests/unit/expected_test_results/attributes/en-nova-groups-markers.json
+++ b/tests/unit/expected_test_results/attributes/en-nova-groups-markers.json
@@ -843,6 +843,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 2.5,
          "percent_max" : "5",
@@ -946,10 +947,9 @@
       "en:cow-s-milk",
       "en:e412",
       "en:garlic-flavouring",
-      "en:microbial-culture",
-      "en:sugar"
+      "en:microbial-culture"
    ],
-   "ingredients_without_ciqual_codes_n" : 5,
+   "ingredients_without_ciqual_codes_n" : 4,
    "known_ingredients_n" : 18,
    "languages" : {},
    "languages_codes" : {},

--- a/tests/unit/expected_test_results/attributes/fr-palm-oil-free.json
+++ b/tests/unit/expected_test_results/attributes/fr-palm-oil-free.json
@@ -639,6 +639,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 9.375,
          "percent_max" : 33.3333333333333,
@@ -708,10 +709,9 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:chocolate",
-      "en:flour",
-      "en:sugar"
+      "en:flour"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 6,
    "languages" : {},
    "languages_codes" : {},

--- a/tests/unit/expected_test_results/ecoscore/category-without-ecoscore-sodas.json
+++ b/tests/unit/expected_test_results/ecoscore/category-without-ecoscore-sodas.json
@@ -253,6 +253,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 25,
          "percent_max" : 50,
@@ -295,10 +296,8 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 4,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field-multiple.json
@@ -417,6 +417,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "origins" : "en:martinique",
          "percent" : 30,
@@ -485,10 +486,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 10,
    "ingredients_without_ciqual_codes" : [
-      "en:apricot",
-      "en:cane-sugar"
+      "en:apricot"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-in-origins-field.json
@@ -413,6 +413,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "origins" : "en:martinique",
          "percent" : 30,
@@ -481,10 +482,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 10,
    "ingredients_without_ciqual_codes" : [
-      "en:apricot",
-      "en:cane-sugar"
+      "en:apricot"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-nested-2.json
@@ -520,11 +520,13 @@
    "ingredients_with_unspecified_percent_n" : 5,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
+      "en:chocolate",
       "en:cocoa",
       "en:e951",
-      "en:milk"
+      "en:milk",
+      "en:sweetener"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 5,
    "known_ingredients_n" : 9,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-nested.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-nested.json
@@ -479,10 +479,11 @@
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
+      "en:colour",
       "en:e160b",
       "en:milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 5,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-not-specified.json
@@ -410,6 +410,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "percent" : 30,
          "percent_estimate" : 30,
@@ -477,10 +478,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 10,
    "ingredients_without_ciqual_codes" : [
-      "en:apricot",
-      "en:cane-sugar"
+      "en:apricot"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-partly-specified.json
@@ -413,6 +413,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "percent" : 30,
          "percent_estimate" : 30,
@@ -480,10 +481,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 10,
    "ingredients_without_ciqual_codes" : [
-      "en:apricot",
-      "en:cane-sugar"
+      "en:apricot"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-specified-multiple.json
@@ -429,6 +429,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "origins" : "en:martinique,en:guadeloupe,en:dominican-republic",
          "percent" : 30,
@@ -497,10 +498,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 10,
    "ingredients_without_ciqual_codes" : [
-      "en:apricot",
-      "en:cane-sugar"
+      "en:apricot"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-specified.json
+++ b/tests/unit/expected_test_results/ecoscore/origins-of-ingredients-specified.json
@@ -418,6 +418,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "origins" : "en:martinique",
          "percent" : 30,
@@ -487,10 +488,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 10,
    "ingredients_without_ciqual_codes" : [
-      "en:apricot",
-      "en:cane-sugar"
+      "en:apricot"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/forest_footprint/fr-ingredients-nested-matching-ingredient.json
+++ b/tests/unit/expected_test_results/forest_footprint/fr-ingredients-nested-matching-ingredient.json
@@ -23,6 +23,7 @@
    },
    "ingredients" : [
       {
+         "ciqual_food_code" : "36005",
          "id" : "fr:viande-de-poulet-traitee-en-salaison",
          "ingredients" : [
             {

--- a/tests/unit/expected_test_results/forest_footprint/fr-ingredients-nested-matching-sub-ingredient.json
+++ b/tests/unit/expected_test_results/forest_footprint/fr-ingredients-nested-matching-sub-ingredient.json
@@ -28,6 +28,7 @@
    },
    "ingredients" : [
       {
+         "ciqual_food_code" : "36005",
          "id" : "fr:viande-de-poulet-traitee-en-salaison",
          "ingredients" : [
             {

--- a/tests/unit/expected_test_results/ingredients/ca-middle-dot.json
+++ b/tests/unit/expected_test_results/ingredients/ca-middle-dot.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_food_code" : "19590",
          "id" : "en:mozzarella",
          "ingredients" : [
             {
@@ -138,12 +139,13 @@
    "ingredients_with_unspecified_percent_n" : 5,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
+      "en:anti-caking-agent",
       "en:e460",
       "en:lactic-ferments",
       "en:pasteurised-cow-s-milk",
       "en:rennet"
    ],
-   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ciqual_codes_n" : 5,
    "known_ingredients_n" : 16,
    "lc" : "ca",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-emulsifier-synonyms.json
+++ b/tests/unit/expected_test_results/ingredients/en-emulsifier-synonyms.json
@@ -113,9 +113,11 @@
       "en:e410",
       "en:e412",
       "en:e471",
-      "en:e477"
+      "en:e477",
+      "en:emulsifier",
+      "en:stabiliser"
    ],
-   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ciqual_codes_n" : 6,
    "known_ingredients_n" : 6,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-fruits-sub-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/en-fruits-sub-ingredients.json
@@ -35,6 +35,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "13009",
                "id" : "en:lemon",
                "percent_estimate" : 3.75,
                "percent_max" : 7.5,
@@ -53,6 +54,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 50,
          "percent_max" : 50,
@@ -112,11 +114,10 @@
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 65,
    "ingredients_without_ciqual_codes" : [
-      "en:lemon",
-      "en:pear",
-      "en:sugar"
+      "en:fruit",
+      "en:pear"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/en-illegal-division-by-zero.json
+++ b/tests/unit/expected_test_results/ingredients/en-illegal-division-by-zero.json
@@ -62,9 +62,10 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
+      "en:each-capsule-contains",
       "en:paracetamol-500-m-5-060198-790"
    ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 0,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing-parenthesis.json
+++ b/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing-parenthesis.json
@@ -132,9 +132,11 @@
    "ingredients_with_unspecified_percent_n" : 5,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:avocado"
+      "en:avocado",
+      "en:fruit",
+      "en:vegetable"
    ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 13,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-ingredients-analysis-unknown-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/en-ingredients-analysis-unknown-ingredients.json
@@ -34,6 +34,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 2.734375,
          "percent_max" : 20,
@@ -149,10 +150,9 @@
       "en:milk",
       "en:pepper",
       "en:some-unknown-ingredient",
-      "en:spice",
-      "en:sugar"
+      "en:spice"
    ],
-   "ingredients_without_ciqual_codes_n" : 6,
+   "ingredients_without_ciqual_codes_n" : 5,
    "known_ingredients_n" : 11,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-origin-field-with-commas-and.json
+++ b/tests/unit/expected_test_results/ingredients/en-origin-field-with-commas-and.json
@@ -11,6 +11,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "origins" : "en:paraguay,en:uruguay,en:costa-rica",
          "percent_estimate" : 25,
@@ -61,10 +62,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:milk",
-      "en:sugar"
+      "en:milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 5,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-origin-field-with-commas.json
+++ b/tests/unit/expected_test_results/ingredients/en-origin-field-with-commas.json
@@ -11,6 +11,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 25,
          "percent_max" : 50,
@@ -60,10 +61,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:milk",
-      "en:sugar"
+      "en:milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 5,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-origins-u.json
+++ b/tests/unit/expected_test_results/ingredients/en-origins-u.json
@@ -60,9 +60,10 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
+      "en:something",
       "en:u"
    ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 0,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-specific-ingredients-multiple-strings-of-one-ingredient.json
+++ b/tests/unit/expected_test_results/ingredients/en-specific-ingredients-multiple-strings-of-one-ingredient.json
@@ -21,6 +21,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
@@ -74,10 +75,9 @@
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:milk",
-      "en:sugar"
+      "en:milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 6,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-specific-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/en-specific-ingredients.json
@@ -20,6 +20,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
@@ -73,10 +74,9 @@
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:milk",
-      "en:sugar"
+      "en:milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 6,
    "lc" : "en",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/en-wheat-flour-organic-gluten-free.json
+++ b/tests/unit/expected_test_results/ingredients/en-wheat-flour-organic-gluten-free.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "percent_estimate" : 75,
          "percent_max" : 100,
@@ -65,10 +66,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:fish",
-      "en:wheat-flour"
+      "en:fish"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 6,
    "labels" : "Organic, en:no-gluten",
    "labels_hierarchy" : [

--- a/tests/unit/expected_test_results/ingredients/es-percent-loop.json
+++ b/tests/unit/expected_test_results/ingredients/es-percent-loop.json
@@ -67,6 +67,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 1.5,
          "percent_max" : 3,
@@ -205,8 +206,8 @@
    "ingredients_with_unspecified_percent_n" : 5,
    "ingredients_with_unspecified_percent_sum" : 68,
    "ingredients_without_ciqual_codes" : [
-      "en:e330",
-      "en:sugar"
+      "en:acid",
+      "en:e330"
    ],
    "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 24,

--- a/tests/unit/expected_test_results/ingredients/fi-additive.json
+++ b/tests/unit/expected_test_results/ingredients/fi-additive.json
@@ -49,9 +49,10 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:e440a"
+      "en:e440a",
+      "en:gelling-agent"
    ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 2,
    "lc" : "fi",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fi-additives-origins.json
+++ b/tests/unit/expected_test_results/ingredients/fi-additives-origins.json
@@ -29,6 +29,7 @@
          "vegetarian" : "maybe"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "origins" : "en:france",
          "percent" : 33,
@@ -40,6 +41,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 0.25,
          "percent_max" : 1,
@@ -111,12 +113,11 @@
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 67,
    "ingredients_without_ciqual_codes" : [
+      "en:emulsifier",
       "en:flavouring",
-      "en:sugar",
-      "en:sunflower-lecithin",
-      "en:wheat-flour"
+      "en:sunflower-lecithin"
    ],
-   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 13,
    "lc" : "fi",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/fi-additives-percents.json
+++ b/tests/unit/expected_test_results/ingredients/fi-additives-percents.json
@@ -20,6 +20,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "31016",
                "id" : "en:sugar",
                "percent_estimate" : 11,
                "text" : "sokeri",
@@ -253,6 +254,9 @@
    "ingredients_with_unspecified_percent_n" : 14,
    "ingredients_with_unspecified_percent_sum" : 88,
    "ingredients_without_ciqual_codes" : [
+      "en:acid",
+      "en:acidity-regulator",
+      "en:chocolate",
       "en:e322",
       "en:e330",
       "en:e333",
@@ -262,11 +266,11 @@
       "en:e472",
       "en:e474",
       "en:e475",
+      "en:emulsifier",
       "en:flour",
-      "en:milk-proteins",
-      "en:sugar"
+      "en:milk-proteins"
    ],
-   "ingredients_without_ciqual_codes_n" : 12,
+   "ingredients_without_ciqual_codes_n" : 15,
    "known_ingredients_n" : 26,
    "lc" : "fi",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/fi-do-not-match-myanmar.json
+++ b/tests/unit/expected_test_results/ingredients/fi-do-not-match-myanmar.json
@@ -132,9 +132,10 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:coriander",
+      "en:spice",
       "en:turmeric"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 15,
    "lc" : "fi",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-additive.json
+++ b/tests/unit/expected_test_results/ingredients/fr-additive.json
@@ -49,9 +49,10 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:e440a"
+      "en:e440a",
+      "en:gelling-agent"
    ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 2,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-chocolate-cake.json
+++ b/tests/unit/expected_test_results/ingredients/fr-chocolate-cake.json
@@ -20,6 +20,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "31016",
                "id" : "en:sugar",
                "percent_estimate" : 11,
                "text" : "sucre",
@@ -251,6 +252,9 @@
    "ingredients_with_unspecified_percent_n" : 14,
    "ingredients_with_unspecified_percent_sum" : 88,
    "ingredients_without_ciqual_codes" : [
+      "en:acid",
+      "en:acidity-regulator",
+      "en:chocolate",
       "en:e322",
       "en:e330",
       "en:e333",
@@ -260,11 +264,11 @@
       "en:e472",
       "en:e474",
       "en:e475",
+      "en:emulsifier",
       "en:flour",
-      "en:milk-proteins",
-      "en:sugar"
+      "en:milk-proteins"
    ],
-   "ingredients_without_ciqual_codes_n" : 12,
+   "ingredients_without_ciqual_codes_n" : 15,
    "known_ingredients_n" : 25,
    "lc" : "fr",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/fr-farines-labels-and-processes.json
+++ b/tests/unit/expected_test_results/ingredients/fr-farines-labels-and-processes.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "labels" : "fr:crc",
          "percent_estimate" : 62.5,
@@ -85,10 +86,9 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:einkorn-wheat",
-      "en:flour",
-      "en:wheat-flour"
+      "en:flour"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 7,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-huile-de-palme-certifiee-durable.json
+++ b/tests/unit/expected_test_results/ingredients/fr-huile-de-palme-certifiee-durable.json
@@ -82,8 +82,10 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [],
-   "ingredients_without_ciqual_codes_n" : 0,
+   "ingredients_without_ciqual_codes" : [
+      "en:non-hydrogenated-vegetable-oils"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 8,
    "labels" : "en:sustainable-palm-oil",
    "labels_hierarchy" : [

--- a/tests/unit/expected_test_results/ingredients/fr-illegal-division-by-zero.json
+++ b/tests/unit/expected_test_results/ingredients/fr-illegal-division-by-zero.json
@@ -62,9 +62,10 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "fr:1472-kj"
+      "fr:1472-kj",
+      "fr:analyse-moyenne-pour-1"
    ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 0,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-label-and-multiple-origins.json
+++ b/tests/unit/expected_test_results/ingredients/fr-label-and-multiple-origins.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_food_code" : "22000",
          "id" : "en:egg",
          "ingredients" : [
             {

--- a/tests/unit/expected_test_results/ingredients/fr-marmelade.json
+++ b/tests/unit/expected_test_results/ingredients/fr-marmelade.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_food_code" : "31039",
          "id" : "en:orange-marmalade",
          "ingredients" : [
             {
@@ -12,6 +13,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "31016",
                "id" : "en:sugar",
                "percent_estimate" : 10.25,
                "text" : "sucre",
@@ -123,6 +125,7 @@
          "id" : "en:chocolate",
          "ingredients" : [
             {
+               "ciqual_proxy_food_code" : "31016",
                "id" : "en:sugar",
                "percent_estimate" : 12.45,
                "text" : "sucre",
@@ -221,6 +224,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "percent_estimate" : 17.05,
          "text" : "farine de blé",
@@ -228,6 +232,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 8.525,
          "text" : "sucre",
@@ -534,7 +539,11 @@
    "ingredients_with_unspecified_percent_n" : 29,
    "ingredients_with_unspecified_percent_sum" : 93.5,
    "ingredients_without_ciqual_codes" : [
+      "en:acid",
+      "en:acidity-regulator",
+      "en:chocolate",
       "en:cocoa-paste",
+      "en:concentrated-orange-juice",
       "en:e330",
       "en:e333",
       "en:e415",
@@ -542,19 +551,22 @@
       "en:e450i",
       "en:e500ii",
       "en:e503ii",
+      "en:emulsifier",
       "en:flavouring",
+      "en:gelling-agent",
       "en:illipe-oil",
       "en:lactose-and-milk-proteins",
       "en:mango-kernel-oil",
       "en:natural-orange-flavouring",
+      "en:orange",
       "en:palm-fat",
+      "en:raising-agent",
       "en:shea-butter",
       "en:shorea-robusta-seed-oil",
       "en:sodium-citrate",
-      "en:sugar",
-      "en:wheat-flour"
+      "en:thickener"
    ],
-   "ingredients_without_ciqual_codes_n" : 19,
+   "ingredients_without_ciqual_codes_n" : 26,
    "known_ingredients_n" : 71,
    "lc" : "fr",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/fr-origin-ingredient-origin-and-origin.json
+++ b/tests/unit/expected_test_results/ingredients/fr-origin-ingredient-origin-and-origin.json
@@ -49,6 +49,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "16400",
          "id" : "en:butter",
          "origins" : "en:france",
          "percent" : 2.69353551476456,
@@ -58,6 +59,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_food_code" : "11013",
          "id" : "fr:moutarde-a-l-ancienne",
          "ingredients" : [],
          "origins" : "en:france",
@@ -76,6 +78,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_food_code" : "11013",
          "id" : "en:dijon-mustard",
          "ingredients" : [],
          "origins" : "en:france",
@@ -228,7 +231,7 @@
    "ingredients_with_unspecified_percent_n" : 0,
    "ingredients_with_unspecified_percent_sum" : 0,
    "ingredients_without_ciqual_codes" : [
-      "en:butter",
+      "en:broth",
       "en:pork",
       "en:semi-skimmed-milk",
       "en:spice"

--- a/tests/unit/expected_test_results/ingredients/fr-origins-labels.json
+++ b/tests/unit/expected_test_results/ingredients/fr-origins-labels.json
@@ -54,6 +54,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "13009",
          "id" : "en:lemon",
          "labels" : "en:organic",
          "percent_estimate" : 1.38888888888889,
@@ -159,10 +160,9 @@
    "ingredients_without_ciqual_codes" : [
       "en:cocoa",
       "en:grapefruit",
-      "en:lemon",
       "en:orange"
    ],
-   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 14,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-percents-origins-2.json
+++ b/tests/unit/expected_test_results/ingredients/fr-percents-origins-2.json
@@ -23,6 +23,7 @@
          "vegetarian" : "maybe"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "origins" : "en:france",
          "percent" : 33,
@@ -32,6 +33,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 0,
          "text" : "sucre",
@@ -126,12 +128,11 @@
    "ingredients_with_unspecified_percent_sum" : 75,
    "ingredients_without_ciqual_codes" : [
       "en:butterfat",
+      "en:emulsifier",
       "en:flavouring",
-      "en:sugar",
-      "en:sunflower-lecithin",
-      "en:wheat-flour"
+      "en:sunflower-lecithin"
    ],
-   "ingredients_without_ciqual_codes_n" : 5,
+   "ingredients_without_ciqual_codes_n" : 4,
    "known_ingredients_n" : 18,
    "lc" : "fr",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/fr-processing-multi.json
+++ b/tests/unit/expected_test_results/ingredients/fr-processing-multi.json
@@ -12,6 +12,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "13009",
          "id" : "en:lemon",
          "percent_estimate" : 20.8333333333333,
          "percent_max" : 50,
@@ -138,10 +139,9 @@
    "ingredients_with_unspecified_percent_n" : 6,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:lemon",
       "en:raw-milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 18,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-semi.json
+++ b/tests/unit/expected_test_results/ingredients/fr-semi.json
@@ -11,6 +11,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:semi-wholemeal-wheat-flour",
          "percent_estimate" : 25,
          "percent_max" : 50,
@@ -65,10 +66,8 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:semi-wholemeal-wheat-flour"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 10,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/fr-specific-ingredients.json
+++ b/tests/unit/expected_test_results/ingredients/fr-specific-ingredients.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "labels" : "en:organic",
          "percent_estimate" : 62.5,
@@ -109,8 +110,8 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:apricot",
-      "en:cane-sugar",
-      "en:fruit-pectin"
+      "en:fruit-pectin",
+      "en:gelling-agent"
    ],
    "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 14,

--- a/tests/unit/expected_test_results/ingredients/fr-starred-label.json
+++ b/tests/unit/expected_test_results/ingredients/fr-starred-label.json
@@ -13,6 +13,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "labels" : "en:fair-trade, en:organic",
          "percent_estimate" : 18.75,
@@ -77,10 +78,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 25,
    "ingredients_without_ciqual_codes" : [
-      "en:cane-sugar",
       "en:cocoa-paste"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 8,
    "lc" : "fr",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients/fr-viande-de-boeuf-issue-d-animaux-nourris-sans-ogm.json
+++ b/tests/unit/expected_test_results/ingredients/fr-viande-de-boeuf-issue-d-animaux-nourris-sans-ogm.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "6101",
          "id" : "en:beef-meat",
          "labels" : "en:fed-without-gmos",
          "percent_estimate" : 100,
@@ -50,10 +51,8 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:beef-meat"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 4,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/ja-additives.json
+++ b/tests/unit/expected_test_results/ingredients/ja-additives.json
@@ -37,6 +37,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:trehalose",
          "percent_estimate" : 10.9375,
          "percent_max" : 33.3333333333333,
@@ -207,16 +208,19 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:amino-acids",
+      "en:antioxidant",
+      "en:colour",
+      "en:condiment",
       "en:e262",
       "en:e415",
       "en:e640i",
       "en:modified-starch",
-      "en:trehalose",
+      "en:thickener",
       "en:vegetable-pigment",
       "en:vitamin-c",
       "en:vitamin-e"
    ],
-   "ingredients_without_ciqual_codes_n" : 9,
+   "ingredients_without_ciqual_codes_n" : 12,
    "known_ingredients_n" : 18,
    "lc" : "ja",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/ja-origin-and.json
+++ b/tests/unit/expected_test_results/ingredients/ja-origin-and.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_food_code" : "20047",
          "id" : "en:tomato",
          "ingredients" : [
             {

--- a/tests/unit/expected_test_results/ingredients/ja-origins.json
+++ b/tests/unit/expected_test_results/ingredients/ja-origins.json
@@ -33,6 +33,7 @@
          "vegetarian" : "no"
       },
       {
+         "ciqual_proxy_food_code" : "17270",
          "from_palm_oil" : "no",
          "id" : "en:olive-oil",
          "origins" : "en:brazil,en:ethiopia",
@@ -65,6 +66,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "origins" : "en:outside-japan,en:japan",
          "percent_estimate" : 0.710227272727273,
@@ -225,11 +227,9 @@
       "en:breadfruit",
       "en:cocoa",
       "en:malt",
-      "en:meat",
-      "en:olive-oil",
-      "en:sugar"
+      "en:meat"
    ],
-   "ingredients_without_ciqual_codes_n" : 6,
+   "ingredients_without_ciqual_codes_n" : 4,
    "known_ingredients_n" : 31,
    "lc" : "ja",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/ja-parenthesis.json
+++ b/tests/unit/expected_test_results/ingredients/ja-parenthesis.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_food_code" : "11104",
          "id" : "en:soy-sauce",
          "ingredients" : [
             {
@@ -22,6 +23,7 @@
          "vegetarian" : "maybe"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "ingredients" : [
             {
@@ -44,6 +46,7 @@
                "vegetarian" : "yes"
             },
             {
+               "ciqual_proxy_food_code" : "31016",
                "id" : "en:sugar",
                "percent_estimate" : 5.625,
                "percent_max" : 16.6666666666667,
@@ -257,9 +260,9 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:amino-acids",
+      "en:condiment",
       "en:glucose-syrup",
       "en:mirin",
-      "en:sugar",
       "ja:さば節",
       "ja:たん白加水分解物混合物"
    ],

--- a/tests/unit/expected_test_results/ingredients/ja-slash.json
+++ b/tests/unit/expected_test_results/ingredients/ja-slash.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 53.3333333333333,
          "percent_max" : 100,
@@ -10,6 +11,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "percent_estimate" : 23.3333333333333,
          "percent_max" : 50,
@@ -68,6 +70,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:whole-wheat-flour",
          "percent_estimate" : 0.364583333333329,
          "percent_max" : 12.5,
@@ -260,18 +263,16 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:cocoa-paste",
+      "en:emulsifier",
       "en:fat",
       "en:flavouring",
       "en:modified-starch",
       "en:raising-agent",
-      "en:sugar",
       "en:vegetable-oil-and-fat",
-      "en:wheat-flour",
-      "en:whole-wheat-flour",
       "ja:大豆由来",
       "ja:小麦胚芽"
    ],
-   "ingredients_without_ciqual_codes_n" : 11,
+   "ingredients_without_ciqual_codes_n" : 9,
    "known_ingredients_n" : 27,
    "lc" : "ja",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients/xx-single-letters.json
+++ b/tests/unit/expected_test_results/ingredients/xx-single-letters.json
@@ -546,6 +546,7 @@
       "fr:r",
       "fr:s",
       "fr:something",
+      "fr:somethingelse",
       "fr:t",
       "fr:u",
       "fr:v",
@@ -555,7 +556,7 @@
       "fr:y",
       "fr:z"
    ],
-   "ingredients_without_ciqual_codes_n" : 35,
+   "ingredients_without_ciqual_codes_n" : 36,
    "known_ingredients_n" : 1,
    "lc" : "fr",
    "nutriments" : {

--- a/tests/unit/expected_test_results/ingredients_contents/fruits-water-sugar.json
+++ b/tests/unit/expected_test_results/ingredients_contents/fruits-water-sugar.json
@@ -45,6 +45,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 5,
          "percent_estimate" : 5,
@@ -103,10 +104,8 @@
    "ingredients_with_specified_percent_sum" : 100,
    "ingredients_with_unspecified_percent_n" : 0,
    "ingredients_with_unspecified_percent_sum" : 0,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/ingredients_contents/vegetable-oils.json
+++ b/tests/unit/expected_test_results/ingredients_contents/vegetable-oils.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "17270",
          "from_palm_oil" : "no",
          "id" : "en:olive-oil",
          "percent" : 40,
@@ -89,10 +90,9 @@
    "ingredients_with_unspecified_percent_n" : 0,
    "ingredients_with_unspecified_percent_sum" : 0,
    "ingredients_without_ciqual_codes" : [
-      "en:olive-oil",
       "en:rapeseed-oil"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 7,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/nutriscore/94-percent-sugar-and-unknown-ingredient.json
+++ b/tests/unit/expected_test_results/nutriscore/94-percent-sugar-and-unknown-ingredient.json
@@ -35,6 +35,7 @@
    ],
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 94,
          "percent_estimate" : 94,
@@ -101,10 +102,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 6,
    "ingredients_without_ciqual_codes" : [
-      "en:strange-ingredient",
-      "en:sugar"
+      "en:strange-ingredient"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 3,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/beverage-with-80-percent-milk.json
+++ b/tests/unit/expected_test_results/nutriscore/beverage-with-80-percent-milk.json
@@ -35,6 +35,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 20,
          "percent_max" : 20,
@@ -91,10 +92,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 20,
    "ingredients_without_ciqual_codes" : [
-      "en:fresh-milk",
-      "en:sugar"
+      "en:fresh-milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 6,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/dairy-drink-with-80-percent-milk.json
+++ b/tests/unit/expected_test_results/nutriscore/dairy-drink-with-80-percent-milk.json
@@ -43,6 +43,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 20,
          "percent_max" : 20,
@@ -99,10 +100,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 20,
    "ingredients_without_ciqual_codes" : [
-      "en:fresh-milk",
-      "en:sugar"
+      "en:fresh-milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 6,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/dairy-drink-with-less-than-80-percent-milk.json
+++ b/tests/unit/expected_test_results/nutriscore/dairy-drink-with-less-than-80-percent-milk.json
@@ -42,6 +42,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 10,
          "percent_max" : 20,
@@ -96,10 +97,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:milk",
-      "en:sugar"
+      "en:milk"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 5,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/dairy-drinks-without-milk.json
+++ b/tests/unit/expected_test_results/nutriscore/dairy-drinks-without-milk.json
@@ -43,6 +43,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 5,
          "percent_max" : 10,
@@ -90,10 +91,8 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 4,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-olive-oil.json
+++ b/tests/unit/expected_test_results/nutriscore/en-olive-oil.json
@@ -47,6 +47,7 @@
    ],
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "17270",
          "from_palm_oil" : "no",
          "id" : "en:olive-oil",
          "percent_estimate" : 100,
@@ -94,10 +95,8 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:olive-oil"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 4,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-orange-juice-category-and-ingredients.json
+++ b/tests/unit/expected_test_results/nutriscore/en-orange-juice-category-and-ingredients.json
@@ -67,6 +67,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 4.45,
          "percent_max" : 8.9,
@@ -128,10 +129,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 50,
    "ingredients_without_ciqual_codes" : [
-      "en:orange-juice",
-      "en:sugar"
+      "en:orange-juice"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-red-meat-ambiguous-category-ingredients-with-no-meat.json
+++ b/tests/unit/expected_test_results/nutriscore/en-red-meat-ambiguous-category-ingredients-with-no-meat.json
@@ -46,6 +46,7 @@
          "vegetarian" : "no"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "percent_estimate" : 13.625,
          "percent_max" : 49.5,
@@ -122,10 +123,8 @@
    "ingredients_with_specified_percent_sum" : 1,
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 87.375,
-   "ingredients_without_ciqual_codes" : [
-      "en:wheat-flour"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 9,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-red-meat-ambiguous-category-ingredients-with-very-little-meat.json
+++ b/tests/unit/expected_test_results/nutriscore/en-red-meat-ambiguous-category-ingredients-with-very-little-meat.json
@@ -46,6 +46,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "percent_estimate" : 24.0833333333333,
          "percent_max" : 46.5,
@@ -165,10 +166,9 @@
    "ingredients_with_unspecified_percent_n" : 4,
    "ingredients_with_unspecified_percent_sum" : 95.9791666666667,
    "ingredients_without_ciqual_codes" : [
-      "en:lamb",
-      "en:wheat-flour"
+      "en:lamb"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 13,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-sugar-estimated-nutrients.json
+++ b/tests/unit/expected_test_results/nutriscore/en-sugar-estimated-nutrients.json
@@ -35,6 +35,7 @@
    ],
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 100,
          "percent_max" : 100,
@@ -79,10 +80,8 @@
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 3,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-sweeteners-erythritol.json
+++ b/tests/unit/expected_test_results/nutriscore/en-sweeteners-erythritol.json
@@ -63,6 +63,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 2.25,
          "percent_max" : 4.5,
@@ -136,10 +137,9 @@
    "ingredients_with_unspecified_percent_n" : 4,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:e968",
-      "en:sugar"
+      "en:e968"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 11,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/en-sweeteners.json
+++ b/tests/unit/expected_test_results/nutriscore/en-sweeteners.json
@@ -63,6 +63,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 2.25,
          "percent_max" : 4.5,
@@ -136,10 +137,9 @@
    "ingredients_with_unspecified_percent_n" : 4,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:e951",
-      "en:sugar"
+      "en:e951"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 11,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/fr-canned-green-beans.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-canned-green-beans.json
@@ -70,6 +70,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 10,
          "percent_estimate" : 10,
@@ -138,10 +139,8 @@
    "ingredients_with_specified_percent_sum" : 100,
    "ingredients_with_unspecified_percent_n" : 0,
    "ingredients_with_unspecified_percent_sum" : 0,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 8,
    "lc" : "fr",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/fr-canned-pineapple.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-canned-pineapple.json
@@ -46,6 +46,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 10,
          "percent_estimate" : 10,
@@ -110,10 +111,9 @@
    "ingredients_with_unspecified_percent_n" : 0,
    "ingredients_with_unspecified_percent_sum" : 0,
    "ingredients_without_ciqual_codes" : [
-      "en:pineapple",
-      "en:sugar"
+      "en:pineapple"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 6,
    "lc" : "fr",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/fr-green-beans-beverage.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-green-beans-beverage.json
@@ -40,6 +40,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 10,
          "percent_estimate" : 10,
@@ -108,10 +109,8 @@
    "ingredients_with_specified_percent_sum" : 100,
    "ingredients_with_unspecified_percent_n" : 0,
    "ingredients_with_unspecified_percent_sum" : 0,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 8,
    "lc" : "fr",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/fr-ice-tea-with-sweetener.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-ice-tea-with-sweetener.json
@@ -68,6 +68,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 2.85,
          "percent_max" : 4.5,
@@ -114,6 +115,7 @@
          "text" : "acidifiants"
       },
       {
+         "ciqual_food_code" : "18154",
          "id" : "en:black-tea-extract",
          "ingredients" : [
             {
@@ -314,6 +316,9 @@
    "ingredients_with_unspecified_percent_n" : 10,
    "ingredients_with_unspecified_percent_sum" : 99.9,
    "ingredients_without_ciqual_codes" : [
+      "en:acid",
+      "en:acidity-regulator",
+      "en:antioxidant",
       "en:e296",
       "en:e300",
       "en:e330",
@@ -321,10 +326,10 @@
       "en:flavouring",
       "en:peach",
       "en:sodium-citrate",
-      "en:sugar",
+      "en:sweetener",
       "fr:l"
    ],
-   "ingredients_without_ciqual_codes_n" : 9,
+   "ingredients_without_ciqual_codes_n" : 12,
    "known_ingredients_n" : 25,
    "lc" : "fr",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/nutriscore/fr-orange-nectar-0-fat.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-orange-nectar-0-fat.json
@@ -63,6 +63,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent_estimate" : 11,
          "percent_max" : 12,
@@ -138,10 +139,9 @@
    "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 43,
    "ingredients_without_ciqual_codes" : [
-      "en:orange",
-      "en:sugar"
+      "en:orange"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 11,
    "lc" : "en",
    "minerals_tags" : [],

--- a/tests/unit/expected_test_results/recipes/fr-margherita-pizzas.fr-margherita-pizza-1.json
+++ b/tests/unit/expected_test_results/recipes/fr-margherita-pizzas.fr-margherita-pizza-1.json
@@ -1,6 +1,7 @@
 {
    "ingredients" : [
       {
+         "ciqual_proxy_food_code" : "9410",
          "id" : "en:wheat-flour",
          "labels" : "en:organic",
          "percent_estimate" : 33,
@@ -183,10 +184,9 @@
    "ingredients_without_ciqual_codes" : [
       "en:herb",
       "en:spice",
-      "en:wheat-flour",
       "en:yeast"
    ],
-   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 22,
    "lc" : "fr",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/recipes/fr-margherita-pizzas.fr-margherita-pizza-2-compound-ingredients.json
+++ b/tests/unit/expected_test_results/recipes/fr-margherita-pizzas.fr-margherita-pizza-2-compound-ingredients.json
@@ -43,9 +43,11 @@
          "vegetarian" : "maybe"
       },
       {
+         "ciqual_food_code" : "23403",
          "id" : "en:pizza-dough",
          "ingredients" : [
             {
+               "ciqual_proxy_food_code" : "9410",
                "id" : "en:wheat-flour",
                "percent_estimate" : 20,
                "percent_max" : 30,
@@ -163,7 +165,7 @@
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
       "en:cheese",
-      "en:wheat-flour"
+      "en:filling"
    ],
    "ingredients_without_ciqual_codes_n" : 2,
    "known_ingredients_n" : 19,

--- a/tests/unit/expected_test_results/recipes/nectars.guava-nectar.json
+++ b/tests/unit/expected_test_results/recipes/nectars.guava-nectar.json
@@ -22,6 +22,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:cane-sugar",
          "percent" : 10,
          "percent_estimate" : 10,
@@ -107,12 +108,11 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 62,
    "ingredients_without_ciqual_codes" : [
-      "en:cane-sugar",
       "en:e330",
       "en:guava",
       "en:some-unknown-ingredient"
    ],
-   "ingredients_without_ciqual_codes_n" : 4,
+   "ingredients_without_ciqual_codes_n" : 3,
    "known_ingredients_n" : 8,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/recipes/nectars.impossible-ingredients.json
+++ b/tests/unit/expected_test_results/recipes/nectars.impossible-ingredients.json
@@ -17,6 +17,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 30,
          "percent_estimate" : 25,
@@ -72,10 +73,9 @@
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 25,
    "ingredients_without_ciqual_codes" : [
-      "en:orange-juice",
-      "en:sugar"
+      "en:orange-juice"
    ],
-   "ingredients_without_ciqual_codes_n" : 2,
+   "ingredients_without_ciqual_codes_n" : 1,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [

--- a/tests/unit/expected_test_results/recipes/nectars.strawberry-nectar.json
+++ b/tests/unit/expected_test_results/recipes/nectars.strawberry-nectar.json
@@ -22,6 +22,7 @@
          "vegetarian" : "yes"
       },
       {
+         "ciqual_proxy_food_code" : "31016",
          "id" : "en:sugar",
          "percent" : 5,
          "percent_estimate" : 5,
@@ -78,10 +79,8 @@
    "ingredients_with_specified_percent_sum" : 25,
    "ingredients_with_unspecified_percent_n" : 1,
    "ingredients_with_unspecified_percent_sum" : 75,
-   "ingredients_without_ciqual_codes" : [
-      "en:sugar"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "known_ingredients_n" : 10,
    "lc" : "en",
    "misc_tags" : [


### PR DESCRIPTION
- Refactor to create an extend_ingredients service, that assigns ciqual food codes and ciqual proxy food codes, and add origins and labels from other fields like labels
- Add both ciqual food codes and ciqual proxy food codes

Used by:
- https://github.com/openfoodfacts/recipe-estimator-metrics/pull/4
- https://github.com/openfoodfacts/recipe-estimator/pull/10
