### PR TITLE
fix: dq_nutriscore_alert_and_category_rework

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1277,19 +1277,19 @@ sub check_nutrition_data ($product_ref) {
 		my ($expected_nutriscore_grade, $category_id)
 			= get_inherited_property_from_categories_tags($product_ref, "expected_nutriscore_grade:en");
 
-		# we expect single letter a, b, c, d, e for nutriscore grade in the taxonomy. Case insensitive (/i).
-		if ((defined $expected_nutriscore_grade) and ($expected_nutriscore_grade =~ /^([a-e]){1}$/i)) {
-			if (
-				# nutriscore not calculated but should have expected nutriscore grade
-				(not(defined $product_ref->{nutrition_grade_fr}))
-				# nutriscore calculated but unexpected nutriscore grade
-				or (    (defined $product_ref->{nutrition_grade_fr})
-					and ($product_ref->{nutrition_grade_fr} ne $expected_nutriscore_grade))
-				)
-			{
-				push @{$product_ref->{data_quality_errors_tags}},
-					"en:nutri-score-grade-from-category-does-not-match-calculated-grade";
-			}
+		if (
+			# exclude error if nutriscore cannot be calculated due to missing nutrients information (see issue #9297)
+			($product_ref->{nutriscore}{2023}{nutrients_available} == 1)
+			# we expect single letter a, b, c, d, e for nutriscore grade in the taxonomy. Case insensitive (/i).
+			and (defined $expected_nutriscore_grade)
+			and (($expected_nutriscore_grade =~ /^([a-e]){1}$/i))
+			# nutriscore calculated but unexpected nutriscore grade
+			and (defined $product_ref->{nutrition_grade_fr})
+			and ($product_ref->{nutrition_grade_fr} ne $expected_nutriscore_grade)
+			)
+		{
+			push @{$product_ref->{data_quality_errors_tags}},
+				"en:nutri-score-grade-from-category-does-not-match-calculated-grade";
 		}
 
 		# some categories have an expected ingredient - push data quality error if ingredient differs from expected ingredient

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -967,7 +967,10 @@ $product_ref = {
 		'en:olive-oils', 'en:virgin-olive-oils',
 		'en:extra-virgin-olive-oils'
 	],
-	nutrition_grade_fr => "d"
+	nutrition_grade_fr => "d",
+	nutriscore => {
+		2023 => {"nutrients_available" => 1,},
+	},
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 check_quality_and_test_product_has_quality_tag(
@@ -987,7 +990,10 @@ $product_ref = {
 		"en:ice-cream-tubs", "en:virgin-olive-oils",
 		"en:extra-virgin-olive-oils", "fr:glace-aux-calissons"
 	],
-	nutrition_grade_fr => "d"
+	nutrition_grade_fr => "d",
+	nutriscore => {
+		2023 => {"nutrients_available" => 1,},
+	},
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 check_quality_and_test_product_has_quality_tag(
@@ -1004,13 +1010,16 @@ $product_ref = {
 		'en:olive-tree-products', 'en:vegetable-oils',
 		'en:olive-oils', 'en:virgin-olive-oils',
 		'en:extra-virgin-olive-oils'
-	]
+	],
+	nutriscore => {
+		2023 => {"nutrients_available" => 0,},
+	},
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
 	'en:nutri-score-grade-from-category-does-not-match-calculated-grade',
-	'Calculate nutriscore grade should be the same as the one provided in the taxonomy for this category', 1
+	'Calculate nutriscore grade should be the same as the one provided in the taxonomy for this category', 0
 );
 # category with expected nutriscore grade. Same nutriscore grade as compared to the expected nutriscore grade
 $product_ref = {
@@ -1021,7 +1030,10 @@ $product_ref = {
 		'en:olive-oils', 'en:virgin-olive-oils',
 		'en:extra-virgin-olive-oils'
 	],
-	nutrition_grade_fr => "c"
+	nutrition_grade_fr => "c",
+	nutriscore => {
+		2023 => {"nutrients_available" => 1,},
+	},
 };
 ProductOpener::DataQuality::check_quality($product_ref);
 check_quality_and_test_product_has_quality_tag(


### PR DESCRIPTION
### What
Categories with expected nutriscore should not raise error when not enough nutrients are provided. Because it could be that picture of nutrition table is missing and it could not be fixed.

> do not trigger the error if:
> 
>     nothing is entered in the nutrition table, or
>     "Nutrition facts are not specified on the product." is checked
> 

### Related issue(s) and discussion
- Fixes #9297