### PR TITLE
fix: dq_serving_size_cant_be_parsed

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1039,10 +1039,6 @@ sub check_nutrition_data ($product_ref) {
 			elsif ($product_ref->{serving_quantity} eq "0") {
 				push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-data-per-serving-serving-quantity-is-0";
 			}
-			elsif ($product_ref->{serving_quantity} == 0) {
-				push @{$product_ref->{data_quality_errors_tags}},
-					"en:nutrition-data-per-serving-serving-quantity-is-not-recognized";
-			}
 		}
 	}
 
@@ -1690,6 +1686,17 @@ sub check_quantity ($product_ref) {
 		if ($product_ref->{serving_size} =~ /\d\s?mg\b/i) {
 			push @{$product_ref->{data_quality_warnings_tags}}, "en:serving-size-in-mg";
 		}
+	}
+
+	# serving size not recognized (undefined serving quantity)
+	# serving_size = 10g -> serving_quantity = 10
+	# serving_size = 10  -> serving_quantity will be undefined
+	if (    (defined $product_ref->{serving_size})
+		and ($product_ref->{serving_size} ne "")
+		and (!defined $product_ref->{serving_quantity}))
+	{
+		push @{$product_ref->{data_quality_warnings_tags}},
+			"en:nutrition-data-per-serving-serving-quantity-is-not-recognized";
 	}
 
 	return;

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -62,8 +62,8 @@ en:Nutrition data per serving - Missing serving size, serving quantity is unknow
 description:en:"Nutrition facts are specified for the product as sold." is checked. "per serving" is selected. But the serving size is missing.
 
 <en:Nutrition errors
-en:Nutrition data per serving - Serving quantity is not recognized
-description:en: although serving size is given, it cannot be parsed (digit or unit may be missing or unknown)
+en:Nutrition data per serving - Serving size is not recognized
+description:en:serving size cannot be parsed (digit or unit may be missing or unknown)
 
 <en:Nutrition errors
 en:Nutrition data per serving - Serving quantity is 0

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -643,6 +643,14 @@ check_quality_and_test_product_has_quality_tag(
 	'serving size cannot be parsed', 0
 );
 
+# serving size not recognized (leading to undefined serving quantity)
+$product_ref = {serving_size => "50",};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-data-per-serving-serving-quantity-is-not-recognized',
+	'serving size is not recognized', 1
+);
+
 # percentage for ingredient is higher than 100% in extracted ingredients from the picture
 $product_ref = {
 	ingredients => [


### PR DESCRIPTION
### What
Updated the existing "en:nutrition-data-per-serving-serving-quantity-is-not-recognized" facet
To be triggered even if nutrition data or per portion are not checked.
Existing unit tests are still valid
Added one unit tests covering the case when only serving_size is given (per portion is not checked, nutrition table is empty)


### Related issue(s) and discussion
- Fixes #9116