### PR TITLE
fix: Dq saturated fat only if fat defined

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1245,14 +1245,9 @@ sub check_nutrition_data ($product_ref) {
 				"en:nutrition-fructose-plus-glucose-plus-maltose-plus-lactose-plus-sucrose-greater-than-sugars";
 		}
 
-		if (
-			(
-				(defined $product_ref->{nutriments}{"saturated-fat_100g"})
-				? $product_ref->{nutriments}{"saturated-fat_100g"}
-				: 0
-			)
-			> (((defined $product_ref->{nutriments}{"fat_100g"}) ? $product_ref->{nutriments}{"fat_100g"} : 0) + 0.001)
-			)
+		if (    (defined $product_ref->{nutriments}{"saturated-fat_100g"})
+			and (defined $product_ref->{nutriments}{"fat_100g"})
+			and ($product_ref->{nutriments}{"saturated-fat_100g"} > ($product_ref->{nutriments}{"fat_100g"} + 0.001)))
 		{
 
 			push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-saturated-fat-greater-than-fat";

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -957,6 +957,31 @@ check_quality_and_test_product_has_quality_tag(
 	'1 kcal = 4.184 kJ, value in kcal is between 165*3.7-2=608.5 and 165*4.7+2=777.5', 1
 );
 
+# nutrition - saturated fat is greater than fat
+## trigger the error because saturated-fat_100g is greated than fat
+$product_ref = {
+	nutriments => {
+		fat_100g => 0,
+		"saturated-fat_100g" => 1,
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-saturated-fat-greater-than-fat',
+	'saturated fat greater than fat', 1
+);
+## if undefined fat, error should not be triggered
+$product_ref = {
+	nutriments => {
+		"saturated-fat_100g" => 1,
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-saturated-fat-greater-than-fat',
+	'saturated fat may be greater than fat but fat is missing', 0
+);
+
 # category with expected nutriscore grade. Prerequisite: "expected_nutriscore_grade:en:c" under "en:Extra-virgin olive oils" category, in the taxonomy
 # category with expected nutriscore grade. Different nutriscore grade as compared to the expected nutriscore grade
 $product_ref = {


### PR DESCRIPTION
### What
rework error for saturated fat greater than fat to be triggered only if fat is defined

### Related issue(s) and discussion
- Fixes #9305
