### PR TITLE
fix: dq_nutrition_rm_salt_under_01g

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1260,6 +1260,7 @@ sub check_nutrition_data ($product_ref) {
 		}
 
 		# Too small salt value? (e.g. g entered in mg)
+		# warning for salt < 0.1 was removed because it was leading to too much false positives (see #9346)
 		if ((defined $product_ref->{nutriments}{"salt_100g"}) and ($product_ref->{nutriments}{"salt_100g"} > 0)) {
 
 			if ($product_ref->{nutriments}{"salt_100g"} < 0.001) {
@@ -1267,9 +1268,6 @@ sub check_nutrition_data ($product_ref) {
 			}
 			elsif ($product_ref->{nutriments}{"salt_100g"} < 0.01) {
 				push @{$product_ref->{data_quality_warnings_tags}}, "en:nutrition-value-under-0-01-g-salt";
-			}
-			elsif ($product_ref->{nutriments}{"salt_100g"} < 0.1) {
-				push @{$product_ref->{data_quality_warnings_tags}}, "en:nutrition-value-under-0-1-g-salt";
 			}
 		}
 

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -2733,10 +2733,6 @@ en:Nutrition value under 0,01 g - Salt
 #description:en:
 
 <en:Nutrition warnings
-en:Nutrition value under 0,1 g salt
-#description:en:
-
-<en:Nutrition warnings
 en:Nutrition value very high for category - Carbohydrates
 description:en:Compared to the category average, the Carbohydrates value is abnormally high.
 

--- a/tests/integration/expected_test_results/api_v2_product_write/get-product-auth-good-password.json
+++ b/tests/integration/expected_test_results/api_v2_product_write/get-product-auth-good-password.json
@@ -99,12 +99,10 @@
          "en:food-groups-1-known",
          "en:food-groups-2-known",
          "en:food-groups-3-unknown",
-         "en:nutrition-value-under-0-1-g-salt",
          "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
          "en:ecoscore-packaging-packaging-data-missing"
       ],
       "data_quality_warnings_tags" : [
-         "en:nutrition-value-under-0-1-g-salt",
          "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
          "en:ecoscore-packaging-packaging-data-missing"
       ],

--- a/tests/integration/expected_test_results/api_v2_product_write/get-product.json
+++ b/tests/integration/expected_test_results/api_v2_product_write/get-product.json
@@ -99,12 +99,10 @@
          "en:food-groups-1-known",
          "en:food-groups-2-known",
          "en:food-groups-3-unknown",
-         "en:nutrition-value-under-0-1-g-salt",
          "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
          "en:ecoscore-packaging-packaging-data-missing"
       ],
       "data_quality_warnings_tags" : [
-         "en:nutrition-value-under-0-1-g-salt",
          "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
          "en:ecoscore-packaging-packaging-data-missing"
       ],

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -848,6 +848,59 @@ check_quality_and_test_product_has_quality_tag(
 	'sum of fructose plus glucose plus maltose plus lactose plus sucrose cannot be greater than sugars', 0
 );
 
+# salt_100g is very small warning (may be in mg)
+## lower than 0.001
+$product_ref = {
+	nutriments => {
+		salt_100g => 0.0009,    # lower than 0.001
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-value-under-0-001-g-salt',
+	'value for salt is lower than 0.001g', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-value-under-0-01-g-salt',
+	'value for salt is lower than 0.001g, should not trigger warning for 0.01', 0
+);
+## lower than 0.01
+$product_ref = {
+	nutriments => {
+		salt_100g => 0.009,    # lower than 0.01
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-value-under-0-001-g-salt',
+	'value for salt is above 0.001g', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-value-under-0-01-g-salt',
+	'value for salt is lower than 0.001g, and above 0.01', 1
+);
+## above 0.01
+$product_ref = {
+	nutriments => {
+		salt_100g => 0.02,    # above 0.01
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-value-under-0-001-g-salt',
+	'value for salt is above 0.001g', 0
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-value-under-0-01-g-salt',
+	'value for salt is above 0.001g', 0
+);
+
 # testing of ProductOpener::DataQualityFood::check_quantity subroutine
 $product_ref = {quantity => "300g"};
 ProductOpener::DataQuality::check_quality($product_ref);


### PR DESCRIPTION
### What
remove quality warning for salt under 0.1g

remaing quality warnings: salt under 0.01g and 0.001g

note that the warnings aim to detect if values could have been given in mg instead of g.


### Related issue(s) and discussion
- Fixes #9346