### PR TITLE
fix: move Intermarché / Les Mousquetaires import to producers platform

### DIFF
--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -1413,7 +1413,7 @@ sub import_csv_file ($args_ref) {
 		'orgs_with_gln_but_no_party_name' => {},
 	};
 
-	my $csv = Text::CSV->new({binary => 1, sep_char => "\t"})    # should set binary attribute.
+	my $csv = Text::CSV->new({binary => 1, sep_char => "\t", auto_diag => 1, diag_verbose => 1 })    # should set binary attribute.
 		or die "Cannot use CSV: " . Text::CSV->error_diag();
 
 	my $time = time();
@@ -1424,16 +1424,27 @@ sub import_csv_file ($args_ref) {
 		$images_ref = import_images_from_dir($args_ref->{images_dir}, $stats_ref);
 	}
 
-	$log->debug("importing products", {}) if $log->is_debug();
+	$log->debug("importing products", { csv_file => $args_ref->{csv_file}}) if $log->is_debug();
 
 	my $io;
 	if (not open($io, '<:encoding(UTF-8)', $args_ref->{csv_file})) {
-		$stats_ref->{error} = "Could not open " . $args_ref->{csv_file} . ": $!";
+		$stats_ref->{error} = { error => "Could not open " . $args_ref->{csv_file} . ": $!"};
 		return $stats_ref;
 	}
 
 	# first line contains headers
+	# We use $csv->getline instead of $csv->header so that we can dedupe column names
+	# Unfortunately that means we can't autodetect the BOM using the detect_bom option
+	# of the header method: this will fail if there is a bom
 	my $columns_ref = $csv->getline($io);
+
+	# Check that we were able to read the file
+	if (not defined $columns_ref) {
+		$log->error("unable to read CSV file", { csv_file => $args_ref->{csv_file}, error_input => $csv->error_input , error_diag => $csv->error_diag}) if $log->is_error();
+		$stats_ref->{error} = { error => "Could not read " . $args_ref->{csv_file} . ": $!"};
+		                return $stats_ref;
+						    }
+	
 	$csv->column_names(@{deduped_colnames($columns_ref)});
 
 	my $i = 0;
@@ -1568,7 +1579,7 @@ sub import_csv_file ($args_ref) {
 
 				# For files uploaded through the producers platform, the source_id is org-[id of org]
 
-				if ((defined $args_ref->{source_id}) and ($args_ref->{source_id} ne "org-${org_id}")) {
+				if ((defined $args_ref->{source_id}) and (($args_ref->{source_id} ne $org_id) and ($args_ref->{source_id} ne "org-${org_id}"))) {
 					if (not $org_ref->{"import_source_" . $args_ref->{source_id}}) {
 						$log->debug(
 							"skipping import for org without authorization for the source",

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -1413,7 +1413,8 @@ sub import_csv_file ($args_ref) {
 		'orgs_with_gln_but_no_party_name' => {},
 	};
 
-	my $csv = Text::CSV->new({binary => 1, sep_char => "\t", auto_diag => 1, diag_verbose => 1 })    # should set binary attribute.
+	my $csv = Text::CSV->new(
+		{binary => 1, sep_char => "\t", auto_diag => 1, diag_verbose => 1})    # should set binary attribute.
 		or die "Cannot use CSV: " . Text::CSV->error_diag();
 
 	my $time = time();
@@ -1424,11 +1425,11 @@ sub import_csv_file ($args_ref) {
 		$images_ref = import_images_from_dir($args_ref->{images_dir}, $stats_ref);
 	}
 
-	$log->debug("importing products", { csv_file => $args_ref->{csv_file}}) if $log->is_debug();
+	$log->debug("importing products", {csv_file => $args_ref->{csv_file}}) if $log->is_debug();
 
 	my $io;
 	if (not open($io, '<:encoding(UTF-8)', $args_ref->{csv_file})) {
-		$stats_ref->{error} = { error => "Could not open " . $args_ref->{csv_file} . ": $!"};
+		$stats_ref->{error} = {error => "Could not open " . $args_ref->{csv_file} . ": $!"};
 		return $stats_ref;
 	}
 
@@ -1440,11 +1441,13 @@ sub import_csv_file ($args_ref) {
 
 	# Check that we were able to read the file
 	if (not defined $columns_ref) {
-		$log->error("unable to read CSV file", { csv_file => $args_ref->{csv_file}, error_input => $csv->error_input , error_diag => $csv->error_diag}) if $log->is_error();
-		$stats_ref->{error} = { error => "Could not read " . $args_ref->{csv_file} . ": $!"};
-		                return $stats_ref;
-						    }
-	
+		$log->error("unable to read CSV file",
+			{csv_file => $args_ref->{csv_file}, error_input => $csv->error_input, error_diag => $csv->error_diag})
+			if $log->is_error();
+		$stats_ref->{error} = {error => "Could not read " . $args_ref->{csv_file} . ": $!"};
+		return $stats_ref;
+	}
+
 	$csv->column_names(@{deduped_colnames($columns_ref)});
 
 	my $i = 0;
@@ -1579,7 +1582,9 @@ sub import_csv_file ($args_ref) {
 
 				# For files uploaded through the producers platform, the source_id is org-[id of org]
 
-				if ((defined $args_ref->{source_id}) and (($args_ref->{source_id} ne $org_id) and ($args_ref->{source_id} ne "org-${org_id}"))) {
+				if (    (defined $args_ref->{source_id})
+					and (($args_ref->{source_id} ne $org_id) and ($args_ref->{source_id} ne "org-${org_id}")))
+				{
 					if (not $org_ref->{"import_source_" . $args_ref->{source_id}}) {
 						$log->debug(
 							"skipping import for org without authorization for the source",

--- a/scripts/export_producers_platform_data_to_public_database.sh
+++ b/scripts/export_producers_platform_data_to_public_database.sh
@@ -23,6 +23,8 @@ org-kambly-france
 org-saint-hubert
 org-d-aucy
 org-lea-nature
+org-auchan-apaw
+org-les-mousquetaires
 )
 
 for producer in ${PRODUCERS[@]}

--- a/scripts/import_csv_file.pl
+++ b/scripts/import_csv_file.pl
@@ -252,3 +252,7 @@ if ($mail =~ /^\s*Subject:\s*(.*)\n/i) {
 	print "email body:\n$body\n\n";
 }
 
+if ($stats_ref->{error}) {
+	print STDERR "An error occured: " . $stats_ref->{error}{error} . "\n";
+	exit(1);
+}

--- a/scripts/imports/carrefour/images.rules
+++ b/scripts/imports/carrefour/images.rules
@@ -1,0 +1,14 @@
+# Rules used by Import.pm to assign an image file to a specific image type
+# Example file names from Carrefour:
+# 3560070968985.1.jpeg
+# 3270190028505.1.99.jpeg
+# 3270190028505.1.99.jpeg
+#- Avant 1
+#- Arrière  7
+#- 3/4 0
+#- Droite  8
+#- Gauche  2
+#- Dessus 3
+#- Dessous 9
+#- Autre      4
+(\d+)\.1\.(.*)	$1.front.$2

--- a/scripts/imports/carrefour/run_carrefour_import.sh
+++ b/scripts/imports/carrefour/run_carrefour_import.sh
@@ -70,7 +70,7 @@ echo "Convert Carrefour XML files to OFF csv file"
 
 # import data
 echo "Import data"
-./scripts/import_csv_file.pl --csv_file $DATA_TMP_DIR/carrefour-data.tsv --user_id carrefour --comment "Import Carrefour" --source_id "carrefour" --source_name "Carrefour" --source_url "https://www.carrefour.fr" --manufacturer --org_id carrefour-test-off2 --define lc=fr --images_dir $IMAGES_TMP_DIR
+./scripts/import_csv_file.pl --csv_file $DATA_TMP_DIR/carrefour-data.tsv --user_id carrefour --comment "Import Carrefour" --source_id "carrefour" --source_name "Carrefour" --source_url "https://www.carrefour.fr" --manufacturer --org_id carrefour --define lc=fr --images_dir $IMAGES_TMP_DIR
 
 # mark successful run
 mark_successful_run $SUCCESS_FILE_PATH

--- a/scripts/imports/imports_utils.sh
+++ b/scripts/imports/imports_utils.sh
@@ -21,8 +21,8 @@ function import_since() {
         # 86400 seconds in a day, +1 because we want upper bound
         IMPORT_SINCE=$(( $DIFF / 86400 + 1 ))
     else
-        # defaults to one week
-        IMPORT_SINCE=7
+        # defaults to one year
+        IMPORT_SINCE=365
     fi
     echo $IMPORT_SINCE
 }

--- a/scripts/imports/intermarche/run_intermarche_import.sh
+++ b/scripts/imports/intermarche/run_intermarche_import.sh
@@ -81,7 +81,7 @@ for file in $DATA_TMP_DIR/data/*.csv; do
     # Remove it if there is one
     sed -i '1s/^\xEF\xBB\xBF//' $file
     echo "Importing $file"
-    ./scripts/import_csv_file.pl --csv_file $file --user_id perfqual --comment "Import Intermarché" --source_id "les-mousquetaires" --source_name "Les Mousquetaires" --source_url "https://www.intermarche.com/" --manufacturer --org_id les-mousquetaires --define lc=fr --images_dir $IMAGES_TMP_DIR
+    ./scripts/import_csv_file.pl --csv_file $file --user_id perfqual --comment "Import Perfqual" --source_id "les-mousquetaires" --source_name "Les Mousquetaires" --source_url "https://www.intermarche.com/" --manufacturer --org_id les-mousquetaires --define lc=fr --images_dir $IMAGES_TMP_DIR
 done
 
 # mark successful run

--- a/scripts/imports/intermarche/run_intermarche_import.sh
+++ b/scripts/imports/intermarche/run_intermarche_import.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# do not continue on failure
+set -e
+
+# load utils
+. scripts/imports/imports_utils.sh
+
+# this script must be launched from server root (/srv/off-pro)
+export PERL5LIB=lib:$PERL5LIB
+
+# load paths
+echo "Load paths"
+. <(perl -e 'use ProductOpener::Paths qw/:all/; print base_paths_loading_script()')
+
+if [[ -z "$OFF_SFTP_HOME_DIR" ]]
+then
+    >&2 "OFF_SFTP_HOME_DIR not defined, exiting"
+    exit 10
+fi
+
+DATA_TMP_DIR=$OFF_CACHE_TMP_DIR/intermarche-data
+
+# Separate image directory as we want to keep images cached for later imports
+IMAGES_TMP_DIR=$OFF_CACHE_TMP_DIR/intermarche-images
+
+SUCCESS_FILE_PATH="$OFF_PRIVATE_DATA_DIR/intermarche-import-success"
+
+IMPORT_SINCE=$(import_since $SUCCESS_FILE_PATH)
+
+echo "IMPORT_SINCE: $IMPORT_SINCE days"
+
+# Intermarche prefers that we do not keep already processed files in the sftp
+# directory, so we move them to a different place, but still keep past files
+# in case we need to reprocess them
+echo "Move csv and image files to $OFF_SFTP_HOME_DIR/artinformatique/data/intermarche/"
+cp -a $OFF_SFTP_HOME_DIR/artinformatique/data/intermarche/* $OFF_SFTP_HOME_DIR/artinformatique-backup/data/intermarche/
+
+# copy CSV files modified since the last successful run
+echo "Copy CSV files modified since the last successful run"
+rm -rf $DATA_TMP_DIR
+mkdir $DATA_TMP_DIR
+mkdir $DATA_TMP_DIR/data
+
+find $OFF_SFTP_HOME_DIR/artinformatique-backup/data/intermarche/ -mtime -$IMPORT_SINCE -type f -name "*.csv*" -exec cp {} $DATA_TMP_DIR/data/ \;
+
+# The CSV files are in a format like 19-11-2023-intermarche.csv and sometimes they
+# send us files from multiple months
+# In order to import them in the right order, we rename them with YYYY-MM-DD first
+
+for filepath in $DATA_TMP_DIR/data/*.csv; do
+    # Check if the file is in the right format
+    echo "Renaming $file"
+    # Keep only the file name
+    file="${filepath##*/}"
+    if [[ $file =~ ^[0-9]{2}-[0-9]{2}-[0-9]{4}-intermarche\.csv$ ]]; then
+        # Extract the day, month, and year from the filename
+        day=${file:0:2}
+        month=${file:3:2}
+        year=${file:6:4}
+        # Construct the new filename
+        newfile="${year}-${month}-${day}-intermarche.csv"
+        # Rename the file
+        mv -- "$filepath" "$DATA_TMP_DIR/data/$newfile"
+    else
+        echo "File $file, is not in DD-MM-YYYY-intermarche.csv format"
+	exit 1
+    fi
+done
+
+# Copy images
+echo $IMAGES_TMP_DIR
+mkdir -p $IMAGES_TMP_DIR
+find $OFF_SFTP_HOME_DIR/artinformatique-backup/data/intermarche/ -mtime -$IMPORT_SINCE -type f -name "*.jp*" -exec cp {} $IMAGES_TMP_DIR/ \;
+
+
+# import CSV files in alphabetical order (starting by YYYY-MM-DD)
+echo "Import data"
+for file in $DATA_TMP_DIR/data/*.csv; do
+    # Intermarche files have a BOM at the start of the file, which confuses Text::CSV
+    # Remove it if there is one
+    sed -i '1s/^\xEF\xBB\xBF//' $file
+    echo "Importing $file"
+    ./scripts/import_csv_file.pl --csv_file $file --user_id perfqual --comment "Import Intermarché" --source_id "les-mousquetaires" --source_name "Les Mousquetaires" --source_url "https://www.intermarche.com/" --manufacturer --org_id les-mousquetaires --define lc=fr --images_dir $IMAGES_TMP_DIR
+done
+
+# mark successful run
+mark_successful_run $SUCCESS_FILE_PATH


### PR DESCRIPTION
A few things to note:
- Intermarché wants us to remove the files from the SFTP as we process them, thus we move them to a backup folder, so that we can reprocess them if needed
- The files are named in DD-MM-YYYY format and sometimes we get multiple months uploaded at the same second, we rename them to YYYY-MM-DD so that can import them in order
- The CSV files are in OFF format, but they have a byte order mark which breaks Text::CSV, so we remove the mark first