### PR TITLE
taxonomy: dq_serving_size_parsing_improvements

### DIFF
--- a/lib/ProductOpener/Units.pm
+++ b/lib/ProductOpener/Units.pm
@@ -283,8 +283,6 @@ sub normalize_serving_size ($serving) {
 
 		return unit_to_g($q, $u);
 	}
-
-	#$log->trace("serving size normalized", { serving => $serving, q => $q, u => $u }) if $log->is_trace();
 	return;
 }
 

--- a/taxonomies/units.txt
+++ b/taxonomies/units.txt
@@ -11,7 +11,7 @@
 # symbol:en:µg
 # This is needed because µg in the xx: entry (xx:µg) would be canonicalized to xx:g
 
-xx:g, gr, grs
+xx:g, gr, grs, grm
 ar:جرام, جرامات
 bn:গ্রাম, গ্রামগুলি
 bs:gram, grama
@@ -50,7 +50,7 @@ ne:ग्राम, ग्रामहरू
 nl:gram, gram
 no:gram, gram
 pl:gram, gramy
-pt:grama, gramas
+pt:grama, gramas, gm
 ro:gram, grame
 ru:грамм, граммы, г
 sk:gram, gramov
@@ -320,7 +320,7 @@ standard_unit:en:g
 
 
 # Ounces
-xx:oz, ozs
+xx:oz, ozs, onz
 ar:أونصة, أونصات
 bg:унция, унции
 bn:ঔঞ্জ, ঔঞ্জ
@@ -613,6 +613,11 @@ ur:ملی لیٹر, ملی لیٹرز
 vi:millilit, millilit
 zh:毫升, 毫升, 毫升
 conversion_factor:en:1
+standard_unit:en:ml
+
+# Metric teaspoon
+en:metric teaspoon
+conversion_factor:en:5
 standard_unit:en:ml
 
 # Fluid ounces


### PR DESCRIPTION
### What
Reviewed the Mirabelle results from the issue for serving size (see below)

> Here are 100 examples randomly: http://mirabelle.openfoodfacts.org/products?sql=select+code%2C+url%2C+creator%2C+created_datetime%2C+last_modified_datetime%2C+product_name%2C+serving_size%2C+serving_quantity%0D%0Afrom+%5Ball%5D+%0D%0Awhere+%28serving_quantity+%3D%3D+%22%22+or+serving_quantity+IS+NULL%29+and+%28serving_size+%21%3D+%22%22%29%0D%0Aorder+by+random%28%29%0D%0Alimit+100

Brazil (pt:) added "gm". 5,484 rows
xx:onz, 128 rows
en:metric teaspoon 2 rows
	note that beside metric teaspoon, teaspoon or tsp depends on the country (us, uk, canada)
	same for cup and tbsp which is also a factor of the density (i.e., 1 tbsp of water will be different than 1 tbsp of sugar, for example)
gg instead of g is typo, not added in taxonomy. It has to be fixed by contributors.

### Related issue(s) and discussion

- Related to #7768 