### PR TITLE
fix: dq_sugar_plus_starch_greater_than_carbohydrates

### DIFF
--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1469,4 +1469,59 @@ check_quality_and_test_product_has_quality_tag(
 	'Detected category from brand - Beauty', 1
 );
 
+# Nutrition errors - sugar + starch > carbohydrates
+## without "<" symbol
+$product_ref = {
+	nutriments => {
+		"carbohydrates_100g" => 1,
+		"sugars_100g" => 2,
+		"starch_100g" => 3,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(has_tag($product_ref, 'data_quality', 'en:nutrition-sugars-plus-starch-greater-than-carbohydrates'),
+	'sum of sugars and starch greater carbohydrates')
+	or diag explain $product_ref;
+## with "<" symbol
+$product_ref = {
+	nutriments => {
+		"carbohydrates_100g" => 1,
+		"sugars_100g" => 1,
+		"sugars_modifier" => "<",
+		"starch_100g" => 1,
+		"starch_modifier" => "<",
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	!has_tag($product_ref, 'data_quality', 'en:nutrition-sugars-plus-starch-greater-than-carbohydrates'),
+	'sum of sugars and starch greater carbohydrates, presence of "<" symbol,  and sugars or starch is smaller than carbohydrates'
+) or diag explain $product_ref;
+## sugar or starch is greater than carbohydrates, with "<" symbol
+$product_ref = {
+	nutriments => {
+		"carbohydrates_100g" => 3,
+		"sugars_100g" => 1,
+		"starch_100g" => 5,
+		"starch_modifier" => "<",
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag($product_ref, 'data_quality', 'en:nutrition-sugars-plus-starch-greater-than-carbohydrates'),
+	'sum of sugars and starch greater carbohydrates, presence of "<" symbol, and sugars or starch is greater than carbohydrates'
+) or diag explain $product_ref;
+## should not be triggered
+$product_ref = {
+	nutriments => {
+		"carbohydrates_100g" => 3,
+		"sugars_100g" => 2,
+		"starch_100g" => 1,
+	}
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(!has_tag($product_ref, 'data_quality', 'en:nutrition-sugars-plus-starch-greater-than-carbohydrates'),
+	'sum of sugars and starch greater carbohydrates')
+	or diag explain $product_ref;
+
 done_testing();


### PR DESCRIPTION
### What
See linked issue.

Suggested solution:
	trigger error if "<" symbol is missing
	do not trigger error if at least one nutriment has "<" symbol
		but trigger error if there is "<" symbol and 1 nutrient (sugar or starch) is above carbohydrates (that way we can still get error if the sugar or starch too high)

### Related issue(s) and discussion
- Fixes #9267
