### PR TITLE
taxonomy: Remove redundant alias

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -21904,6 +21904,8 @@ auth_url:fr:https://hve-asso.com
 fr:Produit certifié, CQ Produit Certifié
 en:Certified product
 
+# Note: "es:Calidad Certificada" is a specific Spanish label, it should not be added as a translation of "en:Certified quality"
+# example product: https://es.openfoodfacts.org/producto/8437002590468/aceite-de-oliva-virgen-extra-iznaoliva
 en:Certified quality
 fr:Qualité certifiée
 

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -21906,7 +21906,6 @@ en:Certified product
 
 en:Certified quality
 fr:Qualité certifiée
-es:Calidad certificada
 
 en:QS certification mark
 de:QS-Prüfzeichen


### PR DESCRIPTION
### What

Remove redundant `es:Calidad certificada` taxonomy label entry.