### PR TITLE
taxonomy: Add (gym) protein nutrients

### DIFF
--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -6604,3 +6604,32 @@ es:Residuo seco
 fr:Résidu sec
 nl:Droogrest
 unit:en: mg
+
+zz:beta-alanine
+en:Beta-Alanine
+xx:Beta-Alanine
+es:Beta-Alanina
+fr:Bêta-Alanine
+unit:en: g
+wikidata:en: Q310919
+wikipedia:en: https://en.wikipedia.org/wiki/%CE%92-Alanine
+
+zz:creatine
+en:Creatine, Creatine Monohydrate
+ca:Creatina, Monohidrat de creatina, Monohidrat Creatina
+es:Creatina, Monohidrato de creatina, Monohidrato Creatina
+fr:Créatine, Monohydrate de Créatine
+xx:Creatine
+unit:en: g
+wikidata:en: Q223600
+wikipedia:en: https://en.wikipedia.org/wiki/Creatine
+
+zz:l-citrulline
+en:L-citrulline
+ca:L-citrul·lina
+es:L-Citrulina, Citrulina
+fr:L-citruline
+xx:L-citrulline
+unit:en: g
+wikidata:en: Q408641
+wikipedia:en: https://en.wikipedia.org/wiki/Citrulline

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -6625,11 +6625,81 @@ wikidata:en: Q223600
 wikipedia:en: https://en.wikipedia.org/wiki/Creatine
 
 zz:l-citrulline
-en:L-citrulline
+en:L-citrulline, Citrulline
 ca:L-citrul·lina
 es:L-Citrulina, Citrulina
 fr:L-citruline
-xx:L-citrulline
-unit:en: g
+xx:L-citrulline, Citrulline
+unit:en: mg
 wikidata:en: Q408641
 wikipedia:en: https://en.wikipedia.org/wiki/Citrulline
+
+zz:l-glutamine
+en:L-Glutamine, Glutamine, Gln
+es:L-Glutamina, Glutamina
+ca:L-Glutamina, Glutamina
+xx:L-Glutamine
+unit:en: mg
+wikidata:en: Q181619
+wikipedia:en: https://en.wikipedia.org/wiki/Glutamine
+
+zz:bcaa
+en:BCAA, BCAAs, Branched-Chain Amino Acid
+xx:BCAA
+unit:en: g
+wikidata:en: Q420726
+wikipedia:en: https://en.wikipedia.org/wiki/Branched-chain_amino_acid
+
+zz:l-valine
+en:L-Valine, Valine
+es:L-Valina, Valina
+ca:L-Valina, Valina
+xx:L-Valine, Valine
+unit:en: mg
+wikidata:en: Q483752
+wikipedia:en: https://en.wikipedia.org/wiki/Valine
+
+zz:l-leucine
+en:L-Leucine, Leucine
+es:L-Leucina, Leucina
+ca:L-Leucina, Leucina
+en:L-Leucine, Leucine
+unit:en: mg
+wikidata:en: Q483745
+wikipedia:en: https://en.wikipedia.org/wiki/Leucine
+
+zz:l-isoleucine
+en:L-Isoleucine, Isoleucine
+es:L-Isoleucina, Isoleucina
+ca:L-Isoleucina, Isoleucina
+en:L-Isoleucine, Isoleucine
+unit:en: mg
+wikidata:en: Q484940
+wikipedia:en: https://en.wikipedia.org/wiki/Isoleucine
+
+zz:l-arginine
+en:L-Arginine, Arginine
+es:L-Arginina, Arginina
+ca:L-Arginina, Arginina
+xx:L-Arginine, Arginine
+unit:en: mg
+wikidata:en: Q173670
+wikipedia:en: https://en.wikipedia.org/wiki/Arginine
+
+zz:l-cysteine
+en:L-Cysteine, Cysteine, Cystein
+es:L-Cisteína, Cisteína
+ca:L-Cisteïna, Cisteïna
+xx:L-Cysteine, Cysteine, Cystein
+unit:en: mg
+wikidata:en: Q186474
+wikipedia:en: https://en.wikipedia.org/wiki/Cysteine
+
+zz:l-Glutathione
+en:L-Glutathione, Glutathione
+es:L-Glutatión, Glutationa
+ca:L-Glutatió, Glutatió
+xx:L-Glutathione, Glutathione
+unit:en: mg
+wikidata:en: Q116907
+wikipedia:en: https://en.wikipedia.org/wiki/Glutathione


### PR DESCRIPTION
Multiple "sport suplements" contain differnt proteins that can be listed.
Most commonly there is `creatine`, but there are other aminoacids that are interesting.