### PR TITLE
chore: Re-enable devcontainers (experimental) 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,23 +3,48 @@
   "dockerComposeFile": [
     "../docker-compose.yml",
     "../docker/dev.yml",
-    "../docker/admin-uis.yml",
-    "../docker/vscode.yml"
+    "../docker/devcontainer.yml"
+  ],
+  "containerUser": "root",
+  "capAdd": [
+    "SYS_PTRACE"
+  ],
+  "securityOpt": [
+    "seccomp=unconfined"
   ],
   "service": "backend",
+  "runServices": [
+    "memcached",
+    "postgres",
+    "mongodb",
+    "dynamicfront",
+    "frontend",
+    "incron",
+    "minion",
+    "redis"
+  ],
   "workspaceFolder": "/opt/product-opener",
-  "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash"
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "richterger.perl",
+        "d9705996.perl-toolbox",
+        "redhat.vscode-yaml",
+        "dbaeumer.vscode-eslint",
+        "stylelint.vscode-stylelint",
+        "syler.sass-indented",
+        "mrorz.language-gettext"
+      ]
+    }
   },
-  "runArgs": ["-u", "vscode", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
-  "extensions": [
-    "mortenhenriksen.perl-debug",
-    "d9705996.perl-toolbox",
-    "redhat.vscode-yaml",
-    "dbaeumer.vscode-eslint",
-    "stylelint.vscode-stylelint",
-    "syler.sass-indented",
-    "mrorz.language-gettext",
-    "eg2.vscode-npm-script"
-  ]
+  "features": {
+    "ghcr.io/devcontainers/features/git:1":{},
+    "ghcr.io/devcontainers/features/github-cli:1":{},
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "libterm-readline-gnu-perl"
+    }
+  }
 }

--- a/docker/devcontainer.yml
+++ b/docker/devcontainer.yml
@@ -1,0 +1,6 @@
+version: "3.7"
+services:
+  backend:
+    build:
+      args:
+        CPANMOPTS: "${CPANMOPTS:---with-develop --with-feature=off_server_dev_tools}"

--- a/docker/vscode.yml
+++ b/docker/vscode.yml
@@ -1,6 +1,0 @@
-version: "3.7"
-services:
-  backend:
-    image: productopener-backend-vscode
-    build:
-      target: vscode

--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -175,7 +175,7 @@ Specific notes are provide on [applying AGRIBALYSE updates to support the Ecosco
 
 ## Visual Studio Code
 
-**WARNING**: for now this is deprecated, some work needs to be done.
+**WARNING**: Devcontainer support is currently experimental. It's recommended to run the normal docker commands before, and stop the containers: `make dev down`. Note that `make dev`, `make test`, and so on may currently conflict with the devcontainer.
 
 This repository comes with a configuration for Visual Studio Code (VS Code) [development containers (devcontainer)](https://code.visualstudio.com/docs/remote/containers). This enables some Perl support in VS Code without the need to install the correct Perl version and modules on your local machine.
 


### PR DESCRIPTION
Updated to the newer [devcontainer spec](https://containers.dev/), this allows using Perl in vscode via `Perl::LanguageServer`.

Note that this doesn't have feature parity with what's available in the Makefile, yet. Notably, tests don't work, yet, and it might be beneficial to run `make dev`  before opening the devcontainer.