### PR TITLE
taxonomy: typo in labels taxonomy fegg -> egg

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -4150,7 +4150,7 @@ zh:无色素
 label_categories:en: en:Health, en:Additives
 
 #instruction:en:Do NOT change the english key.
-en:No feggs, egg free
+en:No eggs, egg free
 bg:Без яйца
 ca:Sense ou, Lliure d'ou
 de:Ohne Ei


### PR DESCRIPTION
Reported on Slack by Binzy: https://openfoodfacts.slack.com/archives/C02VDSWHT/p1703058824686139

(already fixed in production)