### PR TITLE
taxonomy: vit. abbreviation for vitamins

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -335,14 +335,6 @@ my %abbreviations = (
 		["S. thermophilus", "streptococcus thermophilus"],
 	],
 
-	da => [
-		["bl. a.", "blandt andet"],
-		["inkl.", "inklusive"],
-		["mod.", "modificeret"],
-		["past.", "pasteuriserede"],
-		["pr.", "per"],
-	],
-
 	en => [
 		["w/o", "without"],
 		["w/", "with "],    # note trailing space
@@ -351,9 +343,19 @@ my %abbreviations = (
 
 	],
 
-	es => [["vit.", "vitamina"], ["m.g.", "materia grasa"]],
-
 	ca => [["vit.", "vitamina"], ["m.g.", "matèria grassa"]],
+
+	da => [
+		["bl. a.", "blandt andet"],
+		["inkl.", "inklusive"],
+		["mod.", "modificeret"],
+		["past.", "pasteuriserede"],
+		["pr.", "per"],
+	],
+
+	de => [["vit.", "vitamin"],],
+
+	es => [["vit.", "vitamina"], ["m.g.", "materia grasa"]],
 
 	fi => [["mikro.", "mikrobiologinen"], ["mm.", "muun muassa"], ["sis.", "sisältää"], ["n.", "noin"],],
 

--- a/taxonomies/ingredients.txt
+++ b/taxonomies/ingredients.txt
@@ -9031,101 +9031,101 @@ wikipedia:en:https://en.wikipedia.org/wiki/American_cheese
 
 # description:en: A vitamin is an organic molecule (or related set of molecules) which is an essential micronutrient that an organism needs in small quantities for the proper functioning of its metabolism. This ingredient is written in plural
 
-en:Vitamins, vitamin
-af:Vitamien
+en:Vitamins, vitamin, vit.
+af:Vitamien, vit.
 ar:فيتامين
 as:ভিটামিন
-az:Vitaminlər
+az:Vitaminlər, vit.
 ba:Витаминдар
 be:Вітаміны, Вітамін
-bg:Витамини, Витамин, vitamins
+bg:Витамини, Витамин, vitamins, vit.
 bn:ভিটামিন
-bs:Vitamini, Vitamin
-ca:vitamina, vitamines
-cs:Vitaminy, vitamín
+bs:Vitamini, Vitamin, vit.
+ca:vitamina, vitamines, vit.
+cs:Vitaminy, vitamín, vit.
 cv:Витамин
 cy:Fitaminau, Fitamin
-da:Vitaminer, Vitamin
-de:Vitamine, Vitamin, Vitaminmischung
+da:Vitaminer, Vitamin, vit.
+de:Vitamine, Vitamin, Vitaminmischung, vit.
 dv:ވިޓަމިން
 el:Βιταμίνες, Βιταμίνη
 eo:vitamino
-es:Vitaminas, vitamina
-et:Vitamiin, Vitamiinid
+es:Vitaminas, vitamina, vit.
+et:Vitamiin, Vitamiinid, vit.
 eu:Bitamina
 fa:ویتامین
-fi:Vitamiinit, vitamiini
+fi:Vitamiinit, vitamiini, vit.
 fo:Vitamin
-fr:Vitamines, vitamine, mélange de vitamines
-ga:Vitimín
-gl:Vitamina
+fr:Vitamines, vitamine, mélange de vitamines, vit.
+ga:Vitimín, vit.
+gl:Vitamina, vit.
 he:ויטמין
 hi:विटामिन
-hr:vitamin, vitamini, vitaminska mješavina
-ht:Vitamin
-hu:Vitaminok, vitamin
+hr:vitamin, vitamini, vitaminska mješavina, vit.
+ht:Vitamin, vit.
+hu:Vitaminok, vitamin, vit.
 hy:Վիտամին
-ia:Vitamina
-id:Vitamin
-is:Vítamín
-it:Vitamine
+ia:Vitamina, vit.
+id:Vitamin, vit.
+is:Vítamín, vit.
+it:Vitamine, vit.
 ja:ビタミン
-jv:Vitamin
+jv:Vitamin, vit.
 ka:ვიტამინი
 kk:Дәрумен
 km:វីតាមីន
 kn:ಜೀವಸತ್ವಗಳು
 ko:비타민
 ky:Витаминдер
-la:Vitaminum
-lb:Vitamin
-lg:Vitamin
+la:Vitaminum, vit.
+lb:Vitamin, vit.
+lg:Vitamin, vit.
 lo:ວິຕາມິນ
-lt:Vitaminai, Vitaminas
-lv:Vitamīni
+lt:Vitaminai, Vitaminas, vit.
+lv:Vitamīni, vit.
 mk:Витамин
 ml:ജീവകം
 mr:जीवनसत्त्व
-ms:Vitamin
-mt:Vitamini
+ms:Vitamin, vit.
+mt:Vitamini, vit.
 my:ဗီတာမင်
-nb:Vitaminer, vitamin
+nb:Vitaminer, vitamin, vit.
 ne:भिटामिन
-nl:Vitamines, vitaminen, Vitamine
-nn:Vitaminer, vitamin
-no:vitaminer, vitamin
-nv:Vitamine
-oc:Vitamina
-or:ଜୀବସାର‎
+nl:Vitamines, vitaminen, Vitamine, vit.
+nn:Vitaminer, vitamin, vit.
+no:vitaminer, vitamin, vit.
+nv:Vitamine, vit.
+oc:Vitamina, vit.
+or:ଜୀବସାର
 pa:ਵਿਟਾਮਿਨ
 pl:Witamina, Witaminy
 ps:ويټامين
-pt:Vitaminas, vitamina, Premezcla de Vitaminas
-ro:Vitamine, Vitamină
+pt:Vitaminas, vitamina, Premezcla de Vitaminas, vit.
+ro:Vitamine, Vitamină, vit.
 ru:витамин
-sh:Vitamini, Vitamin
+sh:Vitamini, Vitamin, vit.
 si:විටමින්
-sk:Vitamíny, vitamín
-sl:Vitamini, Vitamin
+sk:Vitamíny, vitamín, vit.
+sl:Vitamini, Vitamin, vit.
 so:Fiitamiin
-sq:Vitamina, Vitaminat
+sq:Vitamina, Vitaminat, vit.
 sr:Витамини, витамин
-su:Vitamin
-sv:Vitaminer, Vitamin
-sw:Vitamini
+su:Vitamin, vit.
+sv:Vitaminer, Vitamin, vit.
+sw:Vitamini, vit.
 ta:உயிர்ச்சத்து
 te:విటమిన్
 tg:Витамин
 th:วิตามิน
 tk:Witamin
 tl:Bitamina
-tr:Vitamin
+tr:Vitamin, vit.
 tt:Витамин
 uk:Вітаміни
 ur:حیاتین
-uz:Vitaminlar
-vi:vitamin
-wa:Vitamene
+uz:Vitaminlar, vit.
+vi:vitamin, vit.
+wa:Vitamene, vit.
 yi:וויטאמין
 yo:Àmínìamáralókun
 zh:维生素

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -1523,6 +1523,7 @@ sv:hydroxykobalamin
 
 en:biotin
 bg:Биотин
+de:Biotin, Vitamin B7
 el:Βιοτίνη
 es:Biotina, Vitamina B7
 et:Biotiin


### PR DESCRIPTION
In ingredients preparasing, replace Vit. by Vitamin in German.

+ added "vit." as a synonym of "vitamin" in ingredients.txt taxonomy so that it also applies if ingredients are not preparsed.

It should be a more generic solution than https://github.com/openfoodfacts/openfoodfacts-server/pull/9564