### PR TITLE
feat: allow_longer_user_name

### DIFF
--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -505,7 +505,7 @@ sub check_user_form ($type, $user_ref, $errors_ref) {
 		elsif ($user_ref->{userid} !~ /^[a-z0-9]+[a-z0-9\-]*[a-z0-9]+$/) {
 			push @{$errors_ref}, $Lang{error_invalid_username}{$lang};
 		}
-		elsif (length($user_ref->{userid}) > 20) {
+		elsif (length($user_ref->{userid}) > 40) {
 			push @{$errors_ref}, $Lang{error_username_too_long}{$lang};
 		}
 

--- a/po/common/aa.po
+++ b/po/common/aa.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ach.po
+++ b/po/common/ach.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/af.po
+++ b/po/common/af.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ak.po
+++ b/po/common/ak.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/am.po
+++ b/po/common/am.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "يجب أن يحتوي اسم المستخدم على أحرف وأرقام وشرطات غير معلمة فقط."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/as.po
+++ b/po/common/as.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ast.po
+++ b/po/common/ast.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/az.po
+++ b/po/common/az.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/be.po
+++ b/po/common/be.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Імя карыстальніка павінна змяшчаць толькі літары без надрадковых знакаў, лічбы і злучкі."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Імя карыстальніка занадта доўгае (максімум 20 сімвалаў)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Імя карыстальніка занадта доўгае (максімум 40 сімвалаў)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ber.po
+++ b/po/common/ber.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -656,8 +656,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Потребителското име трябва да съдържа само нецентрирани букви, цифри и тирета."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Потребителското име е твърде дълго (максимум 20 знака)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Потребителското име е твърде дълго (максимум 40 знака)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/bm.po
+++ b/po/common/bm.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "এউজার নামের মধ্যে কেবল অসংরক্ষিত অক্ষর, সংখ্যা এবং ড্যাশ থাকা আবশ্যক।"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/bo.po
+++ b/po/common/bo.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/bs.po
+++ b/po/common/bs.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "El nom d'usuari ha de contenir només lletres sense accentuar, dígits i guions."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "El nom d'usuari és massa llarg (20 caràcters com a màxim)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "El nom d'usuari és massa llarg (40 caràcters com a màxim)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ce.po
+++ b/po/common/ce.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/chr.po
+++ b/po/common/chr.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/co.po
+++ b/po/common/co.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -662,7 +662,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/crs.po
+++ b/po/common/crs.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -654,8 +654,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Uživatelské jméno musí obsahovat pouze písmena bez diakritiky, číslice a pomlčky."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Uživatelské jméno je příliš dlouhé (maximálně 20 znaků)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Uživatelské jméno je příliš dlouhé (maximálně 40 znaků)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/cv.po
+++ b/po/common/cv.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/cy.po
+++ b/po/common/cy.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -654,8 +654,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Brugernavn må kun indeholde versaler, minuskler, cifre og streger."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Brugernavnet for langt (maks. 20 tegn)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Brugernavnet for langt (maks. 40 tegn)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Der Benutzername darf nur Buchstaben ohne Umlaute, Zahlen und Bindestriche enthalten."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Benutzername ist zu lang (maximal 20 Zeichen)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Benutzername ist zu lang (maximal 40 Zeichen)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Το όνομα χρήστη πρέπει να περιέχει μόνο μη τονισμένες λέξεις, ψηφία και παύλες"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -667,8 +667,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "The user name must contain only unaccented letters, digits and dashes."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "The user name is too long (maximum 40 characters)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "The user name must contain only unaccented letters, digits and dashes."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "The user name is too long (maximum 40 characters)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "The user name must contain only unaccented letters, digits and dashes."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "The user name is too long (maximum 40 characters)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/eo.po
+++ b/po/common/eo.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "El nombre de usuario sólo puede contener caracteres sin acentuar, dígitos y guiones."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "El nombre de usuario es demasiado largo (máximo 20 caracteres)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "El nombre de usuario es demasiado largo (máximo 40 caracteres)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/et.po
+++ b/po/common/et.po
@@ -654,8 +654,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Kasutajanimes võivad olla vaid ilma täppdeta tähed, numbrid ja kriipsud."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Liiga pikk kasutajanimi (lubatud on kuni 20 tähemärki)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Liiga pikk kasutajanimi (lubatud on kuni 40 tähemärki)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -654,8 +654,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Käyttäjätunnuksessa on oltava vain tarkemerkittömiä kirjaimia, numeroita ja väliviivoja."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Käyttäjänimi on liian pitkä (enintään 20 merkkiä)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Käyttäjänimi on liian pitkä (enintään 40 merkkiä)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/fil.po
+++ b/po/common/fil.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Ang pangalan ng user ay dapat maglalaman ng hindi maayos na mga titik, mga numero at gitling."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/fo.po
+++ b/po/common/fo.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -656,8 +656,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Le nom d'utilisateur doit être composé de lettres minuscules sans accents, de tirets et/ou de chiffres."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Le nom d'utilisateur est trop long (20 caractères maximum)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Le nom d'utilisateur est trop long (40 caractères maximum)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ga.po
+++ b/po/common/ga.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/gd.po
+++ b/po/common/gd.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/gl.po
+++ b/po/common/gl.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "O nome de usuario debe conter letras non acentuadas, números e trazos."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/gu.po
+++ b/po/common/gu.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "વપરાશકર્તા નામમાં ફક્ત બિનઆકાશી અક્ષરો, અંકો અને ડેશ્સ હોવા જોઈએ."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ha.po
+++ b/po/common/ha.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "שם המשתמש יכול להכיל רק אותיות לטיניות קטנות, ספרות ומקפים."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "שם המשתמש ארוך מדי (20 תווים לכל היותר)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "שם המשתמש ארוך מדי (40 תווים לכל היותר)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/hi.po
+++ b/po/common/hi.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/hr.po
+++ b/po/common/hr.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ht.po
+++ b/po/common/ht.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "A felhasználónév csak ékezet nélküli angol betűket (a-z), számjegyeket (0-9), és kötőjeleket (-) tartalmazhat!"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/hy.po
+++ b/po/common/hy.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/id.po
+++ b/po/common/id.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Nama pengguna hanya boleh berisi huruf tanpa aksen, angka, dan tanda penghubung."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ii.po
+++ b/po/common/ii.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/is.po
+++ b/po/common/is.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Lo username può contenere solo caratteri senza accento, trattini e cifre"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Il nome utente è troppo lungo (massimo 20 caratteri)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Il nome utente è troppo lungo (massimo 40 caratteri)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/iu.po
+++ b/po/common/iu.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "ユーザー名はアクセントのない文字、数字、ダッシュのみ含めることができます。"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr "ユーザ名が長すぎます（最大20文字）。"
 
 msgctxt "error_name_too_long"

--- a/po/common/jv.po
+++ b/po/common/jv.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ka.po
+++ b/po/common/ka.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/kab.po
+++ b/po/common/kab.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Isem n umseqdec ilaq kan ad isɛu isekkilen, uṭṭunen akked tezdit."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/kk.po
+++ b/po/common/kk.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/km.po
+++ b/po/common/km.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/kmr_TR.po
+++ b/po/common/kmr_TR.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/kn.po
+++ b/po/common/kn.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "사용자 이름에는 악센트가 없는 문자, 숫자 및 대시만 포함되어야합니다."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr "사용자 이름이 너무 깁니다(최대 20자)."
 
 msgctxt "error_name_too_long"

--- a/po/common/kw.po
+++ b/po/common/kw.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ky.po
+++ b/po/common/ky.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/la.po
+++ b/po/common/la.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/lb.po
+++ b/po/common/lb.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "De Benotzernumm muss nëmmen Buchszawen ouni Acceent, Zifferen an Zeechen enthalen."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/lol.po
+++ b/po/common/lol.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "crwdns225403:0crwdne225403:0"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr "crwdns225405:0crwdne225405:0"
 
 msgctxt "error_name_too_long"

--- a/po/common/lt.po
+++ b/po/common/lt.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Vartotojo varde gali būti tik paprastos raidės, skaitmenys ir brūkšneliai."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Naudotojo vardas per ilgas (daugiausia 20 simbolių)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Naudotojo vardas per ilgas (daugiausia 40 simbolių)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/lv.po
+++ b/po/common/lv.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Lietotājvārdam ir jābūt tikai neapstiprinātiem burtiem, cipariem un defisēm."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/mg.po
+++ b/po/common/mg.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/mi.po
+++ b/po/common/mi.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ml.po
+++ b/po/common/ml.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/mn.po
+++ b/po/common/mn.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/mr.po
+++ b/po/common/mr.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Nama pengguna mesti mengandungi hanya huruf, angka dan sengkang tanpa tanda aksen."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/mt.po
+++ b/po/common/mt.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/my.po
+++ b/po/common/my.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/nb.po
+++ b/po/common/nb.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Brukernavnet kan kun inneholde bokstaver uten aksent, tall og bindestreker."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Brukernavnet er for langt (maks 20 tegn)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Brukernavnet er for langt (maks 40 tegn)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ne.po
+++ b/po/common/ne.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "De gebruikersnaam mag alleen niet-geaccentueerde kleine letters, cijfers en streepjes bevatten."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "De gebruikersnaam is te lang (maximaal 20 tekens)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "De gebruikersnaam is te lang (maximaal 40 tekens)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "De gebruikersnaam mag enkel kleine letters zonder accenten, streepjes en/of cijfers bevatten"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "De gebruikersnaam is te lang (maximaal 20 tekens)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "De gebruikersnaam is te lang (maximaal 40 tekens)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/nn.po
+++ b/po/common/nn.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/no.po
+++ b/po/common/no.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/nr.po
+++ b/po/common/nr.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/oc.po
+++ b/po/common/oc.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/or.po
+++ b/po/common/or.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/pa.po
+++ b/po/common/pa.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Nazwa użytkownika powinna zawierać jedynie nieakcentowane litery, cyfry i myślniki."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Nazwa użytkownika jest zbyt długa (maksymalnie 20 znaków)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Nazwa użytkownika jest zbyt długa (maksymalnie 40 znaków)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "O nome de utilizador deve conter apenas letras sem acento, cedilhas, números ou hífens."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "O nome de usuário é muito longo (máximo de 20 caracteres)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "O nome de usuário é muito longo (máximo de 40 caracteres)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "O nome de utilizador deve conter apenas letras sem acento, cedilhas, números ou hífens."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "O nome de utilizador é muito longo (máximo de 20 caracteres)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "O nome de utilizador é muito longo (máximo de 40 caracteres)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/qu.po
+++ b/po/common/qu.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/rm.po
+++ b/po/common/rm.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Numele de utilizator trebuie să conțină doar litere neaccentuate, cifre și liniuțe."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Numele de utilizator este prea lung (maxim 20 de caractere)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Numele de utilizator este prea lung (maxim 40 de caractere)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Имя пользователя должно содержать только латинские буквы, цифры и дефисы."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sa.po
+++ b/po/common/sa.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sat.po
+++ b/po/common/sat.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sc.po
+++ b/po/common/sc.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sco.po
+++ b/po/common/sco.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sd.po
+++ b/po/common/sd.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sg.po
+++ b/po/common/sg.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/si.po
+++ b/po/common/si.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -654,8 +654,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Uporabniško ime mora vsebovati le nenaglasne črke, številke in pomišljaje."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Uporabniško ime je predolgo (največ 20 znakov)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Uporabniško ime je predolgo (največ 40 znakov)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/sma.po
+++ b/po/common/sma.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sn.po
+++ b/po/common/sn.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/so.po
+++ b/po/common/so.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/son.po
+++ b/po/common/son.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sq.po
+++ b/po/common/sq.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sr.po
+++ b/po/common/sr.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sr_CS.po
+++ b/po/common/sr_CS.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Korisničko ime može sadržati samo slova (bez dijakritika), brojeve i crtice."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sr_RS.po
+++ b/po/common/sr_RS.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ss.po
+++ b/po/common/ss.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/st.po
+++ b/po/common/st.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Användarnamnet får endast innehålla bokstäver utan diakritiska tecken, siffror och bindestreck."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/sw.po
+++ b/po/common/sw.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ta.po
+++ b/po/common/ta.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/te.po
+++ b/po/common/te.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tg.po
+++ b/po/common/tg.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "ชื่อผู้ใช้ยาวเกินไป (สูงสุดได้ถึง 20 อักขระ)"
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "ชื่อผู้ใช้ยาวเกินไป (สูงสุดได้ถึง 40 อักขระ)"
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ti.po
+++ b/po/common/ti.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tl.po
+++ b/po/common/tl.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Ang pangalan ng user ay dapat maglalaman ng hindi maayos na mga titik, mga numero at gitling."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tn.po
+++ b/po/common/tn.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Kullanıcı adı yalnızca renksiz rakamlar, rakamlar ve çizgiler içermelidir."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Kullanıcı adı çok uzun (maksimum 20 karakter)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Kullanıcı adı çok uzun (maksimum 40 karakter)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ts.po
+++ b/po/common/ts.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tt.po
+++ b/po/common/tt.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tw.po
+++ b/po/common/tw.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ty.po
+++ b/po/common/ty.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/tzl.po
+++ b/po/common/tzl.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ug.po
+++ b/po/common/ug.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Ім’я користувача має містити лише букви без надрядкових знаків, цифри та тире."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Ім'я користувача задовге. (максимум 20 символів)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Ім'я користувача задовге. (максимум 40 символів)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/ur.po
+++ b/po/common/ur.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Foydalanuvchi nomi faqat harflar, raqamlar va chiziqlardan iborat boʻlishi lozim."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/val.po
+++ b/po/common/val.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/ve.po
+++ b/po/common/ve.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/vec.po
+++ b/po/common/vec.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "Tên người dùng chỉ được chứa các chữ cái, chữ số và dấu gạch ngang không có dấu."
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "Tên đăng nhập quá dài! (tối đa 20 ký tự)."
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "Tên đăng nhập quá dài! (tối đa 40 ký tự)."
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/vls.po
+++ b/po/common/vls.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/wa.po
+++ b/po/common/wa.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/wo.po
+++ b/po/common/wo.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/xh.po
+++ b/po/common/xh.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/yi.po
+++ b/po/common/yi.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/yo.po
+++ b/po/common/yo.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/zea.po
+++ b/po/common/zea.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -655,8 +655,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "用户名智能包括无重音的字母，数字和特殊符号"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "用户名太长（最多 20 个字符）。"
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "用户名太长（最多 40 个字符）。"
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -655,7 +655,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "使用者名稱只能有字母、數字及破折號。"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -656,8 +656,8 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr "使用者帳號只能包含字母、數字及破折號。"
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
-msgstr "使用者名稱太長 (20 字元為上限)。"
+msgid "The user name is too long (maximum 40 characters)."
+msgstr "使用者名稱太長 (40 字元為上限)。"
 
 msgctxt "error_name_too_long"
 msgid "The name is too long (maximum 60 characters)."

--- a/po/common/zu.po
+++ b/po/common/zu.po
@@ -654,7 +654,7 @@ msgid "The user name must contain only unaccented letters, digits and dashes."
 msgstr ""
 
 msgctxt "error_username_too_long"
-msgid "The user name is too long (maximum 20 characters)."
+msgid "The user name is too long (maximum 40 characters)."
 msgstr ""
 
 msgctxt "error_name_too_long"


### PR DESCRIPTION
### What
allow users to have user_name length up to 40 characters
updated all files in po, but not sure how it is working, if it will be overwritten by crowdin or something like that...

### Screenshot
![Screenshot_20231223_112757_2](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/15f62741-0721-4da4-92be-576b8f7d8e19)




### Related issue(s) and discussion
- Fixes #9558
