### PR TITLE
fix: dq_all_val_in_nutrition_are_identical_2

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1167,15 +1167,19 @@ sub check_nutrition_data ($product_ref) {
 		#  OR
 		# all values but one - because sodium and salt can be automatically calculated one depending on the value of the other - are identical
 		# and values (check first value only) are above 1 (see issue #9572)
+		# and at least 4 values are input by contributors (see issue #9572)
 		if (
-			($nutriments_values_occurences_max_value == scalar @major_nutriments_values)
-			or (
-				($nutriments_values_occurences_max_value >= scalar @major_nutriments_values - 1)
-				and (   (defined $nutriments_values{'salt_100g'})
-					and ($nutriments_values{'sodium_100g'})
-					and ($nutriments_values{'salt_100g'} != $nutriments_values{'sodium_100g'}))
+			(
+				($nutriments_values_occurences_max_value == scalar @major_nutriments_values)
+				or (
+					($nutriments_values_occurences_max_value >= scalar @major_nutriments_values - 1)
+					and (   (defined $nutriments_values{'salt_100g'})
+						and ($nutriments_values{'sodium_100g'})
+						and ($nutriments_values{'salt_100g'} != $nutriments_values{'sodium_100g'}))
+				)
 			)
 			and (@major_nutriments_values[0] > 1)
+			and (scalar @major_nutriments_values > 3)
 			)
 		{
 			push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-values-are-all-identical";

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1166,6 +1166,7 @@ sub check_nutrition_data ($product_ref) {
 		# all values are identical
 		#  OR
 		# all values but one - because sodium and salt can be automatically calculated one depending on the value of the other - are identical
+		# and values (check first value only) are above 1 (see issue #9572)
 		if (
 			($nutriments_values_occurences_max_value == scalar @major_nutriments_values)
 			or (
@@ -1174,6 +1175,7 @@ sub check_nutrition_data ($product_ref) {
 					and ($nutriments_values{'sodium_100g'})
 					and ($nutriments_values{'salt_100g'} != $nutriments_values{'sodium_100g'}))
 			)
+			and (@major_nutriments_values[0] > 1)
 			)
 		{
 			push @{$product_ref->{data_quality_errors_tags}}, "en:nutrition-values-are-all-identical";

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/3270190128403.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/3270190128403.json
@@ -116,7 +116,6 @@
       "32xxxxxxxxxxx",
       "3xxxxxxxxxxxx"
    ],
-   "compared_to_category" : "en:cereals-and-potatoes",
    "complete" : 0,
    "completeness" : 0.8625,
    "correctors_tags" : [],

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/3270190128403.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/3270190128403.json
@@ -116,6 +116,7 @@
       "32xxxxxxxxxxx",
       "3xxxxxxxxxxxx"
    ],
+   "compared_to_category" : "en:cereals-and-potatoes",
    "complete" : 0,
    "completeness" : 0.8625,
    "correctors_tags" : [],

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/4270190128403.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/4270190128403.json
@@ -69,9 +69,7 @@
    "created_t" : "--ignore--",
    "creator" : "test-user",
    "data_quality_bugs_tags" : [],
-   "data_quality_errors_tags" : [
-      "en:nutrition-values-are-all-identical"
-   ],
+   "data_quality_errors_tags" : [],
    "data_quality_info_tags" : [
       "en:no-packaging-data",
       "en:ingredients-percent-analysis-ok",
@@ -92,8 +90,7 @@
       "en:nutri-score-grade-from-producer-does-not-match-calculated-grade",
       "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
       "en:ecoscore-packaging-packaging-data-missing",
-      "en:ecoscore-production-system-no-label",
-      "en:nutrition-values-are-all-identical"
+      "en:ecoscore-production-system-no-label"
    ],
    "data_quality_warnings_tags" : [
       "en:ingredients-unknown-score-above-0",

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -775,16 +775,16 @@ check_quality_and_test_product_has_quality_tag(
 );
 $product_ref = {
 	nutriments => {
-		"energy-kj_100g" => 0,
-		"energy-kcal_100g" => 0,
-		"fat_100g" => 0,
-		"saturated-fat_100g" => 0,
-		"carbohydrates_100g" => 0,
-		"sugars_100g" => 0,
-		"fibers_100g" => 0,
-		"proteins_100g" => 0,
-		"salt_100g" => 0,
-		"sodium_100g" => 1,
+		"energy-kj_100g" => 2,
+		"energy-kcal_100g" => 2,
+		"fat_100g" => 2,
+		"saturated-fat_100g" => 2,
+		"carbohydrates_100g" => 2,
+		"sugars_100g" => 2,
+		"fibers_100g" => 2,
+		"proteins_100g" => 2,
+		"salt_100g" => 2,
+		"sodium_100g" => 0.8,
 	}
 };
 check_quality_and_test_product_has_quality_tag(

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -734,7 +734,7 @@ check_quality_and_test_product_has_quality_tag(
 	'en:nutrition-3-or-more-values-are-identical',
 	'3 or more identical values and above 1 in the nutrition table', 1
 );
-# en:nutrition-values-are-all-identical
+## en:nutrition-values-are-all-identical but equal to 0
 $product_ref = {
 	nutriments => {
 		"energy-kj_100g" => 0,
@@ -752,26 +752,7 @@ $product_ref = {
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
 	'en:nutrition-values-are-all-identical',
-	'all identical values and above 1 in the nutrition table', 1
-);
-$product_ref = {
-	nutriments => {
-		"energy-kj_100g" => 1,
-		"energy-kcal_100g" => 0,
-		"fat_100g" => 0,
-		"saturated-fat_100g" => 0,
-		"carbohydrates_100g" => 0,
-		"sugars_100g" => 0,
-		"fibers_100g" => 0,
-		"proteins_100g" => 0,
-		"salt_100g" => 0,
-		"sodium_100g" => 0,
-	}
-};
-check_quality_and_test_product_has_quality_tag(
-	$product_ref,
-	'en:nutrition-values-are-all-identical',
-	'all identical values and above 1 in the nutrition table', 0
+	'all identical values and above 1 in the nutrition table 1', 0
 );
 $product_ref = {
 	nutriments => {
@@ -790,7 +771,20 @@ $product_ref = {
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
 	'en:nutrition-values-are-all-identical',
-	'all identical values and above 1 in the nutrition table', 1
+	'all identical values and above 1 in the nutrition table 2', 1
+);
+## should have enough input nutriments
+$product_ref = {
+	nutriments => {
+		"energy-kj_100g" => 2,
+		"salt_100g" => 2,
+		"sodium_100g" => 0.8,
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-values-are-all-identical',
+	'all identical values and above 1 in the nutrition table BUT not enough nutriments given', 0
 );
 
 # sum of fructose plus glucose plus maltose plus lactose plus sucrose cannot be greater than sugars


### PR DESCRIPTION
### What

Updated condition for "en:nutrition-values-are-all-identical": 
- at least 4 nutriments should be entered.
- first element of the list that contains all values should be larger than 1

### Related issue(s) and discussion
- Fixes #9572 

