### PR TITLE
feat: dq_category_specific_ingredient_percent_2

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -2391,6 +2391,62 @@ sub check_labels ($product_ref) {
 				"en:high-in-omega-3-label-claim-but-ala-or-sum-of-epa-and-dha-below-limitation");
 		}
 	}
+
+	# In EU, compare categories and regulations
+	# https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+	# my %spread_categories_regulation = (
+	# 		europe => {
+	# 			"en:jams" => "35",
+
+	# some categories have mininal amount content required by regulations
+	# $expected_minimal_amount_specific_ingredients = "en:fruit, 35, en:eu"
+	my ($expected_minimal_amount_specific_ingredients, $category_id)
+		= get_inherited_property_from_categories_tags($product_ref, "expected_minimal_amount_specific_ingredients:en");
+
+	# convert as a list, in case there are more than a countries having regulations
+	my @expected_minimal_amount_specific_ingredients_list = split /;/, $expected_minimal_amount_specific_ingredients;
+	foreach
+		my $expected_minimal_amount_specific_ingredients_element (@expected_minimal_amount_specific_ingredients_list)
+	{
+		# split on ", " to extract ingredient id, quantity in g and country
+		my ($specific_ingredient_id, $quantity_threshold, $country) = split /, /,
+			$expected_minimal_amount_specific_ingredients_element;
+
+		if (
+				(defined $specific_ingredient_id)
+			and (defined $quantity_threshold)
+			and (defined $country)
+			and
+			((($country eq "en:eu") and ($european_product == 1)) or (has_tag(($product_ref, "countries", $country))))
+			)
+		{
+			my $specific_ingredient_quantity;
+			if (defined $product_ref->{specific_ingredients}) {
+				foreach my $specific_ingredient ($product_ref->{specific_ingredients}[0]) {
+					if (    (defined $specific_ingredient->{id})
+						and (defined $specific_ingredient->{quantity_g})
+						and ($specific_ingredient->{id} eq $specific_ingredient_id))
+					{
+						$specific_ingredient_quantity = $specific_ingredient->{quantity_g};
+					}
+				}
+			}
+
+			if (defined $specific_ingredient_quantity) {
+				if ($specific_ingredient_quantity < $quantity_threshold) {
+					add_tag($product_ref, "data_quality_errors",
+							  "en:specific-ingredient-"
+							. substr($specific_ingredient_id, 3)
+							. "-quantity-is-below-the-minimum-value-of-$quantity_threshold-for-category-"
+							. substr($category_id, 3));
+				}
+			}
+			else {
+				add_tag($product_ref, "data_quality_info", "en:missing-specific-ingredient-for-this-category");
+			}
+
+		}
+	}
 	return;
 }
 

--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -65,6 +65,12 @@ stopwords:de:und,mit,von
 # And for categories where we are certain there is 100% fruits/vegetables/legumes
 # we put nutriscore_category_override_for_fruits_vegetables_legumes:en: 100
 
+# For categories for which a minimum amount of specific ingredients is required in some countries
+# we put expected_minimal_amount_specific_ingredients:en followed by the specific ingredient, 
+#   the quantity in g and the country where it applis. 
+# additional countries can be added separated by a semi colon (";"). Example for en:fruit, 35g, in EU and en:fruit, 35g in en:other-country:
+# expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu;  en:fruit, 35, en:other-country
+
 en:Artisan products
 ca:Prouctes artesans
 de:Handgefertigte Produkte, Artisanale Produkte, Handgemachte Produkte
@@ -92462,6 +92468,7 @@ ciqual_proxy_food_code:en:31024
 ciqual_proxy_food_name:en:Jam, strawberry
 ciqual_proxy_food_name:fr:Confiture de fraise (extra ou classique)
 intake24_category_code:en:JAMS
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 <en:Jams
 en:Shelf-stable jams
@@ -92621,6 +92628,7 @@ hu:Vörös ribizli lekvár
 it:Confetture di ribes
 nl:Aalbessenjams
 pt:Doces de groselha
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Berry jams
 en:Gooseberries jams, gooseberry jams

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -817,7 +817,15 @@ en:vegetarian-label-but-non-vegetarian-ingredient
 description:en:This product has a vegetarian label but contains non-vegetarian ingredients.
 
 
+### Categories
 
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams
+description:en:As a general rule quantity of fruit for jam should be above 35g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams
+description:en:Quantity of fruit for redcurrants jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 
 


### PR DESCRIPTION
### What
Add quality facets for jams having too small fruit quantity:
errors:
- en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams
- en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams
- ["en:specific-ingredient-<$specific_ingredient_id>-quantity-is-below-the-minimum-value-of-$quantity_threshold-for-category-<$category_id>]

info:
- en:missing-specific-ingredient-for-this-category


Following comment from @CharlesNepote and @aleene, I tried (maybe not perfectly done) to write the thresholds values directly in the taxonomy. 

This is only for specific ingredients, only for lower than the value provided. If it works well, in future PR, it could be generalized for ingredients and nutriments and for maximal values (for labels it can be minimum (sugar, for example) or maximum (fibers, for example)). Also, to do eventually in the future, detect if jam/jelly should be extra-jam/extra-jelly.

### Screenshot
![Screenshot_20231231_002712](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/4abe2a91-cbfe-4850-85e8-f7aa6f95121b)



### Related issue(s) and discussion
Part of https://github.com/openfoodfacts/openfoodfacts-server/issues/1414

