### PR TITLE
build: Migrate to Compose V2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -144,6 +144,6 @@ jobs:
         make dev
         make status
     - name: Test all is running
-      run: make livecheck || ( tail -n 300 logs/apache2/*error*log; docker-compose logs; false )
+      run: make livecheck || ( tail -n 300 logs/apache2/*error*log; docker compose logs; false )
     - name: test clean
       run: make hdown

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@ endif
 
 HOSTS=127.0.0.1 world.productopener.localhost fr.productopener.localhost static.productopener.localhost ssl-api.productopener.localhost fr-en.productopener.localhost
 # commands aliases
-DOCKER_COMPOSE=docker-compose --env-file=${ENV_FILE} ${LOAD_EXTRA_ENV_FILE}
+DOCKER_COMPOSE=docker compose --env-file=${ENV_FILE} ${LOAD_EXTRA_ENV_FILE}
 # we run tests in a specific project name to be separated from dev instances
 # we also publish mongodb on a separate port to avoid conflicts
 # we also enable the possibility to fake services in po_test_runner
-DOCKER_COMPOSE_TEST=ROBOTOFF_URL="http://backend:8881/" GOOGLE_CLOUD_VISION_API_URL="http://backend:8881/" COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_test PO_COMMON_PREFIX=test_ MONGO_EXPOSE_PORT=27027 docker-compose --env-file=${ENV_FILE}
+DOCKER_COMPOSE_TEST=ROBOTOFF_URL="http://backend:8881/" GOOGLE_CLOUD_VISION_API_URL="http://backend:8881/" COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_test PO_COMMON_PREFIX=test_ MONGO_EXPOSE_PORT=27027 docker compose --env-file=${ENV_FILE}
 # Enable Redis only for integration tests
 DOCKER_COMPOSE_INT_TEST=REDIS_URL="redis:6379" ${DOCKER_COMPOSE_TEST}
 
@@ -93,7 +93,7 @@ edit_etc_hosts:
 
 create_folders:
 # create some folders to avoid having them owned by root (when created by docker compose)
-	@echo "🥫 Creating folders before docker-compose use them."
+	@echo "🥫 Creating folders before docker compose use them."
 	mkdir -p logs/apache2 logs/nginx debug || ( whoami; ls -l . ; false )
 
 # TODO: Figure out events => actions and implement live reload
@@ -156,7 +156,7 @@ livecheck:
 	docker/docker-livecheck.sh
 
 log:
-	@echo "🥫 Reading logs (docker-compose) …"
+	@echo "🥫 Reading logs (docker compose) …"
 	${DOCKER_COMPOSE} logs -f
 
 tail:
@@ -200,7 +200,7 @@ init_backend: build_lang build_taxonomies
 
 create_mongodb_indexes:
 	@echo "🥫 Creating MongoDB indexes …"
-	docker cp conf/mongodb/create_indexes.js $(shell docker-compose ps -q mongodb):/data/db
+	docker cp conf/mongodb/create_indexes.js $(shell docker compose ps -q mongodb):/data/db
 	${DOCKER_COMPOSE} exec -T mongodb //bin/sh -c "mongo off /data/db/create_indexes.js"
 
 refresh_product_tags:
@@ -234,13 +234,13 @@ import_prod_data:
 #--------#
 
 front_npm_update:
-	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker-compose run --rm dynamicfront  npm update
+	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm update
 
 front_lint:
-	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker-compose run --rm dynamicfront  npm run lint
+	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm run lint
 
 front_build:
-	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker-compose run --rm dynamicfront  npm run build
+	COMPOSE_PATH_SEPARATOR=";" COMPOSE_FILE="docker-compose.yml;docker/dev.yml;docker/jslint.yml" docker compose run --rm dynamicfront  npm run build
 
 
 checks: front_build front_lint check_perltidy check_perl_fast check_critic

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,8 +6,8 @@ NOTE: this file is copied to ref-docker-commands.md at documentation build time
 
 See also [Docker best practice at Open Food Facts](https://openfoodfacts.github.io/openfoodfacts-infrastructure/docker/)
 
-The docker/ directory contains `docker-compose` overrides for running Product Opener on [Docker](https://docker.com).
-The main docker-compose file [`docker-compose.yml`](../docker-compose.yml) is located in the root of the repository.
+The docker/ directory contains `docker compose` overrides for running Product Opener on [Docker](https://docker.com).
+The main docker compose file [`docker-compose.yml`](../docker-compose.yml) is located in the root of the repository.
 
 The step-by-step guide to setup the Product Opener using Docker is available on [dev environment quick start guide](../docs/dev/how-to-quick-start-guide.md).
 
@@ -15,7 +15,7 @@ The step-by-step guide to setup the Product Opener using Docker is available on 
 
 Makefile targets are handy for beginners to start the project and for some usual tasks.
 
-It's better though, as you progress, if you understand how things work and be able to use targeted docker-compose commands.
+It's better though, as you progress, if you understand how things work and be able to use targeted docker compose commands.
 
 See also [targets to run tests](../docs/dev/how-to-write-and-run-tests.md#running-tests)
 
@@ -39,6 +39,6 @@ See also [targets to run tests](../docs/dev/how-to-write-and-run-tests.md#runnin
 
 [^lint]: If you are having permission issues with `make lint` try writing the following commands :
 `export MSYS_NO_PATHCONV=1
-docker-compose run --rm --no-deps -u root backend chown www-data:www-data -R /opt/product-opener/`
+docker compose run --rm --no-deps -u root backend chown www-data:www-data -R /opt/product-opener/`
 then run again `make lint` and you should be good to go
 

--- a/docker/docker-livecheck.sh
+++ b/docker/docker-livecheck.sh
@@ -2,8 +2,8 @@
 
 ENV_FILE="${ENV_FILE:-.env}"
 RET_CODE=0
-for service in `docker-compose --env-file=${ENV_FILE} config  --service | tr '\n' ' '`; do 
-if [ -z `docker-compose ps -q $service` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose --env-file=${ENV_FILE} ps -q $service)` ]; then
+for service in `docker compose --env-file=${ENV_FILE} config  --service | tr '\n' ' '`; do 
+if [ -z `docker compose ps -q $service` ] || [ -z `docker ps -q --no-trunc | grep $(docker compose --env-file=${ENV_FILE} ps -q $service)` ]; then
     echo "$service: DOWN"
     RET_CODE=1
 else

--- a/docs/dev/explain-pro-dev-setup.md
+++ b/docs/dev/explain-pro-dev-setup.md
@@ -32,7 +32,7 @@ To satisfy the access to the same database,
 we will use postgres database from off as the common database.
 
 In order to achieve that:
-* we use profiles, so we won't start postgres in pro docker-compose
+* we use profiles, so we won't start postgres in pro docker compose
 * we connect `postgres`, `backend` and `minion` services to a shared network, called `minion_db`
 Fortunately this works, but note that there is a pitfall:
 on `minion_db` network both `backend` services (`off` and `off-pro`) will respond to same name.

--- a/docs/dev/how-to-develop-producer-platform.md
+++ b/docs/dev/how-to-develop-producer-platform.md
@@ -24,13 +24,13 @@ To develop on the producers platform, follow these steps:
 ### Working with Product Import/Export and Interacting with the Public Platform:
 If you need to work on product import/export or interact with the public platform, you must start the following services: `PostgreSQL`, `MongoDB`, and the `Minion`. Here's how:
 
-- In a *non-pro* shell (OpenFoodFacts shell), run the command `docker-compose up postgres minion mongodb`.
+- In a *non-pro* shell (OpenFoodFacts shell), run the command `docker compose up postgres minion mongodb`.
   - This command starts the necessary services in the background.
 
 #### Note: The setup does not currently support running the http server for both public and pro platform at the same simultaneously. Therefore, to access the public platform, you need to follow these steps:
 
-- in your *pro shell*, run a `docker-compose stop frontend`
-- in your *non pro shell*, run a `docker-compose up frontend`
+- in your *pro shell*, run a `docker compose stop frontend`
+- in your *non pro shell*, run a `docker compose up frontend`
 Now, the public database can be accessed at `openfoodfacts.localhost`.If you need to access the *pro* HTTP server, reverse these steps.
 
 Note that if you [use direnv](how-to-use-direnv.md), the setup should work seamlessly without redefining the variables set by `setenv-pro.sh`.
@@ -40,13 +40,13 @@ An explanation of the setup can be found at [explain-pro-dev-setup.md](explain-p
 - If you want to see state of tasks, you can run:
 
 ```
-docker-compose exec minion /opt/product-opener/scripts/minion_producers.pl  minion job
+docker compose exec minion /opt/product-opener/scripts/minion_producers.pl  minion job
 ```
 (add --help to see all options), or refer to https://docs.mojolicious.org/Minion/Command/minion/job
 
 - You may also inspect database by running:
 ```
-docker-compose exec  postgres psql -U productopener -W minion
+docker compose exec  postgres psql -U productopener -W minion
 ```
 The password is given by the `POSTGRES_PASSWORD` variable in the `.env` file and defaults to `productopener`. 
 Inspecting the minion table can be helpful in understanding the database structure and contents.

--- a/docs/dev/how-to-develop-using-docker.md
+++ b/docs/dev/how-to-develop-using-docker.md
@@ -59,7 +59,7 @@ log4perl.rootLogger=TRACE, LOGFILE
 Run the following to open a bash shell within the `backend` container:
 
 ```
-docker-compose exec backend bash
+docker compose exec backend bash
 ```
 
 You should see `root@<CONTAINER_ID>:/#` (opened root shell): you are now within the Docker container and can begin typing some commands !
@@ -125,15 +125,15 @@ as it does a full rebuild, which, in dev mode, should only be necessary in a few
 
 On a daily bases you could better run those:
 
-* `docker-compose up` to start and monitor the stack.
-* `docker-compose restart backend` to account for a code change in a `.pm` file
+* `docker compose up` to start and monitor the stack.
+* `docker compose restart backend` to account for a code change in a `.pm` file
   (cgi `pl` files do not need a restart)
-* `docker-compose stop` to stop them all
+* `docker compose stop` to stop them all
 
 If some important file changed (like Dockerfile or cpanfile, etc.), or in case of doubt,
-you can run `docker-compose build` (or maybe it's a good time to use `make up` once)
+you can run `docker compose build` (or maybe it's a good time to use `make up` once)
 
-You should explore the [docker-compose commands](https://docs.docker.com/compose/reference/)
+You should explore the [docker compose commands](https://docs.docker.com/compose/reference/)
 most are useful!
 
 
@@ -142,7 +142,7 @@ To automate the live reload on code changes, you can install the Python package 
 ```
 pip3 install when-changed
 when-changed -r docker/ docker-compose.yml .env -c "make restart"                                         # restart backend container on compose changes
-when-changed -r lib/ -r docker/ docker-compose.yml -c "docker-compose backend restart" # restart Apache on code changes
+when-changed -r lib/ -r docker/ docker-compose.yml -c "docker compose backend restart" # restart Apache on code changes
 when-changed -r html/ Dockerfile Dockerfile.frontend package.json -c "make up" # rebuild containers on asset or Dockerfile changes
 ```
 
@@ -152,7 +152,7 @@ An alternative to `when-changed` is `inotifywait`.
 ## Run queries on MongoDB database
 
 ```
-docker-compose exec mongodb mongo
+docker compose exec mongodb mongo
 ```
 
 The above command will open a MongoDB shell, allowing you to use all the `mongo` 
@@ -182,7 +182,7 @@ To add a new environment variable `TEST`:
 
 The call stack goes like this:
 
-`make up` > `docker-compose` > loads `.env` > pass env variables to the `backend` container > pass to `mod_perl` > initialized in `Config2.pm`.
+`make up` > `docker compose` > loads `.env` > pass env variables to the `backend` container > pass to `mod_perl` > initialized in `Config2.pm`.
 
 ## Managing multiple deployments
 
@@ -191,7 +191,7 @@ there are different possible strategies.
 
 ### a set env script
 
-Docker-compose takes it settings from, in order of priority:
+docker compose takes it settings from, in order of priority:
 * the environment
 * the `.env` file
 
@@ -209,7 +209,7 @@ To use it, open a terminal, where you want to be in pro environment and simply u
 . setenv-pro.sh
 ```
 
-then you can use whatever docker-compose command.
+then you can use whatever docker compose command.
 
 **Note:** This terminal will remain in `pro` mode until you end its session.
 
@@ -236,7 +236,7 @@ You will need:
   so that frontend containers don't port-conflict with each other.
 
 To switch between configurations, set `ENV_FILE` before running `make` commands,
-(or `docker-compose` command):
+(or `docker compose` command):
 
 ```
 ENV_FILE=.env.off-pro make up # starts the OFF Producer's Platform containers.

--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -83,7 +83,7 @@ cd openfoodfacts-server/
 
 > _Note: you can skip this step for the first setup since the default `.env` in the repo contains all the default values required to get started._
 
-Before running the `docker-compose` deployment, you can review and configure
+Before running the `docker compose` deployment, you can review and configure
 Product Opener's environment (`.env` file).
 
 The `.env` file contains ProductOpener default settings:
@@ -297,10 +297,10 @@ systemctl status mongod | grep Active
 
 Then, executed this:
 ```console
-docker-compose up 
+docker compose up 
 ```
 > **Note:**
-> To know more about docker-compose commands do read [this guide](how-to-develop-using-docker.md)
+> To know more about docker compose commands do read [this guide](how-to-develop-using-docker.md)
 
 ### make dev error: [build_lang] Error 13 - can't write into /mnt/podata/data/Lang.openfoodfacts.localhost.sto
 

--- a/docs/dev/how-to-use-direnv.md
+++ b/docs/dev/how-to-use-direnv.md
@@ -16,7 +16,7 @@ As a quick guide as an openfoodfacts developer:
   that you wan't to
 
 ```
-echo "setting up docker-compose env"
+echo "setting up docker compose env"
 export DOCKER_BUILDKIT=1
 export USER_UID=${UID}
 export USER_UID=$(id -g)

--- a/docs/dev/how-to-use-gitpod.md
+++ b/docs/dev/how-to-use-gitpod.md
@@ -65,7 +65,7 @@ Create an account to be able to edit products.
 ## Some commands
 After you made devs and want to apply changes and see them on the website, you can run:  
 ```
-$ docker-compose restart 
+$ docker compose restart 
 ```
 ```
 $ make up  

--- a/docs/dev/how-to-use-repl.md
+++ b/docs/dev/how-to-use-repl.md
@@ -17,7 +17,7 @@ Also it as the right
 Just run
 
 ```
-docker-compose run --rm backend re.pl
+docker compose run --rm backend re.pl
 ```
 
 If you want to access external services (like mongodb), do not forget to start them.

--- a/docs/dev/how-to-use-vscode.md
+++ b/docs/dev/how-to-use-vscode.md
@@ -15,7 +15,7 @@ One way to have perlcritic work is the following:
   ```bash
   #!/usr/bin/env bash
   . .envrc >/dev/null 2>&1
-  docker-compose run --rm --no-deps backend perlcritic "$@" 2>/dev/null
+  docker compose run --rm --no-deps backend perlcritic "$@" 2>/dev/null
   ```
   the second line is useful only if you [use direnv](how-to-use-direnv.md)
 * `chmod +x perlcritic.sh`
@@ -38,7 +38,7 @@ The extension [Language Server and Debugger](https://marketplace.visualstudio.co
   source .envrc
   COMMAND=$(echo "$@" | sed 's/^.*perl /perl /')
   >&2 echo "launching $COMMAND"
-  docker-compose run --rm --no-deps -T -p 127.0.0.  1:13603:13603 backend $COMMAND
+  docker compose run --rm --no-deps -T -p 127.0.0.  1:13603:13603 backend $COMMAND
   ```
   Note: the second line is useful only if you [use direnv](how-to-use-direnv.md)
 * `chmod +x shell-into-appserver.sh`

--- a/docs/dev/how-to-write-and-run-tests.md
+++ b/docs/dev/how-to-write-and-run-tests.md
@@ -31,7 +31,7 @@ Integration tests are in `tests/integration/`.
 
 Most integration tests issue queries to an open food facts
 
-## Integration with docker-compose
+## Integration with docker compose
 
 Using Makefile targets, tests are run 
 * with a specific `COMPOSE_PROJECT_NAME° to avoid crashing your development data while running tests (as the project name [changes container, network and volumes names](https://docs.docker.com/compose/environment-variables/envvars/#compose_project_name))

--- a/env.pro
+++ b/env.pro
@@ -12,6 +12,6 @@ MINION_QUEUE=pro.openfoodfacts.localhost
 # neither do we change PRODUCT_OPENER_FLAVOR, as off-pro use same contents as off
 
 # Set a variable that we use in Makefile to add an extra env file 
-# in addition to .env when we run docker-compose
+# in addition to .env when we run docker compose
 EXTRA_ENV_FILE=env.pro
 LOAD_EXTRA_ENV_FILE=--env-file=env.pro


### PR DESCRIPTION
Docker Compose V1 (`docker-compose`)  is deprecated and should not be used any more. ([Source](https://docs.docker.com/compose/migrate/)) This replaces the old command with `docker compose`, which is Compose V2, and bundled with current Docker distributions.