### PR TITLE
fix: Product name truncated #7502

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -9,7 +9,7 @@
 // Output values are returned in the product object
 //
 // - match_score: number from 0 to 100
-//		- the score is 0 if 
+//		- the score is 0 if
 //		- otherwise the score is a weighted average of how well the product matches
 //		each attribute selected by the user
 //
@@ -21,7 +21,7 @@
 //		- may_not_match		at least one mandatory attribute score is <= 50 (e.g. may contain traces of an allergen)
 //		- does_not_match	at least one mandatory attribute score is <= 10 (e.g. contains an allergen, is not vegan)
 //
-// - match_attributes: array of arrays of attributes corresponding to the product and 
+// - match_attributes: array of arrays of attributes corresponding to the product and
 // each set of preferences: mandatory, very_important, important
 
 function match_product_to_preferences(product, product_preferences) {
@@ -235,7 +235,7 @@ function display_products(target, product_groups, user_prefs) {
 
 		$.each(product_group, function (key, product) {
 
-			let product_html = `<li><a href="${product.url}" class="list_product_a">`;
+			let product_html = `<li><a href="${product.url}" class="list_product_a" title="${product.product_display_name}">`;
 
 			// Add a colored banner to show how the product matches the user's preferences
 			if (user_prefs.use_ranking) {
@@ -290,8 +290,8 @@ function display_products(target, product_groups, user_prefs) {
 				const edit_url = product_edit_url(product);
 				const edit_title = lang().edit_product_page;
 				product_html += `
-				<a class="list_edit_link" 
-				    alt="Edit ${product.product_display_name}" 
+				<a class="list_edit_link"
+				    alt="Edit ${product.product_display_name}"
 				    href="${edit_url}"
 				    title="${edit_title}">
 					<img src="/images/icons/dist/edit.svg">
@@ -417,7 +417,7 @@ function display_product_summary(target, product) {
 			// note: on the website, the id for the panel contains : instead of - (e.g. for the ingredients_analysis_en:vegan panel)
 			const panel_element_id = 'panel_' + attribute.panel_id.replace(':', '-');
 			if (document.getElementById(panel_element_id)) {
-				// onclick : open the panel content + reflow to make sur all column content is shown			
+				// onclick : open the panel content + reflow to make sur all column content is shown
 				card_html = '<a href="#' + panel_element_id
 					+ '" onclick="document.getElementById(\'' + panel_element_id + '_content\').classList.add(\'active\'); $(document).foundation(\'equalizer\', \'reflow\');"' + card_html + '</a>';
 			}

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -256,9 +256,9 @@ function display_products(target, product_groups, user_prefs) {
 			product_html += "</div>";
 
 			if (product.product_display_name) {
-				product_html += '<div class="list_product_name v-space-tiny">' + product.product_display_name + "</div>";
+				product_html += '<div class="list_product_name">' + product.product_display_name + "</div>";
 			} else {
-				product_html += '<div class="list_product_name v-space-tiny">' + product.code + "</div>";
+				product_html += '<div class="list_product_name">' + product.code + "</div>";
 			}
 
 			product_html += '<div class="list_product_sc">';

--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -288,9 +288,7 @@ ul.products {
 
 .products a {
   display: block;
-  height: 167px;
   margin: 10px;
-  overflow: hidden;
   padding: 10px;
   width: 120px;
   word-wrap: break-word;
@@ -314,6 +312,14 @@ ul.products {
 
 .products img {
   vertical-align: middle;
+}
+
+.products span {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  height: 50px;
+  overflow: hidden;
 }
 
 #pages {
@@ -1213,7 +1219,7 @@ $font-green: #008c8c;
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  padding: .5rem 2rem; 
+  padding: .5rem 2rem;
   width: 100%;
   gap: 1rem;
   background-color: $section-sand;
@@ -1398,7 +1404,7 @@ $font-green: #008c8c;
       color: white;
       opacity: 0.5;
       margin-right: 1rem;
-      @media #{$small-only} { 
+      @media #{$small-only} {
         position: relative;
         top: -25px;
         margin-right: 2rem;
@@ -1472,7 +1478,7 @@ $font-green: #008c8c;
       color: white;
       opacity: 0.5;
       margin-right: 1rem;
-      @media #{$small-only} { 
+      @media #{$small-only} {
         position: relative;
         top: -25px;
         margin-right: 2rem;
@@ -1764,7 +1770,7 @@ a.panel_title {
       padding-top: 3rem;
       padding-bottom: 3rem;
     }
-  
+
     @media #{$large-up} {
       padding-top: 5rem;
       padding-bottom: 5rem;
@@ -1790,7 +1796,7 @@ a.panel_title {
       padding-top: 2rem;
       padding-bottom: 2rem;
     }
-  
+
     @media #{$large-up} {
       padding-top: 3rem;
       padding-bottom: 3rem;
@@ -1799,19 +1805,19 @@ a.panel_title {
     &-blue {
       background-color: #e3f6ff;
     }
-    
+
     &-seashell {
       background-color: #fff5f1;
     }
-    
+
     &-yellow {
       background-color: #fffad1;
     }
-    
+
     &-light-green {
       background-color: #ebffdf;
     }
-  
+
     &-white {
       background-color: $white;
     }

--- a/scss/_product-list.scss
+++ b/scss/_product-list.scss
@@ -126,10 +126,12 @@ $productsGutter:12;
     padding-left: 8px;
     font-size: 14px;
     color: $black;
-    display: inline-flex;
-    // Force the height of the product name so that icons
-    // below are vertically aligned with other cards on the same line
-    height:82px;
+    // Force the height and use line-clamp of the product name so that
+    // icons below are vertically aligned with other cards on the same line
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    height: 82px;
     overflow: hidden;
 }
 
@@ -164,11 +166,11 @@ $productsGutter:12;
   .f-dropdown {
     a { color: $primary-color; }
   }
-  &__results { 
+  &__results {
     display: flex;
     align-items: center;
     gap: 8px;
-    color: $white; 
+    color: $white;
     .material-icons { font-size: 18px; }
   }
   &__buttons {
@@ -287,7 +289,7 @@ $greeter-contribute-bgcolor: #FFF2DF;
       background: linear-gradient(90deg, $greeter-discover-bgcolor 50%, $greeter-contribute-bgcolor 50%);
     }
   }
-  &__discover, 
+  &__discover,
   &__contribute {
     display: flex;
     margin: 0;
@@ -314,7 +316,7 @@ $greeter-contribute-bgcolor: #FFF2DF;
       }
     }
   }
-  &__discover { 
+  &__discover {
     background-color: $greeter-discover-bgcolor;
     &--content {
       @media #{$xlarge-up} { padding-left: 0; }


### PR DESCRIPTION
### What

The product name is truncated due to a fixed height defined in the product link. This allows you to have a list of products with a unified height.   

Several solutions are possible (such as using grids), I preferred:
- keep a fixed height by adapting it to avoid seeing part of the text truncated.   
- use the [`-webkit-line-clamp` property](https://developer.mozilla.org/fr/docs/Web/CSS/-webkit-line-clamp) to display 3 points if the text is longer. The latter is still in [WD](https://drafts.csswg.org/css-overflow-4/#line-clamp) but supported by [97% of browsers](https://caniuse.com/?search=-webkit-line-clamp) and offers gracefull degradation if not supported.  

The full product name remains accessible by screen readers and when hovering over the map (via the title attribute of the link).  
I also added the line-clamp when JS is activated with the alternative in the link title.

### Screenshot
- JS disabled, before fix: 
![7502-js-disabled-ko](https://github.com/openfoodfacts/openfoodfacts-server/assets/5670642/2ebae445-1783-4ef5-8b7e-d3e3c85b33af)
- JS disabled, after fix: 
![7502-js-disabled-ok](https://github.com/openfoodfacts/openfoodfacts-server/assets/5670642/5cb9eaba-051d-4e71-b314-4fa563a4aee0)
- JS disabled, show title:
![7502-js-disabled-ok-title](https://github.com/openfoodfacts/openfoodfacts-server/assets/5670642/9acf2a4d-462a-4282-8d49-58d1b11cb54d)
- JS enabled, before fix:  
![7502-js-enabled-ko](https://github.com/openfoodfacts/openfoodfacts-server/assets/5670642/c40eebd2-4908-434a-9858-fb1d1aee6415)
- JS enabled, after fix:  
![7502-js-enabled-ok](https://github.com/openfoodfacts/openfoodfacts-server/assets/5670642/aab400a4-8da7-43b1-b045-a80c97452f72)
- JS enabled, show title: 
![7502-js-enabled-ok-title](https://github.com/openfoodfacts/openfoodfacts-server/assets/5670642/4b3eab1e-b769-4185-810a-f6af40685010)
  

### Related issue(s) and discussion
- Fixes #7502 

