### PR TITLE
fix: bug_ingredients_wrongly_specific_ingredients

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -197,7 +197,7 @@ my %may_contain_regexps = (
 	fi =>
 		"saattaa sisältää pienehköjä määriä muita|saattaa sisältää pieniä määriä muita|saattaa sisältää pienehköjä määriä|saattaa sisältää pieniä määriä|voi sisältää vähäisiä määriä|saattaa sisältää hivenen|saattaa sisältää pieniä|saattaa sisältää jäämiä|sisältää pienen määrän|jossa käsitellään myös|saattaa sisältää myös|joka käsittelee myös|jossa käsitellään|saattaa sisältää",
 	fr =>
-		"peut également contenir|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace|Traces éventuelles de|Peut contenir des traces de",
+		"peut également contenir|peut contenir des traces de|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles de|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace",
 	hr =>
 		"mogući ostaci|mogući sadržaj|mogući tragovi|može sadržavati|može sadržavati alergene u tragovima|može sadržavati tragove|može sadržavati u tragovima|može sadržati|može sadržati tragove|proizvod može sadržavati|proizvod može sadržavati tragove",
 	is => "getur innihaldið leifar|gæti innihaldið snefil|getur innihaldið",
@@ -1182,7 +1182,7 @@ sub parse_specific_ingredients_from_text ($product_ref, $text, $percent_or_quant
 		# - prepared with 60g of fruits
 		# - prepared with 40g of fruits per 100g of finished product
 		elsif (
-			(defined $percent_or_quantity_regexp)
+			((defined $percent_or_quantity_regexp) and (defined $of) and ($of ne "") and (defined $per_100g_regexp) and ($per_100g_regexp ne ""))
 			and (
 				# if the string does not start with "prepared with", it needs to finish with "per 100g",
 				# otherwise we will match items that could be part of the ingredients list such as "75% of tomatoes
@@ -1190,8 +1190,10 @@ sub parse_specific_ingredients_from_text ($product_ref, $text, $percent_or_quant
 				# prepared with, percent, ingredient, optional per 100g, separator
 				# $of needs to be first in (?:$of|\s|:) so that " of " is matched by it, instead of the ingredient capturing group
 				(
-					$text
-					=~ /((?:^|;|,|\.| - )\s*)$prepared_with(?:$of|\s|:)+$percent_or_quantity_regexp(?:$of|\s|:)+\s*([^,.;]+?)\s*(?:$per_100g_regexp)?(?:;|,|\.| - |$)/i
+					(defined $prepared_with) and ($prepared_with ne "")
+					and ($text
+						=~ /((?:^|;|,|\.| - )\s*)$prepared_with(?:$of|\s|:)+$percent_or_quantity_regexp(?:$of|\s|:)+\s*([^,.;]+?)\s*(?:$per_100g_regexp)?(?:;|,|\.| - |$)/i
+					)
 				)
 				or
 				# percent, ingredient, per 100g, separator

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -197,7 +197,7 @@ my %may_contain_regexps = (
 	fi =>
 		"saattaa sisältää pienehköjä määriä muita|saattaa sisältää pieniä määriä muita|saattaa sisältää pienehköjä määriä|saattaa sisältää pieniä määriä|voi sisältää vähäisiä määriä|saattaa sisältää hivenen|saattaa sisältää pieniä|saattaa sisältää jäämiä|sisältää pienen määrän|jossa käsitellään myös|saattaa sisältää myös|joka käsittelee myös|jossa käsitellään|saattaa sisältää",
 	fr =>
-		"peut également contenir|peut contenir des traces de|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles de|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace",
+		"peut également contenir|peut contenir|qui utilise|utilisant|qui utilise aussi|qui manipule|manipulisant|qui manipule aussi|traces possibles|traces d'allergènes potentielles|trace possible|traces potentielles|trace potentielle|traces éventuelles|traces eventuelles|trace éventuelle|trace eventuelle|traces|trace|Traces éventuelles de|Peut contenir des traces de",
 	hr =>
 		"mogući ostaci|mogući sadržaj|mogući tragovi|može sadržavati|može sadržavati alergene u tragovima|može sadržavati tragove|može sadržavati u tragovima|može sadržati|može sadržati tragove|proizvod može sadržavati|proizvod može sadržavati tragove",
 	is => "getur innihaldið leifar|gæti innihaldið snefil|getur innihaldið",

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1182,7 +1182,13 @@ sub parse_specific_ingredients_from_text ($product_ref, $text, $percent_or_quant
 		# - prepared with 60g of fruits
 		# - prepared with 40g of fruits per 100g of finished product
 		elsif (
-			((defined $percent_or_quantity_regexp) and (defined $of) and ($of ne "") and (defined $per_100g_regexp) and ($per_100g_regexp ne ""))
+			(
+					(defined $percent_or_quantity_regexp)
+				and (defined $of)
+				and ($of ne "")
+				and (defined $per_100g_regexp)
+				and ($per_100g_regexp ne "")
+			)
 			and (
 				# if the string does not start with "prepared with", it needs to finish with "per 100g",
 				# otherwise we will match items that could be part of the ingredients list such as "75% of tomatoes
@@ -1190,7 +1196,8 @@ sub parse_specific_ingredients_from_text ($product_ref, $text, $percent_or_quant
 				# prepared with, percent, ingredient, optional per 100g, separator
 				# $of needs to be first in (?:$of|\s|:) so that " of " is matched by it, instead of the ingredient capturing group
 				(
-					(defined $prepared_with) and ($prepared_with ne "")
+						(defined $prepared_with)
+					and ($prepared_with ne "")
 					and ($text
 						=~ /((?:^|;|,|\.| - )\s*)$prepared_with(?:$of|\s|:)+$percent_or_quantity_regexp(?:$of|\s|:)+\s*([^,.;]+?)\s*(?:$per_100g_regexp)?(?:;|,|\.| - |$)/i
 					)

--- a/tests/unit/expected_test_results/ingredients_percent/percentage-range-negative-pl.json
+++ b/tests/unit/expected_test_results/ingredients_percent/percentage-range-negative-pl.json
@@ -1,0 +1,43 @@
+[
+   {
+      "id" : "en:apple",
+      "percent" : 84,
+      "percent_estimate" : 84,
+      "percent_max" : 84,
+      "percent_min" : 84,
+      "text" : "jabłka"
+   },
+   {
+      "id" : "en:mango",
+      "percent" : 10,
+      "percent_estimate" : 10,
+      "percent_max" : 10,
+      "percent_min" : 10,
+      "processing" : "en:pureed",
+      "text" : "mango"
+   },
+   {
+      "id" : "en:concentrated-apple-juice",
+      "percent" : 3,
+      "percent_estimate" : 3,
+      "percent_max" : 3,
+      "percent_min" : 3,
+      "text" : "zagęszczony sok jabłkowy"
+   },
+   {
+      "id" : "pl:zagęszczony-sok-z-marakuji",
+      "percent" : 1.5,
+      "percent_estimate" : 1.5,
+      "percent_max" : 1.5,
+      "percent_min" : 1.5,
+      "text" : "zagęszczony sok z marakuji"
+   },
+   {
+      "id" : "en:acerola-juice",
+      "percent_estimate" : 1.5,
+      "percent_max" : 1.5,
+      "percent_min" : 1.5,
+      "processing" : "en:concentrated",
+      "text" : "sok z aceroli"
+   }
+]

--- a/tests/unit/ingredients_percent.t
+++ b/tests/unit/ingredients_percent.t
@@ -246,6 +246,14 @@ my @tests = (
 				"Lait entier pasteurisé équitable (73,4-74,3%), sucre de canne (9 - 10%), crème (5.1-5.5%), amidon de mais 4-5%, café lyophilisé."
 		},
 	],
+	[
+		'percentage-range-negative-pl',
+		{
+			lc => "pl",
+			ingredients_text =>
+				"84% jabłka, 10% przecier z mango, 3% zagęszczony sok jabłkowy, 1,5% zagęszczony sok z marakuji, zagęszczony sok z aceroli."
+		},
+	],
 	# max sugar and salt from nutrition facts
 	[
 		'max-sugar-salt-nutrition-facts',


### PR DESCRIPTION
### What
Make sure that variables are 1) defined + 2) non equal to "", to detect specific ingredients

### Screenshot
![Screenshot_20240106_124229](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/eca1c45b-ef23-4f30-85ba-f442a8e4fa94)

### Related issue(s) and discussion
- Fixes #9623