### PR TITLE
fix: verification md5sum and sha256sum generation on mongodb dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ edit_etc_hosts:
 create_folders:
 # create some folders to avoid having them owned by root (when created by docker compose)
 	@echo "🥫 Creating folders before docker compose use them."
-	mkdir -p logs/apache2 logs/nginx debug || ( whoami; ls -l . ; false )
+	mkdir -p logs/apache2 logs/nginx debug html/data || ( whoami; ls -l . ; false )
 
 # TODO: Figure out events => actions and implement live reload
 # live_reload:

--- a/scripts/mongodb_dump.sh
+++ b/scripts/mongodb_dump.sh
@@ -17,16 +17,16 @@ mongoexport --collection products --host $HOST --db $DB | gzip > new.$PREFIX-pro
 mv new.$PREFIX-products.jsonl.gz $PREFIX-products.jsonl.gz
 
 mongodump --collection products --host $HOST --db $DB --gzip --archive="new.${PREFIX}-mongodbdump.gz" && \
-sha256sum new.$PREFIX-mongodbdump.gz > new.gz-sha256sum && \
-md5sum new.$PREFIX-mongodbdump.gz > new.gz-md5sum && \
+sha256sum new.$PREFIX-mongodbdump.gz |sed -e 's/new\.//' > new.gz-sha256sum && \
+md5sum new.$PREFIX-mongodbdump.gz |sed -e 's/new\.//' > new.gz-md5sum && \
 mv new.${PREFIX}-mongodbdump.gz ${PREFIX}-mongodbdump.gz && \
 mv new.gz-sha256sum gz-sha256sum && \
 mv new.gz-md5sum gz-md5sum
 
 mongodump --collection products --host $HOST --db $DB && \
 tar cvfz new.$PREFIX-mongodbdump.tar.gz dump && \
-sha256sum new.$PREFIX-mongodbdump.tar.gz > new.sha256sum && \
-md5sum new.$PREFIX-mongodbdump.tar.gz > new.md5sum && \
+sha256sum new.$PREFIX-mongodbdump.tar.gz |sed -e 's/new\.//' > new.sha256sum && \
+md5sum new.$PREFIX-mongodbdump.tar.gz |sed -e 's/new\.//' > new.md5sum && \
 mv new.$PREFIX-mongodbdump.tar.gz $PREFIX-mongodbdump.tar.gz && \
 mv new.sha256sum sha256sum && \
 mv new.md5sum md5sum


### PR DESCRIPTION
The name of the file was wrong in the sums files.

Also ensure creation of html/data before it is created by docker with root ownership


**NOTE** I already edited the file in production to be back on track on mongodb-dev imports