### PR TITLE
feat: Added email warning in the Producers Platform

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -168,6 +168,10 @@ msgctxt "alcohol_warning"
 msgid "Excess drinking is harmful for health."
 msgstr ""
 
+msgctxt "email_warning"
+msgid "Please note that your Pro account will only be valid if you use your professional e-mail address. Our moderation team checks that the domain name is consistent with the organisation you wish to join."
+msgstr ""
+
 msgctxt "all_missions"
 msgid "All missions"
 msgstr ""

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -879,7 +879,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr ""
+msgstr "Open Food Facts for Producers"
 
 msgctxt "for"
 msgid "for"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -172,6 +172,10 @@ msgctxt "alcohol_warning"
 msgid "Excess drinking is harmful for health."
 msgstr "Excess drinking is harmful for health."
 
+msgctxt "email_warning"
+msgid "Please note that your Pro account will only be valid if you use your professional e-mail address. Our moderation team checks that the domain name is consistent with the organisation you wish to join."
+msgstr "Please note that your Pro account will only be valid if you use your professional e-mail address. Our moderation team checks that the domain name is consistent with the organisation you wish to join."
+
 msgctxt "all_missions"
 msgid "All missions"
 msgstr "All missions"

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -88,6 +88,9 @@
                         [% ELSIF field.type == 'email' %]
                             <label for="[% field.field %]">	[% field.label %]</label>
                             <input type="email" id="[% field.field %]" name="[% field.field %]" value = "[% field.value %]" autocomplete="email"/>
+                            [% IF server_options_producers_platform %]
+                            <div style="color: red; font-weight: 600;">🚨 [% lang('email_warning') %]</div>
+                            [% END %]
                         [% ELSIF field.type == 'select' %]
                             <label for="[% field.field %]">	[% lang(field.label) %]</label>
                             <select name="[% field.field %]" id="[% field.field %]-select">


### PR DESCRIPTION
Fixes #9658 
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/99353300/1e1f1499-5a2a-4348-a1d9-659a18eeaed2)

- Also added the text **"Open Food Facts for Producers"** in `en.po` and now the producers text is visible on the site.
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/99353300/696f4b66-fd60-4fde-8704-23b3ec15b4c9)
