### PR TITLE
feat: dq_category_specific_ingredient_percent_3

### DIFF
--- a/taxonomies/categories.txt
+++ b/taxonomies/categories.txt
@@ -93166,6 +93166,7 @@ ro:Gemul de calitate superioară
 sk:Extra džem
 sl:Ekstra džem
 sv:Extra sylt
+expected_minimal_amount_specific_ingredients:en: en:fruit, 45, en:eu
 
 <en:Jams
 en:Shelf-stable jams
@@ -93334,6 +93335,7 @@ fr:Confitures de cassis
 hu:Fekete ribizli lekvár
 it:Confetture di ribes nero
 nl:Cassisjams
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Berry jams
 en:Blackberry jams
@@ -93465,6 +93467,7 @@ wikidata:en:Q65545224
 <en:Jams
 en:ginger jams
 fr:Confitures de gingembre
+expected_minimal_amount_specific_ingredients:en: en:fruit, 15, en:eu
 
 <en:Jams
 en:Grape jams
@@ -93617,6 +93620,7 @@ ciqual_proxy_food_code:en:31037
 ciqual_proxy_food_name:en:Jam, apricot
 ciqual_proxy_food_name:fr:Confiture d'abricot (extra ou classique)
 wikidata:en:Q6855605
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Jams
 en:Rhubarb jams
@@ -93641,6 +93645,7 @@ hu:Csipkebogyó lekvár
 it:Marmellate di rosa canina
 nl:Rozenbotteljam
 sv:Nyponsylter
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 # in eu, Sea-buckthorn jams/jellies should have specific 
 # content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
@@ -93650,6 +93655,7 @@ de:Sanddorn Konfitüren
 es:Mermeladas y confituras d'espino amarillo
 fi:Tyrnihillot
 fr:Confitures d'argousiers
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Jams
 en:Sweet pepper jams
@@ -93790,6 +93796,7 @@ sk:Marmeláda
 sl:Marmelada
 sv:Marmelad
 wikidata:en:Q5834964
+expected_minimal_amount_specific_ingredients:en: en:fruit, 20, en:eu
 
 <en:Fruit and vegetable preserves
 en:Citrus jams
@@ -93806,6 +93813,7 @@ it:Confetture di agrumi
 nl:Citrusmarmelades
 pt:Citrinada
 wikidata:en:Q5834964
+expected_minimal_amount_specific_ingredients:en: en:fruit, 20, en:eu
 
 <en:Citrus jams
 en:Bigarade orange marmelades
@@ -93953,6 +93961,7 @@ de:Schwarze Johannisbeere Gelees
 fi:Mustaherukkahyytelöt
 fr:Gelées de cassis
 sv:Svartvinbärsgeléer, Svartvinbärsgelé
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Fruit jellies
 en:Elderberry jellies
@@ -93999,6 +94008,7 @@ ja:パッションフルーツゼリー
 nl:Passievruchtgeleien
 pt:Geleias de maracujá
 sv:Passionsfruktgeléer
+expected_minimal_amount_specific_ingredients:en: en:fruit, 6, en:eu
 
 # in eu, quince jams/jellies should have specific 
 # content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
@@ -94010,6 +94020,7 @@ fr:Gelées de coings
 nl:Kweepeergeleien
 pt:Geleias de marmelo
 sv:Kvittengeléer
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Fruit jellies
 en:Raspberry jellies
@@ -94032,6 +94043,7 @@ fr:Gelées de groseilles
 nl:Aalbessengeleien
 pt:Geleias de groselha
 sv:Vinbärsgeléer
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 # in eu, Sea-buckthorn jams/jellies should have specific 
 # content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
@@ -94040,6 +94052,7 @@ en:Sea-buckthorn jellies
 de:Sanddorn Gelees
 fi:Tyrnihyytelöt
 fr:Gelées d'argousiers
+expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
 
 <en:Fruit jellies
 en:Wine jellies, wine gelees
@@ -94079,6 +94092,7 @@ agribalyse_food_code:en:15013
 ciqual_food_code:en:15013
 ciqual_food_name:en:Chestnut cream
 ciqual_food_name:fr:Crème de marrons
+expected_minimal_amount_specific_ingredients:en: en:fruit, 38, en:eu
 
 <en:Chestnut spreads
 en:Vanilla flavoured chestnut cream, Canned vanilla flavoured chestnut cream

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -849,12 +849,12 @@ show_on_producers_platform:en:yes
 marker_type:en: error
 
 <en:Ingredients errors
-en:nutri-score-grade-from-category-does-not-match-calculated-grade
+en:nutri score grade from category does not match calculated grade
 description:en: The calculated nutriscore grade is different than the one expected for this category
 fix_action:en: add_nutrition_facts
 
 <en:Ingredients errors
-en:ingredients-single-ingredient-from-category-does-not-match-actual-ingredients
+en:ingredients single ingredient from category does not match actual ingredients
 description:en: This category expect a single and specific ingredient
 fix_action:en: add_ingredients_text
 
@@ -862,74 +862,74 @@ fix_action:en: add_ingredients_text
 ### Labels
 
 <en:Data quality errors
-en:vegan-label-but-non-vegan-ingredient
+en:vegan label but non vegan ingredient
 description:en:This product has a vegan label but contains non-vegan ingredients.
 
 <en:Data quality errors
-en:vegetarian-label-but-non-vegetarian-ingredient
+en:vegetarian label but non vegetarian ingredient
 description:en:This product has a vegetarian label but contains non-vegetarian ingredients.
 
 
 ### Categories
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams
+en:specific ingredient fruit quantity is below the minimum value of 35 for category jams
 description:en:As a general rule quantity of fruit for jam should be above 35g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-extra-jams
+en:specific ingredient fruit quantity is below the minimum value of 45 for category extra jams
 description:en:As a general rule quantity of fruit for extra jam should be above 45g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-20-for-category-marmalades
+en:specific ingredient fruit quantity is below the minimum value of 20 for category marmalades
 description:en:As a general rule quantity of fruit for marmalades and citrus jams should be above 20g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-20-for-category-citrus-jams
+en:specific ingredient fruit quantity is below the minimum value of 20 for category citrus jams
 description:en:As a general rule quantity of fruit for marmalades and citrus jams should be above 20g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrant-jams
+en:specific ingredient fruit quantity is below the minimum value of 25 for category blackcurrant jams
 description:en:Quantity of fruit for blackcurrant jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams
+en:specific ingredient fruit quantity is below the minimum value of 25 for category redcurrants jams
 description:en:Quantity of fruit for redcurrants jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-15-for-category-ginger-jams
+en:specific ingredient fruit quantity is below the minimum value of 15 for category ginger jams
 description:en:Quantity of fruit for ginger jams should be above 15 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jams
+en:specific ingredient fruit quantity is below the minimum value of 25 for category quince jams
 description:en:Quantity of fruit for quince jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-rosehip-jams
+en:specific ingredient fruit quantity is below the minimum value of 25 for category rosehip jams
 description:en:Quantity of fruit for rosehip jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jams
+en:specific ingredient fruit quantity is below the minimum value of 25 for category sea buckthorn jams
 description:en:Quantity of fruit for sea-buckthorn jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrants-jellies
+en:specific ingredient fruit quantity is below the minimum value of 25 for category blackcurrants jellies
 description:en:Quantity of fruit for blackcurrants jellies should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-6-for-category-passion-fruit-jellies
+en:specific ingredient fruit quantity is below the minimum value of 6 for category passion fruit jellies
 description:en:Quantity of fruit for passion fruit jellies should be above 6 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jellies
+en:specific ingredient fruit quantity is below the minimum value of 25 for category quince jellies
 description:en:Quantity of fruit for quince jellies should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jellies
+en:specific ingredient fruit quantity is below the minimum value of 25 for category sea buckthorn jellies
 description:en:Quantity of fruit for Sea-buckthorn jellies should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
-en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-38-for-category-chestnut-spreads
+en:specific ingredient fruit quantity is below the minimum value of 38 for category chestnut spreads
 description:en:Quantity of fruit for chestnut purée should be above 38 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 
@@ -3233,238 +3233,238 @@ en:Carbon footprint from known ingredients more than from meat or fish
 ### Labels
 
 <en:Data quality warnings
-en:vegan-label-but-could-not-confirm-for-all-ingredients 
+en:vegan label but could not confirm for all ingredients 
 description:en:This product has a vegan label, however some ingredients are not known as non-vegan in the taxonomy (could be unknown ingredients or missing vegan true/false in the taxonomy).
 
 <en:Data quality warnings
-en:vegetarian-label-but-could-not-confirm-for-all-ingredients 
+en:vegetarian label but could not confirm for all ingredients 
 description:en:This product has a vegetarian label, however some ingredients are not known as non-vegetarian in the taxonomy (could be unknown ingredients or missing vegetarian true/false in the taxonomy).
 
 
 <en:Data quality warnings
-en:low-energy-label-claim-but-energy-above-limitation
+en:low energy label claim but energy above limitation
 description:en:In EU, a claim that a food is low in energy may only be made where the product does not contain more than 40 kcal or 170 kJ /100 g for solids or more than 20 kcal or 80 kJ /100 ml for liquids. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:energy-free-label-claim-but-energy-above-limitation
+en:energy free label claim but energy above limitation
 description:en:In EU, a claim that a food is energy free may only be made where the product does not contain more than 4 kcal or 17 kJ /100 ml. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:low-fat-label-claim-but-fat-above-limitation
+en:low fat label claim but fat above limitation
 description:en:In EU, a claim that a food is low fat may only be made where the product contains no more than 3 g of fat per 100 g for solids or 1,5 g of fat per 100 ml for liquids. 1,8 g of fat per 100 ml for semi-skimmed milk. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:en:no-fat-label-claim-but-fat-above-0.5
+en:en:no fat label claim but fat above 0.5
 description:en:In EU, a claim that a food is fat free may only be made where the product contains no more than 0,5 g of fat per 100 g or 100 ml. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:low-saturated-fat-label-claim-but-fat-above-limitation
+en:low saturated fat label claim but fat above limitation
 description:en:In EU, a claim that a food is fat free may only be made if the sum of saturated fatty acids and trans-fatty acids in the product does not exceed 1,5 g per 100 g for solids or 0,75 g/100 ml for liquids and in either case the sum of saturated fatty acids and trans-fatty acids must not provide more than 10 % of energy. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:saturated-fat-free-label-claim-but-fat-above-0.1
+en:saturated fat free label claim but fat above 0.1
 description:en:In EU, a claim that a food does not contain sturated fat may only be made where the sum of saturated fat and trans-fatty acids does not exceed 0,1 g of saturated fat per 100 g or 100 ml. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:low-sugar-label-claim-but-sugar-above-limitation
+en:low sugar label claim but sugar above limitation
 description:en:In EU, a claim that a food is low sugar may only be made where the product contains no more than 5 g of sugars per 100 g for solids or 2,5 g of sugars per 100 ml for liquids. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:sugar-free-label-claim-but-sugar-above-limitation
+en:sugar free label claim but sugar above limitation
 description:en:In EU, a claim that a food is sugar-free may only be made where the product contains no more than 0,5 g of sugars per 100 g or 100 ml. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:no-added-sugar-label-claim-but-contains-added-sugar
+en:no added sugar label claim but contains added sugar
 description:en:In EU, a claim that a food is with no added sugars may only be made where the product does not contain any added mono- or disaccharides or any other food used for its sweetening properties. If sugars are naturally present in the food, the following indication should also appear on the label: ‘CONTAINS NATURALLY OCCURRING SUGARS’. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:low-sodium-or-low-salt-label-claim-but-sodium-or-salt-above-limitation
+en:low sodium or low salt label claim but sodium or salt above limitation
 description:en:In EU, a claim that a food is low sodium or low salt may only be made where the product contains no more than 0,12 g of sodium, or the equivalent value for salt, per 100 g or per 100 ml. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:very-low-sodium-or-very-low-salt-label-claim-but-sodium-or-salt-above-limitation
+en:very low sodium or very low salt label claim but sodium or salt above limitation
 description:en:In EU, a claim that a food is very low in sodium/salt may only be made where the product contains no more than 0,04 g of sodium, or the equivalent value for salt, per 100 g or per 100 ml. This claim shall not be used for natural mineral waters and other waters. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:no-added-sodium-or-no-added-salt-label-claim-but-sodium-or-salt-above-limitation
+en:no added sodium or no added salt label claim but sodium or salt above limitation
 description:en:In EU, a claim that sodium/salt has not been added to a food may only be made where the product does not contain any added sodium/salt or any other ingredient containing added sodium/salt and the product contains no more than 0,12 g sodium, or the equivalent value for salt, per 100 g or 100 ml. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:source-of-fibre-label-claim-but-fibre-below-limitation
+en:source of fibre label claim but fibre below limitation
 description:en:In EU, a claim that a food is a source of fibre may only be made where the product contains at least 3 g of fibre per 100 g or at least 1,5 g of fibre per 100 kcal. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:high-fibres-label-claim-but-fibre-below-limitation
+en:high fibres label claim but fibre below limitation
 description:en:In EU, a claim that a food is high in fibre may only be made where the product contains at least 6 g of fibre per 100 g or at least 3 g of fibre per 100 kcal. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:source-of-proteins-label-claim-but-proteins-below-limitation
+en:source of proteins label claim but proteins below limitation
 description:en:In EU, a claim that a food is a source of protein may only be made where at least 12 % of the energy value of the food is provided by protein. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:high-proteins-label-claim-but-proteins-below-limitation
+en:high proteins label claim but proteins below limitation
 description:en:In EU, a claim that a food is high in protein may only be made where at least 20 % of the energy value of the food is provided by protein. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:vitamin-a-source-label-claim-but-vitamin-a-below-0.0008
+en:vitamin a source label claim but vitamin a below 0.0008
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-a-label-claim-but-vitamin-a-below-0.0016
+en:rich in vitamin a label claim but vitamin a below 0.0016
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-d-source-label-claim-but-vitamin-d-below-5e-06
+en:vitamin d source label claim but vitamin d below 5e-06
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-d-label-claim-but-vitamin-d-below-1e-05
+en:rich in vitamin d label claim but vitamin d below 1e-05
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-e-source-label-claim-but-vitamin-e-below-0.01
+en:vitamin e source label claim but vitamin e below 0.01
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-e-label-claim-but-vitamin-e-below-0.02
+en:rich in vitamin e label claim but vitamin e below 0.02
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-c-source-label-claim-but-vitamin-c-below-0.06
+en:vitamin c source label claim but vitamin c below 0.06
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-c-label-claim-but-vitamin-c-below-0.12
+en:rich in vitamin c label claim but vitamin c below 0.12
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-b1-source-label-claim-but-vitamin-b1-below-0.0014
+en:vitamin b1 source label claim but vitamin b1 below 0.0014
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-b1-label-claim-but-vitamin-b1-below-0.0028
+en:rich in vitamin b1 label claim but vitamin b1 below 0.0028
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-b2-source-label-claim-but-vitamin-b2-below-0.0016
+en:vitamin b2 source label claim but vitamin b2 below 0.0016
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-b2-label-claim-but-vitamin-b2-below-0.0032
+en:rich in vitamin b2 label claim but vitamin b2 below 0.0032
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-b3-source-label-claim-but-vitamin-b3-below-0.018
+en:vitamin b3 source label claim but vitamin b3 below 0.018
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-b3-label-claim-but-vitamin-b3-below-0.036
+en:rich in vitamin b3 label claim but vitamin b3 below 0.036
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-b6-source-label-claim-but-vitamin-b6-below-0.002
+en:vitamin b6 source label claim but vitamin b6 below 0.002
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-b6-label-claim-but-vitamin-b6-below-0.004
+en:rich in vitamin b6 label claim but vitamin b6 below 0.004
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-b9-source-label-claim-but-vitamin-b9-below-0.0002
+en:vitamin b9 source label claim but vitamin b9 below 0.0002
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-b9-label-claim-but-vitamin-b9-below-0.0004
+en:rich in vitamin b9 label claim but vitamin b9 below 0.0004
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:vitamin-b12-source-label-claim-but-vitamin-b12-below-1e-06
+en:vitamin b12 source label claim but vitamin b12 below 1e-06
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:rich-in-vitamin-b12-label-claim-but-vitamin-b12-below-2e-06
+en:rich in vitamin b12 label claim but vitamin b12 below 2e-06
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:source-of-biotin-label-claim-but-biotin-below-0.00015
+en:source of biotin label claim but biotin below 0.00015
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-biotin-label-claim-but-biotin-below-0.0003
+en:high in biotin label claim but biotin below 0.0003
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:source-of-pantothenic-acid-label-claim-but-pantothenic-acid-below-0.006
+en:source of pantothenic acid label claim but pantothenic acid below 0.006
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-pantothenic-acid-label-claim-but-pantothenic-acid-below-0.012
+en:high in pantothenic acid label claim but pantothenic acid below 0.012
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:calcium-source-label-claim-but-calcium-below-0.8
+en:calcium source label claim but calcium below 0.8
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-calcium-label-claim-but-calcium-below-1.6
+en:high in calcium label claim but calcium below 1.6
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:phosphore-source-label-claim-but-phosphorus-below-0.8
+en:phosphore source label claim but phosphorus below 0.8
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-phosphore-label-claim-but-phosphorus-below-1.6
+en:high in phosphore label claim but phosphorus below 1.6
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:iron-source-label-claim-but-iron-below-0.014
+en:iron source label claim but iron below 0.014
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-iron-label-claim-but-iron-below-0.028
+en:high in iron label claim but iron below 0.028
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:magnesium-source-label-claim-but-magnesium-below-0.3
+en:magnesium source label claim but magnesium below 0.3
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-magnesium-label-claim-but-magnesium-below-0.6
+en:high in magnesium label claim but magnesium below 0.6
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:zinc-source-label-claim-but-zinc-below-0.015
+en:zinc source label claim but zinc below 0.015
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-zinc-label-claim-but-zinc-below-0.03
+en:high in zinc label claim but zinc below 0.03
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:iodine-source-label-claim-but-iodine-below-0.00015
+en:iodine source label claim but iodine below 0.00015
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:high-in-iodine-label-claim-but-iodine-below-0.0003
+en:high in iodine label claim but iodine below 0.0003
 description:en:In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
 
 <en:Data quality warnings
-en:source-of-omega-3-label-claim-but-ala-or-sum-of-epa-and-dha-below-limitation
+en:source of omega 3 label claim but ala or sum of epa and dha below limitation
 description:en:In EU, a claim that a food is a source of omega-3 may only be made where the product contains at least 0,3 g alpha-linolenic acid per 100 g and per 100 kcal, or at least 40 mg of the sum of eicosapentaenoic acid and docosahexaenoic acid per 100 g and per 100 kcal. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:high-in-omega-3-label-claim-but-ala-or-sum-of-epa-and-dha-below-limitation
+en:high in omega 3 label claim but ala or sum of epa and dha below limitation
 description:en:In EU, a claim that a food is high in omega-3 may only be made where the product contains at least 0,6 g alpha-linolenic acid per 100 g and per 100 kcal, or at least 80 mg of the sum of eicosapentaenoic acid and docosahexaenoic acid per 100 g and per 100 kcal. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:high-monounsaturated-fat-label-claim-but-monounsaturated-fat-under-limitation
+en:high monounsaturated fat label claim but monounsaturated fat under limitation
 description:en:In EU, a claim that a food is high in monounsaturated fat may only be made where at least 45 % of the fatty acids present in the product derive from monounsaturated fat under the condition that monounsaturated fat provides more than 20 % of energy of the product. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:rich-in-polyunsaturated-fatty-acids-label-claim-but-polyunsaturated-fat-under-limitation
+en:rich in polyunsaturated fatty acids label claim but polyunsaturated fat under limitation
 description:en:In EU, a claim that a food is high in polyunsaturated fat may only be made where at least 45 % of the fatty acids present in the product derive from polyunsaturated fat under the condition that polyunsaturated fat provides more than 20 % of energy of the product. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213
 
 <en:Data quality warnings
-en:rich-in-unsaturated-fatty-acids-label-claim-but-unsaturated-fat-under-limitation
+en:rich in unsaturated fatty acids label claim but unsaturated fat under limitation
 description:en:In EU, a claim that a food is high in unsaturated fat may only be made where at least 70 % of the fatty acids present in the product derive from unsaturated fat under the condition that unsaturated fat provides more than 20 % of energy of the product. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -877,8 +877,61 @@ en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-categ
 description:en:As a general rule quantity of fruit for jam should be above 35g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
 
 <en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-extra-jams
+description:en:As a general rule quantity of fruit for extra jam should be above 45g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-20-for-category-marmalades
+description:en:As a general rule quantity of fruit for marmalades and citrus jams should be above 20g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-20-for-category-citrus-jams
+description:en:As a general rule quantity of fruit for marmalades and citrus jams should be above 20g per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrant-jams
+description:en:Quantity of fruit for blackcurrant jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
 en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams
 description:en:Quantity of fruit for redcurrants jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-15-for-category-ginger-jams
+description:en:Quantity of fruit for ginger jams should be above 15 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jams
+description:en:Quantity of fruit for quince jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-rosehip-jams
+description:en:Quantity of fruit for rosehip jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jams
+description:en:Quantity of fruit for sea-buckthorn jams should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrants-jellies
+description:en:Quantity of fruit for blackcurrants jellies should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-6-for-category-passion-fruit-jellies
+description:en:Quantity of fruit for passion fruit jellies should be above 6 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jellies
+description:en:Quantity of fruit for quince jellies should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jellies
+description:en:Quantity of fruit for Sea-buckthorn jellies should be above 25 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
+<en:Data quality errors
+en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-38-for-category-chestnut-spreads
+description:en:Quantity of fruit for chestnut purée should be above 38 per 100g in EU. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32001L0113
+
 
 
 

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1432,7 +1432,7 @@ $product_ref = {
 			ingredient => "fruit",
 			quantity => "50 g",
 			quantity_g => 50,
-			text => "Prepared with 50g fruit per 100g",
+			text => "Prepared with 50g of fruit per 100g",
 		},
 	]
 };
@@ -1457,7 +1457,7 @@ $product_ref = {
 			ingredient => "fruit",
 			quantity => "5 g",
 			quantity_g => 5,
-			text => "Prepared with 5g fruit per 100g",
+			text => "Prepared with 5g of fruit per 100g",
 		},
 	]
 };
@@ -1482,7 +1482,7 @@ $product_ref = {
 			ingredient => "fruit",
 			quantity => "10 g",
 			quantity_g => 10,
-			text => "Prepared with 10 fruit per 100g",
+			text => "Prepared with 10g of fruit per 100g",
 		},
 	]
 };
@@ -1511,7 +1511,7 @@ $product_ref = {
 			ingredient => "fruit",
 			quantity => "30 g",
 			quantity_g => 30,
-			text => "Prepared with 30 fruit per 100g",
+			text => "Prepared with 30g of fruit per 100g",
 		},
 	]
 };
@@ -1529,6 +1529,314 @@ ok(
 		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams'
 	),
 	'en:fruit content too small'
+) or diag explain $product_ref;
+## extra jams
+$product_ref = {
+	categories_tags => ["en:extra-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "1 g",
+			quantity_g => 1,
+			text => "Prepared with 1g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-extra-jams'
+	),
+	'en:fruit content too small extra jams'
+) or diag explain $product_ref;
+## Blackcurrant jams
+$product_ref = {
+	categories_tags => ["en:blackcurrant-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "2 g",
+			quantity_g => 3,
+			text => "Prepared with 2g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrant-jams'
+	),
+	'en:fruit content too small blackcurrant jams'
+) or diag explain $product_ref;
+## ginger jams
+$product_ref = {
+	categories_tags => ["en:ginger-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "3 g",
+			quantity_g => 3,
+			text => "Prepared with 3g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-15-for-category-ginger-jams'
+	),
+	'en:fruit content too small ginger jams'
+) or diag explain $product_ref;
+## quince jams
+$product_ref = {
+	categories_tags => ["en:quince-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "4 g",
+			quantity_g => 4,
+			text => "Prepared with 4g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jams'
+	),
+	'en:fruit content too small quince jams'
+) or diag explain $product_ref;
+## rosehip jams
+$product_ref = {
+	categories_tags => ["en:rosehip-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "5 g",
+			quantity_g => 5,
+			text => "Prepared with 5g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-rosehip-jams'
+	),
+	'en:fruit content too small rosehip jams'
+) or diag explain $product_ref;
+## Sea-buckthorn jams
+$product_ref = {
+	categories_tags => ["en:sea-buckthorn-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "6 g",
+			quantity_g => 6,
+			text => "Prepared with 6g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jams'
+	),
+	'en:fruit content too small sea-buckthorn jams'
+) or diag explain $product_ref;
+## marmalades
+$product_ref = {
+	categories_tags => ["en:marmalades"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "7 g",
+			quantity_g => 7,
+			text => "Prepared with 7g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-20-for-category-marmalades'
+	),
+	'en:fruit content too small marmalades jams'
+) or diag explain $product_ref;
+## citrus jams
+$product_ref = {
+	categories_tags => ["en:citrus-jams"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "8 g",
+			quantity_g => 8,
+			text => "Prepared with 8g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-20-for-category-citrus-jams'
+	),
+	'en:fruit content too small citrus jams'
+) or diag explain $product_ref;
+## blackcurrants jellies
+$product_ref = {
+	categories_tags => ["en:blackcurrants-jellies"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "9 g",
+			quantity_g => 9,
+			text => "Prepared with 9g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrants-jellies'
+	),
+	'en:fruit content too small blackcurrants jellies'
+) or diag explain $product_ref;
+## passion fruit jellies
+$product_ref = {
+	categories_tags => ["en:passion-fruit-jellies"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "1 g",
+			quantity_g => 1,
+			text => "Prepared with 1g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-6-for-category-passion-fruit-jellies'
+	),
+	'en:fruit content too small passion fruit jellies'
+) or diag explain $product_ref;
+## Quince jellies
+$product_ref = {
+	categories_tags => ["en:quince-jellies"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "10 g",
+			quantity_g => 10,
+			text => "Prepared with 10g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jellies'
+	),
+	'en:fruit content too small quince jellies'
+) or diag explain $product_ref;
+## Redcurrants jellies
+$product_ref = {
+	categories_tags => ["en:redcurrants-jellies"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "11 g",
+			quantity_g => 11,
+			text => "Prepared with 11g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jellies'
+	),
+	'en:fruit content too small redcurrants jellies'
+) or diag explain $product_ref;
+## sea-buckthorn jellies
+$product_ref = {
+	categories_tags => ["en:sea-buckthorn-jellies"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "12 g",
+			quantity_g => 12,
+			text => "Prepared with 12g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jellies'
+	),
+	'en:fruit content too small sea-buckthorn jellies'
+) or diag explain $product_ref;
+## chestnut spreads
+$product_ref = {
+	categories_tags => ["en:chestnut-spreads"],
+	countries_tags => ["en:slovenia",],
+	specific_ingredients => [
+		{
+			id => "en:fruit",
+			ingredient => "fruit",
+			quantity => "13 g",
+			quantity_g => 13,
+			text => "Prepared with 13g of fruit per 100g",
+		},
+	]
+};
+ProductOpener::DataQuality::check_quality($product_ref);
+ok(
+	has_tag(
+		$product_ref, 'data_quality',
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-38-for-category-chestnut-spreads'
+	),
+	'en:fruit content too small chestnut-spreads'
 ) or diag explain $product_ref;
 
 done_testing();


### PR DESCRIPTION
### What
Continuity of previous PR https://github.com/openfoodfacts/openfoodfacts-server/pull/9606.
Now, for all jams, extra-jams, jellies.
According to EU regulations: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
For existing categories in the taxonomy only.


### Screenshot
![Screenshot_20240126_230542](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/46b55bf8-b151-42fb-9627-7798ac42dd98)

### Related issue(s) and discussion
- Fixes #1414