### PR TITLE
fix: fix_dq_facet_all_values_identical

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1091,7 +1091,7 @@ sub check_nutrition_data ($product_ref) {
 			}
 		}
 
-		foreach my $nid (keys %{$product_ref->{nutriments}}) {
+		foreach my $nid (sort keys %{$product_ref->{nutriments}}) {
 			$log->debug("nid: " . $nid . ": " . $product_ref->{nutriments}{$nid}) if $log->is_debug();
 
 			if ($nid =~ /_prepared_100g$/ && $product_ref->{nutriments}{$nid} > 0) {
@@ -1173,7 +1173,7 @@ sub check_nutrition_data ($product_ref) {
 			(
 				(
 					$nutriments_values_occurences_max_value == scalar @major_nutriments_values
-					and (@major_nutriments_values[0] > 1)
+					and ($major_nutriments_values[0] > 1)
 				)
 				or (
 					($nutriments_values_occurences_max_value >= scalar @major_nutriments_values - 1)

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1164,21 +1164,25 @@ sub check_nutrition_data ($product_ref) {
 		}
 		# raise error if
 		# all values are identical
+		# and values (check first value only) are above 1 (see issue #9572)
 		#  OR
 		# all values but one - because sodium and salt can be automatically calculated one depending on the value of the other - are identical
-		# and values (check first value only) are above 1 (see issue #9572)
+		# and values (check salt (should not check sodium which could be lower)) are above 1 (see issue #9572)
 		# and at least 4 values are input by contributors (see issue #9572)
 		if (
 			(
-				($nutriments_values_occurences_max_value == scalar @major_nutriments_values)
+				(
+					$nutriments_values_occurences_max_value == scalar @major_nutriments_values
+					and (@major_nutriments_values[0] > 1)
+				)
 				or (
 					($nutriments_values_occurences_max_value >= scalar @major_nutriments_values - 1)
 					and (   (defined $nutriments_values{'salt_100g'})
-						and ($nutriments_values{'sodium_100g'})
-						and ($nutriments_values{'salt_100g'} != $nutriments_values{'sodium_100g'}))
+						and (defined $nutriments_values{'sodium_100g'})
+						and ($nutriments_values{'salt_100g'} != $nutriments_values{'sodium_100g'})
+						and ($nutriments_values{'salt_100g'} > 1))
 				)
 			)
-			and (@major_nutriments_values[0] > 1)
 			and (scalar @major_nutriments_values > 3)
 			)
 		{


### PR DESCRIPTION
### What
Bug reported on Slack
Sometimes the unit test 'all identical values and above 1 in the nutrition table 2' in dataqualityfood.t fails.


It happens because the array "@major_nutriments_values" (see Ingredients.pm) can have values in random order. Sometimes the first value is "0.8" and since we have the condition "@major_nutriments_values[0] > 1" facet is not raised. And test fails.

See the code for suggested solution


