### PR TITLE
fix: use a different redis stream depending on the project

### DIFF
--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -418,4 +418,7 @@ $options{other_servers} = {
 
 $options{no_nutrition_table} = 1;
 
+# Name of the Redis stream to which product updates are published
+$options{redis_stream_name} = "product_updates_obf";
+
 1;

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -1027,6 +1027,9 @@ $options{other_servers} = {
 	}
 };
 
+# Name of the Redis stream to which product updates are published
+$options{redis_stream_name} = "product_updates_off";
+
 # used to rename texts and to redirect to the new name
 $options{redirect_texts} = {
 	"en/nova-groups-for-food-processing" => "nova",

--- a/lib/ProductOpener/Config_opf.pm
+++ b/lib/ProductOpener/Config_opf.pm
@@ -391,4 +391,7 @@ $options{other_servers} = {
 
 $options{no_nutrition_table} = 1;
 
+# Name of the Redis stream to which product updates are published
+$options{redis_stream_name} = "product_updates_opf";
+
 1;

--- a/lib/ProductOpener/Config_opff.pm
+++ b/lib/ProductOpener/Config_opff.pm
@@ -430,4 +430,7 @@ $options{other_servers} = {
 	}
 };
 
+# Name of the Redis stream to which product updates are published
+$options{redis_stream_name} = "product_updates_opff";
+
 1;

--- a/lib/ProductOpener/Redis.pm
+++ b/lib/ProductOpener/Redis.pm
@@ -112,7 +112,7 @@ sub push_to_redis_stream ($user_id, $product_ref, $action, $comment, $diffs) {
 		eval {
 			$redis_client->xadd(
 				# name of the Redis stream
-				'product_update',
+				$options{redis_stream_name},
 				# We do not add a MAXLEN
 				'MAXLEN', '~', '10000000',
 				# We let Redis generate the id


### PR DESCRIPTION
After https://github.com/openfoodfacts/search-a-licious/pull/81

Now there is one stream per project (OFF, OBF,..).