### PR TITLE
fix: single allergen infinite loop 

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2165,7 +2165,7 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 							}
 							# try to remove the allergens and store them as allergens
 							# in Japanese allergens are not separated from the ingredients list, instead they are in parenthesis.
-							if ($between =~ /\s*(?:>allergens<:)\s?:?\s?\b(.*)$/i) {
+							if ($between =~ /\s*(?:>allergens<:)(.*)$/i) {
 								$log->debug("parse_ingredients_text - sub-ingredients: contains allergens in $between")
 									if $log->is_debug();
 

--- a/tests/integration/expected_test_results/api_v2_product_read/get-existing-product.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-existing-product.json
@@ -104,7 +104,7 @@
             "origins_of_ingredients" : {
                "aggregated_origins" : [
                   {
-                     "epi_score" : 0,
+                     "epi_score" : "0",
                      "origin" : "en:unknown",
                      "percent" : 100,
                      "transportation_score" : null

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -835,6 +835,15 @@ puffed orange and caramelized unknown_fruit4.",
 			ingredients_text => "beurre (lait), fromage (parmesan)",
 		}
 	],
+	# Infinite loop https://github.com/openfoodfacts/openfoodfacts-server/issues/9755
+	[
+		"fr-infinite-loop-allergens",
+		{
+			lc => "fr",
+			ingredients_text =>
+				"Sucre, LAIT* entier en poudre 25%, graisse végétale (palme, palmiste), beurre de cacao1, pâte de cacao1, LAIT* écrémé en poudre 3%, huile de tournesol, émulsifiant: lécithines, arômes de vanille. Traces éventuelles de fruits à coque et de céréales contenant du gluten. Cacao: 30% minimum dans le chocolat au lait. *Lait: origine UE et/ou non UE (Royaume-Uni)",
+		}
+	],
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
fixes #9755

Needed for this ingredient list:

"Sucre, LAIT* entier en poudre 25%, graisse végétale (palme, palmiste), beurre de cacao1, pâte de cacao1, LAIT* écrémé en poudre 3%, huile de tournesol, émulsifiant: lécithines, arômes de vanille. Traces éventuelles de fruits à coque et de céréales contenant du gluten. Cacao: 30% minimum dans le chocolat au lait. *Lait: origine UE et/ou non UE (Royaume-Uni)"

"*Lait: origine UE et/ou non UE (Royaume-Uni)" is not understood and ignored, but there is no infinite loop anymore.