### PR TITLE
fix: nutriscore misc_tags removal

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -1693,6 +1693,11 @@ sub remove_nutriscore_fields ($product_ref) {
 		]
 	);
 
+	# remove misc_tags fields related to Nutri-Score
+	if (defined $product_ref->{misc_tags}) {
+		$product_ref->{misc_tags} = [grep {$_ !~ /^en:(nutriscore|nutrition)-/} @{$product_ref->{misc_tags}}];
+	}
+
 	return;
 }
 

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -1116,7 +1116,6 @@ while (my $product_ref = $cursor->next) {
 		}
 
 		if ($compute_nutriscore) {
-			$product_ref->{misc_tags} = [];
 			fix_salt_equivalent($product_ref);
 			compute_nutriscore($product_ref);
 			compute_nutrient_levels($product_ref);


### PR DESCRIPTION
small fix so that we correctly remove Nutri-Score related misc_tags (and only those tags) when we recompute Nutri-Score with update_all_products.pl