### PR TITLE
fix: code stored as string

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -209,6 +209,13 @@ sub make_sure_numbers_are_stored_as_numbers ($product_ref) {
 		}
 	}
 
+	# Make sure product _id and code are saved as string and not a number
+	# see bug #1077 - https://github.com/openfoodfacts/openfoodfacts-server/issues/1077
+	# make sure that code is saved as a string, otherwise mongodb saves it as number, and leading 0s are removed
+	# Note: #$product_ref->{code} .= ''; does not seem to be enough to force the type to be a string
+	$product_ref->{_id} = "$product_ref->{_id}";
+	$product_ref->{code} = "$product_ref->{code}";
+
 	return;
 }
 

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -1116,6 +1116,7 @@ while (my $product_ref = $cursor->next) {
 		}
 
 		if ($compute_nutriscore) {
+			$product_ref->{misc_tags} = [];
 			fix_salt_equivalent($product_ref);
 			compute_nutriscore($product_ref);
 			compute_nutrient_levels($product_ref);

--- a/scripts/update_all_products.pl
+++ b/scripts/update_all_products.pl
@@ -1116,7 +1116,6 @@ while (my $product_ref = $cursor->next) {
 		}
 
 		if ($compute_nutriscore) {
-			$product_ref->{misc_tags} = [];
 			fix_salt_equivalent($product_ref);
 			compute_nutriscore($product_ref);
 			compute_nutrient_levels($product_ref);
@@ -1419,9 +1418,6 @@ while (my $product_ref = $cursor->next) {
 				# In all cases (even if the product data did not change),
 				# we store the product with the new update_key in the .sto file and the mongodb collection
 
-				# make sure nutrient values are numbers
-				ProductOpener::Products::make_sure_numbers_are_stored_as_numbers($product_ref);
-
 				# Set last modified time if something was changed
 				if ($any_change) {
 					$product_ref->{last_updated_t} = time() + 0;
@@ -1432,6 +1428,9 @@ while (my $product_ref = $cursor->next) {
 						$product_ref->{last_updated_t} = $product_ref->{last_modified_t};
 					}
 				}
+
+				# make sure nutrient values are numbers
+				ProductOpener::Products::make_sure_numbers_are_stored_as_numbers($product_ref);
 
 				if (!$mongodb_to_mongodb) {
 					# Store data to .sto file


### PR DESCRIPTION
Something very strange is happening:

$product_ref->{code} .= '';   worked if it was just before the store() call, but not inside the make_sure_numbers_as_stored_as_numbers() function.

This change seems to work, but I don't know why.