### PR TITLE
Fix: Addition of privacy link, and translatable strings #9776

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -821,6 +821,15 @@ msgctxt "footer_legal_link"
 msgid "/legal"
 msgstr ""
 
+msgctxt "footer_privacy"
+msgid "Privacy"
+msgstr ""
+
+# Do not translate without having the same exact string in the Tags template. Do not use spaces, special characters, only alphanumeric characters separated by hyphens
+msgctxt "footer_privacy_link"
+msgid "/privacy"
+msgstr ""
+
 msgctxt "footer_press"
 msgid "Press"
 msgstr ""

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -828,6 +828,16 @@ msgctxt "footer_legal_link"
 msgid "/legal"
 msgstr "/legal"
 
+msgctxt "footer_privacy"
+msgid "Privacy"
+msgstr "Privacy"
+
+# Do not translate without having the same exact string in the Tags template. Do not use spaces, special characters, only alphanumeric characters separated by hyphens
+msgctxt "footer_privacy_link"
+msgid "/privacy"
+msgstr "/privacy"
+
+
 msgctxt "footer_press"
 msgid "Press"
 msgstr "Press"

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -388,6 +388,7 @@
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="[% lang('footer_legal_link') %]">[% lang('footer_legal') %]</a></li>
+									<li><a href="[% lang('footer_privacy_link') %]">[% lang('footer_privacy') %]</a></li>
 									<li><a href="[% lang('footer_terms_link') %]">[% lang('footer_terms') %]</a></li>
 									<li><a href="[% lang('footer_data_link') %]">[% lang('footer_data') %]</a></li>
 									<li><a href="[% lang('donate_link') %]">[% lang('donate') %]</a></li>


### PR DESCRIPTION
### What
Added privacy policy link in addition to translatable strings into .pot and en.po

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/127800544/55ada757-4af8-4440-b050-a4cad822ecb1)

### Related issue(s) and discussion
- Fixes #9776 