### PR TITLE
fix: js and json lang quotes escape

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -398,7 +398,7 @@ sub process_template ($template_filename, $template_data_ref, $result_content_re
 	$template_data_ref->{f_lang} = \&f_lang;
 	# escaping quotes for use in javascript or json
 	# using short names to favour readability
-	$template_data_ref->{esq} = sub {escape_char(@_, "\'")};    # esq as escape_single_quote
+	$template_data_ref->{esq} = sub {escape_char(@_, "\'")};    # esq as escape_single_quote_and_newlines
 	$template_data_ref->{edq} = sub {escape_char(@_, '"')};    # edq as escape_double_quote
 	$template_data_ref->{lang_sprintf} = \&lang_sprintf;
 	$template_data_ref->{lc} = $lc;
@@ -5740,27 +5740,6 @@ sub search_and_export_products ($request_ref, $query_ref, $sort_by) {
 	return;
 }
 
-sub escape_char($s, $char) {
-	if ($s && $char) {
-		# normalize already escaped chars to avoid double escaping
-		$s =~ s/\\$char/$char/g;
-		$s =~ s/$char/\\$char/g;
-	}
-	return $s;
-}
-
-sub escape_single_quote ($s) {
-
-	if (not defined $s) {
-		return '';
-	}
-	# some app escape single quotes already, so we have \' already
-	$s =~ s/\\'/'/g;
-	$s =~ s/'/\\'/g;
-	$s =~ s/\n/ /g;
-	return $s;
-}
-
 @search_series = (qw/organic fairtrade with_sweeteners default/);
 
 my %search_series_colors = (
@@ -5815,29 +5794,29 @@ sub get_search_field_title_and_details ($field) {
 
 	if ($field eq 'additives_n') {
 		$allow_decimals = "allowDecimals:false,\n";
-		$title = escape_single_quote(lang("number_of_additives"));
+		$title = escape_single_quote_and_newlines(lang("number_of_additives"));
 	}
 	elsif ($field eq "forest_footprint") {
 		$allow_decimals = "allowDecimals:true,\n";
-		$title = escape_single_quote(lang($field));
+		$title = escape_single_quote_and_newlines(lang($field));
 	}
 	elsif ($field =~ /_n$/) {
 		$allow_decimals = "allowDecimals:false,\n";
-		$title = escape_single_quote(lang($field . "_s"));
+		$title = escape_single_quote_and_newlines(lang($field . "_s"));
 	}
 	elsif ($field eq "product_quantity") {
 		$allow_decimals = "allowDecimals:false,\n";
-		$title = escape_single_quote(lang("quantity"));
+		$title = escape_single_quote_and_newlines(lang("quantity"));
 		$unit = ' (g)';
 		$unit2 = 'g';
 	}
 	elsif ($field eq "nova_group") {
 		$allow_decimals = "allowDecimals:false,\n";
-		$title = escape_single_quote(lang("nova_groups_s"));
+		$title = escape_single_quote_and_newlines(lang("nova_groups_s"));
 	}
 	elsif ($field eq "ecoscore_score") {
 		$allow_decimals = "allowDecimals:false,\n";
-		$title = escape_single_quote(lang("ecoscore_score"));
+		$title = escape_single_quote_and_newlines(lang("ecoscore_score"));
 	}
 	elsif ($field =~ /^packagings_materials\.([^.]+)\.([^.]+)$/) {
 		my $material = $1;
@@ -6278,7 +6257,7 @@ sub display_histogram ($graph_ref, $products_ref) {
 	}
 
 	$axis_details{"y"} = {
-		title => escape_single_quote(lang("number_of_products")),
+		title => escape_single_quote_and_newlines(lang("number_of_products")),
 		allow_decimals => "allowDecimals:false,\n",
 		unit => '',
 		unit2 => '',
@@ -6692,7 +6671,7 @@ sub search_and_graph_products ($request_ref, $query_ref, $graph_ref) {
 
 	if ($count > 0) {
 
-		$graph_ref->{graph_title} = escape_single_quote($graph_ref->{graph_title});
+		$graph_ref->{graph_title} = escape_single_quote_and_newlines($graph_ref->{graph_title});
 
 		# 1 axis: histogram / bar chart -> axis_y == "product_n" or is empty
 		# 2 axis: scatter plot
@@ -6823,7 +6802,7 @@ sub map_of_products ($products_iter, $request_ref, $graph_ref) {
 	init_packager_codes();
 	init_geocode_addresses();
 
-	$graph_ref->{graph_title} = escape_single_quote($graph_ref->{graph_title});
+	$graph_ref->{graph_title} = escape_single_quote_and_newlines($graph_ref->{graph_title});
 
 	my $matching_products = 0;
 	my $places = 0;
@@ -6836,7 +6815,7 @@ sub map_of_products ($products_iter, $request_ref, $graph_ref) {
 	while (my $product_ref = $products_iter->()) {
 		my $url = $formatted_subdomain . product_url($product_ref->{code});
 
-		my $manufacturing_places = escape_single_quote($product_ref->{"manufacturing_places"});
+		my $manufacturing_places = escape_single_quote_and_newlines($product_ref->{"manufacturing_places"});
 		$manufacturing_places =~ s/,( )?/, /g;
 		if ($manufacturing_places ne '') {
 			$manufacturing_places
@@ -6845,7 +6824,7 @@ sub map_of_products ($products_iter, $request_ref, $graph_ref) {
 				. $manufacturing_places . "<br>";
 		}
 
-		my $origins = escape_single_quote($product_ref->{origins});
+		my $origins = escape_single_quote_and_newlines($product_ref->{origins});
 		$origins =~ s/,( )?/, /g;
 		if ($origins ne '') {
 			$origins = ucfirst(lang("origins_p")) . separator_before_colon($lc) . ": " . $origins . "<br>";

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -398,8 +398,8 @@ sub process_template ($template_filename, $template_data_ref, $result_content_re
 	$template_data_ref->{f_lang} = \&f_lang;
 	# escaping quotes for use in javascript or json
 	# using short names to favour readability
-	$template_data_ref->{esq} = sub { escape_char(@_, "\'") };  # esq as escape_single_quote
-	$template_data_ref->{edq} = sub { escape_char(@_, '"') }; # edq as escape_double_quote
+	$template_data_ref->{esq} = sub {escape_char(@_, "\'")};    # esq as escape_single_quote
+	$template_data_ref->{edq} = sub {escape_char(@_, '"')};    # edq as escape_double_quote
 	$template_data_ref->{lang_sprintf} = \&lang_sprintf;
 	$template_data_ref->{lc} = $lc;
 	$template_data_ref->{cc} = $cc;
@@ -5760,7 +5760,6 @@ sub escape_single_quote ($s) {
 	$s =~ s/\n/ /g;
 	return $s;
 }
-
 
 @search_series = (qw/organic fairtrade with_sweeteners default/);
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -396,6 +396,10 @@ sub process_template ($template_filename, $template_data_ref, $result_content_re
 	$template_data_ref->{sep} = separator_before_colon($lc);
 	$template_data_ref->{lang} = \&lang;
 	$template_data_ref->{f_lang} = \&f_lang;
+	# escaping quotes for use in javascript or json
+	# using short names to favour readability
+	$template_data_ref->{esq} = sub { escape_char(@_, "\'") };  # esq as escape_single_quote
+	$template_data_ref->{edq} = sub { escape_char(@_, '"') }; # edq as escape_double_quote
 	$template_data_ref->{lang_sprintf} = \&lang_sprintf;
 	$template_data_ref->{lc} = $lc;
 	$template_data_ref->{cc} = $cc;
@@ -5736,17 +5740,27 @@ sub search_and_export_products ($request_ref, $query_ref, $sort_by) {
 	return;
 }
 
+sub escape_char($s, $char) {
+	if ($s && $char) {
+		# normalize already escaped chars to avoid double escaping
+		$s =~ s/\\$char/$char/g;
+		$s =~ s/$char/\\$char/g;
+	}
+	return $s;
+}
+
 sub escape_single_quote ($s) {
 
-	# some app escape single quotes already, so we have \' already
 	if (not defined $s) {
 		return '';
 	}
+	# some app escape single quotes already, so we have \' already
 	$s =~ s/\\'/'/g;
 	$s =~ s/'/\\'/g;
 	$s =~ s/\n/ /g;
 	return $s;
 }
+
 
 @search_series = (qw/organic fairtrade with_sweeteners default/);
 

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -119,26 +119,7 @@ In the .po translation files, we use the msgctxt field for the string id.
 =cut
 
 sub lang ($stringid) {
-
-	my $short_l = undef;
-	if ($lang =~ /_/) {
-		$short_l = $`;    # pt_pt
-	}
-
-	# English values have been copied to languages that do not have defined values
-
-	if (not defined $Lang{$stringid}) {
-		return '';
-	}
-	elsif (defined $Lang{$stringid}{$lang}) {
-		return $Lang{$stringid}{$lang};
-	}
-	elsif ((defined $short_l) and (defined $Lang{$stringid}{$short_l}) and ($Lang{$stringid}{$short_l} ne '')) {
-		return $Lang{$stringid}{$short_l};
-	}
-	else {
-		return '';
-	}
+	return lang_in_other_lc($lang, $stringid);
 }
 
 =head2 f_lang( $stringid, $variables_ref )

--- a/lib/ProductOpener/Text.pm
+++ b/lib/ProductOpener/Text.pm
@@ -53,6 +53,8 @@ BEGIN {
 
 		&get_decimal_formatter
 		&get_percent_formatter
+		&escape_char
+		&escape_single_quote_and_newlines
 
 		&remove_tags
 		&remove_tags_and_quote
@@ -159,6 +161,41 @@ sub get_decimal_formatter ($locale) {
 	$ProductOpener::Text::decimal_formatters{$locale} = $decf;
 	return $decf;
 
+}
+
+=head2 escape_char( $s, $char )
+
+Escape character $char in string $s
+
+This is use in templates to say escape single quote or double quote
+for expressions displayed with single/double quotes (in json or html for example)
+=cut
+
+sub escape_char($s, $char) {
+	if ($s && $char) {
+		# normalize already escaped chars to avoid double escaping
+		$s =~ s/\\$char/$char/g;
+		$s =~ s/$char/\\$char/g;
+	}
+	return $s;
+}
+
+=head2 escape_single_quote_and_newlines( $s )
+
+Escape single quotes in $s but also transform newlines to spaces
+
+=cut
+
+sub escape_single_quote_and_newlines ($s) {
+
+	if (not defined $s) {
+		return '';
+	}
+	# some app escape single quotes already, so we have \' already
+	$s =~ s/\\'/'/g;
+	$s =~ s/'/\\'/g;
+	$s =~ s/\n/ /g;
+	return $s;
 }
 
 =head2 get_percent_formatter( LOCALE, MAXIMUM_FRACTION_DIGITS )

--- a/lib/ProductOpener/Text.pm
+++ b/lib/ProductOpener/Text.pm
@@ -168,7 +168,7 @@ sub get_decimal_formatter ($locale) {
 Escape character $char in string $s
 
 This is use in templates to say escape single quote or double quote
-for expressions displayed with single/double quotes (in json or html for example)
+for expressions displayed with single/double quotes (in json or HTML for example)
 =cut
 
 sub escape_char($s, $char) {

--- a/templates/api/knowledge-panels/contribution/contribution_card.tt.json
+++ b/templates/api/knowledge-panels/contribution/contribution_card.tt.json
@@ -6,7 +6,7 @@
         "contribution"
     ],
     "title_element": {
-        "title": "[% lang('contribution_panel_title') %]",
+        "title": "[% edq(lang('contribution_panel_title')) %]",
     },
     "elements": [
         [%# Panels displaying data_quality errors / warnings / info %]

--- a/templates/api/knowledge-panels/contribution/data_quality_tags.tt.json
+++ b/templates/api/knowledge-panels/contribution/data_quality_tags.tt.json
@@ -22,8 +22,8 @@
         [% icon_name = "data-info" %]
     [% END %]
     "title_element": {
-        "title": "[% lang(panel.tags_type _ '_panel_title') %]",
-        "subtitle": "[% lang(panel.tags_type _ '_panel_subtitle') %]",
+        "title": "[% edq(lang(panel.tags_type _ '_panel_title')) %]",
+        "subtitle": "[% edq(lang(panel.tags_type _ '_panel_subtitle')) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/[% icon_name %].svg",
         "icon_color_from_evaluation": true,
     },
@@ -58,7 +58,7 @@
                 {
                     "element_type": "action",
                     "action_element": {
-                        "html": `[% lang(action_name) %]`,
+                        "html": `[% edq(lang(action_name)) %]`,
                         "actions": [
                             "[% fix_action %]",
                         ]

--- a/templates/api/knowledge-panels/contribution/data_quality_tags.tt.json
+++ b/templates/api/knowledge-panels/contribution/data_quality_tags.tt.json
@@ -58,7 +58,7 @@
                 {
                     "element_type": "action",
                     "action_element": {
-                        "html": `[% edq(lang(action_name)) %]`,
+                        "html": `[% lang(action_name) %]`,
                         "actions": [
                             "[% fix_action %]",
                         ]

--- a/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
+++ b/templates/api/knowledge-panels/environment/carbon_footprint.tt.json
@@ -16,9 +16,9 @@
     [% END %]
     "title_element": {
         [% SET driving_100g_rounded = sprintf('%.1f', driving_100g) %]
-        "title": "[% f_lang('f_equal_to_driving_km_in_a_petrol_car',  { 'kilometers' => driving_100g_rounded } ) %]",
+        "title": "[% edq(f_lang('f_equal_to_driving_km_in_a_petrol_car',  { 'kilometers' => driving_100g_rounded } )) %]",
         [% SET co2_100g_rounded = sprintf('%.0f', co2_100g * 1000) %]
-        "subtitle": "[% f_lang('f_carbon_footprint_per_100g_of_product', { 'grams' => co2_100g_rounded }) %]",
+        "subtitle": "[% edq(f_lang('f_carbon_footprint_per_100g_of_product', { 'grams' => co2_100g_rounded })) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/car.svg",
         "icon_color_from_evaluation": true,
     },
@@ -40,14 +40,14 @@
             "table_element": {
                 "id": "ecoscore_carbon_impact_by_stages_table",
                 "table_type": "percents",
-                "title": "[% lang('ecoscore_impact_detail_by_stages') %]",
+                "title": "[% edq(lang('ecoscore_impact_detail_by_stages')) %]",
                 "columns": [
                     {
-                        "text": "[% lang('ecoscore_stage') %]",
+                        "text": "[% edq(lang('ecoscore_stage')) %]",
                         "type": "text",
                     },
                     {
-                        "text": "[% lang('ecoscore_impact') %]",
+                        "text": "[% edq(lang('ecoscore_impact')) %]",
                         "type": "percent",
                     }
                 ],
@@ -58,7 +58,7 @@
                         "values": [
                             {
                                 "icon_url": "[% static_subdomain %]/images/icons/dist/[% step %].svg",
-                                "text": "[% lang("ecoscore_$step") %]"
+                                "text": "[% edq(lang("ecoscore_$step")) %]"
                             },
                             {
                                 [% co2_step = "co2_$step" %]

--- a/templates/api/knowledge-panels/environment/ecoscore/agribalyse.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/agribalyse.tt.json
@@ -7,8 +7,8 @@
         "icon_url": "[% static_subdomain %]/images/icons/dist/lca.svg",
         "icon_color_from_evaluation": true,
         "icon_size": "small",
-        "title": "[% lang('average_impact_of_the_category') %][% sep %]: [% panel.agribalyse_grade FILTER upper %] (Score: [% panel.agribalyse_score %]/100)",
-        "subtitle": "[% lang('categories_s') FILTER ucfirst %][% sep %]: [% panel.agribalyse_category_name.dquote %]",
+        "title": "[% edq(lang('average_impact_of_the_category')) %][% sep %]: [% panel.agribalyse_grade FILTER upper %] (Score: [% panel.agribalyse_score %]/100)",
+        "subtitle": "[% edq(lang('categories_s')) FILTER ucfirst %][% sep %]: [% panel.agribalyse_category_name.dquote %]",
         "type": "grade",
         "grade": "[% panel.agribalyse_grade %]",
     },
@@ -39,14 +39,14 @@
             "table_element": {
                 "id": "ecoscore_lca_impacts_by_stages_table",
                 "table_type": "percents",
-                "title": "[% lang('ecoscore_impact_detail_by_stages') %]",
+                "title": "[% edq(lang('ecoscore_impact_detail_by_stages')) %]",
                 "columns": [
                     {
-                        "text": "[% lang('ecoscore_stage') %]",
+                        "text": "[% edq(lang('ecoscore_stage')) %]",
                         "type": "text",
                     },
                     {
-                        "text": "[% lang('ecoscore_impact') %]",
+                        "text": "[% edq(lang('ecoscore_impact')) %]",
                         "type": "percent",
                     }
                 ],
@@ -57,7 +57,7 @@
                         "values": [
                             {
                                 "icon_url": "[% static_subdomain %]/images/icons/dist/[% step %].svg",
-                                "text": "[% lang("ecoscore_$step") %]"
+                                "text": "[% edq(lang("ecoscore_$step")) %]"
                             },
                             {
                                 [% ef_step = "ef_$step" %]

--- a/templates/api/knowledge-panels/environment/ecoscore/ecoscore.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/ecoscore.tt.json
@@ -41,7 +41,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('life_cycle_analysis') %]",
+                "title": "[% edq(lang('life_cycle_analysis')) %]",
                 "panel_ids": [
                     "ecoscore_agribalyse",
                 ],
@@ -50,7 +50,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('ecoscore_bonuses_and_maluses') %]",
+                "title": "[% edq(lang('ecoscore_bonuses_and_maluses')) %]",
                 "panel_ids": [
                     [% FOREACH adjustment IN ["production_system", "origins_of_ingredients", "threatened_species", "packaging"] %]
                         [% IF (adjustment == "origins_of_ingredients") or (adjustment == "packaging") or (product.ecoscore_data.adjustments.$adjustment.value != 0) %]
@@ -63,7 +63,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('ecoscore_for_this_product') %]",
+                "title": "[% edq(lang('ecoscore_for_this_product')) %]",
                 "panel_ids": [ "ecoscore_total"],
             },
         },

--- a/templates/api/knowledge-panels/environment/ecoscore/ecoscore_extended.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/ecoscore_extended.tt.json
@@ -1,7 +1,7 @@
 [% SET climate_change_ratio_to_category = panel.climate_change / panel.ecoscore_extended_data_for_category.climate_change %]
 
 
-    // "title": "[% f_lang('f_equal_to_driving_km_in_a_petrol_car',  { 'kilometers' => driving_100g_rounded } ) %]",
+    // "title": "[% edq(f_lang('f_equal_to_driving_km_in_a_petrol_car',  { 'kilometers' => driving_100g_rounded } )) %]",
 {
     "level" :"info",
     "topics": [
@@ -25,7 +25,7 @@
             [% SET climate_change_ratio_percent_less = sprintf('%d', (1 - climate_change_ratio_to_category) * 100) %]
             "title": "Environmental impact of ingredients [% climate_change_ratio_percent_less %]% smaller than similar products",
         [% END %]
-        "subtitle": "Compared to: [% lang('categories_s') FILTER ucfirst %][% sep %]: [% panel.agribalyse_category_name.dquote %]",
+        "subtitle": "Compared to: [% edq(lang('categories_s')) FILTER ucfirst %][% sep %]: [% panel.agribalyse_category_name.dquote %]",
         "type": "grade",
         "icon_url": "[% static_subdomain %]/images/icons/dist/scale-balance.svg",
         "icon_color_from_evaluation": true,        

--- a/templates/api/knowledge-panels/environment/ecoscore/ecoscore_not_applicable.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/ecoscore_not_applicable.tt.json
@@ -5,7 +5,7 @@
     ],
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/attributes/dist/ecoscore-not-applicable.svg",
-        "title": "[% lang("attribute_ecoscore_not_applicable_title") %]",
+        "title": "[% edq(lang('attribute_ecoscore_not_applicable_title')) %]",
         "subtitle": "[% panel.subtitle %]",
         "type": "grade",
         "grade": "unknown",
@@ -15,7 +15,7 @@
             "element_type": "text",
             "text_element": {
                 "type": "summary",
-                "html": "[% lang("ecoscore_not_applicable_coming_soon") %]"
+                "html": "[% edq(lang('ecoscore_not_applicable_coming_soon')) %]"
             }
         },       
     ]

--- a/templates/api/knowledge-panels/environment/ecoscore/ecoscore_unknown.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/ecoscore_unknown.tt.json
@@ -5,7 +5,7 @@
     ],
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/attributes/dist/ecoscore-unknown.svg",
-        "title": "[% eqq(lang('attribute_ecoscore_unknown_title')) %] - [% edq(lang('attribute_ecoscore_unknown_description_short')) %]",
+        "title": "[% edq(lang('attribute_ecoscore_unknown_title')) %] - [% edq(lang('attribute_ecoscore_unknown_description_short')) %]",
         "type": "grade",
         "grade": "unknown",
     },

--- a/templates/api/knowledge-panels/environment/ecoscore/ecoscore_unknown.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/ecoscore_unknown.tt.json
@@ -5,7 +5,7 @@
     ],
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/attributes/dist/ecoscore-unknown.svg",
-        "title": "[% lang("attribute_ecoscore_unknown_title") %] - [% lang("attribute_ecoscore_unknown_description_short") %]",
+        "title": "[% eqq(lang('attribute_ecoscore_unknown_title')) %] - [% edq(lang('attribute_ecoscore_unknown_description_short')) %]",
         "type": "grade",
         "grade": "unknown",
     },
@@ -14,7 +14,7 @@
             "element_type": "text",
             "text_element": {
                 "type": "summary",
-                "html": "[% lang("ecoscore_unknown_call_to_help") %]"
+                "html":  "[% edq(lang('ecoscore_unknown_call_to_help')) %]"
             }
         },
         {

--- a/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json
@@ -6,8 +6,8 @@
 [% IF product.ecoscore_data.adjustments.origins_of_ingredients.warning == "origins_are_100_percent_unknown" %]
     "evaluation": "unknown",
     "title_element": {
-        "title": "[% lang('ecoscore_origins_of_ingredients_missing_information') %]",
-        "subtitle": "[% lang('malus') %][% sep %]: [% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
+        "title": "[% edq(lang('ecoscore_origins_of_ingredients_missing_information')) %]",
+        "subtitle": "[% edq(lang('malus')) %][% sep %]: [% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/public.svg",
         "icon_size": "small",
@@ -28,20 +28,20 @@
     [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 0 %]
     "evaluation": "bad",
     "title_element": {
-        "title": "[% lang('ecoscore_origins_of_ingredients_impact_high') %]",
+        "title": "[% edq(lang('ecoscore_origins_of_ingredients_impact_high')) %]",
     [% ELSIF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 15 %]
     "evaluation": "average",
     "title_element": {
-        "title": "[% lang('ecoscore_origins_of_ingredients_impact_medium') %]",    
+        "title": "[% edq(lang('ecoscore_origins_of_ingredients_impact_medium')) %]",    
     [% ELSE %]
     "evaluation": "good",
     "title_element": {
-        "title": "[% lang('ecoscore_origins_of_ingredients_impact_low') %]",
+        "title": "[% edq(lang('ecoscore_origins_of_ingredients_impact_low')) %]",
     [% END %]
         [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value > 0 %]
-            "subtitle": "[% lang('bonus') %][% sep %]: +[% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
+            "subtitle": "[% edq(lang('bonus')) %][% sep %]: +[% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
         [% ELSE %]
-            "subtitle": "[% lang('malus') %][% sep %]: [% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
+            "subtitle": "[% edq(lang('malus')) %][% sep %]: [% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
         [% END %]
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/public.svg",
@@ -62,18 +62,18 @@
             "element_type": "table",
             "table_element": {
                 "id": "ecoscore_origins_of_ingredients_table",
-                "title": "[% lang('ecoscore_origins_of_ingredients') %]",
+                "title": "[% edq(lang('ecoscore_origins_of_ingredients')) %]",
                 "columns": [
                     {
-                        "text": "[% lang('origin') %]",
+                        "text": "[% edq(lang('origin')) %]",
                         "type": "text",
                     },
                     {
-                        "text": "[% lang('percent_of_ingredients') %]",
+                        "text": "[% edq(lang('percent_of_ingredients')) %]",
                         "type": "percent",
                     },
                     {
-                        "text": "[% lang('ecoscore_impact') %]",
+                        "text": "[% edq(lang('ecoscore_impact')) %]",
                         "type": "text",
                     }
                 ],
@@ -100,13 +100,13 @@
                             },
                             {
                                 [% IF score >= 15 %]
-                                    "text": "[% lang('low') FILTER ucfirst %]",
+                                    "text": "[% edq(lang('low')) FILTER ucfirst %]",
                                     "evaluation": "good",
                                 [% ELSIF score <= 0 %]
-                                    "text": "[% lang('high') FILTER ucfirst %]",
+                                    "text": "[% edq(lang('high')) FILTER ucfirst %]",
                                     "evaluation": "bad",
                                 [% ELSE %]
-                                    "text": "[% lang('medium') FILTER ucfirst %]",
+                                    "text": "[% edq(lang('medium')) FILTER ucfirst %]",
                                     "evaluation": "neutral",
                                 [% END %]
                             }

--- a/templates/api/knowledge-panels/environment/ecoscore/packaging.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/packaging.tt.json
@@ -6,8 +6,8 @@
 [% IF not (product.ecoscore_data.adjustments.packaging.packagings && product.ecoscore_data.adjustments.packaging.packagings.size) %]
     "evaluation": "unknown",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_missing_information') %]",
-        "subtitle": "[% lang('malus') %][% sep %]: [% product.ecoscore_data.adjustments.packaging.value %]",
+        "title": "[% edq(lang('ecoscore_packaging_missing_information')) %]",
+        "subtitle": "[% edq(lang('malus')) %][% sep %]: [% product.ecoscore_data.adjustments.packaging.value %]",
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/packaging.svg",
         "icon_size": "small",
@@ -26,17 +26,17 @@
     [% IF product.ecoscore_data.adjustments.packaging.value <= -15 %]
     "evaluation": "bad",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_impact_high') %]",
+        "title": "[% edq(lang('ecoscore_packaging_impact_high')) %]",
     [% ELSIF product.ecoscore_data.adjustments.packaging.value <= -5 %]
     "evaluation": "average",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_impact_medium') %]",    
+        "title": "[% edq(lang('ecoscore_packaging_impact_medium')) %]",    
     [% ELSE %]
     "evaluation": "good",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_impact_low') %]",
+        "title": "[% edq(lang('ecoscore_packaging_impact_low')) %]",
     [% END %]
-        "subtitle": "[% lang('malus') %][% sep %]: [% product.ecoscore_data.adjustments.packaging.value %]",
+        "subtitle": "[% edq(lang('malus')) %][% sep %]: [% product.ecoscore_data.adjustments.packaging.value %]",
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/packaging.svg",
         "icon_size": "small",
@@ -46,22 +46,22 @@
             "element_type": "table",
             "table_element": {
                 "id": "ecoscore_packaging_components",
-                "title": "[% lang('packaging_parts') %]",
+                "title": "[% edq(lang('packaging_parts')) %]",
                 "columns": [
                     {
-                        "text": "[% lang('packaging_shape') %]",
+                        "text": "[% edq(lang('packaging_shape')) %]",
                         "type": "text",
                     },
                     { 
-                        "text": "[% lang('packaging_material') %]",
+                        "text": "[% edq(lang('packaging_material')) %]",
                         "type": "text",
                     },
                     { 
-                        "text": "[% lang('packaging_recycling') %]",
+                        "text": "[% edq(lang('packaging_recycling')) %]",
                         "type": "text",
                     },
                     { 
-                        "text": "[% lang('ecoscore_impact') %]",
+                        "text": "[% edq(lang('ecoscore_impact')) %]",
                         "type": "text",
                     }
                 ],
@@ -86,13 +86,13 @@
                             },
                             {
                             [% IF score >= 75 %]
-                                "text": "[% lang('low') FILTER ucfirst %]",
+                                "text": "[% edq(lang('low')) FILTER ucfirst %]",
                                 "evaluation": "good",
                             [% ELSIF score <= 25 %]
-                                "text": "[% lang('high') FILTER ucfirst %]",
+                                "text": "[% edq(lang('high')) FILTER ucfirst %]",
                                 "evaluation": "bad",
                             [% ELSE %]
-                                "text": "[% lang('medium') FILTER ucfirst %]",
+                                "text": "[% edq(lang('medium')) FILTER ucfirst %]",
                                 "evaluation": "neutral",
                             [% END %]
                             }

--- a/templates/api/knowledge-panels/environment/ecoscore/production_system.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/production_system.tt.json
@@ -6,7 +6,7 @@
     [% IF product.ecoscore_data.adjustments.production_system.value == 0 %]
     "evaluation": "neutral",
     "title_element": {
-        "title": "[% lang('ecoscore_production_system_no_labels_with_environmental_benefits') %]",
+        "title": "[% edq(lang('ecoscore_production_system_no_labels_with_environmental_benefits')) %]",
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/agriculture.svg",
         "icon_size": "small",
@@ -17,13 +17,13 @@
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/agriculture.svg",
         "icon_size": "small",
-        "subtitle": "[% lang('bonus') %][% sep %]: +[% product.ecoscore_data.adjustments.production_system.value %]",
+        "subtitle": "[% edq(lang('bonus')) %][% sep %]: +[% product.ecoscore_data.adjustments.production_system.value %]",
         [% IF product.ecoscore_data.adjustments.production_system.value >= 20 %]
-            "title": "[% lang('ecoscore_production_system_labels_with_environmental_benefits_very_high') %]",
+            "title": "[% edq(lang('ecoscore_production_system_labels_with_environmental_benefits_very_high')) %]",
         [% ELSIF product.ecoscore_data.adjustments.production_system.value >= 15 %]
-            "title": "[% lang('ecoscore_production_system_labels_with_environmental_benefits_high') %]",
+            "title": "[% edq(lang('ecoscore_production_system_labels_with_environmental_benefits_high')) %]",
         [% ELSE %]
-            "title": "[% lang('ecoscore_production_system_labels_with_environmental_benefits') %]",
+            "title": "[% edq(lang('ecoscore_production_system_labels_with_environmental_benefits')) %]",
         [% END %]
         },
         "elements": [

--- a/templates/api/knowledge-panels/environment/ecoscore/threatened_species.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/threatened_species.tt.json
@@ -6,7 +6,7 @@
     [% IF product.ecoscore_data.adjustments.threatened_species.warning.defined %]
         "evaluation": "neutral",
         "title_element": {
-            "title": "[% lang('missing_ingredients_list') %]",
+            "title": "[% edq(lang('missing_ingredients_list')) %]",
             "icon_color_from_evaluation": true,
             "icon_url": "[% static_subdomain %]/images/icons/dist/monkey_uncertain.svg",
             "icon_size": "small",
@@ -27,8 +27,8 @@
     [% ELSIF product.ecoscore_data.adjustments.threatened_species.value < 0 %]
         "evaluation": "bad",
         "title_element": {
-            "title": "[% lang('ecoscore_ingredients_whose_cultivation_threatens_species') %]",
-            "subtitle": "[% lang('malus') %][% sep %]: [% product.ecoscore_data.adjustments.threatened_species.value %]",
+            "title": "[% edq(lang('ecoscore_ingredients_whose_cultivation_threatens_species')) %]",
+            "subtitle": "[% edq(lang('malus')) %][% sep %]: [% product.ecoscore_data.adjustments.threatened_species.value %]",
             "icon_color_from_evaluation": true,
             "icon_url": "[% static_subdomain %]/images/icons/dist/monkey_unhappy.svg",
             "icon_size": "small",
@@ -48,7 +48,7 @@
     [% ELSE %]    
         "evaluation": "good",
         "title_element": {
-            "title": "[% lang('ecoscore_no_species_threatening_ingredients') %]",
+            "title": "[% edq(lang('ecoscore_no_species_threatening_ingredients')) %]",
             "icon_color_from_evaluation": true,
             "icon_url": "[% static_subdomain %]/images/icons/dist/monkey_happy.svg",
             "icon_size": "small",

--- a/templates/api/knowledge-panels/environment/ecoscore/total.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/total.tt.json
@@ -5,8 +5,8 @@
         "environment"
     ],
     "title_element": {
-        "title":  "[% lang('impact_for_this_product') %]: [% panel.grade FILTER upper %] (Score: [% panel.score %]/100)",
-        "subtitle": "[% lang("front_alt") %][% sep %]: [% product_name_brand_quantity(product) %]",
+        "title":  "[% edq(lang('impact_for_this_product')) %]: [% panel.grade FILTER upper %] (Score: [% panel.score %]/100)",
+        "subtitle": "[% edq(lang('front_alt')) %][% sep %]: [% product_name_brand_quantity(product) %]",
         "type": "grade",
         "grade": "[% panel.grade %]",
         "icon_url": "[% static_subdomain %]/images/attributes/dist/ecoscore-[% panel.grade %].svg",

--- a/templates/api/knowledge-panels/environment/environment_card.tt.json
+++ b/templates/api/knowledge-panels/environment/environment_card.tt.json
@@ -5,7 +5,7 @@
         "environment"
     ],
     "title_element": {
-        "title": "[% lang('environment_card_title') %]",
+        "title": "[% edq(lang('environment_card_title')) %]",
     },    
     "elements": [
         {
@@ -26,7 +26,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('carbon_footprint') %]",
+                "title": "[% edq(lang('carbon_footprint')) %]",
                 "panel_ids": ["carbon_footprint"],
             },
         },
@@ -35,7 +35,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('ecoscore_packaging') %]",
+                "title": "[% edq(lang('ecoscore_packaging')) %]",
                 "panel_group_id": "packaging_recycling",
                 "panel_ids": [
                     "packaging_recycling",
@@ -49,7 +49,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('ecoscore_transportation') %]",
+                "title": "[% edq(lang('ecoscore_transportation')) %]",
                 "panel_ids": [
                     [% IF panels.manufacturing_place.defined %]"manufacturing_place",[% END %]
                     "origins_of_ingredients",
@@ -60,7 +60,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('ecoscore_threatened_species') %]",
+                "title": "[% edq(lang('ecoscore_threatened_species')) %]",
                 "panel_ids": [
                     "palm_oil"
                 ],
@@ -71,7 +71,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('labels_p') FILTER ucfirst %]",
+                "title": "[% edq(lang('labels_p')) FILTER ucfirst %]",
                 "panel_ids": [
                     [% FOREACH label IN product.ecoscore_data.adjustments.production_system.labels %]
                         "environment_label_[% label %]",

--- a/templates/api/knowledge-panels/environment/manufacturing_place.tt.json
+++ b/templates/api/knowledge-panels/environment/manufacturing_place.tt.json
@@ -6,7 +6,7 @@
     "evaluation": "neutral",
     "expanded": true,
     "title_element": {
-        "title": "[% lang('manufacturing_places_s') FILTER ucfirst %]",
+        "title": "[% edq(lang('manufacturing_places_s')) FILTER ucfirst %]",
         [% IF panel.packager_code_data.cc == 'fr' %]
             "subtitle": "[% panel.packager_code_data.commune %] - [% display_taxonomy_tag_name('countries', 'en:france') %]",        
         [% ELSIF panel.packager_code_data.cc == 'ch' %]

--- a/templates/api/knowledge-panels/environment/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/environment/origins_of_ingredients.tt.json
@@ -7,8 +7,8 @@
 [% IF product.ecoscore_data.adjustments.origins_of_ingredients.warning == "origins_are_100_percent_unknown" %]
     "evaluation": "unknown",
     "title_element": {
-        "title": "[% lang('ecoscore_origins_of_ingredients') %]",
-        "subtitle": "[% lang('ecoscore_origins_of_ingredients_missing_information') %]",
+        "title": "[% edq(lang('ecoscore_origins_of_ingredients')) %]",
+        "subtitle": "[% edq(lang('ecoscore_origins_of_ingredients_missing_information')) %]",
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/public.svg",
     },
@@ -38,17 +38,17 @@
     [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 0 %]
     "evaluation": "bad",
     "title_element": {
-        "subtitle": "[% lang('ecoscore_origins_of_ingredients_impact_high') %]",
+        "subtitle": "[% edq(lang('ecoscore_origins_of_ingredients_impact_high')) %]",
     [% ELSIF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 15 %]
     "evaluation": "average",
     "title_element": {
-        "subtitle": "[% lang('ecoscore_origins_of_ingredients_impact_medium') %]",    
+        "subtitle": "[% edq(lang('ecoscore_origins_of_ingredients_impact_medium')) %]",    
     [% ELSE %]
     "evaluation": "good",
     "title_element": {
-        "subtitle": "[% lang('ecoscore_origins_of_ingredients_impact_low') %]",
+        "subtitle": "[% edq(lang('ecoscore_origins_of_ingredients_impact_low')) %]",
     [% END %]
-        "title": "[% lang('ecoscore_origins_of_ingredients') %]",
+        "title": "[% edq(lang('ecoscore_origins_of_ingredients')) %]",
         "icon_color_from_evaluation": true,
         "icon_url": "[% static_subdomain %]/images/icons/dist/public.svg",
     },
@@ -58,18 +58,18 @@
             "table_element": {
                 "id": "ecoscore_origins_of_ingredients_table",
                 "table_type": "percents",
-                "title": "[% lang('ecoscore_origins_of_ingredients') %]",
+                "title": "[% edq(lang('ecoscore_origins_of_ingredients')) %]",
                 "columns": [
                     {
-                        "text": "[% lang('origin') %]",
+                        "text": "[% edq(lang('origin')) %]",
                         "type": "text",
                     },
                     {
-                        "text": "[% lang('percent_of_ingredients') %]",
+                        "text": "[% edq(lang('percent_of_ingredients')) %]",
                         "type": "percent",
                     },
                     {
-                        "text": "[% lang('ecoscore_impact') %]",
+                        "text": "[% edq(lang('ecoscore_impact')) %]",
                         "type": "text",
                     }
                 ],
@@ -96,13 +96,13 @@
                             },
                             {
                                 [% IF score >= 15 %]
-                                    "text": "[% lang('low') FILTER ucfirst %]",
+                                    "text": "[% edq(lang('low')) FILTER ucfirst %]",
                                     "evaluation": "good",
                                 [% ELSIF score <= 0 %]
-                                    "text": "[% lang('high') FILTER ucfirst %]",
+                                    "text": "[% edq(lang('high')) FILTER ucfirst %]",
                                     "evaluation": "bad",
                                 [% ELSE %]
-                                    "text": "[% lang('medium') FILTER ucfirst %]",
+                                    "text": "[% edq(lang('medium')) FILTER ucfirst %]",
                                     "evaluation": "neutral",
                                 [% END %]
                             }

--- a/templates/api/knowledge-panels/environment/packaging_components.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_components.tt.json
@@ -18,7 +18,7 @@
         "environment"
     ],
     "title_element": {
-        "title": "[% lang('packaging_parts') %]",           
+        "title": "[% edq(lang('packaging_parts')) %]",           
     },    
     "expanded": true,
     "elements": [
@@ -40,7 +40,7 @@
                     [% ELSE %]
                     "evaluation": "neutral",
                     "icon_url": "[% static_subdomain %]/images/icons/dist/help.svg",
-                    "icon_alt": "[% lang('unknown') %]",
+                    "icon_alt": "[% edq(lang('unknown')) %]",
                     [% END %]                
                     "html": `
                         [% FOREACH packaging IN product.packagings %]

--- a/templates/api/knowledge-panels/environment/packaging_materials.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_materials.tt.json
@@ -4,7 +4,7 @@
         "environment"
     ],
     "title_element": {
-        "title": "[% lang('packaging_materials') %]",           
+        "title": "[% edq(lang('packaging_materials')) %]",           
     },    
     "expanded": true,
     "elements": [
@@ -12,10 +12,10 @@
             "element_type": "table",
             "table_element": {
                 "id": "packaging_materials",
-                "title": "[% lang('packaging_materials') %]",
+                "title": "[% edq(lang('packaging_materials')) %]",
                 "columns": [                
                     { 
-                        "text": "[% lang('packaging_material') %]",
+                        "text": "[% edq(lang('packaging_material')) %]",
                         "type": "text",
                     },
                     { 
@@ -23,13 +23,13 @@
                         "type": "text",
                     },                        
                     { 
-                        "text": "[% lang('packaging_weight_total') %]",
+                        "text": "[% edq(lang('packaging_weight_total')) %]",
                         "type": "text",
                     },
                     // packaging weight per 100g of product is computed only if we have a quantity
                     [% IF product.product_quantity %]
                     { 
-                        "text": "[% lang('packaging_weight_100g') %]",
+                        "text": "[% edq(lang('packaging_weight_100g')) %]",
                         "type": "text",
                     },
                     [% END %]
@@ -49,7 +49,7 @@
                                     "values": [
                                         {
                                             [% IF parent_material == 'all' %]
-                                            "text": "[% lang('total') %]",
+                                            "text": "[% edq(lang('total')) %]",
                                             [% ELSE %]
                                             "text": "[% display_taxonomy_tag_name('packaging_materials',parent_material) %]"
                                             [% END %]

--- a/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
+++ b/templates/api/knowledge-panels/environment/packaging_recycling.tt.json
@@ -6,7 +6,7 @@
 [% IF NOT (product.ecoscore_data.adjustments.packaging.packagings AND product.ecoscore_data.adjustments.packaging.packagings.size) %]
     "evaluation": "unknown",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_missing_information') %]",
+        "title": "[% edq(lang('ecoscore_packaging_missing_information')) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/packaging.svg",
         "icon_color_from_evaluation": true,
         "evaluation": "neutral",                
@@ -35,15 +35,15 @@
     [% IF product.ecoscore_data.adjustments.packaging.value <= -15 %]
     "evaluation": "bad",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_impact_high') %]",
+        "title": "[% edq(lang('ecoscore_packaging_impact_high')) %]",
     [% ELSIF product.ecoscore_data.adjustments.packaging.value <= -5 %]
     "evaluation": "average",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_impact_medium') %]",    
+        "title": "[% edq(lang('ecoscore_packaging_impact_medium')) %]",    
     [% ELSE %]
     "evaluation": "good",
     "title_element": {
-        "title": "[% lang('ecoscore_packaging_impact_low') %]",
+        "title": "[% edq(lang('ecoscore_packaging_impact_low')) %]",
     [% END %]
         "icon_url": "[% static_subdomain %]/images/icons/dist/packaging.svg",
         "icon_color_from_evaluation": true,

--- a/templates/api/knowledge-panels/environment/palm_oil.tt.json
+++ b/templates/api/knowledge-panels/environment/palm_oil.tt.json
@@ -5,8 +5,8 @@
     ],
     "evaluation": "bad",
     "title_element": {
-        "title": "[% lang('contains_palm_oil') %]",
-        "subtitle": "[% lang('contains_palm_oil_subtitle') %]",
+        "title": "[% edq(lang('contains_palm_oil')) %]",
+        "subtitle": "[% edq(lang('contains_palm_oil_subtitle')) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/palm-oil.svg",
         "icon_color_from_evaluation": true,
     },

--- a/templates/api/knowledge-panels/health/health_card.tt.json
+++ b/templates/api/knowledge-panels/health/health_card.tt.json
@@ -5,7 +5,7 @@
         "health"
     ],
     "title_element": {
-        "title": "[% lang('health') %]",
+        "title": "[% edq(lang('health')) %]",
     },    
     "elements": [
         [% IF panels.recommendation_health.defined %]

--- a/templates/api/knowledge-panels/health/ingredients/ingredients_analysis_details.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/ingredients_analysis_details.tt.json
@@ -12,12 +12,12 @@
     "evaluation": "unknown",
     [% END %]
     "title_element": {
-        "title":"[% lang("ingredients_analysis_details") %]",
+        "title":"[% edq(lang('ingredients_analysis_details')) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/off-magnifying-glass.svg",
         "icon_size": "small",
         "icon_color_from_evaluation": true,        
         [% IF panel.unknown_ingredients %]
-        "subtitle": "[% lang("we_need_your_help") %]",
+        "subtitle": "[% edq(lang('we_need_your_help')) %]",
         [% END %]
     },    
     "elements": [

--- a/templates/api/knowledge-panels/health/ingredients/nova.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients/nova.tt.json
@@ -7,10 +7,10 @@
         [% IF product.nova_group.defined && product.nova_group > 0 %]
             [% SET nova_group = product.nova_group %]
             "icon_url": "[% static_subdomain %]/images/attributes/dist/nova-group-[% product.nova_group %].svg",
-            "title": "[% lang('attribute_nova_' _ nova_group _ '_description_short') %]",
+            "title": "[% edq(lang('attribute_nova_' _ nova_group _ '_description_short')) %]",
         [% ELSE %]
             "icon_url": "[% static_subdomain %]/images/attributes/dist/nova-group-unknown.svg",
-            "title": "[% lang('attribute_nova_unknown_description_short') %]",       
+            "title": "[% edq(lang('attribute_nova_unknown_description_short')) %]",       [%# why are there parenthesis around the name ? %]
         [% END %]
     },
     "elements": [

--- a/templates/api/knowledge-panels/health/ingredients_panels.tt.json
+++ b/templates/api/knowledge-panels/health/ingredients_panels.tt.json
@@ -2,7 +2,7 @@
 {
     "element_type": "panel_group",
     "panel_group_element": {
-        "title": "[% lang('ingredients') %]",
+        "title": "[% edq(lang('ingredients')) %]",
         "type": "subcard",
         "panel_group_id": "ingredients",
         "panel_ids": ["ingredients"],
@@ -16,7 +16,7 @@
 {
     "element_type": "panel_group",
     "panel_group_element": {
-        "title": "[% lang('attribute_group_processing_name').ucfirst %]",
+        "title": "[% edq(lang('attribute_group_processing_name')).ucfirst %]",
         "panel_ids": ["nova"],
     },
 }, 
@@ -25,7 +25,7 @@
 {
     "element_type": "panel_group",
     "panel_group_element": {
-        "title": "[% lang('additives_p').ucfirst %]",
+        "title": "[% edq(lang('additives_p')).ucfirst %]",
         "panel_ids": ["additives"],
     },
 }, 
@@ -34,7 +34,7 @@
 {
     "element_type": "panel_group",
     "panel_group_element": {
-        "title": "[% lang("ingredients_analysis") %]",
+        "title":  "[% edq(lang('ingredients_analysis')) %]",
         "panel_ids": [
             "ingredients_analysis",
             [% IF panels.ingredients_analysis_details.defined %]

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore_2023.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore_2023.tt.json
@@ -44,7 +44,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('nutriscore_negative_points') %][% sep %]: [% product.nutriscore.2023.data.negative_points %]/[% product.nutriscore.2023.data.negative_points_max %]",
+                "title": "[% edq(lang('nutriscore_negative_points')) %][% sep %]: [% product.nutriscore.2023.data.negative_points %]/[% product.nutriscore.2023.data.negative_points_max %]",
                 "evaluation": "bad",
                 "icon_url": "[% static_subdomain %]/images/icons/dist/circle-minus.svg",
                 "icon_size": "small",
@@ -62,7 +62,7 @@
         {
             "element_type": "panel_group",
             "panel_group_element": {
-                "title": "[% lang('nutriscore_positive_points') %][% sep %]: [% product.nutriscore.2023.data.positive_points %]/[% product.nutriscore.2023.data.positive_points_max %]",
+                "title": "[% edq(lang('nutriscore_positive_points')) %][% sep %]: [% product.nutriscore.2023.data.positive_points %]/[% product.nutriscore.2023.data.positive_points_max %]",
                 "evaluation": "good",
                 "icon_url": "[% static_subdomain %]/images/icons/dist/circle-plus.svg",
                 "icon_size": "small",

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore_component.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore_component.tt.json
@@ -6,7 +6,7 @@
     "size": "small",
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/attributes/dist/points-[% panel.type %]-[% panel.points %]-[% panel.points_max %].svg",
-        "title": "[% lang("nutriscore_component_" _ panel.id) %]",
+        "title": "[% edq(lang('nutriscore_component_' _ panel.id)) %]",
         "subtitle": "[% panel.points %]/[% panel.points_max %] points ([% panel.value %][% panel.space_before_unit %][% panel.unit %])",
     },
     "elements": [

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore_description.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore_description.tt.json
@@ -6,7 +6,7 @@
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/icons/dist/info.svg",
         "icon_size": "small",
-        "title": "[% lang("nutriscore_explanation_title") %]",
+        "title":  "[% edq(lang('nutriscore_explanation_title')) %]",
         "type": "info",
     },
     "elements": [

--- a/templates/api/knowledge-panels/health/nutriscore/nutriscore_details.tt.json
+++ b/templates/api/knowledge-panels/health/nutriscore/nutriscore_details.tt.json
@@ -6,8 +6,8 @@
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/icons/dist/info.svg",
         "icon_size": "small",
-        "title": "[% lang("nutriscore_calculation_details") %]",
-        "type": "info",
+        "title":  "[% edq(lang('nutriscore_calculation_details')) %]",
+        "type": "info"
     },
     "elements": [
         // Display warnings

--- a/templates/api/knowledge-panels/health/nutrition/nutrient_levels.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/nutrient_levels.tt.json
@@ -8,7 +8,7 @@
     "evaluation": "unknown",
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/icons/dist/nutrition.svg",
-        "title": "[% lang('nutrient_levels_p') FILTER ucfirst %]",
+        "title": "[% edq(lang('nutrient_levels_p')) FILTER ucfirst %]",
         "icon_color_from_evaluation": true,        
     },    
     "elements": [

--- a/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/nutrition_facts_table.tt.json
@@ -7,7 +7,7 @@
     "expand_for": "large",
     "evaluation": "unknown",
     "title_element": {
-        "title": "[% lang('nutrition_data_table') %]",
+        "title": "[% edq(lang('nutrition_data_table')) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/scale-balance.svg",
         "icon_color_from_evaluation": true,
     },
@@ -16,7 +16,7 @@
             "element_type": "table",
             "table_element": {
                 "id": "nutrition_facts_table",
-                "title": "[% lang('nutrition_data_table') %]",
+                "title": "[% edq(lang('nutrition_data_table')) %]",
                 // Create a structure to check if we already have seen a column for a given scope
                 // so that we can mark the first one as the default column for the group
                 [% SET scopes = {} %]              

--- a/templates/api/knowledge-panels/health/nutrition/physical_activities.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition/physical_activities.tt.json
@@ -6,8 +6,8 @@
     "expanded": false,
     "evaluation": "[% panel.evaluation %]",
     "title_element": {
-        "title": "[% f_lang('f_energy_per_100g', { 'kj' => panel.energy }) %]",
-        "subtitle": "[% f_lang('f_equal_to_walking_minutes_or_steps',  { 'minutes' => round(panel.walking_minutes), 'steps' => round(panel.walking_steps) } ) %]",
+        "title": "[% edq(f_lang('f_energy_per_100g', { 'kj' => panel.energy })) %]",
+        "subtitle": "[% edq(f_lang('f_equal_to_walking_minutes_or_steps',  { 'minutes' => round(panel.walking_minutes), 'steps' => round(panel.walking_steps) } )) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/activity-walking.svg",
         "icon_color_from_evaluation": true,
     },    

--- a/templates/api/knowledge-panels/health/nutrition_panels.tt.json
+++ b/templates/api/knowledge-panels/health/nutrition_panels.tt.json
@@ -1,7 +1,7 @@
 {
     "element_type": "panel_group",
     "panel_group_element": {
-        "title": "[% lang('nutrition') %]",
+        "title": "[% edq(lang('nutrition')) %]",
         "type": "subcard",
         "panel_group_id": "nutrition",
         [% IF panel.nutrition_image.defined %]

--- a/templates/api/knowledge-panels/recommendations/health/world/who_alcohol.tt.json
+++ b/templates/api/knowledge-panels/recommendations/health/world/who_alcohol.tt.json
@@ -5,8 +5,8 @@
     ],
     "evaluation": "bad",
     "title_element": {
-        "title": "[% lang('recommendation_who_reduce_or_stop_drinking_alcohol_title') %]",
-        "subtitle": "[% lang('recommendation_who_reduce_or_stop_drinking_alcohol_subtitle') %]",
+        "title": "[% edq(lang('recommendation_who_reduce_or_stop_drinking_alcohol_title')) %]",
+        "subtitle": "[% edq(lang('recommendation_who_reduce_or_stop_drinking_alcohol_subtitle')) %]",
         "icon_url": "[% static_subdomain %]/images/icons/dist/arrow-bottom-right-thick.svg",
         "icon_color_from_evaluation": true,
         "evaluation": "bad",                

--- a/templates/api/knowledge-panels/tags/categories/packagings_materials.tt.json
+++ b/templates/api/knowledge-panels/tags/categories/packagings_materials.tt.json
@@ -4,7 +4,7 @@
         "environment"
     ],
     "title_element": {
-        "title": "[% lang('packaging_materials') %]",           
+        "title": "[% edq(lang('packaging_materials')) %]",           
     },    
     "expanded": true,
     "elements": [
@@ -12,30 +12,30 @@
             "element_type": "table",
             "table_element": {
                 "id": "packaging_materials",
-                "title": "[% lang('packaging_materials') %]",
+                "title": "[% edq(lang('packaging_materials')) %]",
                 "columns": [                
                     { 
-                        "text": "[% lang('packaging_material') %]",
+                        "text": "[% edq(lang('packaging_material')) %]",
                         "type": "text",
                     },
                     { 
-                        "text": "[% lang('packaging_material_products_percent_main') %]",
+                        "text": "[% edq(lang('packaging_material_products_percent_main')) %]",
                         "type": "text",
                     },   
                     { 
-                        "text": "[% lang('packaging_weight_100g_mean') %] ([% lang('relative_to_products_containing_mostly_the_material') %])",
+                        "text": "[% edq(lang('packaging_weight_100g_mean')) %] ([% edq(lang('relative_to_products_containing_mostly_the_material')) %])",
                         "type": "text",
                     },                    
                     { 
-                        "text": "[% lang('packaging_material_products_percent') %]",
+                        "text": "[% edq(lang('packaging_material_products_percent')) %]",
                         "type": "text",
                     },                                        
                     { 
-                        "text": "[% lang('packaging_weight_100g_mean') %] ([% lang('relative_to_products_containing_the_material') %])",
+                        "text": "[% edq(lang('packaging_weight_100g_mean')) %] ([% edq(lang('relative_to_products_containing_the_material')) %])",
                         "type": "text",
                     },
                     { 
-                        "text": "[% lang('packaging_weight_100g_mean') %] ([% lang('relative_to_all_products') %])",
+                        "text": "[% edq(lang('packaging_weight_100g_mean')) %] ([% edq(lang('relative_to_all_products')) %])",
                         "type": "text",
                     },
                 ],
@@ -51,7 +51,7 @@
                                 "values": [
                                     [% IF material == 'all' %]
                                     {
-                                        "text": "[% lang('total') %]",
+                                        "text": "[% edq(lang('total')) %]",
                                     },
                                     {
                                         "text": "-"

--- a/templates/web/common/includes/display_product_search_or_add.tt.html
+++ b/templates/web/common/includes/display_product_search_or_add.tt.html
@@ -8,14 +8,14 @@
 
     <div class="row">
         <div class="small-9 columns">
-          <input type="text" name="code" placeholder="[% lang('or').remove('|\W?:') %] [% lang('barcode') %]">
+          <input type="text" name="code" placeholder="[% edq(lang('or')).remove('|\W?:') %] [% edq(lang('barcode')) %]">
         </div>
         <div class="small-3 columns">
-           <input type="submit" value="[% lang('add') %]" class="button postfix">
+           <input type="submit" value="[% edq(lang('add')) %]" class="button postfix">
         </div>
     </div>
 
-	<input type="submit" value="[% lang('no_barcode') %]" class="button tiny">
+	<input type="submit" value="[% edq(lang('no_barcode')) %]" class="button tiny">
   <input type="hidden" name="action" value="process">
   <input type="hidden" name="type" value="search_or_add">
 

--- a/templates/web/common/includes/list_of_products.tt.html
+++ b/templates/web/common/includes/list_of_products.tt.html
@@ -8,16 +8,16 @@
     [% IF (current_link.defined) && !(jqm.defined) %]
       [% IF !(server_options_producers_platform) %]
       [% IF country != 'en:world' %]
-        <p>&rarr; <a href= "[% world_subdomain %][% current_link %]"> [% lang('view_results_from_the_entire_world') %]</a></p>
+        <p>&rarr; <a href= "[% world_subdomain %][% current_link %]"> [% edq(lang('view_results_from_the_entire_world')) %]</a></p>
       [% END %]
       [% END %]
       <!-- display a permalink if the url is for a script that may have POST parameters -->
       [% IF current_link.match('/(search|search.pl)') %]
-        <p>&rarr; <a href="[% current_link %]">[% lang('search_link') %]</a></p>
+        <p>&rarr; <a href="[% current_link %]">[% edq(lang('search_link')) %]</a></p>
       [% END %]
     [% END %]
     [% IF (current_link_query_edit.defined) && !(jqm.defined) %]
-      <p>&rarr; <a href="[% current_link_query_edit %]">[% lang('search_edit') %]</a></p>
+      <p>&rarr; <a href="[% current_link_query_edit %]">[% edq(lang('search_edit')) %]</a></p>
     [% END %]
   </div>
 </div>
@@ -29,11 +29,11 @@
       [% IF count <= export_limit %]
       <ul>
         <li>
-          <a href="[% current_link_query_download %]&format=xlsx">[% lang('search_download_xlsx') %]</a>
+          <a href="[% current_link_query_download %]&format=xlsx">[% edq(lang('search_download_xlsx')) %]</a>
           ([% lang('search_download_xlsx_description') %])
         </li>
         <li>
-          <a href="[% current_link_query_download %]&format=csv">[% lang('search_download_csv') %]</a>
+          <a href="[% current_link_query_download %]&format=csv">[% edq(lang('search_download_csv')) %]</a>
           ([% lang('search_download_csv_description') %])
         </li>
       </ul>

--- a/templates/web/common/includes/producers_platform_top_panel.tt.html
+++ b/templates/web/common/includes/producers_platform_top_panel.tt.html
@@ -20,8 +20,8 @@
                     <input type="hidden" name="type" value="edit_owner">
                     <input type="hidden" name="action" value="process">
                     <input type="hidden" name="userid" value="[% user_id %]">
-                    <input type="text" name="pro_moderator_owner" value="" placeholder="[% lang('pro_moderator_edit_owner_placeholder') %]">
-                    <input type="submit" name=".submit" value="[% lang('pro_moderator_edit_owner') %]" class="button small">
+                    <input type="text" name="pro_moderator_owner" value="" placeholder="[% edq(lang('pro_moderator_edit_owner_placeholder')) %]">
+                    <input type="submit" name=".submit" value="[% edq(lang('pro_moderator_edit_owner')) %]" class="button small">
                 </form>
             </div>
         </div>

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -1,7 +1,7 @@
 <!-- start templates/[% template.name %] -->
 
 <!doctype html>
-<html class="no-js" lang="[% language %]" data-serverdomain="[% server_domain %]" dir="[% lang('text_direction') %]">
+<html class="no-js" lang="[% language %]" data-serverdomain="[% server_domain %]" dir="[% edq(lang('text_direction')) %]">
 <head>
     <meta charset="utf-8">
     <title>[% title %]</title>
@@ -16,10 +16,10 @@
     <meta property="og:description" content="[% canon_description %]">
     [% options_favicons %]
     <link rel="canonical" href="[% canon_url %]">
-    <link rel="stylesheet" href="[% static_subdomain %]/css/dist/app-[% lang('text_direction') %].css?v=[% css_timestamp %]" data-base-layout="true">
+    <link rel="stylesheet" href="[% static_subdomain %]/css/dist/app-[% edq(lang('text_direction')) %].css?v=[% css_timestamp %]" data-base-layout="true">
     <link rel="stylesheet" href="[% static_subdomain %]/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
     <link rel="stylesheet" href="[% static_subdomain %]/css/dist/select2.min.css">
-    <link rel="search" href="[% formatted_subdomain %]/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="[% lang('site_name') %]">
+    <link rel="search" href="[% formatted_subdomain %]/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="[% edq(lang('site_name')) %]">
 	[% header %]
     <style media="all">
         [% lang("css") %]
@@ -46,11 +46,11 @@
 							</a>
 							<ul class="dropdown">				
 								[% IF !(server_options_producers_platform) %]
-									<li><a href="[% lang('menu_discover_link') %]">[% lang('menu_discover') %]</a></li>
-									<li><a href="[% lang('menu_contribute_link') %]">[% lang('menu_contribute') %]</a></li>
+									<li><a href="[% edq(lang('menu_discover_link')) %]">[% lang('menu_discover') %]</a></li>
+									<li><a href="[% edq(lang('menu_contribute_link')) %]">[% lang('menu_contribute') %]</a></li>
 									<li class="divider"></li>
 									<li><label>[% lang("add_products") %]</label></li>
-									<li><a href="[% lang('get_the_app_link') %]">[% lang('install_the_app_to_add_products') %]</a></li>
+									<li><a href="[% edq(lang('get_the_app_link')) %]">[% lang('install_the_app_to_add_products') %]</a></li>
 									<li><a href="/cgi/product.pl?type=search_or_add&action=display">[% lang('add_product') %]</a></li>
 								[% ELSE %]
 									<li><label>[% lang("import_and_export_products") %]</label></li>
@@ -81,7 +81,7 @@
 						<li>
 							<ul class="country_language_selection">
 								<li class="has-form has-dropdown" id="select_country_li">
-									<select id="select_country" style="width:100%" data-placeholder="[% lang('select_country') %]">
+									<select id="select_country" style="width:100%" data-placeholder="[% edq(lang('select_country')) %]">
 										<option></option>
 									</select>
 								</li>
@@ -139,7 +139,7 @@
 									<li class="has-form">
 										<form method="post" action="/cgi/session.pl">
 											<input type="hidden" name="length" value="logout">
-											<input type="submit" name=".submit" value="[% lang('sign_out') %]" class="button small">
+											<input type="submit" name=".submit" value="[% edq(lang('sign_out')) %]" class="button small">
 										</form>
 									</li>
 								</ul>
@@ -160,7 +160,7 @@
 						<li class="name">
 							<div style="position:relative;max-width:292px;">
 								<a href="/">
-								<img id="logo" src="[% static_subdomain %]/images/logos/off-logo-horizontal-light.svg" alt="[% lang('logo_site_name') %]" style="margin:8px;height:48px;width:auto;">
+								<img id="logo" src="[% static_subdomain %]/images/logos/off-logo-horizontal-light.svg" alt="[% edq(lang('logo_site_name')) %]" style="margin:8px;height:48px;width:auto;">
 								[% IF server_options_producers_platform %]
 								<span id="professionals" style="position:absolute;bottom:2px;right:8px;line-height:1rem;font-size:1.2rem;">professionals</span>
 								[% END %]
@@ -180,12 +180,12 @@
 								<div class="row"><div class="small-12">
 								<div class="row collapse postfix-round">
 									<div class="columns">
-									<input type="text" placeholder="[% lang('search_a_product_placeholder') %]" name="search_terms" value="[% search_terms %]" style="background-color:white">
+									<input type="text" placeholder="[% edq(lang('search_a_product_placeholder')) %]" name="search_terms" value="[% search_terms %]" style="background-color:white">
 									<input name="search_simple" value="1" type="hidden">
 									<input name="action" value="process" type="hidden">
 									</div>
 									<div class="columns">
-									<button type="submit" title="[% lang('search') %]" class="button postfix" style="line-height:normal">[% display_icon('search') %]</button>
+									<button type="submit" title="[% edq(lang('search')) %]" class="button postfix" style="line-height:normal">[% display_icon('search') %]</button>
 									</div>
 								</div>
 								</div></div>
@@ -193,10 +193,10 @@
 							</li>
 						</ul>
 					<ul class="search_and_links">
-						<li><a href="[% lang('menu_discover_link') %]" class="top-bar-links">[% lang('menu_discover') %]</a></li>
-						<li><a href="[% lang('menu_contribute_link') %]" class="top-bar-links">[% lang('menu_contribute') %]</a></li>
-						<li class="show-for-xlarge-up"><a href="[% lang('footer_producers_link') %]" class="top-bar-links">[% lang('footer_producers') %]</a></li>
-						<li class="flex-grid getapp"><a href="[% lang('get_the_app_link') %]" class="buttonbar button" style="top:0;">[% display_icon('phone_android') %] <span class="bt-text">[% lang('get_the_app') %]</span></a></li>
+						<li><a href="[% edq(lang('menu_discover_link')) %]" class="top-bar-links">[% lang('menu_discover') %]</a></li>
+						<li><a href="[% edq(lang('menu_contribute_link')) %]" class="top-bar-links">[% lang('menu_contribute') %]</a></li>
+						<li class="show-for-xlarge-up"><a href="[% edq(lang('footer_producers_link')) %]" class="top-bar-links">[% lang('footer_producers') %]</a></li>
+						<li class="flex-grid getapp"><a href="[% edq(lang('get_the_app_link')) %]" class="buttonbar button" style="top:0;">[% display_icon('phone_android') %] <span class="bt-text">[% lang('get_the_app') %]</span></a></li>
 					</ul>
 					</section>
 					[% END %]
@@ -218,7 +218,7 @@
 				<form action="/cgi/search.pl">
 					<div class="row collapse">
 						<div class="small-8 columns">
-							<input type="text" placeholder="[% lang('search_a_product_placeholder') %]" name="search_terms">
+							<input type="text" placeholder="[% edq(lang('search_a_product_placeholder')) %]" name="search_terms">
 							<input name="search_simple" value="1" type="hidden">
 							<input name="action" value="process" type="hidden">
 						</div>
@@ -226,7 +226,7 @@
 							<button type="submit" class="button postfix">[% display_icon('search') %]</button>
 						</div>
 						<div class="small-2 columns">
-							<a href="/cgi/search.pl" title="[% lang('advanced_search') %]">[% display_icon('search') %] [% display_icon('add') %]</a>
+							<a href="/cgi/search.pl" title="[% edq(lang('advanced_search')) %]">[% display_icon('search') %] [% display_icon('add') %]</a>
 						</div>
 					</div>
 				</form>
@@ -248,11 +248,11 @@
 						</div>
 						<div class="small-6 columns">
 							[% IF mobile.system == "ios" %]
-									<img src="[% lang('ios_app_icon_url') %]" alt="[% lang('ios_app_icon_alt_text') %]">
+									<img src="[% edq(lang('ios_app_icon_url')) %]" alt="[% edq(lang('ios_app_icon_alt_text')) %]">
 							[% ELSIF mobile.system == "android" %]
-									<img src="[% lang('android_app_icon_url') %]" alt="[% lang('android_app_icon_alt_text') %]">
+									<img src="[% edq(lang('android_app_icon_url')) %]" alt="[% edq(lang('android_app_icon_alt_text')) %]">
 							[% ELSIF mobile.system == "windows" %]
-									<img src="[% lang('windows_phone_app_icon_url') %]" alt="[% lang('windows_phone_app_icon_alt_text') %]">
+									<img src="[% edq(lang('windows_phone_app_icon_url')) %]" alt="[% edq(lang('windows_phone_app_icon_alt_text')) %]">
 							[% END %]
 						
 						</div>
@@ -325,10 +325,10 @@
 							</div>
 						</div>
 						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
-							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% lang('ios_app_link') %]"><img src="[% lang('ios_app_icon_url') %]" alt="[% lang('ios_app_icon_alt_text') %]"  loading="lazy" class="full-width"></a>
-							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% lang('android_app_link') %]"><img src="https://static.openfoodfacts.org[% lang('android_app_icon_url') %]" alt="[% lang('android_app_icon_alt_text') %]" loading="lazy" class="full-width"></a>
-							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% lang('windows_phone_app_link') %]"><img src="[% lang('windows_phone_app_icon_url') %]" alt="[% lang('windows_phone_app_icon_alt_text') %]"  loading="lazy" class="full-width"></a>
-							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% lang('android_apk_app_link') %]"><img src="https://static.openfoodfacts.org[% lang('android_apk_app_icon_url') %]" alt="[% lang('android_apk_app_icon_alt_text') %]" loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% edq(lang('ios_app_link')) %]"><img src="[% edq(lang('ios_app_icon_url')) %]" alt="[% edq(lang('ios_app_icon_alt_text')) %]"  loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% edq(lang('android_app_link')) %]"><img src="https://static.openfoodfacts.org[% edq(lang('android_app_icon_url')) %]" alt="[% edq(lang('android_app_icon_alt_text')) %]" loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% edq(lang('windows_phone_app_link')) %]"><img src="[% edq(lang('windows_phone_app_icon_url')) %]" alt="[% edq(lang('windows_phone_app_icon_alt_text')) %]"  loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="[% edq(lang('android_apk_app_link')) %]"><img src="https://static.openfoodfacts.org[% edq(lang('android_apk_app_icon_url')) %]" alt="[% edq(lang('android_apk_app_icon_alt_text')) %]" loading="lazy" class="full-width"></a>
 						</div>
 					</div>
 				</div>
@@ -358,16 +358,16 @@
 					<div class="small-12 large-6 columns project v-space-normal">
 						<h3 class="title-5 text-medium">[% lang('footer_discover_the_project') %]</h3>
 						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
-							<li><a class="button small white-button radius" href="[% lang('footer_who_we_are_link') %]">[% lang('footer_who_we_are') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_vision_link') %]">[% lang('footer_vision') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_faq_link') %]">[% lang('footer_faq') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_blog_link') %]">[% lang('footer_blog') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_press_link') %]">[% lang('footer_press') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_wiki_link') %]">[% lang('footer_wiki') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_translators_link') %]">[% lang('footer_translators') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_partners_link') %]">[% lang('footer_partners') %]</a></li>
-							<li><a class="button small white-button radius" href="[% lang('footer_obf_link') %]">[% lang('footer_obf') %]</a></li>
-							<li><a class="button small white-button radius" href="[% producers_platform_url %]">[% lang('footer_pro') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_who_we_are_link')) %]">[% lang('footer_who_we_are') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_vision_link')) %]">[% lang('footer_vision') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_faq_link')) %]">[% lang('footer_faq') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_blog_link')) %]">[% lang('footer_blog') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_press_link')) %]">[% lang('footer_press') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_wiki_link')) %]">[% lang('footer_wiki') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_translators_link')) %]">[% lang('footer_translators') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_partners_link')) %]">[% lang('footer_partners') %]</a></li>
+							<li><a class="button small white-button radius" href="[% edq(lang('footer_obf_link')) %]">[% lang('footer_obf') %]</a></li>
+							<li><a class="button small white-button radius" href="[% producers_platform_url %]">[% edq(lang('footer_pro')) %]</a></li>
 						</ul>
 					</div>
 				</div>
@@ -382,17 +382,17 @@
 
 							<div class="small-12 text-center v-space-short h-space-large">
 
-								<a href="/" style="font-size:1rem;"><img id="logo" src="[% static_subdomain %]/images/logos/off-logo-horizontal-mono-white.svg" alt="[% lang('logo_site_name') %]" style="margin:8px;height:48px;width:auto;"></a>
+								<a href="/" style="font-size:1rem;"><img id="logo" src="[% static_subdomain %]/images/logos/off-logo-horizontal-mono-white.svg" alt="[% edq(lang('logo_site_name')) %]" style="margin:8px;height:48px;width:auto;"></a>
 
 								<p>[% lang('footer_tagline') %]</p>
 								
 								<ul class="inline-list text-center text-small">
-									<li><a href="[% lang('footer_legal_link') %]">[% lang('footer_legal') %]</a></li>
-									<li><a href="[% lang('footer_privacy_link') %]">[% lang('footer_privacy') %]</a></li>
-									<li><a href="[% lang('footer_terms_link') %]">[% lang('footer_terms') %]</a></li>
-									<li><a href="[% lang('footer_data_link') %]">[% lang('footer_data') %]</a></li>
-									<li><a href="[% lang('donate_link') %]">[% lang('donate') %]</a></li>
-									<li><a href="[% lang('footer_producers_link') %]">[% lang('footer_producers') %]</a></li>
+									<li><a href="[% edq(lang('footer_legal_link')) %]">[% lang('footer_legal') %]</a></li>
+									<li><a href="[% edq(lang('footer_privacy_link')) %]">[% lang('footer_privacy') %]</a></li>
+									<li><a href="[% edq(lang('footer_terms_link')) %]">[% lang('footer_terms') %]</a></li>
+									<li><a href="[% edq(lang('footer_data_link')) %]">[% lang('footer_data') %]</a></li>
+									<li><a href="[% edq(lang('donate_link')) %]">[% lang('donate') %]</a></li>
+									<li><a href="[% edq(lang('footer_producers_link')) %]">[% lang('footer_producers') %]</a></li>
 									<li><a href="https://link.openfoodfacts.org/newsletter-[% language %]">[% lang('subscribe_to_our_newsletter') %]</a></li>
 								</ul>
 							</div>
@@ -453,7 +453,7 @@
 {
 	"@context" : "https://schema.org",
 	"@type" : "WebSite",
-	"name" : "[% lang('site_name') %]",
+	"name" : "[% edq(lang('site_name')) %]",
 	"url" : "[% formatted_subdomain %]",
 	"potentialAction": {
 		"@type": "SearchAction",
@@ -468,8 +468,8 @@
 	"@type": "Organization",
 	"url": "[% formatted_subdomain %]",
 	"logo": "[% static_subdomain %]/images/logos/off-logo-vertical-light.svg",
-	"name": "[% lang('site_name') %]",
-	"sameAs" : [ "[% lang("facebook_page") %]", "https://twitter.com/[% twitter_account %]"]
+	"name": "[% edq(lang('site_name')) %]",
+	"sameAs" : [  "[% edq(lang('facebook_page')) %]", "https://twitter.com/[% twitter_account %]"]
 }
 </script>
 

--- a/templates/web/pages/export_products/export_products.tt.html
+++ b/templates/web/pages/export_products/export_products.tt.html
@@ -48,7 +48,7 @@
 		[% END %]
 	[% END %]
 		
-	<input type="submit" class="button small" value="[% lang('export_product_data_photos') %]">
+	<input type="submit" class="button small" value="[% edq(lang('export_product_data_photos')) %]">
 		
 </form>
 

--- a/templates/web/pages/import_file_process/import_file_process.tt.js
+++ b/templates/web/pages/import_file_process/import_file_process.tt.js
@@ -4,10 +4,10 @@ var timeout = 5000;
 var job_info_state;
 
 var statuses = {
-	"inactive" : "[% lang("job_status_inactive") %]",
-	"active" : "[% lang("job_status_active") %]",
-	"finished" : "[% lang("job_status_finished") %]",
-	"failed" : "[% lang("job_status_failed") %]",
+	"inactive" :  "[% edq(lang('job_status_inactive')) %]",
+	"active" :  "[% edq(lang('job_status_active')) %]",
+	"finished" :  "[% edq(lang('job_status_finished')) %]",
+	"failed" :  "[% edq(lang('job_status_failed')) %]",
 };
 
 (function poll() {

--- a/templates/web/pages/import_file_select_format/import_file_select_format.tt.html
+++ b/templates/web/pages/import_file_select_format/import_file_select_format.tt.html
@@ -17,7 +17,7 @@
 
 <form id="select_format_form" action="/cgi/import_file_process.pl" method="POST" enctype="multipart/form-data">
 
-    <input type="submit" class="button small" value="[% lang('import_data') %]">
+    <input type="submit" class="button small" value="[% edq(lang('import_data')) %]">
     [% selected_columns_count %]
 
     <table id="select_fields" aria-label="data table">
@@ -47,7 +47,7 @@
 
     <input type="hidden" name="columns_fields_json" id="columns_fields_json">
     <input type="hidden" name="file_id" id="file_id" value="[% file_id %]">
-    <input type="submit" class="button small" value="[% lang('import_data') %]">
+    <input type="submit" class="button small" value="[% edq(lang('import_data')) %]">
     [% selected_columns_count %]
 
 </form>

--- a/templates/web/pages/import_file_select_format/import_file_select_format.tt.js
+++ b/templates/web/pages/import_file_select_format/import_file_select_format.tt.js
@@ -38,7 +38,7 @@ function init_select_field_option(col) {
 
 			if (field ==  "[% tagtype %]_specific") {
 
-				var input = '<input id="select_field_option_tag_' + col + '" name="select_field_option_tag_' + col +  '" placeholder= "[% lang("${tagtype}_s") %]" style="width:150px;margin-bottom:0;height:28px;">';
+				var input = '<input id="select_field_option_tag_' + col + '" name="select_field_option_tag_' + col +  '" placeholder= "[% edq(lang("${tagtype}_s")) %]" style="width:150px;margin-bottom:0;height:28px;">';
 
 				\$("#select_field_option_" + col).html(input);
 
@@ -54,7 +54,7 @@ function init_select_field_option(col) {
 					columns_fields[column]["tag"] = \$(this).val();
 				});
 
-				instructions += "<p>[% lang('${tagtype}_specific_tag') %]</p>" + "<p>[% lang('${tagtype}_specific_tag_value') %]</p>";
+				instructions += "<p>[% edq(lang('${tagtype}_specific_tag')) %]</p>" + "<p>[% edq(lang('${tagtype}_specific_tag_value')) %]</p>";
 		
 			}
 		[% END %]
@@ -80,7 +80,7 @@ function init_select_field_option(col) {
 
 			// setup a select2 widget
 			\$('#select_field_option_lc_' + col).select2({
-				placeholder: "[% lang('specify') %]"
+				placeholder: "[% edq(lang('specify')) %]"
 			}).on("select2:select", function(e) {
 				var id = e.params.data.id;
 				var col = this.id.replace(/select_field_option_lc_/, '');
@@ -96,36 +96,36 @@ function init_select_field_option(col) {
 			+ '<option></option>';
 
 			if (field.match(/^energy/)) {
-				select += "<option value='value_in_kj'>[% lang('value_in_kj') %]</option>"
+				select += "<option value='value_in_kj'>[% edq(lang('value_in_kj')) %]</option>"
 				+ "<option value='value_in_kcal'>[% lang('value_in_kcal') %]</option>";
 			}
 			else if (field.match(/weight/)) {
-				select += "<option value='value_in_g'>[% lang('value_in_g') %]</option>";
+				select += "<option value='value_in_g'>[% edq(lang('value_in_g')) %]</option>";
 			}
 			else if (field.match(/volume/)) {
-				select += "<option value='value_in_l'>[% lang('value_in_l') %]</option>"
-				+ "<option value='value_in_dl'>[% lang('value_in_dl') %]</option>"
-				+ "<option value='value_in_cl'>[% lang('value_in_cl') %]</option>"
-				+ "<option value='value_in_ml'>[% lang('value_in_ml') %]</option>";
+				select += "<option value='value_in_l'>[% edq(lang('value_in_l')) %]</option>"
+				+ "<option value='value_in_dl'>[% edq(lang('value_in_dl')) %]</option>"
+				+ "<option value='value_in_cl'>[% edq(lang('value_in_cl')) %]</option>"
+				+ "<option value='value_in_ml'>[% edq(lang('value_in_ml')) %]</option>";
 			}
 			else if (field.match(/quantity/)) {
-				select += "<option value='value_in_g'>[% lang('value_in_g') %]</option>"
-				+ "<option value='value_in_l'>[% lang('value_in_l') %]</option>"
-				+ "<option value='value_in_dl'>[% lang('value_in_dl') %]</option>"
-				+ "<option value='value_in_cl'>[% lang('value_in_cl') %]</option>"
-				+ "<option value='value_in_ml'>[% lang('value_in_ml') %]</option>";
+				select += "<option value='value_in_g'>[% edq(lang('value_in_g')) %]</option>"
+				+ "<option value='value_in_l'>[% edq(lang('value_in_l')) %]</option>"
+				+ "<option value='value_in_dl'>[% edq(lang('value_in_dl')) %]</option>"
+				+ "<option value='value_in_cl'>[% edq(lang('value_in_cl')) %]</option>"
+				+ "<option value='value_in_ml'>[% edq(lang('value_in_ml')) %]</option>";
 			}
 			else {
-				select += "<option value='value_in_g'>[% lang('value_in_g') %]</option>"
-				+ "<option value='value_in_mg'>[% lang('value_in_mg') %]</option>"
-				+ "<option value='value_in_mcg'>[% lang('value_in_mcg') %]</option>"
-				+ "<option value='value_in_iu'>[% lang('value_in_iu') %]</option>"
-				+ "<option value='value_in_percent'>[% lang('value_in_percent') %]</option>";
+				select += "<option value='value_in_g'>[% edq(lang('value_in_g')) %]</option>"
+				+ "<option value='value_in_mg'>[% edq(lang('value_in_mg')) %]</option>"
+				+ "<option value='value_in_mcg'>[% edq(lang('value_in_mcg')) %]</option>"
+				+ "<option value='value_in_iu'>[% edq(lang('value_in_iu')) %]</option>"
+				+ "<option value='value_in_percent'>[% edq(lang('value_in_percent')) %]</option>";
 			}
 
-			select += "<option value='value_unit'>[% lang('value_unit') %]</option>"
-			+ "<option value='value'>[% lang('value') %]</option>"
-			+ "<option value='unit'>[% lang('unit') %]</option>"
+			select += "<option value='value_unit'>[% edq(lang('value_unit')) %]</option>"
+			+ "<option value='value'>[% edq(lang('value')) %]</option>"
+			+ "<option value='unit'>[% edq(lang('unit')) %]</option>"
 			+ "</select>";
 
 			\$("#select_field_option_" + col).html(select);
@@ -135,7 +135,7 @@ function init_select_field_option(col) {
 			}
 
 			\$('#select_field_option_value_unit_' + col).select2({
-				placeholder: "[% lang('specify') %]"
+				placeholder: "[% edq(lang('specify')) %]"
 			}).on("select2:select", function(e) {
 				var id = e.params.data.id;
 				var col = this.id.replace(/select_field_option_value_unit_/, '');
@@ -144,7 +144,7 @@ function init_select_field_option(col) {
 			}).on("select2:unselect", function(e) {
 			});
 
-			instructions += "<p>[% lang('value_unit_dropdown') %]'</p>"
+			instructions += "<p>[% edq(lang('value_unit_dropdown')) %]'</p>"
 			+ "<ul>"
 			+ "<li>[% lang('value_unit_dropdown_value_specific_unit') %]</li>"
 			+ "<li>[% lang('value_unit_dropdown_value_unit') %]</li>"
@@ -158,7 +158,7 @@ function init_select_field_option(col) {
 
 function init_select_field() {
 	var options = {
-		placeholder: "[% lang('select_a_field') %]",
+		placeholder: "[% edq(lang('select_a_field')) %]",
 		data:select2_options,
 		allowClear: true
 	};

--- a/templates/web/pages/import_photos_upload/import_photos_upload.tt.html
+++ b/templates/web/pages/import_photos_upload/import_photos_upload.tt.html
@@ -27,7 +27,7 @@
             </div>
 
             <div class="small-12 medium-12 large-7 columns tag-add-field-value">
-                <input type="text" id="tag_[% i %]" name="tag_[% i %]" value="" placeholder="[% lang('add_value') %]">
+                <input type="text" id="tag_[% i %]" name="tag_[% i %]" value="" placeholder="[% edq(lang('add_value')) %]">
             </div>
         </div>
     </div>  

--- a/templates/web/pages/import_product_categories/import_product_categories_from_public_database.tt.html
+++ b/templates/web/pages/import_product_categories/import_product_categories_from_public_database.tt.html
@@ -3,7 +3,7 @@
 
 <form id = "import_products_categories_form"  method="POST" enctype="multipart/form-data" action="/cgi/import_products_categories_from_public_database.pl">
   
-    <input type="submit" class="button small" value="[% lang('import_products_categories') %]">
+    <input type="submit" class="button small" value="[% edq(lang('import_products_categories')) %]">
     <input type="hidden" name="action" value="process">
 
 </form>

--- a/templates/web/pages/org_form/org_form.tt.html
+++ b/templates/web/pages/org_form/org_form.tt.html
@@ -49,7 +49,7 @@
 						<input type="hidden" name="type" value="user_delete" />
 						<input type="hidden" name="org_id" value="[% orgid %]">
 						<input type="hidden" name="user_id" value="[% users.userid %]">
-						<input type="submit" name="remove_user" class="button small" value="[% lang("remove_user") %]"/>
+						<input type="submit" name="remove_user" class="button small" value= "[% edq(lang('remove_user')) %]"/>
 					</form>
 				</td>
 			</tr>
@@ -62,7 +62,7 @@
 				<!-- admin_status_xxxx elements above are also part of it, thanks to form attribute -->
 				<input type="hidden" name="action" value="process" />
 				<input type="hidden" name="type" value="admin_status" />
-				<input type="submit" name="grant_remove_admin_status" class="button" style="margin-bottom: 10px;" value="[% lang("grant_remove_admin_status") %]"/>
+				<input type="submit" name="grant_remove_admin_status" class="button" style="margin-bottom: 10px;" value= "[% edq(lang('grant_remove_admin_status')) %]"/>
 			</form>
 		</div>
 	</div>
@@ -74,7 +74,7 @@
 		<input type="hidden" name="action" value="process" />
 		<input type="hidden" name="type" value="add_users" />
 		<input type="hidden" name="orgid" value="[% orgid %]" />
-		<input type="submit" name=".submit" class="button" value="[% lang("invite_user") %]"/>
+		<input type="submit" name=".submit" class="button" value= "[% edq(lang('invite_user')) %]"/>
 	</form>
 
     <!-- Start form -->
@@ -148,7 +148,7 @@
 		<input type="hidden" name="action" value="process" />
 		<input type="hidden" name="type" value="[% type %]" />
 		<input type="hidden" name="orgid" value="[% orgid %]" />
-		<input type="submit" name=".submit" class="button" value="[% lang("save") %]"/>
+		<input type="submit" name=".submit" class="button" value= "[% edq(lang('save')) %]"/>
     </form>
 
     <!-- End form -->

--- a/templates/web/pages/org_profile/org_profile.tt.html
+++ b/templates/web/pages/org_profile/org_profile.tt.html
@@ -3,7 +3,7 @@
 [% IF edit_profile %]
 	<!-- Edit product page -->
 	<div class="edit_button">
-		<a href="/cgi/org.pl?orgid=[% orgid %]" class="button small" title="[% lang("edit_org_profile") %]">
+		<a href="/cgi/org.pl?orgid=[% orgid %]" class="button small" title= "[% edq(lang('edit_org_profile')) %]">
 			[% display_icon('edit') %]
 			<span class="show-for-large-up">[% lang("edit_org_profile") %]</span>
 		</a>

--- a/templates/web/pages/product/includes/display_rev_info.tt.html
+++ b/templates/web/pages/product/includes/display_rev_info.tt.html
@@ -11,11 +11,11 @@
 	</p>
 	<p>[% lang('edit_comment') %]: [% comment %]</p>
 	[% IF previous_link %]
-		<span class="rev_previous"><a href="[% previous_link %]">← [% lang('rev_previous') %]</a></span>
+		<span class="rev_previous"><a href="[% previous_link %]">← [% edq(lang('rev_previous')) %]</a></span>
 	[% END %]
-	<span class="rev_latest"><a href="[% current_link %]">[% lang('rev_latest') %]</a></span>
+	<span class="rev_latest"><a href="[% current_link %]">[% edq(lang('rev_latest')) %]</a></span>
 	[% IF next_link %]
-		<span class="rev_next"><a href="[% next_link %]">[% lang('rev_next') %] →</a></span>
+		<span class="rev_next"><a href="[% next_link %]">[% edq(lang('rev_next')) %] →</a></span>
 	[% END %]
 </div>
 

--- a/templates/web/pages/product/includes/edit_history.tt.html
+++ b/templates/web/pages/product/includes/edit_history.tt.html
@@ -6,7 +6,7 @@
   <li>
     [% revision.date %] - [% display_editor_link(revision.userid) %] [% revision.diffs %] [% IF
     revision.comment %] - [% revision.comment %] [% END %] -
-    <a href="[% this_product_url %]?rev=[% revision.number %]">[% lang('view') %]</a>
+    <a href="[% this_product_url %]?rev=[% revision.number %]">[% edq(lang('view')) %]</a>
   </li>
   [% END %]
 </ul>

--- a/templates/web/pages/product/includes/nutrient_levels.tt.html
+++ b/templates/web/pages/product/includes/nutrient_levels.tt.html
@@ -3,13 +3,13 @@
 <!-- Nutrient levels template -->
 
 <h4>[% lang('nutrient_levels_info') %]
-    <a href="[% lang('nutrient_levels_link') %]" title="[% lang('nutrient_levels_info') %]">
+    <a href="[% edq(lang('nutrient_levels_link')) %]" title="[% edq(lang('nutrient_levels_info')) %]">
         [% display_icon('info') %]
     </a>
 </h4>
 [% FOREACH level IN nutrient_levels %]
     <img src="[% static_subdomain %]/images/misc/[% level.nutrient_level %].svg" width="30" height="30" style="vertical-align:middle;margin-right:15px;margin-bottom:4px;"
-    alt="[% lang('${level.nutrient_level}_quantity') %]"> [% level.nutrient_quantity_in_grams %] g [% level.nutrient_bold_in_quantity %] <br>
+    alt="[% edq(lang('${level.nutrient_level}_quantity')) %]"> [% level.nutrient_quantity_in_grams %] g [% level.nutrient_bold_in_quantity %] <br>
 [% END %]
 
 <!-- end templates/[% component.name %] -->

--- a/templates/web/pages/product/includes/nutriscore.tt.html
+++ b/templates/web/pages/product/includes/nutriscore.tt.html
@@ -1,13 +1,13 @@
 <!-- start templates/[% component.name %] -->
 
 <h4>[% lang('nutrition_grade_fr_title') %]
-    <a href="/nutriscore" title="[% lang('nutrition_grade_fr_formula') %]">
+    <a href="/nutriscore" title="[% edq(lang('nutrition_grade_fr_formula')) %]">
         [% display_icon('info') %]</a>
 </h4>
 
 [% IF nutriscore_grade.defined %]
-<a href="/nutriscore" title="[% lang('nutrition_grade_fr_formula') %]">
-    <img src="[% static_subdomain %]/images/attributes/dist/nutriscore-[% nutriscore_grade %].svg" alt="[% lang('nutrition_grade_fr_alt}') %] [% nutriscore_grade | ucfirst %]" style="margin-bottom:1rem;max-width:100%">
+<a href="/nutriscore" title="[% edq(lang('nutrition_grade_fr_formula')) %]">
+    <img src="[% static_subdomain %]/images/attributes/dist/nutriscore-[% nutriscore_grade %].svg" alt="[% edq(lang('nutrition_grade_fr_alt')) %] [% nutriscore_grade | ucfirst %]" style="margin-bottom:1rem;max-width:100%">
 </a>
 <br>
 [% END %]

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -15,7 +15,7 @@
     <!-- Anonymous users will only be able to vote see AnnotationVote in robotoff,
         the voter uniqueness is based on a hash of its ip address
     -->
-	<robotoff-asker url='[% robotoff_url %]' code='[% code %]' lang='[% lc %]' style='display: none;' caption-yes='[% lang("button_caption_yes") %]' caption-no='[% lang("button_caption_no") %]' caption-skip='[% lang("button_caption_skip") %]'></robotoff-asker>
+	<robotoff-asker url='[% robotoff_url %]' code='[% code %]' lang='[% lc %]' style='display: none;' caption-yes='[% esq(lang("button_caption_yes")) %]' caption-no='[% esq(lang("button_caption_no")) %]' caption-skip='[% esq(lang("button_caption_skip")) %]'></robotoff-asker>
 [% END %]
 
 <a href="#upNav" class="back-to-top scrollto button">
@@ -31,7 +31,7 @@
                 <div class="buttons_prod">
                     <!-- Edit product page -->
                     <div class="edit_button">
-                        <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round" title="[% lang('edit_product_page') %]">
+                        <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round" title="[% edq(lang('edit_product_page')) %]">
                             <span class="material-icons size-20 ">
                             edit
                             </span>
@@ -54,7 +54,7 @@
                     [% IF user_moderator %]
                     <!-- Delete product page -->
                         <div class="delete_button">
-                            <a href="/cgi/product.pl?type=delete&code=[% code %]" class="button small alert" title="[% lang('delete_product_page') %]">
+                            <a href="/cgi/product.pl?type=delete&code=[% code %]" class="button small alert" title="[% edq(lang('delete_product_page')) %]">
                                 <span class="material-icons size-20 ">
                                 delete
                                 </span>
@@ -65,7 +65,7 @@
 
                     [% IF server_options_producers_platform %]
                         <div class="delete_button">
-                            <a href="/cgi/export_products.pl?query_code=[% code %]" class="button small" title="[% lang('export_product_page') %]">
+                            <a href="/cgi/export_products.pl?query_code=[% code %]" class="button small" title="[% edq(lang('export_product_page')) %]">
                                 <span class="material-icons size-20 ">
                                 publish
                                 </span>

--- a/templates/web/pages/product_edit/product_edit_form.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form.tt.html
@@ -38,7 +38,7 @@
                         </label>
                     </div>
                 </div>
-                <input type="submit" name=".submit" value="[% lang('login_register_title') %]" class="button small" />
+                <input type="submit" name=".submit" value="[% edq(lang('login_register_title')) %]" class="button small" />
                 <input type="hidden" name="code" value="[% code %]" />
                 <input type="hidden" name="next_action" value="product_[% type %]" />
                 <button type="submit" formaction="/cgi/user.pl" method ="get" class="button small">[% lang('login_create_your_account') %]</button>

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -171,9 +171,9 @@
                         <input type="checkbox" id="[% nutrient.nutrition_data %]" name="[% nutrient.nutrition_data %]" [% nutrient.checked %] />
                         <label for="[% nutrient.nutrition_data %]" class="checkbox_label">[% nutrient.nutrition_data_exists %]</label> &nbsp;
                         <input type="radio" id="[% nutrient.nutrition_data_per %]_100g" value="100g" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_100g %] />
-                        <label for="[% nutrient.nutrition_data_per %]_100g">[% lang('nutrition_data_per_100g') %]</label>
+                        <label for="[% nutrient.nutrition_data_per %]_100g">[% edq(lang('nutrition_data_per_100g')) %]</label>
                         <input type="radio" id="[% nutrient.nutrition_data_per %]_serving" value="serving" name="[% nutrient.nutrition_data_per %]" [% nutrient.checked_per_serving %] />
-                        <label for="[%nutrient. nutrition_data_per %]_serving">[% lang('nutrition_data_per_serving') %]</label><br/>
+                        <label for="[%nutrient. nutrition_data_per %]_serving">[% edq(lang('nutrition_data_per_serving')) %]</label><br/>
 
                         [% IF nutrition_data_instructions_check && nutrition_data_instructions_check != '' %]
                             <p id="[% nutrient.nutrition_data_instructions %]" [% nutrient.hidden %]>[% lang(nutrient.nutrition_data_instructions) %]</p>
@@ -311,7 +311,7 @@
 
                 <div class="row">
                     <div class="small-12 medium-12 large-8 xlarge-8 columns" style="margin-bottom:0.5rem;">
-                        <input id="comment" name="comment" placeholder="[% lang('edit_comment') %]" value="" type="text" class="text" style="margin:0" />
+                        <input id="comment" name="comment" placeholder="[% edq(lang('edit_comment')) %]" value="" type="text" class="text" style="margin:0" />
                     </div>
                     <div class="small-6 medium-6 large-2 xlarge-2 columns">
                         <button type="submit" id="save" name=".submit" class="button postfix success small">
@@ -329,7 +329,7 @@
 
                 <div class="row">
                     <div class="small-12 medium-12 large-12 xlarge-12 columns bg-primary h-space-normal v-space-normal text-center">
-                        <input type="submit" name=".submit" value="[% lang('save') %]" class="button success">
+                        <input type="submit" name=".submit" value="[% edq(lang('save')) %]" class="button success">
                     </div>
                 </div>
 

--- a/templates/web/pages/product_edit/product_edit_form_display_user-moderator.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display_user-moderator.tt.html
@@ -12,7 +12,7 @@
     <label for="comment" style="margin-left:10px">[% lang("delete_comment") %]</label>
     <input type="text" id="comment" name="comment" value="" />
 
-    <input type="submit" name="save" class="button small" value="[% lang('delete_product_page') %]" />
+    <input type="submit" name="save" class="button small" value="[% edq(lang('delete_product_page')) %]" />
 
 </form>
 

--- a/templates/web/pages/products_map/map_of_products.tt.html
+++ b/templates/web/pages/products_map/map_of_products.tt.html
@@ -12,7 +12,7 @@
 <p>&nbsp;</p>
 
 [% IF current_link_query %]
-<p>&rarr; <a href="[% current_link_query %]">[% lang('search_map_link') %]</a></p>
+<p>&rarr; <a href="[% current_link_query %]">[% edq(lang('search_map_link')) %]</a></p>
 [% END %]
 
 <script>

--- a/templates/web/pages/remove_products/remove_products.tt.html
+++ b/templates/web/pages/remove_products/remove_products.tt.html
@@ -7,7 +7,7 @@
 
     <!--Start the form-->
     <form id="remove_products_form" method="post" onsubmit="return confirm('[% confirm_alert.squote %]')" enctype="multipart/form-data">
-        <input type="submit" class="button small" value="[% lang('remove_products') %] ">
+        <input type="submit" class="button small" value="[% edq(lang('remove_products')) %] ">
         <input type="hidden" name="action" value="process">
     </form>
 

--- a/templates/web/pages/search_form/search_form.tt.html
+++ b/templates/web/pages/search_form/search_form.tt.html
@@ -43,7 +43,7 @@
                     </div>
 
                     <div class="small-12 medium-12 large-4 columns tag-search-criterion">
-                        <input type="text" id="tag_[% type.id %]" name="tag_[% tagtype.id %]" value="[% tagtype.input_value %]" placeholder="[% lang('search_value') %]"/>
+                        <input type="text" id="tag_[% type.id %]" name="tag_[% tagtype.id %]" value="[% tagtype.input_value %]" placeholder="[% edq(lang('search_value')) %]"/>
                     </div>
                 </div>
             </div>
@@ -177,7 +177,7 @@
                         [% END %]
                     </div>
                 </div>
-                <input type="submit" name="graph" value="[% lang('search_generate_graph') %]" class="button" />
+                <input type="submit" name="graph" value="[% edq(lang('search_generate_graph')) %]" class="button" />
             </div>
         </li>
 
@@ -210,7 +210,7 @@
                 <input type="radio" name="format" value="csv" id="format_csv" />
                     <label for="format_csv">[% lang('search_download_csv') %] - [% lang('search_download_csv_description') %]</label><br>
 
-                <input type="submit" name="download" value="[% lang('search_download_button') %]" class="button" />
+                <input type="submit" name="download" value="[% edq(lang('search_download_button')) %]" class="button" />
 
             </div>
         </li>

--- a/templates/web/pages/session/sign_in_form.tt.html
+++ b/templates/web/pages/session/sign_in_form.tt.html
@@ -42,7 +42,7 @@
     <div class="row">
         <div class="large-12 columns">
             <label for="submit">
-                <input type="submit" name="submit" class="button" id="submit" value="[% lang('sign_in') %]" />
+                <input type="submit" name="submit" class="button" id="submit" value="[% edq(lang('sign_in')) %]" />
                 <input type="hidden" name="redirect" value="[% redirect %]"/>
             </label>
         </div>

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -165,7 +165,8 @@
         [% IF userid and (type != 'add') %]
             <fieldset>
                 <legend class="text_warning">[% lang("danger_zone") %]</legend>
-                <input type="button" name=".delete" class="button text_warning" value="[% lang("delete_user") %]" onclick="if ('[% userid %]'.localeCompare(prompt('[% lang("delete_confirmation") %]'),undefined,'base') === 0) {document.getElementById('delete_input').value='on';document.getElementById('user_form').submit();}"/>
+                [% define delete_confirm=esq(lang("delete_confirmation")) %]
+                <input type="button" name=".delete" class="button text_warning" value= "[% edq(lang('delete_user')) %]" onclick="if ('[% userid %]'.localeCompare(prompt('[% delete_confirm %]'),undefined,'base') === 0) {document.getElementById('delete_input').value='on';document.getElementById('user_form').submit();}"/>
                 <input type="hidden" name="delete" id="delete_input"/>
             </fieldset>
         [% END %]
@@ -174,9 +175,9 @@
         <input type="hidden" name="type" value="[% type %]" />
         [% IF userid %]
             <input type="hidden" name="userid" value="[% userid %]" />
-            <input type="submit" name=".submit" class="button" value="[% lang("save") %]" />
+            <input type="submit" name=".submit" class="button" value= "[% edq(lang('save')) %]" />
         [% ELSE %]
-            <input type="submit" name=".submit" class="button" value="[% lang("add_user") %]" />
+            <input type="submit" name=".submit" class="button" value= "[% edq(lang('add_user')) %]" />
         [% END %]
     </form>
 

--- a/templates/web/pages/user_form/user_form_page.tt.html
+++ b/templates/web/pages/user_form/user_form_page.tt.html
@@ -165,7 +165,7 @@
         [% IF userid and (type != 'add') %]
             <fieldset>
                 <legend class="text_warning">[% lang("danger_zone") %]</legend>
-                [% define delete_confirm=esq(lang("delete_confirmation")) %]
+                [% delete_confirm=esq(lang("delete_confirmation")) %]
                 <input type="button" name=".delete" class="button text_warning" value= "[% edq(lang('delete_user')) %]" onclick="if ('[% userid %]'.localeCompare(prompt('[% delete_confirm %]'),undefined,'base') === 0) {document.getElementById('delete_input').value='on';document.getElementById('user_form').submit();}"/>
                 <input type="hidden" name="delete" id="delete_input"/>
             </fieldset>

--- a/templates/web/pages/user_profile/user_profile.tt.html
+++ b/templates/web/pages/user_profile/user_profile.tt.html
@@ -3,7 +3,7 @@
 [% IF edit_profile %]
 	<!-- Edit product page -->
 	<div class="edit_button">
-		<a href="/cgi/user.pl?userid=[% userid %]&type=edit&action=display" class="button small" title="[% lang("edit_user_profile") %]">
+		<a href="/cgi/user.pl?userid=[% userid %]&type=edit&action=display" class="button small" title= "[% edq(lang('edit_user_profile')) %]">
 			[% display_icon('edit') %]
 			<span class="show-for-large-up">[% lang("edit_user_profile") %]</span>
 		</a>


### PR DESCRIPTION
Translations coming from crowdin might contain single quotes or double quotes. So whenever we use lang in a json or javascript string we should escape quotes.

I created edq and esq (Escape Single/Double Quotes) function for that (1st commit) and applied it in a lot of place (2nd commit). This should be the pattern to use from now on. 

fixes: 
- #9820
- #9533


**Note:** I will do a hotfix in prod for the remove account case, because it's important to fix quickly (GDPR).