### PR TITLE
fix: missing_translations_in_dq_button

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6209,6 +6209,10 @@ msgctxt "action_add_packaging_components"
 msgid "Add packaging components"
 msgstr "Take a photo of the recycling information"
 
+msgctxt "action_add_quantity"
+msgid "Add quantity for the product"
+msgstr "Add quantity for the product"
+
 # this is not used yet
 msgctxt "action_add_basic_details"
 msgid "Add basic details"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6210,8 +6210,8 @@ msgid "Add packaging components"
 msgstr "Take a photo of the recycling information"
 
 msgctxt "action_add_quantity"
-msgid "Add quantity for the product"
-msgstr "Add quantity for the product"
+msgid "Add quantity of the product"
+msgstr "Add quantity of the product"
 
 # this is not used yet
 msgctxt "action_add_basic_details"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6234,6 +6234,10 @@ msgctxt "action_add_packaging_components"
 msgid "Add packaging components"
 msgstr "Take a photo of the recycling information"
 
+msgctxt "action_add_quantity"
+msgid "Add quantity for the product"
+msgstr "Add quantity for the product"
+
 # this is not used yet
 msgctxt "action_add_basic_details"
 msgid "Add basic details"


### PR DESCRIPTION
### What
@teolemon, I did not know what it means "missing translations in the Data Quality action button", I had to search.

1)
In the provided example, there is another facet where the button is as expected. Let's look at it first.
We can find reference to this "action" in

- data_quality.txt -> fix_action:en: add_origins - BUT not for all facets ( EcoScore - packaging - Packaging data missing, for example)

- Products.pm -> add_origins + url suffix

- en.po -> msgtxt "action_add_origins" + message in the box

```
origins_of_ingredients.tt.json -> 
	    	"element_type": "action",
            "action_element": {
                "html": `[% lang("action_add_origins") %]`,
                "actions": [
                    "add_origins",
                ]
            }
```

however, more generic in data_quality_tags.tt.json:
```
            [% IF fix_action != 'undef' %]
                {
                    "element_type": "action",
                    "action_element": {
                        "html": `[% lang(action_name) %]`,
                        "actions": [
                            "[% fix_action %]",
                        ]
                    },
                },
```

2)
for serving quantity facet.

- we have in data_quality.txt

```
en:Serving quantity defined but quantity undefined
fix_action:en: add_quantity
```

- we also have add_quantity url define in Products.pm

- However it is missing in en.pot. Which make sense because it is where we have translations (now, I understand message from @teolemon :-) )

 - so (following advice from @alexgarel  in a previous PR: https://github.com/openfoodfacts/openfoodfacts-server/pull/9588#discussion_r1439298329) we will add, in common.pot only.

```
msgctxt "action_add_quantity"
msgid "Add quantity for the product"
msgstr "Add quantity for the product"
```

3) test. It does not work. Try also to add the translation in en.po. Yes, it works!

### Screenshot
![Screenshot_20240224_173146](https://github.com/openfoodfacts/openfoodfacts-server/assets/110821832/c05d6e66-047c-4e62-8625-818e2c9d2720)

### Related issue(s) and discussion
- Fixes #9783