### PR TITLE
fix: remove underline from zoom controls.

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -1691,7 +1691,7 @@ $font-green: #008c8c;
 .if-empty-dnone:empty { display: none !important; }
 
 // underline links
-#main_container a {
+#main_container a:not(.leaflet-control-zoom-in):not(.leaflet-control-zoom-out) {
   text-decoration:underline;
 }
 // except buttons


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
This PR removes duplicate underlines from zoom controls in the map, ensuring cleaner appearance while maintaining underlines for other elements.
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<img width="949" alt="screenshot" src="https://github.com/openfoodfacts/openfoodfacts-server/assets/120312681/810d087a-b23c-4320-a0dd-86be24e55740">

<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #9161 

