### PR TITLE
fix: pull request action, needs build_taxonomies before running tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -106,6 +106,8 @@ jobs:
       uses: ishworkh/docker-image-artifact-download@v1
       with:
         image: "openfoodfacts-server/backend:dev"
+    - name: build taxonomies (should use cache)
+        run: make build_taxonomies        
     - name: tests
       run: |
         make codecov_prepare

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -106,8 +106,6 @@ jobs:
       uses: ishworkh/docker-image-artifact-download@v1
       with:
         image: "openfoodfacts-server/backend:dev"
-    - name: build taxonomies (should use cache)
-        run: make build_taxonomies        
     - name: tests
       run: |
         make codecov_prepare

--- a/scripts/build_lang.pl
+++ b/scripts/build_lang.pl
@@ -55,6 +55,8 @@ ProductOpener::Lang::build_json();
 
 # Nutrients level taxonomy file is built using languages
 create_nutrients_level_taxonomy();
+# and generate corresponding taxonomy
+build_tags_taxonomy('nutrients_levels', 1);
 
 exit(0);
 


### PR DESCRIPTION
It looks like the nutrient_levels taxonomy has not already been generated when tests are run. It should work anyway but it fails for some reason.

e.g. https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/8189813679/job/22395977705?pr=9854

 Container po_off_test-memcached-1  Running
Could not load taxonomy: /mnt/podata/taxonomies/nutrient_levels.result.sto at /opt/product-opener/lib/ProductOpener/Tags.pm line 2507.
Compilation failed in require at tests/unit/additives_tags.t line 9.

This seems to happen only for the first test case, and only sometimes, maybe a race condition.