### PR TITLE
feat: issue#9793 Automatically unselect image when the source image is deleted

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -180,6 +180,7 @@ use ProductOpener::Config2;
 	stephane
 	tacinte
 	teolemon
+    himanshi-154
 );
 
 $options{export_limit} = 10000;

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -1181,6 +1181,13 @@ sub process_image_move ($user_id, $code, $imgids, $move_to, $ownerid) {
 						result => $ok
 					}
 				);
+
+            # Unselect images with matching imgid
+        	foreach my $selected_imgid (keys %{$product_ref->{images}}) {
+          		if ($selected_imgid eq $imgid) {
+            			process_image_unselect($user_id, $code, $selected_imgid);
+          			}
+        		}
 			}
 
 			# Don't delete images to be moved if they weren't moved correctly


### PR DESCRIPTION
Made changes in Config.pm to add my github userid in admins list and then made changes in Images.pm to solve the [issue #9793 ](https://github.com/openfoodfacts/openfoodfacts-server/issues/9793) of automatically unselecting images when source image is deleted.
fix:  First checked if the images that have the "imgid" field equal to the id of the image deleted, then called the process_image_unselect.
