### PR TITLE
fix: remove JS script loaded twice

### DIFF
--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -363,6 +363,4 @@
 
 [% INCLUDE web/common/includes/folksonomy_script.tt.html %]
 
-<script src="[% static_subdomain %]/js/dist/product-history.js"></script>
-
 <!-- end templates/[% template.name %] -->


### PR DESCRIPTION
I made a mistake and loaded the product-history script twice, which caused a JS error.