### PR TITLE
fix: nginx docker access_log location

### DIFF
--- a/conf/nginx-docker/nginx.conf
+++ b/conf/nginx-docker/nginx.conf
@@ -29,7 +29,7 @@ server {
 	# Product Opener needs a root domain + a wildcard for all subdomains
 	server_name ${PRODUCT_OPENER_DOMAIN} *.${PRODUCT_OPENER_DOMAIN};
 
-	access_log /var/log/${productopener_access_file_prefix}access.log;
+	access_log /var/log/nginx/${productopener_access_file_prefix}access.log;
 
 	# static file we serve are in html/
 	root /opt/product-opener/html/;


### PR DESCRIPTION
The docker nginx log file was in to /var/log/ instead of /var/log/nginx but I'm still getting a Permission denied.
Strangely nginx seems to be able to write to error_log but not access_log...

```
root@36323da821cb:/var/log/nginx# ls -lrt
total 75196
-rw-r--r-- 1 www-data www-data 45164097 Mar  7 08:10 access.log
-rw-r--r-- 1 www-data www-data 31825385 Mar 14 08:49 error.log
root@36323da821cb:/var/log/nginx# tail -n 1 error.log 
2024/03/14 08:49:11 [crit] 38#38: *5 open() "/var/log/nginx/access.log" failed (13: Permission denied) while logging request, client: 172.23.0.1, server: openfoodfacts.localhost, request: "GET /api/v0/preferences HTTP/1.1", upstream: "http://172.23.0.8:80/cgi/display.pl?/api/v0/preferences", host: "fr.openfoodfacts.localhost", referrer: "http://fr.openfoodfacts.localhost/"
```
