### PR TITLE
fix: nginx config changes for prod

### DIFF
--- a/conf/nginx/conf.d/expires-no-json-xml.conf
+++ b/conf/nginx/conf.d/expires-no-json-xml.conf
@@ -1,0 +1,1 @@
+../snippets/expires-no-json-xml.conf

--- a/conf/nginx/sites-available/howmuchsugar
+++ b/conf/nginx/sites-available/howmuchsugar
@@ -36,19 +36,19 @@ server {
 	index index.html index.htm index.nginx-debian.html;
 
 	location ~* \.(eot|ttf|woff|woff2)$ {
-		include /etc/nginx/snippets/expiry-headers.conf;
+		include snippets/expiry-headers.include;
 		add_header Access-Control-Allow-Origin *;
 	}
 
 	location ~ ^/(favicon.ico) {
-		include /etc/nginx/snippets/expiry-headers.conf;
+		include snippets/expiry-headers.include;
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $howmuchsugar_name-favicon.ico =404;
 	}
 
 	location ~ ^/(.well-known|images|js|rss|data|files|resources|foundation)/ {
-		include /etc/nginx/snippets/expiry-headers.conf;
+		include snippets/expiry-headers.include;
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;
@@ -59,13 +59,13 @@ server {
 	}
 
 	location ~ ^/$ {
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 		try_files $uri /$howmuchsugar_name.html;
 	}
 
 	# redirect to .html files
 	location / {
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 		try_files $uri $uri.html =404;
 	}
 

--- a/conf/nginx/sites-available/howmuchsugar
+++ b/conf/nginx/sites-available/howmuchsugar
@@ -11,7 +11,7 @@ map $howmuchsugar_name $howmuchsugar_lang {
 	combiendesucres fr;
 }
 
-include /etc/nginx/snippets/expires-no-json-xml.conf;
+# variables definitions for expiry headers are loaded from /etc/nginx/conf.d/expires-no-json-xml.conf
 
 log_format proxied_requests2
   '$http_x_forwarded_for - $remote_user [$time_local] '

--- a/conf/nginx/sites-available/madenearme
+++ b/conf/nginx/sites-available/madenearme
@@ -28,19 +28,19 @@ server {
 
 	location ~* \.(eot|ttf|woff|woff2)$ {
 		add_header Access-Control-Allow-Origin *;
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 	}
 
 	location ~ ^/images/products/ {
 		add_header Link "<http://creativecommons.org/licenses/by-sa/3.0/>; rel='license'; title='CC-BY-SA 3.0'";
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 	}
 
 	location ~ ^/(favicon.ico) {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri /images/misc/$madenearme_name.16x16.png;
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 	}
 
 
@@ -48,7 +48,7 @@ server {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 	}
 
 	location = /robots.txt {
@@ -57,7 +57,7 @@ server {
 
 	location / {
 		try_files $uri /data/$madenearme_name.html;
-		include /etc/nginx/snippets/expires-no-json-xml.conf;
+		include snippets/expiry-headers.include;
 	}
 
 }

--- a/conf/nginx/sites-available/madenearme
+++ b/conf/nginx/sites-available/madenearme
@@ -7,7 +7,7 @@ map $host $madenearme_name {
 
 }
 
-include /etc/nginx/snippets/expires-no-json-xml.conf;
+# variables definitions for expiry headers are loaded from /etc/nginx/conf.d/expires-no-json-xml.conf
 
 server {
 	listen 80;

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -30,9 +30,10 @@ server {
 	client_body_timeout 120s;
 	client_header_timeout 120s;
 
-	# logs location
-	access_log /var/log/nginx/off-access.log proxied_requests buffer=256K flush=1s;
-	error_log /var/log/nginx/off-error.log;
+	# logs location: default is static-off, will be changed to proxy-off
+	# for requests passed to Apache
+	access_log /var/log/nginx/static-off-access.log proxied_requests buffer=256K flush=1s;
+	error_log /var/log/nginx/static-off-error.log;
 
 	# some redirection for specific subdomains
 	include snippets/off.domain-redirects.include;
@@ -128,6 +129,8 @@ server {
 		# recursive hosts as we are proxying behind a proxy
 		set_real_ip_from 10.0.0.0/8;
 		real_ip_recursive on;
+	        access_log /var/log/nginx/proxy-off-access.log proxied_requests buffer=256K flush=1s;
+	        error_log /var/log/nginx/proxy-off-error.log;
 
 		proxy_pass http://127.0.0.1:8004/cgi/display.pl?;
 	}
@@ -137,6 +140,8 @@ server {
 		# recursive hosts as we are proxying behind a proxy
 		set_real_ip_from 10.0.0.0/8;
 		real_ip_recursive on;
+	        access_log /var/log/nginx/proxy-off-access.log proxied_requests buffer=256K flush=1s;
+	        error_log /var/log/nginx/proxy-off-error.log;
 
 		proxy_pass http://127.0.0.1:8004;
 	}

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -13,9 +13,7 @@ server {
 	}
 }
 
-# variables definitions for expiry headers
-include /etc/nginx/snippets/expires-no-json-xml.conf;
-
+# variables definitions for expiry headers are loaded from /etc/nginx/conf.d/expires-no-json-xml.conf
 
 server {
 

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -33,7 +33,7 @@ server {
 	client_header_timeout 120s;
 
 	# logs location
-	access_log /var/log/nginx/${productopener_access_file_prefix}off-access.log proxied_requests buffer=256K flush=1s;
+	access_log /var/log/nginx/off-access.log proxied_requests buffer=256K flush=1s;
 	error_log /var/log/nginx/off-error.log;
 
 	# some redirection for specific subdomains
@@ -116,7 +116,6 @@ server {
 	location = /.well-known/assetlinks.json {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
-		expires 1d;
 		try_files $uri =404;
 	}
 

--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -44,14 +44,6 @@ server {
 
 	index index.html index.htm index.nginx-debian.html;
 
-	location /data/ {
-        include snippets/off.cors-headers.include;
-		include snippets/expiry-headers.include;
-		# First attempt to serve request as file, then
-		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
-	}
-
 	location ~ ^/images/products/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
@@ -71,12 +63,6 @@ server {
 	try_files /1.json = 404;
 	}
 
-	location ~ ^/(favicon.ico) {
-		# First attempt to serve request as file, then
-		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
-	}
-
 	# Static files are served directly by NGINX
 
 	location ~ ^/(favicon.ico) {
@@ -86,7 +72,7 @@ server {
 	}
 
 	# Static files are served directly by NGINX
-	location ~ ^/(.well-known|files)/ {
+	location ~ ^/(.well-known|files|data|exports|dump)/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
 		# First attempt to serve request from resource, then as file,
@@ -95,7 +81,7 @@ server {
 		gzip_static always;
 		gunzip on;
 	}
-	location ~ ^/(images|fonts|css|js|rss|foundation|bower_components)/ {
+	location ~ ^/(images|fonts|css|js|donate|resources)/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
 		# First attempt to serve request as file, off_web_html acting as an override,

--- a/conf/nginx/sites-available/off-pro
+++ b/conf/nginx/sites-available/off-pro
@@ -47,14 +47,6 @@ server {
 
 	index index.html index.htm index.nginx-debian.html;
 
-	location /data/ {
-        include snippets/off.cors-headers.include;
-		include snippets/expiry-headers.include;
-		# First attempt to serve request as file, then
-		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
-	}
-
 	location ~ ^/images/products/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
@@ -71,7 +63,7 @@ server {
 	}
 
 	# Static files are served directly by NGINX
-	location ~ ^/(.well-known|files)/ {
+	location ~ ^/(.well-known|files|data|exports|dump)/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
 		# First attempt to serve request from resource, then as file,
@@ -80,7 +72,7 @@ server {
 		gzip_static always;
 		gunzip on;
 	}
-	location ~ ^/(images|fonts|css|js|rss|foundation|bower_components)/ {
+	location ~ ^/(images|fonts|css|js|donate|resources)/ {
 		include snippets/off.cors-headers.include;
 		include snippets/expiry-headers.include;
 		# First attempt to serve request as file, off_web_html acting as an override,

--- a/conf/nginx/sites-available/off-pro
+++ b/conf/nginx/sites-available/off-pro
@@ -13,7 +13,7 @@ server {
 	}
 }
 
-include /etc/nginx/snippets/expires-no-json-xml.conf;
+# variables definitions for expiry headers are loaded from /etc/nginx/conf.d/expires-no-json-xml.conf
 
 server {
 

--- a/conf/nginx/sites-available/off-pro
+++ b/conf/nginx/sites-available/off-pro
@@ -36,8 +36,10 @@ server {
 	send_timeout                1200;
 
 	# logs location
-	access_log /var/log/nginx/${productopener_access_file_prefix}off-access.log proxied_requests;
-	error_log /var/log/nginx/off-error.log;
+	# logs location: default is static-off, will be changed to proxy-off
+	# for requests passed to Apache
+	access_log /var/log/nginx/static-off-access.log proxied_requests buffer=256K flush=1s;
+	error_log /var/log/nginx/static-off-error.log;
 
 	gzip on;
 	gzip_min_length 1000;
@@ -97,6 +99,8 @@ server {
 		# recursive hosts as we are proxying behind a proxy
 		set_real_ip_from 10.0.0.0/8;
 		real_ip_recursive on;
+		access_log /var/log/nginx/proxy-off-access.log proxied_requests buffer=256K flush=1s;
+	        error_log /var/log/nginx/proxy-off-error.log;
 
 		proxy_pass http://127.0.0.1:8014/cgi/display.pl?;
 	}
@@ -106,6 +110,8 @@ server {
 		# recursive hosts as we are proxying behind a proxy
 		set_real_ip_from 10.0.0.0/8;
 		real_ip_recursive on;
+		access_log /var/log/nginx/proxy-off-access.log proxied_requests buffer=256K flush=1s;
+	        error_log /var/log/nginx/proxy-off-error.log;
 
 		proxy_pass http://127.0.0.1:8014;
 	}

--- a/conf/nginx/snippets/expires-no-json-xml.conf
+++ b/conf/nginx/snippets/expires-no-json-xml.conf
@@ -30,17 +30,6 @@ map $uri $productopener_is_public_cache {
   "~*\.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|ico)$" public;
 }
 
-map $uri $productopener_access_file_prefix {
-	default "";
-	# Media: images, icons, video, audio, HTC
-	"~*\.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$" "static-";
-	# CSS and Javascript
-	"~*\.(?:css|js)$" "static-";
-	# Web Fonts
-	"~*\.(?:ttf|ttc|otf|eot|woff|woff2)$" "static-";
-}
-
-
 # # cache.appcache, your document html and data
 # location ~* \.(?:manifest|appcache|html?)$ {
 #   expires -1;


### PR DESCRIPTION
Notes:

- each site conf had a include /etc/nginx/snippets/expires-no-json-xml.conf which is in fact server wide, it's now moved to the conf.d directory
- the whole conf.d directory is symlinked to the conf.d dir in GitHub (instead of having symlinks for each file in it)

root@off:/etc/nginx# ls -lrt | grep conf.d
drwxr-xr-x 2 root root    3 Aug 17  2023 conf.d.old
lrwxrwxrwx 1 root root   26 Mar 14 15:01 conf.d -> /srv/off/conf/nginx/conf.d

- changed the way we determine which log file to use (static-access-log or proxy-access-log) using location instead of file extensions. This is because we can't use variables in log file names + buffers:

```
-nginx: [emerg] buffered logs cannot have variables in name in /etc/nginx/sites-enabled/off:36
nginx: configuration file /etc/nginx/nginx.conf test failed
access_log /var/log/nginx/${productopener_access_file_prefix}off-access.log proxied_requests buffer=256K flush=1s;
```
