### PR TITLE
fix: Added a description line to the import spreadsheet template

### DIFF
--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -56,9 +56,30 @@ my $workbook = Excel::Writer::XLSX->new(\*STDOUT);
 my $worksheet = $workbook->add_worksheet();
 my %formats = (
 	normal => $workbook->add_format(border => 1, bold => 1),
-	mandatory => $workbook->add_format(border => 1, bold => 1, bg_color => '#0f55cc', color => 'white', valign => 'vcenter', align=>'center'),
-	recommended => $workbook->add_format(border => 1, bold => 1, bg_color => '#1f6ced',color => 'white', valign => 'vcenter', align=>'center'),
-	optional => $workbook->add_format(border => 1, bold => 1, bg_color => '#4d89f1', color => 'white', valign => 'vcenter', align=>'center'),
+	mandatory => $workbook->add_format(
+		border => 1,
+		bold => 1,
+		bg_color => '#0f55cc',
+		color => 'white',
+		valign => 'vcenter',
+		align => 'center'
+	),
+	recommended => $workbook->add_format(
+		border => 1,
+		bold => 1,
+		bg_color => '#1f6ced',
+		color => 'white',
+		valign => 'vcenter',
+		align => 'center'
+	),
+	optional => $workbook->add_format(
+		border => 1,
+		bold => 1,
+		bg_color => '#4d89f1',
+		color => 'white',
+		valign => 'vcenter',
+		align => 'center'
+	),
 	description => $workbook->add_format(italic => 1, text_wrap => 1, valign => 'vcenter'),
 );
 
@@ -76,7 +97,7 @@ my $comment;
 $worksheet->set_row(0, 70);
 $worksheet->set_column('A:ZZ', 30);
 $worksheet->set_column('A:A', 30);
-$worksheet->write( $description_row, 0,  $description , $formats{'description'});
+$worksheet->write($description_row, 0, $description, $formats{'description'});
 
 foreach my $group_ref (@$select2_options_ref) {
 	my $group_start_col = $col;

--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -56,10 +56,10 @@ my $workbook = Excel::Writer::XLSX->new(\*STDOUT);
 my $worksheet = $workbook->add_worksheet();
 my %formats = (
 	normal => $workbook->add_format(border => 1, bold => 1),
-	mandatory => $workbook->add_format(border => 1, bold => 1, bg_color => '#aaffcc'),
-	recommended => $workbook->add_format(border => 1, bold => 1, bg_color => '#ccffdd'),
-	optional => $workbook->add_format(border => 1, bold => 1, bg_color => '#eeffee'),
-	description => $workbook->add_format(italic => 1, text_wrap => 1, align => 'left', align => 'vcenter'),
+	mandatory => $workbook->add_format(border => 1, bold => 1, bg_color => '#0f55cc', color => 'white', valign => 'vcenter', align=>'center'),
+	recommended => $workbook->add_format(border => 1, bold => 1, bg_color => '#1f6ced',color => 'white', valign => 'vcenter', align=>'center'),
+	optional => $workbook->add_format(border => 1, bold => 1, bg_color => '#4d89f1', color => 'white', valign => 'vcenter', align=>'center'),
+	description => $workbook->add_format(italic => 1, text_wrap => 1, valign => 'vcenter'),
 );
 
 # Re-use the structure used to output select2 options in import_file_select_format.pl
@@ -69,11 +69,14 @@ my $headers_row = 0;
 my $description_row = 1;
 my $col = 1;
 
+my $description = lang("description");
 my $field_id;
 my $comment;
 
+$worksheet->set_row(0, 70);
+$worksheet->set_column('A:ZZ', 30);
 $worksheet->set_column('A:A', 30);
-$worksheet->write( $description_row, 0, "Description", $formats{'description'});
+$worksheet->write( $description_row, 0,  $description , $formats{'description'});
 
 foreach my $group_ref (@$select2_options_ref) {
 	my $group_start_col = $col;

--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -69,8 +69,6 @@ my $headers_row = 0;
 my $description_row = 1;
 my $col = 0;
 
-my $comment;
-my $field_id;
 
 $worksheet->set_column('A:A', 30);
 $worksheet->write( $description_row, 0, "Description", $formats{'description'});

--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -59,7 +59,7 @@ my %formats = (
 	mandatory => $workbook->add_format(border => 1, bold => 1, bg_color => '#aaffcc'),
 	recommended => $workbook->add_format(border => 1, bold => 1, bg_color => '#ccffdd'),
 	optional => $workbook->add_format(border => 1, bold => 1, bg_color => '#eeffee'),
-	description => workbook->add_format(italic => 1, text_wrap => 1, align => 'left', align => 'vcenter'),
+	description => $workbook->add_format(italic => 1, text_wrap => 1, align => 'left', align => 'vcenter'),
 );
 
 # Re-use the structure used to output select2 options in import_file_select_format.pl
@@ -67,8 +67,10 @@ my $select2_options_ref = generate_import_export_columns_groups_for_select2([$lc
 
 my $headers_row = 0;
 my $description_row = 1;
-my $col = 0;
+my $col = 1;
 
+my $field_id;
+my $comment;
 
 $worksheet->set_column('A:A', 30);
 $worksheet->write( $description_row, 0, "Description", $formats{'description'});
@@ -190,7 +192,7 @@ foreach my $group_ref (@$select2_options_ref) {
 		$worksheet->set_column($col, $col, $width);
 
 		if ($comment ne "") {
-			$worksheet->write_comment($description_row, $col, $comment, $formats{'description'});
+			$worksheet->write($description_row, $col, $comment, $formats{'description'});
 		}
 
 		$col++;

--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -59,13 +59,21 @@ my %formats = (
 	mandatory => $workbook->add_format(border => 1, bold => 1, bg_color => '#aaffcc'),
 	recommended => $workbook->add_format(border => 1, bold => 1, bg_color => '#ccffdd'),
 	optional => $workbook->add_format(border => 1, bold => 1, bg_color => '#eeffee'),
+	description => workbook->add_format(italic => 1, text_wrap => 1, align => 'left', align => 'vcenter'),
 );
 
 # Re-use the structure used to output select2 options in import_file_select_format.pl
 my $select2_options_ref = generate_import_export_columns_groups_for_select2([$lc]);
 
 my $headers_row = 0;
+my $description_row = 1;
 my $col = 0;
+
+my $comment;
+my $field_id;
+
+$worksheet->set_column('A:A', 30);
+$worksheet->write( $description_row, 0, "Description", $formats{'description'});
 
 foreach my $group_ref (@$select2_options_ref) {
 	my $group_start_col = $col;
@@ -184,7 +192,7 @@ foreach my $group_ref (@$select2_options_ref) {
 		$worksheet->set_column($col, $col, $width);
 
 		if ($comment ne "") {
-			$worksheet->write_comment($headers_row, $col, $comment);
+			$worksheet->write_comment($description_row, $col, $comment, $formats{'description'});
 		}
 
 		$col++;

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6845,3 +6845,7 @@ msgstr ""
 msgctxt "sweetener"
 msgid "sweetener"
 msgstr ""
+
+msgctxt "description"
+msgid "Description"
+msgstr "Description"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6864,3 +6864,7 @@ msgstr "sweeteners"
 msgctxt "sweetener"
 msgid "sweetener"
 msgstr "sweetener"
+
+msgctxt "description"
+msgid "Description"
+msgstr "Description"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -490,7 +490,7 @@ msgid "This will delete your user details and anonymise all of your contribution
 msgstr "Esto eliminará sus datos de usuario y anonimizará todas sus contribuciones. Vuelva a ingresar su nombre de usuario para confirmar."
 
 msgctxt "description"
-msgid "Descripton"
+msgid "Description"
 msgstr "Descripción"
 
 msgctxt "danger_zone"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -489,6 +489,10 @@ msgctxt "delete_confirmation"
 msgid "This will delete your user details and anonymise all of your contributions. Please re-enter your user name to confirm."
 msgstr "Esto eliminará sus datos de usuario y anonimizará todas sus contribuciones. Vuelva a ingresar su nombre de usuario para confirmar."
 
+msgctxt "description"
+msgid "Descripton"
+msgstr "Descripción"
+
 msgctxt "danger_zone"
 msgid "Danger Zone"
 msgstr "Zona peligrosa"


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->
I added a description row to the import spreadsheet template, which now includes all the comments previously located in the header line.

### Screenshot
<img width="1419" alt="Screenshot 2024-03-15 at 01 36 53" src="https://github.com/openfoodfacts/openfoodfacts-server/assets/24766978/40093f70-f63d-47f3-80ec-2f1ace044c28">



### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Added a new column on the right to accommodate the Description and Example rows
- Added some width to the Description cell 
- Changed the code that wrote the comments in the header row to write them in the description row 
- Fixes #9879 

