### PR TITLE
fix: separate taxonomy src and builds

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -35,6 +35,7 @@ BEGIN {
 		$conf_root
 		$data_root
 		$www_root
+		$src_root
 		$sftp_root
 		$geolite2_path
 		$reference_timezone
@@ -97,6 +98,9 @@ BEGIN {
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
 use vars @EXPORT_OK;    # no 'my' keyword for these
+
+use Cwd qw/abs_path cwd/;
+use File::Basename qw/dirname/;
 
 use ProductOpener::Config2;
 
@@ -383,6 +387,8 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 # server paths
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
+$src_root = $ProductOpener::Config2::src_root // abs_path(dirname(__FILE__) . '../..');
+$src_root = cwd() . $src_root unless $src_root =~ m|^/|;
 $conf_root = $ProductOpener::Config2::conf_root;
 $sftp_root = $ProductOpener::Config2::sftp_root;    # might be undef
 

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -35,7 +35,6 @@ BEGIN {
 		$conf_root
 		$data_root
 		$www_root
-		$src_root
 		$sftp_root
 		$geolite2_path
 		$reference_timezone
@@ -98,9 +97,6 @@ BEGIN {
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
 use vars @EXPORT_OK;    # no 'my' keyword for these
-
-use Cwd qw/abs_path cwd/;
-use File::Basename qw/dirname/;
 
 use ProductOpener::Config2;
 
@@ -387,8 +383,6 @@ $memd_servers = $ProductOpener::Config2::memd_servers;
 # server paths
 $www_root = $ProductOpener::Config2::www_root;
 $data_root = $ProductOpener::Config2::data_root;
-$src_root = $ProductOpener::Config2::src_root // abs_path(dirname(__FILE__) . '../..');
-$src_root = cwd() . $src_root unless $src_root =~ m|^/|;
 $conf_root = $ProductOpener::Config2::conf_root;
 $sftp_root = $ProductOpener::Config2::sftp_root;    # might be undef
 

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -2470,10 +2470,10 @@ sub create_nutrients_level_taxonomy() {
 		}
 	}
 
-	print STDERR "generate $data_root/taxonomies/nutrient_levels.txt \n";
+	print STDERR "generate $BASE_DIRS{CACHE_BUILD}/taxonomies-result/nutrient_levels.txt \n";
 
-	open(my $OUT, ">:encoding(UTF-8)", "$data_root/taxonomies/nutrient_levels.txt")
-		or die("Can't write $data_root/taxonomies/nutrient_levels.txt: $!");
+	open(my $OUT, ">:encoding(UTF-8)", "$BASE_DIRS{CACHE_BUILD}/taxonomies-result/nutrient_levels.txt")
+		or die("Can't write $BASE_DIRS{CACHE_BUILD}/taxonomies-result/nutrient_levels.txt: $!");
 	print $OUT <<TXT
 # nutrient levels taxonomy generated automatically by Food.pm from nutrients taxonomy + language translations (.po files)
 

--- a/lib/ProductOpener/Paths.pm
+++ b/lib/ProductOpener/Paths.pm
@@ -55,6 +55,7 @@ use vars @EXPORT_OK;
 
 use ProductOpener::Config qw/:all/;
 
+
 =head1 VARIABLES
 
 =cut
@@ -93,7 +94,7 @@ $BASE_DIRS{PRODUCTS} = "$data_root/products";
 Directory containing txt taxonomies
 =cut
 
-$BASE_DIRS{TAXONOMIES_SRC} = "$src_root/taxonomies";
+$BASE_DIRS{TAXONOMIES_SRC} = _source_dir() . "/taxonomies";
 
 =head2 $BASE_DIRS{PRIVATE_DATA}
 Directory for private data
@@ -248,6 +249,15 @@ String of path to base directory containing products images
 sub products_images_dir ($server_name) {
 	my $server_www_root = $options{other_servers}{$server_name}{www_root};
 	return "$server_www_root/images/products";
+}
+
+sub _source_dir() {
+	# comput src_root
+	my $src_root = abs_path(dirname(__FILE__) . '../..');
+	unless ($src_root =~ m|^/|) {
+		$src_root = cwd() . $src_root;
+	}
+	return $src_root;
 }
 
 =head2 get_file_for_taxonomy( $tagtype )

--- a/lib/ProductOpener/Paths.pm
+++ b/lib/ProductOpener/Paths.pm
@@ -53,8 +53,10 @@ BEGIN {
 
 use vars @EXPORT_OK;
 
-use ProductOpener::Config qw/:all/;
+use Cwd qw/abs_path cwd/;
+use File::Basename qw/dirname/;
 
+use ProductOpener::Config qw/:all/;
 
 =head1 VARIABLES
 

--- a/lib/ProductOpener/Paths.pm
+++ b/lib/ProductOpener/Paths.pm
@@ -40,6 +40,8 @@ BEGIN {
 	@EXPORT_OK = qw(
 		%BASE_DIRS
 
+		&get_path_for_taxonomy
+		&get_file_for_taxonomy
 		&base_paths
 		&base_paths_loading_script
 		&check_missing_dirs
@@ -86,6 +88,12 @@ Directory containing sto of products
 =cut
 
 $BASE_DIRS{PRODUCTS} = "$data_root/products";
+
+=head2 $BASE_DIRS{TAXONOMIES_SRC}
+Directory containing txt taxonomies
+=cut
+
+$BASE_DIRS{TAXONOMIES_SRC} = "$src_root/taxonomies";
 
 =head2 $BASE_DIRS{PRIVATE_DATA}
 Directory for private data
@@ -240,6 +248,49 @@ String of path to base directory containing products images
 sub products_images_dir ($server_name) {
 	my $server_www_root = $options{other_servers}{$server_name}{www_root};
 	return "$server_www_root/images/products";
+}
+
+=head2 get_file_for_taxonomy( $tagtype )
+
+Taxonomy .txt source files are stored in the /taxonomies directory.
+
+Some Product Opener flavors (Open Food Facts, Open Beauty Facts etc.) can have different taxonomies for the same tag type.
+e.g. OFF and OBF can have different taxonomies for categories and ingredients.
+
+Other categories like countries and languages are common to all flavors.
+
+Taxonomies specific to a flavor are stored in /taxonomies/[product type]
+
+e.g. OFF ingredients are in /taxonomies/food/ingredients.txt and OBF ingredients are in /taxonomies/beauty/ingredients.txt
+
+=cut
+
+sub get_file_for_taxonomy ($tagtype, $product_type) {
+
+	my $file = $tagtype . '.txt';
+	# If the flavor has a specific product type, first check if we have a source file for this product type
+	if ((defined $product_type) and (-e "$BASE_DIRS{TAXONOMIES_SRC}/$product_type/$tagtype.txt")) {
+		$file = "$product_type/$tagtype.txt";
+	}
+
+	return $file;
+}
+
+=head2 get_path_for_taxonomy( $tagtype, $product_type )
+full path for taxonomy file
+=cut
+
+sub get_path_for_taxonomy($tagtype, $product_type) {
+	# The source file can be prefixed by the product type
+	my $source_file = get_file_for_taxonomy($tagtype, $product_type);
+	# handle special cases
+	if ($tagtype eq "nutrient_levels") {
+		# this is a built taxonomy
+		return "$BASE_DIRS{CACHE_BUILD}/taxonomies-result/$source_file";
+	}
+	else {
+		return "$BASE_DIRS{TAXONOMIES_SRC}/$source_file";
+	}
 }
 
 =head2 base_paths()

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1046,7 +1046,7 @@ sub get_file_from_cache ($source, $target) {
 sub get_from_cache ($tagtype, @files) {
 	# If the full set of cached files can't be found then returns the hash to be used
 	# when saving the new cached files.
-	my $tag_data_root = "$data_root/taxonomies/$tagtype";
+	my $tag_data_root = "$BASE_DIRS{CACHE_BUILD}/taxonomies-result/$tagtype";
 	my $tag_www_root = "$BASE_DIRS{PUBLIC_DATA}/taxonomies/$tagtype";
 
 	my $sha1 = Digest::SHA1->new;
@@ -1060,9 +1060,9 @@ sub get_from_cache ($tagtype, @files) {
 
 	foreach my $source_file (@files) {
 		# The source file can be prefixed by the product type
-		$source_file = get_file_for_taxonomy($source_file, $options{product_type});
-		open(my $IN, "<", "$data_root/taxonomies/$source_file")
-			or die("Cannot open $data_root/taxonomies/$source_file : $!\n");
+		my $source_path = get_path_for_taxonomy($source_file, $options{product_type});
+		open(my $IN, "<", $source_path)
+			or die("Cannot open $source_path : src=$src_root path=$BASE_DIRS{TAXONOMIES_SRC} $!\n");
 
 		binmode($IN);
 		$sha1->addfile($IN);
@@ -1124,7 +1124,7 @@ sub put_file_to_cache ($source, $target) {
 }
 
 sub put_to_cache ($tagtype, $cache_prefix) {
-	my $tag_data_root = "$data_root/taxonomies/$tagtype";
+	my $tag_data_root = "$BASE_DIRS{CACHE_BUILD}/taxonomies-result//$tagtype";
 	my $tag_www_root = "$BASE_DIRS{PUBLIC_DATA}/taxonomies/$tagtype";
 
 	put_file_to_cache("$tag_www_root.json", "$cache_prefix.json");
@@ -1133,32 +1133,6 @@ sub put_to_cache ($tagtype, $cache_prefix) {
 	put_file_to_cache("$tag_data_root.result.sto", "$cache_prefix.result.sto");
 
 	return;
-}
-
-=head2 get_file_for_taxonomy( $tagtype )
-
-Taxonomy .txt source files are stored in the /taxonomies directory.
-
-Some Product Opener flavors (Open Food Facts, Open Beauty Facts etc.) can have different taxonomies for the same tag type.
-e.g. OFF and OBF can have different taxonomies for categories and ingredients.
-
-Other categories like countries and languages are common to all flavors.
-
-Taxonomies specific to a flavor are stored in /taxonomies/[product type]
-
-e.g. OFF ingredients are in /taxonomies/food/ingredients.txt and OBF ingredients are in /taxonomies/beauty/ingredients.txt
-
-=cut
-
-sub get_file_for_taxonomy ($tagtype, $product_type) {
-
-	my $file = $tagtype . '.txt';
-	# If the flavor has a specific product type, first check if we have a source file for this product type
-	if ((defined $product_type) and (-e "$data_root/taxonomies/$product_type/$tagtype.txt")) {
-		$file = "$product_type/$tagtype.txt";
-	}
-
-	return $file;
 }
 
 =head2 build_tags_taxonomy( $tagtype, $file, $publish )
@@ -1183,6 +1157,8 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 	binmode STDERR, ":encoding(UTF-8)";
 	binmode STDIN, ":encoding(UTF-8)";
 	binmode STDOUT, ":encoding(UTF-8)";
+
+	my $result_dir = "$BASE_DIRS{CACHE_BUILD}/taxonomies-result/";
 
 	my @files = ($tagtype);
 
@@ -1218,16 +1194,19 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 	# Concatenate taxonomy files if needed
 	my $file = get_file_for_taxonomy($tagtype, $options{product_type});
+	my $file_path = get_path_for_taxonomy($tagtype, $options{product_type});
 	if ((scalar @files) > 1) {
 		$file = "$tagtype.all.txt";
+		$file_path = "$result_dir/$file";
 
-		open(my $OUT, ">:encoding(UTF-8)", "$data_root/taxonomies/$file")
-			or die("Cannot write $data_root/taxonomies/$file : $!\n");
+		open(my $OUT, ">:encoding(UTF-8)", $file_path)
+			or die("Cannot write $file_path : $!\n");
 
 		foreach my $taxonomy (@files) {
 			my $taxonomy_file = get_file_for_taxonomy($taxonomy, $options{product_type});
-			open(my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/$taxonomy_file")
-				or die("Missing $data_root/taxonomies/$taxonomy_file\n");
+			my $taxonomy_path = get_path_for_taxonomy($taxonomy, $options{product_type});
+			open(my $IN, "<:encoding(UTF-8)", $taxonomy_path)
+				or die("Missing $taxonomy_path\n");
 
 			print $OUT "# $taxonomy_file\n\n";
 
@@ -1304,7 +1283,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 	my $errors = '';
 
-	if (open(my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/$file")) {
+	if (open(my $IN, "<:encoding(UTF-8)", $file_path)) {
 
 		# Main name of a tag in a specific language (display form) - e.g. "Café au lait"
 		my $lc_tag;
@@ -1368,7 +1347,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 				# Make sure we don't have empty entries
 				if ($line eq "") {
-					die("Empty entry at line $line_number in $data_root/taxonomies/$file\n");
+					die("Empty entry at line $line_number in $file_path\n");
 				}
 				# split on comma
 				my @tags = split(/\s*,\s*/, $line);
@@ -1754,7 +1733,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		# > Nectars de goyave, nectar de goyave, nectar goyave
 		# > Nectars d'abricot, nectar d'abricot, nectars d'abricots, nectar
 
-		open(my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/$file") or die;
+		open(my $IN, "<:encoding(UTF-8)", $file_path) or die;
 
 		# print STDERR "Tags.pm - load_tags_taxonomy - tagtype: $tagtype - phase 3, computing hierarchy\n";
 
@@ -1882,10 +1861,12 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 		# allow a second file for wikipedia abstracts -> too big, so don't include it in the main file
 		# only process properties
+		my $properties_path = $file_path;
+		$properties_path =~ s/\.txt^/.properties.txt/;
 
-		if (-e "$data_root/taxonomies/${tagtype}.properties.txt") {
+		if (-e $properties_path) {
 
-			open(my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/${tagtype}.properties.txt");
+			open(my $IN, "<:encoding(UTF-8)", $properties_path);
 
 			# print STDERR "Tags.pm - load_tags_taxonomy - tagtype: $tagtype - phase 3, computing hierarchy\n";
 
@@ -2021,7 +2002,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 			$sort_key_parents{$tagid} = $key;
 		}
 
-		open(my $OUT, ">:encoding(UTF-8)", "$data_root/taxonomies/$tagtype.result.txt");
+		open(my $OUT, ">:encoding(UTF-8)", "$result_dir/$tagtype.result.txt");
 
 		print $OUT
 			"# The [taxonomy name].results.txt files are generated by build_tags_taxonomy.pl.\n# Do not edit this file manually. Edit instead the [taxonomy name].txt source.\n\n";
@@ -2207,7 +2188,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		};
 
 		if ($publish) {
-			store("$data_root/taxonomies/$tagtype.result.sto", $taxonomy_ref);
+			store("$result_dir/$tagtype.result.sto", $taxonomy_ref);
 			put_to_cache($tagtype, $cache_prefix);
 		}
 	}
@@ -2472,6 +2453,8 @@ sub retrieve_tags_taxonomy ($tagtype) {
 	$taxonomy_fields{$tagtype} = $tagtype;
 	$tags_fields{$tagtype} = 1;
 
+	my $result_dir = "$BASE_DIRS{CACHE_BUILD}/taxonomies-result/";
+
 	my $file = $tagtype;
 	if ($tagtype eq "traces") {
 		$file = "allergens";
@@ -2482,21 +2465,21 @@ sub retrieve_tags_taxonomy ($tagtype) {
 
 	# Check if we have a taxonomy for the previous or the next version
 	if ($tagtype !~ /_(next|prev)/) {
-		if (-e "$data_root/taxonomies/${file}_prev.result.sto") {
+		if (-e "$result_dir/${file}_prev.result.sto") {
 			retrieve_tags_taxonomy("${tagtype}_prev");
 		}
-		if (-e "$data_root/taxonomies/${file}_next.result.sto") {
+		if (-e "$result_dir/${file}_next.result.sto") {
 			retrieve_tags_taxonomy("${tagtype}_next");
 		}
 	}
 
 	# Build taxonomies on the fly
-	if (!-e "$data_root/taxonomies/$file.result.sto") {
+	if (!-e "$result_dir/$file.result.sto") {
 		print("Building $file on the fly\n");
 		# Nutrients levels taxonomy is generated from the nutrients taxonomy + language translations in Food.pm
 		# nutrient_levels.txt is not checked in the taxonomy directory and will be generated by build_lang.pl
-		# To avoid circular dependencies, we don't build it on the fly when Tags.pm is loaded.
-		if (($tagtype eq "nutrient_levels") and (!-e "$data_root/taxonomies/$file.txt")) {
+		# To avoid circular dependencies, we don't build it on the fly when Tags.pm is loaded.
+		if (($tagtype eq "nutrient_levels") and (!-e get_path_for_taxonomy($tagtype, $options{product_type}))) {
 			print("Skipping nutrient_levels.txt as it is has not been generated by build_lang.pl yet\n");
 			return;
 		}
@@ -2505,8 +2488,8 @@ sub retrieve_tags_taxonomy ($tagtype) {
 		}
 	}
 
-	my $taxonomy_ref = retrieve("$data_root/taxonomies/$file.result.sto")
-		or die("Could not load taxonomy: $data_root/taxonomies/$file.result.sto");
+	my $taxonomy_ref = retrieve("$result_dir/$file.result.sto")
+		or die("Could not load taxonomy: $result_dir/$file.result.sto");
 	if (defined $taxonomy_ref) {
 
 		$loaded_taxonomies{$tagtype} = 1;
@@ -2530,7 +2513,7 @@ sub retrieve_tags_taxonomy ($tagtype) {
 	}
 
 	$special_tags{$tagtype} = [];
-	if (open(my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/special_$file.txt")) {
+	if (open(my $IN, "<:encoding(UTF-8)", "$BASE_DIRS{TAXONOMIES_SRC}/special_$file.txt")) {
 
 		while (<$IN>) {
 
@@ -2604,6 +2587,7 @@ else {
 }
 
 # It would be nice to move this from BEGIN to INIT, as it's slow, but other BEGIN code depends on it.
+ensure_dir_created_or_die("$BASE_DIRS{CACHE_BUILD}/taxonomies-result");
 foreach my $taxonomyid (@ProductOpener::Config::taxonomy_fields) {
 	$log->info("loading taxonomy $taxonomyid");
 	retrieve_tags_taxonomy($taxonomyid);
@@ -4801,7 +4785,9 @@ sub add_users_translations_to_taxonomy ($tagtype) {
 
 	load_users_translations($users_translations_ref, $tagtype);
 
-	if (open(my $IN, "<:encoding(UTF-8)", "$data_root/taxonomies/$tagtype.txt")) {
+	my $file_path = get_path_for_taxonomy($tagtype, $options{product_type});
+
+	if (open(my $IN, "<:encoding(UTF-8)", $file_path)) {
 
 		binmode(STDIN, ":encoding(UTF-8)");
 		binmode(STDOUT, ":encoding(UTF-8)");

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1062,7 +1062,7 @@ sub get_from_cache ($tagtype, @files) {
 		# The source file can be prefixed by the product type
 		my $source_path = get_path_for_taxonomy($source_file, $options{product_type});
 		open(my $IN, "<", $source_path)
-			or die("Cannot open $source_path : src=$src_root path=$BASE_DIRS{TAXONOMIES_SRC} $!\n");
+			or die("Cannot open $source_path: $!\n");
 
 		binmode($IN);
 		$sha1->addfile($IN);

--- a/scripts/build_countries_taxonomy_from_wikidata.pl
+++ b/scripts/build_countries_taxonomy_from_wikidata.pl
@@ -26,6 +26,7 @@ use Modern::Perl '2017';
 use utf8;
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Store qw/:all/;
 use ProductOpener::Index qw/:all/;
 
@@ -158,7 +159,7 @@ foreach my $language (keys %languages) {
 	}
 }
 
-open(my $OUT, ">:encoding(UTF-8)", "$data_root/taxonomies/countries.txt.temp");
+open(my $OUT, ">:encoding(UTF-8)", "$BASE_DIRS{TAXONOMIES_SRC}/countries.txt.temp");
 
 # loop through countries
 foreach my $qc (sort {$names{$a} cmp $names{$b}} keys %names) {

--- a/scripts/build_languages_taxonomy_from_wikidata.pl
+++ b/scripts/build_languages_taxonomy_from_wikidata.pl
@@ -26,6 +26,7 @@ use Modern::Perl '2017';
 use utf8;
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Store qw/:all/;
 use ProductOpener::Index qw/:all/;
 
@@ -294,7 +295,7 @@ foreach my $qc (@languages) {
 	}
 }
 
-open(my $OUT, ">:encoding(UTF-8)", "$data_root/taxonomies/languages.txt.temp");
+open(my $OUT, ">:encoding(UTF-8)", "$BASE_DIRS{TAXONOMIES_SRC}/languages.txt.temp");
 
 foreach my $qc (sort {$names{$a} cmp $names{$b}} keys %names) {
 

--- a/scripts/obsolete/add_efsa_evaluations_to_additives_taxonomy.pl
+++ b/scripts/obsolete/add_efsa_evaluations_to_additives_taxonomy.pl
@@ -24,11 +24,12 @@ use Modern::Perl '2017';
 use utf8;
 
 use ProductOpener::Store qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Config qw/:all/;
 
 # tmx files contain translations from the EU laws
 
-my $classes_file = "$data_root/taxonomies/off/additives/additives.classes.txt";
+my $classes_file = "$BASE_DIRS{TAXONOMIES_SRC}/old/off/additives/additives.classes.txt";
 
 open(my $IN, "<:encoding(UTF-8)", $classes_file) or die("Could not open $classes_file: $!");
 
@@ -56,7 +57,7 @@ while (<$IN>) {
 
 #exit;
 
-my $csv_file = "$data_root/taxonomies/off/additives/additives.openfoodtoxtx22051_opinion.csv";
+my $csv_file = "$BASE_DIRS{TAXONOMIES_SRC}/old/off/additives/additives.openfoodtoxtx22051_opinion.csv";
 
 use Text::CSV;
 

--- a/scripts/obsolete/create_wikipedia_properties_for_taxonomy.pl
+++ b/scripts/obsolete/create_wikipedia_properties_for_taxonomy.pl
@@ -24,11 +24,12 @@ use Modern::Perl '2017';
 use utf8;
 
 use ProductOpener::Store qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Config qw/:all/;
 
 # tmx files contain translations from the EU laws
 
-my $wikipedia_file = "$data_root/taxonomies/off/additives/additives.wikipedia.txt";
+my $wikipedia_file = "$BASE_DIRS{TAXONOMIES_SRC}/old/off/additives/additives.wikipedia.txt";
 
 open(my $IN, "<:encoding(UTF-8)", $wikipedia_file) or die("Could not open $wikipedia_file: $!");
 

--- a/scripts/taxonomies/generators/add_descriptions_to_taxonomy_from_eu_translations.pl
+++ b/scripts/taxonomies/generators/add_descriptions_to_taxonomy_from_eu_translations.pl
@@ -24,11 +24,12 @@ use Modern::Perl '2017';
 use utf8;
 
 use ProductOpener::Store qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Config qw/:all/;
 
 # tmx files contain translations from the EU laws
 
-my @tmx_files = ("$data_root/taxonomies/off/additives_classes/32008R1333.tmx");
+my @tmx_files = ("$BASE_DIRS{TAXONOMIES_SRC}/old/off/additives_classes/32008R1333.tmx");
 
 my %translations = ();
 

--- a/scripts/taxonomies/generators/gen_obf_inci_functions_taxonomy_from_cosing.pl
+++ b/scripts/taxonomies/generators/gen_obf_inci_functions_taxonomy_from_cosing.pl
@@ -26,6 +26,7 @@ use utf8;
 use CGI::Carp qw(fatalsToBrowser);
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Store qw/:all/;
 
 use URI::Escape::XS;
@@ -133,7 +134,7 @@ my %functions = (
 my %translations = ();
 my %english = ();
 
-if (open(my $IN, "<:encoding(UTF-16)", "$data_root/taxonomies-obf/32006D0257.tmx.txt")) {
+if (open(my $IN, "<:encoding(UTF-16)", "$BASE_DIRS{TAXONOMIES_SRC}/old/obf/32006D0257.tmx.txt")) {
 
 	my $english;
 
@@ -174,7 +175,7 @@ if (open(my $IN, "<:encoding(UTF-16)", "$data_root/taxonomies-obf/32006D0257.tmx
 	close $IN;
 }
 else {
-	print STDERR "Could not open $data_root/taxonomies-obf/32006D0257.tmx.txt\n";
+	print STDERR "Could not open $BASE_DIRS{TAXONOMIES_SRC}/old/obf/32006D0257.tmx.txt\n";
 	exit;
 }
 

--- a/scripts/taxonomies/generators/gen_obf_ingredients_taxonomy_from_cosing.pl
+++ b/scripts/taxonomies/generators/gen_obf_ingredients_taxonomy_from_cosing.pl
@@ -26,6 +26,7 @@ use utf8;
 use CGI::Carp qw(fatalsToBrowser);
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Store qw/:all/;
 
 use URI::Escape::XS;
@@ -42,7 +43,7 @@ binmode(STDOUT, ":encoding(UTF-8)");
 
 my %translations = ();
 
-if (open(my $IN, "<:encoding(UTF-16)", "$data_root/taxonomies-obf/32006D0257.tmx.txt")) {
+if (open(my $IN, "<:encoding(UTF-16)", "$BASE_DIRS{TAXONOMIES_SRC}/old/obf/32006D0257.tmx.txt")) {
 
 	my $english;
 
@@ -78,11 +79,11 @@ if (open(my $IN, "<:encoding(UTF-16)", "$data_root/taxonomies-obf/32006D0257.tmx
 	close $IN;
 }
 else {
-	print STDERR "Could not open $data_root/taxonomies-obf/32006D0257.tmx.txt\n";
+	print STDERR "Could not open $BASE_DIRS{TAXONOMIES_SRC}/old/obf/32006D0257.tmx.txt\n";
 	exit;
 }
 
-my $csv_file = "$data_root/taxonomies-obf/COSING_Ingredients-Fragrance-Inventory_v2.wikidata.tsv";
+my $csv_file = "$BASE_DIRS{TAXONOMIES_SRC}/old/obf/COSING_Ingredients-Fragrance-Inventory_v2.wikidata.tsv";
 
 my $csv = Text::CSV->new({binary => 1, sep_char => "\t"})    # should set binary attribute.
 	or die "Cannot use CSV: " . Text::CSV->error_diag();

--- a/scripts/taxonomies/translate_taxonomy_with_eu_translations.pl
+++ b/scripts/taxonomies/translate_taxonomy_with_eu_translations.pl
@@ -24,13 +24,14 @@ use Modern::Perl '2017';
 use utf8;
 
 use ProductOpener::Store qw/:all/;
+use ProductOpener::Paths qw/:all/;
 use ProductOpener::Config qw/:all/;
 
 # tmx files contain translations from the EU laws
 
 my @tmx_files = (
-	"$data_root/taxonomies/off/nutritional-substances/32013R0609.tmx",
-	"$data_root/taxonomies/off/nutritional-substances/32006R1925.tmx"
+	"$BASE_DIRS{TAXONOMIES_SRC}/old/off/nutritional-substances/32013R0609.tmx",
+	"$BASE_DIRS{TAXONOMIES_SRC}/old/off/nutritional-substances/32006R1925.tmx"
 );
 
 my %translations = ();

--- a/tests/unit/paths.t
+++ b/tests/unit/paths.t
@@ -8,6 +8,9 @@ use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/:all/;
 use File::Path qw/remove_tree/;
 
+# hardcode docker path for now
+my $src_root = "/opt/product-opener";
+
 my $EXPECTED_BASE_PATHS = {
 	CACHE_BUILD => "$data_root/build-cache",
 	CACHE_DEBUG => "$data_root/debug",
@@ -31,6 +34,7 @@ my $EXPECTED_BASE_PATHS = {
 	PUBLIC_EXPORTS => "$www_root/exports",
 	PUBLIC_FILES => "$www_root/files",
 	REVERTED_PRODUCTS => "$data_root/reverted_products",
+	TAXONOMIES_SRC => "$src_root/taxonomies",
 	USERS => "$data_root/users",
 	USERS_TRANSLATIONS => "$data_root/translate",
 };


### PR DESCRIPTION
This will avoid having current error on deployment (which breaks deployments).

It cleanly separate data from sources.