### PR TITLE
fix: updated z-index of map

### DIFF
--- a/templates/web/pages/tag/tag.tt.html
+++ b/templates/web/pages/tag/tag.tt.html
@@ -70,7 +70,7 @@
 
             <div class="large-6 column">                
             <!-- injecting facet-knowledge-panel -->
-            <div id="facet-knowledge-panel" style="margin-left: 70px;">
+            <div id="facet-knowledge-panel" style="margin-left: 70px; z-index: 1;">
                 <h2 id="facet_panels_title"></h2>
                 <div id="facet_panels_content"></div>
             </div>

--- a/templates/web/panels/panel.tt.html
+++ b/templates/web/panels/panel.tt.html
@@ -311,7 +311,7 @@
                 [% map_element = element_ref.map_element %]
                 <!-- start templates/[% template.name %] -->
 
-                <div id="tag_map" class="large-9 columns" style="display: none;">
+                <div id="tag_map" class="large-9 columns" style="display: none;  z-index: 1;">
                     <div id="container" style="height: 300px; z-index: 1;"></div>
                 </div>
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
When scrolling, the map would cover other content. This PR corrects the z-index for the same for normal functioning and better UI. 
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->
Before:
![Screenshot 2024-03-18 031604](https://github.com/openfoodfacts/openfoodfacts-server/assets/120312681/fbc99b59-94fe-4fa5-a88b-2e54af19799b)


After:
![Screenshot 2024-03-18 031634](https://github.com/openfoodfacts/openfoodfacts-server/assets/120312681/7489cca1-114e-45d6-9077-5e9ceca72854)


### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #7509 

