### PR TITLE
fix: keep only one (or two?) mongodb export

### DIFF
--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -272,7 +272,7 @@ Use the Git Bash shell to run the make commands in windows so that programs like
 When running `make import_prod_data`.
 
 ```console
-process_begin: CreateProcess(NULL, wget --no-verbose https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.tar.gz, ...) failed.
+process_begin: CreateProcess(NULL, wget --no-verbose https://static.openfoodfacts.org/data/openfoodfacts-mongodbdump.gz, ...) failed.
 make (e=2): The system cannot find the file specified.
 ```
 

--- a/scripts/mongodb_dump.sh
+++ b/scripts/mongodb_dump.sh
@@ -35,8 +35,8 @@ else
   LASTTS=$(($(date +%s)-24*60*60))
 fi
 NEWTS=$(date +%s)
-mongoexport --collection products --host $HOST --db $DB --query "{ \"last_modified_t\": { \"\$gt\": $LASTTS, \"\$lte\": $NEWTS } }" | gzip -9 > new.${PREFIX}_products_${LASTTS}_${NEWTS}.jsonl.gz_${NEWTS}.json.gz && \
-mv new.${PREFIX}_products_${LASTTS}_${NEWTS}.jsonl.gz_${NEWTS}.json.gz ${PREFIX}_products_${LASTTS}_${NEWTS}.jsonl.gz_${NEWTS}.json.gz
+mongoexport --collection products --host $HOST --db $DB --query "{ \"last_modified_t\": { \"\$gt\": $LASTTS, \"\$lte\": $NEWTS } }" | gzip -9 > new.${PREFIX}_products_${LASTTS}_${NEWTS}.json.gz && \
+mv new.${PREFIX}_products_${LASTTS}_${NEWTS}.json.gz ${PREFIX}_products_${LASTTS}_${NEWTS}.json.gz
 
 # Delete all but the last 14 delta files - https://stackoverflow.com/a/34862475/11963
 ls -tp ${PREFIX}-products_*.json.gz | grep -v '/$' | tail -n +14 | xargs -I {} rm -- {}

--- a/scripts/mongodb_dump.sh
+++ b/scripts/mongodb_dump.sh
@@ -23,16 +23,6 @@ mv new.${PREFIX}-mongodbdump.gz ${PREFIX}-mongodbdump.gz && \
 mv new.gz-sha256sum gz-sha256sum && \
 mv new.gz-md5sum gz-md5sum
 
-mongodump --collection products --host $HOST --db $DB && \
-tar cvfz new.$PREFIX-mongodbdump.tar.gz dump && \
-sha256sum new.$PREFIX-mongodbdump.tar.gz |sed -e 's/new\.//' > new.sha256sum && \
-md5sum new.$PREFIX-mongodbdump.tar.gz |sed -e 's/new\.//' > new.md5sum && \
-mv new.$PREFIX-mongodbdump.tar.gz $PREFIX-mongodbdump.tar.gz && \
-mv new.sha256sum sha256sum && \
-mv new.md5sum md5sum
-
-
-
 # Export delta of products modified in the last 24h or since last run of the script
 mkdir -p delta
 pushd delta/ > /dev/null
@@ -45,14 +35,14 @@ else
   LASTTS=$(($(date +%s)-24*60*60))
 fi
 NEWTS=$(date +%s)
-mongoexport --collection products --host $HOST --db $DB --query "{ \"last_modified_t\": { \"\$gt\": $LASTTS, \"\$lte\": $NEWTS } }" | gzip -9 > new.products_${LASTTS}_${NEWTS}.json.gz && \
-mv new.products_${LASTTS}_${NEWTS}.json.gz products_${LASTTS}_${NEWTS}.json.gz
+mongoexport --collection products --host $HOST --db $DB --query "{ \"last_modified_t\": { \"\$gt\": $LASTTS, \"\$lte\": $NEWTS } }" | gzip -9 > new.${PREFIX}_products_${LASTTS}_${NEWTS}.jsonl.gz_${NEWTS}.json.gz && \
+mv new.${PREFIX}_products_${LASTTS}_${NEWTS}.jsonl.gz_${NEWTS}.json.gz ${PREFIX}_products_${LASTTS}_${NEWTS}.jsonl.gz_${NEWTS}.json.gz
 
 # Delete all but the last 14 delta files - https://stackoverflow.com/a/34862475/11963
-ls -tp products_*.json.gz | grep -v '/$' | tail -n +14 | xargs -I {} rm -- {}
+ls -tp ${PREFIX}-products_*.json.gz | grep -v '/$' | tail -n +14 | xargs -I {} rm -- {}
 
 echo $NEWTS > $TSFILE
-ls -tp products_*.json.gz > index.txt
+ls -tp ${PREFIX}-products_*.json.gz > index.txt
 
 popd > /dev/null # data/delta
 


### PR DESCRIPTION
We currently generate 3 MongoDB exports, each of them takes more than one hour to generate every day:

```
-rw-r--r--   1 off  off   4675987404 Mar 18 08:08 fr.openfoodfacts.org.products.rdf
-rw-r--r--   1 off  off   7311036936 Mar 18 09:36 openfoodfacts-products.jsonl.gz
-rw-r--r--   1 off  off   8859132762 Mar 18 10:28 openfoodfacts-mongodbdump.gz
-rw-r--r--   1 off  off           95 Mar 18 10:30 gz-sha256sum
-rw-r--r--   1 off  off           63 Mar 18 10:30 gz-md5sum
-rw-r--r--   1 off  off   8932229671 Mar 18 11:42 openfoodfacts-mongodbdump.tar.gz
```

I suggest that we completely remove openfoodfacts-mongodbdump.tar.gz which has exactly the same usage as openfoodfacts-mongodbdump.gz

I'm not sure if we should keep the jsonl. As I recall, it was added for Robotoff. Do we still need it? Or do we still want to provide it to others, so that's it's possible to get JSON data without having MongoDB?