### PR TITLE
feat: Automatically unselect images when source image deleted Issue#9793

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -180,6 +180,7 @@ use ProductOpener::Config2;
 	stephane
 	tacinte
 	teolemon
+ 	himanshi-154
 );
 
 $options{export_limit} = 10000;

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -1213,6 +1213,12 @@ sub process_image_move ($user_id, $code, $imgids, $move_to, $ownerid) {
 
 				delete $product_ref->{images}{$imgid};
 
+				# Check if any selected image's imgid equals the deleted imgid
+				foreach my $selected_imgid (keys %{$product_ref->{images}}) {
+   					process_image_unselect($user_id, $code, $imgid) if $selected_imgid eq $imgid;
+				}
+
+
 			}
 
 		}


### PR DESCRIPTION
**##What?**
Issue#9793 that states that images should be automatically unselected when their source image is deleted

**# Why?**
This saves time for contributors on problematic images, and avoid forgetting to unselect it.

**# How?**
First checked if selected image id is equal to image id and then deleted the image id as the siurce image is already deleted

