### PR TITLE
fix: Add org name directly in url for a logged in user on producer platform

### DIFF
--- a/cgi/login.pl
+++ b/cgi/login.pl
@@ -47,11 +47,18 @@ my $r = shift;
 my $redirect = single_param('redirect');
 $template_data_ref->{redirect} = $redirect;
 if (defined $User_id) {
-	my $loc = $redirect || $formatted_subdomain . "/cgi/session.pl";
-	$r->headers_out->set(Location => $loc);
-	$r->err_headers_out->add('Set-Cookie' => $request_ref->{cookie});
-	$r->status(302);
-	return Apache2::Const::OK;
+	my $url_suffix;
+	if (defined $Org_id) {
+		$url_suffix = "/cgi/session.pl/owner/org-$Org_id";
+	} else {
+		$url_suffix = "/cgi/session.pl/";
+	}
+
+	my $loc = $redirect || $formatted_subdomain . $url_suffix;
+    $r->headers_out->set(Location => $loc);
+    $r->err_headers_out->add('Set-Cookie' => $request_ref->{cookie});
+    $r->status(302);
+    return Apache2::Const::OK;
 }
 
 my @errors = ();


### PR DESCRIPTION
### What

In the "cgi/login.pl" file, I created a url_suffix variable that concatenates organisation id with existing url if user has an organisation id and uses the existing url if user has not updated their account with organisation details. This url is displayed once the user is logged in.

This will help users see at first glance their organisation name.

- Fixes #9685

