### PR TITLE
fix: Add lang tag to import template title

### DIFF
--- a/cgi/generate_sample_import_file.pl
+++ b/cgi/generate_sample_import_file.pl
@@ -48,7 +48,7 @@ my $request_ref = ProductOpener::Display::init_request();
 my $r = Apache2::RequestUtil->request();
 
 $r->headers_out->set("Content-type" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-$r->headers_out->set("Content-disposition" => "attachment;filename=openfoodfacts_import.xlsx");
+$r->headers_out->set("Content-disposition" => "attachment;filename=openfoodfacts_import_template_$lc.xlsx");
 
 print "Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet\r\n\r\n";
 


### PR DESCRIPTION
### What

I changed the title of the import template spreadsheet from `openfoodfacts_import.xlsx` to `openfoodfacts_import_template_en.xlsx`

The latter title is more descriptive and can help producers differentiate between files especially if they download in multiple languages.
