### PR TITLE
fix: Added Translations in Spanish

### DIFF
--- a/po/common/de.po
+++ b/po/common/de.po
@@ -879,7 +879,7 @@ msgstr "https://world-de.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Open Food Fakten für Produzenten"
+msgstr "Open Food Facts für Produzenten"
 
 msgctxt "for"
 msgid "for"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -174,7 +174,7 @@ msgstr "El exceso de alcohol es perjudicial para la salud."
 
 msgctxt "email_warning"
 msgid "Please note that your Pro account will only be valid if you use your professional e-mail address. Our moderation team checks that the domain name is consistent with the organisation you wish to join."
-msgstr ""
+msgstr "Tenga en cuenta que su cuenta Pro solo será válida si utiliza su dirección de correo electrónico profesional. Nuestro equipo de moderación verifica que el nombre de dominio coincida con la organización a la que desea unirse."
 
 msgctxt "all_missions"
 msgid "All missions"
@@ -883,7 +883,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr ""
+msgstr "Open Food Facts para los productores"
 
 msgctxt "for"
 msgid "for"


### PR DESCRIPTION
Translations for https://de.openfoodfacts.org/ had already been added.

As per the changes suggested on #9658 and https://openfoodfacts.slack.com/archives/C02LDQDDD/p1707921684661859?thread_ts=1707083612.774809&cid=C02LDQDDD, added translations for https://es.openfoodfacts.org/



![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/99353300/a59d5e21-a678-498a-8589-86b5f8ba5327)
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/99353300/68eca6d9-05fe-44d3-9f9c-07170f98f6a6)
