### PR TITLE
fix: canonicalize food_group field

### DIFF
--- a/lib/ProductOpener/FoodGroups.pm
+++ b/lib/ProductOpener/FoodGroups.pm
@@ -248,7 +248,7 @@ sub compute_food_groups ($product_ref) {
 			if (    (defined $properties{categories}{$categoryid})
 				and (defined $properties{categories}{$categoryid}{"food_groups:en"}))
 			{
-				$product_ref->{food_groups} = $properties{categories}{$categoryid}{"food_groups:en"};
+				$product_ref->{food_groups} = canonicalize_taxonomy_tag("en", "food_groups", $properties{categories}{$categoryid}{"food_groups:en"});
 				$log->debug("found food group for category",
 					{category_id => $categoryid, food_groups => $product_ref->{food_groups}})
 					if $log->is_debug();

--- a/lib/ProductOpener/FoodGroups.pm
+++ b/lib/ProductOpener/FoodGroups.pm
@@ -248,7 +248,8 @@ sub compute_food_groups ($product_ref) {
 			if (    (defined $properties{categories}{$categoryid})
 				and (defined $properties{categories}{$categoryid}{"food_groups:en"}))
 			{
-				$product_ref->{food_groups} = canonicalize_taxonomy_tag("en", "food_groups", $properties{categories}{$categoryid}{"food_groups:en"});
+				$product_ref->{food_groups} = canonicalize_taxonomy_tag("en", "food_groups",
+					$properties{categories}{$categoryid}{"food_groups:en"});
 				$log->debug("found food group for category",
 					{category_id => $categoryid, food_groups => $product_ref->{food_groups}})
 					if $log->is_debug();


### PR DESCRIPTION
for some reason the tests have values like "en:cheese" for the "food_groups" field, but we generate "en:Cheese". I don't understand why we had en:cheese before and why it recently changed.

This PR canonicalizes the food_groups field, so that we do get "en:cheese".