### PR TITLE
fix: Fix ecoscore origins

### DIFF
--- a/lib/ProductOpener/Ecoscore.pm
+++ b/lib/ProductOpener/Ecoscore.pm
@@ -1385,7 +1385,10 @@ sub compute_ecoscore_origins_of_ingredients_adjustment ($product_ref) {
 		foreach my $category (@{$product_ref->{categories_tags}}) {
 			my $origin_id = get_property("categories", $category, "origins:en");
 			if (defined $origin_id) {
-				push @origins_from_categories, split(',', $origin_id);
+				# There may be multiple comma separated origins, and they might not be canonical
+				# so we split them and canonicalize them
+				push @origins_from_categories,
+					map ({canonicalize_taxonomy_tag("en", "origins", $_)} split(',', $origin_id));
 			}
 		}
 	}

--- a/lib/ProductOpener/FoodGroups.pm
+++ b/lib/ProductOpener/FoodGroups.pm
@@ -248,7 +248,7 @@ sub compute_food_groups ($product_ref) {
 			if (    (defined $properties{categories}{$categoryid})
 				and (defined $properties{categories}{$categoryid}{"food_groups:en"}))
 			{
-				$product_ref->{food_groups} = $properties{categories}{$categoryid}{"food_groups:en"};
+				$product_ref->{food_groups} = canonicalize_taxonomy_tag("en", "food_groups", $properties{categories}{$categoryid}{"food_groups:en"});
 				$log->debug("found food group for category",
 					{category_id => $categoryid, food_groups => $product_ref->{food_groups}})
 					if $log->is_debug();

--- a/lib/ProductOpener/FoodGroups.pm
+++ b/lib/ProductOpener/FoodGroups.pm
@@ -248,7 +248,8 @@ sub compute_food_groups ($product_ref) {
 			if (    (defined $properties{categories}{$categoryid})
 				and (defined $properties{categories}{$categoryid}{"food_groups:en"}))
 			{
-				$product_ref->{food_groups} = canonicalize_taxonomy_tag("en", "food_groups", $properties{categories}{$categoryid}{"food_groups:en"});
+				$product_ref->{food_groups} = canonicalize_taxonomy_tag("en", "food_groups",
+					$properties{categories}{$categoryid}{"food_groups:en"});
 				$log->debug("found food group for category",
 					{category_id => $categoryid, food_groups => $product_ref->{food_groups}})
 					if $log->is_debug();


### PR DESCRIPTION
Fix for food_groups + fix for Eco-Score origins

The test was failing probably because the origins:en property for the category en:calvados changed. I'm not sure how the corresponding change was merged without the test failing though.