### PR TITLE
fix: remove unused Graphics::Color::RGB/HSL modules

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -18,8 +18,6 @@ requires 'JSON::MaybeXS'; # libjson-maybexs-perl
 requires 'Clone'; # libclone-perl
 requires 'Crypt::PasswdMD5'; # libcrypt-passwdmd5-perl
 requires 'Encode::Detect'; # libencode-detect-perl
-requires 'Graphics::Color::RGB'; # libgraphics-color-perl
-requires 'Graphics::Color::HSL'; # libgraphics-color-perl
 requires 'Barcode::ZBar'; # libbarcode-zbar-perl
 requires 'XML::FeedPP'; # libxml-feedpp-perl
 requires 'URI::Find'; # liburi-find-perl

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -131,8 +131,6 @@ use ProductOpener::Products qw/:all/;
 use CGI qw/:cgi :form escapeHTML/;
 
 use Image::Magick;
-use Graphics::Color::RGB;
-use Graphics::Color::HSL;
 use Barcode::ZBar;
 use Imager;
 use Imager::zxing;


### PR DESCRIPTION
The modules were in some old code I had from past projects but were not in actual use in Product Opener.