### PR TITLE
fix: drop Encode::Punycode (no longer used)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,6 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt set -x && \
         libclass-singleton-perl \
         # DateTime::Locale
         libfile-sharedir-install-perl \
-        # Encode::Punycode
-        libnet-idn-encode-perl \
-        libtest-nowarnings-perl \
         # File::chmod::Recursive
         libfile-chmod-perl \
         # GeoIP2

--- a/cpanfile
+++ b/cpanfile
@@ -44,7 +44,6 @@ requires 'Path::Tiny', '>= 0.118'; # libpath-tiny-perl
 requires 'MongoDB', '>= 2.2.2, < 2.3'; # libmongodb-perl has 1.8.1/2.0.3 vs 2.2.2. deps: libauthen-sasl-saslprep-perl, libbson-perl, libauthen-scram-perl, libclass-xsaccessor-perl, libdigest-hmac-perl, libsafe-isa-perl, libconfig-autoconf-perl, libpath-tiny-perl
 # we fix this because MongoDB depends on it, and 0.023 does not install correctly
 requires 'Type::Tiny::XS', '==0.022';
-requires 'Encode::Punycode'; # deps: libnet-idn-encode-perl, libtest-nowarnings-perl
 requires 'GraphViz2'; # deps: libfile-which-perl, libdata-section-simple-perl, libwant-perl, libipc-run3-perl, liblog-handler-perl, libtest-deep-perl
 requires 'Algorithm::CheckDigits'; # libalgorithm-checkdigits-perl has 0.50 vs 1.3.3. deps: libprobe-perl-perl
 requires 'Image::OCR::Tesseract'; # deps: libfile-find-rule-perl

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -45,8 +45,6 @@ use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/:all/;
 
 use Storable qw(lock_store lock_nstore lock_retrieve);
-use Encode;
-use Encode::Punycode;
 use URI::Escape::XS;
 use Unicode::Normalize;
 use Log::Any qw($log);


### PR DESCRIPTION
It appears ProductOpener::Store does not use Encode::Punycode to normalize strings but uses the tr and s instructions.