### PR TITLE
docs: update and copyedit docs/dev/how-to-quick-start-guide.md

### DIFF
--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -13,21 +13,19 @@ First setup time estimate is `~10min` with the following specs:
 
 **Docker** is the easiest way to install the Open Food Facts server, play with it, and even modify the code.
 
-Docker provides an isolated environment, very close to a Virtual Machine. This environment contains everything required to launch the Open Food Facts server. There is **no need to install** Perl, Perl modules, Nginx, nor Apache separately.
+Docker provides an isolated environment, very close to a Virtual Machine. This environment contains everything required to launch the Open Food Facts server. There is **no need to install** Perl, Perl modules, Nginx, or Apache separately.
 
 > **_NOTE:_**  New to Perl? Check [how to learn perl](how-to-learn-perl.md)!
 
 **Installation steps:**
-- [Install Docker CE](https://docs.docker.com/install/#supported-platforms)
+- [Install Docker CE](https://docs.docker.com/engine/install/)
 > If you run e.g. Debian, don't forget to add your user to the `docker` group!
-- [Install Docker Compose](https://docs.docker.com/compose/install/)
-- [Enable command-line completion](https://docs.docker.com/compose/completion/)
 
 ### Windows Prerequisites
 
 When running with Windows, install [Docker Desktop](https://www.docker.com/products/docker-desktop/) **which will cover all of the above**.
 
-The Make tasks use a number of Linux commands, such as rm and nproc, so it is recommeded to run Make commands from the Git Bash shell. In addition, the following need to be installed and included in the PATH:
+The Make tasks use a number of Linux commands, such as rm and nproc, so it is recommended to run Make commands from the Git Bash shell. In addition, the following need to be installed and included in the PATH:
 
 - [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm)
 - [wget for windows](https://eternallybored.org/misc/wget/) (In order to download the full product database). If you want to download wget with the executable, copy the wget.exe file to C:/Windows/System32 and you are done.
@@ -38,7 +36,7 @@ The process of cloning the repository will create a number of symbolic links whi
  - Completely disable UAC
  - Specifically grant the [Create symbolic links](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links) permission to your user
 
-Make sure you also activated the [Developper mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on your device.
+Make sure you also activated the [Developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on your device.
 
 ## 2. Fork and clone the repository from GitHub
 
@@ -49,7 +47,7 @@ Make sure you also activated the [Developper mode](https://learn.microsoft.com/e
 ### Fork the repository
 
 If you want to collaborate you will need to fork the repository.
-(see [*Creating a pull request from a fork* in Github documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) for an explanation)
+(See [*Creating a pull request from a fork* in Github documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) for an explanation.)
 
 Go to https://github.com/openfoodfacts/openfoodfacts-server and click the "Fork" button.
 
@@ -59,10 +57,10 @@ eg. (for an hypothetical my-user-id user): https://github.com/my-user-id/openfoo
 This is the url you have to use in the following instructions.
 
 Very important: always work in new branches, never in "main", otherwise it will be difficult
-to sync your project with upstream repository (the openfoodfacts original repository).
+to sync your project with the upstream repository (the openfoodfacts original repository).
 
 From time to time (before starting a new branch), it's a good idea to sync your fork,
-either using the github interface and then pulling "main" locally, either from the command line.
+either using the github interface and then pulling "main" locally, or from the command line.
 
 ### Clone
 
@@ -112,7 +110,7 @@ git clone --single-branch --depth=1 https://github.com/openfoodfacts/openfoodfac
 
 To save your PC's resources, consider using a shallow clone by only cloning the `main` branch combined with a shallow fetch. This reduces the downloaded data to approximately 333 MiB and the repo will only use around 350 MiB of drive space.
 
-You will still be able to contribute PRs based on the `main`. However, you will not be able to view the full Git version history of any files, and you need to use an additional from GitHub, e.g., `gh-pages`, you can do it like this:
+You will still be able to contribute PRs based on the `main` branch. However, you will not be able to view the full Git version history of any files, and you need to use an additional branch from GitHub, e.g., `gh-pages`, you can do it like this:
 
 ```console
 git remote set-branches --add origin gh-pages
@@ -154,12 +152,12 @@ The `.env` file also contains some useful Docker Compose variables:
 * `COMPOSE_SEPARATOR` is the separator used for `COMPOSE_FILE`.
 
 **Note:**
-Instead of modifying `.env` (with the risk commit it inadvertently),
-You can also set needed variables in your shell, they will override `.env` values.
+Instead of modifying `.env` (and risk committing it inadvertently),
+you can also set needed variables in your shell; they will override `.env` values.
 Consider creating a `.envrc` file that you source each time you need to work on the project.
 On linux and macOS, you can automatically do it if you [use direnv](how-to-use-direnv.md).
 
-## 4. Build your dev environment
+## 3. Build your dev environment
 
 From the repository root, run:
 
@@ -200,17 +198,17 @@ Since the default `PRODUCT_OPENER_DOMAIN` in the `.env` file is set to `openfood
 127.0.0.1 world.openfoodfacts.localhost fr.openfoodfacts.localhost static.openfoodfacts.localhost ssl-api.openfoodfacts.localhost fr-en.openfoodfacts.localhost
 ```
 
-**You're done ! Check http://openfoodfacts.localhost/ !**
+**You're done! Check `http://openfoodfacts.localhost/`.**
 
 ### Going further
 
 To learn more about developing with Docker, see the [Docker developer's guide](how-to-develop-using-docker.md).
 
-To have all site page on your dev instance, see [Using pages from openfoodfacts-web](how-to-use-pages-from-openfoodfacts-web.md)
+To have all site pages on your dev instance, see [Using pages from openfoodfacts-web](how-to-use-pages-from-openfoodfacts-web.md)
 
 [Using Repl](how-to-use-repl.md) offers you a way to play with perl.
 
-Specific notes are provide on [applying AGRIBALYSE updates to support the Ecoscore](how-to-update-agribalyse-ecoscore.md) calculation.
+Specific notes are provided on [applying AGRIBALYSE updates to support the Ecoscore](how-to-update-agribalyse-ecoscore.md) calculation.
 
 ## Visual Studio Code
 
@@ -230,9 +228,18 @@ When running `make dev`:
 bash: make: command not found
 ```
 
-**Solution:** 
+**Solution (if using Windows):** 
 Click the Windows button, then type “environment properties” into the search bar and hit Enter. Click Environment Variables, then under System variables choose Path and click Edit. Click New and insert C:\Program Files (x86)\GnuWin32\bin, then save the changes. Open a new terminal and test that the command works.
-(see [Make Windows](https://pakstech.com/blog/make-windows/) for more)
+(See [Make Windows](https://pakstech.com/blog/make-windows/) for more.)
+
+**Solution (if using a Linux distro):**
+Check that your bash PATH setting is correct. If it is, your Linux distro doesn't include `make` by default. For Debian (which I had that problem with --Pau Amma), use
+
+```shell
+sudo apt-get install make
+```
+
+For other distros, consult your distro's documentation or support resources for the command to use.
 
 ### make dev error: [build_lang] Error 2 - Could not load taxonomy: /mnt/podata/taxonomies/traces.result.sto
 
@@ -268,7 +275,7 @@ and turn on the toggle for *Developer Mode*.
 
 On Windows systems, the git repository needs to be cloned with symlinks enabled.
 
-You need to remove current directory where you clone the project, and clone the project again, using right options:
+You need to remove the directory where you cloned the project, and clone the project again, using the right options:
 
 ```console
 # replace my-user-id with your user id if you forked the repository, otherwise use openfoodfacts
@@ -320,7 +327,7 @@ make: *** [Makefile:154: import_sample data] Error 22
 **Solution:**
 The cause of this issue is that you already have the mongodb database server running on your local machine at port 27017. 
 
-*For linux users:*
+*For Linux users:*
 
 First stop the MongoDB server from your OS
 ```console
@@ -335,7 +342,7 @@ systemctl status mongod | grep Active
 > The output of this command should be:
   `Active: inactive (dead)`
 
-Then, executed this:
+Then, execute this:
 ```console
 docker compose up 
 ```


### PR DESCRIPTION
- Update URL for installing Docker CE
- Remove instructions for installing Docker Compose (which the above procedure will install) to limit confusion
- Remove dead link for Docker command completion
- Renumber toplevel sections so there's no missing section 3
- Add problem I had on Debian to troubleshooting section