### PR TITLE
refactor: Moosify ProductOpener::Nutriscore.pm

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -8907,6 +8907,8 @@ the rounded value according to the Nutri-Score rules, and the corresponding poin
 
 sub display_nutriscore_calculation_details ($nutriscore_data_ref, $version = "2021") {
 
+	my %points_thresholds = ProductOpener::Nutriscore->new->points_thresholds->%*;
+
 	my $beverage_view;
 
 	if ($nutriscore_data_ref->{is_beverage}) {

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -2092,7 +2092,7 @@ sub compute_nutriscore ($product_ref, $current_version = "2021") {
 		}
 		else {
 			($nutriscore_score, $nutriscore_grade)
-				= ProductOpener::Nutriscore::compute_nutriscore_score_and_grade(
+				= ProductOpener::Nutriscore->new->compute_nutriscore_score_and_grade(
 				$product_ref->{nutriscore}{$version}{data}, $version);
 		}
 

--- a/tests/unit/nutriscore.t
+++ b/tests/unit/nutriscore.t
@@ -910,6 +910,8 @@ foreach my $test_ref (@tests) {
 	compare_to_expected_results($product_ref, "$expected_result_dir/$testid.json", $update_expected_results);
 }
 
-is(compute_nutriscore_grade(1.56, 1, 0), "c");
+my $nutriscore = ProductOpener::Nutriscore->new;
+
+is($nutriscore->compute_nutriscore_grade(1.56, 1, 0), "c", 'Nutriscore returns the right grade');
 
 done_testing();


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
## What

This is just an experiment that tries to `use Moose` in `Nutriscore.pm`. 

Could have been done with Moo or the core Class feature too: no strong opinion about which one should be chosen. We want to try and see what happens, and evaluate the amount of refactoring needed if we make one module an object.

I guess this is not too bad, but a couple of tests still fail.

