### PR TITLE
ci: add external volumes for build-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,6 +427,7 @@ create_external_volumes: _clean_old_external_volumes
 	docker volume create --driver=local --opt type=nfs --opt o=addr=${NFS_VOLUMES_ADDRESS},rw,nolock --opt device=:${NFS_VOLUMES_BASE_PATH}/orgs ${COMPOSE_PROJECT_NAME}_orgs
 # local data
 	docker volume create --driver=local -o type=none -o o=bind -o device=${DOCKER_LOCAL_DATA}/data ${COMPOSE_PROJECT_NAME}_html_data
+	docker volume create --driver=local -o type=none -o o=bind -o device=${DOCKER_LOCAL_DATA}/build_cache ${COMPOSE_PROJECT_NAME}_build_cache
 	docker volume create --driver=local -o type=none -o o=bind -o device=${DOCKER_LOCAL_DATA}/podata ${COMPOSE_PROJECT_NAME}_podata
 # note for this one, it should be shared with pro instance in the future
 	docker volume create --driver=local -o type=none -o o=bind -o device=${DOCKER_LOCAL_DATA}/export_files ${COMPOSE_PROJECT_NAME}_export_files

--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -52,6 +52,9 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME}_redisdata
   export_files:
     name: ${COMPOSE_PROJECT_NAME}_export_files
+  build_cache:
+    name: ${COMPOSE_PROJECT_NAME}_build_cache
+
 
 networks:
   webnet:


### PR DESCRIPTION
Because taxonomies must survive a `docker-compose down -v`
