### PR TITLE
fix: sort_by param issue in the url with "?" instead of "&" 

### DIFF
--- a/cgi/search.pl
+++ b/cgi/search.pl
@@ -665,11 +665,11 @@ elsif ($action eq 'process') {
 		}
 	}
 
-	if (defined $sort_by) {
-		$current_link .= "&sort_by=$sort_by";
-	}
+	# if (defined $sort_by) {
+	# 	$current_link .= "&sort_by=$sort_by";
+	# }
 
-	$current_link .= "\&page_size=$limit";
+	# $current_link .= "\&page_size=$limit";
 
 	# Graphs
 

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -5002,13 +5002,13 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 		push @{$template_data_ref->{sort_options}},
 			{
 			value => "popularity",
-			link => $request_ref->{current_link} . "?sort_by=popularity",
+			link => add_params($request_ref->{current_link}, "sort_by=popularity") . "&page_size=$limit",
 			name => lang("sort_by_popularity")
 			};
 		push @{$template_data_ref->{sort_options}},
 			{
 			value => "nutriscore_score",
-			link => $request_ref->{current_link} . "?sort_by=nutriscore_score",
+			link => add_params($request_ref->{current_link}, "sort_by=nutriscore_score") . "&page_size=$limit",
 			name => lang("sort_by_nutriscore_score")
 			};
 
@@ -5017,7 +5017,7 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 			push @{$template_data_ref->{sort_options}},
 				{
 				value => "ecoscore_score",
-				link => $request_ref->{current_link} . "?sort_by=ecoscore_score",
+				link => add_params($request_ref->{current_link}, "sort_by=ecoscore_score") . "&page_size=$limit",
 				name => lang("sort_by_ecoscore_score")
 				};
 		}
@@ -5026,13 +5026,13 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 	push @{$template_data_ref->{sort_options}},
 		{
 		value => "created_t",
-		link => $request_ref->{current_link} . "?sort_by=created_t",
+		link => add_params($request_ref->{current_link}, "sort_by=created_t") . "&page_size=$limit",
 		name => lang("sort_by_created_t")
 		};
 	push @{$template_data_ref->{sort_options}},
 		{
 		value => "last_modified_t",
-		link => $request_ref->{current_link} . "?sort_by=last_modified_t",
+		link => add_params($request_ref->{current_link}, "sort_by=last_modified_t") . "&page_size=$limit",
 		name => lang("sort_by_last_modified_t")
 		};
 

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -60,7 +60,8 @@ BEGIN {
 		&display_knowledge_panel
 		&get_languages_options_list
 		&get_countries_options_list
-	);    #the fucntions which are called outside this file
+		&add_params
+	);    #the functions which are called outside this file
 	%EXPORT_TAGS = (all => [@EXPORT_OK]);
 }
 
@@ -376,6 +377,35 @@ sub get_countries_options_list ($target_lc, $exclude_world = 1) {
 		@countries_list = grep {$_->{value} ne "world"} @countries_list;
 	}
 	return \@countries_list;
+}
+
+=head2 add_params( $url, $params )
+
+Adds parameters to a URL while properly handling the existing query string.
+
+=head3 Arguments
+
+=head4 $url - The URL to which parameters need to be added.
+
+=head4 $params - The parameters to be added in the format "key=value".
+
+=head3 Return value
+
+The modified URL with added parameters.
+
+=cut
+
+sub add_params ($url, $params) {
+
+	# Check if the URL already contains parameters
+	if ($url =~ /\?/) {
+		$url .= "&$params";    # Append using '&' if parameters already exist
+	}
+	else {
+		$url .= "?$params";    # Append using '?' if no parameters exist
+	}
+
+	return $url;
 }
 
 1;


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
After searching for a product, and then applying a sort_by filter, the resulting url contained 2 sort_by params and "?" instead of "&"

- A new subroutine add_params($url, $param) was added to the Web.pm which checks whether we have a "?" in the current url and if yes then concatenates the sort_by param with "&" else with "?"
The urls now looks like this:

- http://world.openfoodfacts.localhost/?sort_by=nutriscore_score&page_size=100
- http://world.openfoodfacts.localhost/cgi/search.pl?action=process&search_terms=sugar&sort_by=nutriscore_score&page_size=24

<!-- Describe the changes made and why they were made instead of how they were made. -->


### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #9392 

