### PR TITLE
build: Use central buildcache image from GitHub to build dev images locally

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ See also [targets to run tests](../docs/dev/how-to-write-and-run-tests.md#runnin
 | Command                   | Description                                                                            | Notes                                                         |
 | ------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | `make dev`                | Setup a fresh dev environment.                                                         | Run only once, then use the `up`, `down`, `restart` commands. |
-| `make build`              | build containers. Add `container=name` to build a specific container                   | args="--progress log" keeps all log in console (to debug failing build) |
+| `make build`              | build containers. Add `container=name` to build a specific container                   | `args="--progress log"` keeps all log in console (to debug failing build)<br>`args=="--no-cache"` if your build is stale (so that the central buildcache is not used) |
 | `make up`                 | Start containers.                                                                      |                                                               |
 | `make down`               | Stop containers and keep the volumes.                                                  | Products and users data will be kept.                         |
 | `make hdown`              | Stop containers and delete the volumes (hard down).                                    | Products and users data will be lost !                        |

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -5,6 +5,8 @@ x-backend-conf: &backend-conf
   build:
     context: .
     dockerfile: Dockerfile
+    cache_from:
+      - ghcr.io/openfoodfacts/openfoodfacts-server/backend:buildcache
     # align user id
     args:
       USER_UID: ${USER_UID:-1000}
@@ -51,6 +53,8 @@ services:
     image: openfoodfacts-server/dynamicfront:dev
     build:
       context: .
+      cache_from:
+        - ghcr.io/openfoodfacts/openfoodfacts-server/frontend:buildcache
       target: builder
       dockerfile: Dockerfile.frontend
       args:
@@ -73,6 +77,8 @@ services:
     image: openfoodfacts-server/frontend:dev
     build:
       context: .
+      cache_from:
+        - ghcr.io/openfoodfacts/openfoodfacts-server/frontend:buildcache
       dockerfile: Dockerfile.frontend
       args:
         USER_UID: ${USER_UID:-1000}


### PR DESCRIPTION
Updates docker dev to use the latest `buildcache` when building images during local development.

<details>
<summary>Performance</summary>

Results will probably vary based on the mirrors/CDN that you get to download images/packages from. This change will also change in effectiveness based on how far the cache and git repo have drifted apart, but it'll probably still help with build duration for a lot of cases.

```bash
~/openfoodfacts-server$ time make build args="--no-cache"
real    5m45.153s
user    0m6.251s
sys     0m4.050s
~/openfoodfacts-server$ time make build
real    3m8.989s
user    0m5.233s
sys     0m2.939s
```

Note that this was run on Windows 11, in WSL2 (Ubuntu) on an AMD Ryzen 7 7800X3D with 32 GB RAM, and a Samsung SSD 980 Pro 2TB on a standard Vodafone 1 Gbit/s cable connection, so your mileage may vary. 

</details>

<details>
<summary>
Image details show cache being used
</summary>

The benchmark builds were made with all images and containers deleted prior to the execution. The image history shows that several days old cache images from GitHub artifacts were used for the build.

```bash
~/openfoodfacts-server$ docker history docker.io/openfoodfacts-server/frontend:dev
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
e07592332125   49 seconds ago   COPY /opt/product-opener/node_modules/ /opt/…   199MB     buildkit.dockerfile.v0
<missing>      50 seconds ago   COPY /opt/product-opener/html/ /opt/product-…   155MB     buildkit.dockerfile.v0
<missing>      10 days ago      RUN |2 USER_UID=1000 USER_GID=1000 /bin/sh -…   327kB     buildkit.dockerfile.v0
<missing>      10 days ago      ARG USER_GID                                    0B        buildkit.dockerfile.v0
<missing>      10 days ago      ARG USER_UID                                    0B        buildkit.dockerfile.v0
<missing>      12 days ago      WORKDIR /opt/product-opener                     0B        buildkit.dockerfile.v0
<missing>      11 months ago    CMD ["nginx" "-g" "daemon off;"]                0B        buildkit.dockerfile.v0
<missing>      11 months ago    STOPSIGNAL SIGQUIT                              0B        buildkit.dockerfile.v0
<missing>      11 months ago    EXPOSE map[80/tcp:{}]                           0B        buildkit.dockerfile.v0
<missing>      11 months ago    ENTRYPOINT ["/docker-entrypoint.sh"]            0B        buildkit.dockerfile.v0
<missing>      11 months ago    COPY 30-tune-worker-processes.sh /docker-ent…   4.62kB    buildkit.dockerfile.v0
<missing>      11 months ago    COPY 20-envsubst-on-templates.sh /docker-ent…   1.27kB    buildkit.dockerfile.v0
<missing>      11 months ago    COPY 10-listen-on-ipv6-by-default.sh /docker…   2.12kB    buildkit.dockerfile.v0
<missing>      11 months ago    COPY docker-entrypoint.sh / # buildkit          1.62kB    buildkit.dockerfile.v0
<missing>      11 months ago    RUN /bin/sh -c set -x     && addgroup --syst…   61.7MB    buildkit.dockerfile.v0
<missing>      11 months ago    ENV PKG_RELEASE=1~bullseye                      0B        buildkit.dockerfile.v0
<missing>      11 months ago    ENV NJS_VERSION=0.7.12                          0B        buildkit.dockerfile.v0
<missing>      11 months ago    ENV NGINX_VERSION=1.24.0                        0B        buildkit.dockerfile.v0
<missing>      11 months ago    LABEL maintainer=NGINX Docker Maintainers <d…   0B        buildkit.dockerfile.v0
<missing>      11 months ago    /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      11 months ago    /bin/sh -c #(nop) ADD file:3cd55ecee0ffd78be…   80.6MB
~/openfoodfacts-server$ docker history docker.io/openfoodfacts-server/backend:dev
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
994236317285   About a minute ago   CMD ["apache2ctl" "-D" "FOREGROUND"]            0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENTRYPOINT ["/docker-entrypoint.sh"]            0B        buildkit.dockerfile.v0
<missing>      About a minute ago   USER www-data                                   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   WORKDIR /opt/product-opener/                    0B        buildkit.dockerfile.v0
<missing>      About a minute ago   COPY ./docker/docker-entrypoint.sh / # build…   2.67kB    buildkit.dockerfile.v0
<missing>      About a minute ago   EXPOSE map[80/tcp:{}]                           0B        buildkit.dockerfile.v0
<missing>      About a minute ago   COPY . /opt/product-opener/ # buildkit          641MB     buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c mkdir -p var/run/apache2/ && …   1.11MB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c a2dismod mpm_event &&     a2e…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENV PATH=/opt/perl/local/bin:/usr/local/sbin…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENV PERL5LIB=/opt/product-opener/lib/:/opt/p…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   COPY /tmp/local/ /opt/perl/local/ # buildkit    93.5MB    buildkit.dockerfile.v0
<missing>      2 days ago           RUN /bin/sh -c rm /etc/apache2/sites-enabled…   0B        buildkit.dockerfile.v0
<missing>      2 days ago           RUN |2 USER_UID=1000 USER_GID=1000 /bin/sh -…   328kB     buildkit.dockerfile.v0
<missing>      2 days ago           ARG USER_GID                                    0B        buildkit.dockerfile.v0
<missing>      2 days ago           ARG USER_UID                                    0B        buildkit.dockerfile.v0
<missing>      2 days ago           RUN /bin/sh -c set -x &&     cd /tmp &&     …   1.27MB    buildkit.dockerfile.v0
<missing>      2 days ago           RUN /bin/sh -c set -x &&     apt install -y …   919MB     buildkit.dockerfile.v0
<missing>      4 days ago           RUN /bin/sh -c set -x &&     apt update &&  …   722MB     buildkit.dockerfile.v0
<missing>      13 days ago          /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      13 days ago          /bin/sh -c #(nop) ADD file:ff6bc341b5945acf6…   124MB
```

</details>