### PR TITLE
fix: improve the POD documentation so that it conforms to usual Perl conventions

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -123,6 +123,8 @@ on 'test' => sub {
   requires 'Devel::Cover::Report::Codecovbash';
   requires 'Test::Fake::HTTPD';
   requires 'URL::Encode';
+  requires 'FindBin';
+  requires 'Test::Pod';
 };
 
 on 'develop' => sub {

--- a/lib/ProductOpener/APIProductRevert.pm
+++ b/lib/ProductOpener/APIProductRevert.pm
@@ -21,6 +21,7 @@
 =head1 NAME
 
 ProductOpener::APIProductRevert - implementation of API to revert a product to a specific revision
+
 =head1 DESCRIPTION
 
 =cut

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -304,6 +304,7 @@ Return if a form displays errors
 
 Most forms will return a 200 while displaying an error message.
 This function assumes error_list.tt.html was used.
+
 =cut
 
 sub html_displays_error ($page) {
@@ -685,7 +686,9 @@ sub tail_log_read ($tail) {
 }
 
 =head2 mails_from_log($text)
+
 Retrieve mails in a log extract
+
 =cut
 
 sub mails_from_log ($text) {
@@ -696,15 +699,19 @@ sub mails_from_log ($text) {
 }
 
 =head2 mail_to_text($text)
+
 Make mail more easy to search by removing some specific formatting
 
 Especially we replace "3D=" for "=" and join line and their continuation
+
 =head3 Arguments
 
 =head4 $mail text of mail
 
 =head3 Returns
+
 Reformatted text
+
 =cut
 
 sub mail_to_text ($mail) {
@@ -720,12 +727,15 @@ sub mail_to_text ($mail) {
 
 Replace parts of mail that varies from tests to tests,
 and also in a format that's nice in json.
+
 =head3 Arguments
 
 =head4 $mail text of mail
 
 =head3 Returns
+
 ref to an array of lines of the email
+
 =cut
 
 sub normalize_mail_for_comparison ($mail) {
@@ -815,21 +825,26 @@ sub fake_http_server ($port, $dump_path, $responses_ref) {
 }
 
 =head2 get_minion_jobs($task_name, $created_after_ts, $max_waiting_time)
+
 Subprogram which wait till the minion finished its job or
 if it takes too much time
 
 =head3 Arguments
 
 =head4 $task_name
+
 The name of the task 
 
 =head4 $created_after_ts
+
 The timestamp of the creation of the task
 
 =head4 $max_waiting_time
+
 The max waiting time for this given task
 
 =head3 Returns
+
 Returns a list of jobs information associated with the task_name
 
 Note: for each job we return the job information (as returned by the jobs() iterator),

--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Attributes - Generate product attributes that can be requested through the API
@@ -1081,6 +1083,7 @@ e.g. "salt", "sugars", "fat", "saturated-fat"
 The return value is a reference to the resulting attribute data structure.
 
 =head4 % Match
+
 For "low" levels:
 
 - 100% if the nutrient quantity is 0%
@@ -1381,6 +1384,7 @@ vegan, non-vegan, maybe-vegan, vegan-status-unknown
 The return value is a reference to the resulting attribute data structure.
 
 =head4 % Match
+
 For "low" levels:
 
 - 100% if the property matches

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -273,12 +273,14 @@ correspond to the _id field
 =head3 Return values
 
 Returns a hash with:
-<dl>
-  <dt>removed</dt>
-  <dd>int - number of effectively removed items</dd>
-  <dt>errors</dt>
-  <dd>ref to a list of errors</dd>
-</dl>
+
+	<dl>
+	  <dt>removed</dt>
+	  <dd>int - number of effectively removed items</dd>
+	  <dt>errors</dt>
+	  <dd>ref to a list of errors</dd>
+	</dl>
+
 =cut
 
 sub remove_documents_by_ids ($ids_to_remove_ref, $coll, $bulk_write_size = 100) {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -6683,6 +6683,7 @@ or city.
 The traceability code
 
 =head3 returns - list of 2 elements
+
 (latitude, longitude) if found, or (undef, undef) otherwise
 
 =cut
@@ -6987,6 +6988,7 @@ sub search_and_map_products ($request_ref, $query_ref, $graph_ref) {
 add a permalink to a search result page
 
 =head3 return - string - generated HTML
+
 =cut
 
 sub search_permalink ($request_ref) {

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -1,4 +1,4 @@
-# This file is part of Product Opener.
+ # This file is part of Product Opener.
 #
 # Product Opener
 # Copyright (C) 2011-2023 Association Open Food Facts
@@ -17,6 +17,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=encoding UTF-8
 
 =head1 NAME
 
@@ -419,9 +421,13 @@ It is a list of nutrients names with eventual prefixes and suffixes:
 =item The level of each nutrient is indicated by leading dashes before its id:
 
 =over
+
 =item C<nutrient> - no dash for top nutrients
+
 =item C<-sub-nutrient> - for level 2
+
 =item C<--sub-sub-nutrient> - for level 3, etc.
+
 =back
 
 =item C<nutrient-> a C<-> at the end indicates that the nutrient should be hidden and only shown if explicitly added.

--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -1,4 +1,4 @@
- # This file is part of Product Opener.
+# This file is part of Product Opener.
 #
 # Product Opener
 # Copyright (C) 2011-2023 Association Open Food Facts

--- a/lib/ProductOpener/FoodGroups.pm
+++ b/lib/ProductOpener/FoodGroups.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Food - functions related to food products and nutrition

--- a/lib/ProductOpener/HTTP.pm
+++ b/lib/ProductOpener/HTTP.pm
@@ -140,6 +140,7 @@ sub get_cors_headers ($allow_credentials = 0, $sub_domain_only = 0) {
 This function write cors_headers in response.
 
 see get_cors_headers to see how they are computed and parameters
+
 =cut
 
 sub write_cors_headers ($allow_credentials = 0, $sub_domain_only = 0) {

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Ingredients - process and analyze ingredients lists

--- a/lib/ProductOpener/Mail.pm
+++ b/lib/ProductOpener/Mail.pm
@@ -72,13 +72,17 @@ use Log::Any qw($log);
 =head1 CONSTANTS
 
 =head2 LOG_EMAIL_START
+
 Text used before logging an email
+
 =cut
 
 $LOG_EMAIL_START = "---- EMAIL START ----\n";
 
 =head2 LOG_EMAIL_END
+
 Text used after logging an email
+
 =cut
 
 $LOG_EMAIL_END = "\n---- EMAIL END ----\n";

--- a/lib/ProductOpener/Nutriscore.pm
+++ b/lib/ProductOpener/Nutriscore.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Nutriscore - compute the Nutriscore grade of a food product

--- a/lib/ProductOpener/Packaging.pm
+++ b/lib/ProductOpener/Packaging.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Packaging 

--- a/lib/ProductOpener/Paths.pm
+++ b/lib/ProductOpener/Paths.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Paths - functions to get, check and initialize important directories
@@ -62,133 +64,177 @@ use ProductOpener::Config qw/:all/;
 =cut
 
 =head2 %BASE_DIRS
+
 A hashmap containing references to base directories
+
 =cut
 
 %BASE_DIRS = ();
 
 =head3 $BASE_DIRS{LOGS}
+
 Directory for logging
+
 =cut
 
 $BASE_DIRS{LOGS} = "$data_root/logs";
 
 =head2 $BASE_DIRS{ORGS}
+
 Directory containing sto of organizations
+
 =cut
 
 $BASE_DIRS{ORGS} = "$data_root/orgs";
 
 =head2 $BASE_DIRS{USERS}
+
 Directory containing sto of users
+
 =cut
 
 $BASE_DIRS{USERS} = "$data_root/users";
 
 =head2 $BASE_DIRS{PRODUCTS}
+
 Directory containing sto of products
+
 =cut
 
 $BASE_DIRS{PRODUCTS} = "$data_root/products";
 
 =head2 $BASE_DIRS{TAXONOMIES_SRC}
+
 Directory containing txt taxonomies
+
 =cut
 
 $BASE_DIRS{TAXONOMIES_SRC} = _source_dir() . "/taxonomies";
 
 =head2 $BASE_DIRS{PRIVATE_DATA}
+
 Directory for private data
+
 =cut
 
 $BASE_DIRS{PRIVATE_DATA} = "$data_root/data";
 
 =head2 $BASE_DIRS{LANG}
+
 Directory with language files (.po). Normally linked to openfoodfacts-web
+
 =cut
 
 $BASE_DIRS{LANG} = "$data_root/lang";
 
 =head2 $BASE_DIRS{IMPORT_FILES}
+
 files to import in producer platform
+
 =cut
 
 $BASE_DIRS{IMPORT_FILES} = "$data_root/import_files";
 
 =head2 $BASE_DIRS{EXPORT_FILES}
+
 files to export from producer platform to public platform
+
 =cut
 
 $BASE_DIRS{EXPORT_FILES} = "$data_root/export_files";
 
 =head2 $BASE_DIRS{PRODUCTS_IMAGES}
+
 product images is a big directory, normally a volume of its own
+
 =cut
 
 $BASE_DIRS{PRODUCTS_IMAGES} = "$www_root/images/products";
 
 =head2 $BASE_DIRS{CACHE_TMP}
+
 temporary files we manage locally
+
 =cut
 
 $BASE_DIRS{CACHE_TMP} = "$data_root/tmp";
 
 =head2 $BASE_DIRS{CACHE_NEW_IMAGES}
+
 A directory to link newly updated images in order to apply processing (like OCR)
+
 =cut
 
 $BASE_DIRS{CACHE_NEW_IMAGES} = "$data_root/new_images";
 
 =head2 $BASE_DIRS{CACHE_DEBUG}
+
 Temporary files for debugging purposes
+
 =cut
 
 $BASE_DIRS{CACHE_DEBUG} = "$data_root/debug";
 
 =head2 $BASE_DIRS{CACHE_BUILD}
+
 Files needed for various build phases - eg taxonomy and cached
+
 =cut
 
 $BASE_DIRS{CACHE_BUILD} = "$data_root/build-cache";
 
 =head2 $BASE_DIRS{DELETED_PRODUCTS}
+
 Products deleted from the public platform
+
 =cut
 
 $BASE_DIRS{DELETED_PRODUCTS} = "$data_root/deleted_products";
 
 =head2 $BASE_DIRS{DELETED_PRODUCTS_IMAGES}
+
 Products deleted from the public platform
+
 =cut
 
 $BASE_DIRS{DELETED_PRODUCTS_IMAGES} = "$data_root/deleted_products_images";
 
 =head2 $BASE_DIRS{DELETED_PRIVATE_PRODUCTS}
+
 Products deleted from the producers platform
+
 =cut
 
 $BASE_DIRS{DELETED_PRIVATE_PRODUCTS} = "$data_root/deleted_private_products";
 
 =head2 $BASE_DIRS{DELETED_IMAGES}
+
 A directory to store deleted images (not accessible from web)
+
 =cut
 
 $BASE_DIRS{DELETED_IMAGES} = "$data_root/deleted.images";
 
 =head2 $BASE_DIRS{REVERTED_PRODUCTS}
+
 A directory where we store revisions we reverted for some products
+
 =cut
 
 $BASE_DIRS{REVERTED_PRODUCTS} = "$data_root/reverted_products";
 
 =head2 $BASE_DIRS{FILES_DEBUG}
+
 A directory used to debug knowledge panels
+
 =cut
 
 $BASE_DIRS{FILES_DEBUG} = "$www_root/files/debug";
 
 =head2 $BASE_DIRS{PUBLIC_DATA}
+
 The main public data directory where database dumps are published along with other assets
+
 =cut
 
 $BASE_DIRS{PUBLIC_DATA} = "$www_root/data";
@@ -196,28 +242,35 @@ $BASE_DIRS{PUBLIC_DATA} = "$www_root/data";
 # FIXME: can we move those in PUBLIC_DATA_DIR ?
 
 =head2 $BASE_DIRS{PUBLIC_DUMP}
+
 =cut
 
 $BASE_DIRS{PUBLIC_DUMP} = "$www_root/dump";
 
 =head2 $BASE_DIRS{PUBLIC_FILES}
+
 =cut
 
 $BASE_DIRS{PUBLIC_FILES} = "$www_root/files";
 
 =head2 $BASE_DIRS{PUBLIC_EXPORTS}
+
 =cut
 
 $BASE_DIRS{PUBLIC_EXPORTS} = "$www_root/exports";
 
 =head2 $BASE_DIRS{USERS_TRANSLATIONS}
+
 Users contributed translations directory
+
 =cut
 
 $BASE_DIRS{USERS_TRANSLATIONS} = "$data_root/translate";
 
 =head2 $BASE_DIRS{SFTP_HOME}
+
 sftp home directory, only for producers platform
+
 =cut
 
 $BASE_DIRS{SFTP_HOME} = $sftp_root;
@@ -227,11 +280,17 @@ my @PRO_ONLY_PATHS = qw(SFTP_HOME);
 =head1 FUNCTIONS
 
 =head2 products_dir($server_name)
+
 products directory for a foreign server
+
 =head3 Arguments
+
 =head4 $server_name - off/obf/opf/opff…
+
 =head3 Return
+
 String of path to base directory containing products sto
+
 =cut
 
 sub products_dir ($server_name) {
@@ -240,11 +299,17 @@ sub products_dir ($server_name) {
 }
 
 =head2 products_images_dir($server_name)
+
 products images directory for a foreign server
+
 =head3 Arguments
+
 =head4 $server_name - off/obf/opf/opff…
+
 =head3 Return
+
 String of path to base directory containing products images
+
 =cut
 
 sub products_images_dir ($server_name) {
@@ -285,7 +350,9 @@ sub get_file_for_taxonomy ($tagtype, $product_type) {
 }
 
 =head2 get_path_for_taxonomy( $tagtype, $product_type )
+
 full path for taxonomy file
+
 =cut
 
 sub get_path_for_taxonomy($tagtype, $product_type) {
@@ -295,7 +362,9 @@ sub get_path_for_taxonomy($tagtype, $product_type) {
 }
 
 =head2 base_paths()
+
 Return the list of base paths as a hashmap
+
 =cut
 
 sub base_paths() {
@@ -320,9 +389,13 @@ sub base_paths() {
 }
 
 =head2 check_missing_dirs()
+
 Check main directories, needed for the project to run, exists
+
 =head3 Return
+
 A ref to a list of missing paths
+
 =cut
 
 sub check_missing_dirs() {
@@ -335,7 +408,9 @@ sub check_missing_dirs() {
 }
 
 =head2 ensure_dir_created($path, $mode=oct(755))
+
 Ensure a multiple path is created but die if a fundamental path is missing
+
 =cut
 
 sub ensure_dir_created ($path, $mode = oct(755)) {
@@ -363,7 +438,9 @@ sub ensure_dir_created ($path, $mode = oct(755)) {
 }
 
 =head2 ensure_dir_created_or_die($path, $mode=0755)
+
 Ensure a multiple path is created but die if a fundamental path is missing
+
 =cut
 
 sub ensure_dir_created_or_die ($path, $mode = 0755) {
@@ -375,6 +452,7 @@ sub ensure_dir_created_or_die ($path, $mode = 0755) {
 }
 
 =head2 base_paths_loading_script()
+
 Return a sh script to define environment variables
 
 You can then use it in a script by running:

--- a/lib/ProductOpener/Producers.pm
+++ b/lib/ProductOpener/Producers.pm
@@ -98,12 +98,15 @@ use Minion;
 my $minion;
 
 =head2 get_minion()
+
 Function to get the backend minion
 
 =head3 Arguments
+
 None
 
 =head3 Return values
+
 The backend minion $minion
 
 =cut

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -3014,7 +3014,7 @@ It does not block image upload.
 
 =item * name: rule name to identify it in logs and describe it
 
-=item * conditions: the conditions the product must match, a list of [fieldname, value]
+=item * conditions: the conditions the product must match, a list of [field name, value]
 
 =item * actions: the actions to take, a list, where each element is a list with a rule name, and eventual arguments
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1836,6 +1836,7 @@ to determine if the change was done through an app, the OFF userid, or an app sp
 =head3 Parameters
 
 =head4 $change_ref
+
 reference to a change record
 
 =head3 Return value
@@ -3010,10 +3011,15 @@ It does not block image upload.
 =head3 edit_rules structure
 
 =over 1
+
 =item * name: rule name to identify it in logs and describe it
+
 =item * conditions: the conditions the product must match, a list of [fieldname, value]
+
 =item * actions: the actions to take, a list, where each element is a list with a rule name, and eventual arguments
+
 =item * notifications: also notify, list of email addresses or specific notification rules
+
 =back
 
 =head4 conditions
@@ -3039,12 +3045,19 @@ C<ignore_if_CONDITION_FIELD> or C<warn_if_CONDITION_FIELD>
 This time it's to check the value the user want's to add.
 
 C<CONDITION> is one of the following:
+
 =over 1
+
 =item * existing - user tries to edit this field with a non empty value
+
 =item * 0 - user tries to put numerical value 0 in the field
+
 =item * equal / lesser / greater - comparison of numeric value (requires a value as argument)
+
 =item * match - comparison to a string (equality, requires a value as argument)
+
 =item * regexp_match - match against a regexp (requires a regexp value as argument)
+
 =back
 
 =head4 notifications
@@ -3055,6 +3068,7 @@ or "slack_CHANNEL_NAME" (B<warning> currently channel name is ignored, we post t
 =head4 Example of an edit rule
 
 =begin text
+
 {
 	name => "App XYZ",
 	conditions => [
@@ -3072,6 +3086,7 @@ or "slack_CHANNEL_NAME" (B<warning> currently channel name is ignored, we post t
 		slack_channel_edit-alert-test
 	),
 },
+
 =end text
 
 =cut

--- a/lib/ProductOpener/Redis.pm
+++ b/lib/ProductOpener/Redis.pm
@@ -33,7 +33,9 @@ use ProductOpener::Config qw/$redis_url/;
 use Redis;
 
 =head2 $redis_client
+
 The connection to redis
+
 =cut
 
 my $redis_client;
@@ -74,19 +76,24 @@ Add an event to Redis stream to inform that a product was updated.
 =head3 Arguments
 
 =head4 String $user_id
+
 The user that updated the product.
 
 =head4 Product Object $product_ref
+
 The product that was updated.
 
 =head4 String $action
+
 The action that was performed on the product (either "updated" or "deleted").
 A product creation is considered as an update.
 
 =head4 String $comment
+
 The user comment associated with the update.
 
 =head4 HashRef $diffs
+
 a hashref of the differences between the previous and new revision of the product.
 
 =cut

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Tags - multilingual tags taxonomies (hierarchies of tags)
@@ -195,6 +197,7 @@ use Data::DeepAccess qw(deep_get deep_exists);
 binmode STDERR, ":encoding(UTF-8)";
 
 =head1 GLOBAL VARIABLES
+
 =cut
 
 =head2 %tags_fields
@@ -485,6 +488,7 @@ Iterating from the most specific category, try to get a property for a tag by ex
 =head3 Parameters
 
 =head4 $product_ref - the product reference
+
 =head4 $property - the property - string
 
 =head3 Return
@@ -527,9 +531,13 @@ and then decide the order, but this methods is more eager to save time.
 =head3 Parameters
 
 =head4 $tagtype - str, name of taxonomy
+
 =head4 $canon_tagid - tag id for which we want properties
+
 =head4 $properties_names - ref to a list of property name
+
 =head4 $fallback_lcs - fallback language code to try
+
 If may search a description:fr but if fallback is ['xx', 'en']
 and we find a description:xx or description:en property we will use this value.
 
@@ -635,11 +643,13 @@ sub get_inherited_properties ($tagtype, $canon_tagid, $properties_names_ref, $fa
 }
 
 =head2 get_tags_grouped_by_property ($tagtype, $tagids_ref, $prop_name, $props_ref, $inherited_props_ref, $fallback_lcs = ["xx", "en"])
+
 Retrieve properties of a series of tags given in C<$tagids_ref>
 and return them, but grouped by C<$prop_name>,
 also fetching C<$props_ref> and C<$inherited_props_ref>
 
 =head3 Return
+
 A ref to a hashmap, where keys are property C<$prop_name> values,
 and values are in turn hashmaps where keys are tag ids,
 and values are a hashmap with of properties and their values.
@@ -647,6 +657,7 @@ and values are a hashmap with of properties and their values.
 Tags with undefined property are with group under "undef" value.
 
 =head4 Example
+
 we asks for quality tags, grouped by fix_action, while getting descriptions
 {
 	"add_nutrition_facts" => {
@@ -664,6 +675,7 @@ we asks for quality tags, grouped by fix_action, while getting descriptions
 		}
 	}
 }
+
 =cut
 
 sub get_tags_grouped_by_property ($tagtype, $tagids_ref, $prop_name, $props_ref, $inherited_props_ref,

--- a/lib/ProductOpener/Test.pm
+++ b/lib/ProductOpener/Test.pm
@@ -87,6 +87,7 @@ Read gzipped file and return binary content
 =head3 Parameters
 
 =head4 String $filepath
+
 The path of the gzipped file.
 
 =cut
@@ -107,6 +108,7 @@ Check that OCR result returned by Google Cloud Vision is as expected:
 =head3 Parameters
 
 =head4 String $ocr_result
+
 String of OCR result JSON as returned by Google Cloud Vision.
 
 =cut
@@ -132,6 +134,7 @@ There are two modes: one to update expected results, and one to test against the
 =head3 Parameters
 
 =head4 String $filepath
+
 The path of the file containing the test.
 Generally should be <pre>__FILE__</pre> within the test.
 
@@ -805,6 +808,7 @@ sub normalize_org_for_test_comparison ($org_ref) {
 }
 
 =head2 wait_for($code, $timeout=3, $poll_time=1)
+
 Wait for an event to happen, up to a certain amount of time
 
 =head3 parameters

--- a/lib/ProductOpener/TestDefaults.pm
+++ b/lib/ProductOpener/TestDefaults.pm
@@ -45,13 +45,17 @@ BEGIN {
 use vars @EXPORT_OK;
 
 =head2 $test_password
+
 The default test password
+
 =cut
 
 my $test_password = "testtest";
 
 =head2 %default_user_form
+
 A basic user.
+
 =cut
 
 %default_user_form = (
@@ -72,7 +76,9 @@ A basic user.
 );
 
 =head2 %admin_user_form
+
 a user which is an admin
+
 =cut
 
 %admin_user_form = (
@@ -83,9 +89,11 @@ a user which is an admin
 );
 
 =head2 %moderator_user_form and %pro_moderator_user_form
+
 a user which is a moderator, or a pro platform moderator
 
 NB: must be created by an admin
+
 =cut
 
 %moderator_user_form = (

--- a/lib/ProductOpener/Text.pm
+++ b/lib/ProductOpener/Text.pm
@@ -168,6 +168,7 @@ Escape character $char in string $s
 
 This is use in templates to say escape single quote or double quote
 for expressions displayed with single/double quotes (in json or HTML for example)
+
 =cut
 
 sub escape_char($s, $char) {

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -341,6 +341,7 @@ This will then be used in process_user_form
 =head3 Parameters
 
 =head4 String action type $type
+
 edit / add / delete
 
 =head4 User object $user_ref
@@ -635,6 +636,7 @@ To be used after check_user_form
 =head3 Parameters
 
 =head4 String action type $type
+
 edit / add / delete
 
 =head4 User object $user_ref

--- a/lib/ProductOpener/Web.pm
+++ b/lib/ProductOpener/Web.pm
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 ProductOpener::Web - contains display functions for the website.

--- a/scripts/preprocess_intermarche_packaging_csv_file.pl
+++ b/scripts/preprocess_intermarche_packaging_csv_file.pl
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+=encoding UTF-8
+
 =head1 NAME
 
 

--- a/tests/unit/all_pod_correct.t
+++ b/tests/unit/all_pod_correct.t
@@ -9,8 +9,7 @@ use Path::Tiny;
 # files to inspect
 my $root = path($Bin)->parent(2);
 my @poddirs = map {$root->child($_)->canonpath} qw/lib cgi scripts/;
-my @podfiles = grep {!/_DAL_/ && !/local_lib/} 
-                    all_pod_files( @poddirs );
+my @podfiles = grep all_pod_files( @poddirs );
 
 
 foreach my $file (@podfiles) {

--- a/tests/unit/all_pod_correct.t
+++ b/tests/unit/all_pod_correct.t
@@ -9,7 +9,7 @@ use Path::Tiny;
 # files to inspect
 my $root = path($Bin)->parent(2);
 my @poddirs = map {$root->child($_)->canonpath} qw/lib cgi scripts/;
-my @podfiles = grep all_pod_files(@poddirs);
+my @podfiles = all_pod_files(@poddirs);
 
 foreach my $file (@podfiles) {
 

--- a/tests/unit/all_pod_correct.t
+++ b/tests/unit/all_pod_correct.t
@@ -7,17 +7,20 @@ use Test::Pod;
 use Path::Tiny;
 
 # files to inspect
-my @poddirs = ("$Bin/../lib", "$Bin/../cgi", "$Bin/../scripts" );
-my @podfiles = all_pod_files( @poddirs );
+my $root = path($Bin)->parent(2);
+my @poddirs = map {$root->child($_)->canonpath} qw/lib cgi scripts/;
+my @podfiles = grep {!/_DAL_/ && !/local_lib/} 
+                    all_pod_files( @poddirs );
 
 
 foreach my $file (@podfiles) {
 
-	# POD correctness
-	pod_file_ok($file, "POD syntax in $file");
+	my $short_file = path($file)->relative($root);
 
+	# regular check for POD correctness
+	pod_file_ok($file, "POD syntax in $short_file");
 
-	# additional check : its better if =cut directives are preceded by a blank line
+	# additional check : it's better if =cut directives are preceded by a blank line
 	#
 	# see L<perpod> : To end a Pod block, use a blank line, then a line
 	# beginning with "=cut", and a blank line after it. This lets Perl
@@ -27,7 +30,7 @@ foreach my $file (@podfiles) {
 	my @lines      = path($file)->lines_utf8;
 	my @pod_lines  = grep {$lines[$_] =~ /^=/} 0 .. $#lines;
 	my @bad_pod    = grep {$lines[$_ - 1] !~ /^\h*$/ || $lines[$_ + 1] !~ /^\h*$/} @pod_lines;
-	ok !@bad_pod, "empty lines around = directives in $file: " . join(", ", @bad_pod); 
+	ok !@bad_pod, "empty lines around = directives in $short_file: " . join(", ", @bad_pod); 
 }
 
 

--- a/tests/unit/all_pod_correct.t
+++ b/tests/unit/all_pod_correct.t
@@ -9,8 +9,7 @@ use Path::Tiny;
 # files to inspect
 my $root = path($Bin)->parent(2);
 my @poddirs = map {$root->child($_)->canonpath} qw/lib cgi scripts/;
-my @podfiles = grep all_pod_files( @poddirs );
-
+my @podfiles = grep all_pod_files(@poddirs);
 
 foreach my $file (@podfiles) {
 
@@ -26,11 +25,10 @@ foreach my $file (@podfiles) {
 	# (and the Pod formatter) know that this is where Perl code is
 	# resuming. (The blank line before the "=cut" is not technically
 	# necessary, but many older Pod processors require it.)
-	my @lines      = path($file)->lines_utf8;
-	my @pod_lines  = grep {$lines[$_] =~ /^=/} 0 .. $#lines;
-	my @bad_pod    = grep {$lines[$_ - 1] !~ /^\h*$/ || $lines[$_ + 1] !~ /^\h*$/} @pod_lines;
-	ok !@bad_pod, "empty lines around = directives in $short_file: " . join(", ", @bad_pod); 
+	my @lines = path($file)->lines_utf8;
+	my @pod_lines = grep {$lines[$_] =~ /^=/} 0 .. $#lines;
+	my @bad_pod = grep {$lines[$_ - 1] !~ /^\h*$/ || $lines[$_ + 1] !~ /^\h*$/} @pod_lines;
+	ok !@bad_pod, "empty lines around = directives in $short_file: " . join(", ", @bad_pod);
 }
-
 
 done_testing;

--- a/xt/README.txt
+++ b/xt/README.txt
@@ -1,0 +1,5 @@
+Following common practice in CPAN distributions, this directory is for "author tests",
+i.e. additional test scripts that should be executed only by the maintainers of
+ProductOpener, but not by the people who install it.
+
+To run these tests, execute the command "prove xt" in the parent directory.

--- a/xt/README.txt
+++ b/xt/README.txt
@@ -1,5 +1,0 @@
-Following common practice in CPAN distributions, this directory is for "author tests",
-i.e. additional test scripts that should be executed only by the maintainers of
-ProductOpener, but not by the people who install it.
-
-To run these tests, execute the command "prove xt" in the parent directory.

--- a/xt/all_pod_correct.t
+++ b/xt/all_pod_correct.t
@@ -1,0 +1,36 @@
+use utf8;
+use strict;
+use warnings;
+use Test::More;
+use FindBin qw/$Bin/;
+use Test::Pod;
+use Path::Tiny;
+
+# files to inspect
+my @poddirs = ("$Bin/../lib", "$Bin/../cgi", "$Bin/../scripts" );
+my @podfiles = 
+  grep {!/DAL_local/}
+  all_pod_files( @poddirs );
+
+
+foreach my $file (@podfiles) {
+
+	# POD correctness
+	pod_file_ok($file, "POD syntax in $file");
+
+
+	# additional check : its better if =cut directives are preceded by a blank line
+	#
+	# see L<perpod> : To end a Pod block, use a blank line, then a line
+	# beginning with "=cut", and a blank line after it. This lets Perl
+	# (and the Pod formatter) know that this is where Perl code is
+	# resuming. (The blank line before the "=cut" is not technically
+	# necessary, but many older Pod processors require it.)
+	my @lines      = path($file)->lines_utf8;
+	my @pod_lines  = grep {$lines[$_] =~ /^=/} 0 .. $#lines;
+	my @bad_pod    = grep {$lines[$_ - 1] !~ /^\h*$/ || $lines[$_ + 1] !~ /^\h*$/} @pod_lines;
+	ok !@bad_pod, "empty lines around = directives in $file: " . join(", ", @bad_pod); 
+}
+
+
+done_testing;

--- a/xt/all_pod_correct.t
+++ b/xt/all_pod_correct.t
@@ -8,9 +8,7 @@ use Path::Tiny;
 
 # files to inspect
 my @poddirs = ("$Bin/../lib", "$Bin/../cgi", "$Bin/../scripts" );
-my @podfiles = 
-  grep {!/DAL_local/}
-  all_pod_files( @poddirs );
+my @podfiles = all_pod_files( @poddirs );
 
 
 foreach my $file (@podfiles) {


### PR DESCRIPTION
Minor POD fixes in this PR : 
- make sure the =encoding UTF-8 directive is present when the doc uses non-ASCII chars
- always have blank lines before and after =pod directives (some old POD parsers require this)
- add a test to check for the rules above