### PR TITLE
fix: contribution tag not highlighting as part of issue #10061

### DIFF
--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -263,9 +263,8 @@
     </section>
 [% END %]
 
-<a id="contribution"></a>
 [% IF contribution_card_panel %]
-<section class="row">
+<section class="row" id="contribution">
     <div class="large-12 column">
         <div class="card">
             <div class="card-section">
@@ -274,6 +273,8 @@
         </div>
     </div>
 </section>
+[% ELSE %]
+<a id="contribution"></a>
 [% END %]
 
 <section class="row" >


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
The contribution tag in the navigation bar does not get highlighted even when on the page which has a contribution panel .
This issue was solved from the product_page.tt.html file where there was an anchor tag with the id="contribution" that was always being rendered on the product page even if the contribution_card_panel exists or not. I added the id="contribution" to the section tag containing the contribution panel and checked for the existence of the panel, if not the anchor tag with id="contribution" will be rendered.
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->
https://github.com/openfoodfacts/openfoodfacts-server/assets/135853264/a06eb782-8dbd-41f7-97d1-17e039f8cf73

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #10061 

