### PR TITLE
fix: export obsolete products only once and include "obsolete" field in CSV export

### DIFF
--- a/scripts/export_database.pl
+++ b/scripts/export_database.pl
@@ -115,6 +115,7 @@ my %tags_fields = (
 
 my %langs = ();
 my $total = 0;
+my %exported_products;
 
 my $fields_ref = {};
 
@@ -297,6 +298,12 @@ XML
 			my $csv = '';
 			my $url = "http://world-$lc.$server_domain" . product_url($product_ref);
 			my $code = ($product_ref->{code} // '');
+
+			if ($product_ref->{obsolete}) {
+				if ($exported_products{$code}) {
+					next;
+				}
+			}
 
 			$code eq '' and next;
 			$code < 1 and next;
@@ -509,6 +516,7 @@ XML
 
 			print $OUT $csv;
 			print $RDF $rdf;
+			$exported_products{$code} = 1;
 		}
 	}
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

- This PR implements a fix to ensure that obsolete products are exported only once and do not appear as duplicates .
- Introduces a new field "obsolete" in the CSV export.

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #9684

