### PR TITLE
fix: Deleted the Pros' Meet-Up link in Menu

### DIFF
--- a/po/common/aa.po
+++ b/po/common/aa.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ach.po
+++ b/po/common/ach.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/af.po
+++ b/po/common/af.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ak.po
+++ b/po/common/ak.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/am.po
+++ b/po/common/am.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -6580,10 +6580,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/as.po
+++ b/po/common/as.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ast.po
+++ b/po/common/ast.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/az.po
+++ b/po/common/az.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/be.po
+++ b/po/common/be.po
@@ -6568,10 +6568,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ber.po
+++ b/po/common/ber.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -6584,10 +6584,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "ЧЗВ за производителите"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/bm.po
+++ b/po/common/bm.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/bo.po
+++ b/po/common/bo.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/bs.po
+++ b/po/common/bs.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -6584,10 +6584,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Preguntes freqüents per als productors"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Uneix-te a la pròxima trobada de professionals"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ce.po
+++ b/po/common/ce.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/chr.po
+++ b/po/common/chr.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/co.po
+++ b/po/common/co.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6573,10 +6573,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Join the next Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/crs.po
+++ b/po/common/crs.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -6579,10 +6579,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Nejčastější dotazy pro výrobce"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Připojte se k dalšímu setkání profesionálů"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/cv.po
+++ b/po/common/cv.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/cy.po
+++ b/po/common/cy.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producenter"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Deltag i det næste Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ für Produzenten"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Nehmen Sie teil am nächsten Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -6570,10 +6570,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6598,10 +6598,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Join the next Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -6584,10 +6584,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Join the next Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -6584,10 +6584,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for producers"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Join the next Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/eo.po
+++ b/po/common/eo.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -6585,10 +6585,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Preguntas frecuentes para productores"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Participa en el próximo encuentro de profesionales"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/et.po
+++ b/po/common/et.po
@@ -6566,10 +6566,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Maiz egindako galderak produktoreentzat"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Batu zaitez hurrengo profesionalen topaketan"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "UKK tuottajille"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Liity seuraavaan ammattilaisten tapaamiseen"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/fil.po
+++ b/po/common/fil.po
@@ -6574,10 +6574,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/fo.po
+++ b/po/common/fo.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -6586,10 +6586,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ pour les Producteurs"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Rejoignez la prochaine rencontre des Pros"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ga.po
+++ b/po/common/ga.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/gd.po
+++ b/po/common/gd.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/gl.po
+++ b/po/common/gl.po
@@ -6566,10 +6566,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/gu.po
+++ b/po/common/gu.po
@@ -6567,10 +6567,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ha.po
+++ b/po/common/ha.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "שאלות נפוצות של יצרנים"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "הצטרפו למפגש המקצוענים הבא"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/hi.po
+++ b/po/common/hi.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/hr.po
+++ b/po/common/hr.po
@@ -6567,10 +6567,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ht.po
+++ b/po/common/ht.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -6578,10 +6578,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/hy.po
+++ b/po/common/hy.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/id.po
+++ b/po/common/id.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "SSD untuk produsen"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Bergabunglah dalam Pertemuan Profesional berikutnya"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ii.po
+++ b/po/common/ii.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/is.po
+++ b/po/common/is.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -6584,10 +6584,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Domande Frequenti per produttori"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Unisciti al nostro prossimo Incontro per Professionisti"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/iu.po
+++ b/po/common/iu.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "次回のプロの交流会に参加しましょう"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/jv.po
+++ b/po/common/jv.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ka.po
+++ b/po/common/ka.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/kab.po
+++ b/po/common/kab.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/kk.po
+++ b/po/common/kk.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/km.po
+++ b/po/common/km.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/kmr_TR.po
+++ b/po/common/kmr_TR.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/kn.po
+++ b/po/common/kn.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/kw.po
+++ b/po/common/kw.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ky.po
+++ b/po/common/ky.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/la.po
+++ b/po/common/la.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/lb.po
+++ b/po/common/lb.po
@@ -6566,10 +6566,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/lol.po
+++ b/po/common/lol.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "crwdns228253:0crwdne228253:0"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "crwdns228255:0crwdne228255:0"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/lt.po
+++ b/po/common/lt.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "DUK gamintojams"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Prisijunkite prie sekančio gamintojų susitikimo"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/lv.po
+++ b/po/common/lv.po
@@ -6567,10 +6567,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/mg.po
+++ b/po/common/mg.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/mi.po
+++ b/po/common/mi.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ml.po
+++ b/po/common/ml.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/mn.po
+++ b/po/common/mn.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/mr.po
+++ b/po/common/mr.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/mt.po
+++ b/po/common/mt.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/my.po
+++ b/po/common/my.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/nb.po
+++ b/po/common/nb.po
@@ -6580,10 +6580,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ for produsenter"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Bli med på neste Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ne.po
+++ b/po/common/ne.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Veelgestelde vragen voor producenten"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Neem deel aan de volgende Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ voor producenten"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Neem deel aan de volgende Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/nn.po
+++ b/po/common/nn.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/no.po
+++ b/po/common/no.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/nr.po
+++ b/po/common/nr.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/oc.po
+++ b/po/common/oc.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/or.po
+++ b/po/common/or.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/pa.po
+++ b/po/common/pa.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -6582,10 +6582,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Najczęściej zadawane pytanie dla producentów"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Dołącz do kolejnego wydarzenia Pros' Meet-up"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ para produtores"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Participe do próximo Encontro de Profissionais"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Perguntas frequentes para produtores"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Aderir ao próximo Encontro de Profissionais"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/qu.po
+++ b/po/common/qu.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/rm.po
+++ b/po/common/rm.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Întrebări frecvente pentru producători"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Alăturați-vă următoarei întâlniri a profesioniștilor"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -6584,10 +6584,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sa.po
+++ b/po/common/sa.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sat.po
+++ b/po/common/sat.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sc.po
+++ b/po/common/sc.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sco.po
+++ b/po/common/sco.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sd.po
+++ b/po/common/sd.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sg.po
+++ b/po/common/sg.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/si.po
+++ b/po/common/si.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -6579,10 +6579,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sma.po
+++ b/po/common/sma.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sn.po
+++ b/po/common/sn.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/so.po
+++ b/po/common/so.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/son.po
+++ b/po/common/son.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sq.po
+++ b/po/common/sq.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sr.po
+++ b/po/common/sr.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sr_CS.po
+++ b/po/common/sr_CS.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sr_RS.po
+++ b/po/common/sr_RS.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ss.po
+++ b/po/common/ss.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/st.po
+++ b/po/common/st.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -6581,10 +6581,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/sw.po
+++ b/po/common/sw.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ta.po
+++ b/po/common/ta.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "அடுத்த தொழில் வல்லுநர்கள் சந்திப்பில் சேரவும்"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/te.po
+++ b/po/common/te.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tg.po
+++ b/po/common/tg.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ti.po
+++ b/po/common/ti.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tl.po
+++ b/po/common/tl.po
@@ -6574,10 +6574,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tn.po
+++ b/po/common/tn.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -6579,10 +6579,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "Üreticiler için SSS"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Bir sonraki Profesyoneller Buluşması'na katılın"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ts.po
+++ b/po/common/ts.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tt.po
+++ b/po/common/tt.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tw.po
+++ b/po/common/tw.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ty.po
+++ b/po/common/ty.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/tzl.po
+++ b/po/common/tzl.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ug.po
+++ b/po/common/ug.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -6585,10 +6585,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ для виробників"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Приєднуйтесь до наступної зустрічі профі"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ur.po
+++ b/po/common/ur.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/val.po
+++ b/po/common/val.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/ve.po
+++ b/po/common/ve.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/vec.po
+++ b/po/common/vec.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -6583,10 +6583,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "FAQ cho các nhà sản xuất"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "Tham gia Buổi gặp mặt Chuyên gia tiếp theo"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/vls.po
+++ b/po/common/vls.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/wa.po
+++ b/po/common/wa.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/wo.po
+++ b/po/common/wo.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/xh.po
+++ b/po/common/xh.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/yi.po
+++ b/po/common/yi.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/yo.po
+++ b/po/common/yo.po
@@ -6565,10 +6565,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/zea.po
+++ b/po/common/zea.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -6576,10 +6576,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr "生产者常见问题解答"
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr "参加下一次专业人士聚会"
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -6573,10 +6573,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -6579,10 +6579,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/po/common/zu.po
+++ b/po/common/zu.po
@@ -6564,10 +6564,6 @@ msgctxt "faq_for_producers"
 msgid "FAQ for producers"
 msgstr ""
 
-msgctxt "join_the_next_pros_meet_up"
-msgid "Join the next Pros' Meet-up"
-msgstr ""
-
 # variable names between { } must not be translated
 msgctxt "product_js_enter_value_between_0_and_max"
 msgid "Please enter a value between 0 and {max}."

--- a/templates/web/common/producers_resources_list.tt.html
+++ b/templates/web/common/producers_resources_list.tt.html
@@ -29,12 +29,3 @@ Example: <ul> ... INCLUDE 'web/common/producers_resources_list.tt.html' ... </ul
         [% lang('faq_for_producers') %]
     </a>
 </li>
-<li>
-    <a href="[% IF lc == "fr" %]
-    https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=M3ZmNmZlMmo4czlhZHR1dmpndXI2OGN0NDhfMjAyMzA1MTZUMTIwMDAwWiBjXzlkMGU3ZmM2OGYxOWY2NGZkOTFmNjBhYzE5MzZhMDM2NDc1MGVjODY4MjcyY2VmZWI1NzQ2NGRiYTBlZjkwNmNAZw&tmsrc=c_9d0e7fc68f19f64fd91f60ac1936a0364750ec868272cefeb57464dba0ef906c%40group.calendar.google.com&scp=ALL
-            [% ELSE %]
-            https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NGxtYWhla3ZiYnM3YnNpMDJ0OGw3dTY1aG9fMjAyMzA1MTZUMTMwMDAwWiBjXzlkMGU3ZmM2OGYxOWY2NGZkOTFmNjBhYzE5MzZhMDM2NDc1MGVjODY4MjcyY2VmZWI1NzQ2NGRiYTBlZjkwNmNAZw&tmsrc=c_9d0e7fc68f19f64fd91f60ac1936a0364750ec868272cefeb57464dba0ef906c%40group.calendar.google.com&scp=ALL
-            [% END %]">
-        [% lang('join_the_next_pros_meet_up') %]
-    </a>
-</li>


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
Deleted the button "Join the next Pros' Meet-Up" on the Pro platform in the hamburger menu.
<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->
Before: 
<img width="1435" alt="Screenshot 2024-04-02 at 6 54 12 PM" src="https://github.com/openfoodfacts/openfoodfacts-server/assets/135853264/60957842-6144-4f6f-8d80-7a65a5174456">

After:
<img width="1440" alt="Screenshot 2024-04-02 at 6 54 32 PM" src="https://github.com/openfoodfacts/openfoodfacts-server/assets/135853264/1fd422df-d9d9-44cb-b98b-8e3e01aae1fa">

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #10070 

