### PR TITLE
fix: better logs

### DIFF
--- a/conf/logrotate/apache2
+++ b/conf/logrotate/apache2
@@ -4,8 +4,8 @@
     daily
     missingok
     rotate -1
-    # remove after two years
-    maxage 730
+    # remove after 6 month
+    maxage 183
     compress
     delaycompress
     notifempty

--- a/conf/logrotate/nginx
+++ b/conf/logrotate/nginx
@@ -1,0 +1,20 @@
+/var/log/nginx/*.log {
+	daily
+	missingok
+	rotate 14
+	compress
+        # remove after two years
+        maxage 730
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
+}

--- a/conf/systemd/gen_feeds@.service
+++ b/conf/systemd/gen_feeds@.service
@@ -10,5 +10,7 @@ Group=off
 Environment=PERL5LIB=/srv/%i/lib/:/usr/local/share/perl/5.32.1/:/usr/lib/perl5
 # service instance name "%i" is off / obf / opff / opf
 ExecStart=/srv/%i/scripts/gen_feeds_%i.sh
+StandardOutput=append:/var/log/opf/gen_feeds_%i.log
+StandardError=append:/var/log/gen_feeds_%i-err.log
 
 

--- a/conf/systemd/gen_feeds_daily@.service
+++ b/conf/systemd/gen_feeds_daily@.service
@@ -10,5 +10,7 @@ Group=off
 Environment=PERL5LIB=/srv/%i/lib/:/usr/local/share/perl/5.32.1/:/usr/lib/perl5
 # service instance name "%i" is off / obf / opff / opf
 ExecStart=/srv/%i/scripts/gen_feeds_daily_%i.sh
+StandardOutput=append:/var/log/opf/gen_feeds_daily_%i.log
+StandardError=append:/var/log/gen_feeds_daily_%i-err.log
 
 


### PR DESCRIPTION
I have logs far to big on opf, it appears it's because gen_feeds scripts logs in syslog.