### PR TITLE
fix: typo preventing additives.properties.txt to be used when building taxonomies

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1910,7 +1910,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 		# allow a second file for wikipedia abstracts -> too big, so don't include it in the main file
 		# only process properties
 		my $properties_path = $file_path;
-		$properties_path =~ s/\.txt^/.properties.txt/;
+		$properties_path =~ s/\.txt$/.properties.txt/;
 
 		if (-e $properties_path) {
 


### PR DESCRIPTION
A typo in a recent PR prevented additives.properties.txt to be used as a source for the additives taxonomy, so we didn't have the Wikipedia descriptions etc.

Bug uncovered with the new HTML generation tests from https://github.com/openfoodfacts/openfoodfacts-server/pull/10043