### PR TITLE
fix: remove circular parent in ingredients taxonomy

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1058,7 +1058,7 @@ sub get_file_from_cache ($source, $target) {
 # Change this version string if you want to force the taxonomies to be rebuilt
 # e.g. if the taxonomy building algorithm or configuration has changed
 # This needs to be done also when the unaccenting parameters for languages set in Config.pm are changed
-my $BUILD_TAGS_VERSION = "20240403 - fix issue with additives.properties.txt not loaded + circular_parent check";
+my $BUILD_TAGS_VERSION = "20240403 - fix issue with additives.properties.txt not loaded + circular_parent check + moved canonicalization of properties to linter";
 
 sub get_from_cache ($tagtype, @files) {
 	# If the full set of cached files can't be found then returns the hash to be used

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1058,7 +1058,7 @@ sub get_file_from_cache ($source, $target) {
 # Change this version string if you want to force the taxonomies to be rebuilt
 # e.g. if the taxonomy building algorithm or configuration has changed
 # This needs to be done also when the unaccenting parameters for languages set in Config.pm are changed
-my $BUILD_TAGS_VERSION = "20240329 - better taxonomy errors handling";
+my $BUILD_TAGS_VERSION = "20240403 - fix issue with additives.properties.txt not loaded + circular_parent check";
 
 sub get_from_cache ($tagtype, @files) {
 	# If the full set of cached files can't be found then returns the hash to be used

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1058,7 +1058,8 @@ sub get_file_from_cache ($source, $target) {
 # Change this version string if you want to force the taxonomies to be rebuilt
 # e.g. if the taxonomy building algorithm or configuration has changed
 # This needs to be done also when the unaccenting parameters for languages set in Config.pm are changed
-my $BUILD_TAGS_VERSION = "20240403 - fix issue with additives.properties.txt not loaded + circular_parent check + moved canonicalization of properties to linter";
+my $BUILD_TAGS_VERSION
+	= "20240403 - fix issue with additives.properties.txt not loaded + circular_parent check + moved canonicalization of properties to linter";
 
 sub get_from_cache ($tagtype, @files) {
 	# If the full set of cached files can't be found then returns the hash to be used

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1884,19 +1884,9 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				if (defined $canon_tagid) {
 					defined $properties{$tagtype}{$canon_tagid} or $properties{$tagtype}{$canon_tagid} = {};
 
-					# If the property name matches the name of an already loaded taxonomy,
-					# canonicalize the property values for the corresponding synonym
-					# e.g. if an additive has a class additives_classes:en: en:stabilizer (a synonym),
-					# we can map it to en:stabiliser (the canonical name in the additives_classes taxonomy)
-					if (exists $translations_from{$property}) {
-						$properties{$tagtype}{$canon_tagid}{"$property:$lc"}
-							= join(",", map({canonicalize_taxonomy_tag($lc, $property, $_)} split(/\s*,\s*/, $line)));
-					}
-					else {
-						# TODO print a warning if the property is already defined
-						# add property value
-						$properties{$tagtype}{$canon_tagid}{"$property:$lc"} = $line;
-					}
+					# TODO print a warning if the property is already defined
+					# add property value
+					$properties{$tagtype}{$canon_tagid}{"$property:$lc"} = $line;
 				}
 				else {
 					print STDERR "taxonomy : $tagtype : discarding orphan line : $property : "

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -13610,8 +13610,9 @@ fr:gras et couenne de porc
 en:pork minute steak
 hr:svinjski minutni odrezak
 
-<en:broth
+<en:fond
 <en:pork
+en:pork fond
 fr:fond de porc
 
 <en:pork
@@ -13745,6 +13746,7 @@ nutriscore_red_meat:en:yes
 
 # <en:bone
 <en:veal
+en:veal bone
 fr:os de veau
 
 <en:veal
@@ -87982,10 +87984,16 @@ wikipedia:en:https://en.wikipedia.org/wiki/Brine
 
 
 # description:en:BROTH is a savory liquid made of water in which bones, meat, fish, or vegetables have been simmered.
+# We separate it from "fond" which is used for sauces
+
+en:fond, stock for sauce, stocks for sauce, fond for sauce
+da:fond
+fr:fond, fond de sauce, fonds de sauce
+wikipedia:en:https://en.wikipedia.org/wiki/Fond
 
 # <en:compound
 # <en:mainIngredient:en:water
-en:broth, broths, stock, bouillon, Stocks, fond
+en:broth, broths, stock, bouillon, Stocks
 af:bouillon
 ar:زومات
 az:Bulyon
@@ -87995,7 +88003,7 @@ bg:Бульон
 bn:সুরুয়া
 ca:brou
 cs:vývar
-da:fond, bouillon
+da:bouillon
 de:Brühe, Brühen, Bouillons
 el:ζωμός
 eo:buljono
@@ -88004,7 +88012,7 @@ et:puljong
 eu:Salda
 fa:گوشتابه
 fi:liemi, liemivalmiste
-fr:bouillon, fond, Bouillons, fond de sauce
+fr:bouillon, Bouillons
 ga:anraith
 gd:brot
 gl:Caldo
@@ -88112,7 +88120,7 @@ da:Hønsekødsbouillon
 de:Geflügelbouillon
 es:Caldo de ave
 fi:siipikarjaliemi
-fr:bouillon de volaille, fond de volaille, Bouillons de volaille
+fr:bouillon de volaille, Bouillons de volaille
 it:Brodo di pollame
 ja:鶏肉スープ
 nl:gevogeltebouillon
@@ -88124,7 +88132,28 @@ ciqual_food_code:en:11174
 ciqual_food_name:en:Broth, stock or bouillon, poultry, dehydrated
 ciqual_food_name:fr:Bouillon de volaille, déshydraté
 
-<en:poultry broth
+<en:fond
+en:poultry fond
+fr:fond de volaille
+
+<en:poultry fond
+en:chickend fond
+fr:fond de poulet
+
+<en:poultry fond
+en:duck fond
+fr:fond de canard
+
+<en:poultry fond
+en:turkey fond
+fr:fond de dine
+
+<en:fond
+en:shellfish fond
+fr:fond de crustacés
+
+<en:poultry fond
+en:flavored poultry fond
 fr:fond de volaille aromatisé
 # ingredient/fr:fond-de-volaille-aromatisé has 39 products in french @2019-03-09
 
@@ -88136,7 +88165,6 @@ ciqual_food_name:en:Broth, stock or bouillon, poultry, dehydrated
 ciqual_food_name:fr:Bouillon de volaille, déshydraté
 
 #comment:en:a fond has 2/3 less water than a stock
-<en:dehydrated poultry stock
 <en:fond
 en:dehydrated poultry fond, Poultry stock for sauce and cooking dehydrated
 fr:fond de volaille déshydraté, Fond de volaille pour sauces et cuisson déshydraté
@@ -88156,7 +88184,7 @@ da:Kyllingebouillon
 de:Hühnerbrühe
 es:Caldo de pollo
 fi:kanaliemi
-fr:Bouillon de poulet, fond de poulet
+fr:Bouillon de poulet
 it:brodo di pollo
 ja:チキンスープ, チキンブイヨン
 nl:Kippenbouillon


### PR DESCRIPTION
separate "fond" from "broth"