### PR TITLE
ci: Exclude generated test results from code analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+name: "CodeQL config"
+paths-ignore:
+  - 'tests/integration/expected_test_results/**/*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,8 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
+      with:
+        config-file: ./.github/codeql/codeql-config.yml
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,4 @@
 sonar.sources=cgi,docker,lib,scripts,templates,scss,html/css,html/js,docker-compose.yml,Dockerfile,Dockerfile.frontend,gulpfile.ts,Makefile
 sonar.tests=tests
 
-sonar.exclusions=scripts/obsolete/**/*,html/css/normalize.css
+sonar.exclusions=scripts/obsolete/**/*,html/css/normalize.css,tests/integration/expected_test_results/**/*


### PR DESCRIPTION
### What

The generate integration tests results do not need to be included in the analysis. At best, they'll report redundant issues, at works false positives because of test configuration.