### PR TITLE
fix: remove warning in KnowledgePanelsReportProblem.pm, remove report problem card from pro platform

### DIFF
--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -197,15 +197,24 @@ sub create_knowledge_panels ($product_ref, $target_lc, $target_cc, $options_ref)
 
 	create_health_card_panel($product_ref, $target_lc, $target_cc, $options_ref);
 	create_environment_card_panel($product_ref, $target_lc, $target_cc, $options_ref);
-	create_report_problem_card_panel($product_ref, $target_lc, $target_cc, $options_ref);
+	my $has_report_problem_card;
+	if (not $options_ref->{producers_platform}) {
+		$has_report_problem_card = create_report_problem_card_panel($product_ref, $target_lc, $target_cc, $options_ref);
+	}
 	my $has_contribution_card = create_contribution_card_panel($product_ref, $target_lc, $target_cc, $options_ref);
 
 	# Create the root panel that contains the panels we want to show directly on the product page
 	create_panel_from_json_template(
 		"root",
 		"api/knowledge-panels/root.tt.json",
-		{has_contribution_card => $has_contribution_card},
-		$product_ref, $target_lc, $target_cc, $options_ref
+		{
+			has_report_problem_card => $has_report_problem_card,
+			has_contribution_card => $has_contribution_card
+		},
+		$product_ref,
+		$target_lc,
+		$target_cc,
+		$options_ref
 	);
 	return;
 }

--- a/lib/ProductOpener/KnowledgePanelsReportProblem.pm
+++ b/lib/ProductOpener/KnowledgePanelsReportProblem.pm
@@ -116,7 +116,7 @@ sub create_report_problem_card_panel ($product_ref, $target_lc, $target_cc, $opt
 		"api/knowledge-panels/report_problem/report_problem_card.tt.json",
 		$panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref);
 
-	return;
+	return 1;
 }
 
 1;

--- a/lib/ProductOpener/KnowledgePanelsReportProblem.pm
+++ b/lib/ProductOpener/KnowledgePanelsReportProblem.pm
@@ -81,7 +81,6 @@ sub create_report_problem_card_panel ($product_ref, $target_lc, $target_cc, $opt
 	$log->debug("create contribution card panel", {code => $product_ref->{code}}) if $log->is_debug();
 
 	my @panels = ();
-	my $panel_data_ref = {};
 
 	# TODO: add a panel to display the consumer service contact information if we have it
 	# for the owner of the product. Otherwise, warn that we don't make or sell the product
@@ -92,7 +91,7 @@ sub create_report_problem_card_panel ($product_ref, $target_lc, $target_cc, $opt
 	create_panel_from_json_template(
 		"incomplete_or_incorrect_data",
 		"api/knowledge-panels/report_problem/incomplete_or_incorrect_data.tt.json",
-		$panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref
+		{}, $product_ref, $target_lc, $target_cc, $options_ref
 	);
 	push(@panels, "incomplete_or_incorrect_data");
 
@@ -107,7 +106,7 @@ sub create_report_problem_card_panel ($product_ref, $target_lc, $target_cc, $opt
 		create_panel_from_json_template(
 			"fr_report_product_signalconso",
 			"api/knowledge-panels/report_problem/fr_report_product_signalconso.tt.json",
-			$panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref
+			{}, $product_ref, $target_lc, $target_cc, $options_ref
 		);
 		push(@panels, "fr_report_product_signalconso");
 	}

--- a/templates/api/knowledge-panels/report_problem/fr_report_product_signalconso.tt.json
+++ b/templates/api/knowledge-panels/report_problem/fr_report_product_signalconso.tt.json
@@ -17,8 +17,8 @@
                 "html": `
 Vous avez rencontré un problème avec ce produit : <b>étiquetage non conforme, produit périmé encore en vente,
 présence d'un corps étranger, etc.</b> ?<br>
-Faites un signalement à l'entreprise et à la répression des fraudes sur SignalConso, un outil de la
-Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF).
+Faites un signalement à l'entreprise et à la répression des fraudes sur <a href="https://signal.conso.gouv.fr/fr/alimentaire-codebarres/faire-un-signalement?gtin=[% product.code %]&utm_source=openfoodfacts&utm_campaign=product_page_panel">SignalConso</a>,
+un outil de la Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF).
                 `
             },
         },

--- a/templates/api/knowledge-panels/root.tt.json
+++ b/templates/api/knowledge-panels/root.tt.json
@@ -14,12 +14,14 @@
                 "panel_id": "environment_card",
             },
         },
+        [% IF panel.has_report_problem_card %]
         {
             "element_type": "panel",
             "panel_element": {
                 "panel_id": "report_problem_card",
             },
-        },        
+        },
+        [% END %]
         [% IF panel.has_contribution_card %]
             {
                 "element_type": "panel",

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -230,9 +230,6 @@
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
-                 
-                
-                
                     <h2 id="product_other_information" class="text-medium">[% lang('product_other_information') %]</h2>
                     <div class="row">
                         <div class="small-12 columns">
@@ -243,8 +240,10 @@
             </div>
         </div>
     </section>
-    [% END %]
+[% END %]
 
+<!-- Report problem card, if not on the platform for producers -->    
+[% IF ! server_options_producers_platform %]
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -254,6 +253,7 @@
             </div>
         </div>
     </section>
+[% END %]
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 [% IF server_options_producers_platform %]

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -3257,6 +3257,8 @@
 <!-- other fields -->
 
 
+<!-- Report problem card, if not on the platform for producers -->    
+
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -3374,6 +3376,7 @@
             </div>
         </div>
     </section>
+
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -3257,6 +3257,8 @@
 <!-- other fields -->
 
 
+<!-- Report problem card, if not on the platform for producers -->    
+
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -3374,6 +3376,7 @@
             </div>
         </div>
     </section>
+
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -3852,6 +3852,8 @@
 <!-- other fields -->
 
 
+<!-- Report problem card, if not on the platform for producers -->    
+
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -3969,6 +3971,7 @@
             </div>
         </div>
     </section>
+
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -3612,8 +3612,8 @@
              
 Vous avez rencontré un problème avec ce produit : <b>étiquetage non conforme, produit périmé encore en vente,
 présence d'un corps étranger, etc.</b> ?<br>
-Faites un signalement à l'entreprise et à la répression des fraudes sur SignalConso, un outil de la
-Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF).
+Faites un signalement à l'entreprise et à la répression des fraudes sur <a href="//signal.conso.gouv.fr/fr/alimentaire-codebarres/faire-un-signalement?gtin=3300000000002&utm_source=openfoodfacts&utm_campaign=product_page_panel">SignalConso</a>,
+un outil de la Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF).
                 
            </div>
     

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -3453,6 +3453,8 @@
 <!-- other fields -->
 
 
+<!-- Report problem card, if not on the platform for producers -->    
+
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -3647,6 +3649,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
             </div>
         </div>
     </section>
+
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -3626,8 +3626,8 @@
              
 Vous avez rencontré un problème avec ce produit : <b>étiquetage non conforme, produit périmé encore en vente,
 présence d'un corps étranger, etc.</b> ?<br>
-Faites un signalement à l'entreprise et à la répression des fraudes sur SignalConso, un outil de la
-Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF).
+Faites un signalement à l'entreprise et à la répression des fraudes sur <a href="//signal.conso.gouv.fr/fr/alimentaire-codebarres/faire-un-signalement?gtin=3300000000001&utm_source=openfoodfacts&utm_campaign=product_page_panel">SignalConso</a>,
+un outil de la Direction générale de la concurrence, de la consommation et de la répression des fraudes (DGCCRF).
                 
            </div>
     

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -3467,6 +3467,8 @@
 <!-- other fields -->
 
 
+<!-- Report problem card, if not on the platform for producers -->    
+
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -3661,6 +3663,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
             </div>
         </div>
     </section>
+
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -3482,6 +3482,8 @@
 <!-- other fields -->
 
 
+<!-- Report problem card, if not on the platform for producers -->    
+
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
@@ -3599,6 +3601,7 @@
             </div>
         </div>
     </section>
+
 
 <!-- Platform for producers: data quality issues and improvements opportunities -->
 


### PR DESCRIPTION
Removes a warning that $panel_data_ref is redeclared