### PR TITLE
fix: disable the Invite Users button until at least one email address has been entered

### DIFF
--- a/templates/web/pages/org_form/org_form.tt.html
+++ b/templates/web/pages/org_form/org_form.tt.html
@@ -177,7 +177,7 @@
     <p>&rarr; <a href="[% profile_url %]">[% profile_name %]</a></p>
 [% END %]
 
-<script src="https://static.openfoodfacts.org/js/dist/jquery.js"></script>
+<script src="[% static_subdomain %]/js/dist/jquery.js" data-base-layout="true"></script>
 <script>
     \$(document).ready(function() {
         \$('#email_list').on('input', function(event) {

--- a/templates/web/pages/org_form/org_form.tt.html
+++ b/templates/web/pages/org_form/org_form.tt.html
@@ -70,7 +70,7 @@
 
 	<form method="post" action="/cgi/org.pl" enctype="multipart/form-data" style="margin-bottom: 20px;">
 		<p>[% lang('enter_email_addresses_of_users') %]</p>
-		<textarea id="email_list" name="email_list" style="height:100px;width:50vw" oninput="toggleInviteButton()"></textarea>
+		<textarea id="email_list" name="email_list" style="height:100px;width:50vw"></textarea>
 		<input type="hidden" name="action" value="process" />
 		<input type="hidden" name="type" value="add_users" />
 		<input type="hidden" name="orgid" value="[% orgid %]" />
@@ -177,17 +177,21 @@
     <p>&rarr; <a href="[% profile_url %]">[% profile_name %]</a></p>
 [% END %]
 
+<script src="https://static.openfoodfacts.org/js/dist/jquery.js"></script>
 <script>
-	function toggleInviteButton() {
-		var emailList = document.getElementById('email_list').value.trim();
-		var inviteButton = document.getElementById('invite_button');
-		var allValid = emailList.split(',').every(validateEmail); // the button will be enabled, only if all email addresses are valid
-    	inviteButton.disabled = !allValid;
-	}
+    \$(document).ready(function() {
+        \$('#email_list').on('input', function(event) {
+            var emailList = \$(event.target).val().split(',').map(function(email) {
+                return email.trim();
+            });
+            var allValid = emailList.every(validateEmail);
+            \$('#invite_button').prop('disabled', !allValid || emailList.length === 0 || emailList[0] === '');
+        });
+    });
 
-	function validateEmail(email) {
-		return /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email.trim());
-	}
+    function validateEmail(email) {
+        return /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email.trim());
+    }
 </script>
 
 <!-- end templates/[% template.name %] -->

--- a/templates/web/pages/org_form/org_form.tt.html
+++ b/templates/web/pages/org_form/org_form.tt.html
@@ -68,13 +68,13 @@
 	</div>
 	[% END %]
 
-		<form method="post" action="/cgi/org.pl" enctype="multipart/form-data" style="margin-bottom: 20px;">
+	<form method="post" action="/cgi/org.pl" enctype="multipart/form-data" style="margin-bottom: 20px;">
 		<p>[% lang('enter_email_addresses_of_users') %]</p>
-		<textarea id="email_list" name="email_list" style="height:100px;width:50vw"></textarea>
+		<textarea id="email_list" name="email_list" style="height:100px;width:50vw" oninput="toggleInviteButton()"></textarea>
 		<input type="hidden" name="action" value="process" />
 		<input type="hidden" name="type" value="add_users" />
 		<input type="hidden" name="orgid" value="[% orgid %]" />
-		<input type="submit" name=".submit" class="button" value= "[% edq(lang('invite_user')) %]"/>
+		<input type="submit" id="invite_button" name=".submit" class="button" value= "[% edq(lang('invite_user')) %]" disabled />
 	</form>
 
     <!-- Start form -->
@@ -176,5 +176,18 @@
     <p>[% result %]</p>
     <p>&rarr; <a href="[% profile_url %]">[% profile_name %]</a></p>
 [% END %]
+
+<script>
+	function toggleInviteButton() {
+		var emailList = document.getElementById('email_list').value.trim();
+		var inviteButton = document.getElementById('invite_button');
+		var allValid = emailList.split(',').every(validateEmail); // the button will be enabled, only if all email addresses are valid
+    	inviteButton.disabled = !allValid;
+	}
+
+	function validateEmail(email) {
+		return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+	}
+</script>
 
 <!-- end templates/[% template.name %] -->

--- a/templates/web/pages/org_form/org_form.tt.html
+++ b/templates/web/pages/org_form/org_form.tt.html
@@ -186,7 +186,7 @@
 	}
 
 	function validateEmail(email) {
-		return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+		return /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email.trim());
 	}
 </script>
 


### PR DESCRIPTION
### What
- I added a script to the `templates/web/pages/org_form/org_form.tt.html` file that toggles off the Invite Users button until at least one email address has been entered.
- This script also uses Regex to validate the value of each email address entered to ensure users are inviting valid email addresses and not just random texts.



- Fixes #10130 

