### PR TITLE
fix: send cookie in auth.pl

### DIFF
--- a/cgi/auth.pl
+++ b/cgi/auth.pl
@@ -82,6 +82,10 @@ my $json = JSON::PP->new->allow_nonref->canonical->utf8->encode($response_ref);
 my $r = Apache2::RequestUtil->request();
 my $allow_credentials = 1;
 write_cors_headers($allow_credentials);
+# Write a session cookie if we were passed a user id and password
+if ($request_ref->{cookie}) {
+	$r->err_headers_out->add('Set-Cookie' => $request_ref->{cookie});
+}
 print header(-status => $status, -type => 'application/json', -charset => 'utf-8');
 
 # 2022-10-11 - The Open Food Facts Flutter app is expecting an empty body

--- a/lib/ProductOpener/APITest.pm
+++ b/lib/ProductOpener/APITest.pm
@@ -528,6 +528,11 @@ sub check_request_response ($test_ref, $response, $test_id, $test_dir, $expected
 			if (!defined $hvalue) {
 				ok(!defined $rvalue, "$test_case - header $hname should not be defined");
 			}
+			# one may put a /regexp/ to test the value of a header
+			elsif ($hvalue =~ /^\/(.*)\/$/) {
+				my $regexp = $1;
+				like($rvalue, qr/$regexp/, "$test_case - header $hname like $hvalue");
+			}
 			else {
 				is($rvalue, $hvalue, "$test_case - header $hname");
 			}

--- a/tests/integration/auth.t
+++ b/tests/integration/auth.t
@@ -1,0 +1,75 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use Test2::V0;
+use ProductOpener::APITest qw/create_user execute_api_tests login new_client wait_application_ready/;
+use ProductOpener::Test qw/remove_all_products remove_all_users/;
+use ProductOpener::TestDefaults qw/%default_user_form/;
+
+use File::Basename "dirname";
+
+use Storable qw(dclone);
+
+remove_all_users();
+
+remove_all_products();
+
+wait_application_ready();
+
+my $ua = new_client();
+
+my %create_user_args = (%default_user_form, (email => 'bob@gmail.com'));
+create_user($ua, \%create_user_args);
+
+# TODO: add more tests !
+my $tests_ref = [
+	{
+		test_case => 'auth-not-authenticated',
+		method => 'GET',
+		path => '/cgi/auth.pl',
+		expected_status_code => 403,    # we are not authenticated
+		headers => {
+			"Set-Cookie" => undef,
+		},
+		expected_type => "none",
+	},
+	{
+		test_case => 'auth-authenticated-with-userid-and-password',
+		method => 'POST',
+		path => '/cgi/auth.pl',
+		form => {
+			user_id => "tests",
+			password => "testtest",
+			body => 1,
+		},
+		expected_status_code => 200,
+		headers => {
+			"Set-Cookie" => "/session=/",    # We get a session cookie
+		},
+		expected_type => "json",
+	},
+];
+execute_api_tests(__FILE__, $tests_ref);
+
+# Test auth.pl with authenticated user
+create_user($ua, \%default_user_form);
+
+my $auth_ua = new_client();
+login($auth_ua, "tests", 'testtest');
+
+$tests_ref = [
+	{
+		test_case => 'auth-authenticated-with-cookie',
+		method => 'GET',
+		path => '/cgi/auth.pl',
+		expected_status_code => 200,
+		headers => {
+			"Set-Cookie" => undef,    # No session cookie
+		},
+		expected_type => "none",
+	},
+];
+execute_api_tests(__FILE__, $tests_ref, $auth_ua);
+
+done_testing();

--- a/tests/integration/expected_test_results/auth/auth-authenticated-with-userid-and-password.json
+++ b/tests/integration/expected_test_results/auth/auth-authenticated-with-userid-and-password.json
@@ -1,0 +1,12 @@
+{
+   "status" : 1,
+   "status_verbose" : "user signed-in",
+   "user" : {
+      "admin" : 0,
+      "country" : "en:united-states",
+      "moderator" : 0,
+      "name" : "Test",
+      "preferred_language" : "en"
+   },
+   "user_id" : "tests"
+}


### PR DESCRIPTION
This PR changes auth.pl so that it sets the session cookie when auth.pl is called with a user_id and password (similar to what we do in login.pl)

Also added some tests.

Fixes #10140 (needed urgently for testing the new Nutri-Score knowledge panels)