### PR TITLE
fix: improvements to tags suggestions, from contributors feedback

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -535,13 +535,14 @@ function initializeTagifyInputs() {
         forEach((input) => initializeTagifyInput(input));
 }
 
-const maximumRecentEntriesPerTag = 3;
+const maximumRecentEntriesPerTag = 10;
 
 function initializeTagifyInput(el) {
     const input = new Tagify(el, {
         autocomplete: true,
         whitelist: get_recents(el.id) || [],
         dropdown: {
+            highlightFirst: false,
             enabled: 0,
             maxItems: 100
         }
@@ -579,7 +580,7 @@ function initializeTagifyInput(el) {
                     then((RES) => RES.json()).
                     then(function (json) {
                         const lc = (/^\w\w:/).exec(value);
-                        let whitelist = Object.values(json.matched_synonyms);
+                        let whitelist = json.suggestions;
                         if (lc) {
                             whitelist = whitelist.map(function (e) {
                                 return {"value": lc + e, "searchBy": e};

--- a/lib/ProductOpener/APITaxonomySuggestions.pm
+++ b/lib/ProductOpener/APITaxonomySuggestions.pm
@@ -49,6 +49,7 @@ use ProductOpener::Tags qw/%taxonomy_fields/;
 use ProductOpener::Lang qw/:all/;
 use ProductOpener::TaxonomySuggestions qw/get_taxonomy_suggestions_with_synonyms/;
 use ProductOpener::API qw/add_error/;
+use Tie::IxHash;
 
 use Encode;
 
@@ -132,10 +133,17 @@ sub taxonomy_suggestions_api ($request_ref) {
 		$log->debug("taxonomy_suggestions_api", @suggestions) if $log->is_debug();
 		$response_ref->{suggestions} = [map {$_->{tag}} @suggestions];
 		if ($options_ref->{get_synonyms}) {
-			$response_ref->{matched_synonyms} = {};
+			# We need a tie hash so that the keys are ordered by insertion order when returned as JSON
+			my %matched_synonyms;
+			tie(%matched_synonyms, 'Tie::IxHash');
 			foreach (@suggestions) {
-				$response_ref->{matched_synonyms}->{$_->{tag}} = ucfirst($_->{matched_synonym});
+				$matched_synonyms{$_->{tag}} = ucfirst($_->{matched_synonym});
 			}
+			$response_ref->{matched_synonyms} = \%matched_synonyms;
+			# Note: this does not seem to work with JSON::PP, even though the "canonical" option
+			# should preserve the order of the keys of tied hashes.
+			# As JSON hashes are unordered, we will use the "suggestions" array on the client side to get the right order.
+			# It would have been nice to order the matched synonyms anyway, but it is not a huge issue.
 		}
 	}
 

--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -63,7 +63,6 @@ use experimental 'smartmatch';
 use ProductOpener::Config qw/:all/;
 
 use MongoDB;
-use Tie::IxHash;
 use JSON::PP;
 use CGI ':cgi-lib';
 use Log::Any qw($log);


### PR DESCRIPTION
Some changes to tags suggestions (e.g. categories, labels), based on feedback on Slack: https://openfoodfacts.slack.com/archives/C02KVRT2C/p1713363168918539

- changed the number of saved recent entries to 10 instead of 3 (those are shown before the user types something)
- fixed the order of the suggestions, so that we do display them in the order set by the server (e.g. showing first the entries that match at the beginning)
- removed the automatic highlighting of the first suggestion

before:

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/692ae0a6-fc72-44bc-996b-2870b0cb1813)

after:

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/b0e146f6-9650-4341-ba2e-b016a1b0c70e)

and with the sort order fixed:

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/c5e11e14-c61d-4074-8e68-6a6eddc43efd)
