### PR TITLE
fix: Add non EAN barcode in product page

### DIFF
--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -166,6 +166,9 @@
                                 [% lang("barcode") %]:  <span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">[% code %]</span> [% upc %]
                             </p>
                             <div property="gr:hasEAN_UCC-13" content="[% code %]" datatype="xsd:string"></div>
+                        [% ELSE %]
+                          [%# put in DOM for folksonomy %]
+                          <span id="barcode"  style="display: none;">[% code %]</span>
                         [% END %]
                         
                         [% product_fields %]


### PR DESCRIPTION
hidden, for folksonomy engine to work.

fixes: #7267
