### PR TITLE
fix: some translations moved from .po files to Config.pm

### DIFF
--- a/cgi/manifest.pl
+++ b/cgi/manifest.pl
@@ -41,7 +41,7 @@ use JSON::PP;
 
 my $request_ref = ProductOpener::Display::init_request();
 
-my $short_name = lang("site_name");
+my $short_name = $options{site_name};
 my $long_name = $short_name;
 
 # https://stackoverflow.com/a/16533563/11963

--- a/cgi/opensearch.pl
+++ b/cgi/opensearch.pl
@@ -48,7 +48,7 @@ my $request_ref = ProductOpener::Display::init_request();
 
 # https://developer.mozilla.org/en-US/Add-ons/Creating_OpenSearch_plugins_for_Firefox
 # Maximum of 16 characters
-my $short_name = lang("site_name");
+my $short_name = $options{site_name};
 # Maximum of 48 characters
 my $long_name = $short_name;
 if ($cc eq 'world') {

--- a/cgi/product_image.pl
+++ b/cgi/product_image.pl
@@ -93,7 +93,7 @@ else {
 
 my $photographer = $product_ref->{images}{$id}{uploader};
 my $editor = $photographer;
-my $site_name = lang('site_name');
+my $site_name = $options{site_name};
 
 my $original_id = $product_ref->{images}{$id}{imgid};
 my $original_link = "";

--- a/cgi/user.pl
+++ b/cgi/user.pl
@@ -420,7 +420,8 @@ elsif ($action eq 'process') {
 		$template_data_ref->{add_user_pro_url} = sprintf(lang("add_user_you_can_edit_pro_promo"), $pro_url);
 
 		$template_data_ref->{add_user_you_can_edit} = sprintf(lang("add_user_you_can_edit"), lang("get_the_app_link"));
-		$template_data_ref->{add_user_join_the_project} = sprintf(lang("add_user_join_the_project"), lang("site_name"));
+		$template_data_ref->{add_user_join_the_project}
+			= sprintf(lang("add_user_join_the_project"), $options{site_name});
 	}
 
 }

--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -198,7 +198,9 @@ $flavor = 'off';
 	android_app_link => "https://world.openfoodfacts.org/files/off.apk",
 	ios_app_link => "https://apps.apple.com/app/open-food-facts/id588797948",
 	facebook_page_url => "https://www.facebook.com/OpenFoodFacts",
+	facebook_page_url_fr => "https://www.facebook.com/OpenFoodFacts.fr",
 	twitter_account => "OpenFoodFacts",
+	twitter_account_fr => "OpenFoodFactsFr",
 );
 
 $options{export_limit} = 10000;

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -7217,12 +7217,12 @@ sub display_page ($request_ref) {
 	my $join_us_on_slack
 		= sprintf($Lang{footer_join_us_on}{$lc}, '<a href="https://slack.openfoodfacts.org">Slack</a>');
 
-	my $twitter_account = lang("twitter_account");
-	if (defined $Lang{twitter_account_by_country}{$cc}) {
-		$twitter_account = $Lang{twitter_account_by_country}{$cc};
-	}
+	# Twitter account and Facebook page url from Config.pm
+	# Allow to have language specific Twitter accounts and Facebook page url, suffixed by the language code
+	my $twitter_account = $options{"twitter_account_$lc"} || $options{twitter_account};
 	$template_data_ref->{twitter_account} = $twitter_account;
-	# my $facebook_page = lang("facebook_page");
+	my $facebook_page = $options{"facebook_page_url_$lc"} || $options{facebook_page_url};
+	$template_data_ref->{facebook_page_url} = $facebook_page;
 
 	my $torso_class = "anonymous";
 	if (defined $User_id) {

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -247,8 +247,14 @@ if (-e $path) {
 	$log->info("Loaded \%Lang", {path => $path}) if $log->is_info();
 
 	# Initialize @Langs and $lang_lc
-	@Langs = sort keys %{$Lang{site_name}}
-		;    # any existing key can be used, as %Lang should contain values for all languages for all keys
+	# any existing key can be used, as %Lang should contain values for all languages for all keys
+	my $msgctxt = "add";
+	if (not defined $Lang{$msgctxt}) {
+		$log->error("Language translation file does not contain the 'add' key, \%Lang will be empty.", {path => $path})
+			if $log->is_error();
+		die("Language translation file does not contain the 'add' key, \%Lang will be empty.");
+	}
+	@Langs = sort keys %{$Lang{$msgctxt}};
 	%Langs = ();
 	%lang_lc = ();
 	foreach my $l (@Langs) {
@@ -450,22 +456,15 @@ sub build_lang ($Languages_ref) {
 		}
 	}
 
-	my @special_fields = ("site_name");
+	# Some translations have <<site_name>> in them, replace it with the site name
+	my $site_name = $options{site_name};
 
-	foreach my $special_field (@special_fields) {
-
-		foreach my $l (@Langs) {
-			my $value = $Lang{$special_field}{$l};
-			if (not(defined $value)) {
+	foreach my $l (@Langs) {
+		foreach my $key (keys %Lang) {
+			if (not defined $Lang{$key}{$l}) {
 				next;
 			}
-
-			foreach my $key (keys %Lang) {
-				if (not defined $Lang{$key}{$l}) {
-					next;
-				}
-				$Lang{$key}{$l} =~ s/\<\<$special_field\>\>/$value/g;
-			}
+			$Lang{$key}{$l} =~ s/\<\<site_name\>\>/$site_name/g;
 		}
 	}
 

--- a/lib/ProductOpener/Mail.pm
+++ b/lib/ProductOpener/Mail.pm
@@ -162,7 +162,8 @@ sub send_email ($user_ref, $subject, $text) {
 	my $name = $user_ref->{name};
 
 	$text =~ s/<NAME>/$name/g;
-	my $mail = Email::Stuffer->from(lang("site_name") . " <$contact_email>")->to($name . " <$email>")->subject($subject)
+	my $mail
+		= Email::Stuffer->from($options{site_name} . " <$contact_email>")->to($name . " <$email>")->subject($subject)
 		->text_body($text);
 	return _send_email($mail);
 }
@@ -195,7 +196,8 @@ sub send_html_email ($user_ref, $subject, $html_content) {
 	my $email = $user_ref->{email};
 	my $name = $user_ref->{name};
 
-	my $mail = Email::Stuffer->from(lang("site_name") . " <$contact_email>")->to($name . " <$email>")->subject($subject)
+	my $mail
+		= Email::Stuffer->from($options{site_name} . " <$contact_email>")->to($name . " <$email>")->subject($subject)
 		->html_body($html_content);
 	return _send_email($mail);
 }
@@ -257,7 +259,8 @@ On the other hand, if there was no error, it returns 0 indicating that the email
 =cut
 
 sub send_email_to_admin ($subject, $text) {
-	my $mail = Email::Stuffer->from(lang("site_name") . " <$contact_email>")->to(lang("site_name") . " <$admin_email>")
+	my $mail
+		= Email::Stuffer->from($options{site_name} . " <$contact_email>")->to($options{site_name} . " <$admin_email>")
 		->subject($subject)->text_body($text);
 
 	return _send_email($mail);
@@ -284,8 +287,8 @@ On the other hand, if there was no error, it returns 1 indicating that email has
 
 sub send_email_to_producers_admin ($subject, $text) {
 	my $mail
-		= Email::Stuffer->from(lang("site_name") . " <$contact_email>")->to(lang("site_name") . " <$producers_email>")
-		->subject($subject)->text_body($text)->html_body($text);
+		= Email::Stuffer->from($options{site_name} . " <$contact_email>")
+		->to($options{site_name} . " <$producers_email>")->subject($subject)->text_body($text)->html_body($text);
 
 	return _send_email($mail);
 }

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -2638,7 +2638,7 @@ sub init_countries() {
 	%country_codes_reverse = ();
 	%country_languages = ();
 
-	foreach my $country (keys %{$properties{countries}}) {
+	foreach my $country (sort keys %{$properties{countries}}) {
 
 		my $cc = country_to_cc($country);
 		if (not(defined $cc)) {
@@ -2659,9 +2659,11 @@ sub init_countries() {
 				my $nameid = get_string_id_for_lang("no_language", $name);
 				if (not defined $country_names{$nameid}) {
 					$country_names{$nameid} = [$cc, $country, $language];
-					# print STDERR "country_names{$nameid} = [$cc, $country, $language]\n";
 				}
 			}
+		}
+		else {
+			$log->warn("No language_codes:en for country $country") if $log->is_warn();
 		}
 	}
 	return;

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -346,10 +346,11 @@
 						<p>[% f_lang('f_join_us_on_slack', { url => "https://slack.openfoodfacts.org" } ) %]</p>
 						<p><a href="https://forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">[% f_lang('f_footer_follow_us_links', { links => '
-							<a href="https://twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="https://www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="https://twitter.com/' _ twitter_account _ '"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="' _ facebook_page_url _ '"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="https://www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
-							'})
+							'
+							})
 							%]
 						</p>
 						<p><a href="https://link.openfoodfacts.org/newsletter-[% language %]">[% lang('subscribe_to_our_newsletter') %]</a></p>
@@ -467,7 +468,7 @@
 	"url": "[% formatted_subdomain %]",
 	"logo": "[% static_subdomain %]/images/logos/[% flavor %]-logo-vertical-light.svg",
 	"name": "[% options.site_name %]",
-	"sameAs" : [  "[% edq(lang('facebook_page')) %]", "https://twitter.com/[% twitter_account %]"]
+	"sameAs" : ["[% facebook_page_url %]", "https://twitter.com/[% twitter_account %]"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -380,7 +380,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -491,7 +491,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
@@ -1322,7 +1322,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -1340,8 +1340,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -2011,7 +2011,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -1970,7 +1970,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -1988,8 +1988,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -2659,7 +2659,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
@@ -319,7 +319,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
+                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
                      "type" : "warning"
                   }
                }
@@ -632,7 +632,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                Si les informations ne correspondent pas aux informations présentes sur l'emballage, vous pouvez les compléter ou de les corriger. Merci !\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile à tous.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -650,7 +650,7 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Catégorie, labels, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
                "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
@@ -1085,7 +1085,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
+                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
                      "type" : "warning"
                   }
                },

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels.json
@@ -632,7 +632,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -650,8 +650,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -1321,7 +1321,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -380,8 +380,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -415,11 +415,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -491,7 +491,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-all-knowledge-panels.json
@@ -1324,7 +1324,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -1342,8 +1342,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -2013,7 +2013,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -1972,7 +1972,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -1990,8 +1990,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -2661,7 +2661,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
@@ -320,7 +320,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
+                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
                      "type" : "warning"
                   }
                }
@@ -633,7 +633,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                Si les informations ne correspondent pas aux informations présentes sur l'emballage, vous pouvez les compléter ou de les corriger. Merci !\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile à tous.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -651,7 +651,7 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Catégorie, labels, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
                "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
@@ -1086,7 +1086,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
+                     "html" : "\n                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>\n                Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>\n                Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href=\"https://fr.pro.openfoodfacts.org\">plateforme gratuite pour les producteurs</a>.\n                    ",
                      "type" : "warning"
                   }
                },

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels.json
@@ -633,7 +633,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -651,8 +651,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -1322,7 +1322,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-request-fields-updated-attribute-groups-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-request-fields-updated-attribute-groups-knowledge-panels.json
@@ -449,7 +449,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -467,8 +467,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -870,7 +870,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/data_quality_knowledge_panel/data-quality.json
+++ b/tests/integration/expected_test_results/data_quality_knowledge_panel/data-quality.json
@@ -303,7 +303,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -321,8 +321,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -978,7 +978,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/data_quality_knowledge_panel/no-data-quality.json
+++ b/tests/integration/expected_test_results/data_quality_knowledge_panel/no-data-quality.json
@@ -265,7 +265,7 @@
                {
                   "element_type" : "text",
                   "text_element" : {
-                     "html" : "\n                If the information does not match the information on the packaging, please complete or correct it.\n                Open Food Facts is a collaborative database, and every contribution is useful for all.\n                "
+                     "html" : "\n                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!\n                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.\n                "
                   }
                },
                {
@@ -283,8 +283,8 @@
             "level" : "info",
             "title_element" : {
                "icon_url" : "http://static.openfoodfacts.localhost/images/logos/off-logo-icon-light.svg",
-               "subtitle" : "Category, labels, ingredients, allergens, nutritional information, photos etc.",
-               "title" : "Incomplete or incorrect information?"
+               "subtitle" : "Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.",
+               "title" : "Informations incomplètes ou incorrectes ?"
             },
             "topics" : [
                "problem"
@@ -881,7 +881,7 @@
             ],
             "expanded" : true,
             "title_element" : {
-               "title" : "Report a problem"
+               "title" : "Signaler un problème"
             },
             "topics" : [
                "problems"

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -542,7 +542,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -665,7 +665,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -3275,7 +3275,7 @@
 >
     
         
-            <h2 class="panel_title_card text-medium">Report a problem</h2>
+            <h2 class="panel_title_card text-medium">Signaler un problème</h2>
         
     
 
@@ -3311,10 +3311,10 @@
                 
             >
                 
-                Incomplete or incorrect information?
+                Informations incomplètes ou incorrectes ?
             </h4>
             
-                <span >Category, labels, ingredients, allergens, nutritional information, photos etc.</span>
+                <span >Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
             
             <hr class="floatclear">
         </a>
@@ -3334,8 +3334,8 @@
     
            <div class="panel_text">
              
-                If the information does not match the information on the packaging, please complete or correct it.
-                Open Food Facts is a collaborative database, and every contribution is useful for all.
+                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!
+                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.
                 
            </div>
     
@@ -3354,7 +3354,7 @@
     
         <a class="button small action-edit_product"
             href="/cgi/product.pl?type=edit&code=0200000000235">
-            Complete or correct product information
+            Compléter ou corriger les informations du produit
         </a>
     
 
@@ -3520,7 +3520,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -3650,7 +3650,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -605,7 +605,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -728,7 +728,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -583,7 +583,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -706,7 +706,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -493,7 +493,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -425,7 +425,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -550,7 +550,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -578,7 +578,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -701,7 +701,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -3275,7 +3275,7 @@
 >
     
         
-            <h2 class="panel_title_card text-medium">Report a problem</h2>
+            <h2 class="panel_title_card text-medium">Signaler un problème</h2>
         
     
 
@@ -3311,10 +3311,10 @@
                 
             >
                 
-                Incomplete or incorrect information?
+                Informations incomplètes ou incorrectes ?
             </h4>
             
-                <span >Category, labels, ingredients, allergens, nutritional information, photos etc.</span>
+                <span >Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
             
             <hr class="floatclear">
         </a>
@@ -3334,8 +3334,8 @@
     
            <div class="panel_text">
              
-                If the information does not match the information on the packaging, please complete or correct it.
-                Open Food Facts is a collaborative database, and every contribution is useful for all.
+                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!
+                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.
                 
            </div>
     
@@ -3354,7 +3354,7 @@
     
         <a class="button small action-edit_product"
             href="/cgi/product.pl?type=edit&code=0200000000235">
-            Complete or correct product information
+            Compléter ou corriger les informations du produit
         </a>
     
 
@@ -3520,7 +3520,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -3650,7 +3650,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -646,7 +646,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -769,7 +769,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -246,7 +246,7 @@
   <span class="donation-banner__hand"></span>
   <div class="donation-banner__content">
     <p class="donation-banner__main-text">
-        <span>¡Ayúdanos a hacer de la transparencia alimentaria sea la norma!</span>
+        <span>¡Ayúdanos a que la transparencia alimentaria sea la norma!</span>
     </p>
     <div class="donation-banner__aside">
       <div>
@@ -414,7 +414,7 @@
   <span class="donation-banner-footer__hand"></span>
   <div class="donation-banner-footer__content">
     <p class="donation-banner-footer__main-text">
-      <span>¡Ayúdanos a hacer de la transparencia alimentaria sea la norma!</span>
+      <span>¡Ayúdanos a que la transparencia alimentaria sea la norma!</span>
     </p>
     <div class="donation-banner-footer__aside">
       <div>
@@ -438,7 +438,7 @@
 						<p>Únete a nosotros en <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Síguenos: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -456,7 +456,7 @@
 							<li><a class="button small white-button radius" href="//es.wiki.openfoodfacts.org">Open Food Facts wiki (es)</a></li>
 							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traductores</a></li>
 							<li><a class="button small white-button radius" href="/asociados">Asociados</a></li>
-							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosméticos</a></li>
+							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts (cosméticos)</a></li>
 							<li><a class="button small white-button radius" href="//ch-es.pro.openfoodfacts.localhost/">Open Food Facts para los productores</a></li>
 						</ul>
 					</div>
@@ -473,12 +473,12 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Una base de datos colaborativa, libre y abierta de productos alimenticios de todo el mundo.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/legal">Menciones legales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
-									<li><a href="/terms-of-use">Condiciones de uso</a></li>
+									<li><a href="/privacidad">Privacidad</a></li>
+									<li><a href="/condiciones-de-uso">Condiciones de uso</a></li>
 									<li><a href="/data">Datos, API y SDK</a></li>
 									<li><a href="//world-es.openfoodfacts.org/dar-a-open-food-facts">Donar a Open Food Facts</a></li>
 									<li><a href="//world-es.pro.openfoodfacts.org/">Productores</a></li>
@@ -561,7 +561,7 @@ $(document).foundation({
 	"url": "//ch-es.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFactsES"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -3873,7 +3873,7 @@
 >
     
         
-            <h2 class="panel_title_card text-medium">Report a problem</h2>
+            <h2 class="panel_title_card text-medium">Signaler un problème</h2>
         
     
 
@@ -3909,10 +3909,10 @@
                 
             >
                 
-                Incomplete or incorrect information?
+                Informations incomplètes ou incorrectes ?
             </h4>
             
-                <span >Category, labels, ingredients, allergens, nutritional information, photos etc.</span>
+                <span >Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
             
             <hr class="floatclear">
         </a>
@@ -3932,8 +3932,8 @@
     
            <div class="panel_text">
              
-                If the information does not match the information on the packaging, please complete or correct it.
-                Open Food Facts is a collaborative database, and every contribution is useful for all.
+                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!
+                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.
                 
            </div>
     
@@ -3952,7 +3952,7 @@
     
         <a class="button small action-edit_product"
             href="/cgi/product.pl?type=edit&code=200000000034">
-            Complete or correct product information
+            Compléter ou corriger les informations du produit
         </a>
     
 
@@ -4118,7 +4118,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -4248,7 +4248,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -502,7 +502,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -352,7 +352,7 @@
                             <img src="//static.openfoodfacts.localhost/images/icons/dist/volunteer_activism.svg" style="height:72px;float:left;margin-right:1rem;" alt="icon" class="filter-grey">
                             <div>
                                 <p>Vous venez de contribuer à améliorer la plus grande base de données ouverte du monde.</p>
-                                <p>Merci beaucoup de nous avoir rejoints dans notre voyage vers la transparence des données !</p>
+                                <p>Merci beaucoup de nous avoir rejoints dans notre voyage vers la transparence des données !</p>
                             </div>
                         </div>
                         <div>
@@ -686,8 +686,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -721,11 +721,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -797,7 +797,7 @@ $(document).foundation({
 	"url": "//be-fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -352,7 +352,7 @@
                             <img src="//static.openfoodfacts.localhost/images/icons/dist/volunteer_activism.svg" style="height:72px;float:left;margin-right:1rem;" alt="icon" class="filter-grey">
                             <div>
                                 <p>Vous venez de contribuer à améliorer la plus grande base de données ouverte du monde.</p>
-                                <p>Merci beaucoup de nous avoir rejoints dans notre voyage vers la transparence des données !</p>
+                                <p>Merci beaucoup de nous avoir rejoints dans notre voyage vers la transparence des données !</p>
                             </div>
                         </div>
                         <div>
@@ -703,8 +703,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -738,11 +738,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -814,7 +814,7 @@ $(document).foundation({
 	"url": "//be-fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -352,7 +352,7 @@
                             <img src="//static.openfoodfacts.localhost/images/icons/dist/volunteer_activism.svg" style="height:72px;float:left;margin-right:1rem;" alt="icon" class="filter-grey">
                             <div>
                                 <p>Vous venez de contribuer à améliorer la plus grande base de données ouverte du monde.</p>
-                                <p>Merci beaucoup de nous avoir rejoints dans notre voyage vers la transparence des données !</p>
+                                <p>Merci beaucoup de nous avoir rejoints dans notre voyage vers la transparence des données !</p>
                             </div>
                         </div>
                         <div>
@@ -686,8 +686,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -721,11 +721,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -797,7 +797,7 @@ $(document).foundation({
 	"url": "//be-fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -518,7 +518,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -641,7 +641,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -505,7 +505,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -493,7 +493,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -505,7 +505,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -574,7 +574,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -697,7 +697,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -635,7 +635,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -758,7 +758,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -505,7 +505,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -456,7 +456,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -581,7 +581,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -574,7 +574,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -697,7 +697,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -502,7 +502,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -421,8 +421,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -456,11 +456,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -546,7 +546,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -675,8 +675,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -710,11 +710,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -798,7 +798,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -427,8 +427,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -462,11 +462,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -556,7 +556,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -3418,7 +3418,7 @@ by typing the first letters of their name in the last row of the table.</p>
   
   <li>
     <time datetime="--ignore--">--ignore--</time> - <a href="/editor/tests" lang="no_language">tests</a> Data (Added: lang, product_name, quantity, brands, categories, labels, link, countries, nutrition_data_per, nutrition_data_prepared_per, serving_size, ingredients_text, generic_name_en, ingredients_text_en, origin_en, product_name_en, ingredients_text_fr, product_name_fr) -- Nutriments (Added: nutrition-score-fr)   - (app)  &nbsp;
-    <a href="/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert?rev=1" class="button tiny">View this revision</a>
+    <a href="/product/3300000000002/organic-apple-and-raspberry-pie-les-tartes-de-robert?rev=1" class="button tiny"></a>
     
   </li>
   
@@ -3551,7 +3551,7 @@ by typing the first letters of their name in the last row of the table.</p>
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -4053,7 +4053,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -710,8 +710,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -745,11 +745,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -833,7 +833,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -421,8 +421,8 @@
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -456,11 +456,11 @@
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -546,7 +546,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -33,8 +33,8 @@
     <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
     <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
 	<meta name="twitter:card" content="product">
-<meta name="twitter:site" content="@OpenFoodFactsFR">
-<meta name="twitter:creator" content="@OpenFoodFactsFR">
+<meta name="twitter:site" content="@OpenFoodFactsFr">
+<meta name="twitter:creator" content="@OpenFoodFactsFr">
 <meta name="twitter:title" content="Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g">
 <meta name="twitter:description" content="Ingrédients, allergènes, additifs, composition nutritionnelle, labels, origine des ingrédients et informations du produit Tarte aux pommes et aux framboise bio - Les tartes de Robert - 100 g">
 <meta name="twitter:label1" content="marque">
@@ -2555,7 +2555,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>
+                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>
                 Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>
                 Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="//fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
                     
@@ -2695,7 +2695,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                    Les informations sur l'emballage de ce produit ne sont pas renseignées.
+                    Les informations sur l'emballage de ce produit ne sont pas indiquées.
                     
            </div>
 
@@ -3218,7 +3218,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                    Les informations sur l'emballage de ce produit ne sont pas renseignées.
+                    Les informations sur l'emballage de ce produit ne sont pas indiquées.
                     
            </div>
 
@@ -3317,7 +3317,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>
+                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>
                 Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>
                 Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="//fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
                     
@@ -3510,7 +3510,7 @@
                 Informations incomplètes ou incorrectes ?
             </h4>
             
-                <span >Catégorie, labels, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
+                <span >Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
             
             <hr class="floatclear">
         </a>
@@ -3530,8 +3530,8 @@
     
            <div class="panel_text">
              
-                Si les informations ne correspondent pas aux informations présentes sur l'emballage, vous pouvez les compléter ou de les corriger. Merci !
-                Open Food Facts est une base de données collaborative, et chaque contribution est utile à tous.
+                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!
+                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.
                 
            </div>
     
@@ -3793,8 +3793,8 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -3828,11 +3828,11 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -3923,7 +3923,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -33,8 +33,8 @@
     <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
     <link rel="search" href="//fr.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
 	<meta name="twitter:card" content="product">
-<meta name="twitter:site" content="@OpenFoodFactsFR">
-<meta name="twitter:creator" content="@OpenFoodFactsFR">
+<meta name="twitter:site" content="@OpenFoodFactsFr">
+<meta name="twitter:creator" content="@OpenFoodFactsFr">
 <meta name="twitter:title" content="Apple pie - Bob's pies - 100 g">
 <meta name="twitter:description" content="Ingrédients, allergènes, additifs, composition nutritionnelle, labels, origine des ingrédients et informations du produit Apple pie - Bob's pies - 100 g">
 <meta name="twitter:label1" content="marque">
@@ -2569,7 +2569,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>
+                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>
                 Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>
                 Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="//fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
                     
@@ -2709,7 +2709,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                    Les informations sur l'emballage de ce produit ne sont pas renseignées.
+                    Les informations sur l'emballage de ce produit ne sont pas indiquées.
                     
            </div>
 
@@ -3232,7 +3232,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                    Les informations sur l'emballage de ce produit ne sont pas renseignées.
+                    Les informations sur l'emballage de ce produit ne sont pas indiquées.
                     
            </div>
 
@@ -3331,7 +3331,7 @@
     
            <div class="panel_text panel_text_warning">⚠
              ️
-                Les origines des ingrédients de ce produit ne sont pas renseignées.<br><br>
+                Les origines des ingrédients de ce produit ne sont pas indiquées.<br><br>
                 Si elles sont indiquées sur l'emballage, vous pouvez modifier la fiche produit et les ajouter.<br><br>
                 Si vous êtes le fabricant de ce produit, vous pouvez nous transmettre les informations avec notre <a href="//fr.pro.openfoodfacts.org">plateforme gratuite pour les producteurs</a>.
                     
@@ -3524,7 +3524,7 @@
                 Informations incomplètes ou incorrectes ?
             </h4>
             
-                <span >Catégorie, labels, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
+                <span >Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
             
             <hr class="floatclear">
         </a>
@@ -3544,8 +3544,8 @@
     
            <div class="panel_text">
              
-                Si les informations ne correspondent pas aux informations présentes sur l'emballage, vous pouvez les compléter ou de les corriger. Merci !
-                Open Food Facts est une base de données collaborative, et chaque contribution est utile à tous.
+                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!
+                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.
                 
            </div>
     
@@ -3807,8 +3807,8 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 						<p>Rejoignez-nous sur <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Suivez-nous : 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
-							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//twitter.com/OpenFoodFactsFr"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts.fr"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
 						</p>
@@ -3842,11 +3842,11 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 							<div class="small-12 text-center v-space-short h-space-large">
 								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
 
-								<p>A collaborative, free and open database of food products from around the world.</p>
+								<p>Une base de données collaborative, libre et ouverte des produits alimentaires du monde entier.</p>
 								
 								<ul class="inline-list text-center text-small">
 									<li><a href="/mentions-legales">Mentions légales</a></li>
-									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/privacy">Confidentialité</a></li>
 									<li><a href="/conditions-d-utilisation">Conditions d'utilisation</a></li>
 									<li><a href="/data">Données, API et SDK</a></li>
 									<li><a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts">Faire un don à l'association Open Food Facts</a></li>
@@ -3937,7 +3937,7 @@ $(document).foundation({
 	"url": "//fr.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFR"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts.fr", "//twitter.com/OpenFoodFactsFr"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -2002,7 +2002,7 @@ get a cloud of products (scatter plot).</p>
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -2126,7 +2126,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -516,7 +516,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -639,7 +639,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -1575,7 +1575,7 @@ function togglePasswordVisibility(FieldID) {
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -1709,7 +1709,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -429,7 +429,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -554,7 +554,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -834,7 +834,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -957,7 +957,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -439,7 +439,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -568,7 +568,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -3418,7 +3418,7 @@ by typing the first letters of their name in the last row of the table.</p>
   
   <li>
     <time datetime="--ignore--">--ignore--</time> - <a href="/editor/tests" lang="no_language">tests</a> Data (Added: lang, product_name, generic_name, quantity, brands, categories, labels, link, countries, origin, nutrition_data_per, nutrition_data_prepared_per, serving_size, ingredients_text, generic_name_en, ingredients_text_en, origin_en, product_name_en, ingredients_text_fr) -- Nutriments (Added: nutrition-score-fr)   - (app)  &nbsp;
-    <a href="/product/3300000000001/apple-pie-bob-s-pies?rev=1" class="button tiny">View this revision</a>
+    <a href="/product/3300000000001/apple-pie-bob-s-pies?rev=1" class="button tiny"></a>
     
   </li>
   
@@ -3551,7 +3551,7 @@ by typing the first letters of their name in the last row of the table.</p>
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -4053,7 +4053,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -813,7 +813,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -936,7 +936,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -790,7 +790,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -913,7 +913,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -689,7 +689,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -812,7 +812,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -425,7 +425,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -550,7 +550,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -382,7 +382,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -502,7 +502,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -3500,7 +3500,7 @@
 >
     
         
-            <h2 class="panel_title_card text-medium">Report a problem</h2>
+            <h2 class="panel_title_card text-medium">Signaler un problème</h2>
         
     
 
@@ -3536,10 +3536,10 @@
                 
             >
                 
-                Incomplete or incorrect information?
+                Informations incomplètes ou incorrectes ?
             </h4>
             
-                <span >Category, labels, ingredients, allergens, nutritional information, photos etc.</span>
+                <span >Catégorie, étiquettes, ingrédients, allergènes, informations nutritionnelles, photos etc.</span>
             
             <hr class="floatclear">
         </a>
@@ -3559,8 +3559,8 @@
     
            <div class="panel_text">
              
-                If the information does not match the information on the packaging, please complete or correct it.
-                Open Food Facts is a collaborative database, and every contribution is useful for all.
+                Si les informations ne correspondent pas à celles figurant sur l'emballage, vous pouvez les compléter ou les corriger. Merci!
+                Open Food Facts est une base de données collaborative, et chaque contribution est utile pour tous.
                 
            </div>
     
@@ -3579,7 +3579,7 @@
     
         <a class="button small action-edit_product"
             href="/cgi/product.pl?type=edit&code=3300000000001">
-            Complete or correct product information
+            Compléter ou corriger les informations du produit
         </a>
     
 
@@ -3745,7 +3745,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -3875,7 +3875,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -2002,7 +2002,7 @@ get a cloud of products (scatter plot).</p>
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -2126,7 +2126,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -555,7 +555,7 @@
 						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
 						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">Follow us: 
-							<a href="//twitter.com/openfoodfacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
 							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							
@@ -678,7 +678,7 @@ $(document).foundation({
 	"url": "//world.openfoodfacts.localhost",
 	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
 	"name": "Open Food Facts",
-	"sameAs" : [  "//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
 }
 </script>
 


### PR DESCRIPTION
Some translations (that were not really translation but more configuration) were moved from .po files to Config_*.pm
Unfortunately one of the translations removed from .po file "site_name" was the one used to compute the structure that maps country codes to languages, which meant that requests on the fr. subdomain didn't get the French language, and it broke quite a few things downstream.

The tests were passing before the last Crowdin PR as I removed the strings from common.pot but not from all the .po files.

Also a few issues related to some of the other moved translations.