### PR TITLE
feat: display "app_version" in  product edit history

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10400,6 +10400,7 @@ sub display_product_history ($request_ref, $code, $product_ref) {
 
 		my $userid = get_change_userid_or_uuid($change_ref);
 		my $uuid = $change_ref->{app_uuid};
+		my $app_version = $change_ref->{app_version};
 		my $comment = _format_comment($change_ref->{comment});
 
 		my $change_rev = $change_ref->{rev};
@@ -10416,6 +10417,7 @@ sub display_product_history ($request_ref, $code, $product_ref) {
 			date => display_date_tag($change_ref->{t}),
 			userid => $userid,
 			uuid => $uuid,
+			app_version => $app_version,
 			diffs => compute_changes_diff_text($change_ref),
 			comment => $comment
 			};

--- a/templates/web/pages/product/includes/edit_history.tt.html
+++ b/templates/web/pages/product/includes/edit_history.tt.html
@@ -6,7 +6,7 @@
 <ul id="history_list">
   [% FOREACH revision IN revisions %]
   <li>
-    [% revision.date %] - [% display_editor_link(revision.userid) %][% IF revision.uuid %] (UUID: [% revision.uuid %])[% END %] [% revision.diffs %] [% IF
+    [% revision.date %] - [% display_editor_link(revision.userid) %][% IF revision.uuid %] (UUID: [% revision.uuid %])[% END %][% IF revision.app_version %] (App Version: [% revision.app_version %])[% END %] [% revision.diffs %] [% IF
     revision.comment %] - [% revision.comment %] [% END %] &nbsp;
     <a href="[% this_product_url %]?rev=[% revision.number %]" class="button tiny">[% lang('view_this_revision') %]</a>
     [% IF has_permission_product_revert AND product.rev != revision.number %]


### PR DESCRIPTION
### What
Exposing the "app_version" variable from a products changes.sto file in the product edit history if populated. This allows apps to identify if data quality issues are coming from new or old versions which, in-turn, allows to track new bugs, regressions, etc in submissions.

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/79552751/f74d5d0b-53c6-46b8-9eb2-280f79e4f5d3)

### Related issue(s) and discussion
**Discussion from slack**
