### PR TITLE
fix: product page accessibility - img alt attribute

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -401,7 +401,7 @@ function display_product_summary(target, product) {
 		// card_html will be either a <div> or a <a> element, depending on whether it is linked to a knowledge panel
 		let card_html = 'class="attribute_card grade_' + grade + '">' +
 			'<div><div class="attr_card_header">' +
-			'<div class="img_attr"><img src="' + attribute.icon_url + '" style="height:72px;float:right;margin-left:0.5rem;"></div>' +
+			'<div class="img_attr"><img src="' + attribute.icon_url + '" style="height:72px;float:right;margin-left:0.5rem;" alt="'+ attribute.name +' icon"></div>' +
 			'<div class="attr_text"><h4 class="grade_' + grade + '_title attr_title">' + attribute.title + '</h4>';
 
 		if (attribute.description_short) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3170,8 +3170,9 @@ sub display_tags_list ($tagtype, $tags_list) {
 			if ($img =~ /\.(\d+)x(\d+)/) {
 				$size = " width=\"$1\" height=\"$2\"";
 			}
+			my $alt = display_taxonomy_tag_name($lc, $tagtype, $tag);
 			$images .= <<HTML
-<img src="/images/lang/$lc/$tagtype/$img"$size/ style="display:inline">
+<img src="/images/lang/$lc/$tagtype/$img"$size/ style="display:inline" alt="$alt">
 HTML
 				;
 		}
@@ -3284,9 +3285,9 @@ sub display_tags_hierarchy ($tagtype, $tags_ref) {
 					$size = " width=\"$1\" height=\"$2\"";
 				}
 				# print STDERR "abbio - lc: $lc - tagtype: $tagtype - tag: $tag - img: $img\n";
-
+				my $alt = display_taxonomy_tag_name($lc, $tagtype, $tag);
 				$images .= <<HTML
-<img src="/images/lang/$lc/$tagtype/$img"$size/ style="display:inline">
+<img src="/images/lang/$lc/$tagtype/$img"$size/ style="display:inline" atl="$alt">
 HTML
 					;
 			}
@@ -3377,14 +3378,16 @@ sub display_tags_hierarchy_taxonomy ($target_lc, $tagtype, $tags_ref) {
 
 			my $canon_tagid = canonicalize_taxonomy_tag($target_lc, $tagtype, $tag);
 			my $img = get_tag_image($target_lc, $tagtype, $canon_tagid);
-
+			
 			if ($img) {
 				my $size = '';
 				if ($img =~ /\.(\d+)x(\d+)/) {
 					$size = " width=\"$1\" height=\"$2\"";
 				}
+				my $alt = display_taxonomy_tag_name($target_lc, $tagtype, $tag);
+				
 				$images .= <<HTML
-<img src="$img"$size/ style="display:inline">
+<img src="$img"$size/ style="display:inline" alt="$alt">
 HTML
 					;
 			}

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3378,14 +3378,14 @@ sub display_tags_hierarchy_taxonomy ($target_lc, $tagtype, $tags_ref) {
 
 			my $canon_tagid = canonicalize_taxonomy_tag($target_lc, $tagtype, $tag);
 			my $img = get_tag_image($target_lc, $tagtype, $canon_tagid);
-			
+
 			if ($img) {
 				my $size = '';
 				if ($img =~ /\.(\d+)x(\d+)/) {
 					$size = " width=\"$1\" height=\"$2\"";
 				}
 				my $alt = display_taxonomy_tag_name($target_lc, $tagtype, $tag);
-				
+
 				$images .= <<HTML
 <img src="$img"$size/ style="display:inline" alt="$alt">
 HTML

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -453,8 +453,8 @@
 
 <p id="field_labels">
     <span class="field">Labels, certifications, récompenses : </span>
-    <span class="field_value" id="field_labels_value"><a href="/label/commerce-equitable" class="tag well_known">Commerce équitable</a>, <a href="/label/bio" class="tag well_known">Bio</a><br /><img src="/images/lang/fr/labels/commerce-equitable.96x90.png" width="96" height="90"/ style="display:inline">
-<img src="/images/lang/fr/labels/bio.96x90.png" width="96" height="90"/ style="display:inline">
+    <span class="field_value" id="field_labels_value"><a href="/label/commerce-equitable" class="tag well_known">Commerce équitable</a>, <a href="/label/bio" class="tag well_known">Bio</a><br /><img src="/images/lang/fr/labels/commerce-equitable.96x90.png" width="96" height="90"/ style="display:inline" alt="Commerce équitable">
+<img src="/images/lang/fr/labels/bio.96x90.png" width="96" height="90"/ style="display:inline" alt="Bio">
 </span>
 </p>
 

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -461,7 +461,7 @@
 
 <p id="field_labels">
     <span class="field">Labels, certifications, récompenses : </span>
-    <span class="field_value" id="field_labels_value"><a href="/label/commerce-equitable" class="tag well_known">Commerce équitable</a><br /><img src="/images/lang/fr/labels/commerce-equitable.96x90.png" width="96" height="90"/ style="display:inline">
+    <span class="field_value" id="field_labels_value"><a href="/label/commerce-equitable" class="tag well_known">Commerce équitable</a><br /><img src="/images/lang/fr/labels/commerce-equitable.96x90.png" width="96" height="90"/ style="display:inline" alt="Commerce équitable">
 </span>
 </p>
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Missing alt attribute on images in product page: labels, Nutri-score, Ecoscore, Nova

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #10292 
