### PR TITLE
fix: alt tags for images on list of products 

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -247,10 +247,10 @@ function display_products(target, product_groups, user_prefs) {
 			product_html += '<div class="list_product_img_div">';
 
 			if (product.image_front_small_url) {
-				product_html += `<img src="${product.image_front_small_url}" class="list_product_img">`;
+				product_html += `<img src="${product.image_front_small_url}" class="list_product_img" alt="${product.product_display_name}">`;
 			}
 			else {
-				product_html += `<img src="/images/icons/dist/packaging.svg" style="filter:invert(.9)" class="list_product_img">`;
+				product_html += `<img src="/images/icons/dist/packaging.svg" style="filter:invert(.9)" class="list_product_img" alt="${product.product_display_name}">`;
 			}
 
 			product_html += "</div>";
@@ -275,7 +275,7 @@ function display_products(target, product_groups, user_prefs) {
 						title += " - " + attribute.missing;
 					}
 
-					product_html += '<img class="list_product_icons" src="' + attribute.icon_url + '" title="' + title + '">';
+					product_html += '<img class="list_product_icons" src="' + attribute.icon_url + '" title="' + title + '" alt="' + attribute.title + '" >';
 				}
 			});
 			product_html += '</div>';

--- a/templates/web/common/includes/list_of_products.tt.html
+++ b/templates/web/common/includes/list_of_products.tt.html
@@ -47,7 +47,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           [% html_count %]
         </span>
       </div>

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -388,7 +388,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -451,7 +451,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -429,7 +429,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -424,7 +424,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -492,7 +492,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -420,7 +420,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -481,7 +481,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -420,7 +420,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -508,7 +508,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           2 produits
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -370,7 +370,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           6 produits
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -358,7 +358,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           1 product
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -502,7 +502,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           5 products
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -391,7 +391,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           12 products
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -368,7 +368,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           12 products
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -496,7 +496,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           4 products
         </span>
       </div>

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -358,7 +358,7 @@
     <div class="small-12 columns filterProducts">
       <div>
         <span class="filterProducts__results">
-          <span class="material-icons">search</span>
+          <span class="material-icons" aria-hidden="true">search</span>
           4 products
         </span>
       </div>


### PR DESCRIPTION
Should fix #10284

![image](https://github.com/openfoodfacts/openfoodfacts-server/assets/8158668/52c6aebf-233c-46c6-b581-f230d33a35a7)
