### PR TITLE
fix: cache /api/v0/preferences and attribute_groups

### DIFF
--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -170,6 +170,7 @@ function display_user_product_preferences(target_selected, target_selection_form
             attribute_groups = data;
             display_user_product_preferences(target_selected, target_selection_form, change);
         });
+
         return;
     }
 
@@ -180,6 +181,7 @@ function display_user_product_preferences(target_selected, target_selection_form
             preferences = data;
             display_user_product_preferences(target_selected, target_selection_form, change);
         });
+        
         return;
     }
 

--- a/html/js/product-preferences.js
+++ b/html/js/product-preferences.js
@@ -170,6 +170,7 @@ function display_user_product_preferences(target_selected, target_selection_form
             attribute_groups = data;
             display_user_product_preferences(target_selected, target_selection_form, change);
         });
+        return;
     }
 
     if (!preferences) {
@@ -179,6 +180,7 @@ function display_user_product_preferences(target_selected, target_selection_form
             preferences = data;
             display_user_product_preferences(target_selected, target_selection_form, change);
         });
+        return;
     }
 
     if (attribute_groups && preferences && !displayed_user_product_preferences) {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -142,7 +142,7 @@ BEGIN {
 
 use vars @EXPORT_OK;
 
-use ProductOpener::HTTP qw(write_cors_headers);
+use ProductOpener::HTTP qw(write_cors_headers set_http_response_header write_http_response_headers);
 use ProductOpener::Store qw(get_string_id_for_lang retrieve);
 use ProductOpener::Config qw(:all);
 use ProductOpener::Paths qw/%BASE_DIRS/;
@@ -10193,6 +10193,8 @@ sub display_preferences_api ($request_ref, $target_lc) {
 		push @{$request_ref->{structured_response}}, $preference_ref;
 	}
 
+	set_http_response_header($request_ref, "Cache-Control", "public, max-age=86400");
+
 	display_structured_response($request_ref);
 
 	return;
@@ -10239,6 +10241,8 @@ sub display_attribute_groups_api ($request_ref, $target_lc) {
 	}
 
 	$request_ref->{structured_response} = $attribute_groups_ref;
+
+	set_http_response_header($request_ref, "Cache-Control", "public, max-age=86400");
 
 	display_structured_response($request_ref);
 
@@ -10539,6 +10543,8 @@ sub display_product_history ($request_ref, $code, $product_ref) {
 sub display_structured_response ($request_ref) {
 	# directly serve structured data from $request_ref->{structured_response}
 
+	write_http_response_headers($request_ref);
+
 	$log->debug(
 		"Displaying structured response",
 		{
@@ -10619,9 +10625,7 @@ sub display_structured_response ($request_ref) {
 				. $data . ");";
 		}
 		else {
-			$log->warning("XXXXXXXXXXXXXXXXXXXXXX");
 			write_cors_headers();
-			$log->warning("YYYYYYYYYYYYYYYY");
 			print header(
 				-status => $status_code,
 				-type => 'application/json',


### PR DESCRIPTION
This PR sets the Cache-Control: public, max-age=86400 on responses for API /api/v0/preferences and /api/v0/attribute_groups (requested on all web pages for Personal Search). It also fixes the JS so that we don't load /api/v0/preferences twice.

Related: https://github.com/openfoodfacts/openfoodfacts-server/issues/8957