### PR TITLE
fix: warnings modperl_error_log

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1526,7 +1526,8 @@ sub display_text_content ($request_ref, $textid, $text_lc, $file) {
 	}
 
 	if ((defined $request_ref->{page}) and ($request_ref->{page} > 1)) {
-		$request_ref->{title} = $title . lang("title_separator") . sprintf(lang("page_x"), $request_ref->{page});
+		$request_ref->{title}
+			= (defined $title ? $title : '') . lang("title_separator") . sprintf(lang("page_x"), $request_ref->{page});
 	}
 	else {
 		$request_ref->{title} = $title;
@@ -9041,11 +9042,14 @@ sub data_to_display_nutrient_levels ($product_ref) {
 
 			if ((defined $product_ref->{nutrient_levels}) and (defined $product_ref->{nutrient_levels}{$nid})) {
 
+				my $nutriment_value = $product_ref->{nutriments}{$nid . $prepared . "_100g"};
+				my $formatted_value = defined $nutriment_value
+					&& $nutriment_value =~ /^-?\d+(\.\d+)?$/ ? sprintf("%.2e", $nutriment_value + 0.0) : '';
+
 				push @{$result_data_ref->{nutrient_levels}}, {
 					nid => $nid,
 					nutrient_level => $product_ref->{nutrient_levels}{$nid},
-					nutrient_quantity_in_grams =>
-						sprintf("%.2e", $product_ref->{nutriments}{$nid . $prepared . "_100g"}) + 0.0,
+					nutrient_quantity_in_grams => $formatted_value,
 					nutrient_in_quantity => sprintf(
 						lang("nutrient_in_quantity"),
 						display_taxonomy_tag($lc, "nutrients", "zz:$nid"),

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -719,10 +719,13 @@ sub create_environment_card_panel ($product_ref, $target_lc, $target_cc, $option
 	if ($options{product_type} eq "food") {
 		create_ecoscore_panel($product_ref, $target_lc, $target_cc, $options_ref);
 
-		if (    (defined $product_ref->{ecoscore_data})
+		if (
+				(defined $product_ref->{ecoscore_data})
 			and (defined $product_ref->{ecoscore_data}{adjustments})
 			and (defined $product_ref->{ecoscore_data}{adjustments}{threatened_species})
-			and ($product_ref->{ecoscore_data}{adjustments}{threatened_species}{value} != 0))
+			and (defined $product_ref->{ecoscore_data}{adjustments}{threatened_species}{value}
+				&& $product_ref->{ecoscore_data}{adjustments}{threatened_species}{value} != 0)
+			)
 		{
 
 			create_panel_from_json_template("palm_oil", "api/knowledge-panels/environment/palm_oil.tt.json",
@@ -1155,7 +1158,9 @@ sub create_serving_size_panel ($product_ref, $target_lc, $target_cc, $options_re
 	# Generate a panel only for food products that have a serving size
 	if (defined $product_ref->{serving_size}) {
 		my $serving_warning = undef;
-		if (($product_ref->{serving_quantity} <= 5) and ($product_ref->{nutrition_data_per} eq 'serving')) {
+		if (    (defined $product_ref->{serving_quantity} && $product_ref->{serving_quantity} <= 5)
+			and ($product_ref->{nutrition_data_per} eq 'serving'))
+		{
 			$serving_warning = lang_in_other_lc($target_lc, "serving_too_small_for_nutrition_analysis");
 		}
 		my $panel_data_ref = {"serving_warning" => $serving_warning,};
@@ -1334,7 +1339,11 @@ sub create_ingredients_panel ($product_ref, $target_lc, $target_cc, $options_ref
 		title => $title,
 		ingredients_text => $ingredients_text,
 		ingredients_text_with_allergens => $ingredients_text_with_allergens,
-		ingredients_text_lc => $ingredients_text_lc,
+		ingredients_text_lc => (
+			defined $ingredients_text_lc
+			? display_taxonomy_tag($target_lc, 'languages', $language_codes{$ingredients_text_lc})
+			: ''
+		),
 		ingredients_text_language =>
 			display_taxonomy_tag($target_lc, 'languages', $language_codes{$ingredients_text_lc}),
 	};

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -410,6 +410,8 @@ Boolean value indicating if the code is valid or not.
 =cut
 
 sub is_valid_code ($code) {
+	# Return an empty string if $code is undef
+	return '' if !defined $code;
 	return $code =~ /^\d{4,24}$/;
 }
 
@@ -2338,12 +2340,14 @@ sub compute_product_history_and_completeness ($product_data_root, $current_produ
 					my $number_of_units = $packagings_ref->{number_of_units};
 					my $weight_measured = $packagings_ref->{weight_measured};
 
-					$packagings_data_signature .= "number_of_units:" . ($number_of_units || '') . ',';
+					$packagings_data_signature
+						.= "number_of_units:" . (defined $number_of_units ? $number_of_units : '') . ',';
 					foreach my $property (qw(shape material recycling quantity_per_unit)) {
-						$packagings_data_signature .= $property . ":" . ($packagings_ref->{$property} || '') . ',';
+						$packagings_data_signature .= $property . ":"
+							. (defined $packagings_ref->{$property} ? $packagings_ref->{$property} : '') . ',';
 					}
 					$packagings_data_signature .= "\n";
-					$packagings_weights_signature .= ($weight_measured || '') . "\n";
+					$packagings_weights_signature .= (defined $weight_measured ? $weight_measured : '') . "\n";
 				}
 				# If the signature is empty or contains only line feeds, we don't have data
 				if ($packagings_data_signature !~ /^\s*$/) {

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3433,6 +3433,8 @@ sub list_taxonomy_tags_in_language ($target_lc, $tagtype, $tags_ref) {
 }
 
 sub canonicalize_tag2 ($tagtype, $tag) {
+	return $tag if !defined $tag;
+
 	#$tag = lc($tag);
 	my $canon_tag = $tag;
 	$canon_tag =~ s/^ //g;

--- a/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json
@@ -25,11 +25,11 @@
             }
         }, 
 [% ELSE %]
-    [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 0 %]
+    [% IF defined product.ecoscore_data.adjustments.origins_of_ingredients.value && product.ecoscore_data.adjustments.origins_of_ingredients.value <= 0 %]
     "evaluation": "bad",
     "title_element": {
         "title": "[% edq(lang('ecoscore_origins_of_ingredients_impact_high')) %]",
-    [% ELSIF product.ecoscore_data.adjustments.origins_of_ingredients.value <= 15 %]
+    [% ELSIF defined product.ecoscore_data.adjustments.origins_of_ingredients.value && product.ecoscore_data.adjustments.origins_of_ingredients.value <= 15 %]
     "evaluation": "average",
     "title_element": {
         "title": "[% edq(lang('ecoscore_origins_of_ingredients_impact_medium')) %]",    
@@ -38,7 +38,7 @@
     "title_element": {
         "title": "[% edq(lang('ecoscore_origins_of_ingredients_impact_low')) %]",
     [% END %]
-        [% IF product.ecoscore_data.adjustments.origins_of_ingredients.value > 0 %]
+        [% IF defined product.ecoscore_data.adjustments.origins_of_ingredients.value && product.ecoscore_data.adjustments.origins_of_ingredients.value > 0 %]
             "subtitle": "[% edq(lang('bonus')) %][% sep %]: +[% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
         [% ELSE %]
             "subtitle": "[% edq(lang('malus')) %][% sep %]: [% product.ecoscore_data.adjustments.origins_of_ingredients.value %]",
@@ -53,8 +53,8 @@
             "text_element": {
                 "type": "default",
                 "html": `
-                <strong>[% lang('ecoscore_environmental_policy') %][% sep %]: [% IF product.ecoscore_data.adjustments.origins_of_ingredients.epi_value > 0 %]+[% END %][% round(product.ecoscore_data.adjustments.origins_of_ingredients.epi_value) %]</strong><br>
-                <strong>[% lang('ecoscore_transportation') %][% sep %]: [% IF product.ecoscore_data.adjustments.origins_of_ingredients.transportation_value > 0 %]+[% END %][% round(product.ecoscore_data.adjustments.origins_of_ingredients.transportation_value) %]</strong><br>
+                <strong>[% lang('ecoscore_environmental_policy') %][% sep %]: [% IF defined product.ecoscore_data.adjustments.origins_of_ingredients.epi_value && product.ecoscore_data.adjustments.origins_of_ingredients.epi_value > 0 %]+[% END %][% round(product.ecoscore_data.adjustments.origins_of_ingredients.epi_value) %]</strong><br>
+                <strong>[% lang('ecoscore_transportation') %][% sep %]: [% IF defined product.ecoscore_data.adjustments.origins_of_ingredients.transportation_value && product.ecoscore_data.adjustments.origins_of_ingredients.transportation_value > 0 %]+[% END %][% round(product.ecoscore_data.adjustments.origins_of_ingredients.transportation_value) %]</strong><br>
                 `
             }
         },        
@@ -89,7 +89,9 @@
                                 "percent": [% round(origin.percent) %],
                                 // EPI bonus goes from -5 to 5 with the formula bonus = epi_score / 10 - 5
                                 // Transportation bonus goes from 0 to 15 with the formula bonus = transportation_score * 0.15
-                                [% SET score = origin.epi_score / 10 - 5 + origin.transportation_score * 0.15 %]
+                                [% SET epi_score = defined origin.epi_score ? origin.epi_score : 0 %]
+                                [% SET transportation_score = defined origin.transportation_score ? origin.transportation_score : 0 %]
+                                [% SET score = epi_score / 10 - 5 + transportation_score * 0.15 %]
                                 [% IF score >= 15 %]
                                     "evaluation": "good",
                                 [% ELSIF score <= 0 %]

--- a/templates/api/knowledge-panels/environment/ecoscore/threatened_species.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/threatened_species.tt.json
@@ -24,7 +24,7 @@
                 }
             },
         ]
-    [% ELSIF product.ecoscore_data.adjustments.threatened_species.value < 0 %]
+    [% ELSIF defined product.ecoscore_data.adjustments.threatened_species.value && product.ecoscore_data.adjustments.threatened_species.value < 0 %]
         "evaluation": "bad",
         "title_element": {
             "title": "[% edq(lang('ecoscore_ingredients_whose_cultivation_threatens_species')) %]",

--- a/templates/api/knowledge-panels/environment/ecoscore/total.tt.json
+++ b/templates/api/knowledge-panels/environment/ecoscore/total.tt.json
@@ -1,4 +1,27 @@
-[% SET sum_of_bonuses_and_maluses = product.ecoscore_data.adjustments.production_system.value + product.ecoscore_data.adjustments.packaging.value + product.ecoscore_data.adjustments.threatened_species.value + product.ecoscore_data.adjustments.origins_of_ingredients.value %]
+[% USE sum_of_bonuses_and_maluses = 0;
+   USE value;
+   IF (defined product.ecoscore_data.adjustments.production_system.value && product.ecoscore_data.adjustments.production_system.value =~ /^-?\d+(\.\d+)?$/) {
+       value = product.ecoscore_data.adjustments.production_system.value;
+   }
+   sum_of_bonuses_and_maluses += value;
+
+   IF (defined product.ecoscore_data.adjustments.packaging.value && product.ecoscore_data.adjustments.packaging.value =~ /^-?\d+(\.\d+)?$/) {
+       value = product.ecoscore_data.adjustments.packaging.value;
+   }
+   sum_of_bonuses_and_maluses += value;
+
+   IF (defined product.ecoscore_data.adjustments.threatened_species.value && product.ecoscore_data.adjustments.threatened_species.value =~ /^-?\d+(\.\d+)?$/) {
+       value = product.ecoscore_data.adjustments.threatened_species.value;
+   }
+   sum_of_bonuses_and_maluses += value;
+
+   IF (defined product.ecoscore_data.adjustments.origins_of_ingredients.value && product.ecoscore_data.adjustments.origins_of_ingredients.value =~ /^-?\d+(\.\d+)?$/) {
+       value = product.ecoscore_data.adjustments.origins_of_ingredients.value;
+   }
+   sum_of_bonuses_and_maluses += value;
+%]
+
+
 {
     "level": "info",
     "topics": [

--- a/templates/web/pages/product/includes/ecoscore_details.tt.html
+++ b/templates/web/pages/product/includes/ecoscore_details.tt.html
@@ -120,7 +120,7 @@
 		 <div class="panel ecoscore_panel" id="ecoscore_panel_production_system" data-equalizer-watch="ecoscore1">
 	<h4>[% display_icon('agriculture') %] [% lang('ecoscore_production_system') %]</h4>
 	
-	[% IF adjustments.production_system.value > 0 %]
+	[% IF defined adjustments.production_system.value && adjustments.production_system.value > 0 %]
 		
 		<ul>
 		[% FOREACH label IN adjustments.production_system.labels %]
@@ -164,8 +164,8 @@
 	[% END %]
 
 	<p>
-		<strong>[% lang('ecoscore_environmental_policy') %][% sep %]: [% IF adjustments.origins_of_ingredients.epi_value > 0 %]+[% END %][% round(adjustments.origins_of_ingredients.epi_value) %]</strong><br>
-		<strong>[% lang('ecoscore_transportation') %][% sep %]: [% IF adjustments.origins_of_ingredients.transportation_value > 0 %]+[% END %][% round(adjustments.origins_of_ingredients.transportation_value) %]</strong><br>
+		<strong>[% lang('ecoscore_environmental_policy') %][% sep %]: [% IF defined adjustments.origins_of_ingredients.epi_value && adjustments.origins_of_ingredients.epi_value > 0 %]+[% END %][% round(adjustments.origins_of_ingredients.epi_value) %]</strong><br>
+		<strong>[% lang('ecoscore_transportation') %][% sep %]: [% IF defined adjustments.origins_of_ingredients.epi_value && adjustments.origins_of_ingredients.transportation_value > 0 %]+[% END %][% round(adjustments.origins_of_ingredients.transportation_value) %]</strong><br>
 	</p>
 	</div>
 	</div>
@@ -233,7 +233,7 @@
 		<p>[% lang('ecoscore_score_of_all_components') %][% sep %]: [% adjustments.packaging.score %]</p>	
 	[% END %]
 
-	<p><strong>[% lang('ecoscore_packaging') %][% sep %]: [% IF adjustments.packaging.value > 0 %]+[% END %][% adjustments.packaging.value %]</strong></p>
+	<p><strong>[% lang('ecoscore_packaging') %][% sep %]: [% IF defined adjustments.packaging.value && adjustments.packaging.value > 0 %]+[% END %][% adjustments.packaging.value %]</strong></p>
 	
 	</div>
 	</div>


### PR DESCRIPTION
### What
attempt to fix warnings modperl_error_log

I believe it should fix

```
106	-e: Use of uninitialized value $title in concatenation (.) or string at /srv/off/lib/ProductOpener/Display.pm line 1481.
122	-e: Use of uninitialized value $code in pattern match (m//) at /srv/off/lib/ProductOpener/Products.pm line 412.
126	-e: Argument "" isn't numeric in numeric gt (>) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json line 57.
126	-e: Argument "" isn't numeric in numeric le (<=) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json line 40.
126	-e: Argument "" isn't numeric in numeric gt (>) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json line 45.
138	-e: Use of uninitialized value in numeric le (<=) at /srv/off/lib/ProductOpener/KnowledgePanels.pm line 1117.
162	-e: Wide character (U+6210) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
174	-e: Wide character (U+5206) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
184	-e: Invalid conversion in sprintf: end of string at /srv/off/lib/ProductOpener/Display.pm line 9017. -> 9050 (+43)
191	-e: Argument "" isn't numeric in division (/) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json line 92.
223	-e: Argument "" isn't numeric in division (/) at /srv/off/templates/api/knowledge-panels/environment/origins_of_ingredients.tt.json line 88.
229	-e: Argument "" isn't numeric in numeric le (<=) at /srv/off/templates/api/knowledge-panels/environment/origins_of_ingredients.tt.json line 50.
393	-e: Use of uninitialized value $canon_tag in string eq at /srv/off/lib/ProductOpener/Tags.pm line 3448.
393	-e: Use of uninitialized value $tag in ucfirst at /srv/off/lib/ProductOpener/Tags.pm line 3450.
393	-e: Use of uninitialized value $canon_tag in substitution (s///) at /srv/off/lib/ProductOpener/Tags.pm line 3449.
486	-e: Use of uninitialized value $canon_tag in substitution (s///) at /srv/off/lib/ProductOpener/Tags.pm line 3434.
486	-e: Use of uninitialized value $canon_tag in substitution (s///) at /srv/off/lib/ProductOpener/Tags.pm line 3433.
507	-e: Argument "" isn't numeric in multiplication (*) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/origins_of_ingredients.tt.json line 92.
556	-e: Argument "" isn't numeric in numeric gt (>) at /srv/off/templates/web/pages/product/includes/ecoscore_details.tt.html line 168.
718	-e: Argument "" isn't numeric in multiplication (*) at /srv/off/templates/api/knowledge-panels/environment/origins_of_ingredients.tt.json line 88.
815	-e: Use of uninitialized value $number_of_units in concatenation (.) or string at /srv/off/lib/ProductOpener/Products.pm line 2340.
4507	-e: Use of uninitialized value $ingredients_text_lc in hash element at /srv/off/lib/ProductOpener/KnowledgePanels.pm line 1298.
5049	-e: Argument "" isn't numeric in numeric lt (<) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/threatened_species.tt.json line 30.
6743	-e: Argument "" isn't numeric in addition (+) at /srv/off/templates/api/knowledge-panels/environment/ecoscore/total.tt.json line 1.
12333	-e: Use of uninitialized value in numeric ne (!=) at /srv/off/lib/ProductOpener/KnowledgePanels.pm line 709.
```


While following should remain:
```
114	-e: Wide character (U+E2A) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
189	zzz lc: es - request_ref->lc: es
199	-e: Use of uninitialized value in concatenation (.) or string at /srv/off/lib/ProductOpener/Display.pm line 8229.
231	-e: Wide character (U+8425) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
233	-e: Wide character (U+6570) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
248	-e: Use of uninitialized value in string eq at /srv/off/lib/ProductOpener/Display.pm line 9532.
257	-e: Use of uninitialized value in concatenation (.) or string at /srv/off/lib/ProductOpener/Display.pm line 8158.
270	-e: Wide character (U+6DFB) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
292	-e: Use of uninitialized value $ProductOpener::Display::User_id in string eq at /srv/off/lib/ProductOpener/Display.pm line 4055.
302	-e: Wide character (U+645) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
321	-e: Wide character (U+17A) in ucfirst at /usr/local/lib/x86_64-linux-gnu/perl/5.32.1/Template/Filters.pm line 57.
423	zzz lc: de - request_ref->lc: de
688	-e: Use of uninitialized value in concatenation (.) or string at /srv/off/lib/ProductOpener/Display.pm line 10894.
819	zzz lc: fr - request_ref->lc: fr
840	-e: Use of uninitialized value in pattern match (m//) at /srv/off/lib/ProductOpener/Display.pm line 10254.
934	-e: Use of uninitialized value $ingredients_text_lang in string ne at /srv/off/lib/ProductOpener/Display.pm line 7874.
934	-e: Use of uninitialized value $ingredients_text_lang in hash element at /srv/off/lib/ProductOpener/Display.pm line 7876.
1425	zzz lc: en - request_ref->lc: en
1553	-e: Use of uninitialized value $user_agent_str in pattern match (m//) at /srv/off/lib/ProductOpener/Display.pm line 984.
2568	zzz lc: zh - request_ref->lc: zh
5435	-e: Use of uninitialized value in numeric le (<=) at /srv/off/lib/ProductOpener/Display.pm line 5355.
5442	-e: Use of uninitialized value in subroutine argument at /srv/off/lib/ProductOpener/Tags.pm line 4134.
5507	-e: Use of uninitialized value in uc at /srv/off/lib/ProductOpener/Display.pm line 7642.
6189	-e: Argument "" isn't numeric in sprintf at /srv/off/lib/ProductOpener/Display.pm line 453.
8921	-e: Use of uninitialized value $ingredients_text_lc in concatenation (.) or string at /srv/off/lib/ProductOpener/Display.pm line 10939.
15985	-e: Use of uninitialized value in uc at /srv/off/lib/ProductOpener/Display.pm line 8789.
```


@stephanegigandet:
- how can I generate the same log that you showed in the issue?
- how can I test locally that I got rid of these wanings.

### Related issue(s) and discussion
- Fixes #10296 

