### PR TITLE
taxonomy: add Cyanocobalamin -> b12

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -10084,7 +10084,8 @@ wikipedia:en:https://en.wikipedia.org/wiki/Biotin
 # ingredient/biotin has 145 products in 3 languages @2018-11-24
 
 <en:vitamins
-en:cobalamin, Vitamin B12, B12
+en:cobalamin, Vitamin B12, B12, Cyanocobalamin, Cyanocobalamine
+de:Cyanocobalamin, Cyanocobalamine
 hr:kobalamin
 ja:コバラミン, ビタミンB12
 


### PR DESCRIPTION
### What

Adds Cyanocobalamin  -> B12 taxonomy

https://de.openfoodfacts.org/produkt/4337256601238/vegan-soja-vanille-rewe-beste-wahl

https://www.sustagen.com.au/product/sustagen-everyday?selectedValue=12417063

Note that [AGROVOC](https://agrovoc.fao.org/browse/agrovoc/en/) mentions that [`vitamin B12`](https://agrovoc.fao.org/browse/agrovoc/en/page/c_8269) is the preferred term, this does come up in a handful of different ingredient lists.