### PR TITLE
taxonomy: remove duplicate split peas entry in ingredients

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -60636,12 +60636,6 @@ la:pisum sativum
 eurocode_2_group_3:en: 8.45.10
 
 <en:pea
-en:split peas
-fr:Pois cassés
-hr:cijepani grašak
-it:piselli spezzati
-
-<en:pea
 en:green peas
 bg:зелен грах
 da:Grønne ærter
@@ -60769,9 +60763,10 @@ de:Schälerbsen, geschälte Trockenerbsen
 el:Φάβα
 fa:لپه
 fi:halkaistu herne, halkaistut herneet
-fr:pois cassés
+fr:pois cassé, pois cassés
 hr:cijepani grašak
 hu:Sárgaborsó
+it:piselli spezzati
 ko:완두 짜개
 ms:Kacang dal
 nl:spliterwt, Spliterwten


### PR DESCRIPTION
There were 2 entries for split peas, which broke properties for it.