### PR TITLE
fix: better parsing of ingredient (something unknown and something known)

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2286,6 +2286,7 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 		my @ingredients = ();
 
 		# 2 known ingredients separated by "and" ?
+		# or only 1 known ingredient separated by "and"?
 		if ($before =~ /$and/i) {
 
 			my $ingredient = $before;
@@ -2318,14 +2319,14 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 
 					$ingredients_recognized += $is_recognized;
 				}
-				if ($ingredients_recognized == 2) {
+				# Did we recognize at least one ingredient?
+				if ($ingredients_recognized >= 1) {
 
 					push @ingredients, ($ingredient1_orig, $ingredient2_orig);
 				}
 				else {
 					$debug_ingredients
-						and $log->debug(
-						"parse_ingredient_text - and - one or both ingredient(s) of >$before< is/are unknown")
+						and $log->debug("parse_ingredient_text - and - both ingredients of >$before< are unknown")
 						if $log->is_debug();
 				}
 			}

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1753,7 +1753,7 @@ reference to a hash of product fields that have been created or updated
 
 sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 
-	my $debug_ingredients = 0;
+	my $debug_ingredients = 1;
 
 	delete $product_ref->{ingredients};
 
@@ -2285,8 +2285,9 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 
 		my @ingredients = ();
 
-		# 2 known ingredients separated by "and" ?
-		# or only 1 known ingredient separated by "and"?
+		# 2 known ingredients separated by "and" ? -> split them in 2 ingredients
+		# We do not split if we found only 1 ingredient, as the "and" could be part of the processing
+		# e.g. "cut and fried potatoes" should not be split to "cut" + "fried potatoes"
 		if ($before =~ /$and/i) {
 
 			my $ingredient = $before;
@@ -2319,14 +2320,14 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 
 					$ingredients_recognized += $is_recognized;
 				}
-				# Did we recognize at least one ingredient?
-				if ($ingredients_recognized >= 1) {
+				# Did we recognize the two ingredients?
+				if ($ingredients_recognized == 2) {
 
 					push @ingredients, ($ingredient1_orig, $ingredient2_orig);
 				}
 				else {
 					$debug_ingredients
-						and $log->debug("parse_ingredient_text - and - both ingredients of >$before< are unknown")
+						and $log->debug("parse_ingredient_text - and - at least one ingredient of >$before< is unknown")
 						if $log->is_debug();
 				}
 			}
@@ -2357,8 +2358,14 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 
 		my $i = 0;    # Counter for ingredients, used to know if it is the last ingredient
 
-		foreach my $ingredient (@ingredients) {
+		# Note: we use a while loop instead of a foreach as we may modify the array @ingredients when we split ingredients
+		$debug_ingredients
+			and
+			$log->debug("initial number of ingredients", {count => scalar @ingredients, ingredients => \@ingredients})
+			if $log->is_debug();
+		while (@ingredients) {
 
+			my $ingredient = shift @ingredients;
 			chomp($ingredient);
 
 			$debug_ingredients and $log->debug("analyzing ingredient", {ingredient => $ingredient})
@@ -2438,9 +2445,9 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 					# start with uncomposed labels first, so that we decompose "fair-trade organic" into "fair-trade, organic"
 					foreach my $labelid (reverse @labels) {
 						my $regexp = $labels_regexps{$ingredients_lc}{$labelid};
-						$debug_ingredients and $log->trace("checking labels regexps",
-							{ingredient => $ingredient, labelid => $labelid, regexp => $regexp})
-							if $log->is_trace();
+						#$debug_ingredients and $log->trace("checking labels regexps",
+						#	{ingredient => $ingredient, labelid => $labelid, regexp => $regexp})
+						#	if $log->is_trace();
 						if ((defined $regexp) and ($ingredient =~ /\b($regexp)\b/i)) {
 
 							my $label = $1;
@@ -2814,6 +2821,57 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 									$ingredient_recognized = 1;
 									last;
 								}
+							}
+						}
+					}
+
+					if (not $ingredient_recognized) {
+						# 2 ingredients separated by "and" ? -> split them in 2 ingredients
+						# We split if we find at least 1 known ingredient
+						# We might have some false positives as "and" could be part of processing
+						if ($ingredient =~ /$and/i) {
+
+							my $ingredient1 = $`;
+							my $ingredient2 = $';
+
+							$debug_ingredients
+								and $log->debug(
+								"parse_ingredient_text - and - whole ingredient >$ingredient< containing 'and' is still an unknown ingredient"
+								) if $log->is_debug();
+
+							# Create a copy of $ingredients1 and $ingredients2, as we will remove percents to $ingredientX,
+							# but we will push $ingredientX_orig if it is a known ingredient after we remove the processing
+							my $ingredient1_orig = $ingredient1;
+							my $ingredient2_orig = $ingredient2;
+
+							my $ingredients_recognized = 0;
+
+							foreach ($ingredient1, $ingredient2) {
+								# Remove percent
+								$_ =~ s/\s$percent_or_quantity_regexp$//i;
+
+								# Check if we recognize the ingredient
+								(undef, undef, undef, my $is_recognized)
+									= parse_processing_from_ingredient($ingredients_lc, $_);
+
+								$ingredients_recognized += $is_recognized;
+							}
+							# Did we recognize one of the two ingredients?
+							if ($ingredients_recognized >= 1) {
+								$debug_ingredients
+									and $log->debug("parse_ingredient_text - split $ingredient1 - $ingredient2")
+									if $log->is_debug();
+								$ingredient = $ingredient1_orig;
+								$ingredient_id = canonicalize_taxonomy_tag($ingredients_lc, "ingredients", $ingredient);
+								unshift @ingredients, "$ingredient2_orig";
+								$ingredient_recognized = 1;
+							}
+							else {
+								$debug_ingredients
+									and $log->debug(
+									"parse_ingredient_text - and - both ingredients of >$before< are unknown")
+									if $log->is_debug();
+
 							}
 						}
 					}

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -1753,7 +1753,7 @@ reference to a hash of product fields that have been created or updated
 
 sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 
-	my $debug_ingredients = 1;
+	my $debug_ingredients = 0;
 
 	delete $product_ref->{ingredients};
 
@@ -2864,7 +2864,6 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 								$ingredient = $ingredient1_orig;
 								$ingredient_id = canonicalize_taxonomy_tag($ingredients_lc, "ingredients", $ingredient);
 								unshift @ingredients, "$ingredient2_orig";
-								$ingredient_recognized = 1;
 							}
 							else {
 								$debug_ingredients

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -2950,7 +2950,7 @@ sub parse_ingredients_text_service ($product_ref, $updated_product_fields_ref) {
 							# e.g. "salt and acid (acid citric)" -> salt + acid
 							# the sub ingredients only apply to the last ingredient
 
-							if ($i == $#ingredients) {
+							if ((scalar @ingredients) == 0) {
 								$ingredient{ingredients} = [];
 								$analyze_ingredients_self->(
 									$analyze_ingredients_self, $ingredient{ingredients},

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -6313,7 +6313,7 @@ wikidata:en:Q420130
 wikipedia:en:https://en.wikipedia.org/wiki/Sodium_propionate
 
 
-en:E282, calcium propionate, calcium propanoate
+en:E282, calcium propionate, calcium propanoate, cal. pro., cal.pro.
 xx:E282
 ar:E282, بروبيونات الكالسيوم
 bg:E282, Калциев пропионат

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -85,7 +85,7 @@ stopwords:da:av, af, blandt andet, bl a, inklusive, heraf, indeholder, tilsat
 stopwords:de:und, mit, von, aus, enthält, enthalten, mindestens, in veränderlichen gewichtsanteilen, wenig, min, max
 stopwords:el:περιέχει
 # example: "artificial flavouring substances", "natural and nature identical flavouring substances"
-stopwords:en:added to enhance freshness, added to maintain flavor and freshness, assorted, contains, contain, edible, from, including, inter alia, less than 1% of:, minimum, produced with, with, with added, in varying proportions, substances
+stopwords:en:and,or,added to enhance freshness, added to maintain flavor and freshness, assorted, contains, contain, edible, from, including, inter alia, less than 1% of:, minimum, produced with, with, with added, in varying proportions, substances
 stopwords:es:contiene,de,del,la,el,las,los,con,y,e,en,minimo,maximo,puede,contener,por,categoria,calibre,minimo,min,vereidad,variedad,de cultivo,origen,nota,produccion,controlada,equivalente,equivale
 stopwords:fi:sisältää,muun muassa,valio, koskenlaskija, snellmanin, jossa, noin, käymisen aikana muodostuva
 stopwords:fr:aux,au,de,le,du,la,a,et,avec,ou,en,proportion,variable, contient, élaboré avec, papier traité, minimum, filets tournants et filets, pour souleves,dont,avec,autres,d'autres,d', avec ajout, sachet, marquants, demeter, minimum
@@ -61725,8 +61725,10 @@ hr:pasta od indijskih oraščića
 #
 ###################################################################################################
 
+# chesnut is an obsolete spelling of chestnut
+
 <en:tree nut
-en:chestnut, chestnuts
+en:chestnut, chestnuts, chesnut, chesnuts
 ar:كستنة؛أبو فروة
 bg:кестен, кестени
 ca:castanya

--- a/tests/unit/expected_test_results/ingredients/en-comma-and-pepper.json
+++ b/tests/unit/expected_test_results/ingredients/en-comma-and-pepper.json
@@ -23,36 +23,30 @@
          "vegetarian" : "yes"
       },
       {
-         "id" : "en:and-pepper",
-         "is_in_taxonomy" : 0,
+         "ciqual_proxy_food_code" : "11015",
+         "id" : "en:pepper",
+         "is_in_taxonomy" : 1,
          "percent_estimate" : 16.6666666666667,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
-         "text" : "and pepper"
+         "text" : "and pepper",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       }
    ],
-   "ingredients_analysis" : {
-      "en:palm-oil-content-unknown" : [
-         "en:and-pepper"
-      ],
-      "en:vegan-status-unknown" : [
-         "en:and-pepper"
-      ],
-      "en:vegetarian-status-unknown" : [
-         "en:and-pepper"
-      ]
-   },
+   "ingredients_analysis" : {},
    "ingredients_analysis_tags" : [
-      "en:palm-oil-content-unknown",
-      "en:vegan-status-unknown",
-      "en:vegetarian-status-unknown"
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
    ],
    "ingredients_hierarchy" : [
       "en:sugar",
       "en:added-sugar",
       "en:disaccharide",
       "en:salt",
-      "en:and-pepper"
+      "en:pepper",
+      "en:seed"
    ],
    "ingredients_n" : 3,
    "ingredients_n_tags" : [
@@ -62,7 +56,7 @@
    "ingredients_original_tags" : [
       "en:sugar",
       "en:salt",
-      "en:and-pepper"
+      "en:pepper"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
@@ -70,18 +64,17 @@
       "en:added-sugar",
       "en:disaccharide",
       "en:salt",
-      "en:and-pepper"
+      "en:pepper",
+      "en:seed"
    ],
    "ingredients_text" : "sugar, salt, and pepper",
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 3,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:and-pepper"
-   ],
-   "ingredients_without_ciqual_codes_n" : 1,
-   "known_ingredients_n" : 4,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
+   "known_ingredients_n" : 6,
    "lc" : "en",
    "nutriments" : {
       "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 0,
@@ -89,5 +82,5 @@
       "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
       "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0
    },
-   "unknown_ingredients_n" : 1
+   "unknown_ingredients_n" : 0
 }

--- a/tests/unit/expected_test_results/ingredients/en-comma-and-pepper.json
+++ b/tests/unit/expected_test_results/ingredients/en-comma-and-pepper.json
@@ -1,0 +1,93 @@
+{
+   "ingredients" : [
+      {
+         "ciqual_proxy_food_code" : "31016",
+         "id" : "en:sugar",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 66.6666666666667,
+         "percent_max" : 100,
+         "percent_min" : 33.3333333333333,
+         "text" : "sugar",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "ciqual_food_code" : "11058",
+         "id" : "en:salt",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "salt",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:and-pepper",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 16.6666666666667,
+         "percent_max" : 33.3333333333333,
+         "percent_min" : 0,
+         "text" : "and pepper"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil-content-unknown" : [
+         "en:and-pepper"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:and-pepper"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:and-pepper"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "en:sugar",
+      "en:added-sugar",
+      "en:disaccharide",
+      "en:salt",
+      "en:and-pepper"
+   ],
+   "ingredients_n" : 3,
+   "ingredients_n_tags" : [
+      "3",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:sugar",
+      "en:salt",
+      "en:and-pepper"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:sugar",
+      "en:added-sugar",
+      "en:disaccharide",
+      "en:salt",
+      "en:and-pepper"
+   ],
+   "ingredients_text" : "sugar, salt, and pepper",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 3,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:and-pepper"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
+   "known_ingredients_n" : 4,
+   "lc" : "en",
+   "nutriments" : {
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0
+   },
+   "unknown_ingredients_n" : 1
+}

--- a/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
+++ b/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
@@ -4,9 +4,9 @@
          "ciqual_food_code" : "13050",
          "id" : "en:apple",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 53.5714285714286,
+         "percent_estimate" : 52.7777777777778,
          "percent_max" : 100,
-         "percent_min" : 7.14285714285714,
+         "percent_min" : 5.55555555555556,
          "text" : "apple",
          "vegan" : "yes",
          "vegetarian" : "yes"
@@ -15,7 +15,7 @@
          "ciqual_food_code" : "13005",
          "id" : "en:banana",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 23.2142857142857,
+         "percent_estimate" : 23.6111111111111,
          "percent_max" : 50,
          "percent_min" : 0,
          "processing" : "en:non-hydrogenated",
@@ -27,7 +27,7 @@
          "ciqual_food_code" : "13008",
          "id" : "en:cherry",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 11.6071428571429,
+         "percent_estimate" : 11.8055555555556,
          "percent_max" : 33.3333333333333,
          "percent_min" : 0,
          "text" : "cherry",
@@ -38,7 +38,7 @@
          "ciqual_food_code" : "13011",
          "id" : "en:date",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 5.80357142857143,
+         "percent_estimate" : 5.90277777777778,
          "percent_max" : 25,
          "percent_min" : 0,
          "text" : "date",
@@ -49,7 +49,7 @@
          "ciqual_food_code" : "13126",
          "id" : "en:elderberry",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 2.90178571428572,
+         "percent_estimate" : 2.95138888888889,
          "percent_max" : 20,
          "percent_min" : 0,
          "processing" : "en:hydrogenated",
@@ -61,7 +61,7 @@
          "ciqual_food_code" : "13012",
          "id" : "en:fig",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 1.45089285714286,
+         "percent_estimate" : 1.47569444444444,
          "percent_max" : 16.6666666666667,
          "percent_min" : 0,
          "text" : "fig",
@@ -72,7 +72,7 @@
          "ciqual_food_code" : "13112",
          "id" : "en:grape",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 0.725446428571431,
+         "percent_estimate" : 0.737847222222221,
          "percent_max" : 14.2857142857143,
          "percent_min" : 0,
          "text" : "grape",
@@ -83,7 +83,7 @@
          "ciqual_food_code" : "13028",
          "id" : "en:bilberry",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 0.362723214285715,
+         "percent_estimate" : 0.368923611111114,
          "percent_max" : 12.5,
          "percent_min" : 0,
          "processing" : "en:treated",
@@ -94,7 +94,7 @@
       {
          "id" : "en:jackfruit",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 0.181361607142861,
+         "percent_estimate" : 0.184461805555557,
          "percent_max" : 11.1111111111111,
          "percent_min" : 0,
          "processing" : "en:desalted",
@@ -106,7 +106,7 @@
          "ciqual_food_code" : "13021",
          "id" : "en:kiwi",
          "is_in_taxonomy" : 1,
-         "percent_estimate" : 0.0906808035714306,
+         "percent_estimate" : 0.0922309027777786,
          "percent_max" : 10,
          "percent_min" : 0,
          "processing" : "en:grilled",
@@ -115,56 +115,102 @@
          "vegetarian" : "yes"
       },
       {
-         "id" : "en:lemon-and-unknown-fruit",
-         "is_in_taxonomy" : 0,
-         "percent_estimate" : 0.0453404017857153,
+         "ciqual_proxy_food_code" : "13009",
+         "id" : "en:lemon",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.0461154513888857,
          "percent_max" : 9.09090909090909,
          "percent_min" : 0,
-         "text" : "lemon and unknown_fruit"
+         "text" : "lemon",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
-         "id" : "en:toasted-mango-and-unknown-fruit2",
+         "id" : "en:unknown-fruit",
          "is_in_taxonomy" : 0,
-         "percent_estimate" : 0.0226702008928612,
+         "percent_estimate" : 0.0230577256944429,
          "percent_max" : 8.33333333333333,
          "percent_min" : 0,
-         "text" : "toasted mango and unknown_fruit2"
+         "text" : "unknown_fruit"
       },
       {
-         "id" : "en:nectarine-and-fried-unknown-fruit3",
-         "is_in_taxonomy" : 0,
-         "percent_estimate" : 0.0113351004464306,
+         "ciqual_food_code" : "13025",
+         "id" : "en:mango",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.0115288628472214,
          "percent_max" : 7.69230769230769,
          "percent_min" : 0,
-         "text" : "nectarine and fried unknown_fruit3"
+         "processing" : "en:toasted",
+         "text" : "mango",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
-         "id" : "en:puffed-orange-and-caramelized-unknown-fruit4",
+         "id" : "en:unknown-fruit2",
          "is_in_taxonomy" : 0,
-         "percent_estimate" : 0.0113351004464306,
+         "percent_estimate" : 0.00576443142361427,
          "percent_max" : 7.14285714285714,
          "percent_min" : 0,
-         "text" : "puffed orange and caramelized unknown_fruit4"
+         "text" : "unknown_fruit2"
+      },
+      {
+         "ciqual_food_code" : "13030",
+         "id" : "en:nectarine",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.00288221571180713,
+         "percent_max" : 6.66666666666667,
+         "percent_min" : 0,
+         "text" : "nectarine",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:fried-unknown-fruit3",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 0.00144110785590357,
+         "percent_max" : 6.25,
+         "percent_min" : 0,
+         "text" : "fried unknown_fruit3"
+      },
+      {
+         "ciqual_proxy_food_code" : "13034",
+         "id" : "en:orange",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 0.000720553927948231,
+         "percent_max" : 5.88235294117647,
+         "percent_min" : 0,
+         "processing" : "en:puffed",
+         "text" : "orange",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      },
+      {
+         "id" : "en:caramelized-unknown-fruit4",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 0.000720553927948231,
+         "percent_max" : 5.55555555555556,
+         "percent_min" : 0,
+         "text" : "caramelized unknown_fruit4"
       }
    ],
    "ingredients_analysis" : {
       "en:palm-oil-content-unknown" : [
-         "en:lemon-and-unknown-fruit",
-         "en:toasted-mango-and-unknown-fruit2",
-         "en:nectarine-and-fried-unknown-fruit3",
-         "en:puffed-orange-and-caramelized-unknown-fruit4"
+         "en:unknown-fruit",
+         "en:unknown-fruit2",
+         "en:fried-unknown-fruit3",
+         "en:caramelized-unknown-fruit4"
       ],
       "en:vegan-status-unknown" : [
-         "en:lemon-and-unknown-fruit",
-         "en:toasted-mango-and-unknown-fruit2",
-         "en:nectarine-and-fried-unknown-fruit3",
-         "en:puffed-orange-and-caramelized-unknown-fruit4"
+         "en:unknown-fruit",
+         "en:unknown-fruit2",
+         "en:fried-unknown-fruit3",
+         "en:caramelized-unknown-fruit4"
       ],
       "en:vegetarian-status-unknown" : [
-         "en:lemon-and-unknown-fruit",
-         "en:toasted-mango-and-unknown-fruit2",
-         "en:nectarine-and-fried-unknown-fruit3",
-         "en:puffed-orange-and-caramelized-unknown-fruit4"
+         "en:unknown-fruit",
+         "en:unknown-fruit2",
+         "en:fried-unknown-fruit3",
+         "en:caramelized-unknown-fruit4"
       ]
    },
    "ingredients_analysis_tags" : [
@@ -189,14 +235,19 @@
       "en:blueberry",
       "en:jackfruit",
       "en:kiwi",
-      "en:lemon-and-unknown-fruit",
-      "en:toasted-mango-and-unknown-fruit2",
-      "en:nectarine-and-fried-unknown-fruit3",
-      "en:puffed-orange-and-caramelized-unknown-fruit4"
+      "en:lemon",
+      "en:citrus-fruit",
+      "en:unknown-fruit",
+      "en:mango",
+      "en:unknown-fruit2",
+      "en:nectarine",
+      "en:fried-unknown-fruit3",
+      "en:orange",
+      "en:caramelized-unknown-fruit4"
    ],
-   "ingredients_n" : 14,
+   "ingredients_n" : 18,
    "ingredients_n_tags" : [
-      "14",
+      "18",
       "11-20"
    ],
    "ingredients_original_tags" : [
@@ -210,10 +261,14 @@
       "en:bilberry",
       "en:jackfruit",
       "en:kiwi",
-      "en:lemon-and-unknown-fruit",
-      "en:toasted-mango-and-unknown-fruit2",
-      "en:nectarine-and-fried-unknown-fruit3",
-      "en:puffed-orange-and-caramelized-unknown-fruit4"
+      "en:lemon",
+      "en:unknown-fruit",
+      "en:mango",
+      "en:unknown-fruit2",
+      "en:nectarine",
+      "en:fried-unknown-fruit3",
+      "en:orange",
+      "en:caramelized-unknown-fruit4"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
@@ -233,31 +288,36 @@
       "en:blueberry",
       "en:jackfruit",
       "en:kiwi",
-      "en:lemon-and-unknown-fruit",
-      "en:toasted-mango-and-unknown-fruit2",
-      "en:nectarine-and-fried-unknown-fruit3",
-      "en:puffed-orange-and-caramelized-unknown-fruit4"
+      "en:lemon",
+      "en:citrus-fruit",
+      "en:unknown-fruit",
+      "en:mango",
+      "en:unknown-fruit2",
+      "en:nectarine",
+      "en:fried-unknown-fruit3",
+      "en:orange",
+      "en:caramelized-unknown-fruit4"
    ],
    "ingredients_text" : "apple,\nnon-hydrogenated banana,\ncherry and date,\nhardened elderberry and fig,\ngrape and treated huckleberry,\ndesalted jackfruit and grilled kiwifruit,\nlemon and unknown_fruit,\ntoasted mango and unknown_fruit2,\nnectarine and fried unknown_fruit3,\npuffed orange and caramelized unknown_fruit4.",
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
-   "ingredients_with_unspecified_percent_n" : 14,
+   "ingredients_with_unspecified_percent_n" : 18,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
+      "en:caramelized-unknown-fruit4",
+      "en:fried-unknown-fruit3",
       "en:jackfruit",
-      "en:lemon-and-unknown-fruit",
-      "en:nectarine-and-fried-unknown-fruit3",
-      "en:puffed-orange-and-caramelized-unknown-fruit4",
-      "en:toasted-mango-and-unknown-fruit2"
+      "en:unknown-fruit",
+      "en:unknown-fruit2"
    ],
    "ingredients_without_ciqual_codes_n" : 5,
-   "known_ingredients_n" : 16,
+   "known_ingredients_n" : 21,
    "lc" : "en",
    "nutriments" : {
-      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 99.9093191964286,
-      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 99.9093191964286,
-      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 99.9093191964286,
-      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 99.9093191964286
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 99.9690161810981,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 99.9690161810981,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 99.9690161810981,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 99.9690161810981
    },
    "unknown_ingredients_n" : 4
 }

--- a/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
+++ b/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
@@ -134,16 +134,12 @@
          "text" : "unknown_fruit"
       },
       {
-         "ciqual_food_code" : "13025",
-         "id" : "en:mango",
-         "is_in_taxonomy" : 1,
+         "id" : "en:toasted-mango",
+         "is_in_taxonomy" : 0,
          "percent_estimate" : 0.0115288628472214,
          "percent_max" : 7.69230769230769,
          "percent_min" : 0,
-         "processing" : "en:toasted",
-         "text" : "mango",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
+         "text" : "toasted mango"
       },
       {
          "id" : "en:unknown-fruit2",
@@ -173,16 +169,12 @@
          "text" : "fried unknown_fruit3"
       },
       {
-         "ciqual_proxy_food_code" : "13034",
-         "id" : "en:orange",
-         "is_in_taxonomy" : 1,
+         "id" : "en:puffed-orange",
+         "is_in_taxonomy" : 0,
          "percent_estimate" : 0.000720553927948231,
          "percent_max" : 5.88235294117647,
          "percent_min" : 0,
-         "processing" : "en:puffed",
-         "text" : "orange",
-         "vegan" : "yes",
-         "vegetarian" : "yes"
+         "text" : "puffed orange"
       },
       {
          "id" : "en:caramelized-unknown-fruit4",
@@ -196,25 +188,31 @@
    "ingredients_analysis" : {
       "en:palm-oil-content-unknown" : [
          "en:unknown-fruit",
+         "en:toasted-mango",
          "en:unknown-fruit2",
          "en:fried-unknown-fruit3",
+         "en:puffed-orange",
          "en:caramelized-unknown-fruit4"
       ],
       "en:vegan-status-unknown" : [
          "en:unknown-fruit",
+         "en:toasted-mango",
          "en:unknown-fruit2",
          "en:fried-unknown-fruit3",
+         "en:puffed-orange",
          "en:caramelized-unknown-fruit4"
       ],
       "en:vegetarian-status-unknown" : [
          "en:unknown-fruit",
+         "en:toasted-mango",
          "en:unknown-fruit2",
          "en:fried-unknown-fruit3",
+         "en:puffed-orange",
          "en:caramelized-unknown-fruit4"
       ]
    },
    "ingredients_analysis_tags" : [
-      "en:palm-oil-free",
+      "en:palm-oil-content-unknown",
       "en:vegan-status-unknown",
       "en:vegetarian-status-unknown"
    ],
@@ -238,11 +236,11 @@
       "en:lemon",
       "en:citrus-fruit",
       "en:unknown-fruit",
-      "en:mango",
+      "en:toasted-mango",
       "en:unknown-fruit2",
       "en:nectarine",
       "en:fried-unknown-fruit3",
-      "en:orange",
+      "en:puffed-orange",
       "en:caramelized-unknown-fruit4"
    ],
    "ingredients_n" : 18,
@@ -263,11 +261,11 @@
       "en:kiwi",
       "en:lemon",
       "en:unknown-fruit",
-      "en:mango",
+      "en:toasted-mango",
       "en:unknown-fruit2",
       "en:nectarine",
       "en:fried-unknown-fruit3",
-      "en:orange",
+      "en:puffed-orange",
       "en:caramelized-unknown-fruit4"
    ],
    "ingredients_percent_analysis" : 1,
@@ -291,11 +289,11 @@
       "en:lemon",
       "en:citrus-fruit",
       "en:unknown-fruit",
-      "en:mango",
+      "en:toasted-mango",
       "en:unknown-fruit2",
       "en:nectarine",
       "en:fried-unknown-fruit3",
-      "en:orange",
+      "en:puffed-orange",
       "en:caramelized-unknown-fruit4"
    ],
    "ingredients_text" : "apple,\nnon-hydrogenated banana,\ncherry and date,\nhardened elderberry and fig,\ngrape and treated huckleberry,\ndesalted jackfruit and grilled kiwifruit,\nlemon and unknown_fruit,\ntoasted mango and unknown_fruit2,\nnectarine and fried unknown_fruit3,\npuffed orange and caramelized unknown_fruit4.",
@@ -307,17 +305,19 @@
       "en:caramelized-unknown-fruit4",
       "en:fried-unknown-fruit3",
       "en:jackfruit",
+      "en:puffed-orange",
+      "en:toasted-mango",
       "en:unknown-fruit",
       "en:unknown-fruit2"
    ],
-   "ingredients_without_ciqual_codes_n" : 5,
-   "known_ingredients_n" : 21,
+   "ingredients_without_ciqual_codes_n" : 7,
+   "known_ingredients_n" : 19,
    "lc" : "en",
    "nutriments" : {
-      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 99.9690161810981,
-      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 99.9690161810981,
-      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 99.9690161810981,
-      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 99.9690161810981
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 99.9567667643229,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 99.9567667643229,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 99.9567667643229,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 99.9567667643229
    },
-   "unknown_ingredients_n" : 4
+   "unknown_ingredients_n" : 6
 }

--- a/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
+++ b/tests/unit/expected_test_results/ingredients/en-ing1-and-ing2-processing.json
@@ -134,12 +134,16 @@
          "text" : "unknown_fruit"
       },
       {
-         "id" : "en:toasted-mango",
-         "is_in_taxonomy" : 0,
+         "ciqual_food_code" : "13025",
+         "id" : "en:mango",
+         "is_in_taxonomy" : 1,
          "percent_estimate" : 0.0115288628472214,
          "percent_max" : 7.69230769230769,
          "percent_min" : 0,
-         "text" : "toasted mango"
+         "processing" : "en:toasted",
+         "text" : "mango",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:unknown-fruit2",
@@ -169,12 +173,16 @@
          "text" : "fried unknown_fruit3"
       },
       {
-         "id" : "en:puffed-orange",
-         "is_in_taxonomy" : 0,
+         "ciqual_proxy_food_code" : "13034",
+         "id" : "en:orange",
+         "is_in_taxonomy" : 1,
          "percent_estimate" : 0.000720553927948231,
          "percent_max" : 5.88235294117647,
          "percent_min" : 0,
-         "text" : "puffed orange"
+         "processing" : "en:puffed",
+         "text" : "orange",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       },
       {
          "id" : "en:caramelized-unknown-fruit4",
@@ -188,31 +196,25 @@
    "ingredients_analysis" : {
       "en:palm-oil-content-unknown" : [
          "en:unknown-fruit",
-         "en:toasted-mango",
          "en:unknown-fruit2",
          "en:fried-unknown-fruit3",
-         "en:puffed-orange",
          "en:caramelized-unknown-fruit4"
       ],
       "en:vegan-status-unknown" : [
          "en:unknown-fruit",
-         "en:toasted-mango",
          "en:unknown-fruit2",
          "en:fried-unknown-fruit3",
-         "en:puffed-orange",
          "en:caramelized-unknown-fruit4"
       ],
       "en:vegetarian-status-unknown" : [
          "en:unknown-fruit",
-         "en:toasted-mango",
          "en:unknown-fruit2",
          "en:fried-unknown-fruit3",
-         "en:puffed-orange",
          "en:caramelized-unknown-fruit4"
       ]
    },
    "ingredients_analysis_tags" : [
-      "en:palm-oil-content-unknown",
+      "en:palm-oil-free",
       "en:vegan-status-unknown",
       "en:vegetarian-status-unknown"
    ],
@@ -236,11 +238,11 @@
       "en:lemon",
       "en:citrus-fruit",
       "en:unknown-fruit",
-      "en:toasted-mango",
+      "en:mango",
       "en:unknown-fruit2",
       "en:nectarine",
       "en:fried-unknown-fruit3",
-      "en:puffed-orange",
+      "en:orange",
       "en:caramelized-unknown-fruit4"
    ],
    "ingredients_n" : 18,
@@ -261,11 +263,11 @@
       "en:kiwi",
       "en:lemon",
       "en:unknown-fruit",
-      "en:toasted-mango",
+      "en:mango",
       "en:unknown-fruit2",
       "en:nectarine",
       "en:fried-unknown-fruit3",
-      "en:puffed-orange",
+      "en:orange",
       "en:caramelized-unknown-fruit4"
    ],
    "ingredients_percent_analysis" : 1,
@@ -289,11 +291,11 @@
       "en:lemon",
       "en:citrus-fruit",
       "en:unknown-fruit",
-      "en:toasted-mango",
+      "en:mango",
       "en:unknown-fruit2",
       "en:nectarine",
       "en:fried-unknown-fruit3",
-      "en:puffed-orange",
+      "en:orange",
       "en:caramelized-unknown-fruit4"
    ],
    "ingredients_text" : "apple,\nnon-hydrogenated banana,\ncherry and date,\nhardened elderberry and fig,\ngrape and treated huckleberry,\ndesalted jackfruit and grilled kiwifruit,\nlemon and unknown_fruit,\ntoasted mango and unknown_fruit2,\nnectarine and fried unknown_fruit3,\npuffed orange and caramelized unknown_fruit4.",
@@ -305,19 +307,17 @@
       "en:caramelized-unknown-fruit4",
       "en:fried-unknown-fruit3",
       "en:jackfruit",
-      "en:puffed-orange",
-      "en:toasted-mango",
       "en:unknown-fruit",
       "en:unknown-fruit2"
    ],
-   "ingredients_without_ciqual_codes_n" : 7,
-   "known_ingredients_n" : 19,
+   "ingredients_without_ciqual_codes_n" : 5,
+   "known_ingredients_n" : 21,
    "lc" : "en",
    "nutriments" : {
-      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 99.9567667643229,
-      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 99.9567667643229,
-      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 99.9567667643229,
-      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 99.9567667643229
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 99.9690161810981,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 99.9690161810981,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 99.9690161810981,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 99.9690161810981
    },
-   "unknown_ingredients_n" : 6
+   "unknown_ingredients_n" : 4
 }

--- a/tests/unit/expected_test_results/ingredients/en-some-unknown-ingredient-and-salt.json
+++ b/tests/unit/expected_test_results/ingredients/en-some-unknown-ingredient-and-salt.json
@@ -1,23 +1,34 @@
 {
    "ingredients" : [
       {
-         "id" : "en:some-unknown-ingredient-and-salt",
+         "id" : "en:some-unknown-ingredient",
          "is_in_taxonomy" : 0,
-         "percent_estimate" : 100,
+         "percent_estimate" : 75,
          "percent_max" : 100,
-         "percent_min" : 100,
-         "text" : "some unknown ingredient and salt"
+         "percent_min" : 50,
+         "text" : "some unknown ingredient"
+      },
+      {
+         "ciqual_food_code" : "11058",
+         "id" : "en:salt",
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 25,
+         "percent_max" : 50,
+         "percent_min" : 0,
+         "text" : "salt",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
       }
    ],
    "ingredients_analysis" : {
       "en:palm-oil-content-unknown" : [
-         "en:some-unknown-ingredient-and-salt"
+         "en:some-unknown-ingredient"
       ],
       "en:vegan-status-unknown" : [
-         "en:some-unknown-ingredient-and-salt"
+         "en:some-unknown-ingredient"
       ],
       "en:vegetarian-status-unknown" : [
-         "en:some-unknown-ingredient-and-salt"
+         "en:some-unknown-ingredient"
       ]
    },
    "ingredients_analysis_tags" : [
@@ -26,30 +37,33 @@
       "en:vegetarian-status-unknown"
    ],
    "ingredients_hierarchy" : [
-      "en:some-unknown-ingredient-and-salt"
+      "en:some-unknown-ingredient",
+      "en:salt"
    ],
-   "ingredients_n" : 1,
+   "ingredients_n" : 2,
    "ingredients_n_tags" : [
-      "1",
+      "2",
       "1-10"
    ],
    "ingredients_original_tags" : [
-      "en:some-unknown-ingredient-and-salt"
+      "en:some-unknown-ingredient",
+      "en:salt"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
-      "en:some-unknown-ingredient-and-salt"
+      "en:some-unknown-ingredient",
+      "en:salt"
    ],
    "ingredients_text" : "some unknown ingredient and salt",
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
-   "ingredients_with_unspecified_percent_n" : 1,
+   "ingredients_with_unspecified_percent_n" : 2,
    "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:some-unknown-ingredient-and-salt"
+      "en:some-unknown-ingredient"
    ],
    "ingredients_without_ciqual_codes_n" : 1,
-   "known_ingredients_n" : 0,
+   "known_ingredients_n" : 1,
    "lc" : "en",
    "nutriments" : {
       "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 0,

--- a/tests/unit/expected_test_results/ingredients/en-some-unknown-ingredient-and-salt.json
+++ b/tests/unit/expected_test_results/ingredients/en-some-unknown-ingredient-and-salt.json
@@ -1,0 +1,61 @@
+{
+   "ingredients" : [
+      {
+         "id" : "en:some-unknown-ingredient-and-salt",
+         "is_in_taxonomy" : 0,
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "some unknown ingredient and salt"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil-content-unknown" : [
+         "en:some-unknown-ingredient-and-salt"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:some-unknown-ingredient-and-salt"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:some-unknown-ingredient-and-salt"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_hierarchy" : [
+      "en:some-unknown-ingredient-and-salt"
+   ],
+   "ingredients_n" : 1,
+   "ingredients_n_tags" : [
+      "1",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:some-unknown-ingredient-and-salt"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:some-unknown-ingredient-and-salt"
+   ],
+   "ingredients_text" : "some unknown ingredient and salt",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 1,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:some-unknown-ingredient-and-salt"
+   ],
+   "ingredients_without_ciqual_codes_n" : 1,
+   "known_ingredients_n" : 0,
+   "lc" : "en",
+   "nutriments" : {
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g" : 0,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving" : 0
+   },
+   "unknown_ingredients_n" : 1
+}

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -851,6 +851,14 @@ puffed orange and caramelized unknown_fruit4.",
 			ingredients_text => "sugar, salt, and pepper",
 		}
 	],
+	# some unknown ingredient and a known one
+	[
+		"en-some-unknown-ingredient-and-salt",
+		{
+			lc => "en",
+			ingredients_text => "some unknown ingredient and salt",
+		}
+	],
 );
 
 foreach my $test_ref (@tests) {

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -843,6 +843,14 @@ puffed orange and caramelized unknown_fruit4.",
 				"Sucre, LAIT* entier en poudre 25%, graisse végétale (palme, palmiste), beurre de cacao1, pâte de cacao1, LAIT* écrémé en poudre 3%, huile de tournesol, émulsifiant: lécithines, arômes de vanille. Traces éventuelles de fruits à coque et de céréales contenant du gluten. Cacao: 30% minimum dans le chocolat au lait. *Lait: origine UE et/ou non UE (Royaume-Uni)",
 		}
 	],
+	# , and salt
+	[
+		"en-comma-and-pepper",
+		{
+			lc => "en",
+			ingredients_text => "sugar, salt, and pepper",
+		}
+	],
 );
 
 foreach my $test_ref (@tests) {

--- a/tests/unit/ingredients_tags.t
+++ b/tests/unit/ingredients_tags.t
@@ -319,6 +319,12 @@ my @tests = (
 		["en:sunflower-oil", "en:soya-oil", "en:palm-oil"]
 	],
 	[{lc => "fr", ingredients_text => "Banane coupée et cuite au naturel"}, ["en:banana"],],
+	[
+		{lc => "fr", ingredients_text => "Ingrédient inconnu coupée et cuite au naturel"},
+		["fr:ingredient-inconnu-coupee-et-cuite-au-naturel"],
+	],
+	[{lc => "fr", ingredients_text => "Ingrédient inconnu et sel"}, ["fr:ingredient-inconnu", "en:salt"],],
+	[{lc => "fr", ingredients_text => "Sel et ingrédient inconnu"}, ["en:salt", "fr:ingredient-inconnu"],],
 
 );
 

--- a/tests/unit/ingredients_tags.t
+++ b/tests/unit/ingredients_tags.t
@@ -325,6 +325,7 @@ my @tests = (
 	],
 	[{lc => "fr", ingredients_text => "Ingrédient inconnu et sel"}, ["fr:ingredient-inconnu", "en:salt"],],
 	[{lc => "fr", ingredients_text => "Sel et ingrédient inconnu"}, ["en:salt", "fr:ingredient-inconnu"],],
+	[{lc => "en", ingredients_text => "Toasted mango and unknown fruit"}, ["en:mango", "en:unknown-fruit"],],
 
 );
 


### PR DESCRIPTION
A few fixes that will help in particular recognizing more ingredients when we have "A and B": previously we cut it to A + B only if both A and B were in the taxonomy. Now we do it if at least one of them is in the taxonomy. This will help in particular for products that have "some weird ingredient and salt".