### PR TITLE
feat: use more the allergens:en property of the ingredients taxonomy

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -6330,6 +6330,9 @@ sub preparse_ingredients_text ($ingredients_lc, $text) {
 	# Traces de lait, d'oeufs et de soja.
 	# Contains: milk and soy.
 
+	# TODO: we should use the allergens:en: property from the ingredients.txt taxonomy instead of relying
+	# on having extensive "non synonyms" (like fish species) in allergens.txt
+
 	foreach my $allergens_type ("allergens", "traces") {
 
 		if (defined $contains_or_may_contain_regexps{$allergens_type}{$ingredients_lc}) {

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -7212,7 +7212,7 @@ but that are in the ingredients taxonomy and have an inherited allergens:en prop
 (e.g. the allergens taxonomy has an en:fish entry, but users may indicate specific fish species)
 
 This function tries to match the ingredient with an allergen in the allergens taxonomy,
-and otherwise return the taxonomyid for the original ingredient.
+and otherwise return the taxonomy id for the original ingredient.
 
 =head3 Parameters
 
@@ -7223,6 +7223,10 @@ The language code of $ingredient_or_allergen.
 =head4 $ingredient_or_allergen
 
 The ingredient or allergen to match. Can also be an ingredient id or allergens id prefixed with a language code.
+
+=head3 Return value
+
+The taxonomy id for the allergen, or the original ingredient if no allergen was found.
 
 =cut
 

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -73,6 +73,7 @@ BEGIN {
 		&select_ingredients_lc
 
 		&detect_allergens_from_text
+		&get_allergens_taxonomyid
 
 		&normalize_a_of_b
 		&normalize_enumeration
@@ -7201,6 +7202,58 @@ sub detect_allergens_from_ingredients ($product_ref) {
 	return;
 }
 
+=head2 get_allergens_taxonomyid ( $ingredients_lc, $ingredient_or_allergen )
+
+In the allergens provided by users, we may get ingredients that are not in the allergens taxonomy,
+but that are in the ingredients taxonomy and have an inherited allergens:en property.
+(e.g. the allergens taxonomy has an en:fish entry, but users may indicate specific fish species)
+
+This function tries to match the ingredient with an allergen in the allergens taxonomy,
+and otherwise return the taxonomyid for the original ingredient.
+
+=head3 Parameters
+
+=head4 $ingredients_lc
+
+The language code of $ingredient_or_allergen.
+
+=head4 $ingredient_or_allergen
+
+The ingredient or allergen to match. Can also be an ingredient id or allergens id prefixed with a language code.
+
+=cut
+
+sub get_allergens_taxonomyid($ingredients_lc, $ingredient_or_allergen) {
+
+	# Check if $ingredient_or_allergen is in the allergen taxonomy
+	my $allergenid = canonicalize_taxonomy_tag($ingredients_lc, "allergens", $ingredient_or_allergen);
+	if (exists_taxonomy_tag("allergens", $allergenid)) {
+		return $allergenid;
+	}
+	else {
+		# Check if $ingredient_or_allergen is in the ingredients taxonomy and has an inherited allergens:en: property
+		my $ingredient_id = canonicalize_taxonomy_tag($ingredients_lc, "ingredients", $ingredient_or_allergen);
+		my $allergens = get_inherited_property("ingredients", $ingredient_id, "allergens:en");
+		if (defined $allergens) {
+			if ($allergens =~ /,/) {
+				# Currently we support only 1 allergen for a single ingredient
+				$log->warn(
+					"get_allergens_taxonomyid - multiple allergens for ingredient",
+					{ingredient_or_allergen => $ingredient_or_allergen, allergens => $allergens}
+				);
+				$allergens = $`;
+			}
+			$allergenid = canonicalize_taxonomy_tag($ingredients_lc, "allergens", $allergens);
+			if (exists_taxonomy_tag("allergens", $allergenid)) {
+				return $allergenid;
+			}
+		}
+	}
+
+	# If we did not recognize the allergen, return the taxonomy id for the original tag
+	return get_taxonomyid($ingredients_lc, $ingredient_or_allergen);
+}
+
 =head2 detect_allergens_from_text ( $product_ref )
 
 This function:
@@ -7371,7 +7424,7 @@ sub detect_allergens_from_text ($product_ref) {
 		$product_ref->{$field . "_tags"} = [];
 		# print STDERR "result for $field : ";
 		foreach my $tag (@{$product_ref->{$field . "_hierarchy"}}) {
-			push @{$product_ref->{$field . "_tags"}}, get_taxonomyid($ingredients_lc, $tag);
+			push @{$product_ref->{$field . "_tags"}}, get_allergens_taxonomyid($ingredients_lc, $tag);
 			# print STDERR " - $tag";
 		}
 		# print STDERR "\n";

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -1,5 +1,50 @@
-# properties vegan:en, vegetarian:en and from_palm_oil:en can have values yes, no, maybe
-# in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
+### Properties for ingredients
+
+## Description
+
+# description:en:SOYBEAN OIL is a vegetable oil extracted from the seeds of the soybean (Glycine max).
+
+## Allergens
+
+# allergens:en: en:soybeans
+# The value must be the main value from the allergens.txt taxonomy
+
+## NOVA groups markers
+
+# nova:en           NOVA group marker (e.g. value "4" means that the ingredient is a marker for NOVA 4)
+
+## Ingredients analysis properties
+
+# vegan:en          can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
+# vegetarian:en     can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
+# from_palm_oil:en  can have values yes, no, maybe - in the case of maybe, if the ingredient has sub-ingredients, then only its sub-ingredients are considered
+
+## Eurocode properties
+
+# e.g. for palm heart
+# under "version 99/1"
+# it corresponds to "Main group 8: Vegetables and vegetable products"
+# eurocode_2_group_1:en: 8
+# eurocode_2_group_1:en: 8
+# eurocode_2_group_2:en: 8.25
+# eurocode_2_group_3:en: 8.25.50
+# are from https://web.archive.org/web/20170621070633/http://www.ianunwin.demon.co.uk/eurocode/docmn/classpad.htm
+
+# Links to other databases
+
+# wikidata:en:Q421576
+# wikipedia:en:https://en.wikipedia.org/wiki/Enilconazole
+
+# proxy indicates that the match is not perfect, but corresponding values could be used 
+
+# ciqual_food_code:en:42200
+# ciqual_food_name:en:Soy lecithin
+# ciqual_food_name:fr:Lécithine de soja
+
+# ciqual_proxy_food_code:en:16400
+# ciqual_proxy_food_name:en:Butter, 82% fat, unsalted
+# ciqual_proxy_food_name:fr:Beurre à 82% MG, doux
+
 
 #comment:en:These are synonyms of ingredients
 
@@ -116,15 +161,7 @@ stopwords:sl:vsebuje, sestavine
 stopwords:sv:av, från, med, innehåller, inklusive, bl a, bland annat, minimum, maximum, varav, certifierad, tillsatt, valio
 stopwords:zh::配料
 
-# Eurocode properties
-# e.g. for palm heart
-# under "version 99/1"
-# it corresponds to "Main group 8: Vegetables and vegetable products"
-# eurocode_2_group_1:en: 8
-# eurocode_2_group_1:en: 8
-# eurocode_2_group_2:en: 8.25
-# eurocode_2_group_3:en: 8.25.50
-# are from https://web.archive.org/web/20170621070633/http://www.ianunwin.demon.co.uk/eurocode/docmn/classpad.htm
+
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -81705,8 +81742,8 @@ fr:Crevettes entières crues
 # ingredient/fr:Crevettes-entières-crues has 5 products @2019-01-13
 
 <en:shrimp
-en:Pink shrimps
-fr:crevettes roses
+en:pink shrimps, pink schrimp
+fr:crevette rose, crevettes roses
 # ingredient/fr:crevettes-roses has 13 products @2019-01-06
 ciqual_food_code:en:10059
 ciqual_food_name:en:deep water pink shrimp, raw
@@ -81842,7 +81879,7 @@ de:Nordseegarnele, Crangon crangon
 eu:Izkira zuri, Crangon crangon
 fa:میگوی قهوه‌ای, Crangon crangon
 fi:Hietakatkarapu, Crangon crangon
-fr:crevettes grises, Crevette grise européenne, Crangon crangon
+fr:crevette grise, crevettes grises, Crevette grise européenne, Crangon crangon
 ga:Ribe róibéis, Crangon crangon
 hr:sivi škampi
 io:Kreveto, Crangon crangon

--- a/tests/unit/allergens.t
+++ b/tests/unit/allergens.t
@@ -6,11 +6,12 @@ use utf8;
 use Test2::V0;
 use Data::Dumper;
 $Data::Dumper::Terse = 1;
+$Data::Dumper::Sortkeys = 1;
 use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Products qw/compute_languages/;
 use ProductOpener::Tags qw/:all/;
-use ProductOpener::Ingredients qw/detect_allergens_from_text/;
+use ProductOpener::Ingredients qw/detect_allergens_from_text get_allergens_taxonomyid/;
 
 # dummy product for testing
 
@@ -534,5 +535,18 @@ detect_allergens_from_text($product_ref);
 diag Dumper $product_ref->{allergens_tags};
 
 is($product_ref->{allergens_tags}, ['en:gluten', 'en:soybeans',]) || diag Dumper $product_ref->{allergens_tags};
+
+# Get an allergens id from the allergens taxonomy
+is(get_allergens_taxonomyid("en", "egg"), "en:eggs");
+is(get_allergens_taxonomyid("fr", "fromage"), "en:milk");
+is(get_allergens_taxonomyid("en", "tuna"), "en:fish");
+# Get an allergens id from the ingredients taxonomy, using the allergens:en: property
+is(get_allergens_taxonomyid("en", "monkfish"), "en:fish");
+is(get_allergens_taxonomyid("en", "en:monkfish"), "en:fish");
+is(get_allergens_taxonomyid("es", "en:monkfish"), "en:fish");
+# Ingredients that are not in the allergens taxonomy
+is(get_allergens_taxonomyid("en", "pineapple"), "pineapple");
+# Ingredients that are not the ingredients taxonomy
+is(get_allergens_taxonomyid("en", "some very strange ingredient"), "some-very-strange-ingredient");
 
 done_testing();

--- a/tests/unit/allergens_tags.t
+++ b/tests/unit/allergens_tags.t
@@ -228,7 +228,7 @@ my @tests = (
 			allergens => "gluten, monkfish",
 			traces => "white lupin, strange ingredient, grey shrimp",
 		},
-		['en:eggs', 'en:gluten', 'en;milk', 'en:fish'],
+		['en:eggs', 'en:gluten', 'en:milk', 'en:fish'],
 		['en:crustaceans', 'en:strange-ingredient', "en:lupin"],
 	],
 

--- a/tests/unit/allergens_tags.t
+++ b/tests/unit/allergens_tags.t
@@ -6,6 +6,7 @@ use utf8;
 use Test2::V0;
 use Data::Dumper;
 $Data::Dumper::Terse = 1;
+$Data::Dumper::Sortkeys = 1;
 use Log::Any::Adapter 'TAP';
 #use Log::Any::Adapter 'TAP', filter => "none";
 
@@ -218,6 +219,17 @@ my @tests = (
 		},
 		["en:gluten",],    # allergens
 		[],    # traces
+	],
+	# allergens that are in the ingredients taxonomy with the allergens:en: property
+	[
+		{
+			lc => "en",
+			ingredients_text => "avocado, mango, cheese, eggs",
+			allergens => "gluten, monkfish",
+			traces => "white lupin, strange ingredient, grey shrimp",
+		},
+		['en:eggs', 'en:gluten', 'en;milk', 'en:fish'],
+		['en:crustaceans', 'en:strange-ingredient', "en:lupin"],
 	],
 
 );


### PR DESCRIPTION
We currently have many synonyms of allergens listed in the allergens.txt taxonomy, but very often those are not actual synonyms, but more specific ingredients. (e.g. for the en:fish allergen, we list different species of fish).

This does not scale very well. Instead we now have the allergens:en: property in the ingredients taxonomy. It is currently used to identify allergens listed as ingredients.

This PR extends the use of the allergens:en: property so it can be used to normalize the allergens and traces that are listed manually in the "allergens" and "traces" field.

There are still other uses of the synonyms in allergens.txt (e.g. for parsing phrases like "may contain...". We should try to use the allergens:en: property instead, so that we can ultimately remove the "non synonyms" from allergens.txt