### PR TITLE
fix: change mpm_prefork configuration for off and off-pro to reduce memory usage

### DIFF
--- a/conf/apache-2.4/off-mpm_prefork.conf
+++ b/conf/apache-2.4/off-mpm_prefork.conf
@@ -11,7 +11,7 @@
 	MaxSpareServers		 10
 	MaxRequestWorkers	  50
 	ServerLimit		55
-	MaxConnectionsPerChild   500
+	MaxConnectionsPerChild   100
 </IfModule>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf/apache-2.4/off-pro-mpm_prefork.conf
+++ b/conf/apache-2.4/off-pro-mpm_prefork.conf
@@ -6,11 +6,11 @@
 # MaxConnectionsPerChild: maximum number of requests a server process serves
 
 <IfModule mpm_prefork_module>
-	StartServers			 5
-	MinSpareServers		  5
-	MaxSpareServers		 10
-	MaxRequestWorkers	  150
-	MaxConnectionsPerChild   0
+	StartServers			 2
+	MinSpareServers		  2
+	MaxSpareServers		 2
+	MaxRequestWorkers	  10
+	MaxConnectionsPerChild   100
 </IfModule>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf/off-log.conf
+++ b/conf/off-log.conf
@@ -23,4 +23,4 @@ log4perl.appender.RATELIMITER_LOGFILE.filename=/srv/off/logs/ratelimiter_log4per
 log4perl.appender.RATELIMITER_LOGFILE.mode=append
 
 log4perl.appender.RATELIMITER_LOGFILE.layout=PatternLayout
-log4perl.appender.RATELIMITER_LOGFILE.layout.ConversionPattern=[%r] %F %L %c %S %m{chomp}%n
+log4perl.appender.RATELIMITER_LOGFILE.layout.ConversionPattern=[%d] %F %L %c %S %m{chomp}%n


### PR DESCRIPTION
This reduces MaxConnectionsPerChild from 500 to 100 on OFF (and activates it on off-pro) in order to reduce the size of the apache mod_perl processes that grow over time.

The processes start at 1.5Gb, but on off-pro they grew up to 2.5Gb.

I also reduced the number of processes on off-pro, as traffic should be very small.

@raphael0202 I accidentally checked in a change to off-log.conf that was on the off container on off2, I assume it's a wanted change?