### PR TITLE
taxonomy: add support for "chargrilled corn" and "red capsicum"

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -56269,7 +56269,7 @@ it:insalata mista
 # do not make pepper a synonym of bell pepper
 
 <en:fruit vegetable
-en:bell pepper, sweet pepper
+en:bell pepper, sweet pepper, capsicum
 af:soetrissie
 an:pimiento
 ar:فلفل حلو
@@ -56356,7 +56356,7 @@ wikipedia:en:https://en.wikipedia.org/wiki/Bell_pepper
 # "yellow pepper" can probably be safely assumed to be a synonym for "yellow bell pepper"
 
 <en:bell pepper
-en:yellow bell pepper, yellow pepper
+en:yellow bell pepper, yellow pepper, yellow capsicum
 bg:жълта чушка, жълти чушки
 ca:pebrot groc
 cs:žlutá paprika
@@ -56406,7 +56406,7 @@ en:italian bell pepper
 es:pimiento italiano
 
 <en:bell pepper
-en:red bell pepper, red pepper
+en:red bell pepper, red pepper, red capsicum
 ar:فلفل أحمر
 bg:червена чушка, червени чушки, червена капия
 ca:pebrot vermell, pebrot roig, pebrot vermell dolç, pebrots vermells dolços
@@ -56439,7 +56439,7 @@ ciqual_food_name:fr:Poivron rouge, cru
 # 17432 in 13 languages @2021-10-12
 
 <en:red bell pepper
-en:red grilled pepper
+en:red grilled pepper, red grilled capsicum
 hr:crvena pečena paprika
 
 <en:sweet pepper

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1844,6 +1844,8 @@ sv:torrostad, torrostade
 
 #comment:en:In the actual translations on products, there is not always a difference between toasted and roasted
 
+en:chargrilled, char grilled
+
 # en:description:To lightly cook by browning via direct exposure to a fire or other heat source.
 en:toasted
 ca:torrat, torrats, torrada, torrades


### PR DESCRIPTION
### What

https://www.woolworths.com.au/shop/productdetails/220157/edgell-snack-time-black-beans-charred-capsicum-with-zesty-salsa

We don't call capsicums "bell peppers" :)

Source 1:
>In Australia, New Zealand and [Indian English](https://en.wikipedia.org/wiki/Indian_English), heatless varieties are called "capsicums", while hot ones are called "chilli"/"chillies" (double L). The term "bell peppers" is never used
>
> https://en.wikipedia.org/wiki/Capsicum#Synonyms_and_common_names

Source 2:
> Woolworths, capsicums are on sale
> https://www.woolworths.com.au/shop/productdetails/135306/red-capsicum

> Coles, capsicums are on sale
> https://www.coles.com.au/product/coles-red-capsicum-approx.-220g-4580208

Source 3:
[Australian Centre for International Agricultural Research (ACIAR) ](https://www.aciar.gov.au/publication/books-and-manuals/tomato-capsicum-chilli-and-eggplant-field-guide-english): "Tomato, capsicum, chilli and eggplant: a field guide for the identification of insect pests, beneficial, diseases and disorders in Australia and Cambodia (English)"


