### PR TITLE
fix: show GLNs used by orgs in GS1 imports

### DIFF
--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -1494,13 +1494,14 @@ sub import_csv_file ($args_ref) {
 		my @images_ids;
 
 		# Determine the org_id for the product
+		my $gln = $imported_product_ref->{"sources_fields:org-gs1:gln"};
 
 		$log->debug(
 			"org for product - start",
 			{
 				org_name => $imported_product_ref->{org_name},
 				org_id => $org_id,
-				gln => $imported_product_ref->{"sources_fields:org-gs1:gln"}
+				gln => $gln
 			}
 		) if $log->is_debug();
 
@@ -1522,12 +1523,11 @@ sub import_csv_file ($args_ref) {
 				if $log->is_debug();
 		}
 		# if the GLN corresponds to a GLN stored inside organization profiles (loaded in $glns_ref), use it
-		elsif ( (defined $imported_product_ref->{"sources_fields:org-gs1:gln"})
-			and ($glns_ref->{$imported_product_ref->{"sources_fields:org-gs1:gln"}}))
+		elsif ( (defined $gln)
+			and ($glns_ref->{$gln}))
 		{
-			$org_id = $glns_ref->{$imported_product_ref->{"sources_fields:org-gs1:gln"}};
-			$log->debug("org_id from gln",
-				{org_id => $org_id, gln => $imported_product_ref->{"sources_fields:org-gs1:gln"}})
+			$org_id = $glns_ref->{$gln};
+			$log->debug("org_id from gln", {org_id => $org_id, gln => $gln})
 				if $log->is_debug();
 		}
 		# Otherwise, if the CSV includes an org_name (e.g. from GS1 partyName field)
@@ -1544,11 +1544,11 @@ sub import_csv_file ($args_ref) {
 				$log->debug(
 					"skipping product with no org_id specified",
 					{
-						gln => $imported_product_ref->{"sources_fields:org-gs1:gln"},
+						gln => $gln,
 						imported_product_ref => $imported_product_ref
 					}
 				) if $log->is_debug();
-				$stats_ref->{orgs_with_gln_but_no_party_name}{$imported_product_ref->{"sources_fields:org-gs1:gln"}}++;
+				$stats_ref->{orgs_with_gln_but_no_party_name}{$gln}++;
 				next;
 			}
 		}
@@ -1558,11 +1558,11 @@ sub import_csv_file ($args_ref) {
 			{
 				org_name => $imported_product_ref->{org_name},
 				org_id => $org_id,
-				gln => $imported_product_ref->{"sources_fields:org-gs1:gln"}
+				gln => $gln
 			}
 		) if $log->is_debug();
 
-		my $gln = $imported_product_ref->{"sources_fields:org-gs1:gln"};
+		# Keep track of GLNs used by each org
 		if ((defined $gln) and (defined $org_id)) {
 			if (not defined $stats_ref->{orgs_glns}{$org_id}) {
 				$stats_ref->{orgs_glns}{$org_id} = $gln;
@@ -1696,17 +1696,17 @@ sub import_csv_file ($args_ref) {
 					$org_ref->{"activate_automated_daily_export_to_public_platform"} = "on";
 				}
 
-				if (defined $imported_product_ref->{"sources_fields:org-gs1:gln"}) {
+				if (defined $gln) {
 					$org_ref->{sources_field} = {
 						"org-gs1" => {
-							gln => $imported_product_ref->{"sources_fields:org-gs1:gln"}
+							gln => $gln
 						}
 					};
 					if (defined $imported_product_ref->{"sources_fields:org-gs1:partyName"}) {
 						$org_ref->{sources_field}{"org-gs1"}{"partyName"}
 							= $imported_product_ref->{"sources_fields:org-gs1:partyName"};
 					}
-					set_org_gs1_gln($org_ref, $imported_product_ref->{"sources_fields:org-gs1:gln"});
+					set_org_gs1_gln($org_ref, $gln);
 					$glns_ref = retrieve("$BASE_DIRS{ORGS}/orgs_glns.sto");
 				}
 

--- a/lib/ProductOpener/Import.pm
+++ b/lib/ProductOpener/Import.pm
@@ -1412,6 +1412,8 @@ sub import_csv_file ($args_ref) {
 		'orgs_existing' => {},
 		'orgs_in_file' => {},
 		'orgs_with_gln_but_no_party_name' => {},
+		# Keep track of GLNs used by each org
+		'orgs_glns' => {},
 	};
 
 	my $csv = Text::CSV->new(
@@ -1559,6 +1561,16 @@ sub import_csv_file ($args_ref) {
 				gln => $imported_product_ref->{"sources_fields:org-gs1:gln"}
 			}
 		) if $log->is_debug();
+
+		my $gln = $imported_product_ref->{"sources_fields:org-gs1:gln"};
+		if ((defined $gln) and (defined $org_id)) {
+			if (not defined $stats_ref->{orgs_glns}{$org_id}) {
+				$stats_ref->{orgs_glns}{$org_id} = $gln;
+			}
+			elsif ($stats_ref->{orgs_glns}{$org_id} !~ /\b$gln\b/) {
+				$stats_ref->{orgs_glns}{$org_id} .= " " . $gln;
+			}
+		}
 
 		if ((defined $org_id) and ($org_id ne "")) {
 			# Re-assign some organizations

--- a/templates/emails/import_csv_file_admin_notification.tt.html
+++ b/templates/emails/import_csv_file_admin_notification.tt.html
@@ -31,7 +31,7 @@ Subject: Result of import_csv_file.pl: org: [% args.org_id %] - source: [% args.
         <li>
             <a href="https://world.[% server_domain %]/cgi/user.pl?action=process&type=edit_owner&pro_moderator_owner=org-[% org %]">
                 [% org %]
-            </a>:
+            </a> (GLN: [% stats.orgs_glns.$org %]) :
             [% stats.$orgs_stat.$org %]
         </li>
     [% END %]

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/carrefour-images/products/stats.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/carrefour-images/products/stats.json
@@ -5,6 +5,7 @@
    "orgs_existing" : {
       "test-org" : 1
    },
+   "orgs_glns" : {},
    "orgs_in_file" : {
       "test-org" : 2
    },

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/openfoodfacts_import_template_fr_test/products/stats.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/openfoodfacts_import_template_fr_test/products/stats.json
@@ -5,6 +5,7 @@
    "orgs_existing" : {
       "test-org" : 1
    },
+   "orgs_glns" : {},
    "orgs_in_file" : {
       "test-org" : 2
    },

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/packagings-mousquetaires/products/stats.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/packagings-mousquetaires/products/stats.json
@@ -5,6 +5,7 @@
    "orgs_existing" : {
       "test-org" : 17
    },
+   "orgs_glns" : {},
    "orgs_in_file" : {
       "test-org" : 18
    },

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/stats.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/stats.json
@@ -7,6 +7,7 @@
    "orgs_existing" : {
       "world-test-food" : 1
    },
+   "orgs_glns" : {},
    "orgs_in_file" : {
       "carrefour" : 1,
       "test-food-company" : 1,

--- a/tests/integration/expected_test_results/import_csv_file/replace_existing_values/stats.json
+++ b/tests/integration/expected_test_results/import_csv_file/replace_existing_values/stats.json
@@ -3,6 +3,7 @@
    "orgs_existing" : {
       "test-org" : 7
    },
+   "orgs_glns" : {},
    "orgs_in_file" : {
       "test-org" : 7
    },

--- a/tests/integration/expected_test_results/import_csv_file/test/stats.json
+++ b/tests/integration/expected_test_results/import_csv_file/test/stats.json
@@ -5,6 +5,7 @@
    "orgs_existing" : {
       "test-org" : 6
    },
+   "orgs_glns" : {},
    "orgs_in_file" : {
       "test-org" : 7
    },


### PR DESCRIPTION
This is to display the GS1 GLNs used by organizations in the reports (email to pro platform admins) of the import_csv_file.pl script.

Needed so that we can easily override which GLNs goes to which organization.