### PR TITLE
fix: Use a separate make target for production up to not create dependencies

### DIFF
--- a/.env
+++ b/.env
@@ -74,3 +74,5 @@ BUILD_CACHE_REPO=openfoodfacts/openfoodfacts-build-cache
 # If you want the rate limiter to block requests (return 429) instead of doing nothing,
 # set this to 1. Any other value will disable the blocking.
 RATE_LIMITER_BLOCKING_ENABLED=1
+
+COMMON_NET_NAME=off_shared_network

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -239,7 +239,7 @@ jobs:
           cd ${{ matrix.env }} && \
           make hdown && \
           make build_lang && \
-          make up
+          make prod_up
 
     - name: Check services are up
       uses: appleboy/ssh-action@master

--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,7 @@ clean: goodbye hdown prune prune_cache clean_folders
 # Run dependent projects
 run_deps: clone_deps
 	@for dep in ${DEPS} ; do \
-		cd ${DEPS_DIR}/$$dep && $(MAKE) -e run; \
+		cd ${DEPS_DIR}/$$dep && $(MAKE) run; \
 	done
 
 # Clone dependent projects without running them (used to pull in yml for tests)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ TEST_CMD ?= yath test -PProductOpener::LoadData
 
 # Space delimited list of dependant projects
 DEPS=openfoodfacts-shared-services
-ifndef DEPS_DIR
+# Set the DEPS_DIR if it hasn't been set already
+ifeq (${DEPS_DIR},)
 	export DEPS_DIR=${PWD}/deps
 endif
 
@@ -74,6 +75,7 @@ _FORCE:
 # Info #
 #------#
 info:
+	@echo ${DEPS_DIR}
 	@echo "${NAME} version: ${VERSION}"
 
 usage:
@@ -133,6 +135,11 @@ _up:run_deps
 	@echo "🥫 started service at http://openfoodfacts.localhost"
 
 up: build create_folders _up
+
+# Used by staging so that shared services are not created
+prod_up: build create_folders
+	@echo "🥫 Starting containers …"
+	${DOCKER_COMPOSE} up -d 2>&1
 
 down:
 	@echo "🥫 Bringing down containers …"

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ _FORCE:
 # Info #
 #------#
 info:
-	@echo ${DEPS_DIR}
 	@echo "${NAME} version: ${VERSION}"
 
 usage:

--- a/docker/docker-livecheck.sh
+++ b/docker/docker-livecheck.sh
@@ -2,7 +2,7 @@
 
 ENV_FILE="${ENV_FILE:-.env}"
 RET_CODE=0
-for service in `docker compose --env-file=${ENV_FILE} config  --service | tr '\n' ' '`; do 
+for service in `docker compose --env-file=${ENV_FILE} config  --services | tr '\n' ' '`; do 
 if [ -z `docker compose ps -q $service` ] || [ -z `docker ps -q --no-trunc | grep $(docker compose --env-file=${ENV_FILE} ps -q $service)` ]; then
     echo "$service: DOWN"
     RET_CODE=1

--- a/docker/run.yml
+++ b/docker/run.yml
@@ -13,5 +13,5 @@ services:
 networks:
   # This network allows access to shared services like MongoDB and Redis
   shared_network:
-    name: shared_network
+    name: ${COMMON_NET_NAME}
     external: true


### PR DESCRIPTION
### What

Use a different target for docker compose up in production so that dependencies aren't also started in dev mode.
