### PR TITLE
feat: prevent user from deletion if main contact or last admin of an org

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6929,8 +6929,8 @@ msgid "You cannot remove the main contact. Change it first."
 msgstr "You cannot remove the main contact. Change it first."
 
 msgctxt "cant_delete_user_main_contact"
-msgid "This is user can't be deleted, he is the main of his organization"
-msgstr "This is user can't be deleted, he is the main of his organization"
+msgid "This is user can't be deleted, he is the main contact of his organization"
+msgstr "This is user can't be deleted, he is the main contact of his organization"
 
 msgctxt "cant_delete_user_last_admin"
 msgid "This is user can't be deleted, he is the unique admin of his organization"

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -6928,6 +6928,14 @@ msgctxt "cant_delete_main_contact"
 msgid "You cannot remove the main contact. Change it first."
 msgstr "You cannot remove the main contact. Change it first."
 
+msgctxt "cant_delete_user_main_contact"
+msgid "This is user can't be deleted, he is the main of his organization"
+msgstr "This is user can't be deleted, he is the main of his organization"
+
+msgctxt "cant_delete_user_last_admin"
+msgid "This is user can't be deleted, he is the unique admin of his organization"
+msgstr "This is user can't be deleted, he is the unique admin of his organization"
+
 msgctxt "open_in_crm"
 msgid "Open in CRM"
 msgstr "Open in CRM"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6962,6 +6962,14 @@ msgctxt "cant_delete_main_contact"
 msgid "You cannot remove the main contact. Change it first."
 msgstr "You cannot remove the main contact. Change it first."
 
+msgctxt "cant_delete_user_main_contact"
+msgid "This is user can't be deleted, he is the main of his organization"
+msgstr "This is user can't be deleted, he is the main of his organization"
+
+msgctxt "cant_delete_user_last_admin"
+msgid "This is user can't be deleted, he is the unique admin of his organization"
+msgstr "This is user can't be deleted, he is the unique admin of his organization"
+
 msgctxt "open_in_crm"
 msgid "Open in CRM"
 msgstr "Open in CRM"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -6963,8 +6963,8 @@ msgid "You cannot remove the main contact. Change it first."
 msgstr "You cannot remove the main contact. Change it first."
 
 msgctxt "cant_delete_user_main_contact"
-msgid "This is user can't be deleted, he is the main of his organization"
-msgstr "This is user can't be deleted, he is the main of his organization"
+msgid "This is user can't be deleted, he is the main contact of his organization"
+msgstr "This is user can't be deleted, he is the main contact of his organization"
 
 msgctxt "cant_delete_user_last_admin"
 msgid "This is user can't be deleted, he is the unique admin of his organization"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -6935,3 +6935,35 @@ msgstr "Statut vérifié"
 msgctxt "creation_date"
 msgid "Date de création"
 msgstr "Date de création"
+
+msgctxt "enter_main_contact_username"
+msgid "Nom du contact principal :"
+msgstr "Nom du contact principal :"
+
+msgctxt "change_main_contact"
+msgid "Changer le contact principal"
+msgstr "Changer le contact princpal"
+
+msgctxt "main_contact_updated"
+msgid "Le contact principal a été mis à jour"
+msgstr "Le contact principal a été mis à jour"
+
+msgctxt "error_unknown_member"
+msgid "Cet utilisateur n'est pas membre de l'organisation."
+msgstr "Cet utilisateur n'est pas membre de l'organisation."
+
+msgctxt "cant_delete_main_contact"
+msgid "Vous ne pouvez pas supprimer le contact principal. Changez-le d'abord."
+msgstr "Vous ne pouvez pas supprimer le contact principal. Changez-le d'abord."
+
+msgctxt "cant_delete_user_main_contact"
+msgid "Cet utilisateur ne peut pas être supprimé, il est le contact principal dans son organisation."
+msgstr "Cet utilisateur ne peut pas être supprimé, il est le contact principal dans son organisation."
+
+msgctxt "cant_delete_user_last_admin"
+msgid "Cet utilisateur ne peut pas être supprimé, il est l'unique administrateur de son organisation."
+msgstr "Cet utilisateur ne peut pas être supprimé, il est l'unique administrateur de son organisation."
+
+msgctxt "open_in_crm"
+msgid "Voir dans le CRM"
+msgstr "Voir dans le CRM"


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Prevents deletion of the user's account if he is the main contact or only administrator of an organization.

### Screenshot
<img witdh="50%" src="https://github.com/openfoodfacts/openfoodfacts-server/assets/56827368/0fe1d5c9-6e4a-46f5-8615-4c6b15ba24e9">
