### PR TITLE
Display existing Folksonomy Engine properties to all visitors

### DIFF
--- a/templates/web/common/includes/folksonomy_script.tt.html
+++ b/templates/web/common/includes/folksonomy_script.tt.html
@@ -1,5 +1,4 @@
 <!-- start templates/[% component.name %] -->
-[% IF moderator %]
 <!-- Folksonomy Engine script -->
 <scripts>
     <script src="[% static_subdomain %]/js/folksonomy.js"></script>
@@ -7,5 +6,4 @@
 <initjs>
     folskonomy_engine_init();
 </initjs>
-[% END %]
 <!-- end templates/[% component.name %] -->


### PR DESCRIPTION
Related to #10360

Display existing Folksonomy Engine properties to all visitors.

* Remove the condition that checks if the user is a moderator in `templates/web/common/includes/folksonomy_script.tt.html`.
* Include the Folksonomy Engine script for all visitors in `templates/web/common/includes/folksonomy_script.tt.html`.
* Initialize the Folksonomy Engine for all visitors in `templates/web/common/includes/folksonomy_script.tt.html`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openfoodfacts/openfoodfacts-server/issues/10360?shareId=8a2a7694-55c0-4079-9ea4-2672bc90d3f8).