### PR TITLE
feat: allow orgs to not have a main contact if imported from an aggregator

### DIFF
--- a/lib/ProductOpener/CRM.pm
+++ b/lib/ProductOpener/CRM.pm
@@ -439,7 +439,7 @@ sub add_contact_to_company($contact_id, $company_id) {
 	return $result;
 }
 
-=head2 create_onboarding_opportunity ($name, $company_id, $contact_id)
+=head2 create_onboarding_opportunity ($name, $company_id, $partner_id, salesperson_email = undef)
 
 create an opportunity attached to a 
 
@@ -454,9 +454,9 @@ The name of the opportunity
 The id of the partner to attach the opportunity to.
 It can be a contact or a company
 
-=head4 $salesperson_id
+=head4 $salesperson_email
 
-The id of the salesperson to assign the opportunity to
+The email of the salesperson to attach to the opportunity
 
 =head3 Return values
 
@@ -464,10 +464,10 @@ the id of the created opportunity
 
 =cut
 
-sub create_onboarding_opportunity ($name, $company_id, $contact_id, $salesperson_email = undef) {
+sub create_onboarding_opportunity ($name, $company_id, $partner_id, $salesperson_email = undef) {
 
 	my $query_params
-		= {name => $name, partner_id => $contact_id, tag_ids => [[$commands{link}, $crm_data->{tag}{onboarding}]]};
+		= {name => $name, partner_id => $partner_id, tag_ids => [[$commands{link}, $crm_data->{tag}{onboarding}]]};
 	if (defined $salesperson_email) {
 		my $user = (grep {$_->{email} eq $salesperson_email} @{$crm_data->{users}})[0];
 		if (defined $user) {

--- a/lib/ProductOpener/Orgs.pm
+++ b/lib/ProductOpener/Orgs.pm
@@ -180,7 +180,7 @@ sub store_org ($org_ref) {
 			my $partner_id;
 			if (defined $main_contact_user) {
 				my $user_ref = retrieve_user($main_contact_user);
-				$partner_id = find_or_create_contact($user_ref);
+				$partner_id = $user_ref->{crm_user_id} // find_or_create_contact($user_ref);
 				defined $partner_id or die "Failed to get contact";
 				$user_ref->{crm_user_id} = $partner_id;
 				store_user($user_ref);

--- a/scripts/migrations/2024_07_change_main_contact.pl
+++ b/scripts/migrations/2024_07_change_main_contact.pl
@@ -31,20 +31,22 @@ use ProductOpener::Store qw/store/;
 use ProductOpener::Orgs qw/list_org_ids retrieve_org/;
 use ProductOpener::Paths qw/%BASE_DIRS/;
 
-
 my $not_users = qw(agena3000 equadis codeonline bayard database-usda countrybot);
 
 foreach my $org_id (list_org_ids()) {
 	my $org_ref = retrieve_org($org_id);
-    
-	# if main_contact is empty, blank or contains multiple blank or invisble characters or is equal to one of the bad contacts, set it to empty
-    if (not defined $org_ref->{main_contact}          # undefined
-        or $org_ref->{main_contact} =~ /^\s*$/        # empty or only whitespace
-        or $org_ref->{main_contact} =~ /[\p{Z}\p{C}]/ # contains unicode whitespace or control characters
-        or grep { $org_ref->{main_contact} eq $_ } @not_users) {
 
-        $org_ref->{main_contact} = undef;
-    }
+	# if main_contact is empty, blank or contains multiple blank or invisble characters or is equal to one of the bad contacts, set it to empty
+	if (
+		not defined $org_ref->{main_contact}    # undefined
+		or $org_ref->{main_contact} =~ /^\s*$/    # empty or only whitespace
+		or $org_ref->{main_contact} =~ /[\p{Z}\p{C}]/    # contains unicode whitespace or control characters
+		or grep {$org_ref->{main_contact} eq $_} @not_users
+		)
+	{
+
+		$org_ref->{main_contact} = undef;
+	}
 
 	# not using store_org to avoid triggering the odoo sync
 	store("$BASE_DIRS{ORGS}/" . $org_ref->{org_id} . ".sto", $org_ref);

--- a/scripts/migrations/2024_07_change_main_contact.pl
+++ b/scripts/migrations/2024_07_change_main_contact.pl
@@ -31,7 +31,7 @@ use ProductOpener::Store qw/store/;
 use ProductOpener::Orgs qw/list_org_ids retrieve_org/;
 use ProductOpener::Paths qw/%BASE_DIRS/;
 
-my $not_users = qw(agena3000 equadis codeonline bayard database-usda countrybot);
+my @not_users = qw(agena3000 equadis codeonline bayard database-usda countrybot);
 
 foreach my $org_id (list_org_ids()) {
 	my $org_ref = retrieve_org($org_id);

--- a/scripts/migrations/2024_07_change_main_contact.pl
+++ b/scripts/migrations/2024_07_change_main_contact.pl
@@ -1,0 +1,52 @@
+#!/usr/bin/perl -w
+
+# This file is part of Product Opener.
+#
+# Product Opener
+# Copyright (C) 2011-2023 Association Open Food Facts
+# Contact: contact@openfoodfacts.org
+# Address: 21 rue des Iles, 94100 Saint-Maur des Fossés, France
+#
+# Product Opener is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use Modern::Perl '2017';
+use utf8;
+
+# This file is used
+# to change the main_contact field of orgs that are not users
+# to an undef value
+
+use ProductOpener::Store qw/store/;
+use ProductOpener::Orgs qw/list_org_ids retrieve_org/;
+use ProductOpener::Paths qw/%BASE_DIRS/;
+
+
+my $not_users = qw(agena3000 equadis codeonline bayard database-usda countrybot);
+
+foreach my $org_id (list_org_ids()) {
+	my $org_ref = retrieve_org($org_id);
+    
+	# if main_contact is empty, blank or contains multiple blank or invisble characters or is equal to one of the bad contacts, set it to empty
+    if (not defined $org_ref->{main_contact}          # undefined
+        or $org_ref->{main_contact} =~ /^\s*$/        # empty or only whitespace
+        or $org_ref->{main_contact} =~ /[\p{Z}\p{C}]/ # contains unicode whitespace or control characters
+        or grep { $org_ref->{main_contact} eq $_ } @not_users) {
+
+        $org_ref->{main_contact} = undef;
+    }
+
+	# not using store_org to avoid triggering the odoo sync
+	store("$BASE_DIRS{ORGS}/" . $org_ref->{org_id} . ".sto", $org_ref);
+}
+


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

- Added a script to remove orgs main contact that are not regular users. By default last migration, during the CRM integration, used the creator of the org to set the main contact. This caused the main contact to be agena3000/equadis/.. or even empty for some orgs.
- Allow orgs to not have a main contact if it was imported from an aggregator such as agena3000 or equadis
- New members can still be added to the orgs later ; it will be synced with the crm if the orgs has been accepted.

This script must be run in prod: `scripts/migrations/2024_07_change_main_contact.pl`
