### PR TITLE
fix: rate limiter log config

### DIFF
--- a/conf/off-log.conf
+++ b/conf/off-log.conf
@@ -24,4 +24,3 @@ log4perl.appender.RATELIMITER_LOGFILE.mode=append
 
 log4perl.appender.RATELIMITER_LOGFILE.layout=PatternLayout
 log4perl.appender.RATELIMITER_LOGFILE.layout.ConversionPattern=[%d] %F %L %c %S %m{chomp}%n
-log4perl.appender.RATELIMITER_LOGFILE.layout.ConversionPattern=[%d] %F %L %c %S %m{chomp}%n


### PR DESCRIPTION
Important fix, already done in production.

Otherwise log was only displaying `ARRAY(xxxx)` instead of information.