### PR TITLE
build: frontend container cannot be built since npm version 20.15.1

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,7 +3,7 @@
 ARG USER_UID=1000
 ARG USER_GID=1000
 
-FROM node:lts AS builder
+FROM node:20.15.0 AS builder
 ARG USER_UID
 ARG USER_GID
 RUN usermod --uid $USER_UID node && \

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,6 +3,7 @@
 ARG USER_UID=1000
 ARG USER_GID=1000
 
+# 2024-07-11 fixed to 20.15.0 because of https://github.com/npm/cli/issues/7639 in current LTS
 FROM node:20.15.0 AS builder
 ARG USER_UID
 ARG USER_GID


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Frontend docker container build fails with new npm:latest (20.15.1) version. https://github.com/npm/cli/issues/7639

This PR set the version to the previous 20.15.0 until it's fixed.

```
------
 > [dynamicfront builder  6/13] RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm install:
143.0 npm error Exit handler never called!
143.0 npm error This is an error with npm itself. Please report this error at:
143.0 npm error     <https://github.com/npm/cli/issues>
143.0 
143.2 
143.2 npm error A complete log of this run can be found in: /home/node/.npm/_logs/2024-07-11T08_05_58_996Z-debug-0.log
------
failed to solve: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
make: *** [Makefile:129: build] Error 17
```
