### PR TITLE
fix: broken off logo home link, in pro platform when not logged in

### DIFF
--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -160,7 +160,7 @@
 					<ul class="title-area">
 						<li class="name">
 							<div style="position:relative;max-width:292px;">
-								<a href="/[% IF server_options_producers_platform %]org/[% org_id %][% END %]">
+								<a href="/[% IF server_options_producers_platform AND org_id %]org/[% org_id %][% END %]">
 								<img id="logo" src="[% static_subdomain %]/images/logos/[% flavor %]-logo-horizontal-light.svg" alt="[% options.site_name %]" style="margin:8px;height:48px;width:auto;">
 								[% IF server_options_producers_platform %]
 								<span id="professionals" style="position:absolute;bottom:2px;right:8px;line-height:1rem;font-size:1.2rem;">professionals</span>


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

The top-left OFF pro logo was redirecting to a broken link when the user was not logged in.

