### PR TITLE
build(deps-dev): Add `UUID` module

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -126,6 +126,7 @@ on 'test' => sub {
   requires 'Test::File::Contents';
   requires 'FindBin';
   requires 'Test::Pod';
+  requires 'UUID';
 };
 
 on 'develop' => sub {


### PR DESCRIPTION
Fixes the following message spamming test logs:

> yath: Using UUID::Tiny for uuid generation. UUID::Tiny is significantly slower than the 'UUID' or 'Data::UUID::MT' modules, please install 'UUID' or 'Data::UUID::MT' if possible.