### PR TITLE
fix: add product_type to redis events

### DIFF
--- a/lib/ProductOpener/Redis.pm
+++ b/lib/ProductOpener/Redis.pm
@@ -132,7 +132,9 @@ sub push_to_redis_stream ($user_id, $product_ref, $action, $comment, $diffs) {
 				'*',
 				# fields
 				'code', Encode::encode_utf8($product_ref->{code}),
-				'flavor', Encode::encode_utf8($options{current_server}),
+				# product_type should be used over flavor (kept for backward compatibility)
+				'product_type', $product_ref->{product_type},
+				'flavor', $options{current_server},
 				'user_id', Encode::encode_utf8($user_id), 'action', Encode::encode_utf8($action),
 				'comment', Encode::encode_utf8($comment), 'diffs', encode_json($diffs)
 			);

--- a/lib/ProductOpener/Redis.pm
+++ b/lib/ProductOpener/Redis.pm
@@ -133,7 +133,7 @@ sub push_to_redis_stream ($user_id, $product_ref, $action, $comment, $diffs) {
 				# fields
 				'code', Encode::encode_utf8($product_ref->{code}),
 				# product_type should be used over flavor (kept for backward compatibility)
-				'product_type', $product_ref->{product_type},
+				'product_type', $options{product_type},
 				'flavor', $options{current_server},
 				'user_id', Encode::encode_utf8($user_id), 'action', Encode::encode_utf8($action),
 				'comment', Encode::encode_utf8($comment), 'diffs', encode_json($diffs)


### PR DESCRIPTION
going forward, Redis clients should use product_type (currently food, beauty, petfood, products) instead of flavor