### PR TITLE
fix: pro_moderator_owner not stored for the admin/moderator user through org/[orgid] facet

### DIFF
--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -256,8 +256,10 @@ sub org_route($request_ref, @components) {
 	if ($orgid ne $Owner_id) {
 		$log->debug("checking edit owner", {orgid => $orgid, ownerid => $Owner_id}) if $log->is_debug();
 		my @errors = ();
+		my $moderator;
 		if ($request_ref->{admin} or $User{pro_moderator}) {
-			ProductOpener::Users::check_edit_owner(\%User, \@errors, $orgid);
+			$moderator = retrieve_user($request_ref->{user_id});
+			ProductOpener::Users::check_edit_owner($moderator, \@errors, $orgid);
 		}
 		else {
 			$request_ref->{status_code} = 404;
@@ -266,6 +268,8 @@ sub org_route($request_ref, @components) {
 		}
 		if (scalar @errors eq 0) {
 			set_owner_id();
+			# will save the pro_moderator_owner field
+			store_user($moderator);
 		}
 		else {
 			$request_ref->{status_code} = 404;


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

Fixes this problem:

Pro moderator and admins experienced issues with the org/[orgid] facet in the url. The feature that allows them to navigate and act as they are part of the org is not properly working.