### PR TITLE
taxonomy: Add “akaciefiber” synonym (Swedish)

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -55752,7 +55752,7 @@ it:fibre di acacia
 nl:acaciavezels
 pl:błonnik akacjowy
 pt:fibras de acácia
-sv:akaciafiber
+sv:akaciafiber, akaciefiber
 # ingredient/fr:fibre-d’acacia has 131 products @2019-03-03
 
 


### PR DESCRIPTION
### What

Add “akaciefiber” as a synonym of “akaciafiber” for Swedish.

### Screenshot
<!-- Optional, you can delete if not relevant -->
[![“Akaciefiber” as unknown ingredient on 7311312007100](https://github.com/user-attachments/assets/40cb0632-e88a-4770-a4cc-e1a2db62ed39)](https://se.openfoodfacts.org/product/7311312007100/crunchy-granola-%C3%A4pple-kanel-risenta#health)

### Related issue(s) and discussion
- https://openfoodfacts.slack.com/archives/C06A7LENM/p1721573740332399

