### PR TITLE
build: fix working tree removing shared-services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ taxonomies/*.all.txt
 
 # Shared services and other dependencies
 /deps
+/deps/*


### PR DESCRIPTION
the deps subdir was wrongly added to the repository.