### PR TITLE
fix: use allow_non_ref in JSON decoding of off-query

### DIFF
--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -119,6 +119,9 @@ sub execute_count_tags_query ($query) {
 	return execute_tags_query('count', $query);
 }
 
+# $json has utf8 disabled: it encodes to Perl Unicode strings
+my $json = JSON::MaybeXS->new->utf8(0)->allow_nonref->canonical;
+
 sub execute_tags_query ($type, $query) {
 	if ((defined $query_url) and (length($query_url) > 0)) {
 		$query_url =~ s/^\s+|\s+$//g;
@@ -137,7 +140,7 @@ sub execute_tags_query ($type, $query) {
 			'Content-Type' => 'application/json; charset=utf-8'
 		);
 		if ($resp->is_success) {
-			return decode_json($resp->decoded_content);
+			return $json->decode($resp->decoded_content);
 		}
 		else {
 			$log->warn(


### PR DESCRIPTION
We recently switched from JSON::PP to Cpanel::JSON::XS, and it looks like JSON::PP decode_json() was accepting to decode raw numbers, without having to specify allow_non_ref.

We had an issue when trying to deploy to prod, because on count requests, the return value we get from off-query is a raw number, which could not get decoded:

[2024/07/23 15:28:00] /srv/off/lib/ProductOpener/Display.pm 5369 ProductOpener.Display {error => '
JSON text must be an object or array (but found number, string, true, false or null, use allow_non
ref to allow this) at /srv/off/lib/ProductOpener/Data.pm line 140. ',request => 'qwfXeMshf0b7OpAF'
,tags => [{canon_tagid => 'en:canadaschtroumpf',display_tag => 'Canadaschtroumpf',new_tagid => 'en
:canadaschtroumpf',new_tagid_path => '/country/canadaschtroumpf',tag => 'en:canadaschtroumpf',tag_
prefix => '',tagid => 'en:canadaschtroumpf',tagtype => 'countries',tagtype_name => 'country',tagty
pe_path => '/countries'}]} MongoDB error
