### PR TITLE
taxonomy: Add Swedish for habanero chili

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -57289,6 +57289,7 @@ fi: habanero, habanero chili
 fr: Piment Habanero
 hr: habanero čili
 it: Peperoncino Habanero
+sv: habanero chili
 wikidata:en: Q764375
 wikipedia:en: https://en.wikipedia.org/wiki/Habanero
 # scoville:en:100000-350000


### PR DESCRIPTION
### What

Adds Swedish translation of `en:habanero chili` as it was missing.

### Screenshot

![unknown ingredient “sv:habanero-chili”](https://github.com/user-attachments/assets/7044adac-6a66-4adf-a0d5-11fcd964d502)

### Related issue(s) and discussion
- https://se.openfoodfacts.org/product/7350113940056/zeina-s-hummus-mix-original-chili-soltorkad-tomat#health
