### PR TITLE
taxonomy: add “from” Danish+Swedish translation

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -418,11 +418,13 @@ my %of = (
 
 my %from = (
 	en => " from ",
+	da => " fra ",
 	de => " aus ",
 	es => " de ",
 	fr => " de la | de | du | des | d'| de l'",
 	it => " dal | della | dalla | dagli | dall'",
 	pl => " z | ze ",
+	sv => " från ",
 );
 
 my %and = (


### PR DESCRIPTION
### What

Added translations of <q>from</q> (`ProductOpener::Ingredients::from`) to Danish and Swedish.