### PR TITLE
taxonomy: Add Swedish translations and synonyms

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -34165,7 +34165,7 @@ pt: cacau magro em pó
 ro: cacao pudra degresata, pudră de cacao cu conţinut redus de grăsime
 ru: какао порошок с пониженным содержанием жира
 sk: kakaový prášok so zníženým množstvom tuku
-sv: fettreducerat kakaopulver, fettreducerad kakaopulver, skummet kakaopulver, fettreduserat kakaopulver, avfettat kakaopulver, fettfattigt kakaopulver
+sv: fettreducerat kakaopulver, fettreducerad kakaopulver, skummet kakaopulver, fettreduserat kakaopulver, avfettat kakaopulver, fettfattigt kakaopulver, lågfett kakaopulver
 # ingredient/fr:poudre-de-cacao-maigre has 843 products in 8 languages @2019-05-25
 
 #<en:cocoa powder
@@ -44494,6 +44494,7 @@ fi: kookoslastu, kookoslastut
 fr: Chips de coco
 hr: kokos čips
 it: Scaglie di cocco
+sv: kokoschips
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fi:kookoslastu
 # 1 entry @ 2019-10-31
 

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1218,6 +1218,7 @@ nb: frysetørkede
 nl: gevriesdroogde
 pl: liofilizowane, liofilizowana, liofilizowany, liofilizowanej
 pt: liofilizado, liofilizados, liofilizada, liofilizadas
+sv: frystorkade
 
 # <en:dried
 en: sundried, sun dried


### PR DESCRIPTION
### What

Add Swedish translations and synonyms

- lågfett kakaopulver (low-far cocoa powder, ingredients)
- kokoschips (coconut chips, ingredients)
- frystorkade (freeze dried, processing)

### Screenshot

![unknown ingredients](https://github.com/user-attachments/assets/ea4ded11-e234-43a5-87a5-96c52c03b097)

### Related issue(s) and discussion
- https://se.openfoodfacts.org/product/7311312007117/risenta-crunchy-granola-kakao-hallon-kokos#health

