### PR TITLE
taxonomy: Add Idared (red) apples

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -40479,6 +40479,13 @@ hr: kraljevska gala jabuka
 nl: Royal Gala appel, Tenroy, Tenroy appel
 
 < en:apple
+en: Idared apple
+da: Idared æble, Idared æbler
+sv: Idared äpple, Idared äpplen
+wikidata:en: Q494432
+wikipedia:en: https://en.wikipedia.org/wiki/Idared
+
+< en:apple
 fr: pommes d'Aquitaine
 # 22@2019-06-09
 
@@ -40501,11 +40508,19 @@ hr: zelena jabuka
 < en:apple
 en: red apple
 bg: червена ябълка, червени ябълки
+da: rødt æble, røde æbler
 de: roter Apfel, rote Äpfel
 es: manzana roja, manzanas rojas
 fi: punakuorinen omena
 fr: Pomme rouge, pommes rouges
 hr: crvena Jabuka
+sv: rött äpple, röda äpplen
+
+< en:Idared apple
+< en:red apple
+en: Idared red apple
+da: Idared rødt æble, Idared røde æbler
+sv: Idared rött äpple, Idared röda äpplen
 
 < en:apple
 nl: appels van biologisch-dynamische teelt

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -392,6 +392,7 @@
 <li><a href="/ingredient/gala-apple" class="tag well_known">Gala apple</a></li>
 <li><a href="/ingredient/golden-delicious-apple" class="tag well_known">Golden Delicious apple</a></li>
 <li><a href="/ingredient/green-apple" class="tag well_known">Green apple</a></li>
+<li><a href="/ingredient/idared-apple" class="tag well_known">Idared apple</a></li>
 <li><a href="/ingredient/organic-apple" class="tag well_known">Organic apple</a></li>
 <li><a href="/ingredient/pink-lady-apple" class="tag well_known">Pink Lady apple</a></li>
 <li><a href="/ingredient/red-apple" class="tag well_known">Red apple</a></li>


### PR DESCRIPTION
### What

Adds [Idared (red) apples](https://en.wikipedia.org/wiki/Idared) to the ingredients list, including related Danish and Swedish translations/synonyms.

### Screenshot
[![missing ingredient](https://github.com/user-attachments/assets/fc997b59-814a-4db6-a701-32b5231f51b9)](https://se.openfoodfacts.org/product/4056489447665/r%C3%B6da-%C3%A4pplen#health)

### Related issue(s) and discussion
- https://se.openfoodfacts.org/product/4056489447665/r%C3%B6da-%C3%A4pplen#health