### PR TITLE
taxonomy: Add Swedish translations for carrot concentrate and almond chunks/pieces

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -54156,6 +54156,7 @@ it: concentrato di carota, concentrato di carote
 lt: morkų koncentratas, dažiklis morkų koncentratas
 pl: koncentrat z marchwi, koncentrat marchwi, koncentrat z marchwii, koncentrat marchwii
 ro: concentrat de morcov
+sv: morotskoncentrat
 # fr:concentré-de-carotte has 221 products in 4 languages @2018-10-10
 
 < en:carrot
@@ -61229,6 +61230,7 @@ fr: éclats d'amandes
 it: mandorle spezzate
 nl: amandelstukjes
 pl: kawałki migdałów
+sv: mandelbitar
 # ingredient/fr:éclats-d'amandes has 73 products in 4 languages @2018-10-06
 
 < en:almond


### PR DESCRIPTION
### What

Add Swedish translations for carrot concentrate and almond chunks/pieces.

### Screenshot

[![unknown ingredients](https://github.com/user-attachments/assets/228d13fe-c414-42ff-94ff-0d5b3f64a90e)](https://se.openfoodfacts.org/product/4056489627821/vemondo-veganska-mandel-glasspinnar-lidl#health)

### Related issue(s) and discussion

- https://se.openfoodfacts.org/product/4056489627821/vemondo-veganska-mandel-glasspinnar-lidl#health