### PR TITLE
feat: taxonomize brands with a language less xx: taxonomy - proof of concept

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -726,6 +726,7 @@ $options{replace_existing_values_when_importing_those_tags_fields} = {
 	periods_after_opening
 	data_quality data_quality_bugs data_quality_info data_quality_warnings data_quality_errors data_quality_warnings_producers data_quality_errors_producers
 	improvements
+	brands
 );
 
 # tag types (=facets) that should be indexed by web crawlers, all other tag types are not indexable

--- a/lib/ProductOpener/ForestFootprint.pm
+++ b/lib/ProductOpener/ForestFootprint.pm
@@ -145,7 +145,7 @@ sub load_forest_footprint_data() {
 								if (defined $taxonomy_fields{$tagtype}) {
 									$tagid = canonicalize_taxonomy_tag($language, $tagtype, $value);
 
-									if (not exists_taxonomy_tag($tagtype, $tagid)) {
+									if (($tagtype ne "brands") and (not exists_taxonomy_tag($tagtype, $tagid))) {
 
 										$log->error(
 											"forest footprint condition does not exist in taxonomy",
@@ -193,10 +193,11 @@ sub load_forest_footprint_data() {
 
 						my $tagid;
 
+						# Check that the tags used to configure the forest footprint exist in the taxonomies
 						if (defined $taxonomy_fields{$tagtype}) {
 							$tagid = canonicalize_taxonomy_tag($language, $tagtype, $value);
 
-							if (not exists_taxonomy_tag($tagtype, $tagid)) {
+							if (($tagtype ne "brands") and (not exists_taxonomy_tag($tagtype, $tagid))) {
 
 								$log->error("forest footprint ingredient or category tag does not exist in taxonomy",
 									{tagtype => $tagtype, tagid => $tagid})

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -3646,6 +3646,11 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 		$tag = $';
 	}
 
+	# Language less taxonomies (e.g. brands): consider the input to be in the xx language
+	if ($tagtype eq "brands") {
+		$tag_lc = "xx";
+	}
+
 	$tag = normalize_percentages($tag, $tag_lc);
 	my $tagid = get_string_id_for_lang($tag_lc, $tag);
 
@@ -4280,7 +4285,13 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 			$display = $tag;
 
 			if ($target_lc ne $tag_lc) {
-				$display = "$tag_lc:$display";
+				# If the tag language is xx:, we don't want to add the language code
+				# This happens for language less taxonomies (e.g. brands) when we don't have a taxonomized entry
+				# So if someone enters SomeUnknownBrand in the brands field, it is normalized to xx:SomeUnknownBrand
+				# and we display it as SomeUnknownBrand
+				if ($tag_lc ne 'xx') {
+					$display = "$tag_lc:$display";
+				}
 			}
 			else {
 				$display = ucfirst($display);
@@ -4712,6 +4723,11 @@ sub compute_field_tags ($product_ref, $tag_lc, $field) {
 	# fields that should not have a different normalization (accentuation etc.) based on language
 	if ($field eq "teams") {
 		$tag_lc = "no_language";
+	}
+
+	# brands are a language less taxonomy, the input tag_lc is not used, we use xx instead
+	if ($field eq "brands") {
+		$tag_lc = "xx";
 	}
 
 	init_emb_codes() unless %emb_codes_cities;

--- a/taxonomies/brands.txt
+++ b/taxonomies/brands.txt
@@ -1,0 +1,12 @@
+# All brands in the brands taxonomy are language less and use the xx: prefix
+# Brands are not translated, we record what is written on the package, and we display it back as-is
+
+xx: Aldi
+
+xx: Marks & Spencers, Marks and Spencers
+
+xx: Marque Repère
+
+xx: Nestlé
+
+xx: Trader Joe's


### PR DESCRIPTION
This PR is a proof of concept to make brands a taxonomized field using a language less taxonomy (all entries use the xx: prefix).

To taxonomize existing products:

```
~/openfoodfacts-server$ docker exec -it po_off-backend-1 bash
www-data@a01d17ec9489:/opt/product-opener$ ./scripts/update_all_products.pl --fields brands 
```

Fixes #5208

This PR is a proof of concept, it lacks tests, documentation etc.

Also the "brands" taxonomy is hardcoded in Tags.pm, it would probably be better to make this configurable in case we want to do something similar with other taxonomies in the future.