### PR TITLE
fix(docs): Correct OpenAPI definition by fixing missing reference 

### DIFF
--- a/docs/api/ref/api.yml
+++ b/docs/api/ref/api.yml
@@ -232,7 +232,7 @@ paths:
             schema:
               AllOf:
               - $ref: ./requestBodies/add_or_edit_a_product.yaml
-              - $ref: ./responses/change_ref_properties.yaml
+              - $ref: ./requestBodies/change_ref_properties.yaml
       tags:
         - Write Requests
       description: |

--- a/docs/api/ref/responses/change_ref_properties.yaml
+++ b/docs/api/ref/responses/change_ref_properties.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  status_verbose:
+    type: string
+    example: fields saved
+  status:
+    type: integer
+    example: 1


### PR DESCRIPTION
The `api.yaml` file contained a reference to a non-existent `./responses/change_ref_properties.yaml` file, causing validation to fail. This PR adds the missing file to ensure the OpenAPI definition is valid.

### Related issue(s) and discussion

- Fixes #10659 

