### PR TITLE
docs: Add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img height="48" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg"/>
 </picture>
 
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9345/badge)](https://www.bestpractices.dev/projects/9345)
+
 
 ([Looking for the Open Food Facts API doc ?](https://openfoodfacts.github.io/openfoodfacts-server/api/))
 
@@ -19,6 +19,7 @@
 ![GitHub top language](https://img.shields.io/github/languages/top/openfoodfacts/openfoodfacts-server)
 ![GitHub last commit](https://img.shields.io/github/last-commit/openfoodfacts/openfoodfacts-server)
 ![Github Repo Size](https://img.shields.io/github/repo-size/openfoodfacts/openfoodfacts-server)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9345/badge)](https://www.bestpractices.dev/projects/9345)
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <img height="48" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg"/>
 </picture>
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9345/badge)](https://www.bestpractices.dev/projects/9345)
+
 ([Looking for the Open Food Facts API doc ?](https://openfoodfacts.github.io/openfoodfacts-server/api/))
 
 # Open Food Facts - Product Opener (Web Server)


### PR DESCRIPTION
Related to #10666

Add the OpenSSF Best Practices badge to the README file.

* Place the badge near the top of the `README.md` file, next to other existing badges.
* Use the provided markdown for the badge: `[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9345/badge)](https://www.bestpractices.dev/projects/9345)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openfoodfacts/openfoodfacts-server/issues/10666?shareId=9b29307e-6f78-4f6e-8359-90cb1a302dd2).