### PR TITLE
fix: 3 fixes to make /products/[code1],[code2] work again

### DIFF
--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -467,7 +467,7 @@ function rank_and_display_products(target, products, contributor_prefs) {
 
 /* exported search_products */
 
-function search_products(target, products, search_api_url) {
+function search_products(target, products, search_api_url, contributor_prefs) {
 
 	// Retrieve generic search results from the search API
 
@@ -476,7 +476,7 @@ function search_products(target, products, search_api_url) {
 		if (data.products) {
 
 			Array.prototype.push.apply(products, data.products);
-			rank_and_display_products(target, products);
+			rank_and_display_products(target, products, contributor_prefs);
 		}
 	});
 }

--- a/html/js/product-search.js
+++ b/html/js/product-search.js
@@ -467,6 +467,7 @@ function rank_and_display_products(target, products, contributor_prefs) {
 
 /* exported search_products */
 
+/* eslint-disable max-params */
 function search_products(target, products, search_api_url, contributor_prefs) {
 
 	// Retrieve generic search results from the search API

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -4550,7 +4550,7 @@ JS
 display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
 	rank_and_display_products("#search_results", products, contributor_prefs);
 });
-search_products("#search_results", products, "$search_api_url");
+search_products("#search_results", products, "$search_api_url", contributor_prefs);
 JS
 			;
 
@@ -5486,90 +5486,6 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 
 	if ($count > 0) {
 
-		# Show a download link only for search queries (and not for the home page of facets)
-
-		if ($request_ref->{search}) {
-			$request_ref->{current_link_query_download} = $request_ref->{current_link};
-			if ($request_ref->{current_link} =~ /\?/) {
-				$request_ref->{current_link_query_download} .= "&download=on";
-			}
-			else {
-				$request_ref->{current_link_query_download} .= "?download=on";
-			}
-		}
-
-		$template_data_ref->{current_link_query_download} = $request_ref->{current_link_query_download};
-		$template_data_ref->{export_limit} = $export_limit;
-
-		if ($log->is_debug()) {
-			my $debug_log = "search - count: $count";
-			defined $request_ref->{search} and $debug_log .= " - request_ref->{search}: " . $request_ref->{search};
-			defined $request_ref->{tagid2} and $debug_log .= " - tagid2 " . $request_ref->{tagid2};
-			$log->debug($debug_log);
-		}
-
-		if (    (not defined $request_ref->{search})
-			and ($count >= 5)
-			and (not defined $request_ref->{tagid2})
-			and (not defined $request_ref->{product_changes_saved}))
-		{
-			$template_data_ref->{explore_products} = 'true';
-			my $nofollow = '';
-			if (defined $request_ref->{tagid}) {
-				# Prevent crawlers from going too deep in facets #938:
-				# Make the 2nd facet level "nofollow"
-				$nofollow = ' rel="nofollow"';
-			}
-
-			my @current_drilldown_fields = @ProductOpener::Config::drilldown_fields;
-			if ($country eq 'en:world') {
-				unshift(@current_drilldown_fields, "countries");
-			}
-
-			foreach my $newtagtype (@current_drilldown_fields) {
-
-				# Eco-score: currently only for moderators
-
-				if ($newtagtype eq 'ecoscore') {
-					next if not(feature_enabled("ecoscore"));
-				}
-
-				push @{$template_data_ref->{current_drilldown_fields}},
-					{
-					current_link => get_owner_pretty_path() . $request_ref->{current_link},
-					tag_type_plural => $tag_type_plural{$newtagtype}{$lc},
-					nofollow => $nofollow,
-					tagtype => $newtagtype,
-					};
-			}
-		}
-
-		$template_data_ref->{separator_before_colon} = separator_before_colon($lc);
-		$template_data_ref->{jqm_loadmore} = $request_ref->{jqm_loadmore};
-
-		my $jqm = single_param("jqm");    # Assigning to a scalar to make sure we get a scalar
-
-		for my $product_ref (@{$request_ref->{structured_response}{products}}) {
-
-			my $product_display_name = $product_ref->{product_display_name};
-			# Prevent the quantity "750 g" to be split on two lines
-			$product_display_name =~ s/(.*) (.*?)/$1\&nbsp;$2/;
-
-			push @{$template_data_ref->{structured_response_products}},
-				{
-				code => $product_ref->{code},
-				product_name => $product_display_name,
-				img => $product_ref->{image_front_small_html},
-				jqm => $jqm,
-				url => $product_ref->{product_url_path},
-				};
-
-			# remove some debug info
-			delete $product_ref->{additives};
-			delete $product_ref->{additives_prev};
-			delete $product_ref->{additives_next};
-		}
-
 		# For API queries, if the request specified a value for the fields parameter, return only the fields listed
 		# For non API queries with user preferences, we need to add attributes
 		# For non API queries, we need to compute attributes for personal search
@@ -5583,7 +5499,30 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 
 		my $customized_products_ref = [];
 
+		my $jqm = single_param("jqm");    # Assigning to a scalar to make sure we get a scalar
+
 		for my $product_ref (@{$request_ref->{structured_response}{products}}) {
+
+			# remove some debug info
+			delete $product_ref->{additives};
+			delete $product_ref->{additives_prev};
+			delete $product_ref->{additives_next};
+
+			# For non API queries, we will display the products in a template (this is for SEO, before personal search products are displayed through Javascript)
+			if (not defined $request_ref->{api}) {
+				my $product_display_name = $product_ref->{product_display_name};
+				# Prevent the quantity "750 g" to be split on two lines
+				$product_display_name =~ s/(.*) (.*?)/$1\&nbsp;$2/;
+
+				push @{$template_data_ref->{structured_response_products}},
+					{
+					code => $product_ref->{code},
+					product_name => $product_display_name,
+					img => $product_ref->{image_front_small_html},
+					jqm => $jqm,
+					url => $product_ref->{product_url_path},
+					};
+			}
 
 			my $customized_product_ref = customize_response_for_product($request_ref, $product_ref, $fields);
 
@@ -5611,12 +5550,76 @@ sub search_and_display_products ($request_ref, $query_ref, $sort_by, $limit, $pa
 			}
 		}
 
-		$template_data_ref->{request} = $request_ref;
-		$template_data_ref->{page_count} = $page_count;
-		$template_data_ref->{page_limit} = $limit;
-		$template_data_ref->{page} = $page;
-		$template_data_ref->{current_link} = $request_ref->{current_link};
-		$template_data_ref->{pagination} = display_pagination($request_ref, $count, $limit, $page);
+		# Compute data needed for the template to display the search results
+		if (not defined $request_ref->{api}) {
+
+			# Show a download link only for search queries (and not for the home page of facets)
+
+			if ($request_ref->{search}) {
+				$request_ref->{current_link_query_download} = $request_ref->{current_link};
+				if ($request_ref->{current_link} =~ /\?/) {
+					$request_ref->{current_link_query_download} .= "&download=on";
+				}
+				else {
+					$request_ref->{current_link_query_download} .= "?download=on";
+				}
+			}
+
+			$template_data_ref->{current_link_query_download} = $request_ref->{current_link_query_download};
+			$template_data_ref->{export_limit} = $export_limit;
+
+			if ($log->is_debug()) {
+				my $debug_log = "search - count: $count";
+				defined $request_ref->{search} and $debug_log .= " - request_ref->{search}: " . $request_ref->{search};
+				defined $request_ref->{tagid2} and $debug_log .= " - tagid2 " . $request_ref->{tagid2};
+				$log->debug($debug_log);
+			}
+
+			if (    (not defined $request_ref->{search})
+				and ($count >= 5)
+				and (not defined $request_ref->{tagid2})
+				and (not defined $request_ref->{product_changes_saved}))
+			{
+				$template_data_ref->{explore_products} = 'true';
+				my $nofollow = '';
+				if (defined $request_ref->{tagid}) {
+					# Prevent crawlers from going too deep in facets #938:
+					# Make the 2nd facet level "nofollow"
+					$nofollow = ' rel="nofollow"';
+				}
+
+				my @current_drilldown_fields = @ProductOpener::Config::drilldown_fields;
+				if ($country eq 'en:world') {
+					unshift(@current_drilldown_fields, "countries");
+				}
+
+				foreach my $newtagtype (@current_drilldown_fields) {
+
+					# Eco-score: currently only for moderators
+
+					if ($newtagtype eq 'ecoscore') {
+						next if not(feature_enabled("ecoscore"));
+					}
+
+					push @{$template_data_ref->{current_drilldown_fields}},
+						{
+						current_link => get_owner_pretty_path() . $request_ref->{current_link},
+						tag_type_plural => $tag_type_plural{$newtagtype}{$lc},
+						nofollow => $nofollow,
+						tagtype => $newtagtype,
+						};
+				}
+			}
+
+			$template_data_ref->{separator_before_colon} = separator_before_colon($lc);
+			$template_data_ref->{jqm_loadmore} = $request_ref->{jqm_loadmore};
+			$template_data_ref->{request} = $request_ref;
+			$template_data_ref->{page_count} = $page_count;
+			$template_data_ref->{page_limit} = $limit;
+			$template_data_ref->{page} = $page;
+			$template_data_ref->{current_link} = $request_ref->{current_link};
+			$template_data_ref->{pagination} = display_pagination($request_ref, $count, $limit, $page);
+		}
 	}
 
 	# if cc and/or lc have been overridden, change the relative paths to absolute paths using the new subdomain
@@ -5760,6 +5763,8 @@ sub display_pagination ($request_ref, $count, $limit, $page) {
 
 	my $html = '';
 	my $html_pages = '';
+
+	$log->debug("PAGINATION: START\n", {count => $count, limit => $limit, page => $page}) if $log->is_debug();
 
 	my $nb_pages = int(($count - 1) / $limit) + 1;
 

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -386,7 +386,7 @@ sub properties_route($request_ref) {
 # products/[code](+[code])*
 # e.g. /8024884500403+3263855093192
 sub products_route($request_ref) {
-	param("code", $request_ref->{components}[0]);
+	param("code", $request_ref->{components}[1]);
 	$request_ref->{search} = 1;
 	set_request_stats_value($request_ref->{stats}, "route", "search");
 	return 1;
@@ -613,7 +613,13 @@ sub register_route($routes_to_register) {
 		}
 		else {
 			# use a hash key for fast match
-			$routes{$pattern} = {handler => $handler, opt => $opt};
+			# do not overwrite existing routes (e.g. a text route that matches a well known route)
+			if (exists $routes{$pattern}) {
+				$log->warn("route already exists", {pattern => $pattern}) if $log->is_warn();
+			}
+			else {
+				$routes{$pattern} = {handler => $handler, opt => $opt};
+			}
 		}
 	}
 	return 1;

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -1,0 +1,662 @@
+<!-- start templates/web/common/site_layout.tt.html -->
+
+<!doctype html>
+<html class="no-js" lang="es" data-serverdomain="openfoodfacts.localhost" dir="ltr">
+<head>
+    <meta charset="utf-8">
+    <title>Lista de ingredientes - España</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta property="fb:app_id" content="219331381518041">
+    <meta property="og:type" content="food">
+    <meta property="og:title" content="">
+    <meta property="og:url" content="//es.openfoodfacts.localhost/ingredientes">
+    
+    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
+    <meta property="og:description" content="">
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+<link rel="manifest" href="/images/favicon/site.webmanifest">
+<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="shortcut icon" href="/images/favicon/favicon.ico">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-config" content="/images/favicon/browserconfig.xml">
+<meta name="theme-color" content="#ffffff">
+
+<meta name="apple-itunes-app" content="app-id=588797948">
+<meta name="flattr:id" content="dw637l">
+
+    <link rel="canonical" href="//es.openfoodfacts.localhost/ingredientes">
+    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
+    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
+    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
+    <link rel="search" href="//es.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
+	<link rel="stylesheet" href="//static.openfoodfacts.localhost/js/datatables.min.css">
+
+    <style media="all">
+        
+        .show-when-no-access-to-producers-platform {display:none}
+.show-when-logged-in {display:none}
+
+    </style>
+    <!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(["disableCookies"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//analytics.openfoodfacts.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '5']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code -->
+
+
+</head>
+<body class="list_of_tags_page">
+	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+	<div id="page">
+		<div class="upper-nav contain-to-grid"  id="upNav">
+			<nav class="top-bar " data-topbar role="navigation">
+				
+				<section class="top-bar-section">
+					
+					<!-- Left Nav Section -->
+					<ul class="left">
+
+						<li class="has-dropdown">
+							<a id="menu_link">
+								<span class="material-icons">
+									menu
+								</span>
+							</a>
+							<ul class="dropdown">				
+								
+									<li><a href="/descubrir">Descubrir</a></li>
+									<li><a href="/contribuir">Contribuir</a></li>
+									<li class="divider"></li>
+									<li><label>Agrega productos</label></li>
+									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_es">Instalar la aplicación para agregar productos</a></li>
+									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Añadir un producto</a></li>
+								
+
+								<li class="divider"></li>
+								<li><label>Buscar y analizar productos</label></li>
+
+								<li>
+									<a href="/cgi/search.pl">Búsqueda avanzada</a>
+								</li>
+								<li>
+									<a href="/cgi/search.pl?graph=1">Gráficos y mapas</a>
+								</li>
+							</ul>
+						</li>
+						
+						<li>
+							<ul class="country_language_selection">
+								<li class="has-form has-dropdown" id="select_country_li">
+									<select id="select_country" style="width:100%" data-placeholder="País">
+										<option></option>
+									</select>
+								</li>
+								<li class="has-dropdown">
+									<a href="//es.openfoodfacts.localhost/">Español</a>
+
+									<ul class="dropdown">
+										<li><a href="//es-ca.openfoodfacts.localhost/">Català</a></li><li><a href="//es-eu.openfoodfacts.localhost/">Euskara</a></li><li><a href="//es-gl.openfoodfacts.localhost/">Lingua galega</a></li><li><a href="//es-en.openfoodfacts.localhost/">English</a></li>
+									</ul>
+								</li>
+							</ul>
+						</li>
+					</ul>
+
+
+					<!-- Right Nav Section -->
+					
+					<ul class="right">
+						
+							<li class="h-space-tiny has-form">
+								<a href="/cgi/session.pl" class="round button secondary">
+									<span class="material-icons material-symbols-button">account_circle</span>
+									Iniciar sesión
+								</a>
+							</li>
+						
+					</ul>
+				</section>
+			</nav>
+		</div>
+
+		<div id="main_container" style="position:relative" class="block_latte">
+			
+		<div class="topbarsticky">
+			<div class="contain-to-grid " id="offNav" >
+				<nav class="top-bar" data-topbar role="navigation" >
+
+					<ul class="title-area">
+						<li class="name">
+							<div style="position:relative;max-width:292px;">
+								<a href="/">
+								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
+								
+							</a>
+							</div>
+						</li>
+					</ul>
+
+					
+					
+					<section class="top-bar-section">
+					
+						<ul class="left small-4" style="margin-right:2rem;">
+							<li class="search-li">
+							
+								<form action="/cgi/search.pl">
+								<div class="row"><div class="small-12">
+								<div class="row collapse postfix-round">
+									<div class="columns">
+									<input type="text" placeholder="Buscar un producto" name="search_terms" value="" style="background-color:white">
+									<input name="search_simple" value="1" type="hidden">
+									<input name="action" value="process" type="hidden">
+									</div>
+									<div class="columns">
+									<button type="submit" title="Buscar" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
+									</div>
+								</div>
+								</div></div>
+								</form>
+							</li>
+						</ul>
+					<ul class="search_and_links">
+						<li><a href="/descubrir" class="top-bar-links">Descubrir</a></li>
+						<li><a href="/contribuir" class="top-bar-links">Contribuir</a></li>
+						<li class="show-for-xlarge-up"><a href="//world-es.pro.openfoodfacts.org/" class="top-bar-links">Productores</a></li>
+						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_es" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Descargar la aplicación</span></a></li>
+					</ul>
+					</section>
+					
+				</nav>
+			</div>
+		</div>
+
+	
+	
+		<nav class="tab-bar hide">
+			<div class="left-small">
+				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
+				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+				</a>
+			</div>
+			<div class="middle tab-bar-section">
+				<form action="/cgi/search.pl">
+					<div class="row collapse">
+						<div class="small-8 columns">
+							<input type="text" placeholder="Buscar un producto" name="search_terms">
+							<input name="search_simple" value="1" type="hidden">
+							<input name="action" value="process" type="hidden">
+						</div>
+						<div class="small-2 columns">
+							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
+						</div>
+						<div class="small-2 columns">
+							<a href="/cgi/search.pl" title="Búsqueda avanzada"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
+						</div>
+					</div>
+				</form>
+			</div>
+		</nav>
+
+		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+			<div class="inner-wrap">
+			
+				<a class="exit-off-canvas"></a>
+				
+				<!-- full width banner on mobile -->
+				
+				
+
+				<div class="main block_light">
+					<div id="main_column">
+						
+							
+							
+								
+								<!-- start templates/web/common/includes/off_days_2024_banner.tt.html -->
+
+
+								
+
+<a href="//connect.openfoodfacts.org/event/open-food-facts-days-2024-22/register">
+    <section id="off-days-2024-banner-top" class="off-days-banner off-days-banner__ENG">
+    </section>
+</a>
+
+<script>
+    const offDaysBannerID = document.getElementById('off-days-2024-banner-top');
+
+    function getBannerCookie(bcname) {
+        const name = bcname + '=';
+        const decodedCookies = decodeURIComponent(document.cookie);
+        const cookies = decodedCookies.split(';');
+        for (const cookie of cookies) {
+        let c = cookie;
+        while (c.charAt(0) == ' ') { c = c.substring(1); }
+        if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
+        }
+        
+        return '';
+    }
+
+    if (getBannerCookie('off_donation_banner_2023_a') !== '') {
+        console.log('cookie found');
+        offDaysBannerID.style.display = 'flex';
+    } else {
+        console.log('cookie not found');
+        offDaysBannerID.style.display = 'none';
+    }
+</script>
+
+
+								<!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+
+
+<!-- Donation banner @ footer -->
+
+
+<!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+								
+
+<section id="donation-banner-top" class="donation-banner">
+  <span class="donation-banner__logo"></span>
+  <span class="donation-banner__hand"></span>
+  <div class="donation-banner__content">
+    <p class="donation-banner__main-text">
+        <span role="heading">¡Ayúdanos a que la transparencia alimentaria sea la norma!</span>
+    </p>
+    <div class="donation-banner__aside">
+      <div>
+        <p class="donation-banner__secondary-text">Como organización sin fines de lucro, dependemos de tus donaciones para seguir informando a los consumidores de todo el mundo acerca de lo que comen.</p>
+        <p class="donation-banner__tertiary-text">¡La revolución alimentaria comienza contigo!</p>
+      </div>
+      <a class="donation-banner__donate" href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2023-a&utm_term=en-text-button">Donar</a>
+    </div>
+  </div>
+  <div class="donation-banner__image" role="img" aria-label="Photo of the project team"></div>
+  <div class="donation-banner__close">
+    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
+  </div>
+</section>
+
+<script>
+  let d = new Date();
+  let bannerID = document.getElementById('donation-banner-top');
+  let getDomain = window.location.origin.split('.');
+
+  function setBannerCookie(bcname, bcval, bcexdays) {
+    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
+    let expires = 'expires=' + d.toUTCString();
+    // Apply cookie for every domain contains open...facts
+    let domain = 'domain=.' + getDomain.slice(1).join('.');
+    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
+  }
+  
+  function getBannerCookie(bcname) {
+    const name = bcname + '=';
+    const decodedCookies = decodeURIComponent(document.cookie);
+    const cookies = decodedCookies.split(';');
+    for (const cookie of cookies) {
+      let c = cookie;
+      while (c.charAt(0) == ' ') { c = c.substring(1); }
+      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
+    }
+    
+    return '';
+  }
+
+  function DonationButton() {
+    setBannerCookie('off_donation_banner_2023_a', 1, 180);
+    bannerID.style.display = 'none';
+  }
+
+  if (getBannerCookie('off_donation_banner_2023_a') !== '') {
+    bannerID.style.display = 'none';
+  } else { 
+    bannerID.style.display = 'flex';
+  }
+</script>
+
+
+							
+						
+            			
+						
+							<div class="row">
+								<div class="small-12 column">
+									<h1 class="if-empty-dnone">Lista de ingredientes - España</h1>
+									<!-- start templates/web/pages/tag/tag.tt.html -->
+<div class="tag">
+    <div class="row">
+        <div class="large-6 column">
+
+            <div class="tag_navigation">
+                
+            </div>
+
+            
+
+            
+            <p>País: España
+                - <a href="//world-es.openfoodfacts.localhost/ingredientes">Ver la lista de los productos especificados de todo el mundo</a>
+            </p>
+            
+
+            
+        </div>
+
+        
+    </div>
+</div>
+
+<!-- end templates/web/pages/tag/tag.tt.html -->
+<p>37 ingredientes:</p><div style="max-width:600px;"><table id="tagstable">
+<thead><tr><th>Ingrediente</th><th>Productos</th><th>*</th></tr></thead>
+<tbody>
+<tr><td><a href="/ingrediente/aceites-y-grasas" class="tag known">Aceites y grasas</a></td>
+<td style="text-align:right"><a href="/ingrediente/aceites-y-grasas" class="tag known">3</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/aceites-y-grasas-vegetales" class="tag known">Aceites y grasas vegetales</a></td>
+<td style="text-align:right"><a href="/ingrediente/aceites-y-grasas-vegetales" class="tag known">3</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/cereales" class="tag known">Cereales</a></td>
+<td style="text-align:right"><a href="/ingrediente/cereales" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/harina-de-cereales" class="tag known">Harina de cereales</a></td>
+<td style="text-align:right"><a href="/ingrediente/harina-de-cereales" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/productos-lacteos" class="tag known">Productos lácteos</a></td>
+<td style="text-align:right"><a href="/ingrediente/productos-lacteos" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/harina" class="tag known">Harina</a></td>
+<td style="text-align:right"><a href="/ingrediente/harina" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/aceite-de-oliva" class="tag known">Aceite de oliva</a></td>
+<td style="text-align:right"><a href="/ingrediente/aceite-de-oliva" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/sal" class="tag known">Sal</a></td>
+<td style="text-align:right"><a href="/ingrediente/sal" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/aceite-vegetal" class="tag known">Aceite vegetal</a></td>
+<td style="text-align:right"><a href="/ingrediente/aceite-vegetal" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/trigo" class="tag known">Trigo</a></td>
+<td style="text-align:right"><a href="/ingrediente/trigo" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/harina-de-trigo" class="tag known">Harina de trigo</a></td>
+<td style="text-align:right"><a href="/ingrediente/harina-de-trigo" class="tag known">2</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/acidulante" class="tag known">Acidulante</a></td>
+<td style="text-align:right"><a href="/ingrediente/acidulante" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/azucares-anadidos" class="tag known">Azúcares añadidos</a></td>
+<td style="text-align:right"><a href="/ingrediente/azucares-anadidos" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/manzana" class="tag known">Manzana</a></td>
+<td style="text-align:right"><a href="/ingrediente/manzana" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/albahaca" class="tag known">Albahaca</a></td>
+<td style="text-align:right"><a href="/ingrediente/albahaca" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/mantequilla" class="tag known">Mantequilla</a></td>
+<td style="text-align:right"><a href="/ingrediente/mantequilla" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/crema-de-leche" class="tag known">Crema de leche</a></td>
+<td style="text-align:right"><a href="/ingrediente/crema-de-leche" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/disacarido" class="tag known">Disacárido</a></td>
+<td style="text-align:right"><a href="/ingrediente/disacarido" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/e330" class="tag known">E330</a></td>
+<td style="text-align:right"><a href="/ingrediente/e330" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/e500" class="tag known">E500</a></td>
+<td style="text-align:right"><a href="/ingrediente/e500" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/e500ii" class="tag known">E500ii</a></td>
+<td style="text-align:right"><a href="/ingrediente/e500ii" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/huevo" class="tag known">Huevo</a></td>
+<td style="text-align:right"><a href="/ingrediente/huevo" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/fruta" class="tag known">Fruta</a></td>
+<td style="text-align:right"><a href="/ingrediente/fruta" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/en:fruit-vegetable" class="tag known">en:Fruit vegetable</a></td>
+<td style="text-align:right"><a href="/ingrediente/en:fruit-vegetable" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/hierba" class="tag known">Hierba</a></td>
+<td style="text-align:right"><a href="/ingrediente/hierba" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/en:malaceous-fruit" class="tag known">en:Malaceous fruit</a></td>
+<td style="text-align:right"><a href="/ingrediente/en:malaceous-fruit" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/leche" class="tag known">Leche</a></td>
+<td style="text-align:right"><a href="/ingrediente/leche" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/oregano" class="tag known">Orégano</a></td>
+<td style="text-align:right"><a href="/ingrediente/oregano" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/aceite-de-palma" class="tag known">Aceite de palma</a></td>
+<td style="text-align:right"><a href="/ingrediente/aceite-de-palma" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/aceite-y-grasa-de-palma" class="tag known">Aceite y grasa de palma</a></td>
+<td style="text-align:right"><a href="/ingrediente/aceite-y-grasa-de-palma" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/planta" class="tag known">Planta</a></td>
+<td style="text-align:right"><a href="/ingrediente/planta" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/gasificante" class="tag known">Gasificante</a></td>
+<td style="text-align:right"><a href="/ingrediente/gasificante" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/azucar" class="tag known">Azúcar</a></td>
+<td style="text-align:right"><a href="/ingrediente/azucar" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/tomate" class="tag known">Tomate</a></td>
+<td style="text-align:right"><a href="/ingrediente/tomate" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/vainilla" class="tag known">Vainilla</a></td>
+<td style="text-align:right"><a href="/ingrediente/vainilla" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/verduras" class="tag known">Verduras</a></td>
+<td style="text-align:right"><a href="/ingrediente/verduras" class="tag known">1</a></td><td></td></tr>
+<tr><td><a href="/ingrediente/lavadura" class="tag known">Lavadura</a></td>
+<td style="text-align:right"><a href="/ingrediente/lavadura" class="tag known">1</a></td><td></td></tr>
+</tbody></table></div>
+								</div>
+							</div>
+						
+					</div>
+				</div>
+			</div>
+		</div>
+		</div>
+
+		<footer>
+			<div class="block_light bg-white" id="install_the_app_block">
+				<div class="row">
+					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
+						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
+							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
+							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
+								<div id="footer_install_the_app">
+									¡Instala la aplicación!
+								</div>
+								Escanea <span id="everyday">cada día</span> <span id="foods">alimentos</span>
+							</div>
+						</div>
+						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_es"><img src="/images/misc/appstore/black/appstore_ES.svg" alt="Descargar en la App Store"  loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner?utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_es"><img src="//static.openfoodfacts.org/images/misc/playstore/img/es_get.svg" alt="Disponible en Google Play" loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="//world.openfoodfacts.org/files/off.apk?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_es"><img src="//static.openfoodfacts.org/images/misc/android-apk.svg" alt="Android APK" loading="lazy" class="full-width"></a>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			
+      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+
+
+<!-- Donation banner @ footer -->
+
+
+<!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+				
+
+<section class="donation-banner-footer">
+  <span class="donation-banner-footer__logo"></span>
+  <span class="donation-banner-footer__hand"></span>
+  <div class="donation-banner-footer__content">
+    <p class="donation-banner-footer__main-text">
+      <span>¡Ayúdanos a que la transparencia alimentaria sea la norma!</span>
+    </p>
+    <div class="donation-banner-footer__aside">
+      <div>
+        <p class="donation-banner-footer__secondary-text">Como organización sin fines de lucro, dependemos de tus donaciones para seguir informando a los consumidores de todo el mundo acerca de lo que comen.</p>
+        <p class="donation-banner-footer__tertiary-text">¡La revolución alimentaria comienza contigo!</p>
+      </div>
+      <a class="donation-banner-footer__donate" href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2023-a&utm_term=en-text-button">Donar</a>
+    </div>
+  </div>
+  <div class="donation-banner-footer__image" role="img" aria-label="Photo of the project team"></div>
+</section>
+
+
+			
+      		
+			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
+				<div class="row">
+					<div class="small-12 large-6 columns v-space-normal block_off">
+						<h3 class="title-5 text-medium">Únete a la comunidad</h3>
+						<p>Descubra nuestro <a href="/codigo-de-conducta">código de conducta</a></p>
+						<p>Únete a nosotros en <a href="//slack.openfoodfacts.org">Slack</a></p>
+						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+						<p id="footer_social_icons">Síguenos: 
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
+							
+						</p>
+						<p><a href="//link.openfoodfacts.org/newsletter-es">Suscríbete a nuestro boletín</a></p>
+					</div>
+					<div class="small-12 large-6 columns project v-space-normal">
+						<h3 class="title-5 text-medium">Descubre el proyecto</h3>
+						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
+							<li><a class="button small white-button radius" href="/quienes-somos">Quiénes somos</a></li>
+							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Visión, misión, valores y programas</a></li>
+							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/es-es">Preguntas frecuentes</a></li>
+							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/es/">El blog Open Food Facts</a></li>
+							<li><a class="button small white-button radius" href="/prensa">Prensa</a></li>
+							<li><a class="button small white-button radius" href="//es.wiki.openfoodfacts.org">Open Food Facts wiki (es)</a></li>
+							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Traductores</a></li>
+							<li><a class="button small white-button radius" href="/asociados">Asociados</a></li>
+							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts (cosméticos)</a></li>
+							<li><a class="button small white-button radius" href="//es.pro.openfoodfacts.localhost/">Open Food Facts para los productores</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+
+			<div class="block_off block_dark block_ristreto" id="footer_block">
+
+				<div id="footer_block_image_banner_outside">
+					<div id="footer_block_image_banner_outside2">
+
+						<div class="row">
+
+							<div class="small-12 text-center v-space-short h-space-large">
+								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
+
+								<p>Una base de datos colaborativa, libre y abierta de productos alimenticios de todo el mundo.</p>
+								
+								<ul class="inline-list text-center text-small">
+									<li><a href="/legal">Menciones legales</a></li>
+									<li><a href="/privacidad">Privacidad</a></li>
+									<li><a href="/condiciones-de-uso">Condiciones de uso</a></li>
+									<li><a href="/data">Datos, API y SDK</a></li>
+									<li><a href="//world-es.openfoodfacts.org/dar-a-open-food-facts">Donar a Open Food Facts</a></li>
+									<li><a href="//world-es.pro.openfoodfacts.org/">Productores</a></li>
+									<li><a href="//link.openfoodfacts.org/newsletter-es">Suscríbete a nuestro boletín</a></li>
+								</ul>
+							</div>
+
+						</div>
+
+					</div>
+				</div>
+			</div>
+		</footer>
+
+	</div>
+
+<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
+  
+
+<script>
+$(function() {
+let oTable = $('#tagstable').DataTable({
+	language: {
+		search: "Buscar:",
+		info: "_TOTAL_ ingredientes",
+		infoFiltered: " - fuera de _MAX_"
+	},
+	paging: false,
+	order: [[ 1, "desc" ]],
+	columns: [
+		null,
+		{"searchable": false} , {"searchable": false}
+	]
+});
+
+
+});
+</script>
+
+
+
+<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+<script src="//static.openfoodfacts.localhost/js/datatables.min.js"></script>
+
+<script>
+$(document).foundation({
+	equalizer : {
+		equalize_on_stack: true
+	},
+	accordion: {
+		callback : function (accordion) {
+			$(document).foundation('equalizer', 'reflow');
+		}
+	}
+});
+
+</script>
+<script type="application/ld+json">
+{
+	"@context" : "//schema.org",
+	"@type" : "WebSite",
+	"name" : "Open Food Facts",
+	"url" : "//es.openfoodfacts.localhost",
+	"potentialAction": {
+		"@type": "SearchAction",
+		"target": "//es.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+		"query-input": "required name=search_term_string"
+	}
+}
+</script>
+<script type="application/ld+json">
+{
+	"@context": "//schema.org/",
+	"@type": "Organization",
+	"url": "//es.openfoodfacts.localhost",
+	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+	"name": "Open Food Facts",
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+}
+</script>
+
+
+
+
+
+</body>
+</html>
+
+<!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -1,0 +1,567 @@
+<!-- start templates/web/common/site_layout.tt.html -->
+
+<!doctype html>
+<html class="no-js" lang="en" data-serverdomain="openfoodfacts.localhost" dir="ltr">
+<head>
+    <meta charset="utf-8">
+    <title>Search results - World</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta property="fb:app_id" content="219331381518041">
+    <meta property="og:type" content="food">
+    <meta property="og:title" content="">
+    <meta property="og:url" content="//world.openfoodfacts.localhost">
+    
+    <meta property="og:image" content="//static.openfoodfacts.org/images/logos/off-logo-vertical-white-social-media-preview.png">
+    <meta property="og:description" content="">
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+<link rel="manifest" href="/images/favicon/site.webmanifest">
+<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="shortcut icon" href="/images/favicon/favicon.ico">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-config" content="/images/favicon/browserconfig.xml">
+<meta name="theme-color" content="#ffffff">
+
+<meta name="apple-itunes-app" content="app-id=588797948">
+<meta name="flattr:id" content="dw637l">
+
+    <link rel="canonical" href="//world.openfoodfacts.localhost">
+    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/app-ltr.css?v=--ignore--" data-base-layout="true">
+    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/jqueryui/themes/base/jquery-ui.css" data-base-layout="true">
+    <link rel="stylesheet" href="//static.openfoodfacts.localhost/css/dist/select2.min.css">
+    <link rel="search" href="//world.openfoodfacts.localhost/cgi/opensearch.pl" type="application/opensearchdescription+xml" title="Open Food Facts">
+	
+    <style media="all">
+        
+        .show-when-no-access-to-producers-platform {display:none}
+.show-when-logged-in {display:none}
+
+    </style>
+    <!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setCookieDomain", "*.openfoodfacts.org"]);
+  _paq.push(["setDomains", ["*.openfoodfacts.org"]]);
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(["disableCookies"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//analytics.openfoodfacts.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '5']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="//analytics.openfoodfacts.org/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code -->
+
+
+</head>
+<body class="products_page">
+	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
+
+	<div id="page">
+		<div class="upper-nav contain-to-grid"  id="upNav">
+			<nav class="top-bar " data-topbar role="navigation">
+				
+				<section class="top-bar-section">
+					
+					<!-- Left Nav Section -->
+					<ul class="left">
+
+						<li class="has-dropdown">
+							<a id="menu_link">
+								<span class="material-icons">
+									menu
+								</span>
+							</a>
+							<ul class="dropdown">				
+								
+									<li><a href="/discover">Discover</a></li>
+									<li><a href="/contribute">Contribute</a></li>
+									<li class="divider"></li>
+									<li><label>Add products</label></li>
+									<li><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=pro_platform_install_the_app_to_add_products_en">Install the app to add products</a></li>
+									<li><a href="/cgi/product.pl?type=search_or_add&action=display">Add a product</a></li>
+								
+
+								<li class="divider"></li>
+								<li><label>Search and analyze products</label></li>
+
+								<li>
+									<a href="/cgi/search.pl">Advanced search</a>
+								</li>
+								<li>
+									<a href="/cgi/search.pl?graph=1">Graphs and maps</a>
+								</li>
+							</ul>
+						</li>
+						
+						<li>
+							<ul class="country_language_selection">
+								<li class="has-form has-dropdown" id="select_country_li">
+									<select id="select_country" style="width:100%" data-placeholder="Country">
+										<option></option>
+									</select>
+								</li>
+								<li class="has-dropdown">
+									<a href="//world.openfoodfacts.localhost/">English</a>
+
+									<ul class="dropdown">
+										
+									</ul>
+								</li>
+							</ul>
+						</li>
+					</ul>
+
+
+					<!-- Right Nav Section -->
+					
+					<ul class="right">
+						
+							<li class="h-space-tiny has-form">
+								<a href="/cgi/session.pl" class="round button secondary">
+									<span class="material-icons material-symbols-button">account_circle</span>
+									Sign in
+								</a>
+							</li>
+						
+					</ul>
+				</section>
+			</nav>
+		</div>
+
+		<div id="main_container" style="position:relative" class="block_latte">
+			
+		<div class="topbarsticky">
+			<div class="contain-to-grid " id="offNav" >
+				<nav class="top-bar" data-topbar role="navigation" >
+
+					<ul class="title-area">
+						<li class="name">
+							<div style="position:relative;max-width:292px;">
+								<a href="/">
+								<img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-light.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;">
+								
+							</a>
+							</div>
+						</li>
+					</ul>
+
+					
+					
+					<section class="top-bar-section">
+					
+						<ul class="left small-4" style="margin-right:2rem;">
+							<li class="search-li">
+							
+								<form action="/cgi/search.pl">
+								<div class="row"><div class="small-12">
+								<div class="row collapse postfix-round">
+									<div class="columns">
+									<input type="text" placeholder="Search for a product" name="search_terms" value="" style="background-color:white">
+									<input name="search_simple" value="1" type="hidden">
+									<input name="action" value="process" type="hidden">
+									</div>
+									<div class="columns">
+									<button type="submit" title="Search" class="button postfix" style="line-height:normal"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
+									</div>
+								</div>
+								</div></div>
+								</form>
+							</li>
+						</ul>
+					<ul class="search_and_links">
+						<li><a href="/discover" class="top-bar-links">Discover</a></li>
+						<li><a href="/contribute" class="top-bar-links">Contribute</a></li>
+						<li class="show-for-xlarge-up"><a href="//world.pro.openfoodfacts.org/" class="top-bar-links">Producers</a></li>
+						<li class="flex-grid getapp"><a href="/open-food-facts-mobile-app?utm_source=off&utf_medium=web&utm_campaign=search_and_links_promo_en" class="buttonbar button" style="top:0;"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M16 1H8C6.34 1 5 2.34 5 4v16c0 1.66 1.34 3 3 3h8c1.66 0 3-1.34 3-3V4c0-1.66-1.34-3-3-3zm-2 20h-4v-1h4v1zm3.25-3H6.75V4h10.5v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <span class="bt-text">Get the app</span></a></li>
+					</ul>
+					</section>
+					
+				</nav>
+			</div>
+		</div>
+
+	
+	
+		<nav class="tab-bar hide">
+			<div class="left-small">
+				<a href="#idOfLeftMenu" role="button" aria-controls="idOfLeftMenu" aria-expanded="false" class="left-off-canvas-toggle button postfix anonymous">
+				<svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M3 5v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+				</a>
+			</div>
+			<div class="middle tab-bar-section">
+				<form action="/cgi/search.pl">
+					<div class="row collapse">
+						<div class="small-8 columns">
+							<input type="text" placeholder="Search for a product" name="search_terms">
+							<input name="search_simple" value="1" type="hidden">
+							<input name="action" value="process" type="hidden">
+						</div>
+						<div class="small-2 columns">
+							<button type="submit" class="button postfix"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg></button>
+						</div>
+						<div class="small-2 columns">
+							<a href="/cgi/search.pl" title="Advanced search"><svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg> <svg xmlns="//www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg></a>
+						</div>
+					</div>
+				</form>
+			</div>
+		</nav>
+
+		<div id="content" class="off-canvas-wrap block_latte" data-offcanvas>
+			<div class="inner-wrap">
+			
+				<a class="exit-off-canvas"></a>
+				
+				<!-- full width banner on mobile -->
+				
+				
+
+				<div class="main block_light">
+					<div id="main_column">
+						
+							
+							
+								
+								<!-- start templates/web/common/includes/off_days_2024_banner.tt.html -->
+
+
+								
+
+<a href="//connect.openfoodfacts.org/event/open-food-facts-days-2024-22/register">
+    <section id="off-days-2024-banner-top" class="off-days-banner off-days-banner__ENG">
+    </section>
+</a>
+
+<script>
+    const offDaysBannerID = document.getElementById('off-days-2024-banner-top');
+
+    function getBannerCookie(bcname) {
+        const name = bcname + '=';
+        const decodedCookies = decodeURIComponent(document.cookie);
+        const cookies = decodedCookies.split(';');
+        for (const cookie of cookies) {
+        let c = cookie;
+        while (c.charAt(0) == ' ') { c = c.substring(1); }
+        if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
+        }
+        
+        return '';
+    }
+
+    if (getBannerCookie('off_donation_banner_2023_a') !== '') {
+        console.log('cookie found');
+        offDaysBannerID.style.display = 'flex';
+    } else {
+        console.log('cookie not found');
+        offDaysBannerID.style.display = 'none';
+    }
+</script>
+
+
+								<!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+
+
+<!-- Donation banner @ footer -->
+
+
+<!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+								
+
+<section id="donation-banner-top" class="donation-banner">
+  <span class="donation-banner__logo"></span>
+  <span class="donation-banner__hand"></span>
+  <div class="donation-banner__content">
+    <p class="donation-banner__main-text">
+        <span role="heading">Help us make food transparency the norm!</span>
+    </p>
+    <div class="donation-banner__aside">
+      <div>
+        <p class="donation-banner__secondary-text">As a non-profit organization, we depend on your donations to continue informing consumers around the world about what they eat.</p>
+        <p class="donation-banner__tertiary-text">The food revolution starts with you!</p>
+      </div>
+      <a class="donation-banner__donate" href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2023-a&utm_term=en-text-button">Donate</a>
+    </div>
+  </div>
+  <div class="donation-banner__image" role="img" aria-label="Photo of the project team"></div>
+  <div class="donation-banner__close">
+    <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
+  </div>
+</section>
+
+<script>
+  let d = new Date();
+  let bannerID = document.getElementById('donation-banner-top');
+  let getDomain = window.location.origin.split('.');
+
+  function setBannerCookie(bcname, bcval, bcexdays) {
+    d.setTime(d.getTime() + (bcexdays*60*60*24*1000));
+    let expires = 'expires=' + d.toUTCString();
+    // Apply cookie for every domain contains open...facts
+    let domain = 'domain=.' + getDomain.slice(1).join('.');
+    document.cookie = bcname + '=' + bcval + ';' + expires + ';' + domain + ';SameSite=None;Secure;path=/';
+  }
+  
+  function getBannerCookie(bcname) {
+    const name = bcname + '=';
+    const decodedCookies = decodeURIComponent(document.cookie);
+    const cookies = decodedCookies.split(';');
+    for (const cookie of cookies) {
+      let c = cookie;
+      while (c.charAt(0) == ' ') { c = c.substring(1); }
+      if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); }
+    }
+    
+    return '';
+  }
+
+  function DonationButton() {
+    setBannerCookie('off_donation_banner_2023_a', 1, 180);
+    bannerID.style.display = 'none';
+  }
+
+  if (getBannerCookie('off_donation_banner_2023_a') !== '') {
+    bannerID.style.display = 'none';
+  } else { 
+    bannerID.style.display = 'flex';
+  }
+</script>
+
+
+							
+						
+            			
+						
+							
+								<div class="row">
+                  <div class="small-12 column"> 
+										<h1 class="if-empty-dnone">Search results - World</h1>
+									</div>
+								</div>
+								<!-- start templates/web/pages/search_results/search_results.tt.html -->
+
+
+	
+<div id="search_results" style="clear:left">
+Products are being loaded, please wait.
+</div>
+
+<!-- end templates/web/pages/search_results/search_results.tt.html -->
+							
+						
+					</div>
+				</div>
+			</div>
+		</div>
+		</div>
+
+		<footer>
+			<div class="block_light bg-white" id="install_the_app_block">
+				<div class="row">
+					<div class="small-12 flex-grid v-space-short v-align-center direction-row h-space-tiny">
+						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
+							<img class="cell small-50 v-align-center" src="/images/illustrations/app-icon-in-the-clouds.svg" alt="The Open Food Facts logo in the cloud" style="height:120px">
+							<div class="cell small-50 v-align-center" id="footer_scan" style="display:block">
+								<div id="footer_install_the_app">
+									Install the app!
+								</div>
+								Scan your <span id="everyday">everyday</span> <span id="foods">foods</span>
+							</div>
+						</div>
+						<div class="cell small-100 medium-100 large-50 flex-grid v-align-center direction-row">
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="//apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web&utm_campaign=install_the_app_ios_footer_en"><img src="/images/misc/appstore/black/appstore_US.svg" alt="Download on the App Store"  loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="//play.google.com/store/apps/details?id=org.openfoodfacts.scanner?utm_source=off&utf_medium=web&utm_campaign=install_the_app_android_footer_en"><img src="//static.openfoodfacts.org/images/misc/playstore/img/en_get.svg" alt="Get It On Google Play" loading="lazy" class="full-width"></a>
+							<a class="cell small-50 medium-25 large-25 h-space-short v-align-center" href="//world.openfoodfacts.org/files/off.apk?utm_source=off&utf_medium=web&utm_campaign=install_the_app_apk_footer_en"><img src="//static.openfoodfacts.org/images/misc/android-apk.svg" alt="Android APK" loading="lazy" class="full-width"></a>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			
+      			<!-- start templates/web/common/includes/donate_banner.tt.html -->
+
+
+
+<!-- Donation banner @ footer -->
+
+
+<!-- end templates/web/common/includes/donate_banner.tt.html -->
+
+				
+
+<section class="donation-banner-footer">
+  <span class="donation-banner-footer__logo"></span>
+  <span class="donation-banner-footer__hand"></span>
+  <div class="donation-banner-footer__content">
+    <p class="donation-banner-footer__main-text">
+      <span>Help us make food transparency the norm!</span>
+    </p>
+    <div class="donation-banner-footer__aside">
+      <div>
+        <p class="donation-banner-footer__secondary-text">As a non-profit organization, we depend on your donations to continue informing consumers around the world about what they eat.</p>
+        <p class="donation-banner-footer__tertiary-text">The food revolution starts with you!</p>
+      </div>
+      <a class="donation-banner-footer__donate" href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=web&utm_campaign=donate-2023-a&utm_term=en-text-button">Donate</a>
+    </div>
+  </div>
+  <div class="donation-banner-footer__image" role="img" aria-label="Photo of the project team"></div>
+</section>
+
+
+			
+      		
+			<div class="block_light block_cappucino" id="contribute_and_discover_links_block">
+				<div class="row">
+					<div class="small-12 large-6 columns v-space-normal block_off">
+						<h3 class="title-5 text-medium">Join the community</h3>
+						<p>Discover our <a href="/code-of-conduct">Code of conduct</a></p>
+						<p>Join us on <a href="//slack.openfoodfacts.org">Slack</a></p>
+						<p><a href="//forum.openfoodfacts.org/">Forum</a></p>
+						<p id="footer_social_icons">Follow us: 
+							<a href="//twitter.com/OpenFoodFacts"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="//www.facebook.com/OpenFoodFacts"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
+							<a href="//www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
+							
+						</p>
+						<p><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></p>
+					</div>
+					<div class="small-12 large-6 columns project v-space-normal">
+						<h3 class="title-5 text-medium">Discover the project</h3>
+						<ul class="inline-list tags_links v-space-tiny h-space-tiny" >
+							<li><a class="button small white-button radius" href="/who-we-are">Who we are</a></li>
+							<li><a class="button small white-button radius" href="//world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs">Vision, Mission, Values and Programs</a></li>
+							<li><a class="button small white-button radius" href="//support.openfoodfacts.org/help/en-gb">Frequently asked questions</a></li>
+							<li><a class="button small white-button radius" href="//blog.openfoodfacts.org/en/">Open Food Facts blog</a></li>
+							<li><a class="button small white-button radius" href="/press">Press</a></li>
+							<li><a class="button small white-button radius" href="//wiki.openfoodfacts.org">Open Food Facts wiki (en)</a></li>
+							<li><a class="button small white-button radius" href="/cgi/top_translators.pl">Translators</a></li>
+							<li><a class="button small white-button radius" href="/partners">Partners</a></li>
+							<li><a class="button small white-button radius" href="//world.openbeautyfacts.org">Open Beauty Facts - Cosmetics</a></li>
+							<li><a class="button small white-button radius" href="//world.pro.openfoodfacts.localhost/">Open Food Facts for Producers</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+
+			<div class="block_off block_dark block_ristreto" id="footer_block">
+
+				<div id="footer_block_image_banner_outside">
+					<div id="footer_block_image_banner_outside2">
+
+						<div class="row">
+
+							<div class="small-12 text-center v-space-short h-space-large">
+								<a href="/" style="font-size:1rem;"><img id="logo" src="//static.openfoodfacts.localhost/images/logos/off-logo-horizontal-mono-white.svg" alt="Open Food Facts" style="margin:8px;height:48px;width:auto;"></a>
+
+								<p>A collaborative, free and open database of food products from around the world.</p>
+								
+								<ul class="inline-list text-center text-small">
+									<li><a href="/legal">Legal</a></li>
+									<li><a href="/privacy">Privacy</a></li>
+									<li><a href="/terms-of-use">Terms of use</a></li>
+									<li><a href="/data">Data, API and SDKs</a></li>
+									<li><a href="//world.openfoodfacts.org/donate-to-open-food-facts">Donate to Open Food Facts</a></li>
+									<li><a href="//world.pro.openfoodfacts.org/">Producers</a></li>
+									<li><a href="//link.openfoodfacts.org/newsletter-en">Subscribe to our newsletter</a></li>
+								</ul>
+							</div>
+
+						</div>
+
+					</div>
+				</div>
+			</div>
+		</footer>
+
+	</div>
+
+<script src="//static.openfoodfacts.localhost/js/dist/modernizr.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/jquery.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/jquery-ui.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/hc-sticky.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/display.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/stikelem.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/scrollNav.js"></script>
+  
+
+<script>
+$(function() {
+display_user_product_preferences("#preferences_selected", "#preferences_selection_form", function () {
+	rank_and_display_products("#search_results", products, contributor_prefs);
+});
+search_products("#search_results", products, "//world.openfoodfacts.localhost/api/v0/search?code=3300000000001%2C3300000000002&fields=code,product_display_name,url,image_front_small_url,attribute_groups&page_size=50", contributor_prefs);
+
+
+});
+</script>
+
+
+
+<script src="//static.openfoodfacts.localhost/js/dist/foundation.js" data-base-layout="true"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/jquery.cookie.js"></script>
+<script src="//static.openfoodfacts.localhost/js/dist/select2.min.js"></script>
+<script type="text/javascript">
+var page_type = "products";
+var preferences_text = "Classify products according to your preferences";
+var contributor_prefs = {"display_barcode":null,"edit_link":null};
+var products = [];
+</script>
+<script src="//static.openfoodfacts.localhost/js/product-preferences.js"></script>
+<script src="//static.openfoodfacts.localhost/js/product-search.js"></script>
+
+<script>
+$(document).foundation({
+	equalizer : {
+		equalize_on_stack: true
+	},
+	accordion: {
+		callback : function (accordion) {
+			$(document).foundation('equalizer', 'reflow');
+		}
+	}
+});
+
+</script>
+<script type="application/ld+json">
+{
+	"@context" : "//schema.org",
+	"@type" : "WebSite",
+	"name" : "Open Food Facts",
+	"url" : "//world.openfoodfacts.localhost",
+	"potentialAction": {
+		"@type": "SearchAction",
+		"target": "//world.openfoodfacts.localhost/cgi/search.pl?search_terms=?{search_term_string}",
+		"query-input": "required name=search_term_string"
+	}
+}
+</script>
+<script type="application/ld+json">
+{
+	"@context": "//schema.org/",
+	"@type": "Organization",
+	"url": "//world.openfoodfacts.localhost",
+	"logo": "//static.openfoodfacts.localhost/images/logos/off-logo-vertical-light.svg",
+	"name": "Open Food Facts",
+	"sameAs" : ["//www.facebook.com/OpenFoodFacts", "//twitter.com/OpenFoodFacts"]
+}
+</script>
+
+
+
+
+
+</body>
+</html>
+
+<!-- end templates/web/common/site_layout.tt.html -->

--- a/tests/integration/web_html.t
+++ b/tests/integration/web_html.t
@@ -544,6 +544,20 @@ my $tests_ref = [
 			'Cache-Control' => 'no-cache',
 		},
 	},
+	# request with a group_by tagtype in English
+	# e.g. https://es.openfoodfacts.org/ingredients
+	{
+		test_case => 'es-ingredients',
+		subdomain => 'es',
+		path => '/ingredients',
+		expected_type => 'html',
+	},
+	# /products with multiple products
+	{
+		test_case => 'world-products-multiple-codes',
+		path => '/products/3300000000001,3300000000002',
+		expected_type => 'html',
+	},
 ];
 
 execute_api_tests(__FILE__, $tests_ref);

--- a/tests/unit/expected_test_results/routing/api-v0-attribute-groups.json
+++ b/tests/unit/expected_test_results/routing/api-v0-attribute-groups.json
@@ -1,17 +1,21 @@
 {
-    "api" : "v0",
-    "api_action" : "attribute_groups",
-    "api_method" : null,
-    "api_version" : "0",
-    "cc" : "world",
-    "lc" : "en",
-    "original_query_string" : "api/v0/attribute_groups",
-    "page" : 1,
-    "query_string" : "api/v0/attribute_groups",
-    "no_index" : "0",
-    "is_crawl_bot" : "1",
-    "rate_limiter_blocking" : 0,
-    "rate_limiter_limit" : null,
-    "rate_limiter_user_requests" : null,
-    "components" :  ["api", "v0", "attribute_groups"]
+   "api" : "v0",
+   "api_action" : "attribute_groups",
+   "api_method" : null,
+   "api_version" : "0",
+   "cc" : "world",
+   "components" : [
+      "api",
+      "v0",
+      "attribute_groups"
+   ],
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v0/attribute_groups",
+   "page" : 1,
+   "query_string" : "api/v0/attribute_groups",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/api-v3-product-code.json
+++ b/tests/unit/expected_test_results/routing/api-v3-product-code.json
@@ -1,23 +1,23 @@
 {
-    "api": "v3",
-    "api_action": "product",
-    "api_method": null,
-    "api_version": "3",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "api/v3/product/03564703999971",
-    "query_string": "api/v3/product/03564703999971",
-    "code": "03564703999971",
-    "page": "1",
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": 100,
-    "rate_limiter_user_requests": null,
-    "components": [
-        "api",
-        "v3",
-        "product",
-        "03564703999971"
-    ]
+   "api" : "v3",
+   "api_action" : "product",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "code" : "03564703999971",
+   "components" : [
+      "api",
+      "v3",
+      "product",
+      "03564703999971"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/product/03564703999971",
+   "page" : 1,
+   "query_string" : "api/v3/product/03564703999971",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : 100,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/api-v3-product-gs1-data-uri.json
+++ b/tests/unit/expected_test_results/routing/api-v3-product-gs1-data-uri.json
@@ -1,23 +1,23 @@
 {
-    "api": "v3",
-    "api_action": "product",
-    "api_method": null,
-    "api_version": "3",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
-    "query_string": "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
-    "code": "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200",
-    "page": "1",
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": 100,
-    "rate_limiter_user_requests": null,
-    "components": [
-        "api",
-        "v3",
-        "product",
-        "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200"
-    ]
+   "api" : "v3",
+   "api_action" : "product",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "code" : "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200",
+   "components" : [
+      "api",
+      "v3",
+      "product",
+      "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
+   "page" : 1,
+   "query_string" : "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : 100,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/facet-url-group-by-in-english.json
+++ b/tests/unit/expected_test_results/routing/facet-url-group-by-in-english.json
@@ -1,26 +1,26 @@
 {
-    "components": [],
-    "groupby_tagtype": "ingredients",
-    "tags": [
-        {
-            "tag": "es:breads",
-            "tagid": "es:breads",
-            "tag_prefix": "",
-            "tagtype": "categories"
-        }
-    ],
-    "is_crawl_bot": "1",
-    "tag_prefix": "",
-    "tagtype": "categories",
-    "canon_rel_url": "/categoria/es:breads/ingredientes",
-    "cc": "world",
-    "query_string": "category/breads/ingredients",
-    "original_query_string": "category/breads/ingredients",
-    "tagid": "es:breads",
-    "tag": "es:breads",
-    "api": "v0",
-    "lc": "es",
-    "no_index": 1,
-    "param": {},
-    "page": 1
+   "api" : "v0",
+   "canon_rel_url" : "/categoria/es:breads/ingredientes",
+   "cc" : "world",
+   "components" : [],
+   "groupby_tagtype" : "ingredients",
+   "is_crawl_bot" : "1",
+   "lc" : "es",
+   "no_index" : 1,
+   "original_query_string" : "category/breads/ingredients",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads/ingredients",
+   "tag" : "es:breads",
+   "tag_prefix" : "",
+   "tagid" : "es:breads",
+   "tags" : [
+      {
+         "tag" : "es:breads",
+         "tag_prefix" : "",
+         "tagid" : "es:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url-group-by.json
+++ b/tests/unit/expected_test_results/routing/facet-url-group-by.json
@@ -1,26 +1,26 @@
 {
-    "tag_prefix": "",
-    "components": [],
-    "no_index": 1,
-    "canon_rel_url": "/category/en:breads/ingredients",
-    "api": "v0",
-    "query_string": "category/breads/ingredients",
-    "original_query_string": "category/breads/ingredients",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tag": "en:breads",
-    "lc": "en",
-    "cc": "world",
-    "page": 1,
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tagtype": "categories",
-            "tagid": "en:breads",
-            "tag_prefix": ""
-        }
-    ],
-    "is_crawl_bot": "1",
-    "param": {},
-    "groupby_tagtype": "ingredients"
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads/ingredients",
+   "cc" : "world",
+   "components" : [],
+   "groupby_tagtype" : "ingredients",
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : 1,
+   "original_query_string" : "category/breads/ingredients",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads/ingredients",
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url-with-page-number.json
+++ b/tests/unit/expected_test_results/routing/facet-url-with-page-number.json
@@ -1,25 +1,25 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:breads",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "category/breads/4",
-    "page": "4",
-    "query_string": "category/breads/4",
-    "tag": "en:breads",
-    "tag_prefix": "",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tag_prefix": "",
-            "tagid": "en:breads",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "1",
-    "is_crawl_bot": "1",
-    "components": []
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads",
+   "cc" : "world",
+   "components" : [],
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : 1,
+   "original_query_string" : "category/breads/4",
+   "page" : "4",
+   "param" : {},
+   "query_string" : "category/breads/4",
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url-with-synonym-and-page-number.json
+++ b/tests/unit/expected_test_results/routing/facet-url-with-synonym-and-page-number.json
@@ -1,28 +1,28 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:bread",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "category/bread/4",
-    "page": "4",
-    "query_string": "category/bread/4",
-    "tag": "en:bread",
-    "tag_prefix": "",
-    "tagid": "en:bread",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:bread",
-            "tag_prefix": "",
-            "tagid": "en:bread",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": null,
-    "rate_limiter_user_requests": null,
-    "components": []
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:bread",
+   "cc" : "world",
+   "components" : [],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "category/bread/4",
+   "page" : "4",
+   "param" : {},
+   "query_string" : "category/bread/4",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "tag" : "en:bread",
+   "tag_prefix" : "",
+   "tagid" : "en:bread",
+   "tags" : [
+      {
+         "tag" : "en:bread",
+         "tag_prefix" : "",
+         "tagid" : "en:bread",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url.json
+++ b/tests/unit/expected_test_results/routing/facet-url.json
@@ -1,28 +1,28 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:breads",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "category/breads",
-    "page": 1,
-    "query_string": "category/breads",
-    "tag": "en:breads",
-    "tag_prefix": "",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tag_prefix": "",
-            "tagid": "en:breads",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "0",
-    "is_crawl_bot": "1",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": null,
-    "rate_limiter_user_requests": null,
-    "components": []
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads",
+   "cc" : "world",
+   "components" : [],
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "category/breads",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv4-us.json
+++ b/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv4-us.json
@@ -1,22 +1,22 @@
 {
-    "original_query_string": "api/v3/geopip/12.45.23.45",
-    "page": 1,
-    "cc": "world",
-    "api_version": "3",
-    "components": [
-        "api",
-        "v3",
-        "geopip",
-        "12.45.23.45"
-    ],
-    "is_crawl_bot": "0",
-    "no_index": "0",
-    "rate_limiter_blocking": 0,
-    "query_string": "api/v3/geopip/12.45.23.45",
-    "api": "v3",
-    "rate_limiter_limit": null,
-    "api_action": "geopip",
-    "rate_limiter_user_requests": null,
-    "api_method": null,
-    "lc": "en"
+   "api" : "v3",
+   "api_action" : "geopip",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "components" : [
+      "api",
+      "v3",
+      "geopip",
+      "12.45.23.45"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/geopip/12.45.23.45",
+   "page" : 1,
+   "query_string" : "api/v3/geopip/12.45.23.45",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv6-fr.json
+++ b/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv6-fr.json
@@ -1,22 +1,22 @@
 {
-    "api_action": "geopip",
-    "lc": "en",
-    "cc": "world",
-    "rate_limiter_user_requests": null,
-    "api": "v3",
-    "rate_limiter_blocking": 0,
-    "is_crawl_bot": "0",
-    "no_index": "0",
-    "api_version": "3",
-    "page": 1,
-    "api_method": null,
-    "components": [
-        "api",
-        "v3",
-        "geopip",
-        "2001:ac8:25:3b::e01d"
-    ],
-    "original_query_string": "api/v3/geopip/2001:ac8:25:3b::e01d",
-    "query_string": "api/v3/geopip/2001:ac8:25:3b::e01d",
-    "rate_limiter_limit": null
+   "api" : "v3",
+   "api_action" : "geopip",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "components" : [
+      "api",
+      "v3",
+      "geopip",
+      "2001:ac8:25:3b::e01d"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/geopip/2001:ac8:25:3b::e01d",
+   "page" : 1,
+   "query_string" : "api/v3/geopip/2001:ac8:25:3b::e01d",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/invalid-last-url-component.json
+++ b/tests/unit/expected_test_results/routing/invalid-last-url-component.json
@@ -1,32 +1,32 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:breads",
-    "cc": "world",
-    "error_message": "Invalid address.",
-    "lc": "en",
-    "original_query_string": "category/breads/no-nutrition-data",
-    "page": 1,
-    "query_string": "category/breads/no-nutrition-data",
-    "status_code": 404,
-    "tag": "en:breads",
-    "tag_prefix": "",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tag_prefix": "",
-            "tagid": "en:breads",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "components": [
-        "no-nutrition-data"
-    ],
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": null,
-    "rate_limiter_user_requests": null
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads",
+   "cc" : "world",
+   "components" : [
+      "no-nutrition-data"
+   ],
+   "error_message" : "Invalid address.",
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "category/breads/no-nutrition-data",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads/no-nutrition-data",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "status_code" : 404,
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/products-code.json
+++ b/tests/unit/expected_test_results/routing/products-code.json
@@ -1,0 +1,18 @@
+{
+   "api" : "v0",
+   "cc" : "world",
+   "components" : [
+      "products",
+      "3564703999971"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "products/3564703999971",
+   "page" : 1,
+   "query_string" : "products/3564703999971",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "search" : 1
+}

--- a/tests/unit/expected_test_results/routing/products-codes.json
+++ b/tests/unit/expected_test_results/routing/products-codes.json
@@ -1,0 +1,18 @@
+{
+   "api" : "v0",
+   "cc" : "world",
+   "components" : [
+      "products",
+      "3564703999971,3564703999972"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "products/3564703999971,3564703999972",
+   "page" : 1,
+   "query_string" : "products/3564703999971,3564703999972",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "search" : 1
+}

--- a/tests/unit/routing.t
+++ b/tests/unit/routing.t
@@ -151,6 +151,32 @@ my @tests = (
 
 		},
 	},
+	# /products
+	{
+		id => 'products-code',
+		desc => 'products with a single barcode',
+		lc => "en",
+		input_request => {
+			cc => "world",
+			lc => "en",
+			original_query_string => 'products/3564703999971',
+			no_index => '0',
+			is_crawl_bot => '0',
+		}
+	},
+	# /products with multiple barcodes
+	{
+		id => 'products-codes',
+		desc => 'products with multiple barcodes',
+		lc => "en",
+		input_request => {
+			cc => "world",
+			lc => "en",
+			original_query_string => 'products/3564703999971,3564703999972',
+			no_index => '0',
+			is_crawl_bot => '0',
+		}
+	},
 );
 
 foreach my $test_ref (@tests) {


### PR DESCRIPTION
As noted by Telperion on Slack https://openfoodfacts.slack.com/archives/C06KYTQSG/p1719812540659769 , the feature to display several products by barcode on the OFF website is not working anymore:

http://world.openfoodfacts.localhost/products/7622201133337,3229820100234

It turns out it was broken in 3 different ways:

- the routing /products/7543543,43243242 was assigning "products" to code
- the query to the API http://world.openfoodfacts.localhost/api/v0/search?code=7622201133337,3229820100234&fields=code,product_display_name&page_size was crashing (division by 0 error) because it was trying to compute pagination data (unneeded as it is an API query with no pagination) with a $limit of 0 (still need to investigate why $limit was set to 0, possibly some config issue)
- the Javascript to display products from an API search query was broken as we didn't pass contributors_pref