### PR TITLE
taxonomy: Add Swedish translation of rice bran oil

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -17880,6 +17880,7 @@ ko: 겨기름
 lt: Ryžių sėlenų aliejus
 ml: തവിടെണ്ണ
 nl: Rijstolie
+sv: riskliolja
 ta: அரிசித் தவிட்டு எண்ணெய்
 te: తవుడు నూనె
 th: น้ำมันรำข้าว


### PR DESCRIPTION
### What

Adds Swedish translation of rice bran oil to taxonomy, since it was missing.

### Screenshot
[![missing ingredient](https://github.com/user-attachments/assets/f9a3090a-45fc-450c-85c5-20239e961fc1)](https://se.openfoodfacts.org/product/4056489412236/vitasia-rice-cracker-spicy-sweet-chili-flavour-lidl#health)

### Related issue(s) and discussion
- https://se.openfoodfacts.org/product/4056489412236/vitasia-rice-cracker-spicy-sweet-chili-flavour-lidl#health

