### PR TITLE
taxonomy: Have `grape sugar` inherit from `glucose` rather than `monosaccharide`

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -31355,7 +31355,7 @@ nl: biologische kokosbloesem siroop
 < en:coconut sugar
 es: nectar del brote de la flor del coco
 
-< en:monosaccharide
+< en:glucose
 en: grape sugar, raisin sugar
 da: druesukker
 de: Traubenzucker


### PR DESCRIPTION
### What

Have `grape sugar` inherit from `glucose` rather than `monosaccharide`.

Grape sugar is always glucose (and in many languages the two terms are mostly interchangeable) and glucose has the `vegan` and `vegetarian` flags set, while monosaccharide does not.

Glucose also inherits from monosaccharide, so grape sugar should still inherit anything from there that is needed for classifications.

### Screenshot

[![unknown vegan status](https://github.com/user-attachments/assets/db9a1d45-bba3-478a-b5a1-20c9cc4c34ae)](https://se.openfoodfacts.org/product/4056489412236/vitasia-rice-cracker-spicy-sweet-chili-flavour-lidl#health)

### Related issue(s) and discussion

- https://se.openfoodfacts.org/product/4056489412236/vitasia-rice-cracker-spicy-sweet-chili-flavour-lidl#health