### PR TITLE
taxonomy: Add Swedish terms for hydrolysed soy protein and ginger extract

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -33386,6 +33386,7 @@ hu: hidrolizált szójafehérje
 it: proteine di soia idrolizzate
 nl: gehydroliseerd soja-eiwit, gehydrolyseerd soja-eiwit
 pl: hydrolizat białka sojowego, hydrolizowane białko sojowe
+sv: hydrolyserat sojaprotein
 
 < en:soy protein
 fr: protéines de soja i.p
@@ -65954,6 +65955,7 @@ fr: extrait de gingembre, l'extrait de gingembre
 #nl:gemberextract
 hr: ekstrakt đumbira
 pl: ekstrakt z imbiru, ekstrakt imbiru
+sv: ingefärsextrakt
 #vegan:en:yes
 #vegetarian:en:yes
 

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -2637,6 +2637,7 @@ fr: Hydrolisé, hydrolisée, hydrolisés, hydrolisées
 hr: hidrolizat, hidrolizirane, hidrolizirano, hidrolizirani
 nl: gehydrolyseerd, gehydrolyseerde
 pl: hydrolizat, hydrolizowane
+sv: hydrolyserat
 
 #en:description:Transformation of unsaturated glycerides into saturated glycerides (of oils and fats)
 en: hydrogenated, hardened, partially hardened


### PR DESCRIPTION
### What

Adds Swedish terms for hydrolysed soy protein and ginger extract.

I added “hydrolyserat” both to `food/ingredients.txt` and to `ingredients_processing.txt`. Not sure if I should only do the latter, or if it’s fine to have both since “hydrolysed soy protein” is already in `food/ingredients.txt`.

### Screenshot

[![unknown ingredients](https://github.com/user-attachments/assets/8ab60e9b-8627-436d-9bb9-29543c6b8cf7)](https://se.openfoodfacts.org/product/7340083469077/heta-chilin%C3%B6tter-eldorado#health)

### Related issue(s) and discussion

- https://se.openfoodfacts.org/product/7340083469077/heta-chilin%C3%B6tter-eldorado#health

