### PR TITLE
taxonomy: Add “grädd” alias for cream

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -5345,7 +5345,7 @@ sn: Ruomba
 so: Labeen
 sq: Pana
 sr: pavlaka
-sv: Grädde
+sv: grädde, grädd
 sw: Samli
 ta: பாலாடை
 te: మీగడ


### PR DESCRIPTION
### What

Adds “grädd” as Swedish alias for cream.

While “cream” in Swedish is “grädde”, when it joins with other terms it will often drop the -e. E.g., like “powder” → “cream powder” is “gräddpulver”. As such, the “grädd” synonym is needed to properly parse ingredient lists.

### Screenshot

[![“gräddpulver” not being recognised](https://github.com/user-attachments/assets/be77ab91-6248-4398-9a5c-514f7335c339)](https://se.openfoodfacts.org/cgi/test_ingredients_analysis.pl?ingredients_text=gr%C3%A4ddpulver&type=add&action=process&submit=Submit+Query)

### Related issue(s) and discussion

- https://se.openfoodfacts.org/ingredient/gr%C3%A4ddpulver
- https://se.openfoodfacts.org/cgi/test_ingredients_analysis.pl?ingredients_text=gr%C3%A4ddpulver&type=add&action=process&submit=Submit+Query