### PR TITLE
taxonomy: Add sv:högpastöriserad processing

### DIFF
--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1643,6 +1643,9 @@ ru: пастеризованные
 sr: pasterizovana
 sv: pastöriserad
 
+< en:pasteurised
+sv: högpastöriserad
+
 en: thermised, thermized, thermalised, thermalized
 ca: termitzada
 de: thermisiert


### PR DESCRIPTION
### What

Adds `högpastöriserad` processing variant as a child of unspecified/general pasteurisation, as it is used for a number of (esp. dairy) products in Swedish. There will also be equivalents for at least the other Scandinavian/Nordic languages.

### Screenshot

[![“högpastöriserad grädde” isn’t recognised](https://github.com/user-attachments/assets/88b8661e-7819-4eb3-a660-2f1d2a2b49e4)](https://se.openfoodfacts.org/cgi/test_ingredients_analysis.pl?ingredients_text=h%C3%B6gpast%C3%B6riserad+gr%C3%A4dde&type=add&action=process&submit=Submit+Query)


### Related issue(s) and discussion

- https://se.openfoodfacts.org/ingredients?status=unknown&filter=h%C3%B6gpast%C3%B6riserad
- https://se.openfoodfacts.org/cgi/test_ingredients_analysis.pl?ingredients_text=h%C3%B6gpast%C3%B6riserad+gr%C3%A4dde&type=add&action=process&submit=Submit+Query

