### PR TITLE
taxonomy: Add sv:pecannötter and sv:lönnsirap

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -32462,6 +32462,7 @@ nl: esdoornsiroop, ahornsiroop
 pl: syrop klonowy
 ro: sirop de arţar
 ru: кленовый сироп
+sv: lönnsirap
 vegan:en: yes
 vegetarian:en: yes
 
@@ -62251,7 +62252,7 @@ ro: nuci Pecan
 ru: пекан
 sk: pekanové orechy
 sl: ameriški orehi
-sv: pekannöt, pekannötter
+sv: pekannöt, pekannötter, pecannöt, pecannötter
 zh: 碧根果
 ciqual_food_code:en: 15026
 ciqual_food_name:en: Pecan nut


### PR DESCRIPTION
### What

Adds `sv:pecannötter` and `sv:lönnsirap` to the ingredient taxonomy.

### Screenshot

[![unrecognised ingredients](https://github.com/user-attachments/assets/bcc35416-8dc5-40bd-876b-79cde675dd82)](https://se.openfoodfacts.org/product/7311312007865/granola-crunchy-pekan-l%C3%B6nnsirap-risenta#health)


### Related issue(s) and discussion
- https://se.openfoodfacts.org/product/7311312007865/granola-crunchy-pekan-l%C3%B6nnsirap-risenta#health

