### PR TITLE
fix: gen_users_emails.pl

### DIFF
--- a/scripts/gen_users_emails.pl
+++ b/scripts/gen_users_emails.pl
@@ -36,24 +36,19 @@ if (scalar $#userids < 0) {
 	@userids = retrieve_userids();
 }
 
+my $emails_ref = retrieve("$BASE_DIRS{USERS}/users_emails.sto");
+
 foreach my $userid (@userids) {
 	my $user_ref = retrieve_user($userid);
-
-	my $first = '';
-	if (!exists $user_ref->{discussion}) {
-		$first = 'first';
-	}
-
-	# print $user_ref->{email} . "\tnews_$user_ref->{newsletter}$first\tdiscussion_$user_ref->{discussion}\n";
-
-	if ($user_ref->{newsletter}) {
-		print lc($user_ref->{email}) . "\n";
-	}
-
-	if ($user_ref->{twitter} ne '') {
-		#		print "\@" . $user_ref->{twitter} . " ";
+	if (defined $user_ref) {
+		my $email = $user_ref->{email};
+		if ((defined $email) and ($email =~ /\@/)) {
+			$emails_ref->{$email} = [$userid];
+		}
 	}
 }
+
+store("$BASE_DIRS{USERS}/users_emails.sto", $emails_ref);
 
 exit(0);
 


### PR DESCRIPTION
The users_emails.sto file in production got deleted (and rebuilt with new users, but it was missing old users). I ran this script to repair it.

We will move to Keykloak hopefully soon, so we won't have those issues once we move.