### PR TITLE
taxonomy: Add `sv:krispiga flingor` to ingredients

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -23903,6 +23903,12 @@ ro: fulgi de cereale
 ru: хлопья из зерна
 sv: spannmålsflingor
 
+< en:cereal flakes
+en: crispy flakes
+sv: krispiga flingor
+vegan:en: maybe
+vegetarian:en: maybe
+
 < de:Getreideflocken
 < en:wholemeal cereal
 en: wholemeal cereal flakes


### PR DESCRIPTION
### What

Adds taxonomy ingredient entry for `sv:krispiga flingor`.

I wasn’t exactly sure where to put it, but given that the [only current occurrences](https://se.openfoodfacts.org/ingredient/krispiga-flingor) are corn/rice/wheat/rye/sv:korn based, I put it as a child of `cereal flakes`.

I also didn’t know whether to add the English translation or not, so I added it, but commented‐out. 🙃 This way, non-Swedish speakers at least have an idea of what it is when looking at the list.

### Screenshot

[![unknown ingredient](https://github.com/user-attachments/assets/6499da09-b615-4f2e-8f49-d92dc774640b)](https://se.openfoodfacts.org/product/7311312007100/crunchy-granola-%C3%A4pple-kanel-risenta#health)

### Related issue(s) and discussion

- https://openfoodfacts.slack.com/archives/C06A7LENM/p1723472446091359?thread_ts=1721573740.332399&cid=C06A7LENM