### PR TITLE
taxonomy: updates to NOVA 4 markers

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -30845,6 +30845,7 @@ pl: Cukier inwertowany
 pt: açúcar invertido
 ro: zahăr invertit, zahar invertit
 sv: invertsocker
+nova:en: 4
 wikidata:en: Q412082
 wikipedia:en: https://en.wikipedia.org/wiki/Inverted_sugar_syrup
 
@@ -31967,7 +31968,7 @@ ciqual_proxy_food_name:fr: Sucre blanc
 # ast:Almíbar
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-syrup
 # 32467 products in 29 languages @2018-09-24
-nova:en: 4
+# not always a UPF marker (Nova 4)
 wikidata:en: Q14770547
 wikipedia:en: https://en.wikipedia.org/wiki/Glucose_syrup
 
@@ -32163,6 +32164,7 @@ zh: 果糖
 ciqual_food_code:en: 31077
 ciqual_food_name:en: Fructose
 ciqual_food_name:fr: Fructose
+nova:en: 4
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q122043
@@ -32259,7 +32261,6 @@ hr: glukoza-fruktoza
 it: Glucosio-fruttosio
 nl: glucose-fructose
 sv: Glukos-Fruktos
-nova:en: 4
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/glucose-fructose
 # 19 products in 3 languages @2018-09-24
 
@@ -86771,11 +86772,12 @@ ru: растительное волокно
 sl: rastlinske vlaknine
 sr: biljna vlakna
 sv: vegetabilisk fiber, vegetabilisk fibrer, växtfiber, växtfibrer
+# ingredient/fr:fibres-végétales has 536 products in 7 languages @2019-03-11
+nova:en: 4
 # pt-br:fibra vegetal
 vegan:en: yes
 vegetarian:en: yes
 wikidata:en: Q20026824
-# ingredient/fr:fibres-végétales has 536 products in 7 languages @2019-03-11
 
 < en:vegetable fiber
 en: oat fiber

--- a/tests/unit/expected_test_results/attributes/en-attributes.json
+++ b/tests/unit/expected_test_results/attributes/en-attributes.json
@@ -1152,6 +1152,10 @@
          [
             "ingredients",
             "en:milk-proteins"
+         ],
+         [
+            "ingredients",
+            "en:fructose"
          ]
       ]
    },

--- a/tests/unit/expected_test_results/attributes/en-nova-groups-markers.json
+++ b/tests/unit/expected_test_results/attributes/en-nova-groups-markers.json
@@ -1024,6 +1024,10 @@
          [
             "ingredients",
             "en:high-fructose-corn-syrup"
+         ],
+         [
+            "ingredients",
+            "en:fructose"
          ]
       ]
    },

--- a/tests/unit/expected_test_results/nutriscore/fr-ice-tea-with-sweetener.json
+++ b/tests/unit/expected_test_results/nutriscore/fr-ice-tea-with-sweetener.json
@@ -378,6 +378,10 @@
          [
             "ingredients",
             "en:sweetener"
+         ],
+         [
+            "ingredients",
+            "en:fructose"
          ]
       ]
    },

--- a/tests/unit/expected_test_results/routing/api-v0-attribute-groups.json
+++ b/tests/unit/expected_test_results/routing/api-v0-attribute-groups.json
@@ -1,17 +1,21 @@
 {
-    "api" : "v0",
-    "api_action" : "attribute_groups",
-    "api_method" : null,
-    "api_version" : "0",
-    "cc" : "world",
-    "lc" : "en",
-    "original_query_string" : "api/v0/attribute_groups",
-    "page" : 1,
-    "query_string" : "api/v0/attribute_groups",
-    "no_index" : "0",
-    "is_crawl_bot" : "1",
-    "rate_limiter_blocking" : 0,
-    "rate_limiter_limit" : null,
-    "rate_limiter_user_requests" : null,
-    "components" :  ["api", "v0", "attribute_groups"]
+   "api" : "v0",
+   "api_action" : "attribute_groups",
+   "api_method" : null,
+   "api_version" : "0",
+   "cc" : "world",
+   "components" : [
+      "api",
+      "v0",
+      "attribute_groups"
+   ],
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v0/attribute_groups",
+   "page" : 1,
+   "query_string" : "api/v0/attribute_groups",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/api-v3-product-code.json
+++ b/tests/unit/expected_test_results/routing/api-v3-product-code.json
@@ -1,23 +1,23 @@
 {
-    "api": "v3",
-    "api_action": "product",
-    "api_method": null,
-    "api_version": "3",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "api/v3/product/03564703999971",
-    "query_string": "api/v3/product/03564703999971",
-    "code": "03564703999971",
-    "page": "1",
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": 100,
-    "rate_limiter_user_requests": null,
-    "components": [
-        "api",
-        "v3",
-        "product",
-        "03564703999971"
-    ]
+   "api" : "v3",
+   "api_action" : "product",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "code" : "03564703999971",
+   "components" : [
+      "api",
+      "v3",
+      "product",
+      "03564703999971"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/product/03564703999971",
+   "page" : 1,
+   "query_string" : "api/v3/product/03564703999971",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : 100,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/api-v3-product-gs1-data-uri.json
+++ b/tests/unit/expected_test_results/routing/api-v3-product-gs1-data-uri.json
@@ -1,23 +1,23 @@
 {
-    "api": "v3",
-    "api_action": "product",
-    "api_method": null,
-    "api_version": "3",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
-    "query_string": "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
-    "code": "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200",
-    "page": "1",
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": 100,
-    "rate_limiter_user_requests": null,
-    "components": [
-        "api",
-        "v3",
-        "product",
-        "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200"
-    ]
+   "api" : "v3",
+   "api_action" : "product",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "code" : "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200",
+   "components" : [
+      "api",
+      "v3",
+      "product",
+      "https://id.gs1.org/01/03564703999971/10/ABC/21/123456?17=211200"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
+   "page" : 1,
+   "query_string" : "api/v3/product/https%3A%2F%2Fid.gs1.org%2F01%2F03564703999971%2F10%2FABC%2F21%2F123456%3F17%3D211200",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : 100,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/facet-url-group-by-in-english.json
+++ b/tests/unit/expected_test_results/routing/facet-url-group-by-in-english.json
@@ -1,26 +1,26 @@
 {
-    "components": [],
-    "groupby_tagtype": "ingredients",
-    "tags": [
-        {
-            "tag": "es:breads",
-            "tagid": "es:breads",
-            "tag_prefix": "",
-            "tagtype": "categories"
-        }
-    ],
-    "is_crawl_bot": "1",
-    "tag_prefix": "",
-    "tagtype": "categories",
-    "canon_rel_url": "/categoria/es:breads/ingredientes",
-    "cc": "world",
-    "query_string": "category/breads/ingredients",
-    "original_query_string": "category/breads/ingredients",
-    "tagid": "es:breads",
-    "tag": "es:breads",
-    "api": "v0",
-    "lc": "es",
-    "no_index": 1,
-    "param": {},
-    "page": 1
+   "api" : "v0",
+   "canon_rel_url" : "/categoria/es:breads/ingredientes",
+   "cc" : "world",
+   "components" : [],
+   "groupby_tagtype" : "ingredients",
+   "is_crawl_bot" : "1",
+   "lc" : "es",
+   "no_index" : 1,
+   "original_query_string" : "category/breads/ingredients",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads/ingredients",
+   "tag" : "es:breads",
+   "tag_prefix" : "",
+   "tagid" : "es:breads",
+   "tags" : [
+      {
+         "tag" : "es:breads",
+         "tag_prefix" : "",
+         "tagid" : "es:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url-group-by.json
+++ b/tests/unit/expected_test_results/routing/facet-url-group-by.json
@@ -1,26 +1,26 @@
 {
-    "tag_prefix": "",
-    "components": [],
-    "no_index": 1,
-    "canon_rel_url": "/category/en:breads/ingredients",
-    "api": "v0",
-    "query_string": "category/breads/ingredients",
-    "original_query_string": "category/breads/ingredients",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tag": "en:breads",
-    "lc": "en",
-    "cc": "world",
-    "page": 1,
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tagtype": "categories",
-            "tagid": "en:breads",
-            "tag_prefix": ""
-        }
-    ],
-    "is_crawl_bot": "1",
-    "param": {},
-    "groupby_tagtype": "ingredients"
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads/ingredients",
+   "cc" : "world",
+   "components" : [],
+   "groupby_tagtype" : "ingredients",
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : 1,
+   "original_query_string" : "category/breads/ingredients",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads/ingredients",
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url-with-page-number.json
+++ b/tests/unit/expected_test_results/routing/facet-url-with-page-number.json
@@ -1,25 +1,25 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:breads",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "category/breads/4",
-    "page": "4",
-    "query_string": "category/breads/4",
-    "tag": "en:breads",
-    "tag_prefix": "",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tag_prefix": "",
-            "tagid": "en:breads",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "1",
-    "is_crawl_bot": "1",
-    "components": []
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads",
+   "cc" : "world",
+   "components" : [],
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : 1,
+   "original_query_string" : "category/breads/4",
+   "page" : "4",
+   "param" : {},
+   "query_string" : "category/breads/4",
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url-with-synonym-and-page-number.json
+++ b/tests/unit/expected_test_results/routing/facet-url-with-synonym-and-page-number.json
@@ -1,28 +1,28 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:bread",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "category/bread/4",
-    "page": "4",
-    "query_string": "category/bread/4",
-    "tag": "en:bread",
-    "tag_prefix": "",
-    "tagid": "en:bread",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:bread",
-            "tag_prefix": "",
-            "tagid": "en:bread",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": null,
-    "rate_limiter_user_requests": null,
-    "components": []
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:bread",
+   "cc" : "world",
+   "components" : [],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "category/bread/4",
+   "page" : "4",
+   "param" : {},
+   "query_string" : "category/bread/4",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "tag" : "en:bread",
+   "tag_prefix" : "",
+   "tagid" : "en:bread",
+   "tags" : [
+      {
+         "tag" : "en:bread",
+         "tag_prefix" : "",
+         "tagid" : "en:bread",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/facet-url.json
+++ b/tests/unit/expected_test_results/routing/facet-url.json
@@ -1,28 +1,28 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:breads",
-    "cc": "world",
-    "lc": "en",
-    "original_query_string": "category/breads",
-    "page": 1,
-    "query_string": "category/breads",
-    "tag": "en:breads",
-    "tag_prefix": "",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tag_prefix": "",
-            "tagid": "en:breads",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "0",
-    "is_crawl_bot": "1",
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": null,
-    "rate_limiter_user_requests": null,
-    "components": []
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads",
+   "cc" : "world",
+   "components" : [],
+   "is_crawl_bot" : "1",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "category/breads",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }

--- a/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv4-us.json
+++ b/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv4-us.json
@@ -1,22 +1,22 @@
 {
-    "original_query_string": "api/v3/geopip/12.45.23.45",
-    "page": 1,
-    "cc": "world",
-    "api_version": "3",
-    "components": [
-        "api",
-        "v3",
-        "geopip",
-        "12.45.23.45"
-    ],
-    "is_crawl_bot": "0",
-    "no_index": "0",
-    "rate_limiter_blocking": 0,
-    "query_string": "api/v3/geopip/12.45.23.45",
-    "api": "v3",
-    "rate_limiter_limit": null,
-    "api_action": "geopip",
-    "rate_limiter_user_requests": null,
-    "api_method": null,
-    "lc": "en"
+   "api" : "v3",
+   "api_action" : "geopip",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "components" : [
+      "api",
+      "v3",
+      "geopip",
+      "12.45.23.45"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/geopip/12.45.23.45",
+   "page" : 1,
+   "query_string" : "api/v3/geopip/12.45.23.45",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv6-fr.json
+++ b/tests/unit/expected_test_results/routing/geoip-get-country-from-ipv6-fr.json
@@ -1,22 +1,22 @@
 {
-    "api_action": "geopip",
-    "lc": "en",
-    "cc": "world",
-    "rate_limiter_user_requests": null,
-    "api": "v3",
-    "rate_limiter_blocking": 0,
-    "is_crawl_bot": "0",
-    "no_index": "0",
-    "api_version": "3",
-    "page": 1,
-    "api_method": null,
-    "components": [
-        "api",
-        "v3",
-        "geopip",
-        "2001:ac8:25:3b::e01d"
-    ],
-    "original_query_string": "api/v3/geopip/2001:ac8:25:3b::e01d",
-    "query_string": "api/v3/geopip/2001:ac8:25:3b::e01d",
-    "rate_limiter_limit": null
+   "api" : "v3",
+   "api_action" : "geopip",
+   "api_method" : null,
+   "api_version" : "3",
+   "cc" : "world",
+   "components" : [
+      "api",
+      "v3",
+      "geopip",
+      "2001:ac8:25:3b::e01d"
+   ],
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "api/v3/geopip/2001:ac8:25:3b::e01d",
+   "page" : 1,
+   "query_string" : "api/v3/geopip/2001:ac8:25:3b::e01d",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null
 }

--- a/tests/unit/expected_test_results/routing/invalid-last-url-component.json
+++ b/tests/unit/expected_test_results/routing/invalid-last-url-component.json
@@ -1,32 +1,32 @@
 {
-    "api": "v0",
-    "canon_rel_url": "/category/en:breads",
-    "cc": "world",
-    "error_message": "Invalid address.",
-    "lc": "en",
-    "original_query_string": "category/breads/no-nutrition-data",
-    "page": 1,
-    "query_string": "category/breads/no-nutrition-data",
-    "status_code": 404,
-    "tag": "en:breads",
-    "tag_prefix": "",
-    "tagid": "en:breads",
-    "tagtype": "categories",
-    "tags": [
-        {
-            "tag": "en:breads",
-            "tag_prefix": "",
-            "tagid": "en:breads",
-            "tagtype": "categories"
-        }
-    ],
-    "param": {},
-    "no_index": "0",
-    "is_crawl_bot": "0",
-    "components": [
-        "no-nutrition-data"
-    ],
-    "rate_limiter_blocking": 0,
-    "rate_limiter_limit": null,
-    "rate_limiter_user_requests": null
+   "api" : "v0",
+   "canon_rel_url" : "/category/en:breads",
+   "cc" : "world",
+   "components" : [
+      "no-nutrition-data"
+   ],
+   "error_message" : "Invalid address.",
+   "is_crawl_bot" : "0",
+   "lc" : "en",
+   "no_index" : "0",
+   "original_query_string" : "category/breads/no-nutrition-data",
+   "page" : 1,
+   "param" : {},
+   "query_string" : "category/breads/no-nutrition-data",
+   "rate_limiter_blocking" : 0,
+   "rate_limiter_limit" : null,
+   "rate_limiter_user_requests" : null,
+   "status_code" : 404,
+   "tag" : "en:breads",
+   "tag_prefix" : "",
+   "tagid" : "en:breads",
+   "tags" : [
+      {
+         "tag" : "en:breads",
+         "tag_prefix" : "",
+         "tagid" : "en:breads",
+         "tagtype" : "categories"
+      }
+   ],
+   "tagtype" : "categories"
 }


### PR DESCRIPTION
Some adjustments based on details from the NOVA team:

> Vitamins and minerals (e.g., flour enriched with iron, orange juice enriched with calcium, breakfast cereals with minerals and vitamins): Vitamins and minerals are not considered markers of UPF.
> 
> Vegetable fiber (e.g., potato fiber, corn fiber): Soluble or insoluble fiber is considered a food substance with little or no culinary use and is primarily used in the manufacture of UPFs. Therefore, they are markers of UPFs.
> 
> Vegetable extracts (e.g., pepper extract, spice extract, vanilla extract, onion extract, yeast extract): Since yeast extracts (such as Vegemite and Marmite) typically contain colorants and flavorings, we classify them as UPFs. While 100% vanilla extract is not considered a UPF, commercially available vanilla extract often contains other substances that generally classify it as a UPF. 100% vanilla extract appears to be obtained through a maceration process, similar to other spice extracts. In contrast, onion extract involves an enzymatic extraction process from onion cells, although I couldn't find it listed in the Codex or as a commercially available culinary ingredient. If an extract functions as a cosmetic additive according to the Codex (such as annatto extract, grape skin extract, and paprika extract), it could be regarded as a marker of UPFs. In cases of doubt, it is better not to consider it as a UPF marker.
> 
> Glucose, fructose: Fructose is a marker of UPF. Glucose: see my comment below regarding corn syrup. It is the same.
> 
> Corn syrup, maple syrup, agave syrup: We typically state that honey extracted from combs and syrup from maple trees are not UPF markers. However, corn syrup and agave syrup are commercially available for use as culinary ingredients and are listed as 100% corn syrup or agave syrup. Although the processing is different, which could classify them as UPF markers, we believe it is more prudent to be conservative and not consider them as UPF markers.