### PR TITLE
taxonomy: fix specifying Norwegian as Bokmål (labels.txt)

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -829,8 +829,8 @@ it: HACCP, Analisi dei rischi e controllo dei punti critici
 ja: HACCP
 ko: HACCP
 mk: HACCP
+nb: HACCP
 nl: HACCP
-no: HACCP
 pl: HACCP, Analiza zagrożeń i krytyczne punkty kontroli
 ps: HACCP
 pt: HACCP, Análise de Perigos e Pontos Críticos de Controle
@@ -5496,8 +5496,8 @@ it: Biologico UE
 ja: EUオーガニック, ヨーロッパオーガニック, ヨーロッパの葉, ヨーロッパのオーガニック葉, EUオーガニック農業
 ko: EU 유기농, 유럽 유기농, 유럽 잎, 유럽 유기농 잎, EU 유기농 농업
 lt: ES ekologiškas, Europos ekologiškas, europinis lapas, Europos ekologiškas lapas, ES ekologinis ūkininkavimas
+nb: EU-økologisk, Europeisk økologisk, Europeisk blad, Europeisk økologisk blad, EU økologisk landbruk
 nl: EU Organic
-no: EU-økologisk, Europeisk økologisk, Europeisk blad, Europeisk økologisk blad, EU økologisk landbruk
 pl: EU Organic, Europejski Organic, Europejski liść, Europejski organiczny liść, EU organiczne rolnictwo
 pt: Orgânico EU, Orgânico Europeu, Folha Europeia, Folha Orgânica Europeia
 ro: Organic UE, Organic european, Frunză europeană, Frunză organică europeană, Agricultură organică UE
@@ -22771,17 +22771,17 @@ en: Keyhole, the keyhole
 xx: Keyhole, the keyhole
 da: Nøglehullet, nøglehul, nøglehulsmærket
 is: Skráargatið
-no: Nøkkelhullet, nøkkelhull, nøkkelhullmerket
+nb: Nøkkelhullet, nøkkelhull, nøkkelhullmerket
 sv: Nyckelhålet, nyckelhål, nyckelhålsmärke, nyckelhålsmärkning, nyckelmärkt
 auth_url:da: https://foedevarestyrelsen.dk/kost-og-foedevarer/alt-om-mad/gaa-efter-maerkningen/noeglehullet
 auth_url:is: https://island.is/skraargatid
-auth_url:no: https://www.nokkelhullsmerket.no/
+auth_url:nb: https://www.nokkelhullsmerket.no/
 auth_url:sv: https://www.livsmedelsverket.se/nyckelhalet
 image:en: keyhole.90x90.svg
 label_categories:en: en:Health, en:Nutrition
 wikidata:en: Q3428561
 wikipedia:da: https://da.wikipedia.org/wiki/N%C3%B8glehulsm%C3%A6rket
-wikipedia:no: https://no.wikipedia.org/wiki/N%C3%B8kkelhullet
+wikipedia:nb: https://no.wikipedia.org/wiki/N%C3%B8kkelhullet
 wikipedia:sv: https://sv.wikipedia.org/wiki/Nyckelh%C3%A5lsm%C3%A4rkning
 
 < en:fair-trade


### PR DESCRIPTION
### What

Fix `no:` entries in `labels.txt` to be `nb:`.

Norwegian has two (primary) variants: Nynorsk (`nn`) and Bokmål (`nb`). It seems like Norwegian OFF uses `nb` for its language rather than the generic `no` language code—e.g., looking at https://no.openfoodfacts.org/label/n%C3%B8kkelhullet I get directed to answer robotoff questions related to `nb:nøkkelhullet`.

### Screenshot

[![“Answer robotoff questions about label nb:nøkkelhullet for country Norway”](https://github.com/user-attachments/assets/aa1b7aef-e302-4176-a1a8-c0d8bf390aae)](https://no.openfoodfacts.org/label/n%C3%B8kkelhullet)

### Related issue(s) and discussion

- https://no.openfoodfacts.org/label/n%C3%B8kkelhullet