### PR TITLE
taxonomy: Add sv:kakaokräm

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -91202,6 +91202,7 @@ fr: Crème de cacao
 hr: kakao namaz
 pl: krem kakaowy
 pt: creme de cacau
+sv: kakaokräm
 
 #<en:compound
 en: hazelnut and cocoa spread


### PR DESCRIPTION
### What

Adds “kakaokräm” as Swedish translation for cocoa cream.

### Screenshot

[![unknown ingredient “kakaokräm”](https://github.com/user-attachments/assets/bbee3960-c125-463e-a132-a166c16677aa)](https://se.openfoodfacts.org/product/4056489872450/sol-mar-mini-churros-rellenos-with-chocolate-flavoured-filling#health)


### Related issue(s) and discussion

- https://se.openfoodfacts.org/product/4056489872450/sol-mar-mini-churros-rellenos-with-chocolate-flavoured-filling#health

