### PR TITLE
feat: geoip/ api use the remote address if ip not provided as param

### DIFF
--- a/lib/ProductOpener/GeoIP.pm
+++ b/lib/ProductOpener/GeoIP.pm
@@ -144,12 +144,13 @@ sub get_country_for_ip_api ($request_ref) {
 
 	my $error_id;
 
-	if (not defined $request_ref->{ip}) {
+	my $ip = $request_ref->{geoip_ip};
+	if (not defined $ip) {
 		$error_id = "missing_field";
 	}
 	else {
-		$response_ref->{country} = get_country_for_ip($request_ref->{ip});
-		$response_ref->{cc} = get_country_code_for_ip($request_ref->{ip});
+		$response_ref->{country} = get_country_for_ip($ip);
+		$response_ref->{cc} = get_country_code_for_ip($ip);
 		if (not defined $response_ref->{country}) {
 			$error_id = "invalid_field";
 		}

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -319,8 +319,8 @@ sub api_route($request_ref) {
 		param("tagid", $components[4]);
 		$request_ref->{tagid} = $components[4];
 	}
-	elsif ($api_action eq "geoip") {    # api/v3/geoip/[ip]
-		$request_ref->{geoip_ip} = $components[3] // remote_addr();
+	elsif ($api_action eq "geoip") {    # api/v3/geoip/
+		$request_ref->{geoip_ip} = remote_addr();
 	}
 
 	# If return format is not xml or jqm or jsonp, default to json

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -320,7 +320,7 @@ sub api_route($request_ref) {
 		$request_ref->{tagid} = $components[4];
 	}
 	elsif ($api_action eq "geoip") {    # api/v3/geoip/[ip]
-		$request_ref->{ip} = $components[3];
+		$request_ref->{geoip_ip} = $components[3] // remote_addr();
 	}
 
 	# If return format is not xml or jqm or jsonp, default to json
@@ -355,6 +355,7 @@ sub api_route($request_ref) {
 	set_request_stats_value($request_ref->{stats}, "api_method", $request_ref->{api_method});
 	set_request_stats_value($request_ref->{stats}, "api_version", $request_ref->{api_version});
 
+	$log->debug("api_route", {request_ref => $request_ref}) if $log->is_debug();
 	return 1;
 }
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

If the geoip endpoint is called without parameter `/api/v3/geoip` the remote address is used.

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #10699

