### PR TITLE
taxonomy: Add Swedish Rainforest Alliance synonyms

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -18688,6 +18688,7 @@ es: Rainforest Alliance, Alianza para Bosques
 fr: Rainforest Alliance, Vérifié Rainforest Alliance, Rainforest minimum 30% cacao, Certifié Rainforest Alliance
 hr: Rainforest Alliance, Certificirano Rainforest Alliance
 it: Alleanza della Foresta Pluviale
+sv: Rainforest Alliance, Rainforest Alliance-certifierad
 auth_url:en: https://www.rainforest-alliance.org
 wikidata:en: Q2034373
 
@@ -18703,6 +18704,7 @@ bg: Rainforest Alliance Какао
 de: Rainforest Alliance Kakao
 fr: Rainforest Alliance Cacao
 nl: Rainforest Alliance Cacao
+sv: Rainforest Alliance Kakao
 
 < en:Rainforest Alliance
 en: Rainforest Alliance Cassave


### PR DESCRIPTION
### What

Add some Swedish terms for Rainforest Alliance to improve recognition in ingredients lists etc.

Note that “Rainforest Alliance” is intentionally duplicated in the Swedish list to ensure that “Rainforest Alliance” remains the label for the, uh, label in Swedish.

### Screenshot

[![unrecognised label “Rainforest Alliance Kakao”](https://github.com/user-attachments/assets/07968f38-a4e6-4cfe-b3b4-119f89ddf3d8)](https://se.openfoodfacts.org/product/7340083448188/chokoflarn-eldorado)

[![unrecognised qualifier “Rainforest Alliance-certifierad”](https://github.com/user-attachments/assets/914af8d9-71e6-4411-b8e6-1337254f48fd)](https://se.openfoodfacts.org/cgi/test_ingredients_analysis.pl?ingredients_text=Rainforest+Alliance+certifierad+fettreducerat+kakaopulver%2C+Rainforest+Alliance+certifierad+kakaopulver%2C+Rainforest+Alliance-certifierad+fettreducerat+kakaopulver%2C+Rainforest+Alliance-certifierad+kakaopulver%2C+fettreducerat+kakaopulver%2C+kakaopulver&type=add&action=process&submit=Submit+Query)

### Related issue(s) and discussion

- https://se.openfoodfacts.org/product/7340083448188/chokoflarn-eldorado
- https://se.openfoodfacts.org/cgi/test_ingredients_analysis.pl?ingredients_text=Rainforest+Alliance+certifierad+fettreducerat+kakaopulver%2C+Rainforest+Alliance+certifierad+kakaopulver%2C+Rainforest+Alliance-certifierad+fettreducerat+kakaopulver%2C+Rainforest+Alliance-certifierad+kakaopulver%2C+fettreducerat+kakaopulver%2C+kakaopulver&type=add&action=process&submit=Submit+Query

