### PR TITLE
fix: remove unused jquery-ui safe-active-element module

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -104,7 +104,6 @@ function buildjQueryUi() {
     "./node_modules/jquery-ui/ui/position.js",
     "./node_modules/jquery-ui/ui/keycode.js",
     "./node_modules/jquery-ui/ui/unique-id.js",
-    "./node_modules/jquery-ui/ui/safe-active-element.js",
     "./node_modules/jquery-ui/ui/widgets/autocomplete.js",
     "./node_modules/jquery-ui/ui/widgets/menu.js",
   ]).


### PR DESCRIPTION
Remove [no more existing](https://jqueryui.com/changelog/1.14.0/) jQuery UI file from Gulp build.