### PR TITLE
ci: add a NO_DEPLOY flag to temporarily block deployments

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -43,21 +43,12 @@ jobs:
         echo "SSH_HOST=10.1.0.200" >> $GITHUB_ENV
         echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
         echo "SSH_USERNAME=off" >> $GITHUB_ENV
+
     - name: Set various variable for prod (org) deployment
       if: matrix.env == 'off-org'
       run: |
         # FIXME: we do not deploy to prod currently
         false
-    - name: Wait for frontend container build workflow
-      uses: tomchv/wait-my-workflow@v1.1.0
-      id: wait-build
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: build (frontend)
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        intervalSeconds: 10
-        timeoutSeconds: 600 # 10m
-
 
     - name: Check for an eventual NO_DEPLOY file to put deployment on hold
       uses: appleboy/ssh-action@master
@@ -74,6 +65,16 @@ jobs:
             >2 echo "A NO_DEPLOY file exists (in /home/off/${{ matrix.env }}), failing !"
             exit 1
           fi
+
+    - name: Wait for frontend container build workflow
+      uses: tomchv/wait-my-workflow@v1.1.0
+      id: wait-build
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: build (frontend)
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        intervalSeconds: 10
+        timeoutSeconds: 600 # 10m
 
     - name: Wait for backend container build workflow
       uses: tomchv/wait-my-workflow@v1.1.0

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -69,9 +69,9 @@ jobs:
         proxy_username: ${{ env.SSH_USERNAME }}
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
         script: |
-          if [[ -f /home/off/{{ matrix.env }}/NO_DEPLOY ]]
+          if [[ -f /home/off/${{ matrix.env }}/NO_DEPLOY ]]
           then
-            >2 echo "A NO_DEPLOY file exists (in /home/off/{{ matrix.env }}), failing !"
+            >2 echo "A NO_DEPLOY file exists (in /home/off/${{ matrix.env }}), failing !"
             exit 1
           fi
 

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         script: |
           if [[ -f /home/off/${{ matrix.env }}/NO_DEPLOY ]]
           then
-            >2 echo "A NO_DEPLOY file exists (in /home/off/${{ matrix.env }}), failing !"
+            >&2 echo "A NO_DEPLOY file exists (in /home/off/${{ matrix.env }}), failing !"
             exit 1
           fi
 

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -58,6 +58,23 @@ jobs:
         intervalSeconds: 10
         timeoutSeconds: 600 # 10m
 
+
+    - name: Check for an eventual NO_DEPLOY file to put deployment on hold
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ env.SSH_HOST }}
+        username: ${{ env.SSH_USERNAME }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_host: ${{ env.SSH_PROXY_HOST }}
+        proxy_username: ${{ env.SSH_USERNAME }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        script: |
+          if [[ -f /home/off/{{ matrix.env }}/NO_DEPLOY ]]
+          then
+            >2 echo "A NO_DEPLOY file exists (in /home/off/{{ matrix.env }}), failing !"
+            exit 1
+          fi
+
     - name: Wait for backend container build workflow
       uses: tomchv/wait-my-workflow@v1.1.0
       id: wait-build2


### PR DESCRIPTION
This enable long running operations on staging (eg. testing a migration).