### PR TITLE
feat: new [taxonomy].extended.json with extended synonyms

### DIFF
--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -1098,7 +1098,7 @@ sub get_file_from_cache ($source, $target) {
 # e.g. if the taxonomy building algorithm or configuration has changed
 # This needs to be done also when the unaccenting parameters for languages set in Config.pm are changed
 
-my $BUILD_TAGS_VERSION = "20240828 - new [tagtype].extended.json format with extended synonyms";
+my $BUILD_TAGS_VERSION = "20240828 - new [tagtype].extended.json format with normalized extended synonyms";
 
 sub get_from_cache ($tagtype, @files) {
 	# If the full set of cached files can't be found then returns the hash to be used
@@ -2185,14 +2185,15 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					if (defined $synonyms_for{$tagtype}{$lc}{$lc_tagid}) {
 						(defined $taxonomy_full_json{$tagid}{synonyms}) or $taxonomy_full_json{$tagid}{synonyms} = {};
 						$taxonomy_full_json{$tagid}{synonyms}{$lc} = $synonyms_for{$tagtype}{$lc}{$lc_tagid};
-						$taxonomy_extended_json{$tagid}{synonyms}{$lc} = $synonyms_for{$tagtype}{$lc}{$lc_tagid};
+						$taxonomy_extended_json{$tagid}{normalized_synonyms}{$lc}
+							= [map {get_string_id_for_lang($lc, $_)} @{$synonyms_for{$tagtype}{$lc}{$lc_tagid}}];
 					}
 
 					# add extended synonyms to the extended taxonomy
 					if (defined $synonyms_for_extended{$tagtype}{$lc}{$lc_tagid}) {
 						(defined $taxonomy_extended_json{$tagid}{synonyms_extended})
 							or $taxonomy_extended_json{$tagid}{synonyms_extended} = {};
-						$taxonomy_extended_json{$tagid}{synonyms_extended}{$lc}
+						$taxonomy_extended_json{$tagid}{normalized_synonyms_extended}{$lc}
 							= [sort keys %{$synonyms_for_extended{$tagtype}{$lc}{$lc_tagid}}];
 					}
 				}


### PR DESCRIPTION
This creates a new .extended.json file for all taxonomies, that contain extended synonyms.
Fixes #10742

Notes:
- synonyms_extended entries are normalized (no accents, capitals, all non letter chars turned to dashes etc.)
- synonyms are not normalized (as in the normal export)
- properties, parents, childrens are not included (they are in the .full export)
- the .full export is not changed (it does not contain the extended synonyms)

Sample output in test taxonomy:

```
en:passion-fruit-yogurts: {
synonyms_extended: { },
normalized_synonyms: {
nl: [
"yoghurts-met-passievrucht"
],
en: [
"passion-fruit-yogurts"
],
fr: [
"yaourts-au-fruit-de-la-passion"
]
},
name: {
nl: "Yoghurts met passievrucht",
fr: "Yaourts au fruit de la passion",
en: "Passion fruit yogurts"
},
normalized_synonyms_extended: {
en: [
"passion-fruit-yoghurts",
"passion-fruit-yogurts",
"passionfruit-yoghurts",
"passionfruit-yogurts"
],
fr: [
"yaourts-au-fruit-de-la-fruits-de-la-passion",
"yaourts-au-fruit-de-la-maracuja",
"yaourts-au-fruit-de-la-passion",
"yaourts-au-fruits-de-la-passion",
"yaourts-au-maracuja",
"yaourts-au-passion",
"yoghourts-au-fruit-de-la-fruits-de-la-passion",
"yoghourts-au-fruit-de-la-maracuja",
"yoghourts-au-fruit-de-la-passion",
"yoghourts-au-fruits-de-la-passion",
"yoghourts-au-maracuja",
"yoghourts-au-passion",
"yogourts-au-fruit-de-la-fruits-de-la-passion",
"yogourts-au-fruit-de-la-maracuja",
"yogourts-au-fruit-de-la-passion",
"yogourts-au-fruits-de-la-passion",
"yogourts-au-maracuja",
"yogourts-au-passion"
],
nl: [
"yoghurts-met-passievrucht"
]
}
},
```