### PR TITLE
Fix: YAML syntax in schema files.

### DIFF
--- a/docs/api/ref/schemas/product_base.yaml
+++ b/docs/api/ref/schemas/product_base.yaml
@@ -20,7 +20,7 @@ properties:
         and
         A series of mask for the barcode
         It helps retrieve barcodes starting by
-      example:
+      example: |
         ["code-13","3017620422xxx","301762042xxxx","30176204xxxxx","3017620xxxxxx","301762xxxxxxx","30176xxxxxxxx","3017xxxxxxxxx","301xxxxxxxxxx","30xxxxxxxxxxx","3xxxxxxxxxxxx"]
   generic_name:
     type: string
@@ -47,7 +47,7 @@ properties:
       Main language is also used to decide which ingredients list to parse.
   nova_group:
     type: integer
-    description:
+    description: |
       Nova group as an integer from 1 to 4. See https://world.openfoodfacts.org/nova
   nova_groups:
     type: string

--- a/docs/api/ref/schemas/product_images.yaml
+++ b/docs/api/ref/schemas/product_images.yaml
@@ -39,7 +39,7 @@ properties:
           This represents an image uploaded for this product.
         $ref: ./image.yaml
       front:
-        description:
+        description: |
           This represents an image (or part of it) selected for a specific role on this product.
         type: object
         $ref: ./image_role.yaml

--- a/docs/api/ref/schemas/product_meta.yaml
+++ b/docs/api/ref/schemas/product_meta.yaml
@@ -8,7 +8,7 @@ properties:
     description: |
       Date when the product was added (UNIX timestamp format).
       See also `entry_dates_tags`
-    example:
+    example: |
       1457680652
   creator:
     type: string

--- a/docs/api/ref/schemas/product_quality.yaml
+++ b/docs/api/ref/schemas/product_quality.yaml
@@ -52,7 +52,7 @@ properties:
   states_tags:
     type: array
     items:
-      description:
+      description: |
         Each state describe something that is completed or is to be done or improved on the product.
 
         Refer to [states taxonomy](https://static.openfoodfacts.net/data/taxonomies/states.json)


### PR DESCRIPTION
### What

Some schema files have incorrect YAML syntax. When a key-value pair is split on two lines, the colon separating the value from the key should be followed by a pipe. While most YAML files contain the pipe chars when required, some of them miss one or two pipe chars.
