### PR TITLE
fix: incorrect self-reference in ingredient.yaml

### DIFF
--- a/docs/api/ref/schemas/ingredient.yaml
+++ b/docs/api/ref/schemas/ingredient.yaml
@@ -11,7 +11,7 @@ items:
       description: |
         Sub ingredients composing this ingredients.
       # self recursive
-      $ref: "#/"
+      $ref: "#"
     percent:
       type: integer
     percent_estimate:


### PR DESCRIPTION
"#/" refers to a property with empty name. "#" refers to the root.