### PR TITLE
refactor: Update Makefile to use dynamic shell path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 
 # use bash everywhere !
-SHELL := /bin/bash
+SHELL := $(shell which bash)
 # some vars
 ENV_FILE ?= .env
 NAME = "ProductOpener"


### PR DESCRIPTION
Update the `Makefile` to use the dynamic shell path instead of the hardcoded `/bin/bash`. This ensures that the correct shell is used across different environments. Additionally, the environment variable `SHELL` is updated to use the `which` command to locate the path of the bash shell.