### PR TITLE
taxonomy: Fix misplaced ja translation of en:dried-tomatoes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -74,7 +74,7 @@ stopwords:de: und, mit, von
 # expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu;  en:fruit, 35, en:other-country
 
 # if two labels are not compatible, they can be assigned the property 'incompatible_with:en:'
-# for example 
+# for example
 # en:Pasteurised products
 # etc.
 # incompatible_with:en: categories:en:unpasteurised-products
@@ -108234,7 +108234,6 @@ fi: kuivatut vihannekset
 fr: Légumes séchés
 hr: Sušeno povrće
 it: Ortaggi essiccati
-ja: 干しトマト, ドライトマト
 nl: Gedroogde groenten
 pl: Warzywa suszone
 who_id:en: 16
@@ -108249,6 +108248,7 @@ fi: kuivatut tomaatit
 fr: Tomates séchées, Tomate séchée
 hr: Sušene rajčice
 it: Pomodori essiccati
+ja: 干しトマト, ドライトマト
 nl: Gedroogde tomaten
 pl: Pomidory suszone
 agribalyse_food_code:en: 20189


### PR DESCRIPTION
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code passes GitHub workflow checks in your branch
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)

### What

The `ja` translation for `en:dried-tomatoes` was under `en:dried-vegetables` so fix that.

