### PR TITLE
fix: correct element_type to type in element.yaml schema

### DIFF
--- a/docs/api/ref/responses/get_product_by_barcode.yaml
+++ b/docs/api/ref/responses/get_product_by_barcode.yaml
@@ -3,9 +3,6 @@ x-stoplight:
 type: object
 allOf:
   - $ref: ./get_product_by_barcode_base.yaml
-  - type: object
-    properties:
+  - properties:
       product:
-        type: object
-        allOf:
-          - $ref: ../schemas/product.yaml
+        $ref: ../schemas/product.yaml

--- a/docs/api/ref/schemas/knowledge_panels/elements/element.yaml
+++ b/docs/api/ref/schemas/knowledge_panels/elements/element.yaml
@@ -6,7 +6,7 @@ description: |
   Each element object contains one specific element object such as a text element or an image element.
 properties:
   type:
-    element_type: string
+    type: string
     enum:
       - text
       - image


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [✓] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [✓] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [✓] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

This pull request corrects the `element_type` property to `type` in the `element.yaml` schema. This change ensures consistency with other schema definitions and improves clarity.
It also simplify get_product_by_barcode.yaml definition
- Removed unnecessary nested structure.
- Directly referenced `product.yaml` schema for the `product` property.

### Related issue(s) and discussion
No issue related
