### PR TITLE
docs: Fix api def type integer

### DIFF
--- a/docs/api/ref/api.yml
+++ b/docs/api/ref/api.yml
@@ -516,7 +516,7 @@ components:
       required: true
     page:
       schema:
-        type: int
+        type: integer
         example: 24
       in: query
       name: page
@@ -524,7 +524,7 @@ components:
         The page number you request to view (eg. in search results spanning multiple pages)
     page_size:
       schema:
-        type: int
+        type: integer
         example: 24
       in: query
       name: page_size

--- a/docs/api/ref/responses/get_nutrients.yaml
+++ b/docs/api/ref/responses/get_nutrients.yaml
@@ -1,1 +1,1 @@
-$ref: ../schemas/nutrients.yaml
+$ref: '../schemas/nutrients.yaml#/components/schemas/Nutrients'

--- a/docs/api/ref/responses/get_product_by_barcode.yaml
+++ b/docs/api/ref/responses/get_product_by_barcode.yaml
@@ -3,9 +3,6 @@ x-stoplight:
 type: object
 allOf:
   - $ref: ./get_product_by_barcode_base.yaml
-  - type: object
-    properties:
+  - properties:
       product:
-        type: object
-        allOf:
-          - $ref: ../schemas/product.yaml
+        $ref: ../schemas/product.yaml

--- a/docs/api/ref/schemas/knowledge_panels/elements/element.yaml
+++ b/docs/api/ref/schemas/knowledge_panels/elements/element.yaml
@@ -6,7 +6,7 @@ description: |
   Each element object contains one specific element object such as a text element or an image element.
 properties:
   type:
-    element_type: string
+    type: string
     enum:
       - text
       - image

--- a/docs/api/ref/schemas/nutrients.yaml
+++ b/docs/api/ref/schemas/nutrients.yaml
@@ -1,26 +1,32 @@
-type: array
-description: |
-  Nutrients and sub-nutrients of a product, with their name and default unit.
-items:
-  type: object
-  properties:
-    id:
-      type: string
-      description: id of the nutrient
-    name:
-      type: string
-      description: Name of the nutrient in the requested language
-    important:
-      type: boolean
-      description: Indicates if the nutrient is always shown on the nutrition facts table
-    display_in_edit_form:
-      type: boolean
-      description: Indicates if the nutrient should be shown in the nutrition facts edit form
-    unit:
-      description: Default unit of the nutrient
-      $ref: "./nutrient_unit.yaml"
-    nutrients:
+components:
+  schemas:
+    type: object
+    Nutrients:
+      type: array
       description: |
-        Sub-nutrients (e.g. saturated-fat is a sub-nutrient of fat).
-      # self recursive
-      $ref: "#/"
+        Nutrients and sub-nutrients of a product, with their name and default unit.
+        (e.g. saturated-fat is a sub-nutrient of fat).
+      items:
+        type: object
+        title: nutrient
+        properties:
+          id:
+            type: string
+            description: id of the nutrient
+          name:
+            type: string
+            description: Name of the nutrient in the requested language
+          important:
+            type: boolean
+            description: Indicates if the nutrient is always shown on the nutrition facts table
+          display_in_edit_form:
+            type: boolean
+            description: Indicates if the nutrient should be shown in the nutrition facts edit form
+          unit:
+            description: Default unit of the nutrient
+            $ref: "./nutrient_unit.yaml"
+          nutrients:
+            type: array
+            items:
+              # self recursive
+              $ref: "#/components/schemas/Nutrients/items"


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

This pull request corrects the type definitions in the `api.yml` file to conform to the OpenAPI 3.1 specification. Specifically, it replaces `type: int` with `type: integer`.

### Related issue(s) and discussion
- No issues yet