### PR TITLE
fix: Revert "fix: remove unused jquery-ui safe-active-element module (#10708)"

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -104,6 +104,7 @@ function buildjQueryUi() {
     "./node_modules/jquery-ui/ui/position.js",
     "./node_modules/jquery-ui/ui/keycode.js",
     "./node_modules/jquery-ui/ui/unique-id.js",
+    "./node_modules/jquery-ui/ui/safe-active-element.js",
     "./node_modules/jquery-ui/ui/widgets/autocomplete.js",
     "./node_modules/jquery-ui/ui/widgets/menu.js",
   ]).


### PR DESCRIPTION
This reverts commit 9407e860b96cf6be4543878509d7568ce90ad8a8.

<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] ~~Code is well documented~~
- [ ] ~~Include unit tests for new functionality~~
- [ ] Code passes GitHub workflow checks in your branch
- [ ] ~~If you have multiple commits please combine them into one commit by squashing them.~~
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What
After replicating the nutrient autosuggest selection problem (one of a few JavaScript-related problems) described in #10861 in a local development instance, I attempted a revert of #10708 because the name of the dependency seems similar to a missing function that appeared in the JavaScript console as an error:

```
Uncaught TypeError: e.ui.safeActiveElement is not a function
```

After reverting #10708, the error no longer appears and I'm able to select entries from the nutrient autosuggest as expected.

### Screenshot
https://github.com/user-attachments/assets/eb40f7dd-3167-4c0b-a982-9bc46db06988

### Related issue(s) and discussion
- Fixes #10861 (in combination with #10877).