### PR TITLE
Improve logs readability by grouping and triggering events

### DIFF
--- a/scripts/taxonomies/build_tags_taxonomy.pl
+++ b/scripts/taxonomies/build_tags_taxonomy.pl
@@ -32,18 +32,23 @@ my $publish = $ARGV[1] // 1;
 print STDERR "tagtype: $tagtype\n";
 
 if ($tagtype eq '*') {
+	print "::group::Building all taxonomies\n";
 	my $errors_ref = ProductOpener::Tags::build_all_taxonomies($publish);
 	foreach my $taxonomy (keys %{$errors_ref}) {
 		if (@{$errors_ref->{$taxonomy}}) {
 			print STDERR (scalar @{$errors_ref->{$taxonomy}}) . " errors while building $taxonomy taxonomy\n";
+			print "::error::" . (scalar @{$errors_ref->{$taxonomy}}) . " errors while building $taxonomy taxonomy\n";
 		}
 	}
-}
-else {
+	print "::endgroup::\n";
+} else {
+	print "::group::Building $tagtype taxonomy\n";
 	my @errors = ProductOpener::Tags::build_tags_taxonomy($tagtype, $publish);
 	if (@errors) {
 		print STDERR (scalar @errors) . " errors while building $tagtype taxonomy\n";
+		print "::error::" . (scalar @errors) . " errors while building $tagtype taxonomy\n";
 	}
+	print "::endgroup::\n";
 }
 
 print STDERR "done building tags taxonomy\n";


### PR DESCRIPTION
Related to #10782

Improve log readability and management in `scripts/taxonomies/build_tags_taxonomy.pl`.

* Add `::group::` and `::endgroup::` commands to group log lines by topic.
* Add `::error::` commands to trigger error events when errors occur during taxonomy building.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openfoodfacts/openfoodfacts-server/issues/10782?shareId=58a5189a-bd3e-44d4-b567-c8a263ce7e72).