### PR TITLE
Add test for po/common/common.pot string count

### DIFF
--- a/t/po_common.t
+++ b/t/po_common.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+
+# Function to count the number of strings in a .po or .pot file
+sub count_strings {
+    my ($file) = @_;
+    open my $fh, '<', $file or die "Could not open '$file' $!";
+    my $count = 0;
+    while (my $line = <$fh>) {
+        $count++ if $line =~ /^msgid\s+"/;
+    }
+    close $fh;
+    return $count;
+}
+
+# File paths
+my $common_pot = 'po/common/common.pot';
+my $en_po = 'po/common/en.po';
+my $fr_po = 'po/common/fr.po';
+
+# Count the number of strings in each file
+my $common_pot_count = count_strings($common_pot);
+my $en_po_count = count_strings($en_po);
+my $fr_po_count = count_strings($fr_po);
+
+# Test if the number of strings are equal
+is($common_pot_count, $en_po_count, 'common.pot has the same number of strings as en.po');
+is($common_pot_count, $fr_po_count, 'common.pot has the same number of strings as fr.po');
+
+done_testing();


### PR DESCRIPTION
Add a test to check the number of strings in `po/common/common.pot` against `po/common/en.po` and `po/common/fr.po`.

* Create a new test file `t/po_common.t`
* Define a function to count the number of strings in a .po or .pot file
* Count the number of strings in `po/common/common.pot`, `po/common/en.po`, and `po/common/fr.po`
* Compare the number of strings in `po/common/common.pot` with `po/common/en.po` and `po/common/fr.po` and assert they are equal

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openfoodfacts/openfoodfacts-server?shareId=87074545-ba4f-4346-8efe-77b3ed987e21).