### PR TITLE
fix: improve parsing of 'category (type 1, type 2..)' ingredients WIP

### DIFF
--- a/tests/unit/ingredients_parsing.t
+++ b/tests/unit/ingredients_parsing.t
@@ -660,6 +660,11 @@ my @lists = (
 		"arôme naturel de citron, citron vert et d'autres agrumes",
 		"arôme naturel de citron, arôme naturel de citron vert, arôme naturel d'agrumes"
 	],
+	["fr", "Huiles végétales (colza, palme)", "huile de colza, huile de palme"],
+	["fr", "Huiles végétales 54.5% (colza, palme)", ""],
+	["fr", "Huiles végétales non hydrogénées (colza, palme)", ""],
+	["fr", "Huiles végétales bio (olive, palme, tournesol)", ""],
+
 );
 
 foreach my $test_ref (@lists) {


### PR DESCRIPTION
PR to better handle things like "vegetal oil (palm, rapeseed)":

- instead of turning "vegetal oil (palm, rapeseed)" to "palm vegetal oil", "rapeseed vegetal oil", we now turn it to "vegetal oil (palm vegetal oil, rapeseed vegetal oil)", as keeping a parent ingredient is better for ingredient percent estimation
- improved the definition of all the variations of "huile et stéarine végétales non hydrogénées (colza, palme)" to have better coverage
- added support for percentages like "huiles végétales 54% (colza, palme)"

Work in progress, some tests will need to be updated.