### PR TITLE
fix: refactor + ignore 'null' product_type sent by app

### DIFF
--- a/tests/integration/change_product_code_and_product_type.t
+++ b/tests/integration/change_product_code_and_product_type.t
@@ -220,6 +220,29 @@ my $tests_ref = [
 		},
 		ua => $moderator_ua,
 	},
+	# Send null product type
+	# 2024/11/21: the OFF app is sending product_type=null for new products
+	{
+		test_case => 'change-product-type-to-null-api-v2-moderator',
+		method => 'POST',
+		path => '/cgi/product_jqm_multilingual.pl',
+		form => {
+			code => "1234567890102",
+			product_type => "null",
+		},
+		ua => $moderator_ua,
+	},
+	# Send empty string product type
+	{
+		test_case => 'change-product-type-to-empty-string-api-v2-moderator',
+		method => 'POST',
+		path => '/cgi/product_jqm_multilingual.pl',
+		form => {
+			code => "1234567890102",
+			product_type => "",
+		},
+		ua => $moderator_ua,
+	},
 	# Send product_type=beauty to move product to Open Beauty Facts
 	{
 		test_case => 'change-product-type-to-beauty-api-v2-moderator',
@@ -390,7 +413,7 @@ my $tests_ref = [
 		}',
 		ua => $moderator_ua,
 	},
-	# Change the product_type field to petfood, with API v3
+	# Change the product_type field to invalid product type, with API v3
 	{
 		test_case => 'change-product-type-to-opff-api-v3-invalid-product-type',
 		method => 'PATCH',

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-normal-account.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-normal-account.json
@@ -1,4 +1,4 @@
 {
    "status" : 0,
-   "status_verbose" : "No permission: product_change_code"
+   "status_verbose" : "no_permission"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-normal-account.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-normal-account.json
@@ -1,4 +1,4 @@
 {
    "status" : 0,
-   "status_verbose" : "no_permission"
+   "status_verbose" : "no_permission: product_change_code"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-not-logged-in.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-not-logged-in.json
@@ -1,4 +1,4 @@
 {
    "status" : 0,
-   "status_verbose" : "No permission: product_change_code"
+   "status_verbose" : "no_permission"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-not-logged-in.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v2-not-logged-in.json
@@ -1,4 +1,4 @@
 {
    "status" : 0,
-   "status_verbose" : "no_permission"
+   "status_verbose" : "no_permission: product_change_code"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v3-moderator-existing-code.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v3-moderator-existing-code.json
@@ -11,7 +11,7 @@
             "name" : "Failure"
          },
          "message" : {
-            "id" : 0,
+            "id" : "error_new_code_already_exists",
             "lc_name" : "",
             "name" : ""
          }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v3-moderator-invalid-code.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-code-api-v3-moderator-invalid-code.json
@@ -11,9 +11,9 @@
             "name" : "Failure"
          },
          "message" : {
-            "id" : 0,
-            "lc_name" : "",
-            "name" : ""
+            "id" : "invalid_code",
+            "lc_name" : "Invalid code",
+            "name" : "Invalid code"
          }
       }
    ],

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-beauty-api-v2-normal-account.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-beauty-api-v2-normal-account.json
@@ -1,4 +1,4 @@
 {
    "status" : 0,
-   "status_verbose" : "no_permission"
+   "status_verbose" : "no_permission: product_change_product_type"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-beauty-api-v2-normal-account.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-beauty-api-v2-normal-account.json
@@ -1,4 +1,4 @@
 {
    "status" : 0,
-   "status_verbose" : "No permission: product_change_product_type"
+   "status_verbose" : "no_permission"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-empty-string-api-v2-moderator.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-empty-string-api-v2-moderator.json
@@ -1,0 +1,4 @@
+{
+   "status" : 0,
+   "status_verbose" : "invalid_product_type"
+}

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-empty-string-api-v2-moderator.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-empty-string-api-v2-moderator.json
@@ -1,4 +1,4 @@
 {
-   "status" : 0,
-   "status_verbose" : "invalid_product_type"
+   "status" : 1,
+   "status_verbose" : "fields saved"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-null-api-v2-moderator.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-null-api-v2-moderator.json
@@ -1,0 +1,4 @@
+{
+   "status" : 0,
+   "status_verbose" : "invalid_product_type"
+}

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-null-api-v2-moderator.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-null-api-v2-moderator.json
@@ -1,4 +1,4 @@
 {
-   "status" : 0,
-   "status_verbose" : "invalid_product_type"
+   "status" : 1,
+   "status_verbose" : "fields saved"
 }

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-opff-api-v3-invalid-product-type.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/change-product-type-to-opff-api-v3-invalid-product-type.json
@@ -11,9 +11,9 @@
             "name" : "Failure"
          },
          "message" : {
-            "id" : 0,
-            "lc_name" : "",
-            "name" : ""
+            "id" : "invalid_product_type",
+            "lc_name" : "Invalid product type",
+            "name" : "Invalid product type"
          }
       }
    ],

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
@@ -83,7 +83,7 @@
             "origins_of_ingredients" : {
                "aggregated_origins" : [
                   {
-                     "epi_score" : "0",
+                     "epi_score" : 0,
                      "origin" : "en:unknown",
                      "percent" : 100,
                      "transportation_score" : 0

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
@@ -83,7 +83,7 @@
             "origins_of_ingredients" : {
                "aggregated_origins" : [
                   {
-                     "epi_score" : 0,
+                     "epi_score" : "0",
                      "origin" : "en:unknown",
                      "percent" : 100,
                      "transportation_score" : 0


### PR DESCRIPTION
I'm hoping this PR will fix https://github.com/openfoodfacts/smooth-app/issues/5864

If we receive product_type=null, we just ignore it.

Also refactored the code to remove some duplication.