### PR TITLE
fix: labeler.yml for Estonia packager code

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -747,7 +747,7 @@ Portugal:
   - any-glob-to-any-file: 'scripts/packager-codes/portugal-geocode.sh'
   - any-glob-to-any-file: 'scripts/packager-codes/portugal-concatenate-csv-sections.py'
 
-:
+Estonia:
 - changed-files:
   - any-glob-to-any-file: 'scripts/packager-codes/toidukaitlejad-tsv.xsl'
 


### PR DESCRIPTION
This PR fixes a bug from https://github.com/openfoodfacts/openfoodfacts-server/pull/11017 that makes tests fail for all PRs.

```
 750 | :
-------^
 751 | - changed-files:
 752 |   - any-glob-to-any-file: 'scri ...
Error: incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line (750:1)
```