### PR TITLE
Improve edit button visibility

### DIFF
--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -92,6 +92,19 @@
                         <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
                                 href="#contribution"><span>[% lang("contribution_navigation") %]</span></a></li>
 
+                        <!-- Share Button -->
+                        <li class="nav-button" style="float: right;">
+                            <a href="[% request_ref.canon_url %]" class="button small" title="[% title %]"
+                                style="display: inline-flex; align-items: center;">
+                                <span class="material-icons size-20" style="margin-right: 0.25rem;">
+                                    share
+                                </span>
+                                <span class="show-for-large-up">
+                                    [% lang('share') %]
+                                </span>
+                            </a>
+                        </li>
+
                         <!-- Edit Button -->
                         <li class="nav-button" style="float: right;">
                             <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round"
@@ -102,19 +115,6 @@
                                 </span>
                                 <span class="show-for-large-up">
                                     [% lang('edit_product_page') %]
-                                </span>
-                            </a>
-                        </li>
-
-                        <!-- Share Button -->
-                        <li class="nav-button" style="float: right;">
-                            <a href="[% request_ref.canon_url %]" class="button small white-button round"
-                                title="[% title %]" style="display: inline-flex; align-items: center;">
-                                <span class="material-icons size-20" style="margin-right: 0.25rem;">
-                                    share
-                                </span>
-                                <span class="show-for-large-up">
-                                    [% lang('share') %]
                                 </span>
                             </a>
                         </li>

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -1,21 +1,24 @@
 <!-- start templates/[% template.name %] -->
 <script src="[% static_subdomain %]/js/dist/JsBarcode.all.min.js"></script>
 [% IF product_changes_saved %]
-    <div data-alert class="alert-box info">
-        <span>lang('product_changes_saved')</span>
-        <a href="#" class="close">&times;</a>
-    </div>
-    [% IF structured_response_count > 0 %]
-        [% search_result %] <hr>
-    [% END %]
+<div data-alert class="alert-box info">
+    <span>lang('product_changes_saved')</span>
+    <a href="#" class="close">&times;</a>
+</div>
+[% IF structured_response_count > 0 %]
+[% search_result %]
+<hr>
+[% END %]
 [% END %]
 
 
 [% IF (robotoff_url.defined) && (robotoff_url.length > 0) %]
-    <!-- Anonymous users will only be able to vote see AnnotationVote in robotoff,
+<!-- Anonymous users will only be able to vote see AnnotationVote in robotoff,
         the voter uniqueness is based on a hash of its ip address
     -->
-	<robotoff-asker url='[% robotoff_url %]' code='[% code %]' lang='[% lc %]' style='display: none;' caption-yes='[% esq(lang("button_caption_yes")) %]' caption-no='[% esq(lang("button_caption_no")) %]' caption-skip='[% esq(lang("button_caption_skip")) %]'></robotoff-asker>
+<robotoff-asker url='[% robotoff_url %]' code='[% code %]' lang='[% lc %]' style='display: none;'
+    caption-yes='[% esq(lang("button_caption_yes")) %]' caption-no='[% esq(lang("button_caption_no")) %]'
+    caption-skip='[% esq(lang("button_caption_skip")) %]'></robotoff-asker>
 [% END %]
 
 <a href="#upNav" class="back-to-top scrollto button">
@@ -29,235 +32,256 @@
             <div class="large-12 flex-grid ">
                 <h1 class="title-3" property="food:name" itemprop="name">[% title %]</h1>
                 <div class="buttons_prod">
-                    <!-- Edit product page -->
-                    <div class="edit_button">
-                        <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round" title="[% edq(lang('edit_product_page')) %]">
-                            <span class="material-icons size-20 ">
-                            edit
-                            </span>
-                            <span class="show-for-large-up">[% lang('edit_product_page') %]</span>
-                        </a>
-                    </div>
-
-                    <!-- Share -->
-                    <div class="share_button" style="display:none;">
-                        <a href="[% request_ref.canon_url %]" class="button small" title="[% title %]">
-                            <span class="material-icons size-20 ">
-                            share
-                            </span>
-
-                            <span class="show-for-large-up">[% lang('share') %]</span>
-                        </a>
-                    </div>
-
-
                     [% IF user_moderator %]
                     <!-- Delete product page -->
-                        <div class="delete_button">
-                            <a href="/cgi/product.pl?type=delete&code=[% code %]" class="button small alert" title="[% edq(lang('delete_product_page')) %]">
-                                <span class="material-icons size-20 ">
+                    <div class="delete_button">
+                        <a href="/cgi/product.pl?type=delete&code=[% code %]" class="button small alert"
+                            title="[% edq(lang('delete_product_page')) %]">
+                            <span class="material-icons size-20 ">
                                 delete
-                                </span>
-                                <span class="show-for-large-up"> [% lang('delete_product_page') %]</span>
-                            </a>
-                        </div>
+                            </span>
+                            <span class="show-for-large-up"> [% lang('delete_product_page') %]</span>
+                        </a>
+                    </div>
                     [% END %]
 
                     [% IF server_options_producers_platform %]
-                        <div class="delete_button">
-                            <a href="/cgi/export_products.pl?query_code=[% code %]" class="button small" title="[% edq(lang('export_product_page')) %]">
-                                <span class="material-icons size-20 ">
+                    <div class="delete_button">
+                        <a href="/cgi/export_products.pl?query_code=[% code %]" class="button small"
+                            title="[% edq(lang('export_product_page')) %]">
+                            <span class="material-icons size-20 ">
                                 publish
-                                </span>
-                                <span class="show-for-large-up"> [% lang('export_product_page') %]</span>
-                            </a>
-                        </div>
+                            </span>
+                            <span class="show-for-large-up"> [% lang('export_product_page') %]</span>
+                        </a>
+                    </div>
                     [% END %]
                 </div>
-            </div> 
+            </div>
         </div>
     </div>
     <div class="block v-space-tiny prod-nav product_banner_unranked" id="prodNav">
         <div class="row h-space-normal">
             <div class="large-12">
-               <nav id="navbar" class="navbar h-space-tiny">
+                <nav id="navbar" class="navbar h-space-tiny">
                     <ul class="inline-list">
-                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#product"><span>[% lang("product") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#product"><span>[% lang("product") %]</span></a></li>
                         [% IF user_preferences %]
-                            <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#match"><span>[% lang("your_criteria") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#match"><span>[% lang("your_criteria") %]</span></a></li>
                         [% END %]
                         [% IF health_card_panel %]
-                            <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#health"><span>[% lang("health") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#health"><span>[% lang("health") %]</span></a></li>
                         [% END %]
-                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#environment"><span>[% lang("environment") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#environment"><span>[% lang("environment") %]</span></a></li>
                         [% IF secondhand_card_panel %]
-                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#secondhand"><span>[% lang("secondhand") %]</span></a></li>
-                        [% END %]                        
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#secondhand"><span>[% lang("secondhand") %]</span></a></li>
+                        [% END %]
                         [% IF report_problem_card_panel %]
-                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#report_problem"><span>[% lang("report_problem_navigation") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#report_problem"><span>[% lang("report_problem_navigation") %]</span></a></li>
                         [% END %]
                         [% IF display_data_quality_issues_and_improvement_opportunities %]
-                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#improvement"><span>[% lang("improvements_navigation") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#improvement"><span>[% lang("improvements_navigation") %]</span></a></li>
                         [% END %]
-                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button" href="#contribution"><span>[% lang("contribution_navigation") %]</span></a></li>
+                        <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
+                                href="#contribution"><span>[% lang("contribution_navigation") %]</span></a></li>
+
+                        <!-- Edit Button -->
+                        <li class="nav-button" style="float: right;">
+                            <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round"
+                                title="[% edq(lang('edit_product_page')) %]">
+                                <span class="material-icons size-20 ">
+                                    edit
+                                </span>
+                                <span class="show-for-large-up">[% lang('edit_product_page') %]</span>
+                            </a>
+                        </li>
+
+                        <!-- Share Button -->
+                        <li class="nav-button" style="float: right;">
+                            <a href="[% request_ref.canon_url %]" class="button small" title="[% title %]">
+                                <span class="material-icons size-20 ">
+                                    share
+                                </span>
+
+                                <span class="show-for-large-up">[% lang('share') %]</span>
+                            </a>
+                        </li>
                     </ul>
                 </nav><!-- .navbar -->
-            </div> 
+            </div>
         </div>
     </div>
-<div id="prodInfos">
-    <!-- product_characteristics -->
-    <section class="row" id="product">
-        <div class="large-12 column">
-            
-            <div class="card" style="border-top:none">
-                <div id="prodBanner" style="display:none"></div>
-                <div class="card-section">
-                    [% IF front_image %]
+    <div id="prodInfos">
+        <!-- product_characteristics -->
+        <section class="row" id="product">
+            <div class="large-12 column">
+
+                <div class="card" style="border-top:none">
+                    <div id="prodBanner" style="display:none"></div>
+                    <div class="card-section">
+                        [% IF front_image %]
                         <div class="row">
                             <div class="medium-4 small-12 columns">
                                 [% INCLUDE web/panels/image.tt.html code = code image = front_image %]
                             </div>
                             <div class="medium-8 small-12 columns">
-                    [% END %]   
+                                [% END %]
 
 
-                    <h2 class="title-1" property="food:name" itemprop="name">[% title %]</h1>
+                                <h2 class="title-1" property="food:name" itemprop="name">[% title %]</h1>
 
-                    [% IF server_options_producers_platform %]
-                        <p>→ <a href="[% public_product_url %]">[% lang("product_page_on_the_public_database") %]</a></p>
-                    [% END %]
-                    
-            <!-- Obsolete product -->
-            [% IF product_is_obsolete %]
-                <div data-alert class="alert-box warn" id="obsolete" style="display: block; background:#ffaa33;color:black;">
-                    [% warning %]
-                </div>
-            [% END %]
+                                    [% IF server_options_producers_platform %]
+                                    <p>→ <a href="[% public_product_url %]">[%
+                                            lang("product_page_on_the_public_database") %]</a></p>
+                                    [% END %]
 
-            <!-- GS1-Prefixes for restricted circulation numbers within a company - warn for possible conflicts -->
-            [% IF gs1_prefixes %]
-                <div data-alert class="alert-box info" id="warning_gs1_company_prefix" style="display: block;">
-                    [% lang('warning_gs1_company_prefix') %]
-                    <a href="#" class="close">&times;</a></span>
-                </div>
-            [% END %]
+                                    <!-- Obsolete product -->
+                                    [% IF product_is_obsolete %]
+                                    <div data-alert class="alert-box warn" id="obsolete"
+                                        style="display: block; background:#ffaa33;color:black;">
+                                        [% warning %]
+                                    </div>
+                                    [% END %]
 
-            [% IF rev.defined %]
-                [% display_rev_info %]
-            [% ELSIF not_has_tag == "states-en:complete" %]
-                <div data-alert class="alert-box info" id="warning_not_complete" style="display: block;">
-                    [% lang("warning_not_complete") %]
-                    <a href="#" class="close">&times;</a></span>
-                </div>
-            [% END %]
+                                    <!-- GS1-Prefixes for restricted circulation numbers within a company - warn for possible conflicts -->
+                                    [% IF gs1_prefixes %]
+                                    <div data-alert class="alert-box info" id="warning_gs1_company_prefix"
+                                        style="display: block;">
+                                        [% lang('warning_gs1_company_prefix') %]
+                                        <a href="#" class="close">&times;</a></span>
+                                    </div>
+                                    [% END %]
 
-            <!-- owner -->
-            [% IF owner %]
-                <p>
-                    [% FILTER format(lang("sources_manufacturer")) %]<a href="/editor/[% owner %]">[% owner_org.name %]</a>[% END %]
-                    
-                    [% IF owner_org.customer_service.email || owner_org.customer_service.link || owner_org.customer_service.phone %]
-                            - [% lang("customer_service") %][% sep %]:
-                            [% IF owner_org.customer_service.email %]
-                                [% display_icon('email') %] <a href="mailto:[% owner_org.customer_service.email %]">[% owner_org.customer_service.email %]</a>
-                            [% ELSIF owner_org.customer_service.link %]
-                                [% display_icon('email') %] <a href="[% owner_org.customer_service.link %]">[% lang("contact_form") %]</a>
-                            [% END %]
-                            
-                            [% IF owner_org.customer_service.phone %]
-                                [% display_icon('phone') %] <span itemprop="telephone"><a href="tel:[% owner_org.customer_service.phone %]">[% owner_org.customer_service.phone %]</a></span>
-                            [% END %]
-                    [% END %]
-                </p>
-            [% END %]                    
-                    
-                    <!-- Display UPC code if the EAN starts with 0 -->
-                        [% IF upc_code == 'defined' %]
-                            <div id="barcode_div">
-                                <!-- Display only text of the code if mobile -->
-                                <div id="barcode_div_code">
-                                    <p id="barcode_paragraph">[% lang("barcode") %]: <br id="barcode_br"><span id="barcode" property="food:code" itemprop="gtin13" style="speak-as:digits;">[% code %]</span>[% upc %]</p>
-                                </div>
-                                <!-- Display with SVG if not mobile -->
-                                <div id="barcode_div_svg">
-                                    <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
-                                        jsbarcode-value="[% code %]"
-                                        jsbarcode-displayValue="false"
-                                        jsbarcode-height="40">
-                                    </svg>
-                                </div>
-                            </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
-                            <div property="gr:hasEAN_UCC-13" content="[% code %]" datatype="xsd:string"></div>
-                        [% ELSE %]
-                         [%# put in DOM for folksonomy %]
-                          <span id="barcode"  style="display: none;">[% code %]</span>
-                        [% END %]
-                        
-                        [% product_fields %]
+                                    [% IF rev.defined %]
+                                    [% display_rev_info %]
+                                    [% ELSIF not_has_tag == "states-en:complete" %]
+                                    <div data-alert class="alert-box info" id="warning_not_complete"
+                                        style="display: block;">
+                                        [% lang("warning_not_complete") %]
+                                        <a href="#" class="close">&times;</a></span>
+                                    </div>
+                                    [% END %]
 
-                    [% IF front_image.defined %]
+                                    <!-- owner -->
+                                    [% IF owner %]
+                                    <p>
+                                        [% FILTER format(lang("sources_manufacturer")) %]<a
+                                            href="/editor/[% owner %]">[% owner_org.name %]</a>[% END %]
+
+                                        [% IF owner_org.customer_service.email || owner_org.customer_service.link ||
+                                        owner_org.customer_service.phone %]
+                                        - [% lang("customer_service") %][% sep %]:
+                                        [% IF owner_org.customer_service.email %]
+                                        [% display_icon('email') %] <a
+                                            href="mailto:[% owner_org.customer_service.email %]">[%
+                                            owner_org.customer_service.email %]</a>
+                                        [% ELSIF owner_org.customer_service.link %]
+                                        [% display_icon('email') %] <a href="[% owner_org.customer_service.link %]">[%
+                                            lang("contact_form") %]</a>
+                                        [% END %]
+
+                                        [% IF owner_org.customer_service.phone %]
+                                        [% display_icon('phone') %] <span itemprop="telephone"><a
+                                                href="tel:[% owner_org.customer_service.phone %]">[%
+                                                owner_org.customer_service.phone %]</a></span>
+                                        [% END %]
+                                        [% END %]
+                                    </p>
+                                    [% END %]
+
+                                    <!-- Display UPC code if the EAN starts with 0 -->
+                                    [% IF upc_code == 'defined' %]
+                                    <div id="barcode_div">
+                                        <!-- Display only text of the code if mobile -->
+                                        <div id="barcode_div_code">
+                                            <p id="barcode_paragraph">[% lang("barcode") %]: <br id="barcode_br"><span
+                                                    id="barcode" property="food:code" itemprop="gtin13"
+                                                    style="speak-as:digits;">[% code %]</span>[% upc %]</p>
+                                        </div>
+                                        <!-- Display with SVG if not mobile -->
+                                        <div id="barcode_div_svg">
+                                            <svg id="barcode_svg" jsbarcode-format="auto" jsbarcode-value="[% code %]"
+                                                jsbarcode-displayValue="false" jsbarcode-height="40">
+                                            </svg>
+                                        </div>
+                                    </div>
+                                    <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                                    <div property="gr:hasEAN_UCC-13" content="[% code %]" datatype="xsd:string"></div>
+                                    [% ELSE %]
+                                    [%# put in DOM for folksonomy %]
+                                    <span id="barcode" style="display: none;">[% code %]</span>
+                                    [% END %]
+
+                                    [% product_fields %]
+
+                                    [% IF front_image.defined %]
                             </div>
                         </div>
-                    [% END %]   
+                        [% END %]
 
                     </div>
                 </div>
             </div>
-        </div>
+    </div>
     </section>
 
-[% IF user_preferences %]
+    [% IF user_preferences %]
     <!-- product summary -->
     <section class="row" id="match">
         <div class="large-12 column">
-            
+
             <div class="card">
                 <div class="card-section">
                     <h2 id="match_title">[% lang('matching_with_your_preferences') %]</h2>
 
                     <div id="match_score_and_status"></div>
-                            
+
                     <div id="product_summary" class="v-space-short text-left"></div>
 
                     <div id="preferences_selected" class="text-left"></div>
-                        
-                    <div id="preferences_selection_form" class="text-left v-space-whide h-space-wide" style="display:none"></div>                   
+
+                    <div id="preferences_selection_form" class="text-left v-space-whide h-space-wide"
+                        style="display:none"></div>
                 </div>
             </div>
 
         </div>
     </section>
-[% END %]
+    [% END %]
 
-[% IF health_card_panel %]
+    [% IF health_card_panel %]
     <section class="row" id="health">
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
-                        [% health_card_panel %]
+                    [% health_card_panel %]
                 </div>
             </div>
         </div>
     </section>
-[% END %]
+    [% END %]
 
     <section class="row" id="environment">
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
-                        [% environment_card_panel %]
+                    [% environment_card_panel %]
                 </div>
             </div>
         </div>
     </section>
 
-<!-- other fields -->
-[% IF other_fields != "" %]
+    <!-- other fields -->
+    [% IF other_fields != "" %]
     <section class="row" id="other">
-    <!-- product_characteristics -->
+        <!-- product_characteristics -->
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
@@ -271,147 +295,124 @@
             </div>
         </div>
     </section>
-[% END %]
+    [% END %]
 
 
-[% IF secondhand_card_panel %]
-<section class="row" id="secondhand">
+    [% IF secondhand_card_panel %]
+    <section class="row" id="secondhand">
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
-                        [% secondhand_card_panel %]
+                    [% secondhand_card_panel %]
                 </div>
             </div>
         </div>
     </section>
-[% END %]
+    [% END %]
 
-<!-- Report problem card, if not on the platform for producers -->    
-[% IF ! server_options_producers_platform %]
+    <!-- Report problem card, if not on the platform for producers -->
+    [% IF ! server_options_producers_platform %]
     <section class="row" id="report_problem">
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
-                        [% report_problem_card_panel %]
+                    [% report_problem_card_panel %]
                 </div>
             </div>
         </div>
     </section>
-[% END %]
+    [% END %]
 
-<!-- Platform for producers: data quality issues and improvements opportunities -->
-[% IF server_options_producers_platform %]
+    <!-- Platform for producers: data quality issues and improvements opportunities -->
+    [% IF server_options_producers_platform %]
 
     <section class="row" id="improvement">
         <div class="large-12 column">
             <div class="card">
                 <div class="card-section">
-    [% display_data_quality_issues_and_improvement_opportunities %]
+                    [% display_data_quality_issues_and_improvement_opportunities %]
                 </div>
             </div>
         </div>
     </section>
-[% END %]
+    [% END %]
 
-[% IF contribution_card_panel %]
-<section class="row" id="contribution">
-    <div class="large-12 column">
-        <div class="card">
-            <div class="card-section">
+    [% IF contribution_card_panel %]
+    <section class="row" id="contribution">
+        <div class="large-12 column">
+            <div class="card">
+                <div class="card-section">
                     [% contribution_card_panel %]
+                </div>
             </div>
         </div>
-    </div>
-</section>
-[% ELSE %]
-<a id="contribution"></a>
-[% END %]
+    </section>
+    [% ELSE %]
+    <a id="contribution"></a>
+    [% END %]
 
-<section class="row" >
-    <div class="large-12 column">
-        <div class="card">
-            <div class="card-section">
-
-                <h2 id="data_sources" class="text-medium">[% lang('data_sources_p') FILTER ucfirst %]</h2>
-<!-- photos and data sources -->
-[%IF sources %]
-
-	[% lang("list_of_sources") %]
-	<ul>
-	[% FOREACH source IN unique_sources %]
-		<li>
-			[% IF source.url %]
-				<a href="\[% source.url %]\">[% source.name %]</a></li>
-			[% ELSE %]
-				[% source.name %]
-			[% END %]
-			
-			[% IF source.source_licence_url %]
-				<a href="\[% source.source_licence_url %]\">[% source.name %]</a></li>
-			[% ELSE %]
-				[% source.source_licence %]
-			[% END %]
-		</li>
-	[% END %]
-	</ul>
-[% END %]
-
-<!-- databases data sources -->
-
-        [% IF data_source_database_provider %]
-            <p>[% data_source_database_provider %]</p>
-        [% END %]
-        [% IF data_source_database_note_about_the_producers_platform %]
-            <p>[% data_source_database_note_about_the_producers_platform %]</p>
-        [% END %]
-
-
-        <p class="details">
-            [% lang('product_added') %] [% created_date %] [% lang('by') %] [% creator %]<br>
-            [% lang('product_last_edited') %] [% last_modified_date %] [% lang('by') %] [% last_editor %].
-            [% other_editors %]
-            [% checked %]
-        </p>
- 
-            <div class="alert-box info">
-                [% lang('fixme_product') %]
-            </div>
-
-
-[% IF (user_id.defined) %]
-        [% display_field_states %]
-[% END %]
-
-</div>
-</div>
-</div>
-</section>
-
-<section class="row" >
-    <div class="large-12 column">
-        <div class="card">
-            <div class="card-section">
-
-    <section class="row" >
+    <section class="row">
         <div class="large-12 column">
-[% display_product_history %]
+            <div class="card">
+                <div class="card-section">
+
+                    <h2 id="data_sources" class="text-medium">[% lang('data_sources_p') FILTER ucfirst %]</h2>
+                    <!-- photos and data sources -->
+                    [%IF sources %]
+
+                    [% lang("list_of_sources") %]
+                    <ul>
+                        [% FOREACH source IN unique_sources %]
+                        <li>
+                            [% IF source.url %]
+                            <a href="\[% source.url %]\">[% source.name %]</a>
+                        </li>
+                        [% ELSE %]
+                        [% source.name %]
+                        [% END %]
+
+                        [% IF source.source_licence_url %]
+                        <a href="\[% source.source_licence_url %]\">[% source.name %]</a></li>
+                        [% ELSE %]
+                        [% source.source_licence %]
+                        [% END %]
+                        </li>
+                        [% END %]
+                    </ul>
+                    [% END %]
+
+                    <!-- databases data sources -->
+
+                    [% IF data_source_database_provider %]
+                    <p>[% data_source_database_provider %]</p>
+                    [% END %]
+                    [% IF data_source_database_note_about_the_producers_platform %]
+                    <p>[% data_source_database_note_about_the_producers_platform %]</p>
+                    [% END %]
+
+
+                    <p class="details">
+                        [% lang('product_added') %] [% created_date %] [% lang('by') %] [% creator %]<br>
+                        [% lang('product_last_edited') %] [% last_modified_date %] [% lang('by') %] [% last_editor %].
+                        [% other_editors %]
+                        [% checked %]
+                    </p>
+
+                    <div class="alert-box info">
+                        [% lang('fixme_product') %]
+                    </div>
+
+
+                    [% IF (user_id.defined) %]
+                    [% display_field_states %]
+                    [% END %]
+
+                </div>
+            </div>
         </div>
     </section>
 
 
-        <div class="edit_button center text-center" >
-            <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small">
-                [% display_icon('edit') %]
-                [% lang('edit_product_page') %]
-            </a>
-        </div>
+    [% INCLUDE web/common/includes/folksonomy_script.tt.html %]
 
-
-    </div>
-</div>
-</div>
-</section>
-
-[% INCLUDE web/common/includes/folksonomy_script.tt.html %]
-
-<!-- end templates/[% template.name %] -->
+    <!-- end templates/[% template.name %] -->

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -91,7 +91,6 @@
                         [% END %]
                         <li class="product-section-button"><a class="nav-link scrollto button small round white-button"
                                 href="#contribution"><span>[% lang("contribution_navigation") %]</span></a></li>
-
                         <!-- Share Button -->
                         <li class="nav-button" style="float: right;">
                             <a href="[% request_ref.canon_url %]" class="button small" title="[% title %]"
@@ -104,7 +103,6 @@
                                 </span>
                             </a>
                         </li>
-
                         <!-- Edit Button -->
                         <li class="nav-button" style="float: right;">
                             <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round"

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -95,22 +95,27 @@
                         <!-- Edit Button -->
                         <li class="nav-button" style="float: right;">
                             <a href="/cgi/product.pl?type=edit&code=[% code %]" class="button small white-button round"
-                                title="[% edq(lang('edit_product_page')) %]">
-                                <span class="material-icons size-20 ">
+                                title="[% edq(lang('edit_product_page')) %]"
+                                style="display: inline-flex; align-items: center;">
+                                <span class="material-icons size-20" style="margin-right: 0.25rem;">
                                     edit
                                 </span>
-                                <span class="show-for-large-up">[% lang('edit_product_page') %]</span>
+                                <span class="show-for-large-up">
+                                    [% lang('edit_product_page') %]
+                                </span>
                             </a>
                         </li>
 
                         <!-- Share Button -->
                         <li class="nav-button" style="float: right;">
-                            <a href="[% request_ref.canon_url %]" class="button small" title="[% title %]">
-                                <span class="material-icons size-20 ">
+                            <a href="[% request_ref.canon_url %]" class="button small white-button round"
+                                title="[% title %]" style="display: inline-flex; align-items: center;">
+                                <span class="material-icons size-20" style="margin-right: 0.25rem;">
                                     share
                                 </span>
-
-                                <span class="show-for-large-up">[% lang('share') %]</span>
+                                <span class="show-for-large-up">
+                                    [% lang('share') %]
+                                </span>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
### What

This pull request addresses issue [[#10865](https://github.com/openfoodfacts/openfoodfacts-server/issues/10865)](https://github.com/openfoodfacts/openfoodfacts-server/issues/10865) by improving the web user experience on the product page. Previously, the "Edit" and "Share" buttons were positioned at the top and bottom of the page. This placement required users to scroll back to those specific areas to access these actions, which could be inconvenient, especially on pages with extensive product information.

**Changes Made:**

- **Moved "Edit" and "Share" Buttons to Navbar:**
  - Updated the `product_page.tt.html` template to include the "Edit" and "Share" buttons within the navbar's inline list.
  - This change makes the buttons always visible as the user scrolls down the page, enhancing accessibility.

- **Adjusted HTML Structure:**
  - Incorporated the buttons as `<li>` elements within the existing `<ul class="inline-list">` in the navbar.
  - Ensured that the buttons are properly integrated without disrupting the existing navigation items.

- **Removed Redundant "Edit" Button at Bottom:**
  - Eliminated the duplicate "Edit" button from the bottom of the product page to streamline the user interface.
  - This reduces clutter and potential confusion for users.

**Why These Changes Were Made:**

- **Enhanced Usability:**
  - Keeping the "Edit" and "Share" buttons visible at all times allows users to access these actions without unnecessary scrolling.
  - Improves the overall user experience by making key functionalities readily available.

- **Consistency Across Pages:**
  - Aligns the product page with modern web design practices where important actions are accessible within sticky navigation elements.
  - Provides a consistent interface for users across different sections of the website.

### Screenshot
![Screenshot 2024-11-22 at 4 51 18 PM](https://github.com/user-attachments/assets/c88cbc60-64c1-4f25-9b8f-55986a05af46)

#### Before:

*The "Edit" and "Share" buttons are located at the top and bottom of the page, requiring scrolling to access them.*

![Before Screenshot](link_to_before_screenshot)

#### After:

*The "Edit" and "Share" buttons are now located in the navbar, aligned to the right, and remain visible as the user scrolls.*

![After Screenshot](link_to_after_screenshot)

### Related issue(s) and discussion

- Fixes [[#10865](https://github.com/openfoodfacts/openfoodfacts-server/issues/10865)](https://github.com/openfoodfacts/openfoodfacts-server/issues/10865)
