### PR TITLE
fix: API redirects for product types

### DIFF
--- a/lib/ProductOpener/APIProductRead.pm
+++ b/lib/ProductOpener/APIProductRead.pm
@@ -148,7 +148,8 @@ sub read_product_api ($request_ref) {
 			and (($requested_product_type eq "all") or ($requested_product_type eq $product_ref->{product_type})))
 		{
 			redirect_to_url($request_ref, 302,
-				format_subdomain($subdomain, $product_ref->{product_type}) . $request_ref->{original_query_string});
+				format_subdomain($subdomain, $product_ref->{product_type}) . "/"
+					. $request_ref->{original_query_string});
 		}
 		else {
 			add_error(

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -10624,7 +10624,8 @@ sub display_product_api ($request_ref) {
 			and (($requested_product_type eq "all") or ($requested_product_type eq $product_ref->{product_type})))
 		{
 			redirect_to_url($request_ref, 302,
-				format_subdomain($subdomain, $product_ref->{product_type}) . $request_ref->{original_query_string});
+				format_subdomain($subdomain, $product_ref->{product_type}) . "/"
+					. $request_ref->{original_query_string});
 		}
 		else {
 			$request_ref->{status_code} = 404;

--- a/tests/integration/change_product_code_and_product_type.t
+++ b/tests/integration/change_product_code_and_product_type.t
@@ -208,7 +208,7 @@ my $tests_ref = [
 			product_type => "food",
 		},
 		ua => $ua,
-	},	
+	},
 	# Send product_type=beauty to move product to Open Beauty Facts, normal account
 	{
 		test_case => 'change-product-type-to-beauty-api-v2-normal-account',
@@ -451,7 +451,7 @@ my $tests_ref = [
 		}',
 		ua => $ua,
 		expected_status_code => 200,
-	},	
+	},
 	# Change the product_type field to petfood, with API v3, normal account
 	{
 		test_case => 'change-product-type-to-opff-api-v3-normal-account',

--- a/tests/integration/change_product_code_and_product_type.t
+++ b/tests/integration/change_product_code_and_product_type.t
@@ -198,6 +198,17 @@ my $tests_ref = [
 		}',
 		ua => $moderator_ua,
 	},
+	# Send existing product type, normal account
+	{
+		test_case => 'send-existing-product-type-api-v2-normal-account',
+		method => 'POST',
+		path => '/cgi/product_jqm_multilingual.pl',
+		form => {
+			code => "1234567890102",
+			product_type => "food",
+		},
+		ua => $ua,
+	},	
 	# Send product_type=beauty to move product to Open Beauty Facts, normal account
 	{
 		test_case => 'change-product-type-to-beauty-api-v2-normal-account',
@@ -427,7 +438,21 @@ my $tests_ref = [
 		ua => $moderator_ua,
 		expected_status_code => 400,
 	},
-	# Change the product_type field to petfood, with API v3
+	# Send existing product type, with API v3, normal account
+	{
+		test_case => 'send-existing-product-type-api-v3-normal-account',
+		method => 'PATCH',
+		path => '/api/v3/product/1234567890300',
+		body => '{
+			"tags_lc": "en",
+			"product": {
+				"product_type": "food"
+			}
+		}',
+		ua => $ua,
+		expected_status_code => 200,
+	},	
+	# Change the product_type field to petfood, with API v3, normal account
 	{
 		test_case => 'change-product-type-to-opff-api-v3-normal-account',
 		method => 'PATCH',
@@ -441,7 +466,7 @@ my $tests_ref = [
 		ua => $ua,
 		expected_status_code => 403,
 	},
-	# Change the product_type field to petfood, with API v3
+	# Change the product_type field to petfood, with API v3, moderator account
 	{
 		test_case => 'change-product-type-to-opff-api-v3',
 		method => 'PATCH',

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-obf-product-with-api-v3-no-product-type.html
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-obf-product-with-api-v3-no-product-type.html
@@ -3,7 +3,7 @@
 <title>302 Found</title>
 </head><body>
 <h1>Found</h1>
-<p>The document has moved <a href="//world.openbeautyfacts.orgapi/v3/product/1234567890102?product_type=all">here</a>.</p>
+<p>The document has moved <a href="//world.openbeautyfacts.org/api/v3/product/1234567890102?product_type=all">here</a>.</p>
 <hr>
 <address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
 </body></html>

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-all-product-type-api-v2.html
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-all-product-type-api-v2.html
@@ -3,7 +3,7 @@
 <title>302 Found</title>
 </head><body>
 <h1>Found</h1>
-<p>The document has moved <a href="//world.openproductsfacts.orgapi/v2/product/1234567890200?product_type=all">here</a>.</p>
+<p>The document has moved <a href="//world.openproductsfacts.org/api/v2/product/1234567890200?product_type=all">here</a>.</p>
 <hr>
 <address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
 </body></html>

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-all-product-type-api-v3.html
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-all-product-type-api-v3.html
@@ -3,7 +3,7 @@
 <title>302 Found</title>
 </head><body>
 <h1>Found</h1>
-<p>The document has moved <a href="//world.openproductsfacts.orgapi/v3/product/1234567890200?product_type=all">here</a>.</p>
+<p>The document has moved <a href="//world.openproductsfacts.org/api/v3/product/1234567890200?product_type=all">here</a>.</p>
 <hr>
 <address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
 </body></html>

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-right-product-type-api-v2.html
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-right-product-type-api-v2.html
@@ -3,7 +3,7 @@
 <title>302 Found</title>
 </head><body>
 <h1>Found</h1>
-<p>The document has moved <a href="//world.openproductsfacts.orgapi/v2/product/1234567890200?product_type=product">here</a>.</p>
+<p>The document has moved <a href="//world.openproductsfacts.org/api/v2/product/1234567890200?product_type=product">here</a>.</p>
 <hr>
 <address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
 </body></html>

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-right-product-type-api-v3.html
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opf-with-right-product-type-api-v3.html
@@ -3,7 +3,7 @@
 <title>302 Found</title>
 </head><body>
 <h1>Found</h1>
-<p>The document has moved <a href="//world.openproductsfacts.orgapi/v3/product/1234567890200?product_type=product">here</a>.</p>
+<p>The document has moved <a href="//world.openproductsfacts.org/api/v3/product/1234567890200?product_type=product">here</a>.</p>
 <hr>
 <address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
 </body></html>

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opff-with-all-product-type-api-v3.html
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-opff-with-all-product-type-api-v3.html
@@ -3,7 +3,7 @@
 <title>302 Found</title>
 </head><body>
 <h1>Found</h1>
-<p>The document has moved <a href="//world.openpetfoodfacts.orgapi/v3/product/1234567890300?product_type=all">here</a>.</p>
+<p>The document has moved <a href="//world.openpetfoodfacts.org/api/v3/product/1234567890300?product_type=all">here</a>.</p>
 <hr>
 <address>Apache/2.4.62 (Debian) Server at world.openfoodfacts.localhost Port 80</address>
 </body></html>

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
@@ -83,7 +83,7 @@
             "origins_of_ingredients" : {
                "aggregated_origins" : [
                   {
-                     "epi_score" : "0",
+                     "epi_score" : 0,
                      "origin" : "en:unknown",
                      "percent" : 100,
                      "transportation_score" : 0

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/get-product-with-new-code.json
@@ -83,7 +83,7 @@
             "origins_of_ingredients" : {
                "aggregated_origins" : [
                   {
-                     "epi_score" : 0,
+                     "epi_score" : "0",
                      "origin" : "en:unknown",
                      "percent" : 100,
                      "transportation_score" : 0

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/send-existing-product-type-api-v2-normal-account.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/send-existing-product-type-api-v2-normal-account.json
@@ -1,0 +1,4 @@
+{
+   "status" : 1,
+   "status_verbose" : "fields saved"
+}

--- a/tests/integration/expected_test_results/change_product_code_and_product_type/send-existing-product-type-api-v3-normal-account.json
+++ b/tests/integration/expected_test_results/change_product_code_and_product_type/send-existing-product-type-api-v3-normal-account.json
@@ -1,0 +1,7 @@
+{
+   "code" : "1234567890300",
+   "errors" : [],
+   "product" : {},
+   "status" : "success",
+   "warnings" : []
+}


### PR DESCRIPTION
Add a missing / in the redirect URL, spotted by @monsieurtanuki  : 

https://github.com/openfoodfacts/openfoodfacts-dart/issues/995#issuecomment-2495542456