### PR TITLE
ci: add metrics and matomo to the metrics project

### DIFF
--- a/.github/workflows/github-projects-ventilation.yml
+++ b/.github/workflows/github-projects-ventilation.yml
@@ -140,3 +140,9 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🌐 Translations, translations, i18n, Translations
           label-operator: OR
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/openfoodfacts/projects/84 # Add issue to the Metrics project
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: matomo
+          label-operator: OR


### PR DESCRIPTION

### What
ci: add metrics and matomo to the metrics project
      - uses: actions/add-to-project@main
        with:
          project-url: https://github.com/orgs/openfoodfacts/projects/84 # Add issue to the Metrics project
          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
          labeled: matomo
          label-operator: OR