### PR TITLE
build: do not import sample data in GitHub PR checks for make_dev

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -167,7 +167,7 @@ jobs:
         files: cover_db/codecov.json
 
   tests_dev:
-    name: 🧪 Test make dev_without_sample_data
+    name: 🧪 Test make dev
     needs: build_backend  # only to avoid building taxonomies
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -190,9 +190,9 @@ jobs:
         rm -f .envrc
         echo "export USER_UID=$(id -u)" >> .envrc
         echo "export USER_GID=$(id -g)" >> .envrc
-    - name: Test make dev_without_sample_data
+    - name: Test make dev
       run: |
-        make DOCKER_LOCAL_DATA="$(pwd)" dev_without_sample_data
+        make DOCKER_LOCAL_DATA="$(pwd)" SKIP_SAMPLE_IMAGES=1 dev
         make status
     - name: Test all is running
       run: make livecheck || ( tail -n 300 logs/apache2/*error*log; docker compose logs; false )

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -167,7 +167,7 @@ jobs:
         files: cover_db/codecov.json
 
   tests_dev:
-    name: 🧪 Test make dev
+    name: 🧪 Test make dev_without_sample_data
     needs: build_backend  # only to avoid building taxonomies
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -190,9 +190,9 @@ jobs:
         rm -f .envrc
         echo "export USER_UID=$(id -u)" >> .envrc
         echo "export USER_GID=$(id -g)" >> .envrc
-    - name: Test make dev
+    - name: Test make dev_without_sample_data
       run: |
-        make DOCKER_LOCAL_DATA="$(pwd)" dev
+        make DOCKER_LOCAL_DATA="$(pwd)" dev_without_sample_data
         make status
     - name: Test all is running
       run: make livecheck || ( tail -n 300 logs/apache2/*error*log; docker compose logs; false )

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SHELL := $(shell which bash)
 ENV_FILE ?= .env
 NAME = "ProductOpener"
 MOUNT_POINT ?= /mnt
+# in CI, in make dev we want to skip downloading sample images (too slow)
+SKIP_SAMPLE_IMAGES ?= SKIP_SAMPLE_IMAGES
 DOCKER_LOCAL_DATA_DEFAULT = /srv/off/docker_data
 DOCKER_LOCAL_DATA ?= $(DOCKER_LOCAL_DATA_DEFAULT)
 OS := $(shell uname)
@@ -108,11 +110,6 @@ goodbye:
 dev: hello build init_backend _up import_sample_data create_mongodb_indexes refresh_product_tags
 	@echo "🥫 You should be able to access your local install of Open Food Facts at http://world.openfoodfacts.localhost/"
 	@echo "🥫 You have around 100 test products. Please run 'make import_prod_data' if you want a full production dump (~2M products)."
-
-# used to test make dev in GitHub PR tests, without having to rely on getting a data dump from an external source
-# (e.g. https://static.openfoodfacts.org which can be slow)
-dev_without_sample_data: hello build init_backend _up create_mongodb_indexes refresh_product_tags
-	@echo "🥫 You should be able to access your local install of Open Food Facts at http://world.openfoodfacts.localhost/"
 
 edit_etc_hosts:
 	@grep -qxF -- "${HOSTS}" /etc/hosts || echo "${HOSTS}" >> /etc/hosts

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ dev: hello build init_backend _up import_sample_data create_mongodb_indexes refr
 	@echo "🥫 You should be able to access your local install of Open Food Facts at http://world.openfoodfacts.localhost/"
 	@echo "🥫 You have around 100 test products. Please run 'make import_prod_data' if you want a full production dump (~2M products)."
 
+# used to test make dev in GitHub PR tests, without having to rely on getting a data dump from an external source
+# (e.g. https://static.openfoodfacts.org which can be slow)
+dev_without_sample_data: hello build init_backend _up create_mongodb_indexes refresh_product_tags
+	@echo "🥫 You should be able to access your local install of Open Food Facts at http://world.openfoodfacts.localhost/"
+
 edit_etc_hosts:
 	@grep -qxF -- "${HOSTS}" /etc/hosts || echo "${HOSTS}" >> /etc/hosts
 

--- a/scripts/gen_feeds_daily.sh
+++ b/scripts/gen_feeds_daily.sh
@@ -69,15 +69,20 @@ cd $OFF_SCRIPTS_DIR
 ./mongodb_dump.sh $OFF_PUBLIC_DATA_DIR $PRODUCT_OPENER_FLAVOR $MONGODB_HOST $PRODUCT_OPENER_FLAVOR_SHORT
 
 # Small products data and images export for Docker dev environments
-# for about 1/10000th of the products contained in production.
-./export_products_data_and_images.pl --sample-mod 10000,0 \
+# for about 1/100000th of the products contained in production.
+./export_products_data_and_images.pl --sample-mod 100000,0 \
+    --products-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-100000.tar.gz \
+    --images-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-100000.images.tar.gz \
+    --jsonl-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-100000.jsonl.gz \
+    --mongo-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-100000.mongodbdump.gz
+# On saturday, export modulo 1000 and 10000 for larger sample
+if [ "$(date +%u)" = "6" ]
+then
+    ./export_products_data_and_images.pl --sample-mod 10000,0 \
     --products-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-10000.tar.gz \
     --images-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-10000.images.tar.gz \
     --jsonl-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-10000.jsonl.gz \
     --mongo-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-10000.mongodbdump.gz
-# On saturday, export modulo 1000 for larger sample
-if [ "$(date +%u)" = "6" ]
-then
     ./export_products_data_and_images.pl --sample-mod 1000,0 \
         --products-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-1000.tar.gz \
         --images-file $OFF_PUBLIC_EXPORTS_DIR/products.random-modulo-1000.images.tar.gz \

--- a/scripts/import_sample_data.sh
+++ b/scripts/import_sample_data.sh
@@ -7,12 +7,12 @@ cd /tmp
 echo "\033[32m------------------ 1/ Retrieve products -----------------\033[0m";
 # explicitly specify the wget output file name so that wget does not append .1 if already present
 # e.g. if the tar command failed and the script was stopped
-wget -O products.tar.gz https://static.openfoodfacts.org/exports/products.random-modulo-10000.tar.gz 2>&1
+wget -O products.tar.gz https://static.openfoodfacts.org/exports/products.random-modulo-100000.tar.gz 2>&1
 tar -xzvf products.tar.gz -C /mnt/podata/products
 rm products.tar.gz
 
 echo "\033[32m------------------ 2/ Retrieve product images -------------------\033[0m";
-wget -O products.images.tar.gz https://static.openfoodfacts.org/exports/products.random-modulo-10000.images.tar.gz 2>&1
+wget -O products.images.tar.gz https://static.openfoodfacts.org/exports/products.random-modulo-100000.images.tar.gz 2>&1
 tar -xzvf products.images.tar.gz -C /opt/product-opener/html/images/products/
 rm products.images.tar.gz
 

--- a/scripts/import_sample_data.sh
+++ b/scripts/import_sample_data.sh
@@ -11,10 +11,15 @@ wget -O products.tar.gz https://static.openfoodfacts.org/exports/products.random
 tar -xzvf products.tar.gz -C /mnt/podata/products
 rm products.tar.gz
 
-echo "\033[32m------------------ 2/ Retrieve product images -------------------\033[0m";
-wget -O products.images.tar.gz https://static.openfoodfacts.org/exports/products.random-modulo-100000.images.tar.gz 2>&1
-tar -xzvf products.images.tar.gz -C /opt/product-opener/html/images/products/
-rm products.images.tar.gz
+if [[ -z "${SKIP_SAMPLE_IMAGES}" ]]
+then
+    echo "\033[32m------------------ 2/ Retrieve product images -------------------\033[0m";
+    wget -O products.images.tar.gz https://static.openfoodfacts.org/exports/products.random-modulo-100000.images.tar.gz 2>&1
+    tar -xzvf products.images.tar.gz -C /opt/product-opener/html/images/products/
+    rm products.images.tar.gz
+else
+    echo "\033[32m------------------ SKIPPED product images -------------------\033[0m";
+fi
 
 echo "\033[32m------------------ 3/ Import products -------------------\033[0m";
 perl -I/opt/product-opener/lib /opt/product-opener/scripts/update_all_products_from_dir_in_mongodb.pl

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -68441,10 +68441,6 @@ intake24_category_code:en: PEAR
 wikidata:en: Q13099586
 
 < en:Pears
-en: Pears (Guyot)
-fr: Poires Guyot
-
-< en:Pears
 it: Pera dell'Emilia Romagna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1534
@@ -68458,7 +68454,7 @@ hr: Konferencijske kruške
 nl: Conference peren
 
 < en:Pears
-en: Guyot pears
+en: Guyot pears, Pears (Guyot)
 xx: Guyot
 fr: Poires Guyot
 wikidata:en: Q3033517


### PR DESCRIPTION
We currently have an action to run "make dev" in GitHub PR checks. This loads product .sto files and images from static.openfoodfacts.org, and it can be quite slow.

e.g. this test has been running for 3 hours:
https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/12082629626/job/33694707420?pr=11068

also added smaller dump:

```
off@off:/srv/off/html/exports$ (off) ls -lrt products.random-modulo-100*
-rw-r--r-- 1 off off   552875078 May 20  2024 products.random-modulo-100.tar.gz
-rw-r--r-- 1 off off    59335855 Nov 23 12:55 products.random-modulo-1000.tar.gz
-rw-r--r-- 1 off off 13099413539 Nov 23 14:04 products.random-modulo-1000.images.tar.gz
-rw-r--r-- 1 off off     8866855 Nov 23 14:05 products.random-modulo-1000.jsonl.gz
-rw-r--r-- 1 off off    10660049 Nov 23 14:05 products.random-modulo-1000.mongodbdump.gz
-rw-r--r-- 1 off off     5520665 Nov 29 12:09 products.random-modulo-10000.tar.gz
-rw-r--r-- 1 off off  1257096631 Nov 29 12:12 products.random-modulo-10000.images.tar.gz
-rw-r--r-- 1 off off      903732 Nov 29 12:12 products.random-modulo-10000.jsonl.gz
-rw-r--r-- 1 off off     1082138 Nov 29 12:12 products.random-modulo-10000.mongodbdump.gz
-rw-r--r-- 1 off off      451429 Nov 29 13:44 products.random-modulo-100000.tar.gz
-rw-r--r-- 1 off off   118325376 Nov 29 13:45 products.random-modulo-100000.images.tar.gz
-rw-r--r-- 1 off off       82747 Nov 29 13:45 products.random-modulo-100000.jsonl.gz
-rw-r--r-- 1 off off       99513 Nov 29 13:45 products.random-modulo-100000.mongodbdump.gz
```
