### PR TITLE
fix: data quality, false positive, nutrition sum with lower symbol

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1319,30 +1319,30 @@ sub check_nutrition_data ($product_ref) {
 		}
 
 		# sum of nutriments that compose fiber can not be greater than the value of fiber
+		# ignore if there is "<" symbol (example: <1 + 5 = 5, issue #11075)
 		if (defined $product_ref->{nutriments}{fiber_100g}) {
-			my $soluble_fiber
-				= defined $product_ref->{nutriments}{'soluble-fiber_100g'}
-				? $product_ref->{nutriments}{'soluble-fiber_100g'}
-				: 0;
-			my $insoluble_fiber
-				= defined $product_ref->{nutriments}{'insoluble-fiber_100g'}
-				? $product_ref->{nutriments}{'insoluble-fiber_100g'}
-				: 0;
+			my $soluble_fiber = 0;
+			my $insoluble_fiber = 0;
+
+			if (defined $product_ref->{nutriments}{'soluble-fiber_100g'}) {
+				my $soluble_modifier = $product_ref->{nutriments}{'soluble-fiber_modifier'};
+				if (!defined $soluble_modifier || $soluble_modifier ne '<') {
+					$soluble_fiber = $product_ref->{nutriments}{'soluble-fiber_100g'};
+				}
+			}
+
+			if (defined $product_ref->{nutriments}{'insoluble-fiber_100g'}) {
+				my $insoluble_modifier = $product_ref->{nutriments}{'insoluble-fiber_modifier'};
+				if (!defined $insoluble_modifier || $insoluble_modifier ne '<') {
+					$insoluble_fiber = $product_ref->{nutriments}{'insoluble-fiber_100g'};
+				}
+			}
+
 			my $total_fiber = $soluble_fiber + $insoluble_fiber;
 
 			if ($total_fiber > $product_ref->{nutriments}{fiber_100g} + 0.001) {
-				# ignore if there is "<" symbol (example: <1 + 5 = 5, issue #11075)
-				my $soluble_modifier = $product_ref->{nutriments}{'soluble-fiber_modifier'};
-				my $insoluble_modifier = $product_ref->{nutriments}{'insoluble-fiber_modifier'};
-
-				if (
-						((!defined $soluble_modifier) or (defined $soluble_modifier and $soluble_modifier ne '<'))
-					and ((!defined $insoluble_modifier) or (defined $insoluble_modifier and $insoluble_modifier ne '<'))
-					)
-				{
-					push @{$product_ref->{data_quality_errors_tags}},
-						"en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber";
-				}
+				push @{$product_ref->{data_quality_errors_tags}},
+					"en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber";
 			}
 		}
 

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1319,25 +1319,31 @@ sub check_nutrition_data ($product_ref) {
 		}
 
 		# sum of nutriments that compose fiber can not be greater than the value of fiber
-		if (
-			(defined $product_ref->{nutriments}{fiber_100g})
-			and (
-				(
-					(
-						(defined $product_ref->{nutriments}{'soluble-fiber_100g'})
-						? $product_ref->{nutriments}{'soluble-fiber_100g'}
-						: 0
-					) + (
-						(defined $product_ref->{nutriments}{'insoluble-fiber_100g'})
-						? $product_ref->{nutriments}{'insoluble-fiber_100g'}
-						: 0
+		if (defined $product_ref->{nutriments}{fiber_100g}) {
+			my $soluble_fiber
+				= defined $product_ref->{nutriments}{'soluble-fiber_100g'}
+				? $product_ref->{nutriments}{'soluble-fiber_100g'}
+				: 0;
+			my $insoluble_fiber
+				= defined $product_ref->{nutriments}{'insoluble-fiber_100g'}
+				? $product_ref->{nutriments}{'insoluble-fiber_100g'}
+				: 0;
+			my $total_fiber = $soluble_fiber + $insoluble_fiber;
+
+			if ($total_fiber > $product_ref->{nutriments}{fiber_100g} + 0.001) {
+                # ignore if there is "<" symbol (example: <1 + 5 = 5, issue #11075)
+				my $soluble_modifier = $product_ref->{nutriments}{'soluble-fiber_modifier'};
+				my $insoluble_modifier = $product_ref->{nutriments}{'insoluble-fiber_modifier'};
+                
+				if (
+						((!defined $soluble_modifier) or (defined $soluble_modifier and $soluble_modifier ne '<'))
+					and ((!defined $insoluble_modifier) or (defined $insoluble_modifier and $insoluble_modifier ne '<'))
 					)
-				) > ($product_ref->{nutriments}{fiber_100g}) + 0.001
-			)
-			)
-		{
-			push @{$product_ref->{data_quality_errors_tags}},
-				"en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber";
+				{
+					push @{$product_ref->{data_quality_errors_tags}},
+						"en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber";
+				}
+			}
 		}
 
 		# Too small salt value? (e.g. g entered in mg)

--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1331,10 +1331,10 @@ sub check_nutrition_data ($product_ref) {
 			my $total_fiber = $soluble_fiber + $insoluble_fiber;
 
 			if ($total_fiber > $product_ref->{nutriments}{fiber_100g} + 0.001) {
-                # ignore if there is "<" symbol (example: <1 + 5 = 5, issue #11075)
+				# ignore if there is "<" symbol (example: <1 + 5 = 5, issue #11075)
 				my $soluble_modifier = $product_ref->{nutriments}{'soluble-fiber_modifier'};
 				my $insoluble_modifier = $product_ref->{nutriments}{'insoluble-fiber_modifier'};
-                
+
 				if (
 						((!defined $soluble_modifier) or (defined $soluble_modifier and $soluble_modifier ne '<'))
 					and ((!defined $insoluble_modifier) or (defined $insoluble_modifier and $insoluble_modifier ne '<'))

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1893,7 +1893,7 @@ ok(
 # Test case for fiber content
 $product_ref = {
 	nutriments => {
-		'fiber_100g' => 5,
+		fiber_100g => 5,
 		'soluble-fiber_100g' => 3,
 		'insoluble-fiber_100g' => 3,
 	},

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1912,7 +1912,7 @@ $product_ref = {
 	nutriments => {
 		fiber_100g => 5,
 		'soluble-fiber_100g' => 1,
-        'soluble-fiber_modifier' => '<',
+		'soluble-fiber_modifier' => '<',
 		'insoluble-fiber_100g' => 5,
 	},
 	data_quality_errors_tags => [],
@@ -1930,7 +1930,7 @@ $product_ref = {
 	nutriments => {
 		fiber_100g => 5,
 		'soluble-fiber_100g' => 1,
-        'soluble-fiber_modifier' => '>',
+		'soluble-fiber_modifier' => '>',
 		'insoluble-fiber_100g' => 5,
 	},
 	data_quality_errors_tags => [],
@@ -1942,6 +1942,5 @@ ok(
 	has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
 	'Soluble fiber + Insoluble fiber exceeds total fiber and > symbol does not cancel that error to be raised'
 ) or diag Dumper $product_ref;
-
 
 done_testing();

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1936,11 +1936,22 @@ $product_ref = {
 	data_quality_errors_tags => [],
 };
 
+# Test case for fiber content beside other element having "<"
+$product_ref = {
+	nutriments => {
+		fiber_100g => 5,
+		'soluble-fiber_100g' => 1,
+		'soluble-fiber_modifier' => '<',
+		'insoluble-fiber_100g' => 10,
+	},
+	data_quality_errors_tags => [],
+};
+
 ProductOpener::DataQuality::check_quality($product_ref);
 
 ok(
 	has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
-	'Soluble fiber + Insoluble fiber exceeds total fiber and > symbol does not cancel that error to be raised'
+	'insoluble-fiber_100g larger than fiber_100g'
 ) or diag Dumper $product_ref;
 
 done_testing();

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1893,9 +1893,9 @@ ok(
 # Test case for fiber content
 $product_ref = {
 	nutriments => {
-		fiber_100g => 5,
-		'soluble-fiber_100g' => 3,
-		'insoluble-fiber_100g' => 3,
+		"fiber_100g" => 5,
+		"soluble-fiber_100g" => 3,
+		"insoluble-fiber_100g" => 3,
 	},
 	data_quality_errors_tags => [],
 };
@@ -1906,5 +1906,42 @@ ok(
 	has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
 	'Soluble fiber + Insoluble fiber exceeds total fiber'
 ) or diag Dumper $product_ref;
+
+# Test case for fiber content having "<" symbol
+$product_ref = {
+	nutriments => {
+		fiber_100g => 5,
+		'soluble-fiber_100g' => 1,
+        'soluble-fiber_modifier' => '<',
+		'insoluble-fiber_100g' => 5,
+	},
+	data_quality_errors_tags => [],
+};
+
+ProductOpener::DataQuality::check_quality($product_ref);
+
+ok(
+	!has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
+	'Soluble fiber + Insoluble fiber exceeds total fiber but there is < symbol'
+) or diag Dumper $product_ref;
+
+# Test case for fiber content having ">" symbol
+$product_ref = {
+	nutriments => {
+		fiber_100g => 5,
+		'soluble-fiber_100g' => 1,
+        'soluble-fiber_modifier' => '>',
+		'insoluble-fiber_100g' => 5,
+	},
+	data_quality_errors_tags => [],
+};
+
+ProductOpener::DataQuality::check_quality($product_ref);
+
+ok(
+	has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
+	'Soluble fiber + Insoluble fiber exceeds total fiber and > symbol does not cancel that error to be raised'
+) or diag Dumper $product_ref;
+
 
 done_testing();

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1893,9 +1893,9 @@ ok(
 # Test case for fiber content
 $product_ref = {
 	nutriments => {
-		"fiber_100g" => 5,
-		"soluble-fiber_100g" => 3,
-		"insoluble-fiber_100g" => 3,
+		'fiber_100g' => 5,
+		'soluble-fiber_100g' => 3,
+		'insoluble-fiber_100g' => 3,
 	},
 	data_quality_errors_tags => [],
 };


### PR DESCRIPTION
### What
Error is: Nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber should not be raised for 

> Fiber = 5
> insoluble fiber < 1
> soluble fiber = 5

and similar cases.

The PR covers only Fibers, insoluble fiber and soluble fiber.
The PR covers only if symbol is "<"

### Related issue(s) and discussion
- Fixes #11075

