### PR TITLE
taxonomy: banana breads / fr:gâteaux aux bananes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -36545,6 +36545,8 @@ gpc_category_name:en: Cakes - Sweet (Perishable)
 
 < en:Cakes
 en: Banana breads
+fr: Gâteaux aux bananes, gâteau aux bananes, gâteaux à la banane, gâteau à la banane, pains à la banane, pain à la banane, pains aux bananes, pain à la banane
+xx: Banana breads
 wikidata:en: Q806097
 
 < en:Cakes


### PR DESCRIPTION
There seems to be an issue in the integration tests on GitHub that fail because of the banana bread entry. It might be a problem with the GitHub cache, not sure, I'm making a small change to force the taxonomy to rebuild.