### PR TITLE
fix: additives table + clean HTML to remove some validation errors

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -2596,6 +2596,11 @@ HTML
 			$extra_column_searchable .= ', {"searchable": false}';
 		}
 
+		# additive table has an extra column for risks
+		if ($tagtype eq 'additives') {
+			$extra_column_searchable .= ', {"searchable": false}';
+		}
+
 		$request_ref->{initjs} .= <<JS
 let oTable = \$('#tagstable').DataTable({
 	language: {
@@ -5875,7 +5880,6 @@ facets.
 
 sub display_pagination ($request_ref, $count, $limit, $page) {
 
-	my $html = '';
 	my $html_pages = '';
 
 	$log->debug("PAGINATION: START\n", {count => $count, limit => $limit, page => $page}) if $log->is_debug();
@@ -5982,29 +5986,7 @@ sub display_pagination ($request_ref, $count, $limit, $page) {
 			. "</ul>\n";
 	}
 
-	# Close the list
-
-	if (defined single_param("jqm")) {
-		if (defined $next_page_url) {
-			my $loadmore = lang("loadmore");
-			$html .= <<HTML
-<li id="loadmore" style="text-align:center"><a href="${formatted_subdomain}/${next_page_url}&jqm_loadmore=1" id="loadmorelink">$loadmore</a></li>
-HTML
-				;
-		}
-		else {
-			$html .= '<br><br>';
-		}
-	}
-
-	if (not defined $request_ref->{jqm_loadmore}) {
-		$html .= "</ul>\n";
-	}
-
-	if (not defined single_param("jqm")) {
-		$html .= $html_pages;
-	}
-	return $html;
+	return $html_pages;
 }
 
 sub search_and_export_products ($request_ref, $query_ref, $sort_by) {

--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -13,8 +13,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="https://world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -117,8 +117,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="https://world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -26,9 +26,11 @@
         [% lang("css") %]
         [% styles %]
     </style>
-    [% analytics %]
 </head>
 <body[% bodyabout %] class="[% page_type %]_page">
+
+	[% analytics %]
+
 	<div class="skip"><a href="#content" tabindex="0">[% lang('skip_to_content') %]</a></div>
 
 	<div id="page">

--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -35,7 +35,10 @@
         
         
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -58,8 +61,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -252,8 +254,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -404,8 +406,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -35,7 +35,10 @@
         
         
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -58,8 +61,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -252,8 +254,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -404,8 +406,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -492,8 +494,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -557,8 +558,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -48,7 +48,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body about="/product/0200000000235/only-product-nutella" typeof="food:foodProduct" class="product_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -71,8 +74,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body about="/product/0200000000235/only-product-nutella" typeof="food:foodProduct" class="product_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -265,8 +267,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -3665,8 +3667,8 @@ The score is calculated from the data of the nutrition facts table and the compo
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -556,8 +558,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -621,8 +622,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -533,8 +535,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -598,8 +599,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -449,8 +451,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -528,8 +530,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -593,8 +594,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -48,7 +48,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body about="/product/0200000000235/only-product-nutella" typeof="food:foodProduct" class="product_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -71,8 +74,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body about="/product/0200000000235/only-product-nutella" typeof="food:foodProduct" class="product_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -265,8 +267,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -3665,8 +3667,8 @@ The score is calculated from the data of the nutrition facts table and the compo
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -597,8 +599,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -662,8 +663,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Saltar al Contenido</a></div>
 
 	<div id="page">
@@ -253,8 +255,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -463,8 +465,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -46,7 +46,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body about="/product/0200000000034/some-product" typeof="food:foodProduct" class="product_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -69,8 +72,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body about="/product/0200000000034/some-product" typeof="food:foodProduct" class="product_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -263,8 +265,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -4841,8 +4843,8 @@ The score is calculated from the data of the nutrition facts table and the compo
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -37,7 +37,10 @@
 .hide-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="other_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="other_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -277,8 +279,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -716,8 +718,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -37,7 +37,10 @@
 .hide-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="other_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="other_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -277,8 +279,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -716,8 +718,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -37,7 +37,10 @@
 .hide-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="other_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="other_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -277,8 +279,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -716,8 +718,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -542,8 +544,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -524,8 +526,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -589,8 +590,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -585,8 +587,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -650,8 +651,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -480,8 +482,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -524,8 +526,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -589,8 +590,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Saltar al Contenido</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -509,8 +511,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -445,8 +447,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -618,8 +620,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -683,8 +684,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -451,8 +453,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -56,7 +56,10 @@
 }
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="product_edit_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -79,8 +82,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="product_edit_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -296,8 +298,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -3615,8 +3617,8 @@ Vous acceptez d'être crédité par les ré-utilisateurs par un lien vers le pro
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -609,8 +611,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -673,8 +674,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -445,8 +447,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -48,7 +48,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body about="/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert" typeof="food:foodProduct" class="product_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -71,8 +74,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body about="/produit/3300000000002/tarte-aux-pommes-et-aux-framboise-bio-les-tartes-de-robert" typeof="food:foodProduct" class="product_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -265,8 +267,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -3885,8 +3887,8 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -48,7 +48,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body about="/produit/3300000000001/apple-pie-bob-s-pies" typeof="food:foodProduct" class="product_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -71,8 +74,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body about="/produit/3300000000001/apple-pie-bob-s-pies" typeof="food:foodProduct" class="product_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -265,8 +267,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -3899,8 +3901,8 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -40,7 +40,10 @@
 }
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="other_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -63,8 +66,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="other_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -257,8 +259,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -2070,8 +2072,8 @@ sur les deux axes pour obtenir un nuage de produits.</p>
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -466,8 +468,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -535,8 +536,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -466,8 +468,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -535,8 +536,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Aller au contenu</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -466,8 +468,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -535,8 +536,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="other_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="other_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -1612,8 +1614,8 @@ function togglePasswordVisibility(FieldID) {
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -453,8 +455,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -744,8 +746,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -809,8 +810,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -463,8 +465,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -56,7 +56,10 @@
 }
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="product_edit_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -79,8 +82,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="product_edit_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -296,8 +298,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -3613,8 +3615,8 @@ by typing the first letters of their name in the last row of the table.</p>
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -37,7 +37,10 @@
 .hide-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -277,8 +279,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -646,8 +648,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -710,8 +711,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -623,8 +625,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -687,8 +688,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -734,8 +736,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -799,8 +800,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -38,7 +38,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="list_of_tags_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -61,8 +64,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="list_of_tags_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -255,8 +257,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -449,8 +451,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="error_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="error_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -406,8 +408,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -48,7 +48,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body about="/product/3300000000001/apple-pie-bob-s-pies" typeof="food:foodProduct" class="product_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -71,8 +74,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body about="/product/3300000000001/apple-pie-bob-s-pies" typeof="food:foodProduct" class="product_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -265,8 +267,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -4396,8 +4398,8 @@ The score is calculated from the data of the nutrition facts table and the compo
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -416,8 +418,8 @@ Products are being loaded, please wait.
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -40,7 +40,10 @@
 }
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="other_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -63,8 +66,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="other_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -257,8 +259,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -2070,8 +2072,8 @@ get a cloud of products (scatter plot).</p>
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -37,7 +37,10 @@
 .show-when-logged-in {display:none}
 
     </style>
-    <!-- Matomo -->
+</head>
+<body class="products_page">
+
+	<!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -60,8 +63,7 @@
 <!-- End Matomo Code -->
 
 
-</head>
-<body class="products_page">
+
 	<div class="skip"><a href="#content" tabindex="0">Skip to Content</a></div>
 
 	<div id="page">
@@ -254,8 +256,8 @@
     <div class="donation-banner__aside">
       <div class="donation-banner__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />
@@ -470,8 +472,7 @@
   </div>
       
     
-	</ul>
-
+	
   </div>
 </div>
 
@@ -539,8 +540,8 @@
     <div>
       <div class="donation-banner-footer__main-section">
         <img
-          width="50px"
-          height="50px"
+          width="50"
+          height="50"
           src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
           alt="open food facts logo"
         />

--- a/tests/unit/display.t
+++ b/tests/unit/display.t
@@ -59,8 +59,7 @@ my $limit = 24;
 my $page = 1;
 is(
 	display_pagination($request_ref, $count, $limit, $page),
-	'</ul>' . "\n"
-		. '<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2">2</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
+		'<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2">2</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
 		. "\n"
 );
 
@@ -68,8 +67,7 @@ is(
 $request_ref->{current_link} = '/label/organic';
 is(
 	display_pagination($request_ref, $count, $limit, $page),
-	'</ul>' . "\n"
-		. '<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/label/organic/2">2</a></li><li><a href="/label/organic/2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
+		'<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/label/organic/2">2</a></li><li><a href="/label/organic/2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
 		. "\n"
 );
 

--- a/tests/unit/display.t
+++ b/tests/unit/display.t
@@ -59,7 +59,7 @@ my $limit = 24;
 my $page = 1;
 is(
 	display_pagination($request_ref, $count, $limit, $page),
-		'<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2">2</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
+	'<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2">2</a></li><li><a href="/cgi/search.pl?action=process&sort_by=unique_scans_n&page_size=24&page=2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
 		. "\n"
 );
 
@@ -67,7 +67,7 @@ is(
 $request_ref->{current_link} = '/label/organic';
 is(
 	display_pagination($request_ref, $count, $limit, $page),
-		'<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/label/organic/2">2</a></li><li><a href="/label/organic/2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
+	'<ul id="pages" class="pagination"><li class="unavailable">Pages:</li><li class="current"><a href="">1</a></li><li><a href="/label/organic/2">2</a></li><li><a href="/label/organic/2" rel="next$nofollow">Next</a></li><li class="unavailable">(24 products per page)</li></ul>'
 		. "\n"
 );
 


### PR DESCRIPTION
- fixes  #11060 (missing declaration of extra column for additives)
- removes an extra </ul> in pagination
- removes some HTML errors
- moves Matomo script in the body instead of the head as it contains a noscript tag with an image for users that don't have JS