### PR TITLE
fix: new images path

### DIFF
--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -1050,11 +1050,11 @@ sub process_image_upload ($product_id, $imagefield, $user_id, $time, $comment, $
 			# Create a link to the image in /new_images so that it can be batch processed by OCR
 			# and computer vision algorithms
 
-			(-e "$BASE_DIRS{PRODUCTS}/new_images") or mkdir("$BASE_DIRS{PRODUCTS}/new_images", 0755);
+			(-e "$BASE_DIRS{CACHE_NEW_IMAGES}") or mkdir("$BASE_DIRS{CACHE_NEW_IMAGES}", 0755);
 			my $code = $product_id;
 			$code =~ s/.*\///;
 			symlink("$target_image_dir/$imgid.jpg",
-				"$BASE_DIRS{PRODUCTS}/new_images/" . time() . "." . $code . "." . $imagefield . "." . $imgid . ".jpg");
+				"$BASE_DIRS{CACHE_NEW_IMAGES}/" . time() . "." . $code . "." . $imagefield . "." . $imgid . ".jpg");
 
 			# Save the image file size so that we can skip the image before processing it if it is uploaded again
 			$images_ref->{$size_orig} = $imgid;


### PR DESCRIPTION
new images symlinks were mistakenly created in /srv/off/products/new_images/

I will move them to /srv/off/new_images/ so that they get processed