### PR TITLE
fix: nutripatrol url must not have trailing slash

### DIFF
--- a/env/env.obf
+++ b/env/env.obf
@@ -6,4 +6,4 @@ COMPOSE_PROJECT_NAME=po_obf
 PRODUCT_OPENER_FLAVOR=openbeautyfacts
 PRODUCT_OPENER_FLAVOR_SHORT=obf
 ROBOTOFF_URL=https://robotoff.openfoodfacts.org
-NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
+NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org

--- a/env/env.off
+++ b/env/env.off
@@ -6,4 +6,4 @@ COMPOSE_PROJECT_NAME=po_off
 PRODUCT_OPENER_FLAVOR=openfoodfacts
 PRODUCT_OPENER_FLAVOR_SHORT=off
 
-NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
+NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org

--- a/env/env.opf
+++ b/env/env.opf
@@ -6,4 +6,4 @@ COMPOSE_PROJECT_NAME=po_opf
 PRODUCT_OPENER_FLAVOR=openproductfacts
 PRODUCT_OPENER_FLAVOR_SHORT=opf
 
-NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
+NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org

--- a/env/env.opff
+++ b/env/env.opff
@@ -6,4 +6,4 @@ COMPOSE_PROJECT_NAME=po_opff
 PRODUCT_OPENER_FLAVOR=openpetfoodfacts
 PRODUCT_OPENER_FLAVOR_SHORT=opff
 
-NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/
+NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org

--- a/lib/ProductOpener/ConfigEnv.pm
+++ b/lib/ProductOpener/ConfigEnv.pm
@@ -33,5 +33,7 @@ BEGIN {
 use vars @EXPORT_OK;    # no 'my' keyword for these
 
 $nutripatrol_url = $ENV{NUTRIPATROL_URL};
+# remove eventual trailing /
+$nutripatrol_url =~ s/\/+$//;
 
 1;


### PR DESCRIPTION
Otherwise having a // in the url leads to a 404 on nutripatrol side.