### PR TITLE
fix: data quality - increase threshold for comparison between fiber and its subnutriments

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -1340,7 +1340,9 @@ sub check_nutrition_data ($product_ref) {
 
 			my $total_fiber = $soluble_fiber + $insoluble_fiber;
 
-			if ($total_fiber > $product_ref->{nutriments}{fiber_100g} + 0.001) {
+			# increased threshold from 0.001 to 0.01 (see issue #10491)
+			# make sure that floats stop after 2 decimals
+			if (sprintf("%.2f", $total_fiber) > sprintf("%.2f", $product_ref->{nutriments}{fiber_100g} + 0.01)) {
 				push @{$product_ref->{data_quality_errors_tags}},
 					"en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber";
 			}

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1974,4 +1974,38 @@ ok(
 	'insoluble-fiber_100g larger than fiber_100g'
 ) or diag Dumper $product_ref;
 
+# Test case for sum fiber subnutriment comparison with fiber (0.01 difference should be fine)
+$product_ref = {
+	nutriments => {
+		fiber_100g => 3.57,
+		'soluble-fiber_100g' => 1.79,
+		'insoluble-fiber_100g' => 1.79,
+	},
+	data_quality_errors_tags => [],
+};
+
+ProductOpener::DataQuality::check_quality($product_ref);
+
+ok(
+	!has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
+	'insoluble-fiber_100g larger than fiber_100g'
+) or diag Dumper $product_ref;
+
+# Test case for sum fiber subnutriment comparison with fiber (0.02 difference should be raise error)
+$product_ref = {
+	nutriments => {
+		fiber_100g => 3.57,
+		'soluble-fiber_100g' => 1.79,
+		'insoluble-fiber_100g' => 1.80,
+	},
+	data_quality_errors_tags => [],
+};
+
+ProductOpener::DataQuality::check_quality($product_ref);
+
+ok(
+	has_tag($product_ref, 'data_quality_errors', 'en:nutrition-soluble-fiber-plus-insoluble-fiber-greater-than-fiber'),
+	'insoluble-fiber_100g larger than fiber_100g'
+) or diag Dumper $product_ref;
+
 done_testing();


### PR DESCRIPTION
### What
Increase the threshold from 0.001 to 0.01

Soluble fiber + insoluble fiber > fiber + 0.01



### Related issue(s) and discussion
- Fixes #10491