### PR TITLE
fix: nutriscore grade from category change for extra virgin olive oils

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -59164,7 +59164,7 @@ ciqual_food_code:en: 17270
 ciqual_food_name:en: Olive oil, extra virgin
 ciqual_food_name:fr: Huile d'olive vierge extra
 expected_ingredients:en: en:olive-oil
-expected_nutriscore_grade:en: c
+expected_nutriscore_grade:en: b
 
 < en:Olive oils
 en: Olive pomace oils

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1210,17 +1210,12 @@ $product_ref = {
 		'en:olive-oils', 'en:virgin-olive-oils',
 		'en:extra-virgin-olive-oils'
 	],
-	nutrition_grade_fr => "c",
+	nutrition_grade_fr => "b",
 	nutriscore => {
 		2023 => {"nutrients_available" => 1,},
 	},
 };
 ProductOpener::DataQuality::check_quality($product_ref);
-check_quality_and_test_product_has_quality_tag(
-	$product_ref,
-	'en:nutri-score-grade-from-category-does-not-match-calculated-grade',
-	'Calculate nutriscore grade should be the same as the one provided in the taxonomy for this category', 0
-);
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
 	'en:nutri-score-grade-from-category-does-not-match-calculated-grade',


### PR DESCRIPTION
### What
Because the nutriscore has changed recently, **expected_nutriscore_grade:en:** for **Extra-virgin olive oils** category has changed from C to B.

See: https://theconversation.com/en-2024-le-nutri-score-evolue-pourquoi-et-que-faut-il-en-retenir-221697

### Related issue(s) and discussion
See @aleene comment in quality-data channel on Slack
> Something changed? Nutri score grade from category does not match calculated grade https://world.openfoodfacts.org/product/4088700000472/olive-oil and others

