### PR TITLE
build: Minor docker build optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ARG CPANMOPTS=
 FROM debian:bullseye AS modperl
 
 # Install cpm to install cpanfile dependencies
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt set -x && \
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
+    --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt set -x && \
     apt update && \
     apt install -y \
         apache2 \
@@ -80,7 +81,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt set -x && \
         # NB: not available in ubuntu 1804 LTS:
         libgeoip2-perl \
         libemail-valid-perl
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt set -x && \
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
+    --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt set -x && \
     apt install -y \
         #
         # cpan dependencies that can be satisfied by apt even if the package itself can't:

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -38,4 +38,3 @@ ARG USER_GID
 RUN usermod -u $USER_UID www-data && \
     groupmod --gid $USER_GID www-data
 COPY --from=builder /opt/product-opener/html/ /opt/product-opener/html/
-COPY --from=builder /opt/product-opener/node_modules/ /opt/product-opener/node_modules/

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -19,7 +19,7 @@ COPY --chown=node:node package*.json /opt/product-opener/
 COPY --chown=node:node .snyk /opt/product-opener/
 WORKDIR /opt/product-opener
 USER node
-RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm install
+RUN --mount=type=cache,id=npm-cacache,target=/root/.npm/_cacache npm install
 ENV PATH /opt/product-opener/node_modules/.bin:$PATH
 
 COPY --chown=node:node html /opt/product-opener/html


### PR DESCRIPTION
1. Add a cache for `/var/lib/apt` during `backend` image build
2. Cache `/root/.npm/_cacache` instead of `/root/.npm` to avoid polluting the cache with `/root/.npm/_logs`
3. Don't copy (apparently) unused `node_modules` to the `frontend` image - saves a ~200 MiB layer in the final image