### PR TITLE
build: update Makefile to skip downloading sample images in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ SHELL := $(shell which bash)
 ENV_FILE ?= .env
 NAME = "ProductOpener"
 MOUNT_POINT ?= /mnt
-# in CI, in make dev we want to skip downloading sample images (too slow)
-SKIP_SAMPLE_IMAGES ?= SKIP_SAMPLE_IMAGES
 DOCKER_LOCAL_DATA_DEFAULT = /srv/off/docker_data
 DOCKER_LOCAL_DATA ?= $(DOCKER_LOCAL_DATA_DEFAULT)
 OS := $(shell uname)
@@ -226,15 +224,15 @@ refresh_product_tags: run_deps
 	@echo "🥫 Refreshing product data cached in Postgres …"
 	${DOCKER_COMPOSE} run --rm backend perl /opt/product-opener/scripts/refresh_postgres.pl ${from}
 
-import_sample_data:run_deps
+import_sample_data: run_deps
 	@ if [[ "${PRODUCT_OPENER_FLAVOR_SHORT}" = "off" &&  "${PRODUCERS_PLATFORM}" != "1" ]]; then \
    		echo "🥫 Importing sample data (~200 products) into MongoDB …"; \
-		${DOCKER_COMPOSE} run --rm backend bash /opt/product-opener/scripts/import_sample_data.sh; \
+		${DOCKER_COMPOSE} run --rm -e SKIP_SAMPLE_IMAGES backend bash /opt/product-opener/scripts/import_sample_data.sh; \
 	else \
 	 	echo "🥫 Not importing sample data into MongoDB (only for po_off project)"; \
 	fi
 	
-import_more_sample_data:run_deps
+import_more_sample_data: run_deps
 	@echo "🥫 Importing sample data (~2000 products) into MongoDB …"
 	${DOCKER_COMPOSE} run --rm backend bash /opt/product-opener/scripts/import_more_sample_data.sh
 


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to improve the handling of environment variables and streamline the import of sample data.

Environment variables:

* Removed the unused `SKIP_SAMPLE_IMAGES` variable definition to avoid incorrect initialization to a constant string.

Sample data import:

* Updated the `import_sample_data` rule to pass the `SKIP_SAMPLE_IMAGES` environment variable directly to the Docker container, ensuring that sample images are skipped during import.

Fixes #11013 