### PR TITLE
ci: Delete downloaded container image

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,9 +109,17 @@ jobs:
         key: taxonomies-${{ hashFiles('taxonomies/**') }}
         restore-keys: taxonomies-
     - name: Download backend image from artifacts
+      id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.0.0
       with:
         image: "openfoodfacts-server/backend:dev"
+    # downloadbackendimage task loads the image into docker and keeps the original file.
+    # As our runs tend to hit the storage limits for GitHub Actions, manually delete the
+    # downloaded file for now. It's not needed after being loaded into docker.
+    - name: Remove downloaded image
+      env:
+        FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
+      run: rm $FILE
     - name: build taxonomies (should use cache)
       run: make DOCKER_LOCAL_DATA="$(pwd)" build_taxonomies GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
     - name: check taxonomies
@@ -148,9 +156,17 @@ jobs:
       run: |
         git ls-files taxonomies/ | xargs -I{} git log -1 --date=format:%Y%m%d%H%M.%S --format='touch -t %ad "{}"' "{}" | bash
     - name: Download backend image from artifacts
+      id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.0.0
       with:
         image: "openfoodfacts-server/backend:dev"       
+    # downloadbackendimage task loads the image into docker and keeps the original file.
+    # As our runs tend to hit the storage limits for GitHub Actions, manually delete the
+    # downloaded file for now. It's not needed after being loaded into docker.
+    - name: Remove downloaded image
+      env:
+        FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
+      run: rm $FILE
     - name: tests
       run: |
         make codecov_prepare
@@ -182,9 +198,17 @@ jobs:
         key: taxonomies-${{ hashFiles('taxonomies/**') }}
         restore-keys: taxonomies-
     - name: Download backend image from artifacts
+      id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.0.0
       with:
         image: "openfoodfacts-server/backend:dev"
+    # downloadbackendimage task loads the image into docker and keeps the original file.
+    # As our runs tend to hit the storage limits for GitHub Actions, manually delete the
+    # downloaded file for now. It's not needed after being loaded into docker.
+    - name: Remove downloaded image
+      env:
+        FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
+      run: rm $FILE
     - name: set right UID and GID in .envrc
       run: |
         rm -f .envrc


### PR DESCRIPTION
Delete the downloaded container image from the temporary path; the GitHub action has already loaded it into docker.

This annoying workaround should help with build runs still failing with #11013.