### PR TITLE
ci: Speed up build by using pre-built image from previous stage for `make dev`-like check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -216,7 +216,7 @@ jobs:
         echo "export USER_GID=$(id -g)" >> .envrc
     - name: Test make dev
       run: |
-        make DOCKER_LOCAL_DATA="$(pwd)" SKIP_SAMPLE_IMAGES=1 dev
+        make DOCKER_LOCAL_DATA="$(pwd)" SKIP_SAMPLE_IMAGES=1 dev_no_build
         make status
     - name: Test all is running
       run: make livecheck || ( tail -n 300 logs/apache2/*error*log; docker compose logs; false )

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,9 +109,17 @@ jobs:
         key: taxonomies-${{ hashFiles('taxonomies/**') }}
         restore-keys: taxonomies-
     - name: Download backend image from artifacts
+      id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.0.0
       with:
         image: "openfoodfacts-server/backend:dev"
+    # downloadbackendimage task loads the image into docker and keeps the original file.
+    # As our runs tend to hit the storage limits for GitHub Actions, manually delete the
+    # downloaded file for now. It's not needed after being loaded into docker.
+    - name: Remove downloaded image
+      env:
+        FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
+      run: rm $FILE
     - name: build taxonomies (should use cache)
       run: make DOCKER_LOCAL_DATA="$(pwd)" build_taxonomies GITHUB_TOKEN="${{ secrets.TAXONOMY_CACHE_GITHUB_TOKEN }}"
     - name: check taxonomies
@@ -148,9 +156,17 @@ jobs:
       run: |
         git ls-files taxonomies/ | xargs -I{} git log -1 --date=format:%Y%m%d%H%M.%S --format='touch -t %ad "{}"' "{}" | bash
     - name: Download backend image from artifacts
+      id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.0.0
       with:
         image: "openfoodfacts-server/backend:dev"       
+    # downloadbackendimage task loads the image into docker and keeps the original file.
+    # As our runs tend to hit the storage limits for GitHub Actions, manually delete the
+    # downloaded file for now. It's not needed after being loaded into docker.
+    - name: Remove downloaded image
+      env:
+        FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
+      run: rm $FILE
     - name: tests
       run: |
         make codecov_prepare
@@ -182,9 +198,17 @@ jobs:
         key: taxonomies-${{ hashFiles('taxonomies/**') }}
         restore-keys: taxonomies-
     - name: Download backend image from artifacts
+      id: downloadbackendimage
       uses: ishworkh/container-image-artifact-download@v2.0.0
       with:
         image: "openfoodfacts-server/backend:dev"
+    # downloadbackendimage task loads the image into docker and keeps the original file.
+    # As our runs tend to hit the storage limits for GitHub Actions, manually delete the
+    # downloaded file for now. It's not needed after being loaded into docker.
+    - name: Remove downloaded image
+      env:
+        FILE: "${{ steps.downloadbackendimage.outputs.download_path }}"
+      run: rm $FILE
     - name: set right UID and GID in .envrc
       run: |
         rm -f .envrc

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,13 @@ dev: hello build init_backend _up import_sample_data create_mongodb_indexes refr
 	@echo "🥫 You should be able to access your local install of Open Food Facts at http://world.openfoodfacts.localhost/"
 	@echo "🥫 You have around 100 test products. Please run 'make import_prod_data' if you want a full production dump (~2M products)."
 
+#-------#
+# CI    #
+#-------#
+dev_no_build: hello init_backend _up import_sample_data create_mongodb_indexes refresh_product_tags
+	@echo "🥫 You should be able to access your local install of Open Food Facts at http://world.openfoodfacts.localhost/"
+	@echo "🥫 You have around 100 test products. Please run 'make import_prod_data' if you want a full production dump (~2M products)."
+
 edit_etc_hosts:
 	@grep -qxF -- "${HOSTS}" /etc/hosts || echo "${HOSTS}" >> /etc/hosts
 


### PR DESCRIPTION
See https://openfoodfacts.slack.com/archives/C02LDQDDD/p1734814872519649 for discussion.

Pro: Speeds up the `make dev` check by a lot, and it use less disk space, reducing the risk of the build agent running out of space.
Con: While similar, it doesn't run `make build` as part of the `make dev_no_build` check, making it not 100% identical to the local `make dev`