### PR TITLE
build(tests): add JUnit output support and update Docker test workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,10 @@ logs
 debug/
 perl-language-server.log
 
+# tests outputs
+tests/unit/outputs/
+tests/integration/outputs/
+
 openfoodfacts-mongodbdump.tar.gz
 openfoodfacts-products.jsonl.gz
 en.openfoodfacts.org.products.csv

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -181,6 +181,13 @@ jobs:
       if: always()
       with:
         files: cover_db/codecov.json
+        token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./tests/unit/outputs/junit.xml,./tests/integration/outputs/junit.xml
 
   tests_dev:
     name: 🧪 Test make dev

--- a/Makefile
+++ b/Makefile
@@ -267,19 +267,21 @@ tests: build_taxonomies_test build_lang_test unit_test integration_test
 # add COVER_OPTS='-e HARNESS_PERL_SWITCHES="-MDevel::Cover"' if you want to trigger code coverage report generation
 unit_test: create_folders
 	@echo "🥫 Running unit tests …"
+	mkdir -p tests/unit/outputs/
 	${DOCKER_COMPOSE_TEST} up -d memcached postgres mongodb
-	${DOCKER_COMPOSE_TEST} run ${COVER_OPTS} -e PO_EAGER_LOAD_DATA=1 -T --rm backend yath test --job-count=${CPU_COUNT} -PProductOpener::LoadData  tests/unit
+	${DOCKER_COMPOSE_TEST} run ${COVER_OPTS} -e JUNIT_TEST_FILE="tests/unit/outputs/junit.xml" -e PO_EAGER_LOAD_DATA=1 -T --rm backend yath test --renderer=Formatter --renderer=JUnit --job-count=${CPU_COUNT} -PProductOpener::LoadData  tests/unit
 	${DOCKER_COMPOSE_TEST} stop
 	@echo "🥫 unit tests success"
 
 integration_test: create_folders
 	@echo "🥫 Running integration tests …"
+	mkdir -p tests/integration/outputs/
 # we launch the server and run tests within same container
 # we also need dynamicfront for some assets to exists
 # this is the place where variables are important
 	${DOCKER_COMPOSE_INT_TEST} up -d memcached postgres mongodb backend dynamicfront incron minion redis
 # note: we need the -T option for ci (non tty environment)
-	${DOCKER_COMPOSE_INT_TEST} exec ${COVER_OPTS} -e PO_EAGER_LOAD_DATA=1 -T backend yath -PProductOpener::LoadData tests/integration
+	${DOCKER_COMPOSE_INT_TEST} exec ${COVER_OPTS} -e JUNIT_TEST_FILE="tests/integration/outputs/jnit.xml" -e PO_EAGER_LOAD_DATA=1 -T backend yath --renderer=Formatter --renderer=JUnit -PProductOpener::LoadData tests/integration
 	${DOCKER_COMPOSE_INT_TEST} stop
 	@echo "🥫 integration tests success"
 

--- a/cpanfile
+++ b/cpanfile
@@ -142,6 +142,7 @@ on 'develop' => sub {
   requires 'Devel::Cover::Report::Codecov';
   requires 'Devel::Cover::Report::Codecovbash';
   requires 'Test2::Harness';
+  requires 'Test2::Harness::Renderer::JUnit';
 };
 
 feature "off_server_dev_tools", "Optional development tools" => sub {


### PR DESCRIPTION
1. Use `CODECOV_TOKEN` to upload coverage results to Codecov. This is now required: `main` hasn't successfully pushed coverage results in ages due to the missing token.
2. Add `Test2::Harness::Renderer::JUnit` to create a JUni formatted report for unit tests, and integration tests.
3. Upload those new JUnit files to Codecov for their new test analysis.