### PR TITLE
taxonomy: Fix category taxonomy warnings

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -63905,18 +63905,6 @@ hr: Pšenični škrob
 lt: Kviečių krakmolas
 nl: Tarwezetmelen
 
-< en:Starches
-en: Tapioca
-fr: Tapioca, Tapioca cru, Perles du Japon crues, Perles du Japon
-hr: Tapioka
-ja: タピオカ
-pt: Tapioca
-agribalyse_food_code:en: 4000
-ciqual_food_code:en: 4000
-ciqual_food_name:en: Tapioca, raw
-ciqual_food_name:fr: Tapioca ou Perles du Japon, cru
-
-
 < en:Cereals and their products
 en: Groats
 de: Graupen

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -79256,7 +79256,7 @@ ciqual_food_name:en: Provencal-type tripe (with tomato)
 ciqual_food_name:fr: Tripes à la tomate ou à la provençale
 
 < en:Specialty made with tripe
-< en:Tripes
+< en:Tripe
 en: Beef tripes
 fr: Tripes de boeuf
 hr: Goveđi tripice

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -46515,7 +46515,7 @@ it: Formaggi molli
 nl: Zachte kazen
 pt: Queijos macios
 sv: Mjuka ostar
-incompatible_with:en categories:en:hard-cheeses
+incompatible_with:en: categories:en:hard-cheeses
 intake24_category_code:en: SFTC
 
 < en:Soft cheeses
@@ -46579,7 +46579,7 @@ ru: Варёный спрессованный сыр
 ciqual_food_code:en: 12100
 ciqual_food_name:en: Hard cheese (average)
 ciqual_food_name:fr: Fromage à pâte pressée cuite (aliment moyen)
-incompatible_with:en categories:en:soft-cheeses
+incompatible_with:en: categories:en:soft-cheeses
 intake24_category_code:en: HRDC
 wikidata:en: Q3088330
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -65748,8 +65748,8 @@ es: Granizados de mojito
 < en:Frozen ready-made meals
 < en:Ravioli
 en: Frozen ravioli
-es: Ravioli congelado
 de: Tiefkühlravioli, Tiefgekühlte Ravioli
+es: Ravioli congelado
 fi: pakastettu ravioli
 fr: Ravioli surgelés, raviolis surgelés
 hr: Smrznuti ravioli
@@ -65877,9 +65877,9 @@ fr: Quiches surgelées, Quiches salées surgelées
 < en:Meals
 en: Combination Meals
 
+< en:Combination meals
 < en:Frozen foods
 < en:Meals
-< en:Combination meals
 en: Frozen ready-made meals, Frozen prepared meals, Frozen prepared dishes, Frozen dinners
 bg: Готови замразени ястия
 ca: Plats preparats congelats, menjars preparats congelats, plats preparats congelats, sopars congelats

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -65872,8 +65872,12 @@ nl: Diepvries hartige taarten
 en: Frozen quiches
 fr: Quiches surgelées, Quiches salées surgelées
 
+< en:Meals
+en: Combination Meals
+
 < en:Frozen foods
 < en:Meals
+< en:Combination meals
 en: Frozen ready-made meals, Frozen prepared meals, Frozen prepared dishes, Frozen dinners
 bg: Готови замразени ястия
 ca: Plats preparats congelats, menjars preparats congelats, plats preparats congelats, sopars congelats
@@ -65888,12 +65892,6 @@ nl: Diepvriesmaaltijden
 pl: Mrożone dania gotowe
 pt: Refeições prontas a comer congeladas
 ru: Замороженные готовые обеды
-
-< en:Meals
-en: Combination Meals
-
-< en:Combination meals
-en: Frozen ready-made meals
 gpc_category_code:en: 10006751
 gpc_category_description:en: Definition: Ready-made combination meal or microwave meal is a pre-packaged perishable full meal.  The meal requires no preparation, but may be warmed,  and contains all the elements typically contained in a single-serving meal.  A ready-made meal (also known as a TV Dinner) must have a main component and at least one additional component such as a side item, a dessert and/or beverage. These products must be refrigerated to extend their consumable life. Definition Excludes: Excludes products such as Non-Combination Meals, Shelf Stable Ready to Eat Combination Meals, Not Ready to Eat Combination Meals, Ready-Made Combination Meal Variety Packs, Prepared/Processed Products, and Unprepared Meals.
 gpc_category_name:en: Ready-Made Combination Meals - Ready to Eat (Perishable)

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -37792,9 +37792,6 @@ gpc_category_name:en: Snacks Variety Packs
 < en:Snacks
 en: Nut-based snacks
 
-< en:nut-based-snacks
-en: Flavoured nuts
-
 < en:flavoured-nuts
 en: Flavoured pistachios, flavored pistachios
 fr: Pistaches aromatisées
@@ -55112,6 +55109,7 @@ tr: Çerez ve çerez ürünleri
 
 < en: Nuts and their products
 < en: Snacks
+< en:nut-based-snacks
 en: Flavoured nuts
 fr: Fruits de coques aromatisées
 nl: Gearomatiseerde noten

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -117009,14 +117009,6 @@ ciqual_food_name:fr: Feuilleté ou Friand au fromage
 
 < en:Friands
 < en:Puff pastry meals
-en: Ham and cheese in puffed pastry
-fr: Feuilleté jambon fromage, Friand jambon fromage
-agribalyse_food_code:en: 25508
-ciqual_food_code:en: 25508
-ciqual_food_name:en: Ham and cheese in puffed pastry
-
-< en:Friands
-< en:Puff pastry meals
 en: Seafood in puff pastry
 fr: Feuilletés aux fruits de mer
 agribalyse_food_code:en: 25151
@@ -117798,6 +117790,7 @@ nl: Soesjes met groente
 < en:Puff pastry meals
 en: Ham and cheese in puffed pastry
 fr: Feuilleté jambon fromage
+agribalyse_food_code:en: 25508
 ciqual_food_code:en: 25508
 ciqual_food_name:en: Ham and cheese in puffed pastry
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -116391,18 +116391,6 @@ hr: Terine od krvavica
 nl: Bloedworstterinnes, Bloedworstterrine
 
 < en:Terrines
-en: Fish terrines, Fish terrine
-de: Fisch-Terrinen, Fischterrinen
-fi: kalaterriinit
-fr: Terrines de poisson, Terrine de poisson
-hr: Riblje terine
-nl: Visterrines
-agribalyse_food_code:en: 8291
-ciqual_food_code:en: 8291
-ciqual_food_name:en: Fish terrine
-pnns_group_2:en: Fish and seafood
-
-< en:Terrines
 en: Seafood terrine
 fr: Terrine de fruits de mer
 agribalyse_food_code:en: 8292
@@ -117372,12 +117360,17 @@ ciqual_food_name:fr: Yaourt, lait fermenté ou spécialité laitière, aux cér�
 fr: Fromages blancs aromatisés
 
 < en:Terrines
-en: Fish terrines
+en: Fish terrines, Fish terrine
+de: Fisch-Terrinen, Fischterrinen
 fi: kalaterriinit
 fr: Terrines de poisson
 hr: Riblje terine
 it: Terrine di pesce
 nl: Visterrines
+agribalyse_food_code:en: 8291
+ciqual_food_code:en: 8291
+ciqual_food_name:en: Fish terrine
+
 food_groups:en: en:fish-and-seafood
 pnns_group_2:en: Fish and seafood
 #wikidata:en:

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -15586,15 +15586,6 @@ origins:en: en:france
 wikidata:en: Q2669603
 
 < en:Wines from France
-fr: Châteauneuf-du-Pape
-origins:en: en:france
-wikidata:en: Q2914687
-
-< en:White wines
-< fr:Châteauneuf-du-Pape
-fr: Châteauneuf-du-Pape blanc
-
-< en:Wines from France
 fr: Châtillon-en-Diois
 origins:en: en:france
 wikidata:en: Q1090846
@@ -16294,6 +16285,11 @@ fr: Châteauneuf-du-Pape
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0144
 protected_name_type:en: pdo
+wikidata:en: Q2914687
+
+< en:White wines
+< fr:Châteauneuf-du-Pape
+fr: Châteauneuf-du-Pape blanc
 
 < en:Wines from France
 fr: Côtes du Roussillon

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -107241,10 +107241,6 @@ hr: Bintje krumpir
 nl: Bintje aardappelen
 
 < en:Potatoes
-en: Lady Christl potatoes
-fr: Pomme de terre Lady Christl
-
-< en:Potatoes
 en: Ostara potatoes
 fr: Pomme de terre Ostara
 

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -65748,13 +65748,15 @@ es: Granizados de mojito
 < en:Frozen ready-made meals
 < en:Ravioli
 en: Frozen ravioli
-de: Tiefkühlravioli
+es: Ravioli congelado
+de: Tiefkühlravioli, Tiefgekühlte Ravioli
 fi: pakastettu ravioli
 fr: Ravioli surgelés, raviolis surgelés
 hr: Smrznuti ravioli
 hu: Fagyasztott ravioli
+it: Ravioli surgelati
 lt: Šaldyti ravioliai
-nl: Diepvriesraviolis
+nl: Diepvriesraviolis, Bevroren ravioli
 
 < en:Frozen foods
 fr: Cônes et batonnets surgelés
@@ -93494,15 +93496,6 @@ de: Frische Ravioli
 fr: Ravioli frais
 hr: Svježi ravioli
 nl: Verse raviolis
-
-< en:Ravioli
-en: Frozen ravioli
-de: Tiefgekühlte Ravioli
-es: Ravioli congelado
-fr: Ravioli surgelé
-hr: Smrznuti ravioli
-it: Ravioli surgelati
-nl: Bevroren ravioli
 
 < en:Fresh ravioli
 < en:Meat ravioli

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67329,7 +67329,7 @@ ciqual_food_name:fr: Groseille à maquereau, crue
 en: Indian Gooseberries, Amla
 
 < en:Indian Gooseberries
-en Indian goosberry powders, Amla powders
+en: Indian goosberry powders, Amla powders
 nl: Amla poeders
 
 < en:Berries


### PR DESCRIPTION
Fix taxonomy errors and warning spotted using the Taxonomy editor:

![Capture d’écran du 2024-12-23 08-50-17](https://github.com/user-attachments/assets/3858f615-7898-469e-8a2e-13086311dccd)

The only one remaining is this one: `WARNING: Entry with same id fr:terrines-foie-volaille already exists, duplicate id in file at line 116496. The two nodes will be merged, keeping the last values in case of conflicts.`

It looks like `Terrines de foie de volaille` and `Terrines au foie de volaille` are merged into the same entity due to stopwords, I'm not sure how to fix this one.