### PR TITLE
Update Footer "Follow Us" Logo from Twitter to X 

### DIFF
--- a/icons/X_logo_2023.svg
+++ b/icons/X_logo_2023.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 300 300" preserveAspectRatio="xMidYMid meet" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);"><path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z"/></svg>

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -855,7 +855,7 @@ msgid "/cgi/top_translators.pl"
 msgstr ""
 
 msgctxt "footer_follow_us"
-msgid "Follow us on <a href=\"https://twitter.com/openfoodfacts\">Twitter</a>,\n"
+msgid "Follow us on <a href=\"https://twitter.com/OpenFoodFacts">Twitter</a>,\n"
 "<a href=\"https://www.facebook.com/OpenFoodFacts\">Facebook</a> and\n"
 "<a href=\"https://www.instagram.com/open.food.facts/\">Instagram</a>\n"
 msgstr ""

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -367,7 +367,7 @@
 						<p>[% f_lang('f_join_us_on_slack', { url => "https://slack.openfoodfacts.org" } ) %]</p>
 						<p><a href="https://forum.openfoodfacts.org/">Forum</a></p>
 						<p id="footer_social_icons">[% f_lang('f_footer_follow_us_links', { links => '
-							<a href="https://twitter.com/' _ twitter_account _ '"><img src="/images/icons/dist/twitter.svg" class="footer_social_icon" alt="Twitter"></a>
+							<a href="https://x.com/OpenFoodFacts' _ X_account _ '"><img src="/images/icons/dist/X_logo_2023.svg" class="footer_social_icon" alt="X"></a>
 							<a href="' _ facebook_page_url _ '"><img src="/images/icons/dist/facebook.svg" class="footer_social_icon" alt="Facebook"></a>
 							<a href="https://www.instagram.com/open.food.facts/"><img src="/images/icons/dist/instagram.svg" class="footer_social_icon" alt="Instagram"></a>
 							'


### PR DESCRIPTION
---

**What:**  
This PR updates the footer "Follow Us" logo on the **OpenFoodFacts** website to reflect the recent rebranding of Twitter to **X**. The old Twitter logo has been replaced with the new **X logo**, ensuring that the footer is aligned with the current branding of the platform.

**Changes:**
- Replaced the **Twitter logo** in the footer with the new **X logo**.
- Updated the link to point to `https://x.com/openfoodfacts` instead of `https://twitter.com/openfoodfacts`.

**How to Test:**
1. Go to any page on the **OpenFoodFacts** website (such as the homepage or product page).
2. Scroll down to the footer and locate the "Follow Us" section.
3. Verify that the **X logo** is now visible instead of the old Twitter logo.
4. Ensure that clicking the **X logo** redirects to the OpenFoodFacts X profile: `https://x.com/openfoodfacts`.
5. Check that the footer displays correctly on both desktop and mobile devices.

- Fixes Update the Twitter logo to X  #[10287]
 
- The new **X logo** was sourced from (https://fr.m.wikipedia.org/wiki/Fichier:X_logo_2023.svg).
- Only the logo and associated link were updated; no other changes were made to the footer layout or functionality.

---

