### PR TITLE
fix: warnings in import_convert_carrefour_france

### DIFF
--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -1218,14 +1218,14 @@ sub load_xml_file ($file, $xml_rules_ref, $xml_fields_mapping_ref, $code) {
 
 	$log->info("parsing xml file with XML::Rules", {file => $file, xml_rules => $xml_rules_ref}) if $log->is_info();
 
-    # Read the file content
-    # Check if the file is empty or contains only comments
-    # See issue #9655, file 13003_3270190006787_valNut.xml + 5 others are empty
-    my $content = read_file($file);
-    if ($content =~ /^\s*<!--.*-->\s*$/s) {
-        # $log->warn("File is empty or contains only comments", {file => $file}) if $log->is_warn();
-        return 1;
-    }
+	# Read the file content
+	# Check if the file is empty or contains only comments
+	# See issue #9655, file 13003_3270190006787_valNut.xml + 5 others are empty
+	my $content = read_file($file);
+	if ($content =~ /^\s*<!--.*-->\s*$/s) {
+		# $log->warn("File is empty or contains only comments", {file => $file}) if $log->is_warn();
+		return 1;
+	}
 
 	my $parser = XML::Rules->new(rules => $xml_rules_ref);
 

--- a/lib/ProductOpener/ImportConvert.pm
+++ b/lib/ProductOpener/ImportConvert.pm
@@ -51,6 +51,9 @@ use Log::Any qw($log);
 use Storable qw(dclone);
 use Text::Fuzzy;
 
+# to use read_file
+use File::Slurp;
+
 BEGIN {
 	use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
@@ -1214,6 +1217,15 @@ sub load_xml_file ($file, $xml_rules_ref, $xml_fields_mapping_ref, $code) {
 	}
 
 	$log->info("parsing xml file with XML::Rules", {file => $file, xml_rules => $xml_rules_ref}) if $log->is_info();
+
+    # Read the file content
+    # Check if the file is empty or contains only comments
+    # See issue #9655, file 13003_3270190006787_valNut.xml + 5 others are empty
+    my $content = read_file($file);
+    if ($content =~ /^\s*<!--.*-->\s*$/s) {
+        # $log->warn("File is empty or contains only comments", {file => $file}) if $log->is_warn();
+        return 1;
+    }
 
 	my $parser = XML::Rules->new(rules => $xml_rules_ref);
 

--- a/lib/ProductOpener/ImportConvertCarrefourFrance.pm
+++ b/lib/ProductOpener/ImportConvertCarrefourFrance.pm
@@ -155,9 +155,9 @@ sub convert_carrefour_france_files ($file_handle, $files_ref) {
 
 				#"b" => "pass",
 				#"strong" => "pass",
-				"b" => sub {return '<b>' . $_[1]->{_content} . '</b>'},
-				"strong" => sub {return '<strong>' . $_[1]->{_content} . '</strong>'},
-				"u" => sub {return '<u>' . $_[1]->{_content} . '</u>'},
+				"b" => sub {return '<b>' . ($_[1]->{_content} // '') . '</b>'},
+				"strong" => sub {return '<strong>' . ($_[1]->{_content} // '') . '</strong>'},
+				"u" => sub {return '<u>' . ($_[1]->{_content} // '') . '</u>'},
 				"em" => "pass",
 
 				"br" => "==<br />",
@@ -438,6 +438,8 @@ sub convert_carrefour_france_files ($file_handle, $files_ref) {
 			$product_ref->{producer_fr} = $product_ref->{emb_codes};
 			delete $product_ref->{emb_codes};
 		}
+
+        $product_ref -> {lc} = "fr";
 	}
 
 	# Clean and normalize fields

--- a/lib/ProductOpener/ImportConvertCarrefourFrance.pm
+++ b/lib/ProductOpener/ImportConvertCarrefourFrance.pm
@@ -439,7 +439,7 @@ sub convert_carrefour_france_files ($file_handle, $files_ref) {
 			delete $product_ref->{emb_codes};
 		}
 
-        $product_ref -> {lc} = "fr";
+		$product_ref->{lc} = "fr";
 	}
 
 	# Clean and normalize fields

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3580,7 +3580,7 @@ reference to the name of the country
 sub get_geographical_area ($originid) {
 	# Getting information about the country
 	my $ecobalyse_area = "";
-	if (get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") eq "yes") {
+	if (defined get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") && get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") eq "yes") {
 		$ecobalyse_area = "eu";
 	}
 	if ($originid eq "en:france") {

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3580,8 +3580,9 @@ reference to the name of the country
 sub get_geographical_area ($originid) {
 	# Getting information about the country
 	my $ecobalyse_area = "";
-	if (defined get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu")
-		&& get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") eq "yes")
+	my $ecobalyse_is_part_of_eu_result = get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu");
+	if (defined $ecobalyse_is_part_of_eu_result
+		&& $ecobalyse_is_part_of_eu_result eq "yes")
 	{
 		$ecobalyse_area = "eu";
 	}

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3580,7 +3580,9 @@ reference to the name of the country
 sub get_geographical_area ($originid) {
 	# Getting information about the country
 	my $ecobalyse_area = "";
-	if (defined get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") && get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") eq "yes") {
+	if (defined get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu")
+		&& get_inherited_property("countries", $originid, "ecobalyse_is_part_of_eu") eq "yes")
+	{
 		$ecobalyse_area = "eu";
 	}
 	if ($originid eq "en:france") {


### PR DESCRIPTION
### What

```
Error 1

    https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/7462755789/job/20306470532?pr=9288#step:4:3088
    error: error parsing xml file with XML::Rules {error => "\nno element found at line 1, column 83, byte 83 at /opt/perl/local/lib/perl5/XML/Rules.pm line 745.\n",file => "tests/unit//inputs/import_convert_carrefour_france/13003_3270190006787_valNut.xml"}
    Use of uninitialized value in addition (+) at /opt/product-opener/lib/ProductOpener/ImportConvertCarrefourFrance.pm line 399.
    File tests/unit//inputs/import_convert_carrefour_france/13766_8431876196009_text.xml - Code: 8431876196009
    Reading file tests/unit//inputs/import_convert_carrefour_france/13766_8431876196009_text.xml
    Use of uninitialized value in concatenation (.) or string at /opt/product-opener/lib/ProductOpener/ImportConvertCarrefourFrance.pm line 160.
```

### Related issue(s) and discussion
- Related to #9655
