### PR TITLE
fix: environmental_score

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -129,7 +129,7 @@
 
 # Added Kosovo
 
-en: world
+en: world, WO
 als: Welt
 ang: Middangeard
 ar: العالم
@@ -15517,7 +15517,7 @@ es: Tierras Australes y Antárticas Francesas, Territorios Australes Franceses, 
 eu: Frantziaren lurralde austral eta antartikoak, Hegoaldeko Frantziar Lurraldeak
 fa: سرزمین‌های جنوبی و جنوبگانی فرانسه, سرزمین های جنوبی و جنوبگانی فرانسه, سرزمين هاي جنوبي و جنوبگاني فرانسه
 fi: Ranskan eteläiset ja antarktiset alueet, TAAF, Ranskan eteläiset ja antarktiset maat
-fr: Terres australes et antarctiques françaises, TAAF, Terres Australes Françaises, Terres australes et antarctiques francaises
+fr: Terres australes et antarctiques françaises, TAAF, Terres Australes Françaises, Terres australes et antarctiques francaises, Territoires français du Sud
 gag: Franțuz Üülen hem Antarktida Toprakları
 gl: Terras Austrais e Antárticas Francesas, Territorios Austrais Franceses
 he: הארצות הדרומיות והאנטארקטיות של צרפת
@@ -36799,7 +36799,7 @@ fa: سائوتومه و پرینسیپ, جمهوری دموکراتیک سائو
 fi: São Tomé ja Príncipe
 fiu-vro:São Tomé ja Príncipe
 fo: Sao Tomi og Prinsipi
-fr: Sao Tomé-et-Principe
+fr: Sao Tomé-et-Principe, São Tomé e Príncipe
 frp: Sao Tomé-et-Principe
 fy: Sao Tomee en Prinsyp
 ga: São Tomé agus Príncipe
@@ -40898,7 +40898,7 @@ country_code_2:en: SJ
 country_code_3:en: SJM
 language_codes:en:
 
-en: Swaziland, Kingdom of Swaziland, SZ, SWZ
+en: Swaziland, Kingdom of Swaziland, SZ, SWZ, SW
 ace: Swaziland
 af: Swaziland
 als: Swasiland

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -5826,7 +5826,7 @@ nl: Florida
 pl: Floryda
 
 < en:united-states
-en: Georgia, Georgia in the usa, Georgia in the united states, Georgia state, US-GA
+en: Georgia state, Georgia USA, Georgia in the usa, Georgia in the united states, US-GA
 
 < en:united-states
 en: Louisiana, US-LA

--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -5676,6 +5676,136 @@ wikipedia:en: https://en.wikipedia.org/wiki/Yancheng
 # US states
 
 < en:united-states
+en: Alabama, US-AL
+af: Alabama
+am: አላባማ
+an: Alabama
+ar: ألاباما
+ay: Alabama suyu
+az: Alabama
+ba: Алабама
+be: Алабама
+bg: Алабама
+bh: अलबामा
+bi: Alabama
+bn: অ্যালাবামা
+bo: ཨ་ལ་པ་མ།
+br: Alabama
+bs: Alabama
+ca: Alabama
+ce: Алабама
+co: Alabama
+cs: Alabama
+cv: Алабама
+cy: Alabama
+da: Alabama
+de: Alabama
+el: Αλαμπάμα
+eo: Alabamo
+es: Alabama
+et: Alabama
+eu: Alabama
+fa: آلاباما
+fi: Alabama
+fo: Alabama
+fr: Alabama
+fy: Alabama
+ga: Alabama
+gd: Alabama
+gl: Alabama
+gn: Alaváma
+gu: અલાબામા
+gv: Alabama
+ha: Alabama
+he: אלבמה
+hi: अलबामा
+hr: Alabama
+ht: Alabama
+hu: Alabama
+hy: Ալաբամա
+ia: Alabama
+id: Alabama
+ie: Alabama
+ig: Alabama
+ik: Alapaama
+io: Alabama
+is: Alabama
+it: Alabama
+iu: ᐋᓛᐹᒫ
+ja: アラバマ州
+jv: Alabama
+ka: ალაბამა
+kk: Алабама
+kn: ಅಲಬಾಮ
+ko: 앨라배마주
+ku: Alabama
+kw: Alabama
+ky: Алабама
+la: Alabama
+lb: Alabama
+li: Alabama
+lt: Alabama
+lv: Alabama
+mg: Alabama
+mi: Arapama
+mk: Алабама
+ml: അലബാമ
+mn: Алабама
+mr: अलाबामा
+ms: Alabama
+my: အလာဘားမားပြည်နယ်
+ne: अलाबामा
+nl: Alabama
+nn: Alabama
+no: Alabama
+nv: Łeezh Łichxíiʼii Hahoodzo
+oc: Alabama
+os: Алабамæ
+pa: ਅਲਾਬਾਮਾ
+pi: अलाबामा
+pl: Alabama
+ps: آلاباما
+pt: Alabama
+qu: Alabama suyu
+rm: Alabama
+ro: Alabama
+ru: Алабама
+sa: अलाबामा
+sc: Alabama
+sd: الاباما
+se: Alabama
+sh: Alabama
+si: ඇලබාමා
+sk: Alabama
+sl: Alabama
+sm: Alapama
+so: Alabama
+sq: Alabama
+sr: Алабама
+sv: Alabama
+sw: Alabama
+ta: அலபாமா
+te: అలబామా
+tg: Алабама
+th: รัฐแอละแบมา
+tk: Alabama
+tl: Alabama
+to: ʻAlapama
+tr: Alabama
+tt: Алабама
+ug: Alabama Shitati
+uk: Алабама
+ur: الاباما
+uz: Alabama
+vi: Alabama
+vo: Alabama
+xh: I-Alabhama
+yi: אלאבאמא
+yo: Ìpínlẹ̀ Alabama
+za: Alabama
+zh: 亚拉巴马州
+
+< en:united-states
 en: California
 bg: Калифорния
 ca: Califòrnia
@@ -5695,10 +5825,387 @@ hu: Florida
 nl: Florida
 pl: Floryda
 
+< en:united-states
+en: Georgia, Georgia in the usa, Georgia in the united states, Georgia state, US-GA
+
+< en:united-states
+en: Louisiana, US-LA
+af: Louisiana
+am: ሉዊዚያና
+an: Loisiana
+ar: لويزيانا
+ay: Louisiana suyu
+az: Luiziana
+be: Луізіяна
+bg: Луизиана
+bh: लुइसियाना
+bi: Louisiana
+bn: লুইজিয়ানা
+bo: ལུའི་ཟི་ཨཱན་ནཱ།
+br: Louiziana
+bs: Louisiana
+ca: Louisiana
+ce: Луизиана
+co: Luisiana
+cs: Louisiana
+cv: Луизиана
+cy: Louisiana
+da: Louisiana
+de: Louisiana
+el: Λουιζιάνα
+eo: Luiziano
+es: Luisiana
+et: Louisiana
+eu: Louisiana
+fa: لوئیزیانا
+fi: Louisiana
+fo: Louisiana
+fr: Louisiane
+fy: Louisiana
+ga: Louisiana
+gd: Louisiana
+gl: Luisiana
+gn: Luisiana
+gu: લ્યુઇસિયાના
+gv: Louisiana
+ha: Louisiana
+he: לואיזיאנה
+hi: लुईज़ियाना
+hr: Louisiana
+ht: Lwizyàn
+hu: Louisiana
+hy: Լուիզիանա
+ia: Louisiana
+id: Louisiana
+ie: Louisiana
+ig: Luwisiánà
+ik: Luisiana
+io: Louisiana
+is: Louisiana
+it: Louisiana
+iu: ᓗᐄᓰᐋᓈ
+ja: ルイジアナ州
+jv: Louisiana
+ka: ლუიზიანა
+kk: Луизиана
+kn: ಲೂಯಿಸಿಯಾನ
+ko: 루이지애나주
+ks: لوزیانا
+ku: Louisiana
+kw: Louisiana
+ky: Луизиана
+la: Ludoviciana
+lb: Louisiana
+li: Louisiana
+lt: Luiziana
+lv: Luiziāna
+mg: Louisiana
+mi: Rōeihīana
+mk: Луизијана
+ml: ലുയീസിയാന
+mn: Луизиана
+mr: लुईझियाना
+ms: Louisiana
+my: လူဝီစီယားနားပြည်နယ်
+ne: लुइजियाना
+nl: Louisiana
+nn: Louisiana
+no: Louisiana
+nv: Tónteel Biihílį́ Hahoodzo
+oc: Loïsiana
+os: Луизианæ
+pa: ਲੂਈਜ਼ੀਆਨਾ
+pi: लुइजियाना
+pl: Luizjana
+ps: لویزیانا
+pt: Luisiana
+qu: Louisiana suyu
+rm: Louisiana
+ro: Louisiana
+ru: Луизиана
+sa: लुईजियाना
+sc: Louisiana
+sd: لوئزيانا
+se: Louisiana
+sh: Louisiana
+sk: Louisiana
+sl: Louisiana
+sq: Luiziana
+sr: Луизијана
+sv: Louisiana
+sw: Louisiana
+ta: லூசியானா
+tg: Луизиана
+th: รัฐลุยเซียนา
+tl: Louisiana
+tr: Louisiana
+tt: Луизиана
+ug: Loyizanna Shitati
+uk: Луїзіана
+ur: لوویزیانا
+uz: Luiziana
+vi: Louisiana
+vo: Louisiana
+wa: Louwiziane
+xh: ILuwiziyana
+yi: לואיזיאנא
+yo: Louisiana
+zh: 路易斯安那州
+
+< en:united-states
+en: Mississipi, US-MS
+af: Mississippi
+am: ሚሲሲፒ
+an: Mississippi
+ar: مسيسيبي
+ay: Mississippi suyu
+az: Missisipi ştatı
+ba: Миссисипи
+be: Місісіпі
+bg: Мисисипи
+bh: मिसिसिपी
+bi: Mississippi
+bn: মিসিসিপি
+bo: མི་སི་སི་ཕི།
+br: Mississippi
+bs: Mississippi
+ca: Mississipi
+ce: Миссисипи
+co: Mississippi
+cs: Mississippi
+cv: Миссисипи
+cy: Mississippi
+da: Mississippi
+de: Mississippi
+el: Μισισίπι
+eo: Misisipio
+es: Misisipi
+et: Mississippi osariik
+eu: Mississippi
+fi: Mississippi
+fo: Mississippi
+fr: Mississippi
+fy: Mississippy
+ga: Mississippi
+gd: Mississippi
+gl: Mississippi
+gn: Misisípi
+gv: Mississippi
+ha: Mississippi
+he: מיסיסיפי
+hi: मिसिसिप्पी
+hr: Mississippi
+ht: Misisipi
+hu: Mississippi
+hy: Միսսիսիպի
+ia: Mississippi
+id: Mississippi
+ie: Mississippi
+ig: Mississippi
+ik: Misisipi
+io: Mississippi
+is: Mississippi
+it: Mississippi
+iu: ᒦᓰᓰᐲ
+ja: ミシシッピ州
+jv: Mississippi
+ka: მისისიპის შტატი
+kk: Миссисипи
+ko: 미시시피주
+ku: Mîsîsîpî
+kw: Mississippi
+ky: Миссисипи
+la: Mississippia
+lb: Mississippi
+li: Mississippi
+lt: Misisipė
+lv: Misisipi
+mg: Mississippi
+mi: Mihihipi
+mk: Мисисипи
+ml: മിസിസിപ്പി
+mn: Миссисипи
+mr: मिसिसिपी
+ms: Mississippi
+my: မစ္စစ္စပီပြည်နယ်
+ne: मिसिसिपी
+nl: Mississippi
+nn: Mississippi
+no: Mississippi
+nv: Diichiłító Hahoodzo
+oc: Mississipí
+os: Миссисипи
+pa: ਮਿਸੀਸਿੱਪੀ
+pi: मिसिसिप्पी
+pl: Missisipi
+ps: میسیسیپی
+pt: Mississippi
+qu: Mississippi suyu
+rm: Mississippi
+ro: Mississippi
+ru: Миссисипи
+sa: मिसिसिपी
+sc: Mississippi
+sd: مسيسيپي
+se: Mississippi
+sh: Mississippi
+sk: Mississippi
+sl: Misisipi
+sm: Misisipi
+so: Mississippi
+sq: Mississippi
+sr: Мисисипи
+sv: Mississippi
+sw: Mississippi
+ta: மிசிசிப்பி
+tg: Миссисипӣ
+th: รัฐมิสซิสซิปปี
+tk: Missisipi
+tl: Mississippi
+tr: Mississippi
+tt: Миссисипи
+ug: Misisipi Shitati
+uk: Міссісіпі
+ur: مسیسپی
+uz: Mississippi
+vi: Mississippi
+vo: Mississippi
+xh: IMisisiphi
+yi: מיסיסיפי
+yo: Ìpínlẹ̀ Mississippi
+zh: 密西西比州
+
 < en:United States
-en: South Carolina
+en: South Carolina, US-SC
 bg: Южна Каролина
 fr: Caroline du Sud
+
+< en:united-states
+en: Texas, US-TX
+af: Texas
+am: ቴክሳስ
+an: Texas
+ar: تكساس
+ay: Texas suyu
+az: Texas
+ba: Техас
+be: Тэхас
+bg: Тексас
+bh: टेक्सास
+bi: Texas
+bn: টেক্সাস
+bo: ཋེག་ཟ་སི།
+br: Texas
+bs: Teksas
+ca: Texas
+ce: Техас
+co: Texas
+cs: Texas
+cu: Тєѯасъ
+cv: Техас
+cy: Texas
+da: Texas
+de: Texas
+el: Τέξας
+eo: Teksaso
+es: Texas
+et: Texas
+eu: Texas
+fa: تگزاس
+fi: Texas
+fo: Texas
+fr: Texas
+fy: Teksas
+ga: Texas
+gd: Texas
+gl: Texas
+gn: Tehás
+gu: ટેક્સસ
+gv: Texas
+ha: Texas
+he: טקסס
+hi: टेक्सस
+hr: Teksas
+ht: Teksas
+hu: Texas
+hy: Տեխաս
+ia: Texas
+id: Texas
+ie: Texas
+ig: Texas
+ik: Texas
+io: Texas
+is: Texas
+it: Texas
+iu: ᑖᒃᓵᔅ
+ja: テキサス州
+jv: Texas
+ka: ტეხასი
+kk: Техас
+kn: ಟೆಕ್ಸಸ್
+ko: 텍사스주
+ku: Teksas
+kw: Teksas
+la: Texia
+lb: Texas
+li: Texas
+lo: ເທັກຊາສ
+lt: Teksasas
+lv: Teksasa
+mg: Texas
+mi: Tēkiki
+mk: Тексас
+ml: ടെക്സസ്
+mn: Техас
+mr: टेक्सास
+ms: Texas
+my: တက္ကဆပ်ပြည်နယ်
+ne: टेक्सस
+nl: Texas
+nn: Texas
+no: Texas
+nv: Akałii Bikéyah
+oc: Tèxas
+os: Техас
+pa: ਟੈਕਸਸ
+pi: टेक्सास
+pl: Teksas
+ps: تکزاس
+pt: Texas
+qu: Texas suyu
+rm: Texas
+ro: Texas
+ru: Техас
+sa: टेक्सास्
+sc: Texas
+sd: ٽيڪساس
+se: Texas
+sh: Texas
+sk: Texas
+sl: Teksas
+so: Texas
+sq: Teksasi
+sr: Тексас
+sv: Texas
+sw: Texas
+ta: டெக்சஸ்
+te: టెక్సస్
+tg: Техас
+th: รัฐเท็กซัส
+tk: Tehas
+tl: Texas
+tr: Teksas
+tt: Техас
+ug: Téksas Shitati
+uk: Техас
+ur: ٹیکساس
+uz: Texas
+vi: Texas
+vo: Täxasän
+yi: טעקסאס
+yo: Texas
+zh: 德克萨斯州
+zu: Texas
 
 # State of Palestine
 
@@ -5710,6 +6217,57 @@ it: Striscia di Gaza
 nl: Gazastrook
 
 # Marine zones
+en: International waters, IW
+ar: مياه دولية
+az: Neytral sular
+be: Адкрытае мора
+bg: Открито море
+bn: আন্তর্জাতিক জলভাগ
+br: Dourioù etrebroadel
+ca: Alta mar
+cs: Mezinárodní vody
+da: Internationalt farvand
+de: Internationale Gewässer
+el: Ανοικτή θάλασσα
+eo: Internacia maro
+es: Alta mar
+et: Rahvusvahelised veed
+eu: Itsas zabal
+fi: Kansainväliset vedet
+fr: Haute mer, eaux internationales
+he: מים בין-לאומיים
+hi: अंतर्राष्ट्रीय जलक्षेत्र
+hr: Otvoreno more
+hy: Բաց ծով
+id: Perairan internasional
+io: Internacion aqui
+it: Acque internazionali
+ja: 公海
+ka: საერთაშორისო წყლები
+ko: 공해 (바다)
+ky: Ачык деңиз
+lt: Atviroji jūra
+mk: Меѓународни води
+ml: അന്താരാഷ്ട്ര സമുദ്രവിഭജനം
+ms: Perairan antarabangsa
+nl: Internationale wateren
+nn: Internasjonalt farvatn
+no: Internasjonalt farvann
+pl: Morze otwarte
+ps: نړیوالې اوبه
+pt: Alto-mar
+ro: Ape internaționale
+ru: Открытое море
+sh: Otvoreno more
+sq: Ujërat ndërkombëtare
+sv: Internationellt vatten
+tg: Баҳри кушод
+tl: Pandaigdigang katubigan
+tr: Uluslararası sular
+uk: Міжнародні води
+uz: Ochiq dengiz
+vi: Hải phận quốc tế
+zh: 公海
 
 en: FAO fishing areas, FAO major fishing areas, FAO inland waters
 sv:FAO:s Fiskeregioner


### PR DESCRIPTION
### What


```
Error 3

https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/7462755789/job/20306470532?pr=9288#step:4:560
Name "FFI::Platypus::keep" used only once: possible typo at /usr/lib/x86_64-linux-gnu/perl-base/XSLoader.pm line 111.
error: ecoscore origin does not exist in taxonomy {origin => "IW",origin_id => "en:IW"}
error: ecoscore origin does not exist in taxonomy {origin => "SW",origin_id => "en:SW"}
error: ecoscore origin does not exist in taxonomy {origin => "US-AL",origin_id => "en:US-AL"}
error: ecoscore origin does not exist in taxonomy {origin => "US-GA",origin_id => "en:US-GA"}
error: ecoscore origin does not exist in taxonomy {origin => "US-LA",origin_id => "en:US-LA"}
error: ecoscore origin does not exist in taxonomy {origin => "US-MS",origin_id => "en:US-MS"}
error: ecoscore origin does not exist in taxonomy {origin => "US-SC",origin_id => "en:US-SC"}
error: ecoscore origin does not exist in taxonomy {origin => "US-TX",origin_id => "en:US-TX"}
error: ecoscore origin does not exist in taxonomy {origin => "WO",origin_id => "en:WO"}
error: ecoscore origin does not exist in taxonomy {origin => "Eaux internationales",origin_id => "fr:Eaux internationales"}
error: ecoscore origin does not exist in taxonomy {origin => "S\x{e3}o Tom\x{e9} e Pr\x{ed}ncipe",origin_id => "fr:S\x{e3}o Tom\x{e9} e Pr\x{ed}ncipe"}
error: ecoscore origin does not exist in taxonomy {origin => "Territoires fran\x{e7}ais du Sud",origin_id => "fr:Territoires fran\x{e7}ais du Sud"}
Use of uninitialized value $_[0] in substitution (s///) at tests/unit/attributes.t line 221.
```

Added in the taxonomies

### Related issue(s) and discussion
- Fixes #9655 (together with #11189 and #11190)

