### PR TITLE
fix: rm nova drilldown field for beauty

### DIFF
--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -435,7 +435,6 @@ HTML
 
 @drilldown_fields = qw(
 	nutrition_grades
-	nova_groups
 	environmental_score
 	brands
 	categories

--- a/taxonomies/beauty/labels.txt
+++ b/taxonomies/beauty/labels.txt
@@ -1,1482 +1,1505 @@
 ﻿stopwords:en:ingredients, from, with, of, by, the, verified, certified, approved, 100%, pure, product, guaranty, guaranteed, standard
-stopwords:fr:ingrédients, issus, de, l', convient, peut convenir, au, aux, régime, régimes, conforme, validé, vérifié, certifié, par, un, une, approuvé, 100%, pur, garantie, garanti, produit, sas
-stopwords:es:por, la, las, los, el, apto, para, certificado, controlado, registrado, 100%
+stopwords:fr: ingrédients, issus, de, l', convient, peut convenir, au, aux, régime, régimes, conforme, validé, vérifié, certifié, par, un, une, approuvé, 100%, pur, garantie, garanti, produit, sas
+stopwords:es: por, la, las, los, el, apto, para, certificado, controlado, registrado, 100%
 
-synonyms:en:coloring, colouring, color, colour
+synonyms:en: coloring, colouring, color, colour
 
-synonyms:en:GMOs, Genetically Modified Organisms
+synonyms:en: GMOs, Genetically Modified Organisms
 
-synonyms:en:without, 0%
-synonyms:es:sin, 0%
-synonyms:fr:sans, 0%
+synonyms:en: without, 0%
+synonyms:es: sin, 0%
+synonyms:fr: sans, 0%
 
-synonyms:fr:ajout, adjonction
+# already in food labels.txt
+# synonyms:fr: ajout, adjonction
 
-synonyms:fr:carbone, co2
-synonyms:en:carbon, co2
+# already in food labels.txt
+# synonyms:fr: carbone, co2
+# synonyms:en: carbon, co2
 
-synonyms:fr:durable, soutenable, responsable
+# already in food labels.txt
+# synonyms:fr: durable, soutenable, responsable
 
-synonyms:fr:fabrication, production
+synonyms:fr: fabrication, production
 
-synonyms:fr:fabrique, produit
+# already in food labels.txt
+# synonyms:fr: fabrique, produit
 
-synonyms:fr:naturel, d'origine naturelle, origine naturelle
+# already in food labels.txt
+# synonyms:fr: naturel, d'origine naturelle, origine naturelle
 
-synonyms:fr:testé, formule testée
+synonyms:fr: testé, formule testée
 
-en:1% for the planet, 1 percent for the planet, one percent for the planet
-es:1% para el planeta
-fr:1% pour la planète
+en: 1% for the planet, 1 percent for the planet, one percent for the planet
+es: 1% para el planeta
+fr: 1% pour la planète
 
-en:100% natural
-es:100% natural
-fr:100% naturel
-nl_be:100% natuurlijk
-nl:100% natuurlijk
+en: 100% natural
+es: 100% natural
+fr: 100% naturel
+nl: 100% natuurlijk
+nl_be: 100% natuurlijk
 
-en:Carbon compensated product, carbon neutral
-fr:Produit compensé carbone, Carbone neutre, neutre en carbone, carbone compensé
+en: Carbon compensated product, carbon neutral
+fr: Produit compensé carbone, Carbone neutre, neutre en carbone, carbone compensé
 
-en:Carbon footprint, carbon emissions, product that specifies the carbon footprint
-de:CO2-Emissionen
-es:Huella de carbono, Emisiones de CO2
-fr:Empreinte carbone, émissions de carbone
-it:Emissioni di CO2, impronta climatica
-pt:Pegada de carbono, Emissões de CO2
-wikidata:en:Q310667
+# already in food labels.txt
+# en: Carbon footprint, carbon emissions, product that specifies the carbon footprint
+# de: CO2-Emissionen
+# es: Huella de carbono, Emisiones de CO2
+# fr: Empreinte carbone, émissions de carbone
+# it: Emissioni di CO2, impronta climatica
+# pt: Pegada de carbono, Emissões de CO2
+# wikidata:en: Q310667
 
-en:Cooperative product
-es:Producto de cooperativa
-fr:Produit en coopérative, produit de coopérative
-wikidata:en:Q4539
+en: Cooperative product
+es: Producto de cooperativa
+fr: Produit en coopérative, produit de coopérative
+wikidata:en: Q4539
 
-en:ISO 9001
-it:Iso 9001, Uni en iso 9001, Sistema di qualita certificato iso 9001
-fr:Iso 9001, Certifie iso 9001, La certification qualite iso 9001
+en: ISO 9001
+fr: Iso 9001, Certifie iso 9001, La certification qualite iso 9001
+it: Iso 9001, Uni en iso 9001, Sistema di qualita certificato iso 9001
 #xx:ISO 9001
 
-<en:ISO 9001
-en:ISO-9001-2008, ISO 9001 2008 certified qms
-it:Iso-9001-2008
-fr:Iso-9001-2008
+< en:ISO 9001
+en: ISO-9001-2008, ISO 9001 2008 certified qms
+fr: Iso-9001-2008
+it: Iso-9001-2008
 #xx:ISO-9001-2008
 
-en:EU Agriculture, European Union agriculture
-es:Agricultura UE, Agricultura Unión Europea
-fr:Agriculture UE, Agriculture Union Européeenne
-de:EU-Landwirtschaft
-
-en:Fair trade
-es:Comercio justo, Fairtrade-Comercio Justo
-fr:Commerce équitable, équitable
-wikidata:en:Q188485
-
-<en:Fair trade
-en:Fairtrade International, Fairtrade, FLO international, FLO
-es:Fairtrade International, Fairtrade, FLO international, FLO
-fr:Fairtrade International, Fairtrade, FLO international, FLO
-
-<en:Fair trade
-en:Max Havelaar, Max Havelar, Fairtrade/Max Havelaar
-nl_be:Fair trade
-nl:Fair trade
-wikidata:en:Q694008
-
-<en:Max Havelaar
-fr:Max Havelaar Belgique
-nl_be:Max Havelaar Belgie
-nl:Max Havelaar Nederland
-
-<en:Max Havelaar
-fr:Max Havelaar France
-
-<en:Fair trade
-en:TransFer, TransFer Canada
-
-en:In braille
-es:En braille, Producto en braille
-fr:Produit en braille
-de:In Brailleschrift
-nl:In braille
-it:In braille
-wikidata:en:Q79894
-
-en:Incorrect data on label, Incorrect data
-fr:Informations incorrectes sur l'emballage, Informations incorrectes
-de:Falsche Angaben auf der Verpackung
-es:Datos incorrectos en la etiqueta, Datos incorrectos
-nl:Onjuiste gegevens op het etiket, Onjuiste gegevens
-it:Dati errati sull'etichetta, Dati errati
-
-
-en:Without paraben, Paraben-free, No paraben, No parabens
-fr:Sans paraben, Sans parabenes, 0 parabens, 0 paraben, Sans parabene, Sans parabens, Zero paraben
-de:Ohne paraben, Parabenfrei
-nl:Zonder parabeen
-es:Sin Parabenos
-
-en:Organic
-de:Bio, Öko, Biologisch, Ökologisch, Kontrolliert biologisch, Kontrolliert ökologisch, biologische Landwirtschaft, ökologische Landwirtschaft, biologischer Landbau, ökologischer Landbau
-es:Ecológico, Producto ecológico, Biológico, Producto biológico, Orgánico, Producto orgánico, Eco, Bio
-fr:Bio, agriculture biologique, biologique, organic, organique, issu de l'agriculture biologique, ingrédients issus de l'agriculture biologique, Les-ingredients-sont-issus-d-une-agriculture-biologique
-it:Biologico
-wikidata:en:Q380778
-
-<en:Organic
-en:Biodynamic agriculture
-es:Agricultura biodinámica
-fr:Bio-dynamie, biodynamie, agriculture biodynamique, agriculture bio-dynamique, bio-dynamique
-de:Biodynamische Landwirtschaft, Biodynamisch
-wikidata:en:Q847611
-
-<en:Biodynamic agriculture
-en:Demeter
-fr:Demeter, Association Demeter, Demeter France, Association Demeter France
-de:Demeter
-wikidata:en:Q939877
-
-<en:Organic
-en:BO-BIO-126
-
-<en:Organic
-en:India Organic
-
-<en:Organic
-en:EU Organic, European Organic
-de:EG-Öko-Verordnung, EU-Öko-Verordnung, Europäische Öko-Verordnung, EU Ökologische
-es:Ecológico UE, Ecológico U.E., Producto ecológico europeo
-fr:Bio européen, Label bio européen, bio ce, bio europe
-it:Biologico UE
-wikidata:en:Q380448
-
-<en:Organic
-de:Deutsches Bio-Siegel, Deutsches staatliches Bio-Siegel
-
-<en:EU Organic
-en:AT-BIO-004
-country:Austria
-
-<en:EU Organic
-en:AT-BIO-301
-country:Austria
-
-<en:EU Organic
-en:AT-BIO-401
-country:Austria
+en: EU Agriculture, European Union agriculture
+de: EU-Landwirtschaft
+es: Agricultura UE, Agricultura Unión Europea
+fr: Agriculture UE, Agriculture Union Européeenne
+
+en: Fair trade
+es: Comercio justo, Fairtrade-Comercio Justo
+fr: Commerce équitable, équitable
+wikidata:en: Q188485
+
+< en:Fair trade
+en: Fairtrade International, Fairtrade, FLO international, FLO
+es: Fairtrade International, Fairtrade, FLO international, FLO
+fr: Fairtrade International, Fairtrade, FLO international, FLO
+
+# already in food labels.txt
+# < en:Fair trade
+# en: Max Havelaar, Max Havelar, Fairtrade/Max Havelaar
+# nl: Fair trade
+# nl_be: Fair trade
+# wikidata:en: Q694008
+
+# already in food labels.txt
+# < en:Max Havelaar
+# fr: Max Havelaar Belgique
+# nl: Max Havelaar Nederland
+# nl_be: Max Havelaar Belgie
+
+# already in food labels.txt
+# < en:Max Havelaar
+# fr: Max Havelaar France
+
+< en:Fair trade
+en: TransFer, TransFer Canada
+
+# already in food labels.txt
+# en: In braille
+# de: In Brailleschrift
+# es: En braille, Producto en braille
+# fr: Produit en braille
+# it: In braille
+# nl: In braille
+# wikidata:en: Q79894
+
+# already in food labels.txt
+# en: Incorrect data on label, Incorrect data
+# de: Falsche Angaben auf der Verpackung
+# es: Datos incorrectos en la etiqueta, Datos incorrectos
+# fr: Informations incorrectes sur l'emballage, Informations incorrectes
+# it: Dati errati sull'etichetta, Dati errati
+# nl: Onjuiste gegevens op het etiket, Onjuiste gegevens
+
+
+en: Without paraben, Paraben-free, No paraben, No parabens
+de: Ohne paraben, Parabenfrei
+es: Sin Parabenos
+fr: Sans paraben, Sans parabenes, 0 parabens, 0 paraben, Sans parabene, Sans parabens, Zero paraben
+nl: Zonder parabeen
+
+en: Organic
+de: Bio, Öko, Biologisch, Ökologisch, Kontrolliert biologisch, Kontrolliert ökologisch, biologische Landwirtschaft, ökologische Landwirtschaft, biologischer Landbau, ökologischer Landbau
+es: Ecológico, Producto ecológico, Biológico, Producto biológico, Orgánico, Producto orgánico, Eco, Bio
+fr: Bio, agriculture biologique, biologique, organic, organique, issu de l'agriculture biologique, ingrédients issus de l'agriculture biologique, Les-ingredients-sont-issus-d-une-agriculture-biologique
+it: Biologico
+wikidata:en: Q380778
+
+< en:Organic
+en: Biodynamic agriculture
+de: Biodynamische Landwirtschaft, Biodynamisch
+es: Agricultura biodinámica
+fr: Bio-dynamie, biodynamie, agriculture biodynamique, agriculture bio-dynamique, bio-dynamique
+wikidata:en: Q847611
+
+< en:Biodynamic agriculture
+en: Demeter
+de: Demeter
+fr: Demeter, Association Demeter, Demeter France, Association Demeter France
+wikidata:en: Q939877
+
+< en:Organic
+en: BO-BIO-126
+
+< en:Organic
+en: India Organic
+
+# already in food labels.txt
+# < en:Organic
+# en: EU Organic, European Organic
+# de: EG-Öko-Verordnung, EU-Öko-Verordnung, Europäische Öko-Verordnung, EU Ökologische
+# es: Ecológico UE, Ecológico U.E., Producto ecológico europeo
+# fr: Bio européen, Label bio européen, bio ce, bio europe
+# it: Biologico UE
+# wikidata:en: Q380448
+
+# already in food labels.txt
+# < en:Organic
+# de: Deutsches Bio-Siegel, Deutsches staatliches Bio-Siegel
+
+< en:EU Organic
+en: AT-BIO-004
+country: Austria
 
-<en:EU Organic
-en:AT-BIO-402
-country:Austria
+< en:EU Organic
+en: AT-BIO-301
+country: Austria
 
-<en:EU Organic
-en:AT-BIO-501
-country:Austria
+< en:EU Organic
+en: AT-BIO-401
+country: Austria
 
-<en:EU Organic
-en:AT-BIO-701
-country:Austria
+< en:EU Organic
+en: AT-BIO-402
+country: Austria
 
-<en:EU Organic
-en:AT-BIO-901
+< en:EU Organic
+en: AT-BIO-501
+country: Austria
 
-<en:EU Organic
-en:AT-BIO-902
-country:Austria
+< en:EU Organic
+en: AT-BIO-701
+country: Austria
 
-<en:EU Organic
-en:BE-BIO-01, Certisys BE-BIO-01
-country:Belgium
+< en:EU Organic
+en: AT-BIO-901
 
-<en:EU Organic
-en:BE-BIO-02
-country:Belgium
+< en:EU Organic
+en: AT-BIO-902
+country: Austria
 
-<en:EU Organic
-en:BE-BIO-03
-country:Belgium
+< en:EU Organic
+en: BE-BIO-01, Certisys BE-BIO-01
+country: Belgium
 
-<en:EU Organic
-en:BE-BIO-04
-country:Belgium
+< en:EU Organic
+en: BE-BIO-02
+country: Belgium
 
-<en:EU Organic
-en:BG-BIO-02
-country:Bulgaria
+< en:EU Organic
+en: BE-BIO-03
+country: Belgium
 
-<en:EU Organic
-en:BG-BIO-03
-country:Bulgaria
+< en:EU Organic
+en: BE-BIO-04
+country: Belgium
 
-<en:EU Organic
-en:BG-BIO-04
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-02
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-05
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-03
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-06
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-04
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-07
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-05
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-08
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-06
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-10
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-07
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-12
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-08
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-13
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-10
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-14
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-12
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-15
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-13
+country: Bulgaria
 
-<en:EU Organic
-en:BG-BIO-16
-country:Bulgaria
+< en:EU Organic
+en: BG-BIO-14
+country: Bulgaria
 
-<en:EU Organic
-en:CH-BIO-004
-country:Switzerland
+< en:EU Organic
+en: BG-BIO-15
+country: Bulgaria
 
-<en:EU Organic
-en:CH-BIO-006, ch-bio-scesp-006
-country:Switzerland
+< en:EU Organic
+en: BG-BIO-16
+country: Bulgaria
 
-<en:EU Organic
-en:CH-Bio-038
-country:Switzerland
+< en:EU Organic
+en: CH-BIO-004
+country: Switzerland
 
-<en:EU Organic
-en:CH-Bio-086
-country:Switzerland
+< en:EU Organic
+en: CH-BIO-006, ch-bio-scesp-006
+country: Switzerland
 
-<en:EU Organic
-en:CY-BIO-001
-country:Cyprus
+< en:EU Organic
+en: CH-Bio-038
+country: Switzerland
 
-<en:EU Organic
-en:CY-BIO-002
-country:Cyprus
+< en:EU Organic
+en: CH-Bio-086
+country: Switzerland
 
-<en:EU Organic
-en:CZ-BIO-001
+< en:EU Organic
+en: CY-BIO-001
+country: Cyprus
 
-<en:EU Organic
-en:CZ-BIO-002
+< en:EU Organic
+en: CY-BIO-002
+country: Cyprus
 
-<en:EU Organic
-en:CZ-BIO-003
+< en:EU Organic
+en: CZ-BIO-001
 
-<en:EU Organic
-en:CZ-BIO-004
+< en:EU Organic
+en: CZ-BIO-002
 
-<en:EU Organic
-en:DE-ÖKO-001
-country:Germany
+< en:EU Organic
+en: CZ-BIO-003
 
-<en:EU Organic
-en:DE-ÖKO-003
-country:Germany
+< en:EU Organic
+en: CZ-BIO-004
 
-<en:EU Organic
-en:DE-ÖKO-005
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-001
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-006
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-003
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-007
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-005
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-009
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-006
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-012
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-007
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-013
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-009
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-021
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-012
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-022
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-013
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-024
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-021
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-034
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-022
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-037
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-024
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-039
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-034
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-044
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-037
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-060
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-039
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-064
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-044
+country: Germany
 
-<en:EU Organic
-en:DE-ÖKO-070
-country:Germany
+< en:EU Organic
+en: DE-ÖKO-060
+country: Germany
 
-<en:EU Organic
-en:DK-ØKO-050
+< en:EU Organic
+en: DE-ÖKO-064
+country: Germany
 
-<en:EU Organic
-en:DK-ØKO-100
+< en:EU Organic
+en: DE-ÖKO-070
+country: Germany
 
-<en:EU Organic
-en:DK-ØKO-200
+< en:EU Organic
+en: DK-ØKO-050
 
-<en:EU Organic
-en:DK-ØKO-300
+< en:EU Organic
+en: DK-ØKO-100
 
-<en:EU Organic
-en:EE-ÖKO-01
+< en:EU Organic
+en: DK-ØKO-200
 
-<en:EU Organic
-en:EE-ÖKO-02
+< en:EU Organic
+en: DK-ØKO-300
 
-<en:EU Organic
-en:ES-EC0-017-AN
-country:Spain
+< en:EU Organic
+en: EE-ÖKO-01
 
-<en:EU Organic
-en:ES-ECO-001
-country:Spain
+< en:EU Organic
+en: EE-ÖKO-02
 
-<en:EU Organic
-en:ES-ECO-001-AN
-country:Spain
+< en:EU Organic
+en: ES-EC0-017-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-001-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-001
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-001-CM
-country:Spain
+< en:EU Organic
+en: ES-ECO-001-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-002
-country:Spain
+< en:EU Organic
+en: ES-ECO-001-CL
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-002-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-001-CM
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-002-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-002
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-002-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-002-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-002-CM
-country:Spain
+< en:EU Organic
+en: ES-ECO-002-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-003-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-002-CL
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-004
-country:Spain
+< en:EU Organic
+en: ES-ECO-002-CM
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-004-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-003-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-004-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-004
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-005
-country:Spain
+< en:EU Organic
+en: ES-ECO-004-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-005-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-004-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-005-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-005
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-006-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-005-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-007-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-005-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-008-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-006-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-009-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-007-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-010-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-008-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-010-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-009-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-011-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-010-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-011-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-010-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-011-CM
-country:Spain
+< en:EU Organic
+en: ES-ECO-011-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-012-AS
-country:Spain
+< en:EU Organic
+en: ES-ECO-011-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-013-IB
-country:Spain
+< en:EU Organic
+en: ES-ECO-011-CM
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-014-IC
-country:Spain
+< en:EU Organic
+en: ES-ECO-012-AS
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-015-CN
-country:Spain
+< en:EU Organic
+en: ES-ECO-013-IB
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-016-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-014-IC
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-017
-country:Spain
+< en:EU Organic
+en: ES-ECO-015-CN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-017-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-016-CL
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-017-CM
-country:Spain
+< en:EU Organic
+en: ES-ECO-017
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-019-CT
-country:Spain
+< en:EU Organic
+en: ES-ECO-017-CL
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-020-CV
-country:Spain
+< en:EU Organic
+en: ES-ECO-017-CM
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-021-EX
-country:Spain
+< en:EU Organic
+en: ES-ECO-019-CT
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-022-GA
-country:Spain
+< en:EU Organic
+en: ES-ECO-020-CV
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-023-MA
-country:Spain
+< en:EU Organic
+en: ES-ECO-021-EX
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-024-MU
-country:Spain
+< en:EU Organic
+en: ES-ECO-022-GA
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-025-NA
-country:Spain
+< en:EU Organic
+en: ES-ECO-023-MA
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-026-VAS
-country:Spain
+< en:EU Organic
+en: ES-ECO-024-MU
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-027-RI
-country:Spain
+< en:EU Organic
+en: ES-ECO-025-NA
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-028-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-026-VAS
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-028-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-027-RI
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-028-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-028-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-028-CM
-country:Spain
+< en:EU Organic
+en: ES-ECO-028-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-029-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-028-CL
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-029-AR
-country:Spain
+< en:EU Organic
+en: ES-ECO-028-CM
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-029-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-029-AN
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-030-AN
-country:Spain
+< en:EU Organic
+en: ES-ECO-029-AR
+country: Spain
 
-<en:EU Organic
-en:ES-ECO-031-CL
-country:Spain
+< en:EU Organic
+en: ES-ECO-029-CL
+country: Spain
 
-<en:EU Organic
-en:FI-EKO-101
-country:Finland
+< en:EU Organic
+en: ES-ECO-030-AN
+country: Spain
 
-<en:EU Organic
-en:FI-EKO-102
-country:Finland
+< en:EU Organic
+en: ES-ECO-031-CL
+country: Spain
 
-<en:EU Organic
-en:FI-EKO-103
-country:Finland
+< en:EU Organic
+en: FI-EKO-101
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-104
-country:Finland
+< en:EU Organic
+en: FI-EKO-102
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-105
-country:Finland
+< en:EU Organic
+en: FI-EKO-103
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-106
-country:Finland
+< en:EU Organic
+en: FI-EKO-104
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-107
-country:Finland
+< en:EU Organic
+en: FI-EKO-105
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-108
-country:Finland
+< en:EU Organic
+en: FI-EKO-106
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-109
-country:Finland
+< en:EU Organic
+en: FI-EKO-107
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-110
-country:Finland
+< en:EU Organic
+en: FI-EKO-108
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-111
-country:Finland
+< en:EU Organic
+en: FI-EKO-109
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-112
-country:Finland
+< en:EU Organic
+en: FI-EKO-110
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-113
-country:Finland
+< en:EU Organic
+en: FI-EKO-111
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-114
-country:Finland
+< en:EU Organic
+en: FI-EKO-112
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-115
-country:Finland
+< en:EU Organic
+en: FI-EKO-113
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-201
-country:Finland
+< en:EU Organic
+en: FI-EKO-114
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-301
-country:Finland
+< en:EU Organic
+en: FI-EKO-115
+country: Finland
 
-<en:EU Organic
-en:FI-EKO-401
-country:Finland
+< en:EU Organic
+en: FI-EKO-201
+country: Finland
 
-<en:EU Organic
-en:FR-BIO-01
-country:France
+< en:EU Organic
+en: FI-EKO-301
+country: Finland
 
-<en:EU Organic
-en:FR-BIO-07
-country:France
+< en:EU Organic
+en: FI-EKO-401
+country: Finland
 
-<en:EU Organic
-en:FR-BIO-09
-country:France
+< en:EU Organic
+en: FR-BIO-01
+country: France
 
-<en:EU Organic
-en:FR-BIO-10
-country:France
+< en:EU Organic
+en: FR-BIO-07
+country: France
 
-<en:EU Organic
-en:FR-BIO-12
-country:France
+< en:EU Organic
+en: FR-BIO-09
+country: France
 
-<en:EU Organic
-en:FR-BIO-13
-country:France
+< en:EU Organic
+en: FR-BIO-10
+country: France
 
-<en:EU Organic
-en:FR-BIO-15
-country:France
+< en:EU Organic
+en: FR-BIO-12
+country: France
 
-<en:EU Organic
-en:FR-BIO-16
-country:France
+< en:EU Organic
+en: FR-BIO-13
+country: France
 
-<en:EU Organic
-en:GB-ORG-01
-country:United Kingdom
+< en:EU Organic
+en: FR-BIO-15
+country: France
 
-<en:EU Organic
-en:GB-ORG-02
-country:United Kingdom
+< en:EU Organic
+en: FR-BIO-16
+country: France
 
-<en:EU Organic
-en:GB-ORG-03
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-01
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-04
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-02
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-05
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-03
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-06
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-04
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-07
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-05
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-09
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-06
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-13
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-07
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-16
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-09
+country: United Kingdom
 
-<en:EU Organic
-en:GB-ORG-17
-country:United Kingdom
+< en:EU Organic
+en: GB-ORG-13
+country: United Kingdom
 
-<en:EU Organic
-en:GR-BIO-01
-country:Greece
+< en:EU Organic
+en: GB-ORG-16
+country: United Kingdom
 
-<en:EU Organic
-en:GR-BIO-02
-country:Greece
+< en:EU Organic
+en: GB-ORG-17
+country: United Kingdom
 
-<en:EU Organic
-en:GR-BIO-03
-country:Greece
+< en:EU Organic
+en: GR-BIO-01
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-04
-country:Greece
+< en:EU Organic
+en: GR-BIO-02
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-05
-country:Greece
+< en:EU Organic
+en: GR-BIO-03
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-06
-country:Greece
+< en:EU Organic
+en: GR-BIO-04
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-07
-country:Greece
+< en:EU Organic
+en: GR-BIO-05
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-08
-country:Greece
+< en:EU Organic
+en: GR-BIO-06
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-10
-country:Greece
+< en:EU Organic
+en: GR-BIO-07
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-12
-country:Greece
+< en:EU Organic
+en: GR-BIO-08
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-13
-country:Greece
+< en:EU Organic
+en: GR-BIO-10
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-14
-country:Greece
+< en:EU Organic
+en: GR-BIO-12
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-15
-country:Greece
+< en:EU Organic
+en: GR-BIO-13
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-16
-country:Greece
+< en:EU Organic
+en: GR-BIO-14
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-17
-country:Greece
+< en:EU Organic
+en: GR-BIO-15
+country: Greece
 
-<en:EU Organic
-en:GR-BIO-18
-country:Greece
+< en:EU Organic
+en: GR-BIO-16
+country: Greece
 
-<en:EU Organic
-en:HR-EKO-01
+< en:EU Organic
+en: GR-BIO-17
+country: Greece
 
-<en:EU Organic
-en:HR-EKO-02
+< en:EU Organic
+en: GR-BIO-18
+country: Greece
 
-<en:EU Organic
-en:HR-EKO-03
+< en:EU Organic
+en: HR-EKO-01
 
-<en:EU Organic
-en:HR-EKO-04
+< en:EU Organic
+en: HR-EKO-02
 
-<en:EU Organic
-en:HR-EKO-05
+< en:EU Organic
+en: HR-EKO-03
 
-<en:EU Organic
-en:HR-EKO-06
+< en:EU Organic
+en: HR-EKO-04
 
-<en:EU Organic
-en:HR-EKO-07
+< en:EU Organic
+en: HR-EKO-05
 
-<en:EU Organic
-en:HR-EKO-08
+< en:EU Organic
+en: HR-EKO-06
 
-<en:EU Organic
-en:HU-ÖKO-01
+< en:EU Organic
+en: HR-EKO-07
 
-<en:EU Organic
-en:HU-ÖKO-02
+< en:EU Organic
+en: HR-EKO-08
 
-<en:EU Organic
-en:IE-ORG-01
-country:Ireland
+< en:EU Organic
+en: HU-ÖKO-01
 
-<en:EU Organic
-en:IE-ORG-02
-country:Ireland
+< en:EU Organic
+en: HU-ÖKO-02
 
-<en:EU Organic
-en:IE-ORG-03
-country:Ireland
+< en:EU Organic
+en: IE-ORG-01
+country: Ireland
 
-<en:EU Organic
-en:IE-ORG-04
-country:Ireland
+< en:EU Organic
+en: IE-ORG-02
+country: Ireland
 
-<en:EU Organic
-en:IE-ORG-05
-country:Ireland
+< en:EU Organic
+en: IE-ORG-03
+country: Ireland
 
-<en:EU Organic
-en:IT-BIO-001-BZ
-country:Italy
+< en:EU Organic
+en: IE-ORG-04
+country: Ireland
 
-<en:EU Organic
-en:IT-BIO-002
-country:Italy
+< en:EU Organic
+en: IE-ORG-05
+country: Ireland
 
-<en:EU Organic
-en:IT-BIO-002-BZ
+< en:EU Organic
+en: IT-BIO-001-BZ
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-003
-country:Italy
+< en:EU Organic
+en: IT-BIO-002
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-003-BZ
+< en:EU Organic
+en: IT-BIO-002-BZ
 
-<en:EU Organic
-en:IT-BIO-004
-country:Italy
+< en:EU Organic
+en: IT-BIO-003
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-005
-country:Italy
+< en:EU Organic
+en: IT-BIO-003-BZ
 
-<en:EU Organic
-en:IT-BIO-006
-country:Italy
+< en:EU Organic
+en: IT-BIO-004
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-007
-country:Italy
+< en:EU Organic
+en: IT-BIO-005
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-008
-country:Italy
+< en:EU Organic
+en: IT-BIO-006
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-009
-country:Italy
+< en:EU Organic
+en: IT-BIO-007
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-010
-country:Italy
+< en:EU Organic
+en: IT-BIO-008
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-011
-country:Italy
+< en:EU Organic
+en: IT-BIO-009
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-012
-country:Italy
+< en:EU Organic
+en: IT-BIO-010
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-013
-country:Italy
+< en:EU Organic
+en: IT-BIO-011
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-014
-country:Italy
+< en:EU Organic
+en: IT-BIO-012
+country: Italy
 
-<en:EU Organic
-en:IT-BIO-015
-country:Italy
+< en:EU Organic
+en: IT-BIO-013
+country: Italy
 
-<en:EU Organic
-en:li-bio-969
+< en:EU Organic
+en: IT-BIO-014
+country: Italy
 
-<en:EU Organic
-en:LT-EKO-001
+< en:EU Organic
+en: IT-BIO-015
+country: Italy
 
-<en:EU Organic
-en:LU-BIO-01
+< en:EU Organic
+en: li-bio-969
 
-<en:EU Organic
-en:LU-BIO-04
+< en:EU Organic
+en: LT-EKO-001
 
-<en:EU Organic
-en:LU-BIO-05
+< en:EU Organic
+en: LU-BIO-01
 
-<en:EU Organic
-en:LU-BIO-06
+< en:EU Organic
+en: LU-BIO-04
 
-<en:EU Organic
-en:LU-BIO-07
+< en:EU Organic
+en: LU-BIO-05
 
-<en:EU Organic
-en:LV-BIO-01
+< en:EU Organic
+en: LU-BIO-06
 
-<en:EU Organic
-en:LV-BIO-02
+< en:EU Organic
+en: LU-BIO-07
 
-<en:EU Organic
-en:MT-ORG-01
+< en:EU Organic
+en: LV-BIO-01
 
-<en:EU Organic
-en:NL-BIO-01
+< en:EU Organic
+en: LV-BIO-02
 
-<en:EU Organic
-en:NO-ØKO-01
+< en:EU Organic
+en: MT-ORG-01
 
-<en:EU Organic
-en:PL-EKO-01
-country:Poland
+< en:EU Organic
+en: NL-BIO-01
 
-<en:EU Organic
-en:PL-EKO-02
-country:Poland
+< en:EU Organic
+en: NO-ØKO-01
 
-<en:EU Organic
-en:PL-EKO-03
-country:Poland
+< en:EU Organic
+en: PL-EKO-01
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-04
-country:Poland
+< en:EU Organic
+en: PL-EKO-02
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-05
-country:Poland
+< en:EU Organic
+en: PL-EKO-03
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-06
-country:Poland
+< en:EU Organic
+en: PL-EKO-04
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-07
-country:Poland
+< en:EU Organic
+en: PL-EKO-05
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-08
-country:Poland
+< en:EU Organic
+en: PL-EKO-06
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-09
-country:Poland
+< en:EU Organic
+en: PL-EKO-07
+country: Poland
 
-<en:EU Organic
-en:PL-EKO-10
-country:Poland
+< en:EU Organic
+en: PL-EKO-08
+country: Poland
 
-<en:EU Organic
-en:PT-BIO 01
-country:Portugal
+< en:EU Organic
+en: PL-EKO-09
+country: Poland
 
-<en:EU Organic
-en:PT-BIO-02
-country:Portugal
+< en:EU Organic
+en: PL-EKO-10
+country: Poland
 
-<en:EU Organic
-en:PT-BIO-03
-country:Portugal
+< en:EU Organic
+en: PT-BIO 01
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-04
-country:Portugal
+< en:EU Organic
+en: PT-BIO-02
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-05
-country:Portugal
+< en:EU Organic
+en: PT-BIO-03
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-06
-country:Portugal
+< en:EU Organic
+en: PT-BIO-04
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-07
-country:Portugal
+< en:EU Organic
+en: PT-BIO-05
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-08
-country:Portugal
+< en:EU Organic
+en: PT-BIO-06
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-09
-country:Portugal
+< en:EU Organic
+en: PT-BIO-07
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-10
-country:Portugal
+< en:EU Organic
+en: PT-BIO-08
+country: Portugal
 
-<en:EU Organic
-en:PT-BIO-11
-country:Portugal
+< en:EU Organic
+en: PT-BIO-09
+country: Portugal
 
-<en:EU Organic
-en:RO-ECO-001
-country:Romania
+< en:EU Organic
+en: PT-BIO-10
+country: Portugal
 
-<en:EU Organic
-en:RO-ECO-005
-country:Romania
+< en:EU Organic
+en: PT-BIO-11
+country: Portugal
 
-<en:EU Organic
-en:RO-ECO-007
-country:Romania
+< en:EU Organic
+en: RO-ECO-001
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-008
-country:Romania
+< en:EU Organic
+en: RO-ECO-005
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-009
-country:Romania
+< en:EU Organic
+en: RO-ECO-007
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-010
-country:Romania
+< en:EU Organic
+en: RO-ECO-008
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-014
-country:Romania
+< en:EU Organic
+en: RO-ECO-009
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-015
-country:Romania
+< en:EU Organic
+en: RO-ECO-010
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-016
-country:Romania
+< en:EU Organic
+en: RO-ECO-014
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-018
-country:Romania
+< en:EU Organic
+en: RO-ECO-015
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-021
-country:Romania
+< en:EU Organic
+en: RO-ECO-016
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-022
-country:Romania
+< en:EU Organic
+en: RO-ECO-018
+country: Romania
 
-<en:EU Organic
-en:RO-ECO-023
-country:Romania
+< en:EU Organic
+en: RO-ECO-021
+country: Romania
 
-<en:EU Organic
-en:SE-EKO-01
+< en:EU Organic
+en: RO-ECO-022
+country: Romania
 
-<en:EU Organic
-en:SE-EKO-03
+< en:EU Organic
+en: RO-ECO-023
+country: Romania
 
-<en:EU Organic
-en:SE-EKO-04
+< en:EU Organic
+en: SE-EKO-01
 
-<en:EU Organic
-en:SE-EKO-05
+< en:EU Organic
+en: SE-EKO-03
 
-<en:EU Organic
-en:SE-EKO-07
+< en:EU Organic
+en: SE-EKO-04
 
-<en:EU Organic
-en:SE-EKO-08
+< en:EU Organic
+en: SE-EKO-05
 
-<en:EU Organic
-en:SI-EKO-001
+< en:EU Organic
+en: SE-EKO-07
 
-<en:EU Organic
-en:SI-EKO-002
+< en:EU Organic
+en: SE-EKO-08
 
-<en:EU Organic
-en:SI-EKO-003
+< en:EU Organic
+en: SI-EKO-001
 
-<en:EU Organic
-en:SK-BIO-002
+< en:EU Organic
+en: SI-EKO-002
 
-<en:EU Organic
-en:SK-BIO-003
+< en:EU Organic
+en: SI-EKO-003
 
-<en:Fair trade
-<en:Organic
-fr:Bio-équitable, bioéquitable
+< en:EU Organic
+en: SK-BIO-002
 
-<en:Organic
-en:Soil Association Organic, Soil Association
-wikidata:en:Q7554873
+< en:EU Organic
+en: SK-BIO-003
 
-<en:Organic
-en:USDA Organic
-wikidata:en:Q3336915
+< en:Fair trade
+< en:Organic
+fr: Bio-équitable, bioéquitable
 
-<en:USDA Organic
-en:CCOF certified organic, certified CCOF organic, California Certified Organic Farmers
+< en:Organic
+en: Soil Association Organic, Soil Association
+wikidata:en: Q7554873
 
-<en:Organic
-en:Canada Organic, Biologique Canada Organic, Biologique Canada Canada Organic, Canada Organic Biologique Canada
-fr:Biologique Canada, Biologique Canada Organic, Biologique Canada Canada Organic, Canada Organic Biologique Canada
+< en:Organic
+en: USDA Organic
+wikidata:en: Q3336915
 
-<en:Organic
-fr:Bio-Cohérence
+< en:USDA Organic
+en: CCOF certified organic, certified CCOF organic, California Certified Organic Farmers
 
-<en:Organic
-fr:Bio-Solidaire, biosolidaire
+< en:Organic
+en: Canada Organic, Biologique Canada Organic, Biologique Canada Canada Organic, Canada Organic Biologique Canada
+fr: Biologique Canada, Biologique Canada Organic, Biologique Canada Canada Organic, Canada Organic Biologique Canada
 
-<en:Organic
-en:Bioland
-de:Bioland
-wikidata:en:Q864442
+< en:Organic
+fr: Bio-Cohérence
 
-<en:Organic
-en:Naturland
-de:Naturland
-wikidata:en:Q1970376
+< en:Organic
+fr: Bio-Solidaire, biosolidaire
 
-<en:Organic
-en:Biokreis
-de:Biokreis
-fr:Biokreis
-wikidata:en:Q864429
+< en:Organic
+en: Bioland
+de: Bioland
+wikidata:en: Q864442
 
-<en:Organic
-de:Bio 7 Initiative, BIO7 Initiative, Bio7, BIO 7
+< en:Organic
+en: Naturland
+de: Naturland
+wikidata:en: Q1970376
 
+< en:Organic
+en: Biokreis
+de: Biokreis
+fr: Biokreis
+wikidata:en: Q864429
 
-en:Sustainable farming
-fr:Agriculture durable
+< en:Organic
+de: Bio 7 Initiative, BIO7 Initiative, Bio7, BIO 7
 
-<en:Sustainable farming
-en:UTZ Certified, UTZ
-wikidata:en:Q2305872
 
-<en:UTZ Certified
-en:UTZ Certified Cacao, UTZ Certified Cocoa
-de:UTZ Certified Kakao
+en: Sustainable farming
+fr: Agriculture durable
 
-<en:UTZ Certified
-en:UTZ Certified Coffee
-de:UTZ Certified Kaffee
+< en:Sustainable farming
+en: UTZ Certified, UTZ
+wikidata:en: Q2305872
 
-en:Vegetarian, Suitable for vegetarians
-de:Vegetarisch
-es:Vegetariano, Producto vegetariano, Apto para vegetarianos, Vegetarian
-fr:Végétarien, Convient aux végétariens, Adapté au régime végétarien
-it:Vegetariano
-nl:Vegetarisch
-pt:Vegetariano
+# already in food labels.txt
+# < en:UTZ Certified
+# en: UTZ Certified Cacao, UTZ Certified Cocoa
+# de: UTZ Certified Kakao
 
-<en:Vegetarian
-en:Green Dot India, India Green Dot, Indian Green Dot, vegetarian mark India
+< en:UTZ Certified
+en: UTZ Certified Coffee
+de: UTZ Certified Kaffee
 
-<en:Vegetarian
-en:Vegan, Suitable for vegans
-de:Vegan
-es:Vegano, Producto vegano, Vegan
-fr:Végétalien, Végan, végétal
-it:Vegano, Vegan
-nl:Veganistisch
-pt:Vegano, Producto vegano, Vegan
-th:สูตรเจ
+en: Vegetarian, Suitable for vegetarians
+de: Vegetarisch
+es: Vegetariano, Producto vegetariano, Apto para vegetarianos, Vegetarian
+fr: Végétarien, Convient aux végétariens, Adapté au régime végétarien
+it: Vegetariano
+nl: Vegetarisch
+pt: Vegetariano
 
-<en:Vegan
-en:Vegan Action
-wikidata:en:Q7918275
+< en:Vegetarian
+en: Green Dot India, India Green Dot, Indian Green Dot, vegetarian mark India
 
-<en:Vegan
-en:Vegan Society
-wikidata:en:Q1855049
+< en:Vegetarian
+en: Vegan, Suitable for vegans
+de: Vegan
+es: Vegano, Producto vegano, Vegan
+fr: Végétalien, Végan, végétal
+it: Vegano, Vegan
+nl: Veganistisch
+pt: Vegano, Producto vegano, Vegan
+th: สูตรเจ
 
-<en:Vegan
-es:UVE Vegano, Unión Vegetariana Española Vegano, Certificado UVE Vegano
+< en:Vegan
+en: Vegan Action
+wikidata:en: Q7918275
 
-<en:Vegetarian
-en:Vegetarian Society
-wikidata:en:Q2154954
-en:FSC, Forest Stewardship Council
-es:FSC, Forest Stewardship Council, Consejo de Administración Forestal
-wikidata:en:Q748367
+# already in food labels.txt
+# < en:Vegan
+# en: Vegan Society
+# wikidata:en: Q1855049
 
-<en:Vegetarian
-en:No animal derived ingredients
-fr:Pas de composant animal, Sans matière animale
+< en:Vegan
+es: UVE Vegano, Unión Vegetariana Española Vegano, Certificado UVE Vegano
 
-en:PEFC, Pan European Forest Certification, Program for the Endorsement of Forest Certification, Program for the Endorsement of Forest Certification schemes
-fr:PEFC
+< en:Vegetarian
+en: Vegetarian Society
+wikidata:en: Q2154954
 
-fr:Imprim'Vert
+en: FSC, Forest Stewardship Council
+es: FSC, Forest Stewardship Council, Consejo de Administración Forestal
+wikidata:en: Q748367
 
-<en:FSC
-en:FSC Mix
-fr:FSC Mix, FSC Mixte
+< en:Vegetarian
+en: No animal derived ingredients
+fr: Pas de composant animal, Sans matière animale
 
-<en:FSC
-en:FSC Recycling
+en: PEFC, Pan European Forest Certification, Program for the Endorsement of Forest Certification, Program for the Endorsement of Forest Certification schemes
+fr: PEFC
 
-<en:FSC
-en:FSC-C017170
+fr: Imprim'Vert
 
-<en:FSC
-en:FSC-C002324
+< en:FSC
+en: FSC Mix
+fr: FSC Mix, FSC Mixte
 
-<en:FSC
-en:FSC-C066504
+< en:FSC
+en: FSC Recycling
 
-<en:FSC
-en:FSC-C014047
+< en:FSC
+en: FSC-C017170
 
-<en:FSC
-en:FSC-C014207
+< en:FSC
+en: FSC-C002324
 
-<en:FSC
-en:FSC-C016627
+< en:FSC
+en: FSC-C066504
 
-<en:FSC
-en:FSC-C020428
+< en:FSC
+en: FSC-C014047
 
-<en:FSC
-en:FSC-C022488
+< en:FSC
+en: FSC-C014207
 
-<en:FSC
-en:FSC-C074707
+< en:FSC
+en: FSC-C016627
 
-<en:FSC
-en:FSC-C081801
+< en:FSC
+en: FSC-C020428
 
-<en:FSC
-en:FSC-C100482
+< en:FSC
+en: FSC-C022488
 
-<en:FSC
-en:FSC-C104258
+< en:FSC
+en: FSC-C074707
 
-<en:FSC
-en:FSC-C104752
+< en:FSC
+en: FSC-C081801
 
-<en:FSC
-en:FSC-C107894
+< en:FSC
+en: FSC-C100482
 
-<en:FSC
-en:FSC-C109331
+< en:FSC
+en: FSC-C104258
 
-<en:FSC
-en:FSC-C115560
+< en:FSC
+en: FSC-C104752
 
-<en:FSC
-en:FSC-C117156
+< en:FSC
+en: FSC-C107894
 
-<en:organic
-fr:Cosmétique Bio - Charte Cosmebio, Cosmébio, Charte Cosmebio
+< en:FSC
+en: FSC-C109331
 
-fr:Cosmétique Eco - Charte Cosmebio, Cosméco, Charte Cosméco
+< en:FSC
+en: FSC-C115560
 
-fr:Nature & Progrès, Nature et Progrès
+< en:FSC
+en: FSC-C117156
 
-en:BDIH
-fr:BDIH, Cosmétiques naturels certifiés BDIH, BDIH Cosmétiques naturels certifiés
+< en:organic
+fr: Cosmétique Bio - Charte Cosmebio, Cosmébio, Charte Cosmebio
 
-en:NaTrue
+fr: Cosmétique Eco - Charte Cosmebio, Cosméco, Charte Cosméco
 
-<en:organic
-de:Austria Bio Garantie
+# already in food labels.txt
+# fr: Nature & Progrès, Nature et Progrès
 
-en:One Voice
-fr:One Voice, One Voice - pour une éthique animale et planétaire
+en: BDIH
+fr: BDIH, Cosmétiques naturels certifiés BDIH, BDIH Cosmétiques naturels certifiés
 
-en:Ecolabel
+en: NaTrue
 
-<en:Ecolabel
-en:EU Ecolabel
-fr:EU Ecolabel, Ecolabel EU, Ecolabel européen
+# already in food labels.txt
+# < en:organic
+# de: Austria Bio Garantie
 
-<en:Ecolabel
-en:Nordic Ecolabel
+en: One Voice
+fr: One Voice, One Voice - pour une éthique animale et planétaire
 
-fr:Ecocert Equitable, Equitable Ecocert
+en: Ecolabel
 
-fr:Ecocert
+< en:Ecolabel
+en: EU Ecolabel
+fr: EU Ecolabel, Ecolabel EU, Ecolabel européen
 
-en:Hypoallergenic
-fr:Hypoallergénique
-nl:Hypoallergeen
-de:Hypoallergen
+< en:Ecolabel
+en: Nordic Ecolabel
 
-en:Green point
-de:Grüner punkt
-fr:Point vert
+# already in food labels.txt
+# fr: Ecocert Equitable, Equitable Ecocert
 
-en:Not tested on animals
-fr:Non testé sur les animaux, non testé sur des animaux
-es:No testado en animales
-de:Nicht an Tieren getestet
-nl:Niet getest op dieren
+# already in food labels.txt
+# fr: Ecocert
 
-en:Neutral pH for the skin, neutral pH, ph skin neutral
-fr:pH neutre pour la peau, pH neutre, pH respectueux
-es:pH neutro para la piel, pH neutro, pH equilibrado para la piel
-de:Neutraler pH-Wert für die Haut, neutraler pH-Wert, pH-Wert neutral für die Haut
-nl:Neutrale pH-waarde voor de huid, neutrale pH-waarde, pH-waarde neutraal voor de huid
+en: Hypoallergenic
+de: Hypoallergen
+fr: Hypoallergénique
+nl: Hypoallergeen
 
-en:Dermatologically tested, Dermatologically approved, Tested by dermatologists, Dermo tested
-fr:Testé dermatologiquement, Testé dermatologiquemment, Testé sous controle dermatologique, Tolérance testée sous controle dermatologique, Tolerance-cutanee-testee-dermatologiquement, Tolerance-cutanee-testee-sous-controle-dermatologique, testée dermatologiquement, testées dermatologiquement, Approuvé dermatologiquement, dermato-testé
+# already in food labels.txt
+# en: Green point
+# de: Grüner punkt
+# fr: Point vert
 
-en:Fully recyclable packaging
-fr:Packaging entièrement recyclable
-es:Embalaje completamente reciclable
-de:Vollständig recycelbare Verpackung
-nl:Volledig recyclebare verpakking
+en: Not tested on animals
+de: Nicht an Tieren getestet
+es: No testado en animales
+fr: Non testé sur les animaux, non testé sur des animaux
+nl: Niet getest op dieren
 
-en:Easily flammable
-fr:Facilement inflammable
-es:Fácilmente inflamable
-de:Leicht entflammbar
-nl:Makkelijk ontvlambaar
+en: Neutral pH for the skin, neutral pH, ph skin neutral
+de: Neutraler pH-Wert für die Haut, neutraler pH-Wert, pH-Wert neutral für die Haut
+es: pH neutro para la piel, pH neutro, pH equilibrado para la piel
+fr: pH neutre pour la peau, pH neutre, pH respectueux
+nl: Neutrale pH-waarde voor de huid, neutrale pH-waarde, pH-waarde neutraal voor de huid
 
-en:Without phthalates, without phtalates, 0 phthalates
-fr:Sans phtalates, Sans phtalate, 0 phtalate, zero phtalate
+en: Dermatologically tested, Dermatologically approved, Tested by dermatologists, Dermo tested
+fr: Testé dermatologiquement, Testé dermatologiquemment, Testé sous controle dermatologique, Tolérance testée sous controle dermatologique, Tolerance-cutanee-testee-dermatologiquement, Tolerance-cutanee-testee-sous-controle-dermatologique, testée dermatologiquement, testées dermatologiquement, Approuvé dermatologiquement, dermato-testé
 
-en:No colorings, without colorings, no colourings, without colourings, no colour, no color
-fr:Sans colorants, pas de colorants, 0 colorant, zero colorant
+en: Fully recyclable packaging
+de: Vollständig recycelbare Verpackung
+es: Embalaje completamente reciclable
+fr: Packaging entièrement recyclable
+nl: Volledig recyclebare verpakking
 
-fr:Sans colorant de synthese,0 colorant de synthese 
-es:Sin colorante sintético,0 colorante sintético
-de:Ohne synthetische Farbstoffe,0 synthetische Farbstoffe
-nl:Zonder synthetische kleurstoffen,0 synthetische kleurstoffen
+en: Easily flammable
+de: Leicht entflammbar
+es: Fácilmente inflamable
+fr: Facilement inflammable
+nl: Makkelijk ontvlambaar
 
-en:Without soap, soap free
-fr:Sans savon
-es:Sin jabón
-de:Ohne Seife
-nl:Zonder zeep
+en: Without phthalates, without phtalates, 0 phthalates
+fr: Sans phtalates, Sans phtalate, 0 phtalate, zero phtalate
 
-en:Without perfume, no perfume, perfume free
-fr:Sans parfum
-es:Sin perfume
-de:Ohne Parfüm
-nl:Zonder parfum
+en: No colorings, without colorings, no colourings, without colourings, no colour, no color
+fr: Sans colorants, pas de colorants, 0 colorant, zero colorant
 
-en:Synthetic scent free, free from synthesis fragrance, synthesis fragrance free, free from synthetic fragrances, synthetic fragrances free
-fr:Sans parfum de synthèse
-es:Sin fragancia sintética, libre de fragancia de síntesis, sin fragancias sintéticas
-de:Ohne synthetischen Duft, frei von synthetischen Duftstoffen, synthetische Duftstoffe frei
-nl:Zonder synthetische geur, vrij van synthetische geurstoffen, synthetische geurstoffen vrij
+fr: Sans colorant de synthese, 0 colorant de synthese
+de: Ohne synthetische Farbstoffe, 0 synthetische Farbstoffe
+es: Sin colorante sintético, 0 colorante sintético
+nl: Zonder synthetische kleurstoffen, 0 synthetische kleurstoffen
 
-en:Without phenoxyethanol, Phenoxyethanol free
-fr:Sans phenoxyethanol
-es:Sin fenoxietanol
-de:Ohne Phenoxyethanol
-nl:Zonder fenoxyethanol
+en: Without soap, soap free
+de: Ohne Seife
+es: Sin jabón
+fr: Sans savon
+nl: Zonder zeep
 
-en:Without aluminium salts
-fr:Sans sels d'aluminium
-de:Ohne Aluminiumsalze
-es:Sin sales de aluminio
-nl:Zonder aluminiumzouten
+en: Without perfume, no perfume, perfume free
+de: Ohne Parfüm
+es: Sin perfume
+fr: Sans parfum
+nl: Zonder parfum
 
-en:Without silicon, Silicon free
-fr:Sans silicone, 0 silicones, Sans silicones
-de:Ohne Silikon
-nl:Zonder silicone
-es:Sin silicona
-it:Senza silicone
-pt:Sem silicone
+en: Synthetic scent free, free from synthesis fragrance, synthesis fragrance free, free from synthetic fragrances, synthetic fragrances free
+de: Ohne synthetischen Duft, frei von synthetischen Duftstoffen, synthetische Duftstoffe frei
+es: Sin fragancia sintética, libre de fragancia de síntesis, sin fragancias sintéticas
+fr: Sans parfum de synthèse
+nl: Zonder synthetische geur, vrij van synthetische geurstoffen, synthetische geurstoffen vrij
 
-en:Without acetone
-fr:Sans acétone
-es:Sin acetona
-de:Ohne Aceton
-nl:Zonder aceton
+en: Without phenoxyethanol, Phenoxyethanol free
+de: Ohne Phenoxyethanol
+es: Sin fenoxietanol
+fr: Sans phenoxyethanol
+nl: Zonder fenoxyethanol
 
-fr:Sans alcool, Pas d'alcool
-en:No alcohol, 0 alcohol, without alcohol, alcohol free
-es:Sin alcohol, 0 alcohol, sin contenido de alcohol, libre de alcohol
-de:Ohne Alkohol, Kein Alkohol, alkoholfrei
-nl:Zonder alcohol, Geen alcohol, alcoholvrij
+en: Without aluminium salts
+de: Ohne Aluminiumsalze
+es: Sin sales de aluminio
+fr: Sans sels d'aluminium
+nl: Zonder aluminiumzouten
 
-en:Without glycol ethers
-fr:Sans ethers de glycol
-es:Sin éteres de glicol
-de:Ohne Glykolether
-nl:Zonder glycolethers
+en: Without silicon, Silicon free
+de: Ohne Silikon
+es: Sin silicona
+fr: Sans silicone, 0 silicones, Sans silicones
+it: Senza silicone
+nl: Zonder silicone
+pt: Sem silicone
 
-en:Without formaldehyde
-fr:Sans formaldehyde
-es:Sin formaldehído
-de:Ohne Formaldehyd
-nl:Zonder formaldehyde
+en: Without acetone
+de: Ohne Aceton
+es: Sin acetona
+fr: Sans acétone
+nl: Zonder aceton
 
-en:Sulfate free, No sulfate, Without sulfate
-fr:Sans sulfates, Sans sulphates
-es:Sin sulfatos
-de:Ohne Sulfate
-nl:Zonder sulfaten
+# already in food labels.txt
+# fr: Sans alcool, Pas d'alcool
+# en: No alcohol, 0 alcohol, without alcohol, alcohol free
+# de: Ohne Alkohol, Kein Alkohol, alkoholfrei
+# es: Sin alcohol, 0 alcohol, sin contenido de alcohol, libre de alcohol
+# nl: Zonder alcohol, Geen alcohol, alcoholvrij
 
-en:Without ammonia
-fr:Sans ammoniaque
-es:Sin amoníaco
-de:Ohne Ammoniak
-nl:Zonder ammoniak
+en: Without glycol ethers
+de: Ohne Glykolether
+es: Sin éteres de glicol
+fr: Sans ethers de glycol
+nl: Zonder glycolethers
 
-en:Without triclosan, Triclosan free, No triclosan
-fr:Sans triclosan
-es:Sin triclosán
-de:Ohne Triclosan
-nl:Zonder triclosan
+en: Without formaldehyde
+de: Ohne Formaldehyd
+es: Sin formaldehído
+fr: Sans formaldehyde
+nl: Zonder formaldehyde
 
-en:Palm oil free, Without palm oil, No palm oil
-es:Sin aceite de palma
-fr:Sans huile de palme
-de:Ohne Palmöl
-nl:Zonder palmolie
+en: Sulfate free, No sulfate, Without sulfate
+de: Ohne Sulfate
+es: Sin sulfatos
+fr: Sans sulfates, Sans sulphates
+nl: Zonder sulfaten
 
-en:Sustainable Palm Oil, Certified Sustainable Palm Oil, RSPO
-fr:Huile de palme durable, Huile de palme certifiée durable, RSPO
-es:Aceite de palma sostenible, Aceite de palma certificado sostenible, RSPO
-de:Nachhaltiges Palmöl, Zertifiziertes nachhaltiges Palmöl, RSPO
-nl:Duurzame palmolie, Gecertificeerde duurzame palmolie, RSPO
+en: Without ammonia
+de: Ohne Ammoniak
+es: Sin amoníaco
+fr: Sans ammoniaque
+nl: Zonder ammoniak
 
-fr:Ne pique pas les yeux
-en:Does not sting the eyes, No more tears, No tears, No tears formula
-es:No irrita los ojos, Sin lágrimas, Fórmula sin lágrimas
-de:Brennt nicht in den Augen, Keine Tränen, Tränenfrei, Keine Tränen-Formel
-nl:Prikt niet in de ogen, Geen tranen, Geen tranen formule
+en: Without triclosan, Triclosan free, No triclosan
+de: Ohne Triclosan
+es: Sin triclosán
+fr: Sans triclosan
+nl: Zonder triclosan
 
-fr:Non comédogène, Non obstruant les pores
-en:Non comedogenic, Non pore-clogging
+# already in food labels.txt
+# en:Palm oil free, Without palm oil, No palm oil
+# es:Sin aceite de palma
+# fr:Sans huile de palme
+# de:Ohne Palmöl
+# nl:Zonder palmolie
 
-fr:Sans conservateurs, sans conservateur, 0 conservateur
-en:No preservatives, Preservatives free
-es:Sin conservantes, libre de conservantes
-de:Ohne Konservierungsstoffe, Konservierungsstoffe frei
-nl:Zonder conserveermiddelen, conserveermiddelvrij
+# already in food labels.txt
+# en:Sustainable Palm Oil, Certified Sustainable Palm Oil, RSPO
+# fr:Huile de palme durable, Huile de palme certifiée durable, RSPO
+# es:Aceite de palma sostenible, Aceite de palma certificado sostenible, RSPO
+# de:Nachhaltiges Palmöl, Zertifiziertes nachhaltiges Palmöl, RSPO
+# nl:Duurzame palmolie, Gecertificeerde duurzame palmolie, RSPO
 
-fr:Résiste à l'eau, Résistant à l'eau
-en:Waterproof, splashproof, water resistant
-es:Resistente al agua, a prueba de salpicaduras, resistente al agua
-de:Wasserdicht, spritzwassergeschützt, wasserfest
-nl:Waterdicht, spatwaterdicht, waterbestendig
+fr: Ne pique pas les yeux
+en: Does not sting the eyes, No more tears, No tears, No tears formula
+de: Brennt nicht in den Augen, Keine Tränen, Tränenfrei, Keine Tränen-Formel
+es: No irrita los ojos, Sin lágrimas, Fórmula sin lágrimas
+nl: Prikt niet in de ogen, Geen tranen, Geen tranen formule
 
-fr:Anti-traces, anti-trace
+fr: Non comédogène, Non obstruant les pores
+en: Non comedogenic, Non pore-clogging
 
-fr:UFSBD
-en:UFSBD
+# already in food labels.txt
+# fr:Sans conservateurs, sans conservateur, 0 conservateur
+# en:No preservatives, Preservatives free
+# es:Sin conservantes, libre de conservantes
+# de:Ohne Konservierungsstoffe, Konservierungsstoffe frei
+# nl:Zonder conserveermiddelen, conserveermiddelvrij
+
+fr: Résiste à l'eau, Résistant à l'eau
+en: Waterproof, splashproof, water resistant
+de: Wasserdicht, spritzwassergeschützt, wasserfest
+es: Resistente al agua, a prueba de salpicaduras, resistente al agua
+nl: Waterdicht, spatwaterdicht, waterbestendig
+
+fr: Anti-traces, anti-trace
+

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -21942,7 +21942,8 @@ it: Etichette relative alla salute dei denti
 nl: Gebitsgezondheidslabels
 
 < en:Tooth-health related labels
-fr: Union française pour la santé bucco-dentaire, Ufsbd
+en: UFSBD
+fr: Union française pour la santé bucco-dentaire, UFSBD
 
 en: European Fruit Juice Control System, EQCS, European Quality Control System for Juice, European Quality Control System for Juice and Nectars from Fruits and Vegetables
 


### PR DESCRIPTION
### What

Remove the nova drilldown field for Open Beauty Facts

\+ commented duplicates between labels taxonomies for food and beauty. Make lint made more changes. Look for "# already in food labels.txt" in the code.

### Related issue(s) and discussion
- Fixes #11111
