### PR TITLE
fix: Nutripatrol url trailing slash removal regex

### DIFF
--- a/lib/ProductOpener/ConfigEnv.pm
+++ b/lib/ProductOpener/ConfigEnv.pm
@@ -33,6 +33,6 @@ BEGIN {
 use vars @EXPORT_OK;    # no 'my' keyword for these
 
 $nutripatrol_url = $ENV{NUTRIPATROL_URL};
-$nutripatrol_url =~ s/\///;    # remove trailing slash if there is one
+$nutripatrol_url =~ s/\/$//;    # remove trailing slash if there is one
 
 1;

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -3596,7 +3596,7 @@ The score is calculated from the data of the nutrition facts table and the compo
     
         <div>
             <a class="button small action-report_product_to_nutripatrol"
-                href="http:/nutripatrol.localhost/flag/product/?barcode=0200000000235&source=web&flavor=off">
+                href="//nutripatrol.localhost/flag/product/?barcode=0200000000235&source=web&flavor=off">
                 Report this product to our moderators
             </a>
         </div>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -3596,7 +3596,7 @@ The score is calculated from the data of the nutrition facts table and the compo
     
         <div>
             <a class="button small action-report_product_to_nutripatrol"
-                href="http:/nutripatrol.localhost/flag/product/?barcode=0200000000235&source=web&flavor=off">
+                href="//nutripatrol.localhost/flag/product/?barcode=0200000000235&source=web&flavor=off">
                 Report this product to our moderators
             </a>
         </div>

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -4772,7 +4772,7 @@ The score is calculated from the data of the nutrition facts table and the compo
     
         <div>
             <a class="button small action-report_product_to_nutripatrol"
-                href="http:/nutripatrol.localhost/flag/product/?barcode=0200000000034&source=web&flavor=off">
+                href="//nutripatrol.localhost/flag/product/?barcode=0200000000034&source=web&flavor=off">
                 Report this product to our moderators
             </a>
         </div>

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -4300,7 +4300,7 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
         <div>
             <a class="button small action-report_product_to_nutripatrol"
-                href="http:/nutripatrol.localhost/flag/product/?barcode=3300000000002&source=web&flavor=off">
+                href="//nutripatrol.localhost/flag/product/?barcode=3300000000002&source=web&flavor=off">
                 Report this product to our moderators
             </a>
         </div>

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -4314,7 +4314,7 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
     
         <div>
             <a class="button small action-report_product_to_nutripatrol"
-                href="http:/nutripatrol.localhost/flag/product/?barcode=3300000000001&source=web&flavor=off">
+                href="//nutripatrol.localhost/flag/product/?barcode=3300000000001&source=web&flavor=off">
                 Report this product to our moderators
             </a>
         </div>

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -4327,7 +4327,7 @@ The score is calculated from the data of the nutrition facts table and the compo
     
         <div>
             <a class="button small action-report_product_to_nutripatrol"
-                href="http:/nutripatrol.localhost/flag/product/?barcode=3300000000001&source=web&flavor=off">
+                href="//nutripatrol.localhost/flag/product/?barcode=3300000000001&source=web&flavor=off">
                 Report this product to our moderators
             </a>
         </div>


### PR DESCRIPTION
Copy of https://github.com/openfoodfacts/openfoodfacts-server/pull/11182 so that the branch is on the openfoodfacts-server repo, in order to be able to use the /update_tests_results GitHub action