### PR TITLE
fix: Invalid OFF dark icon

### DIFF
--- a/html/images/logos/off-logo-icon-dark.svg
+++ b/html/images/logos/off-logo-icon-dark.svg
@@ -1,91 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   width="178"
-   height="178"
-   viewBox="0 0 178 178"
-   version="1.1"
-   id="svg3069"
-   inkscape:version="1.2 (1:1.2+202205241504+da316b6974)"
-   sodipodi:docname="off-logo-icon-dark.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview3071"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm"
-     showgrid="false"
-     inkscape:zoom="0.80354938"
-     inkscape:cx="128.80353"
-     inkscape:cy="561.88208"
-     inkscape:window-width="2560"
-     inkscape:window-height="1440"
-     inkscape:window-x="0"
-     inkscape:window-y="-37"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
-  <defs
-     id="defs3066" />
-  <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1">
-    <g
-       id="g3232"
-       transform="matrix(-1,0,0,1.0000084,211.85,-30.076)">
-      <g
-         id="g3224">
-        <path
-           class="e"
-           d="m 61.62,122.32 c 0,-33.82 27.41,-61.23 61.23,-61.23 33.82,0 61.23,27.41 61.23,61.23 z"
-           id="path3216"
-           style="fill:#ff8c14" />
-        <circle
-           class="f"
-           cx="143.58"
-           cy="82.779999"
-           r="3.3699999"
-           id="circle3218"
-           style="fill:#8c3c00" />
-        <circle
-           class="f"
-           cx="159.98"
-           cy="97.839996"
-           r="3.3699999"
-           id="circle3220"
-           style="fill:#8c3c00" />
-        <circle
-           class="f"
-           cx="141.42999"
-           cy="101.52"
-           r="3.3699999"
-           id="circle3222"
-           style="fill:#8c3c00" />
-      </g>
-      <path
-         class="d"
-         d="m 93.15,175.84 -10.88,25.97 14.32,6 10.97,-26.19 c 4.89,1.26 10.01,1.93 15.29,1.93 33.76,0 61.23,-27.47 61.23,-61.23 h -15.52 c 0,25.2 -20.5,45.71 -45.71,45.71 -25.21,0 -45.71,-20.5 -45.71,-45.71 H 61.62 c 0,22.99 12.74,43.05 31.53,53.52 z"
-         id="path3226"
-         style="fill:#ffffff" />
-      <path
-         class="b"
-         d="m 148.17,30.34 c -12.04,0 -22.5,6.71 -27.88,16.59 4.14,3.86 7.27,8.79 8.89,14.38 14.01,-3.14 24.53,-15.53 24.77,-30.43 -1.87,-0.35 -3.8,-0.53 -5.78,-0.53 z"
-         id="path3228"
-         style="fill:#00641e" />
-      <path
-         class="c"
-         d="m 98.68,38.42 c -2.38,0 -4.7,0.27 -6.94,0.77 3.83,13.23 16.03,22.91 30.5,22.91 2.38,0 4.7,-0.27 6.94,-0.77 C 125.35,48.1 113.15,38.42 98.68,38.42 Z"
-         id="path3230"
-         style="fill:#00961e" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="178px" height="178px" viewBox="0 0 178 178" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Artboard</title>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="off-logo-icon-dark" transform="translate(27.77, 0.265)" fill-rule="nonzero">
+            <g id="g2989" transform="translate(0, 30.75)">
+                <path d="M0,61.23 C0,27.41 27.41,-1.19949929e-24 61.23,-1.19949929e-24 C95.05,-1.19949929e-24 122.46,27.41 122.46,61.23 L0,61.23 Z" id="path2979" fill="#FF8C14"></path>
+                <circle id="circle2983" fill="#8C3C00" cx="81.96" cy="21.689999" r="3.3699999"></circle>
+                <circle id="circle2985" fill="#8C3C00" cx="98.36" cy="36.749996" r="3.3699999"></circle>
+                <circle id="circle2987" fill="#8C3C00" cx="79.80999" cy="40.43" r="3.3699999"></circle>
+            </g>
+            <path d="M31.53,145.5 L20.65,171.47 L34.97,177.47 L45.94,151.28 C50.83,152.54 55.95,153.21 61.23,153.21 C94.99,153.21 122.46,125.74 122.46,91.98 L106.94,91.98 C106.94,117.18 86.44,137.69 61.23,137.69 C36.02,137.69 15.52,117.19 15.52,91.98 L0,91.98 C0,114.97 12.74,135.03 31.53,145.5 L31.53,145.5 Z" id="path2991" fill="#FFFFFF"></path>
+            <path d="M86.55,-3.55271368e-15 C74.51,-3.55271368e-15 64.05,6.71 58.67,16.59 C62.81,20.45 65.94,25.38 67.56,30.97 C81.57,27.83 92.09,15.44 92.33,0.54 C90.46,0.19 88.53,0.01 86.55,0.01 L86.55,-3.55271368e-15 Z" id="path2993" fill="#00641E"></path>
+            <path d="M37.06,8.08 C34.68,8.08 32.36,8.35 30.12,8.85 C33.95,22.08 46.15,31.76 60.62,31.76 C63,31.76 65.32,31.49 67.56,30.99 C63.73,17.76 51.53,8.08 37.06,8.08 Z" id="path2995" fill="#00961E"></path>
+        </g>
     </g>
-  </g>
 </svg>


### PR DESCRIPTION
Hi everyone!

A really tiny change, but the dark variant of the OFF logo is flipped.
We use it in dark mode in the app.