### PR TITLE
fix: "NutriScore V2" SVGs with blank space

### DIFF
--- a/html/images/attributes/src/nutriscore-not-applicable-new-de.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable-new-de.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-not-applicable-new-en.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable-new-en.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-not-applicable-new-fr.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable-new-fr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-not-applicable-new-lb.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable-new-lb.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-not-applicable-new-nl.svg
+++ b/html/images/attributes/src/nutriscore-not-applicable-new-nl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-unknown-new-de.svg
+++ b/html/images/attributes/src/nutriscore-unknown-new-de.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-unknown-new-en.svg
+++ b/html/images/attributes/src/nutriscore-unknown-new-en.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-unknown-new-fr.svg
+++ b/html/images/attributes/src/nutriscore-unknown-new-fr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-unknown-new-lb.svg
+++ b/html/images/attributes/src/nutriscore-unknown-new-lb.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>

--- a/html/images/attributes/src/nutriscore-unknown-new-nl.svg
+++ b/html/images/attributes/src/nutriscore-unknown-new-nl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="162" version="1.1" viewBox="0 0 240 162">
+<svg xmlns="http://www.w3.org/2000/svg" id="svg2032" width="240" height="130" version="1.1" viewBox="0 0 240 130">
   <defs id="defs2029">
     <clipPath id="clipPath1836" clipPathUnits="userSpaceOnUse">
       <path id="path1838" stroke-width="1" d="M-576.406-131.683h841.89v595.276h-841.89z"/>


### PR DESCRIPTION
Hi everyone!

On some Nutri-score V2 SVG files, there is a blank space:
<img width="266" alt="Screenshot 2025-01-08 at 18 08 36" src="https://github.com/user-attachments/assets/9c9da451-59af-4871-8be2-4f818ca76781" />

<img width="215" alt="Screenshot 2025-01-08 at 18 16 02" src="https://github.com/user-attachments/assets/d241c062-f86b-4c33-8c61-8978e4cca8d2" />

Without this fix, we have this weird layout in the mobile app:

![IMG_21B15B9C47AD-1](https://github.com/user-attachments/assets/f3e3a995-61b9-4384-8842-4ff6cd970bbc)
