### PR TITLE
docs: YAML syntax in the data schema files

### DIFF
--- a/docs/api/ref/api.yml
+++ b/docs/api/ref/api.yml
@@ -35,7 +35,7 @@ paths:
         - Read Requests
       summary: Get information for a specific product by barcode
       description: |
-        Fetches product details by its unique barcode. 
+        Fetches product details by its unique barcode.
         Can return all product details or specific fields like knowledge panels.
       operationId: get-product-by-barcode
       parameters:
@@ -482,7 +482,8 @@ components:
         The value is structured as: user_id&username&user_session&session_token
         e.g. "user_id&exampleuser&user_session&abcdefghijklmnopqrstuvwxyz123456789ABCDEFGHIJKLM"
     userAgentAuth:
-      description: Authentication using User-Agent header
+      description: |
+        Authentication using User-Agent header
         User-Agent header in the format 'app_name/app_version (email)'
       type: apiKey
       in: header
@@ -502,7 +503,7 @@ components:
         app_uuid:
           type: string
           description: |
-            A salted random uuid (Unique identifier) for the user so that Open Food Facts moderators 
+            A salted random uuid (Unique identifier) for the user so that Open Food Facts moderators
             can selectively ban any problematic user without banning your whole app account.
       required:
         - app_name

--- a/docs/api/ref/schemas/ecoscore-country-code.yaml
+++ b/docs/api/ref/schemas/ecoscore-country-code.yaml
@@ -3,71 +3,69 @@ components:
     EcoscoreCountryCode:
       type: string
       enum:
-        [
-          "ad",
-          "al",
-          "at",
-          "ax",
-          "ba",
-          "be",
-          "bg",
-          "ch",
-          "cy",
-          "cz",
-          "de",
-          "dk",
-          "dz",
-          "ee",
-          "eg",
-          "es",
-          "fi",
-          "fo",
-          "fr",
-          "gg",
-          "gi",
-          "gr",
-          "hr",
-          "hu",
-          "ie",
-          "il",
-          "im",
-          "is",
-          "it",
-          "je",
-          "lb",
-          "li",
-          "lt",
-          "lu",
-          "lv",
-          "ly",
-          "ma",
-          "mc",
-          "md",
-          "me",
-          "mk",
-          "mt",
-          "nl",
-          "no",
-          "pl",
-          "ps",
-          "pt",
-          "ro",
-          "rs",
-          "se",
-          "si",
-          "sj",
-          "sk",
-          "sm",
-          "sy",
-          "tn",
-          "tr",
-          "ua",
-          "uk",
-          "us",
-          "va",
-          "world",
-          "xk",
-        ]
+        - "ad"
+        - "al"
+        - "at"
+        - "ax"
+        - "ba"
+        - "be"
+        - "bg"
+        - "ch"
+        - "cy"
+        - "cz"
+        - "de"
+        - "dk"
+        - "dz"
+        - "ee"
+        - "eg"
+        - "es"
+        - "fi"
+        - "fo"
+        - "fr"
+        - "gg"
+        - "gi"
+        - "gr"
+        - "hr"
+        - "hu"
+        - "ie"
+        - "il"
+        - "im"
+        - "is"
+        - "it"
+        - "je"
+        - "lb"
+        - "li"
+        - "lt"
+        - "lu"
+        - "lv"
+        - "ly"
+        - "ma"
+        - "mc"
+        - "md"
+        - "me"
+        - "mk"
+        - "mt"
+        - "nl"
+        - "no"
+        - "pl"
+        - "ps"
+        - "pt"
+        - "ro"
+        - "rs"
+        - "se"
+        - "si"
+        - "sj"
+        - "sk"
+        - "sm"
+        - "sy"
+        - "tn"
+        - "tr"
+        - "ua"
+        - "uk"
+        - "us"
+        - "va"
+        - "world"
+        - "xk"
       # patternProperties not supported by generators
       #patternProperties:
       #  (?<country_code>\w\w):

--- a/docs/api/ref/schemas/product_nutriscore.yaml
+++ b/docs/api/ref/schemas/product_nutriscore.yaml
@@ -172,14 +172,12 @@ components:
         id:
           type: string
           examples:
-            [
-              "energy",
-              "sugars",
-              "saturated_fat",
-              "salt",
-              "fiber",
-              "fruits_vegetables_legumes",
-            ]
+            - "energy"
+            - "sugars"
+            - "saturated_fat"
+            - "salt"
+            - "fiber"
+            - "fruits_vegetables_legumes"
         points:
           type: integer
           examples: [5, 6, 7, 2, 1, 0]

--- a/docs/api/ref/schemas/product_nutrition.yaml
+++ b/docs/api/ref/schemas/product_nutrition.yaml
@@ -166,51 +166,49 @@ properties:
           [default-unit]: https://openfoodfacts.github.io/openfoodfacts-server/dev/ref-perl-pod/ProductOpener/Food.html#default_unit_for_nid_(_%24nid)
         type: string
         enum:
-          [
-            "公斤",
-            "公升",
-            "kg",
-            "кг",
-            "l",
-            "л",
-            "毫克",
-            "mg",
-            "мг",
-            "mcg",
-            "µg",
-            "oz",
-            "fl oz",
-            "dl",
-            "дл",
-            "cl",
-            "кл",
-            "斤",
-            "g",
-            "",
-            " ",
-            "kJ",
-            "克",
-            "公克",
-            "г",
-            "мл",
-            "ml",
-            "mmol/l",
-            "毫升",
-            "% vol",
-            "ph",
-            "%",
-            "% dv",
-            "% vol (alcohol)",
-            "iu",
-            "mol/l",
-            "mval/l",
-            "ppm",
-            "�rh",
-            "�fh",
-            "�e",
-            "�dh",
-            "gpg",
-          ]
+          - "公斤"
+          - "公升"
+          - "kg"
+          - "кг"
+          - "l"
+          - "л"
+          - "毫克"
+          - "mg"
+          - "мг"
+          - "mcg"
+          - "µg"
+          - "oz"
+          - "fl oz"
+          - "dl"
+          - "дл"
+          - "cl"
+          - "кл"
+          - "斤"
+          - "g"
+          - ""
+          - " "
+          - "kJ"
+          - "克"
+          - "公克"
+          - "г"
+          - "мл"
+          - "ml"
+          - "mmol/l"
+          - "毫升"
+          - "% vol"
+          - "ph"
+          - "%"
+          - "% dv"
+          - "% vol (alcohol)"
+          - "iu"
+          - "mol/l"
+          - "mval/l"
+          - "ppm"
+          - "�rh"
+          - "�fh"
+          - "�e"
+          - "�dh"
+          - "gpg"
       '(?<nutrient>[\w-]+)_100g':
         description: |
           The standardized value of a serving of 100g (or 100ml for liquids)


### PR DESCRIPTION
docs: YAML syntax in the data schema files
==========================================

This pull request applies to files

```
  docs/api/ref/schemas/api.yaml
  docs/api/ref/schemas/ecoscore-country-code.yaml
  docs/api/ref/schemas/product-nutriscore.yaml
  docs/api/ref/schemas/product-nutristion.yaml
```

Multi-line string
-----------------

The `api.yaml` file contains the following specification:

```
components:
  securitySchemes:
    [ ... cut ... ]
    userAgentAuth:
      description: Authentication using User-Agent header
        User-Agent header in the format 'app_name/app_version (email)'
      type: apiKey
      in: header
      name: User-Agent
```

The description of `userAgentAuth` spans two lines, so it should be written as:

```
components:
  securitySchemes:
    [ ... cut ... ]
    userAgentAuth:
      description: |
        Authentication using User-Agent header
        User-Agent header in the format 'app_name/app_version (email)'
      type: apiKey
      in: header
      name: User-Agent
```

Array in JSON syntax
--------------------

In a YAML file, an array can use  the YAML syntax, i.e. each item on a separate line, with  a dash prefix at a constant  indent level, or use the JSON syntax,  i.e. all items separated with a  comma and the whole list enclose  dwithin square  brackets. Yet,  with the  `YAML.pm` Perl module, a  JSON-syntax list should be  on a single line.  A multi-line JSON syntax triggers an error.

Therefore the lists:

```
components:
  schemas:
    EcoscoreCountryCode:
      type: string
      enum:
        [
          "ad",
          "al",
          "at",
          [ ... cut ... ]
          "world",
          "xk",
        ]
```

and

```
        id:
          type: string
          examples:
            [
              "energy",
              "sugars",
              "saturated_fat",
              "salt",
              "fiber",
              "fruits_vegetables_legumes",
            ]
```

and

```
        type: string
        enum:
          [
            "公斤",
            "公升",
            "kg",
            "кг",
            "l",
            "л",
            [ ... cut ... ]
            "gpg",
          ]

```

should be  written as  a single  JSON line  (rather cumbersome  in two cases, not tested in the third case)

```
        id:
          type: string
          examples: [ "energy", "sugars", "saturated_fat", "salt", "fiber", "fruits_vegetables_legumes" ]
```

or with the YAML syntax (better):

```
components:
  schemas:
    EcoscoreCountryCode:
      type: string
      enum:
        - "ad"
        - "al"
        - "at"
        [ ... cut ... ]
        - "world"
        - "xk"
```

and

```
        id:
          type: string
          examples:
            - "energy"
            - "sugars"
            - "saturated_fat"
            - "salt"
            - "fiber"
            - "fruits_vegetables_legumes"
```

and

```
        type: string
        enum:
          - "公斤"
          - "公升"
          - "kg"
          - "кг"
          - "l"
          - "л"
          [ ... cut ... ]
          - "gpg"
```

Happy new year!

