### PR TITLE
fix: more positive messages for Nova 4

### DIFF
--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -7363,9 +7363,9 @@ msgid "Limit ultra-processed foods"
 msgstr "Limit ultra-processed foods"
 
 msgctxt "recommendation_limit_ultra_processed_foods_subtitle"
-msgid "Ultra-processed foods increase noncommunicable chronic disease risk"
-msgstr "Ultra-processed foods increase noncommunicable chronic disease risk"
+msgid "Limiting ultra-processed foods reduces the risk of noncommunicable chronic diseases"
+msgstr "Limiting ultra-processed foods reduces the risk of noncommunicable chronic diseases"
 
 msgctxt "recommendation_limit_ultra_processed_foods_text"
-msgid "Several studies have found that a high consumption of ultra-processed foods is associated with an increased risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
-msgstr "Several studies have found that a high consumption of ultra-processed foods is associated with an increased risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+msgid "Several studies have found that a lower consumption of ultra-processed foods is associated with an reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+msgstr "Several studies have found that a lower consumption of ultra-processed foods is associated with an reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -7352,9 +7352,9 @@ msgid "Limit ultra-processed foods"
 msgstr "Limit ultra-processed foods"
 
 msgctxt "recommendation_limit_ultra_processed_foods_subtitle"
-msgid "Ultra-processed foods increase noncommunicable chronic disease risk"
-msgstr "Ultra-processed foods increase noncommunicable chronic disease risk"
+msgid "Limiting ultra-processed foods reduces the risk of noncommunicable chronic diseases"
+msgstr "Limiting ultra-processed foods reduces the risk of noncommunicable chronic diseases"
 
 msgctxt "recommendation_limit_ultra_processed_foods_text"
-msgid "Several studies have found that a high consumption of ultra-processed foods is associated with an increased risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
-msgstr "Several studies have found that a high consumption of ultra-processed foods is associated with an increased risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+msgid "Several studies have found that a lower consumption of ultra-processed foods is associated with an reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+msgstr "Several studies have found that a lower consumption of ultra-processed foods is associated with an reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -7311,9 +7311,9 @@ msgid "Limit ultra-processed foods"
 msgstr "Limiter les aliments ultra-transformés"
 
 msgctxt "recommendation_limit_ultra_processed_foods_subtitle"
-msgid "Ultra-processed foods increase chronic disease risk"
-msgstr "Les aliments ultra-transformés augmentent le risque de maladies chroniques"
+msgid "Limiting ultra-processed foods reduces the risk of noncommunicable chronic diseases"
+msgstr "Limiter les aliments ultra-transformés réduit le risque de maladies chroniques"
 
 msgctxt "recommendation_limit_ultra_processed_foods_text"
-msgid "Several studies have found that a high consumption of ultra-processed foods is associated with an increased risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
-msgstr "Plusieurs études ont montré qu'une consommation élevée d'aliments ultra-transformés est associée à un risque accru de maladies chroniques non transmissibles, telles que l'obésité, l'hypertension et le diabète."
+msgid "Several studies have found that a lower consumption of ultra-processed foods is associated with an reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+msgstr "Plusieurs études ont montré qu'une consommation plus faible d'aliments ultra-transformés est associée à un risque diminué de maladies chroniques non transmissibles, telles que l'obésité, l'hypertension et le diabète."


### PR DESCRIPTION
We got feedback from dieteticians that it's better to have positive messages like "limit nova 4 reduces risk" instead of "nova 4 increases risk"

![image](https://github.com/user-attachments/assets/046e159f-5de0-4641-ac74-104b4ae8e4a4)
