### PR TITLE
chore: make more requests goes to priority apache

### DIFF
--- a/conf/nginx/sites-available/off
+++ b/conf/nginx/sites-available/off
@@ -24,6 +24,8 @@ map $uri $apache_port {
 	"~*^/cgi/product.pl" 8002;
 	# product API read / write
 	"~*^/api/v./product/" 8002;
+        # whitelist most cgi (but display and search)
+        "~*^/cgi/(?!display|search).pl" 8002;
 }
 
 # variables definitions for expiry headers are loaded from /etc/nginx/conf.d/expires-no-json-xml.conf


### PR DESCRIPTION
We added the priority apache.
But initially we did add only a few path to it.
As it's working fine, make more requests goes through it as they are important for product contribution.

A [graph is visible here](https://prometheus.openfoodfacts.org/graph?g0.expr=apache_workers%7Bstate%3D%22busy%22%2Cenv%3D%22prod%22%7D&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2h).