### PR TITLE
fix: Green-Score attributes/panels titles and subtitles

### DIFF
--- a/lib/ProductOpener/Attributes.pm
+++ b/lib/ProductOpener/Attributes.pm
@@ -570,7 +570,8 @@ sub compute_attribute_nutriscore ($product_ref, $target_lc, $target_cc) {
 		$attribute_ref->{match} = 0;
 		if ($target_lc ne "data") {
 			$attribute_ref->{title} = lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_title");
-			$attribute_ref->{description} = f_lang_in_lc(
+			# Note: we now display the not-applicable category in the short description
+			$attribute_ref->{description_short} = f_lang_in_lc(
 				$target_lc,
 				"f_attribute_nutriscore_not_applicable_description",
 				{
@@ -580,8 +581,8 @@ sub compute_attribute_nutriscore ($product_ref, $target_lc, $target_cc) {
 					)
 				}
 			);
-			$attribute_ref->{description_short}
-				= lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_description_short");
+			#$attribute_ref->{description_short}
+			#	= lang_in_other_lc($target_lc, "attribute_nutriscore_not_applicable_description_short");
 		}
 	}
 
@@ -727,7 +728,8 @@ sub compute_attribute_environmental_score ($product_ref, $target_lc, $target_cc)
 		if ($target_lc ne "data") {
 			$attribute_ref->{title}
 				= lang_in_other_lc($target_lc, "attribute_environmental_score_not_applicable_title");
-			$attribute_ref->{description} = f_lang_in_lc(
+			# Note: we now display the not-applicable category in the short description
+			$attribute_ref->{description_short} = f_lang_in_lc(
 				$target_lc,
 				"f_attribute_environmental_score_not_applicable_description",
 				{
@@ -740,8 +742,8 @@ sub compute_attribute_environmental_score ($product_ref, $target_lc, $target_cc)
 					)
 				}
 			);
-			$attribute_ref->{description_short}
-				= lang_in_other_lc($target_lc, "attribute_environmental_score_not_applicable_description_short");
+			#$attribute_ref->{description_short}
+			#	= lang_in_other_lc($target_lc, "attribute_environmental_score_not_applicable_description_short");
 		}
 	}
 	# Environmental-Score is unknown

--- a/lib/ProductOpener/KnowledgePanels.pm
+++ b/lib/ProductOpener/KnowledgePanels.pm
@@ -642,9 +642,9 @@ sub create_environmental_score_panel ($product_ref, $target_lc, $target_cc, $opt
 		}
 
 		# We can reuse some strings from the Environmental-Score attribute
-		my $title
-			= sprintf(lang_in_other_lc($target_lc, "attribute_environmental_score_grade_title"), uc($grade)) . ' - '
-			. lang_in_other_lc($target_lc, "attribute_environmental_score_" . $grade_underscore . "_description_short");
+		my $title = sprintf(lang_in_other_lc($target_lc, "attribute_environmental_score_grade_title"), $letter_grade);
+		my $subtitle
+			= lang_in_other_lc($target_lc, "attribute_environmental_score_" . $grade_underscore . "_description_short");
 
 		my $panel_data_ref = {
 			"agribalyse_category_name" => $agribalyse_category_name,
@@ -658,6 +658,7 @@ sub create_environmental_score_panel ($product_ref, $target_lc, $target_cc, $opt
 			"grade_underscore" => $grade_underscore,
 			"letter_grade" => $letter_grade,
 			"title" => $title,
+			"subtitle" => $subtitle,
 			"transportation_warning" => $transportation_warning,
 		};
 
@@ -672,23 +673,6 @@ sub create_environmental_score_panel ($product_ref, $target_lc, $target_cc, $opt
 			"api/knowledge-panels/environment/environmental_score/agribalyse.tt.json",
 			$panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref
 		);
-
-		# Create an extra panel for products that have extended environmental_score data from the impact estimator
-
-		# 2022/05/06: disabled as we currently have few products with reliable extended environmental_score data
-
-		# if (defined $product_ref->{environmental_score_extended_data}) {
-
-		#     extract_data_from_impact_estimator_best_recipe($product_ref, $panel_data_ref);
-
-		#     compare_impact_estimator_data_to_category_average($product_ref, $panel_data_ref, $target_cc);
-
-		#     # Display a panel only if we can compare the product extended impact
-		#     if (defined $panel_data_ref->{environmental_score_extended_data_for_category}) {
-		#         create_panel_from_json_template("environmental_score_extended", "api/knowledge-panels/environment/environmental_score/environmental_score_extended.tt.json",
-		#             $panel_data_ref, $product_ref, $target_lc, $target_cc, $options_ref);
-		#     }
-		# }
 
 		create_panel_from_json_template("carbon_footprint",
 			"api/knowledge-panels/environment/carbon_footprint_food.tt.json",

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -5385,12 +5385,12 @@ msgid "User is being deleted. This may take a few minutes."
 msgstr "User is being deleted. This may take a few minutes."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
-msgid "Green-Score not yet applicable"
-msgstr "Green-Score not yet applicable"
+msgid "Green-Score not applicable"
+msgstr "Green-Score not applicable"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
-msgid "Not yet applicable for the category"
-msgstr "Not yet applicable for the category"
+msgid "Not applicable for the category"
+msgstr "Not applicable for the category"
 
 # variable names between { } must not be translated
 msgctxt "f_attribute_environmental_score_not_applicable_description"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -5404,17 +5404,17 @@ msgid "User is being deleted. This may take a few minutes."
 msgstr "User is being deleted. This may take a few minutes."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
-msgid "Green-Score not yet applicable"
-msgstr "Green-Score not yet applicable"
+msgid "Green-Score not applicable"
+msgstr "Green-Score not applicable"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
-msgid "Not yet applicable for the category"
-msgstr "Not yet applicable for the category"
+msgid "Not applicable for the category"
+msgstr "Not applicable for the category"
 
 # variable names between { } must not be translated
 msgctxt "f_attribute_environmental_score_not_applicable_description"
-msgid "Not yet applicable for the category: {category}"
-msgstr "Not yet applicable for the category: {category}"
+msgid "Not applicable for the category: {category}"
+msgstr "Not applicable for the category: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -5403,17 +5403,17 @@ msgid "User is being deleted. This may take a few minutes."
 msgstr "L'utilisateur est en cours de suppression. Cela peut prendre quelques minutes."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
-msgid "Green-Score not yet applicable"
-msgstr "Green-Score n'est pas encore applicable"
+msgid "Green-Score not applicable"
+msgstr "Green-Score non applicable"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
-msgid "Not yet applicable for the category"
-msgstr "Pas encore applicable pour la catégorie"
+msgid "Not applicable for the category"
+msgstr "Non applicable pour la catégorie"
 
 # variable names between { } must not be translated
 msgctxt "f_attribute_environmental_score_not_applicable_description"
-msgid "Not yet applicable for the category: {category}"
-msgstr "Pas encore applicable pour la catégorie : {category}"
+msgid "Not applicable for the category: {category}"
+msgstr "Non applicable pour la catégorie : {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."

--- a/templates/api/knowledge-panels/environment/environmental_score/environmental_score.tt.json
+++ b/templates/api/knowledge-panels/environment/environmental_score/environmental_score.tt.json
@@ -7,6 +7,7 @@
         "name": "[% panel.name %]",
         "icon_url": "[% static_subdomain %]/images/attributes/dist/green-score-[% panel.grade %].svg",
         "title": "[% panel.title %]",
+        "subtitle": "[% panel.subtitle %]",
         "type": "grade",
         "grade": "[% panel.grade_underscore %]"
     },

--- a/templates/api/knowledge-panels/environment/environmental_score/environmental_score_unknown.tt.json
+++ b/templates/api/knowledge-panels/environment/environmental_score/environmental_score_unknown.tt.json
@@ -5,7 +5,8 @@
     ],
     "title_element": {
         "icon_url": "[% static_subdomain %]/images/attributes/dist/green-score-unknown.svg",
-        "title": "[% edq(lang('attribute_environmental_score_unknown_title')) %] - [% edq(lang('attribute_environmental_score_unknown_description_short')) %]",
+        "title": "[% edq(lang('attribute_environmental_score_unknown_title')) %]",
+        "subtitle": "[% edq(lang('attribute_environmental_score_unknown_description_short')) %]",
         "type": "grade",
         "grade": "unknown",
     },

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-all-knowledge-panels.json
@@ -1105,7 +1105,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -1759,7 +1759,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card-knowledge_panels_excluded-health_card.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card-knowledge_panels_excluded-health_card.json
@@ -241,7 +241,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
@@ -324,7 +324,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels-fr.json
@@ -331,7 +331,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Impact modéré sur l'environnement",
+               "subtitle" : "Impact modéré sur l'environnement",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-knowledge-panels.json
@@ -324,7 +324,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-all-knowledge-panels.json
@@ -1099,7 +1099,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-attribute-groups-all-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-attribute-groups-all-knowledge-panels.json
@@ -1745,7 +1745,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card-knowledge_panels_excluded-health_card.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card-knowledge_panels_excluded-health_card.json
@@ -242,7 +242,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-fields-knowledge-panels-knowledge-panels_included-health_card-environment_card.json
@@ -325,7 +325,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels-fr.json
@@ -332,7 +332,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Impact modéré sur l'environnement",
+               "subtitle" : "Impact modéré sur l'environnement",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_read/get-knowledge-panels.json
@@ -325,7 +325,8 @@
                "grade" : "c",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-c.svg",
                "name" : "Green-Score",
-               "title" : "Green-Score C - Moderate environmental impact",
+               "subtitle" : "Moderate environmental impact",
+               "title" : "Green-Score C",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/api_v3_product_write/patch-request-fields-updated-attribute-groups-knowledge-panels.json
+++ b/tests/integration/expected_test_results/api_v3_product_write/patch-request-fields-updated-attribute-groups-knowledge-panels.json
@@ -385,7 +385,8 @@
             "title_element" : {
                "grade" : "unknown",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-               "title" : "Green-Score not computed - Unknown environmental impact",
+               "subtitle" : "Unknown environmental impact",
+               "title" : "Green-Score not computed",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/data_quality_knowledge_panel/data-quality.json
+++ b/tests/integration/expected_test_results/data_quality_knowledge_panel/data-quality.json
@@ -197,7 +197,8 @@
             "title_element" : {
                "grade" : "unknown",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-               "title" : "Green-Score not computed - Unknown environmental impact",
+               "subtitle" : "Unknown environmental impact",
+               "title" : "Green-Score not computed",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/data_quality_knowledge_panel/no-data-quality.json
+++ b/tests/integration/expected_test_results/data_quality_knowledge_panel/no-data-quality.json
@@ -160,7 +160,8 @@
             "title_element" : {
                "grade" : "unknown",
                "icon_url" : "http://static.openfoodfacts.localhost/images/attributes/dist/green-score-unknown.svg",
-               "title" : "Green-Score not computed - Unknown environmental impact",
+               "subtitle" : "Unknown environmental impact",
+               "title" : "Green-Score not computed",
                "type" : "grade"
             },
             "topics" : [

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -2228,8 +2228,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 
             >
                 
-                Green-Score D - High environmental impact
+                Green-Score D
             </h4>
+            
+                <span >High environmental impact</span>
             
             <hr class="floatclear">
         </a>

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -2228,8 +2228,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 
             >
                 
-                Green-Score D - High environmental impact
+                Green-Score D
             </h4>
+            
+                <span >High environmental impact</span>
             
             <hr class="floatclear">
         </a>

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -2652,8 +2652,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 
             >
                 
-                Green-Score C - Moderate environmental impact
+                Green-Score C
             </h4>
+            
+                <span >Moderate environmental impact</span>
             
             <hr class="floatclear">
         </a>

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -2834,8 +2834,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                 
             >
                 
-                Green-Score B - Faible impact environnemental
+                Green-Score B
             </h4>
+            
+                <span >Faible impact environnemental</span>
             
             <hr class="floatclear">
         </a>

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -2848,8 +2848,10 @@ Le score est calculé à partir des données du tableau de la déclaration nutri
                 
             >
                 
-                Green-Score B - Faible impact environnemental
+                Green-Score B
             </h4>
+            
+                <span >Faible impact environnemental</span>
             
             <hr class="floatclear">
         </a>

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -2099,8 +2099,7 @@ var products = [
          {
             "attributes":[
                {
-                  "description":"Not yet applicable for the category: Sodas",
-                  "description_short":"Not yet applicable for the category",
+                  "description_short":"Not applicable for the category: Sodas",
                   "grade":"unknown",
                   "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-not-applicable.svg",
                   "id":"ecoscore",
@@ -2108,7 +2107,7 @@ var products = [
                   "name":"Green-Score",
                   "panel_id":"environmental_score",
                   "status":"unknown",
-                  "title":"Green-Score not yet applicable"
+                  "title":"Green-Score not applicable"
                },
                {
                   "description":"",

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -2076,8 +2076,7 @@ var products = [
          {
             "attributes":[
                {
-                  "description":"Not yet applicable for the category: Sodas",
-                  "description_short":"Not yet applicable for the category",
+                  "description_short":"Not applicable for the category: Sodas",
                   "grade":"unknown",
                   "icon_url":"//static.openfoodfacts.localhost/images/attributes/dist/green-score-not-applicable.svg",
                   "id":"ecoscore",
@@ -2085,7 +2084,7 @@ var products = [
                   "name":"Green-Score",
                   "panel_id":"environmental_score",
                   "status":"unknown",
-                  "title":"Green-Score not yet applicable"
+                  "title":"Green-Score not applicable"
                },
                {
                   "description":"",

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -2845,8 +2845,10 @@ The score is calculated from the data of the nutrition facts table and the compo
                 
             >
                 
-                Green-Score B - Low environmental impact
+                Green-Score B
             </h4>
+            
+                <span >Low environmental impact</span>
             
             <hr class="floatclear">
         </a>


### PR DESCRIPTION
A few fixes/changes:
- we still had a "A-PLUS" instead of "A+" in a knowledge panel title
- separated title and subtitle
- for not-applicable, changed the "short description" so that it includes the non-applicable category (e.g. "sodas"), and display it directly in the attribute subtitle. (it's a bit longer, but probably worth displaying directly).