### PR TITLE
feat: add link on pro platform to see nutriscore evolution #11246

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1267,6 +1267,20 @@ sub display_index_for_producer ($request_ref) {
 		}
 	}
 
+	# Count the products with a Nutri-Score computed
+	my $count = count_products($request_ref, {misc_tags => "en:nutriscore-computed"});
+	if ($count > 0) {
+		push @{$template_data_ref->{facets}},
+			{
+			url => "/misc?filter=nutriscore",
+			number_of_products => lang("discover_the_evolution_of_the_nutriscore_grades_of_your_products"),
+			count => $count,
+			};
+	}
+	else {
+		$template_data_ref->{add_products_to_discover_the_evolution_of_their_nutriscore_grades} = 1;
+	}
+
 	# Display a message if some product updates have not been published yet
 	# Updates can also be on obsolete products
 

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -7369,3 +7369,11 @@ msgstr "Limiting ultra-processed foods reduces the risk of noncommunicable chron
 msgctxt "recommendation_limit_ultra_processed_foods_text"
 msgid "Several studies have found that a lower consumption of ultra-processed foods is associated with a reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
 msgstr "Several studies have found that a lower consumption of ultra-processed foods is associated with a reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+
+msgctxt "discover_the_evolution_of_the_nutriscore_grades_of_your_products"
+msgid "Discover the evolution of the Nutri-Score grades of your products"
+msgstr "Discover the evolution of the Nutri-Score grades of your products"
+
+msgctxt "add_products_to_discover_the_evolution_of_their_nutriscore_grades"
+msgid "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."
+msgstr "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -7358,3 +7358,11 @@ msgstr "Limiting ultra-processed foods reduces the risk of noncommunicable chron
 msgctxt "recommendation_limit_ultra_processed_foods_text"
 msgid "Several studies have found that a lower consumption of ultra-processed foods is associated with a reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
 msgstr "Several studies have found that a lower consumption of ultra-processed foods is associated with a reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
+
+msgctxt "discover_the_evolution_of_the_nutriscore_grades_of_your_products"
+msgid "Discover the evolution of the Nutri-Score grades of your products"
+msgstr "Discover the evolution of the Nutri-Score grades of your products"
+
+msgctxt "add_products_to_discover_the_evolution_of_their_nutriscore_grades"
+msgid "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."
+msgstr "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -7317,3 +7317,11 @@ msgstr "Limiter les aliments ultra-transformés réduit le risque de maladies ch
 msgctxt "recommendation_limit_ultra_processed_foods_text"
 msgid "Several studies have found that a lower consumption of ultra-processed foods is associated with a reduced risk of noncommunicable chronic diseases, such as obesity, hypertension and diabetes."
 msgstr "Plusieurs études ont montré qu'une consommation plus faible d'aliments ultra-transformés est associée à un risque diminué de maladies chroniques non transmissibles, telles que l'obésité, l'hypertension et le diabète."
+
+msgctxt "discover_the_evolution_of_the_nutriscore_grades_of_your_products"
+msgid "Discover the evolution of the Nutri-Score grades of your products"
+msgstr "Découvrez l'évolution des notes Nutri-Score de vos produits"
+
+msgctxt "add_products_to_discover_the_evolution_of_their_nutriscore_grades"
+msgid "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."
+msgstr "Ajoutez des produits avec une catégorie, une liste d'ingrédients et des informations nutritionnelles pour découvrir l'évolution de leurs notes Nutri-Score."

--- a/taxonomies/misc.txt
+++ b/taxonomies/misc.txt
@@ -242,3 +242,190 @@ es: Envases - Con todos los pesos - completos
 fr: Emballages - Avec tous les poids - complets
 it: Confezionamenti - Con tutti i pesi - completi
 
+en: NutriScore - Missing nutrition data
+fr: NutriScore - Valeurs nutritionnelles manquantes
+
+en: NutriScore - Missing nutrition data - Sugars
+de: NutriScore - Fehlende Nährwertdaten - Zucker
+es: NutriScore - Datos nutricionales faltantes - Azúcares
+fr: NutriScore - Valeurs nutritionnelles manquantes - Sucres
+it: NutriScore - Dati nutrizionali mancanti - Zuccheri
+nl: NutriScore - Ontbrekende voedingsgegevens - Suikers
+pt: NutriScore - Dados nutricionais em falta - Açúcares
+
+en: NutriScore - Missing nutrition data - Sodium
+de: NutriScore - Fehlende Nährwertdaten - Natrium
+es: NutriScore - Datos nutricionales faltantes - Sodio
+fr: NutriScore - Valeurs nutritionnelles manquantes - Sodium
+it: NutriScore - Dati nutrizionali mancanti - Sodio
+nl: NutriScore - Ontbrekende voedingsgegevens - Natrium
+pt: NutriScore - Dados nutricionais em falta - Sódio
+
+en: NutriScore - Missing nutrition data - Fat
+de: NutriScore - Fehlende Nährwertdaten - Fett
+es: NutriScore - Datos nutricionales faltantes - Grasas
+fr: NutriScore - Valeurs nutritionnelles manquantes - Matières grasses
+it: NutriScore - Dati nutrizionali mancanti - Grassi
+nl: NutriScore - Ontbrekende voedingsgegevens - Vet
+pt: NutriScore - Dados nutricionais em falta - Gorduras
+
+en: NutriScore - Missing nutrition data - Saturated fat
+de: NutriScore - Fehlende Nährwertdaten - Gesättigte Fettsäuren
+es: NutriScore - Datos nutricionales faltantes - Grasas saturadas
+fr: NutriScore - Valeurs nutritionnelles manquantes - Acides gras saturés
+it: NutriScore - Dati nutrizionali mancanti - Grassi saturi
+nl: NutriScore - Ontbrekende voedingsgegevens - Verzadigde vetten
+pt: NutriScore - Dados nutricionais em falta - Gorduras saturadas
+
+en: NutriScore - Missing nutrition data - Proteins
+de: NutriScore - Fehlende Nährwertdaten - Eiweiß
+es: NutriScore - Datos nutricionales faltantes - Proteínas
+fr: NutriScore - Valeurs nutritionnelles manquantes - Protéines
+it: NutriScore - Dati nutrizionali mancanti - Proteine
+nl: NutriScore - Ontbrekende voedingsgegevens - Eiwitten
+pt: NutriScore - Dados nutricionais em falta - Proteínas
+
+en: NutriScore - Missing nutrition data - Energy
+de: NutriScore - Fehlende Nährwertdaten - Energie
+es: NutriScore - Datos nutricionales faltantes - Energía
+fr: NutriScore - Valeurs nutritionnelles manquantes - Énergie
+it: NutriScore - Dati nutrizionali mancanti - Energia
+nl: NutriScore - Ontbrekende voedingsgegevens - Energie
+pt: NutriScore - Dados nutricionais em falta - Energia
+
+en: NutriScore - Missing category
+fr: NutriScore - Catégorie manquante
+
+en: NutriScore - 2021 A - 2023 A
+xx: NutriScore - 2021 A - 2023 A
+
+en: NutriScore - 2021 A - 2023 B
+xx: NutriScore - 2021 A - 2023 B
+
+en: NutriScore - 2021 A - 2023 C
+xx: NutriScore - 2021 A - 2023 C
+
+en: NutriScore - 2021 A - 2023 D
+xx: NutriScore - 2021 A - 2023 D
+
+en: NutriScore - 2021 A - 2023 E
+xx: NutriScore - 2021 A - 2023 E
+
+en: NutriScore - 2021 A - 2023 F
+xx: NutriScore - 2021 A - 2023 F
+
+en: NutriScore - 2021 B - 2023 A
+xx: NutriScore - 2021 B - 2023 A
+
+en: NutriScore - 2021 B - 2023 B
+xx: NutriScore - 2021 B - 2023 B
+
+en: NutriScore - 2021 B - 2023 C
+xx: NutriScore - 2021 B - 2023 C
+
+en: NutriScore - 2021 B - 2023 D
+xx: NutriScore - 2021 B - 2023 D
+
+en: NutriScore - 2021 B - 2023 E
+xx: NutriScore - 2021 B - 2023 E
+
+en: NutriScore - 2021 B - 2023 F
+xx: NutriScore - 2021 B - 2023 F
+
+en: NutriScore - 2021 C - 2023 A
+xx: NutriScore - 2021 C - 2023 A
+
+en: NutriScore - 2021 C - 2023 B
+xx: NutriScore - 2021 C - 2023 B
+
+en: NutriScore - 2021 C - 2023 C
+xx: NutriScore - 2021 C - 2023 C
+
+en: NutriScore - 2021 C - 2023 D
+xx: NutriScore - 2021 C - 2023 D
+
+en: NutriScore - 2021 C - 2023 E
+xx: NutriScore - 2021 C - 2023 E
+
+en: NutriScore - 2021 C - 2023 F
+xx: NutriScore - 2021 C - 2023 F
+
+en: NutriScore - 2021 D - 2023 A
+xx: NutriScore - 2021 D - 2023 A
+
+en: NutriScore - 2021 D - 2023 B
+xx: NutriScore - 2021 D - 2023 B
+
+en: NutriScore - 2021 D - 2023 C
+xx: NutriScore - 2021 D - 2023 C
+
+en: NutriScore - 2021 D - 2023 D
+xx: NutriScore - 2021 D - 2023 D
+
+en: NutriScore - 2021 D - 2023 E
+xx: NutriScore - 2021 D - 2023 E
+
+en: NutriScore - 2021 D - 2023 F
+xx: NutriScore - 2021 D - 2023 F
+
+en: NutriScore - 2021 E - 2023 A
+xx: NutriScore - 2021 E - 2023 A
+
+en: NutriScore - 2021 E - 2023 B
+xx: NutriScore - 2021 E - 2023 B
+
+en: NutriScore - 2021 E - 2023 C
+xx: NutriScore - 2021 E - 2023 C
+
+en: NutriScore - 2021 E - 2023 D
+xx: NutriScore - 2021 E - 2023 D
+
+en: NutriScore - 2021 E - 2023 E
+xx: NutriScore - 2021 E - 2023 E
+
+en: NutriScore - 2021 E - 2023 F
+xx: NutriScore - 2021 E - 2023 F
+
+en: NutriScore - 2021 F - 2023 A
+xx: NutriScore - 2021 F - 2023 A
+
+en: NutriScore - 2021 F - 2023 B
+xx: NutriScore - 2021 F - 2023 B
+
+en: NutriScore - 2021 F - 2023 C
+xx: NutriScore - 2021 F - 2023 C
+
+en: NutriScore - 2021 F - 2023 D
+xx: NutriScore - 2021 F - 2023 D
+
+en: NutriScore - 2021 F - 2023 E
+xx: NutriScore - 2021 F - 2023 E
+
+en: NutriScore - 2021 F - 2023 F
+xx: NutriScore - 2021 F - 2023 F
+
+
+en: NutriScore - 2021 different from 2023
+de: NutriScore - 2021 unterschiedlich von 2023
+es: NutriScore - 2021 diferente de 2023
+fr: NutriScore - 2021 différent de 2023
+it: NutriScore - 2021 diverso da 2023
+nl: NutriScore - 2021 verschillend van 2023
+pt: NutriScore - 2021 diferente de 2023
+
+en: NutriScore - 2021 better than 2023
+de: NutriScore - 2021 besser als 2023
+es: NutriScore - 2021 mejor que 2023
+fr: NutriScore - 2021 meilleur que 2023
+it: NutriScore - 2021 migliore di 2023
+nl: NutriScore - 2021 beter dan 2023
+pt: NutriScore - 2021 melhor que 2023
+
+en: NutriScore - 2021 worse than 2023
+de: NutriScore - 2021 schlechter als 2023
+es: NutriScore - 2021 peor que 2023
+fr: NutriScore - 2021 pire que 2023
+it: NutriScore - 2021 peggiore di 2023
+nl: NutriScore - 2021 slechter dan 2023
+pt: NutriScore - 2021 pior que 2023
+

--- a/templates/web/common/includes/producers_platform_front_page.tt.html
+++ b/templates/web/common/includes/producers_platform_front_page.tt.html
@@ -11,7 +11,11 @@
                 <a href="[% owner_pretty_path %][% facet.url %]">[% facet.number_of_products %][% sep %]: [% facet.count %]</a>
                 <br>
             </p>
-        [% END %]        
+        [% END %]
+
+        [% IF add_products_to_discover_the_evolution_of_their_nutriscore_grades %]
+            <p>[% lang("add_products_to_discover_the_evolution_of_their_nutriscore_grades") %]</p>
+        [% END %]
 
         <h2>[% lang("your_products") %]</h2>
         


### PR DESCRIPTION
fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/11246

added message when no nutriscore has been computed:

![image](https://github.com/user-attachments/assets/8437a755-2906-4173-b8d4-e299bdc9f2ca)

added link when we have some nutriscore computed:

![image](https://github.com/user-attachments/assets/d74a5918-9c6b-4e38-97ec-8b02625e5c93)

added taxonomy entries to make the page less cryptic:

![image](https://github.com/user-attachments/assets/d8cac325-96ed-43cc-a6ce-d9a8d72eb604)
