### PR TITLE
feat: Update the tagline to force the app upgrade

### DIFF
--- a/html/resources/files/tagline-off-android-v3.json
+++ b/html/resources/files/tagline-off-android-v3.json
@@ -1,476 +1,426 @@
 {
   "news": {
-    "donation_campaign": {
-      "start_date": "2024-10-25 00:00:00",
-      "end_date": "2025-01-31 23:59:59",
-      "url": "https://world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
+    "app_update": {
+      "start_date": "2025-01-01 00:00:00",
+      "end_date": "2099-12-25 23:59:59",
+      "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
       "translations": {
         "default": {
-          "title": "Our application needs you!",
-          "message": "Help us inform **millions of consumers** on what they eat!",
-          "button_label": "Support",
-          "url": "https://world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
+          "title": "New update available!",
+          "message": "A new version of the application is available on the Google Play and F-Droid.",
+          "button_label": "Update",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
           "image": {
             "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
             "width": 0.2,
-            "alt": "Support the Open Food Facts project"
-          }
-        },
-        "fr_FR": {
-          "title": "Notre application a besoin de vous !",
-          "message": "Aidez-nous à informer **des millions de consommateurs** sur ce qu'ils mangent !",
-          "button_label": "Je soutiens",
-          "url": "https://fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
-          "image": {
-            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_fr.svg",
-            "width": 0.2,
-            "alt": "Soutenir le projet Open Food Facts"
+            "alt": "Update the Open Food Facts app"
           }
         },
         "fr": {
-          "title": "Notre application a besoin de vous !",
-          "message": "Aidez-nous à informer **des millions de consommateurs** sur ce qu'ils mangent !",
-          "button_label": "Je soutiens",
-          "url": "https://world-fr.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
+          "title": "Nouvelle mise à jour!",
+          "message": "Une nouvelle version de l'application est disponible sur le Google Play et F-Droid.",
+          "button_label": "Mettre à jour",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
           "image": {
             "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_fr.svg",
             "width": 0.2,
-            "alt": "Soutenir le projet Open Food Facts"
+            "alt": "Mettre à jour l'application Open Food Facts"
           }
         },
         "ar": {
-          "title": "تطبيقنا يحتاجك!",
-          "message": "ساعدنا في إبلاغ **ملايين المستهلكين** بما يأكلونه!",
-          "button_label": "أدعم",
-          "url": "https://world-ar.openfoodfacts.org/donate-to-open-food-facts-ar?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "تحديث جديد متاح!",
+          "message": "يتوفر إصدار جديد من التطبيق على Google Play و F-Droid.",
+          "button_label": "تحديث",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ar.svg",
+            "width": 0.2,
+            "alt": "تحديث تطبيق Open Food Facts"
+          }
         },
         "bg": {
-          "title": "Нашето приложение се нуждае от вас!",
-          "message": "Помогнете ни да информираме **милиони потребители** какво ядат!",
-          "button_label": "Поддръжка",
-          "url": "https://world-bg.openfoodfacts.org/даряване-на-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Налична е нова актуализация!",
+          "message": "Нова версия на приложението е налична в Google Play и F-Droid.",
+          "button_label": "Актуализиране",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_bg.svg",
+            "width": 0.2,
+            "alt": "Актуализирайте приложението Open Food Facts"
+          }
         },
         "bn": {
-          "title": "আমাদের অ্যাপ্লিকেশন আপনার প্রয়োজন!",
-          "message": "আমাদের **লক্ষ লক্ষ ভোক্তাদের** তাদের খাবার সম্পর্কে জানাতে সাহায্য করুন!",
-          "button_label": "সমর্থন"
+          "title": "একটি নতুন আপডেট উপলব্ধ!",
+          "message": "অ্যাপ্লিকেশনের একটি নতুন সংস্করণ Google Play এবং F-Droid-এ উপলব্ধ।",
+          "button_label": "আপডেট",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_bn.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts অ্যাপ আপডেট করুন"
+          }
         },
         "ca": {
-          "title": "La nostra aplicació et necessita!",
-          "message": "Ajuda'ns a informar **milions de consumidors** sobre el que mengen!",
-          "button_label": "Suport",
-          "url": "https://world-ca.openfoodfacts.org/dona-a-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Hi ha una nova actualització disponible!",
+          "message": "Hi ha una nova versió de l'aplicació disponible a Google Play i F-Droid.",
+          "button_label": "Actualitzar",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ca.svg",
+            "width": 0.2,
+            "alt": "Actualitza l'aplicació Open Food Facts"
+          }
         },
         "cs": {
-          "title": "Naše aplikace vás potřebuje!",
-          "message": "Pomozte nám informovat **miliony spotřebitelů** o tom, co jedí!",
-          "button_label": "Podpora",
-          "url": "https://world-cs.openfoodfacts.org/darujte-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Je k dispozici nová aktualizace!",
+          "message": "Nová verze aplikace je k dispozici na Google Play a F-Droid.",
+          "button_label": "Aktualizovat",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_cs.svg",
+            "width": 0.2,
+            "alt": "Aktualizujte aplikaci Open Food Facts"
+          }
         },
         "da": {
-          "title": "Vores ansøgning har brug for dig!",
-          "message": "Hjælp os med at informere **millioner af forbrugere** om, hvad de spiser!",
-          "button_label": "Support",
-          "url": "https://world-da.openfoodfacts.org/doner-til-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "En ny opdatering er tilgængelig!",
+          "message": "En ny version af applikationen er tilgængelig på Google Play og F-Droid.",
+          "button_label": "Opdater",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_da.svg",
+            "width": 0.2,
+            "alt": "Opdater Open Food Facts-appen"
+          }
         },
         "de": {
-          "title": "Unsere Anwendung braucht Sie!",
-          "message": "Helfen Sie uns, **Millionen von Verbrauchern** darüber zu informieren, was sie essen!",
-          "button_label": "Unterstützen",
-          "url": "https://world-de.openfoodfacts.org/spenden?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Ein neues Update ist verfügbar!",
+          "message": "Eine neue Version der Anwendung ist auf Google Play und F-Droid verfügbar.",
+          "button_label": "Aktualisieren",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_de.svg",
+            "width": 0.2,
+            "alt": "Aktualisieren Sie die Open Food Facts App"
+          }
         },
         "ee": {
-          "title": "Meie rakendus vajab teid!",
-          "message": "Aidake meil teavitada **miljoneid tarbijaid** sellest, mida nad söövad!",
-          "button_label": "Tugi",
-          "url": "https://world-ee.openfoodfacts.org/anneta-to-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Uus värskendus on saadaval!",
+          "message": "Rakenduse uus versioon on saadaval Google Plays ja F-Droidis.",
+          "button_label": "Värskenda",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ee.svg",
+            "width": 0.2,
+            "alt": "Värskendage Open Food Facts rakendust"
+          }
         },
         "el": {
-          "title": "Η εφαρμογή μας σας χρειάζεται!",
-          "message": "Βοηθήστε μας να ενημερώσουμε **εκατομμύρια καταναλωτές** για το τι τρώνε!",
-          "button_label": "Υποστηρίζω",
-          "url": "https://world-el.openfoodfacts.org/dorea-se-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Μια νέα ενημέρωση είναι διαθέσιμη!",
+          "message": "Μια νέα έκδοση της εφαρμογής είναι διαθέσιμη στο Google Play και στο F-Droid.",
+          "button_label": "Ενημέρωση",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_el.svg",
+            "width": 0.2,
+            "alt": "Ενημερώστε την εφαρμογή Open Food Facts"
+          }
         },
         "es": {
-          "title": "¡Nuestra aplicación te necesita!",
-          "message": "¡Ayúdanos a informar a **millones de consumidores** sobre lo que comen!",
-          "button_label": "Apoyar",
-          "url": "https://world-es.openfoodfacts.org/haz-su-donacion-a-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "¡Una nueva actualización está disponible!",
+          "message": "Una nueva versión de la aplicación está disponible en Google Play y F-Droid.",
+          "button_label": "Actualizar",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_es.svg",
+            "width": 0.2,
+            "alt": "Actualizar la aplicación Open Food Facts"
+          }
         },
         "fa": {
-          "title": "برنامه ما به شما نیاز دارد!",
-          "message": "به ما کمک کنید تا **میلیون‌ها مصرف‌کننده** را در مورد آنچه می‌خورند مطلع کنیم!",
-          "button_label": "حمایت"
+          "title": "به‌روزرسانی جدیدی در دسترس است!",
+          "message": "نسخه جدیدی از برنامه در Google Play و F-Droid موجود است.",
+          "button_label": "به‌روزرسانی",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_fa.svg",
+            "width": 0.2,
+            "alt": "برنامه Open Food Facts را به‌روزرسانی کنید"
+          }
         },
         "fi": {
-          "title": "Sovelluksemme tarvitsee sinua!",
-          "message": "Auta meitä kertomaan **miljoonille kuluttajille** siitä, mitä he syövät!",
-          "button_label": "Tuki",
-          "url": "https://world-fi.openfoodfacts.org/lahjoita-open-food-factsille?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Uusi päivitys on saatavilla!",
+          "message": "Sovelluksen uusi versio on saatavilla Google Playssa ja F-Droidissa.",
+          "button_label": "Päivitä",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_fi.svg",
+            "width": 0.2,
+            "alt": "Päivitä Open Food Facts -sovellus"
+          }
         },
         "he": {
-          "title": "האפליקציה שלנו צריכה אותך!",
-          "message": "עזור לנו ליידע **מיליוני צרכנים** מה הם אוכלים!",
-          "button_label": "תמיכה",
-          "url": "https://world-he.openfoodfacts.org/donate-to-open-food-facts-he?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "עדכון חדש זמין!",
+          "message": "גרסה חדשה של האפליקציה זמינה ב-Google Play וב-F-Droid.",
+          "button_label": "עדכון",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_he.svg",
+            "width": 0.2,
+            "alt": "עדכן את אפליקציית Open Food Facts"
+          }
         },
         "hi": {
-          "title": "हमारे ऐप को आपकी जरूरत है!",
-          "message": "हमें **लाखों उपभोक्ताओं** को उनके खाने के बारे में सूचित करने में मदद करें!",
-          "button_label": "समर्थन"
+          "title": "एक नया अपडेट उपलब्ध है!",
+          "message": "एप्लिकेशन का एक नया संस्करण Google Play और F-Droid पर उपलब्ध है।",
+          "button_label": "अपडेट करें",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_hi.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts ऐप को अपडेट करें"
+          }
         },
         "ht": {
-          "title": "Aplikasyon nou an bezwen ou!",
-          "message": "Ede nou enfòme **dè milyon de konsomatè** sou sa yo manje!",
-          "button_label": "Sipò",
-          "url": "https://world-ht.openfoodfacts.org/donate-to-open-food-facts-ht?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Yon nouvo mizajou disponib!",
+          "message": "Yon nouvo vèsyon aplikasyon an disponib sou Google Play ak F-Droid.",
+          "button_label": "Mizajou",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ht.svg",
+            "width": 0.2,
+            "alt": "Mizajou aplikasyon Open Food Facts la"
+          }
         },
         "hu": {
-          "title": "Alkalmazásunknak szüksége van Önre!",
-          "message": "Segítsen bennünket, hogy **fogyasztók millióit** tájékoztassuk arról, hogy mit esznek!",
-          "button_label": "Támogatás",
-          "url": "https://world-hu.openfoodfacts.org/donate-to-open-food-facts-hu?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Új frissítés érhető el!",
+          "message": "Az alkalmazás új verziója elérhető a Google Playen és az F-Droidon.",
+          "button_label": "Frissítés",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_hu.svg",
+            "width": 0.2,
+            "alt": "Frissítse az Open Food Facts alkalmazást"
+          }
         },
         "id": {
-          "title": "Aplikasi kami membutuhkan Anda!",
-          "message": "Bantu kami memberi tahu **jutaan konsumen** tentang apa yang mereka makan!",
-          "button_label": "Dukung",
-          "url": "https://world-id.openfoodfacts.org/donate-to-open-food-facts-id?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Pembaruan baru tersedia!",
+          "message": "Versi baru aplikasi tersedia di Google Play dan F-Droid.",
+          "button_label": "Perbarui",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_id.svg",
+            "width": 0.2,
+            "alt": "Perbarui aplikasi Open Food Facts"
+          }
         },
         "it": {
-          "title": "La nostra applicazione ha bisogno di te!",
-          "message": "Aiutaci a informare **milioni di consumatori** su ciò che mangiano!",
-          "button_label": "Sostieni",
-          "url": "https://world-it.openfoodfacts.org/dona-a-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "È disponibile un nuovo aggiornamento!",
+          "message": "È disponibile una nuova versione dell'applicazione su Google Play e F-Droid.",
+          "button_label": "Aggiorna",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_it.svg",
+            "width": 0.2,
+            "alt": "Aggiorna l'app Open Food Facts"
+          }
         },
         "ja": {
-          "title": "私たちのアプリケーションはあなたを必要としています！",
-          "message": "何を食べているかについて**何百万人もの消費者**に知らせるのを手伝ってください！",
-          "button_label": "サポート",
-          "url": "https://world-ja.openfoodfacts.org/donate-to-open-food-facts-ja?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "新しいアップデートが利用可能です！",
+          "message": "アプリケーションの新しいバージョンがGoogle PlayとF-Droidで利用可能です。",
+          "button_label": "更新",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ja.svg",
+            "width": 0.2,
+            "alt": "Open Food Factsアプリを更新する"
+          }
         },
         "ko": {
-          "title": "우리 애플리케이션이 당신을 필요로 합니다!",
-          "message": "**수백만 소비자**에게 그들이 먹는 것에 대해 알리는 데 도움을 주세요!",
-          "button_label": "지원"
+          "title": "새로운 업데이트가 있습니다!",
+          "message": "애플리케이션의 새로운 버전이 Google Play와 F-Droid에서 사용할 수 있습니다.",
+          "button_label": "업데이트",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ko.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts 앱을 업데이트하세요"
+          }
         },
         "lu": {
-          "title": "Onze applicatie heeft u nodig!",
-          "message": "Help ons om **miljoenen consumenten** te informeren over wat ze eten!",
-          "button_label": "Ondersteunen",
-          "url": "https://world-lu.openfoodfacts.org/donate-to-open-food-facts-lu?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Een nieuwe update is beschikbaar!",
+          "message": "Een nieuwe versie van de applicatie is beschikbaar op Google Play en F-Droid.",
+          "button_label": "Bijwerken",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_lu.svg",
+            "width": 0.2,
+            "alt": "Update de Open Food Facts app"
+          }
         },
         "lt": {
-          "title": "Mūsų programai reikia jūsų!",
-          "message": "Padėkite mums informuoti **milijonus vartotojų** apie tai, ką jie valgo!",
-          "button_label": "Palaikymas",
-          "url": "https://world-lt.openfoodfacts.org/donate-to-open-food-facts-lt?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Yra naujas atnaujinimas!",
+          "message": "Nauja programos versija pasiekiama „Google Play“ ir „F-Droid“.",
+          "button_label": "Atnaujinti",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_lt.svg",
+            "width": 0.2,
+            "alt": "Atnaujinkite „Open Food Facts“ programą"
+          }
         },
         "ms": {
-          "title": "Aplikasi kami memerlukan anda!",
-          "message": "Bantu kami memaklumkan **jutaan pengguna** tentang apa yang mereka makan!",
-          "button_label": "Sokong",
-          "url": "https://world-ms.openfoodfacts.org/donate-to-open-food-facts-ms?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Kemas kini baharu tersedia!",
+          "message": "Versi baharu aplikasi tersedia di Google Play dan F-Droid.",
+          "button_label": "Kemas kini",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ms.svg",
+            "width": 0.2,
+            "alt": "Kemas kini aplikasi Open Food Facts"
+          }
         },
         "nb": {
-          "title": "Vår applikasjon trenger deg!",
-          "message": "Hjelp oss å informere **millioner av forbrukere** om hva de spiser!",
-          "button_label": "Støtte",
-          "url": "https://world-nb.openfoodfacts.org/donate-to-open-food-facts-nb?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "En ny oppdatering er tilgjengelig!",
+          "message": "En ny versjon av applikasjonen er tilgjengelig på Google Play og F-Droid.",
+          "button_label": "Oppdater",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_nb.svg",
+            "width": 0.2,
+            "alt": "Oppdater Open Food Facts-appen"
+          }
         },
         "nl": {
-          "title": "Onze applicatie heeft u nodig!",
-          "message": "Help ons om **miljoenen consumenten** te informeren over wat ze eten!",
-          "button_label": "Ondersteunen",
-          "url": "https://world-nl.openfoodfacts.org/doneren-aan-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Een nieuwe update is beschikbaar!",
+          "message": "Een nieuwe versie van de applicatie is beschikbaar op Google Play en F-Droid.",
+          "button_label": "Bijwerken",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_nl.svg",
+            "width": 0.2,
+            "alt": "Update de Open Food Facts app"
+          }
         },
         "pt": {
-          "title": "Nosso aplicativo precisa de você!",
-          "message": "Ajude-nos a informar **milhões de consumidores** sobre o que eles comem!",
-          "button_label": "Apoiar",
-          "url": "https://world-pt.openfoodfacts.org/fazer-um-donativo-ao-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Uma nova atualização está disponível!",
+          "message": "Uma nova versão do aplicativo está disponível no Google Play e F-Droid.",
+          "button_label": "Atualizar",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_pt.svg",
+            "width": 0.2,
+            "alt": "Atualize o aplicativo Open Food Facts"
+          }
         },
         "pl": {
-          "title": "Nasza aplikacja potrzebuje Ciebie!",
-          "message": "Pomóż nam informować **miliony konsumentów** o tym, co jedzą!",
-          "button_label": "Wspieram",
-          "url": "https://world-pl.openfoodfacts.org/pozhertvovat-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Dostępna jest nowa aktualizacja!",
+          "message": "Nowa wersja aplikacji jest dostępna w Google Play i F-Droid.",
+          "button_label": "Aktualizuj",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_pl.svg",
+            "width": 0.2,
+            "alt": "Zaktualizuj aplikację Open Food Facts"
+          }
         },
         "ro": {
-          "title": "Aplicația noastră are nevoie de tine!",
-          "message": "Ajută-ne să informăm **milioane de consumatori** despre ce mănâncă!",
-          "button_label": "Suport",
-          "url": "https://world-ro.openfoodfacts.org/donate-to-open-food-facts-ro?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "O nouă actualizare este disponibilă!",
+          "message": "O nouă versiune a aplicației este disponibilă pe Google Play și F-Droid.",
+          "button_label": "Actualizați",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ro.svg",
+            "width": 0.2,
+            "alt": "Actualizați aplicația Open Food Facts"
+          }
         },
         "ru": {
-          "title": "Наше приложение нуждается в вас!",
-          "message": "Помогите нам информировать **миллионы потребителей** о том, что они едят!",
-          "button_label": "Поддержать",
-          "url": "https://world-ru.openfoodfacts.org/donate-to-open-food-facts-ru?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Доступно новое обновление!",
+          "message": "Новая версия приложения доступна в Google Play и F-Droid.",
+          "button_label": "Обновить",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_ru.svg",
+            "width": 0.2,
+            "alt": "Обновите приложение Open Food Facts"
+          }
         },
         "sk": {
-          "title": "Naša aplikácia vás potrebuje!",
-          "message": "Pomôžte nám informovať **milióny spotrebiteľov** o tom, čo jedia!",
-          "button_label": "Podpora",
-          "url": "https://world-bg.openfoodfacts.org/donate-to-open-food-facts-sk?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "K dispozícii je nová aktualizácia!",
+          "message": "Nová verzia aplikácie je k dispozícii na Google Play a F-Droid.",
+          "button_label": "Aktualizovať",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_sk.svg",
+            "width": 0.2,
+            "alt": "Aktualizujte aplikáciu Open Food Facts"
+          }
         },
         "sl": {
-          "title": "Naša aplikacija vas potrebuje!",
-          "message": "Pomagajte nam obveščati **milijone potrošnikov** o tem, kaj jedo!",
-          "button_label": "Podpora",
-          "url": "https://world-sl.openfoodfacts.org/doniraj-k-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "sv": {
-          "title": "Vår applikation behöver dig!",
-          "message": "Hjälp oss att informera **miljontals konsumenter** om vad de äter!",
-          "button_label": "Stöd",
-          "url": "https://world-sv.openfoodfacts.org/donate-to-open-food-facts-sv?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "th": {
-          "title": "แอปพลิเคชันของเราต้องการคุณ!",
-          "message": "ช่วยเราบอก **ผู้บริโภคหลายล้านคน** ว่าพวกเขากินอะไร!",
-          "button_label": "สนับสนุน",
-          "url": "https://world-th.openfoodfacts.org/donate-to-open-food-facts-th?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "tr": {
-          "title": "Uygulamamızın size ihtiyacı var!",
-          "message": "**Milyonlarca tüketiciyi** ne yedikleri konusunda bilgilendirmemize yardımcı olun!",
-          "button_label": "Destek",
-          "url": "https://world-tr.openfoodfacts.org/open-food-factse-bagista-bulununs?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "vi": {
-          "title": "Ứng dụng của chúng tôi cần bạn!",
-          "message": "Giúp chúng tôi thông báo cho **hàng triệu người tiêu dùng** về những gì họ ăn!",
-          "button_label": "Hỗ trợ"
-        },
-        "zh": {
-          "title": "我们的应用程序需要你！",
-          "message": "帮助我们告知**数百万消费者**他们吃的是什么！",
-          "button_label": "支持",
-          "url": "https://world.openfoodfacts.org/donate-to-open-food-facts-cn?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        }
-      }
-    },
-    "translate_openfoodfacts": {
-      "start_date": "2025-02-01 00:00:00",
-      "end_date": "2025-12-31 23:59:59",
-      "url": "https://translate.openfoodfacts.org/project/openfoodfacts/en",
-      "translations": {
-        "default": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/en",
-          "title": "Bring food transparency to your language",
-          "message": "Translate the app, website and more to help others make informed food choices",
-          "button_label": "Join the translators team",
+          "title": "Na voljo je nova posodobitev!",
+          "message": "Nova različica aplikacije je na voljo v Google Play in F-Droid.",
+          "button_label": "Posodobi",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png",
-            "width": 0.2
-          }
-        },
-        "ar": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ar",
-          "title": "اجعل شفافية الغذاء تصل إلى لغتك",
-          "message": "ترجم التطبيق والموقع الإلكتروني والمزيد لمساعدة الآخرين على اتخاذ خيارات غذائية مستنيرة",
-          "button_label": "انضم إلى فريق المترجمين",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "bn": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/bn",
-          "title": "আপনার ভাষায় খাদ্য স্বচ্ছতা আনুন",
-          "message": "অন্যদের তথ্যবহুল খাদ্য পছন্দ করতে সাহায্য করার জন্য অ্যাপ, ওয়েবসাইট এবং আরও অনেক কিছু অনুবাদ করুন",
-          "button_label": "অনুবাদক দলে যোগ দিন",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "de": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/de",
-          "title": "Bringen Sie Lebensmitteltransparenz in Ihre Sprache",
-          "message": "Übersetzen Sie die App, die Website und mehr, um anderen zu helfen, informierte Entscheidungen über Lebensmittel zu treffen",
-          "button_label": "Dem Übersetzerteam beitreten",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "el": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/el",
-          "title": "Φέρτε τη διαφάνεια τροφίμων στη γλώσσα σας",
-          "message": "Μεταφράστε την εφαρμογή, τον ιστότοπο και άλλα για να βοηθήσετε άλλους να κάνουν ενημερωμένες επιλογές τροφίμων",
-          "button_label": "Γίνετε μέλος της ομάδας μεταφραστών",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "es": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/es",
-          "title": "Haz que la transparencia alimentaria llegue a tu idioma",
-          "message": "Traduce la aplicación, el sitio web y más para ayudar a otros a tomar decisiones alimentarias informadas",
-          "button_label": "Únete al equipo de traductores",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "fr": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/fr",
-          "title": "Rendez la transparence alimentaire accessible dans votre langue",
-          "message": "Traduisez l'application, le site web et plus encore pour aider les autres à faire des choix alimentaires éclairés",
-          "button_label": "Rejoindre l'équipe de traducteurs",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "hi": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/hi",
-          "title": "अपनी भाषा में खाद्य पारदर्शिता लाएँ",
-          "message": "दूसरों को सूचित खाद्य विकल्प बनाने में मदद करने के लिए ऐप, वेबसाइट और बहुत कुछ का अनुवाद करें",
-          "button_label": "अनुवादक टीम में शामिल हों",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "pt": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/pt",
-          "title": "Traga transparência alimentar para o seu idioma",
-          "message": "Traduza o aplicativo, o site e muito mais para ajudar outras pessoas a fazer escolhas alimentares informadas",
-          "button_label": "Junte-se à equipe de tradutores",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "it": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/it",
-          "title": "Porta la trasparenza alimentare nella tua lingua",
-          "message": "Traduci l'app, il sito web e altro ancora per aiutare gli altri a fare scelte alimentari informate",
-          "button_label": "Unisciti al team di traduttori",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ja": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ja",
-          "title": "食品の透明性をあなたの言語で",
-          "message": "アプリ、ウェブサイトなどを翻訳して、他の人が情報に基づいた食品の選択をするのを手伝ってください",
-          "button_label": "翻訳チームに参加する",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ko": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ko",
-          "title": "식품 투명성을 귀하의 언어로 가져오세요",
-          "message": "앱, 웹사이트 등을 번역하여 다른 사람들이 정보에 입각한 식품 선택을 할 수 있도록 돕습니다.",
-          "button_label": "번역 팀에 합류하기",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "nl": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/nl",
-          "title": "Breng voedseltransparantie naar uw taal",
-          "message": "Vertaal de app, website en meer om anderen te helpen weloverwogen voedselkeuzes te maken",
-          "button_label": "Word lid van het vertalersteam",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "pl": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/pl",
-          "title": "Przynieś przejrzystość żywności do swojego języka",
-          "message": "Przetłumacz aplikację, stronę internetową i wiele więcej, aby pomóc innym w podejmowaniu świadomych wyborów żywieniowych",
-          "button_label": "Dołącz do zespołu tłumaczy",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ru": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ru",
-          "title": "Обеспечьте прозрачность пищевых продуктов на вашем языке",
-          "message": "Переведите приложение, веб-сайт и многое другое, чтобы помочь другим сделать осознанный выбор продуктов питания",
-          "button_label": "Присоединиться к команде переводчиков",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_sl.svg",
+            "width": 0.2,
+            "alt": "Posodobite aplikacijo Open Food Facts"
           }
         },
         "sv": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/sv",
-          "title": "Ge din språklig insyn i livsmedel",
-          "message": "Översätt appen, webbplatsen och mer för att hjälpa andra att göra välgrundade val av livsmedel",
-          "button_label": "Gå med i översättarteamet",
+          "title": "En ny uppdatering är tillgänglig!",
+          "message": "En ny version av applikationen är tillgänglig på Google Play och F-Droid.",
+          "button_label": "Uppdatera",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "tr": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/tr",
-          "title": "Gıda şeffaflığını dilinize getirin",
-          "message": "Uygulamayı, web sitesini ve daha fazlasını çevirerek başkalarının bilinçli gıda seçimleri yapmasına yardımcı olun",
-          "button_label": "Çevirmenler ekibine katılın",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "uk": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/uk",
-          "title": "Зробіть прозорість харчових продуктів доступною вашою мовою",
-          "message": "Перекладіть додаток, веб-сайт та багато іншого, щоб допомогти іншим зробити усвідомлений вибір продуктів харчування",
-          "button_label": "Приєднатися до команди перекладачів",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "vi": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/vi",
-          "title": "Mang tính minh bạch về thực phẩm đến ngôn ngữ của bạn",
-          "message": "Dịch ứng dụng, trang web và hơn thế nữa để giúp người khác đưa ra lựa chọn thực phẩm sáng suốt",
-          "button_label": "Tham gia đội ngũ dịch thuật",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "zh": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/zh",
-          "title": "将食品透明度带到您的语言",
-          "message": "翻译应用程序、网站等，帮助他人做出明智的食品选择",
-          "button_label": "加入翻译团队",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "id": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/id",
-          "title": "Hadirkan transparansi makanan dalam bahasa Anda",
-          "message": "Terjemahkan aplikasi, situs web, dan lainnya untuk membantu orang lain membuat pilihan makanan yang tepat",
-          "button_label": "Bergabunglah dengan tim penerjemah",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ms": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ms",
-          "title": "Bawa ketelusan makanan ke bahasa anda",
-          "message": "Terjemahkan aplikasi, laman web dan banyak lagi untuk membantu orang lain membuat pilihan makanan yang bijak",
-          "button_label": "Sertai pasukan penterjemah",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_sv.svg",
+            "width": 0.2,
+            "alt": "Uppdatera Open Food Facts-appen"
           }
         },
         "th": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/th",
-          "title": "นำความโปร่งใสด้านอาหารมาสู่ภาษาของคุณ",
-          "message": "แปลแอป เว็บไซต์ และอื่นๆ เพื่อช่วยให้ผู้อื่นตัดสินใจเลือกอาหารได้อย่างชาญฉลาด",
-          "button_label": "เข้าร่วมทีมนักแปล",
+          "title": "มีการอัปเดตใหม่!",
+          "message": "มีเวอร์ชันใหม่ของแอปพลิเคชันใน Google Play และ F-Droid",
+          "button_label": "อัปเดต",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_th.svg",
+            "width": 0.2,
+            "alt": "อัปเดตแอป Open Food Facts"
           }
         },
-        "fa": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/fa",
-          "title": "شفافیت غذایی را به زبان خود بیاورید",
-          "message": "برنامه، وب‌سایت و موارد دیگر را ترجمه کنید تا به دیگران در انتخاب آگاهانه مواد غذایی کمک کنید",
-          "button_label": "به تیم مترجمین بپیوندید",
+        "tr": {
+          "title": "Yeni bir güncelleme mevcut!",
+          "message": "Uygulamanın yeni bir sürümü Google Play ve F-Droid'de mevcut.",
+          "button_label": "Güncelle",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_tr.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts uygulamasını güncelle"
+          }
+        },
+        "vi": {
+          "title": "Có bản cập nhật mới!",
+          "message": "Một phiên bản mới của ứng dụng có sẵn trên Google Play và F-Droid.",
+          "button_label": "Cập nhật",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_vi.svg",
+            "width": 0.2,
+            "alt": "Cập nhật ứng dụng Open Food Facts"
+          }
+        },
+        "zh": {
+          "title": "有新更新可用！",
+          "message": "Google Play 和 F-Droid 上有新版本的应用程序。",
+          "button_label": "更新",
+          "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_zh.svg",
+            "width": 0.2,
+            "alt": "更新 Open Food Facts 应用程序"
           }
         }
       }
@@ -480,10 +430,7 @@
     "default": {
       "news": [
         {
-          "id": "donation_campaign"
-        },
-        {
-          "id": "translate_openfoodfacts"
+          "id": "app_update"
         }
       ]
     }

--- a/html/resources/files/tagline-off-ios-v3.json
+++ b/html/resources/files/tagline-off-ios-v3.json
@@ -1,473 +1,426 @@
 {
   "news": {
-    "donation_campaign": {
-      "start_date": "2024-10-25 00:00:00",
-      "end_date": "2025-01-31 23:59:59",
-      "url": "https://world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
+    "app_update": {
+      "start_date": "2025-01-01 00:00:00",
+      "end_date": "2099-12-25 23:59:59",
+      "url": "https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner",
       "translations": {
         "default": {
-          "title": "Our application needs you!",
-          "message": "Help us inform **millions of consumers** on what they eat!",
-          "button_label": "Support",
-          "url": "https://world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
+          "title": "New update available!",
+          "message": "A new version of the application is available on the App Store.",
+          "button_label": "Update",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
           "image": {
             "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
             "width": 0.2,
-            "alt": "Support the Open Food Facts project"
-          }
-        },
-        "fr_FR": {
-          "title": "Notre application a besoin de vous !",
-          "message": "Aidez-nous à informer **des millions de consommateurs** sur ce qu'ils mangent !",
-          "button_label": "Je soutiens",
-          "url": "https://fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
-          "image": {
-            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_fr.svg",
-            "width": 0.2,
-            "alt": "Soutenir le projet Open Food Facts"
+            "alt": "Update the Open Food Facts app"
           }
         },
         "fr": {
-          "title": "Notre application a besoin de vous !",
-          "message": "Aidez-nous à informer **des millions de consommateurs** sur ce qu'ils mangent !",
-          "button_label": "Je soutiens",
-          "url": "https://world-fr.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024",
+          "title": "Nouvelle mise à jour!",
+          "message": "Une nouvelle version de l'application est disponible sur l'App Store.",
+          "button_label": "Mettre à jour",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
           "image": {
-            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_fr.svg",
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
             "width": 0.2,
-            "alt": "Soutenir le projet Open Food Facts"
+            "alt": "Mettre à jour l'application Open Food Facts"
           }
         },
         "ar": {
-          "title": "تطبيقنا يحتاجك!",
-          "message": "ساعدنا في إبلاغ **ملايين المستهلكين** بما يأكلونه!",
-          "button_label": "أدعم",
-          "url": "https://world-ar.openfoodfacts.org/donate-to-open-food-facts-ar?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "تحديث جديد متاح!",
+          "message": "يتوفر إصدار جديد من التطبيق على App Store.",
+          "button_label": "تحديث",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "تحديث تطبيق Open Food Facts"
+          }
         },
         "bg": {
-          "title": "Нашето приложение се нуждае от вас!",
-          "message": "Помогнете ни да информираме **милиони потребители** какво ядат!",
-          "button_label": "Поддръжка",
-          "url": "https://world-bg.openfoodfacts.org/даряване-на-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Налична е нова актуализация!",
+          "message": "Нова версия на приложението е налична в App Store.",
+          "button_label": "Актуализиране",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Актуализирайте приложението Open Food Facts"
+          }
         },
         "bn": {
-          "title": "আমাদের অ্যাপ্লিকেশন আপনার প্রয়োজন!",
-          "message": "আমাদের **লক্ষ লক্ষ ভোক্তাদের** তাদের খাবার সম্পর্কে জানাতে সাহায্য করুন!",
-          "button_label": "সমর্থন"
+          "title": "একটি নতুন আপডেট উপলব্ধ!",
+          "message": "অ্যাপ্লিকেশনের একটি নতুন সংস্করণ App Store-এ উপলব্ধ।",
+          "button_label": "আপডেট",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts অ্যাপ আপডেট করুন"
+          }
         },
         "ca": {
-          "title": "La nostra aplicació et necessita!",
-          "message": "Ajuda'ns a informar **milions de consumidors** sobre el que mengen!",
-          "button_label": "Suport",
-          "url": "https://world-ca.openfoodfacts.org/dona-a-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Hi ha una nova actualització disponible!",
+          "message": "Hi ha una nova versió de l'aplicació disponible a l'App Store.",
+          "button_label": "Actualitzar",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Actualitza l'aplicació Open Food Facts"
+          }
         },
         "cs": {
-          "title": "Naše aplikace vás potřebuje!",
-          "message": "Pomozte nám informovat **miliony spotřebitelů** o tom, co jedí!",
-          "button_label": "Podpora",
-          "url": "https://world-cs.openfoodfacts.org/darujte-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Je k dispozici nová aktualizace!",
+          "message": "Nová verze aplikace je k dispozici na App Store.",
+          "button_label": "Aktualizovat",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Aktualizujte aplikaci Open Food Facts"
+          }
         },
         "da": {
-          "title": "Vores ansøgning har brug for dig!",
-          "message": "Hjælp os med at informere **millioner af forbrugere** om, hvad de spiser!",
-          "button_label": "Support",
-          "url": "https://world-da.openfoodfacts.org/doner-til-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "En ny opdatering er tilgængelig!",
+          "message": "En ny version af applikationen er tilgængelig på App Store.",
+          "button_label": "Opdater",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Opdater Open Food Facts-appen"
+          }
         },
         "de": {
-          "title": "Unsere Anwendung braucht Sie!",
-          "message": "Helfen Sie uns, **Millionen von Verbrauchern** darüber zu informieren, was sie essen!",
-          "button_label": "Unterstützen",
-          "url": "https://world-de.openfoodfacts.org/spenden?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Ein neues Update ist verfügbar!",
+          "message": "Eine neue Version der Anwendung ist im App Store verfügbar.",
+          "button_label": "Aktualisieren",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Aktualisieren Sie die Open Food Facts App"
+          }
         },
         "ee": {
-          "title": "Meie rakendus vajab teid!",
-          "message": "Aidake meil teavitada **miljoneid tarbijaid** sellest, mida nad söövad!",
-          "button_label": "Tugi",
-          "url": "https://world-ee.openfoodfacts.org/anneta-to-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Uus värskendus on saadaval!",
+          "message": "Rakenduse uus versioon on saadaval App Store'is.",
+          "button_label": "Värskenda",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Värskendage Open Food Facts rakendust"
+          }
         },
         "el": {
-          "title": "Η εφαρμογή μας σας χρειάζεται!",
-          "message": "Βοηθήστε μας να ενημερώσουμε **εκατομμύρια καταναλωτές** για το τι τρώνε!",
-          "button_label": "Υποστηρίζω",
-          "url": "https://world-el.openfoodfacts.org/dorea-se-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Μια νέα ενημέρωση είναι διαθέσιμη!",
+          "message": "Μια νέα έκδοση της εφαρμογής είναι διαθέσιμη στο App Store.",
+          "button_label": "Ενημέρωση",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Ενημερώστε την εφαρμογή Open Food Facts"
+          }
         },
         "es": {
-          "title": "¡Nuestra aplicación te necesita!",
-          "message": "¡Ayúdanos a informar a **millones de consumidores** sobre lo que comen!",
-          "button_label": "Apoyar",
-          "url": "https://world-es.openfoodfacts.org/haz-su-donacion-a-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "¡Una nueva actualización está disponible!",
+          "message": "Una nueva versión de la aplicación está disponible en el App Store.",
+          "button_label": "Actualizar",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Actualizar la aplicación Open Food Facts"
+          }
         },
         "fa": {
-          "title": "برنامه ما به شما نیاز دارد!",
-          "message": "به ما کمک کنید تا **میلیون‌ها مصرف‌کننده** را در مورد آنچه می‌خورند مطلع کنیم!",
-          "button_label": "حمایت"
+          "title": "به‌روزرسانی جدیدی در دسترس است!",
+          "message": "نسخه جدیدی از برنامه در App Store موجود است.",
+          "button_label": "به‌روزرسانی",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "برنامه Open Food Facts را به‌روزرسانی کنید"
+          }
         },
         "fi": {
-          "title": "Sovelluksemme tarvitsee sinua!",
-          "message": "Auta meitä kertomaan **miljoonille kuluttajille** siitä, mitä he syövät!",
-          "button_label": "Tuki",
-          "url": "https://world-fi.openfoodfacts.org/lahjoita-open-food-factsille?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Uusi päivitys on saatavilla!",
+          "message": "Sovelluksen uusi versio on saatavilla App Storessa.",
+          "button_label": "Päivitä",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Päivitä Open Food Facts -sovellus"
+          }
         },
         "he": {
-          "title": "האפליקציה שלנו צריכה אותך!",
-          "message": "עזור לנו ליידע **מיליוני צרכנים** מה הם אוכלים!",
-          "button_label": "תמיכה",
-          "url": "https://world-he.openfoodfacts.org/donate-to-open-food-facts-he?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "עדכון חדש זמין!",
+          "message": "גרסה חדשה של האפליקציה זמינה ב-App Store.",
+          "button_label": "עדכון",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "עדכן את אפליקציית Open Food Facts"
+          }
         },
         "hi": {
-          "title": "हमारे ऐप को आपकी जरूरत है!",
-          "message": "हमें **लाखों उपभोक्ताओं** को उनके खाने के बारे में सूचित करने में मदद करें!",
-          "button_label": "समर्थन"
+          "title": "एक नया अपडेट उपलब्ध है!",
+          "message": "एप्लिकेशन का एक नया संस्करण App Store पर उपलब्ध है।",
+          "button_label": "अपडेट करें",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts ऐप को अपडेट करें"
+          }
         },
         "ht": {
-          "title": "Aplikasyon nou an bezwen ou!",
-          "message": "Ede nou enfòme **dè milyon de konsomatè** sou sa yo manje!",
-          "button_label": "Sipò",
-          "url": "https://world-ht.openfoodfacts.org/donate-to-open-food-facts-ht?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Yon nouvo mizajou disponib!",
+          "message": "Yon nouvo vèsyon aplikasyon an disponib sou App Store.",
+          "button_label": "Mizajou",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Mizajou aplikasyon Open Food Facts la"
+          }
         },
         "hu": {
-          "title": "Alkalmazásunknak szüksége van Önre!",
-          "message": "Segítsen bennünket, hogy **fogyasztók millióit** tájékoztassuk arról, hogy mit esznek!",
-          "button_label": "Támogatás",
-          "url": "https://world-hu.openfoodfacts.org/donate-to-open-food-facts-hu?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Új frissítés érhető el!",
+          "message": "Az alkalmazás új verziója elérhető az App Store-ban.",
+          "button_label": "Frissítés",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Frissítse az Open Food Facts alkalmazást"
+          }
         },
         "id": {
-          "title": "Aplikasi kami membutuhkan Anda!",
-          "message": "Bantu kami memberi tahu **jutaan konsumen** tentang apa yang mereka makan!",
-          "button_label": "Dukung",
-          "url": "https://world-id.openfoodfacts.org/donate-to-open-food-facts-id?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Pembaruan baru tersedia!",
+          "message": "Versi baru aplikasi tersedia di App Store.",
+          "button_label": "Perbarui",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Perbarui aplikasi Open Food Facts"
+          }
         },
         "it": {
-          "title": "La nostra applicazione ha bisogno di te!",
-          "message": "Aiutaci a informare **milioni di consumatori** su ciò che mangiano!",
-          "button_label": "Sostieni",
-          "url": "https://world-it.openfoodfacts.org/dona-a-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "È disponibile un nuovo aggiornamento!",
+          "message": "È disponibile una nuova versione dell'applicazione su App Store.",
+          "button_label": "Aggiorna",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Aggiorna l'app Open Food Facts"
+          }
         },
         "ja": {
-          "title": "私たちのアプリケーションはあなたを必要としています！",
-          "message": "何を食べているかについて**何百万人もの消費者**に知らせるのを手伝ってください！",
-          "button_label": "サポート"
+          "title": "新しいアップデートが利用可能です！",
+          "message": "アプリケーションの新しいバージョンがApp Storeで利用可能です。",
+          "button_label": "更新",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Open Food Factsアプリを更新する"
+          }
         },
         "ko": {
-          "title": "우리 애플리케이션이 당신을 필요로 합니다!",
-          "message": "**수백만 소비자**에게 그들이 먹는 것에 대해 알리는 데 도움을 주세요!",
-          "button_label": "지원"
+          "title": "새로운 업데이트가 있습니다!",
+          "message": "애플리케이션의 새로운 버전이 App Store에서 사용할 수 있습니다.",
+          "button_label": "업데이트",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts 앱을 업데이트하세요"
+          }
         },
         "lu": {
-          "title": "Onze applicatie heeft u nodig!",
-          "message": "Help ons om **miljoenen consumenten** te informeren over wat ze eten!",
-          "button_label": "Ondersteunen",
-          "url": "https://world-lu.openfoodfacts.org/donate-to-open-food-facts-lu?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Een nieuwe update is beschikbaar!",
+          "message": "Een nieuwe versie van de applicatie is beschikbaar op de App Store.",
+          "button_label": "Bijwerken",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Update de Open Food Facts app"
+          }
         },
         "lt": {
-          "title": "Mūsų programai reikia jūsų!",
-          "message": "Padėkite mums informuoti **milijonus vartotojų** apie tai, ką jie valgo!",
-          "button_label": "Palaikymas",
-          "url": "https://world-lt.openfoodfacts.org/donate-to-open-food-facts-lt?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Yra naujas atnaujinimas!",
+          "message": "Nauja programos versija pasiekiama „App Store“.",
+          "button_label": "Atnaujinti",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Atnaujinkite „Open Food Facts“ programą"
+          }
         },
         "ms": {
-          "title": "Aplikasi kami memerlukan anda!",
-          "message": "Bantu kami memaklumkan **jutaan pengguna** tentang apa yang mereka makan!",
-          "button_label": "Sokong"
+          "title": "Kemas kini baharu tersedia!",
+          "message": "Versi baharu aplikasi tersedia di App Store.",
+          "button_label": "Kemas kini",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Kemas kini aplikasi Open Food Facts"
+          }
         },
         "nb": {
-          "title": "Vår applikasjon trenger deg!",
-          "message": "Hjelp oss å informere **millioner av forbrukere** om hva de spiser!",
-          "button_label": "Støtte",
-          "url": "https://world-nb.openfoodfacts.org/donate-to-open-food-facts-nb?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "En ny oppdatering er tilgjengelig!",
+          "message": "En ny versjon av applikasjonen er tilgjengelig på App Store.",
+          "button_label": "Oppdater",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Oppdater Open Food Facts-appen"
+          }
         },
         "nl": {
-          "title": "Onze applicatie heeft u nodig!",
-          "message": "Help ons om **miljoenen consumenten** te informeren over wat ze eten!",
-          "button_label": "Ondersteunen",
-          "url": "https://world-nl.openfoodfacts.org/doneren-aan-openfoodfacts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Nieuwe update beschikbaar!",
+          "message": "Een nieuwe versie van de applicatie is beschikbaar in de App Store.",
+          "button_label": "Bijwerken",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Update de Open Food Facts app"
+          }
         },
         "pt": {
-          "title": "Nosso aplicativo precisa de você!",
-          "message": "Ajude-nos a informar **milhões de consumidores** sobre o que eles comem!",
-          "button_label": "Apoiar",
-          "url": "https://world-pt.openfoodfacts.org/fazer-um-donativo-ao-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Nova atualização disponível!",
+          "message": "Uma nova versão do aplicativo está disponível na App Store.",
+          "button_label": "Atualizar",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Atualize o aplicativo Open Food Facts"
+          }
         },
         "pl": {
-          "title": "Nasza aplikacja potrzebuje Ciebie!",
-          "message": "Pomóż nam informować **miliony konsumentów** o tym, co jedzą!",
-          "button_label": "Wspieram",
-          "url": "https://world-pl.openfoodfacts.org/pozhertvovat-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Dostępna jest nowa aktualizacja!",
+          "message": "Nowa wersja aplikacji jest dostępna w App Store.",
+          "button_label": "Aktualizuj",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Zaktualizuj aplikację Open Food Facts"
+          }
         },
         "ro": {
-          "title": "Aplicația noastră are nevoie de tine!",
-          "message": "Ajută-ne să informăm **milioane de consumatori** despre ce mănâncă!",
-          "button_label": "Suport",
-          "url": "https://world-ro.openfoodfacts.org/donate-to-open-food-facts-ro?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "O nouă actualizare este disponibilă!",
+          "message": "O nouă versiune a aplicației este disponibilă în App Store.",
+          "button_label": "Actualizați",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Actualizați aplicația Open Food Facts"
+          }
         },
         "ru": {
-          "title": "Наше приложение нуждается в вас!",
-          "message": "Помогите нам информировать **миллионы потребителей** о том, что они едят!",
-          "button_label": "Поддержать",
-          "url": "https://world-ru.openfoodfacts.org/donate-to-open-food-facts-ru?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "Доступно новое обновление!",
+          "message": "Новая версия приложения доступна в App Store.",
+          "button_label": "Обновить",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Обновите приложение Open Food Facts"
+          }
         },
         "sk": {
-          "title": "Naša aplikácia vás potrebuje!",
-          "message": "Pomôžte nám informovať **milióny spotrebiteľov** o tom, čo jedia!",
-          "button_label": "Podpora",
-          "url": "https://world-bg.openfoodfacts.org/donate-to-open-food-facts-sk?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
+          "title": "K dispozícii je nová aktualizácia!",
+          "message": "Nová verzia aplikácie je k dispozícii v App Store.",
+          "button_label": "Aktualizovať",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Aktualizujte aplikáciu Open Food Facts"
+          }
         },
         "sl": {
-          "title": "Naša aplikacija vas potrebuje!",
-          "message": "Pomagajte nam obveščati **milijone potrošnikov** o tem, kaj jedo!",
-          "button_label": "Podpora",
-          "url": "https://world-sl.openfoodfacts.org/doniraj-k-open-food-facts?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "sv": {
-          "title": "Vår applikation behöver dig!",
-          "message": "Hjälp oss att informera **miljontals konsumenter** om vad de äter!",
-          "button_label": "Stöd",
-          "url": "https://world-sv.openfoodfacts.org/donate-to-open-food-facts-sv?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "th": {
-          "title": "แอปพลิเคชันของเราต้องการคุณ!",
-          "message": "ช่วยเราบอก **ผู้บริโภคหลายล้านคน** ว่าพวกเขากินอะไร!",
-          "button_label": "สนับสนุน"
-        },
-        "tr": {
-          "title": "Uygulamamızın size ihtiyacı var!",
-          "message": "**Milyonlarca tüketiciyi** ne yedikleri konusunda bilgilendirmemize yardımcı olun!",
-          "button_label": "Destek",
-          "url": "https://world-tr.openfoodfacts.org/open-food-factse-bagista-bulununs?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        },
-        "vi": {
-          "title": "Ứng dụng của chúng tôi cần bạn!",
-          "message": "Giúp chúng tôi thông báo cho **hàng triệu người tiêu dùng** về những gì họ ăn!",
-          "button_label": "Hỗ trợ"
-        },
-        "zh": {
-          "title": "我们的应用程序需要你！",
-          "message": "帮助我们告知**数百万消费者**他们吃的是什么！",
-          "button_label": "支持",
-          "url": "https://world.openfoodfacts.org/donate-to-open-food-facts-cn?utm_source=off&utf_medium=smooth-app&utm_campaign=donation-2024"
-        }
-      }
-    },
-    "translate_openfoodfacts": {
-      "start_date": "2025-02-01 00:00:00",
-      "end_date": "2025-12-31 23:59:59",
-      "url": "https://translate.openfoodfacts.org/project/openfoodfacts/en",
-      "translations": {
-        "default": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/en",
-          "title": "Bring food transparency to your language",
-          "message": "Translate the app, website and more to help others make informed food choices",
-          "button_label": "Join the translators team",
+          "title": "Na voljo je nova posodobitev!",
+          "message": "Nova različica aplikacije je na voljo v App Store.",
+          "button_label": "Posodobi",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png",
-            "width": 0.2
-          }
-        },
-        "ar": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ar",
-          "title": "اجعل شفافية الغذاء تصل إلى لغتك",
-          "message": "ترجم التطبيق والموقع الإلكتروني والمزيد لمساعدة الآخرين على اتخاذ خيارات غذائية مستنيرة",
-          "button_label": "انضم إلى فريق المترجمين",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "bn": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/bn",
-          "title": "আপনার ভাষায় খাদ্য স্বচ্ছতা আনুন",
-          "message": "অন্যদের তথ্যবহুল খাদ্য পছন্দ করতে সাহায্য করার জন্য অ্যাপ, ওয়েবসাইট এবং আরও অনেক কিছু অনুবাদ করুন",
-          "button_label": "অনুবাদক দলে যোগ দিন",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "de": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/de",
-          "title": "Bringen Sie Lebensmitteltransparenz in Ihre Sprache",
-          "message": "Übersetzen Sie die App, die Website und mehr, um anderen zu helfen, informierte Entscheidungen über Lebensmittel zu treffen",
-          "button_label": "Dem Übersetzerteam beitreten",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "el": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/el",
-          "title": "Φέρτε τη διαφάνεια τροφίμων στη γλώσσα σας",
-          "message": "Μεταφράστε την εφαρμογή, τον ιστότοπο και άλλα για να βοηθήσετε άλλους να κάνουν ενημερωμένες επιλογές τροφίμων",
-          "button_label": "Γίνετε μέλος της ομάδας μεταφραστών",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "es": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/es",
-          "title": "Haz que la transparencia alimentaria llegue a tu idioma",
-          "message": "Traduce la aplicación, el sitio web y más para ayudar a otros a tomar decisiones alimentarias informadas",
-          "button_label": "Únete al equipo de traductores",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "fr": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/fr",
-          "title": "Rendez la transparence alimentaire accessible dans votre langue",
-          "message": "Traduisez l'application, le site web et plus encore pour aider les autres à faire des choix alimentaires éclairés",
-          "button_label": "Rejoindre l'équipe de traducteurs",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "hi": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/hi",
-          "title": "अपनी भाषा में खाद्य पारदर्शिता लाएँ",
-          "message": "दूसरों को सूचित खाद्य विकल्प बनाने में मदद करने के लिए ऐप, वेबसाइट और बहुत कुछ का अनुवाद करें",
-          "button_label": "अनुवादक टीम में शामिल हों",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "pt": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/pt",
-          "title": "Traga transparência alimentar para o seu idioma",
-          "message": "Traduza o aplicativo, o site e muito mais para ajudar outras pessoas a fazer escolhas alimentares informadas",
-          "button_label": "Junte-se à equipe de tradutores",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "it": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/it",
-          "title": "Porta la trasparenza alimentare nella tua lingua",
-          "message": "Traduci l'app, il sito web e altro ancora per aiutare gli altri a fare scelte alimentari informate",
-          "button_label": "Unisciti al team di traduttori",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ja": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ja",
-          "title": "食品の透明性をあなたの言語で",
-          "message": "アプリ、ウェブサイトなどを翻訳して、他の人が情報に基づいた食品の選択をするのを手伝ってください",
-          "button_label": "翻訳チームに参加する",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ko": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ko",
-          "title": "식품 투명성을 귀하의 언어로 가져오세요",
-          "message": "앱, 웹사이트 등을 번역하여 다른 사람들이 정보에 입각한 식품 선택을 할 수 있도록 돕습니다.",
-          "button_label": "번역 팀에 합류하기",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "nl": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/nl",
-          "title": "Breng voedseltransparantie naar uw taal",
-          "message": "Vertaal de app, website en meer om anderen te helpen weloverwogen voedselkeuzes te maken",
-          "button_label": "Word lid van het vertalersteam",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "pl": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/pl",
-          "title": "Przynieś przejrzystość żywności do swojego języka",
-          "message": "Przetłumacz aplikację, stronę internetową i wiele więcej, aby pomóc innym w podejmowaniu świadomych wyborów żywieniowych",
-          "button_label": "Dołącz do zespołu tłumaczy",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ru": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ru",
-          "title": "Обеспечьте прозрачность пищевых продуктов на вашем языке",
-          "message": "Переведите приложение, веб-сайт и многое другое, чтобы помочь другим сделать осознанный выбор продуктов питания",
-          "button_label": "Присоединиться к команде переводчиков",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Posodobite aplikacijo Open Food Facts"
           }
         },
         "sv": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/sv",
-          "title": "Ge din språklig insyn i livsmedel",
-          "message": "Översätt appen, webbplatsen och mer för att hjälpa andra att göra välgrundade val av livsmedel",
-          "button_label": "Gå med i översättarteamet",
+          "title": "En ny uppdatering är tillgänglig!",
+          "message": "En ny version av applikationen är tillgänglig i App Store.",
+          "button_label": "Uppdatera",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "tr": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/tr",
-          "title": "Gıda şeffaflığını dilinize getirin",
-          "message": "Uygulamayı, web sitesini ve daha fazlasını çevirerek başkalarının bilinçli gıda seçimleri yapmasına yardımcı olun",
-          "button_label": "Çevirmenler ekibine katılın",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "uk": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/uk",
-          "title": "Зробіть прозорість харчових продуктів доступною вашою мовою",
-          "message": "Перекладіть додаток, веб-сайт та багато іншого, щоб допомогти іншим зробити усвідомлений вибір продуктів харчування",
-          "button_label": "Приєднатися до команди перекладачів",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "vi": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/vi",
-          "title": "Mang tính minh bạch về thực phẩm đến ngôn ngữ của bạn",
-          "message": "Dịch ứng dụng, trang web và hơn thế nữa để giúp người khác đưa ra lựa chọn thực phẩm sáng suốt",
-          "button_label": "Tham gia đội ngũ dịch thuật",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "zh": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/zh",
-          "title": "将食品透明度带到您的语言",
-          "message": "翻译应用程序、网站等，帮助他人做出明智的食品选择",
-          "button_label": "加入翻译团队",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "id": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/id",
-          "title": "Hadirkan transparansi makanan dalam bahasa Anda",
-          "message": "Terjemahkan aplikasi, situs web, dan lainnya untuk membantu orang lain membuat pilihan makanan yang tepat",
-          "button_label": "Bergabunglah dengan tim penerjemah",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
-          }
-        },
-        "ms": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/ms",
-          "title": "Bawa ketelusan makanan ke bahasa anda",
-          "message": "Terjemahkan aplikasi, laman web dan banyak lagi untuk membantu orang lain membuat pilihan makanan yang bijak",
-          "button_label": "Sertai pasukan penterjemah",
-          "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Uppdatera Open Food Facts-appen"
           }
         },
         "th": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/th",
-          "title": "นำความโปร่งใสด้านอาหารมาสู่ภาษาของคุณ",
-          "message": "แปลแอป เว็บไซต์ และอื่นๆ เพื่อช่วยให้ผู้อื่นตัดสินใจเลือกอาหารได้อย่างชาญฉลาด",
-          "button_label": "เข้าร่วมทีมนักแปล",
+          "title": "มีการอัปเดตใหม่!",
+          "message": "มีเวอร์ชันใหม่ของแอปพลิเคชันใน App Store",
+          "button_label": "อัปเดต",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "อัปเดตแอป Open Food Facts"
           }
         },
-        "fa": {
-          "url": "https://translate.openfoodfacts.org/project/openfoodfacts/fa",
-          "title": "شفافیت غذایی را به زبان خود بیاورید",
-          "message": "برنامه، وب‌سایت و موارد دیگر را ترجمه کنید تا به دیگران در انتخاب آگاهانه مواد غذایی کمک کنید",
-          "button_label": "به تیم مترجمین بپیوندید",
+        "tr": {
+          "title": "Yeni bir güncelleme mevcut!",
+          "message": "Uygulamanın yeni bir sürümü App Store'da mevcut.",
+          "button_label": "Güncelle",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
           "image": {
-            "url": "https://world.openfoodfacts.org/images/misc/tagline-images/worldwide.png"
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Open Food Facts uygulamasını güncelle"
+          }
+        },
+        "vi": {
+          "title": "Có bản cập nhật mới!",
+          "message": "Một phiên bản mới của ứng dụng có sẵn trên App Store.",
+          "button_label": "Cập nhật",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "Cập nhật ứng dụng Open Food Facts"
+          }
+        },
+        "zh": {
+          "title": "有新更新可用！",
+          "message": "App Store 上有新版本的应用程序。",
+          "button_label": "更新",
+          "url": "https://apps.apple.com/app/open-food-facts/id588797948",
+          "image": {
+            "url": "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/ios/assets/donation_campaign/donation_campaign_en.svg",
+            "width": 0.2,
+            "alt": "更新 Open Food Facts 应用程序"
           }
         }
       }
@@ -477,10 +430,7 @@
     "default": {
       "news": [
         {
-          "id": "donation_campaign"
-        },
-        {
-          "id": "translate_openfoodfacts"
+          "id": "app_update"
         }
       ]
     }


### PR DESCRIPTION
Hi everyone!

We don't use these 2 JSON files for the tagline in the mobile app (hosted on GitHub instead).
That's why we force the old users to update the app.