### PR TITLE
taxonomy: Added PL translations to some categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -1172,6 +1172,7 @@ fr: Boissons et préparations de boissons
 hr: Pića i pripravci za piće
 it: Bevande e preparati per bevande
 nl: Dranken en drankbereidingen
+pl: Napoje i składniki do napojów
 description:en: This mixes ready to drink beverages and not-ready to drink beverages
 incompatible_with:en: categories:en:meals
 
@@ -37884,6 +37885,7 @@ hu: Cukrász áruk
 it: Dolci, dolce
 lt: Saldumynai
 nl: Zoetwaren, Confiserie, Suikerwerk
+pl: Słodycze
 pt: Confeitaria
 ru: Кондитерские изделия
 sv: Konfekt
@@ -39235,6 +39237,7 @@ en: Marshmallows coated with chocolate
 fr: Guimauves enrobées de chocolat
 hr: Marshmallows preliven čokoladom
 lt: Zefyrai su šokolado glajumi
+pl: Pianki w polewie czekoladowej
 
 < en:Chocolate candies
 en: Nut butter cups
@@ -39525,7 +39528,7 @@ it: Caramelle
 ja: キャンディ, キャンディー, キャンデー
 lt: Saldainiai
 nl: Snoep
-pl: Cukierki, słodycze, cukierek, słodkości
+pl: Cukierki, cukierek, słodkości
 pt: Rebuçados e gomas
 ru: Сладости
 sv: Godis, Sötsaker
@@ -41692,6 +41695,7 @@ hu: Gabonamagvak
 it: Semi di cereale
 lt: Javų grūdai
 nl: Graankorrels
+pl: Ziarna zbóż
 pt: Grãos de cereais
 ru: Злаковое зерно
 intake24_category_code:en: CARB
@@ -69762,6 +69766,7 @@ hr: Suhe marelice
 it: Albicocche secche
 lt: Džiovinti abrikosai
 nl: Gedroogde abrikozen
+pl: Suszone morele
 pt: Alperces desidratados
 ru: Абрикосы сушёные, курага, сушёные абрикосы
 tr: Kuru kayısı
@@ -69927,12 +69932,14 @@ hr: Sušeno miješano voće
 it: Frutta essiccata mista
 lt: Džiovinti įvairūs vaisiai
 nl: Gedroogde fruitmelanges
+pl: Suszona mieszanka owoców
 
 < en:Dried mixed fruits
 en: Mix of grains and dried fruit, Mix of nuts and dried fruit
 fr: Mélange apéritif de graines et fruits séchés
 hr: Mješavina žitarica i suhog voća
 lt: Džiovinti vaisių ir riešutų mišiniai
+pl: Mieszanka ziaren i suszonych owoców, Mieszanka orzechów i suszonych owoców
 agribalyse_food_code:en: 15048
 ciqual_food_code:en: 15048
 ciqual_food_name:en: Mix of unsalted grains/nuts and dried fruit
@@ -69941,6 +69948,7 @@ ciqual_food_name:fr: Mélange apéritif de graines (non salées) et fruits séch
 < en:Mix of grains and dried fruit
 en: Mix of grains and raisins, Mix of nuts and raisins
 fr: Mélange apéritif de graines et raisins secs
+pl: Mieszanka ziaren i rodzynek, Mieszanka orzechów i rodzynek
 agribalyse_food_code:en: 15049
 ciqual_food_code:en: 15049
 ciqual_food_name:en: Mix of unsalted grains/nuts and raisins
@@ -81131,7 +81139,7 @@ en: Fermented vegetables
 fr: Légumes fermentés
 hr: Fermentirano povrće
 nl: Gefermenteerde groenten
-
+pl: Kiszone warzywa
 
 < en:Appetizers
 en: Cold starters
@@ -95026,6 +95034,7 @@ hu: Savanyúságok
 it: Sottaceti, Sottoaceti, Sott'aceti, Alimenti sottoaceto, Alimenti sottaceto, Alimenti sott'aceto
 ja: ピクルス
 nl: Tafelzuren
+pl: Produkty marynowane
 pt: Picles
 ru: Солёные или маринованные огурцы
 sv: Inlagd mat, Pickels, Pickles
@@ -104449,6 +104458,7 @@ hr: Kiseli krastavci na biljnoj bazi
 hu: Növényi savanyúságok, Savanyított zöldségek
 it: Sottaceti a base di vegetali, Sottoaceti a base di vegetali, Sott'aceti a base di vegetali
 nl: Plantaardige zoetzuren
+pl: Marynowane produkty roślinne
 pt: Pickles à base de plantas
 ro: Legume murate
 ru: Маринованные растительные продукты
@@ -104858,6 +104868,7 @@ it: Verdure a foglia
 ja: 葉菜, 葉物, 葉野菜, 菜っ葉
 nl: Bladgroenten
 nl_be: Bladgewas
+pl: Warzywa liściaste
 ru: Листовые овощи
 wikidata_category:en: Q7469413
 
@@ -108749,6 +108760,7 @@ hr: Lisnate salate
 it: Insalate a foglia
 ja: 葉野菜サラダ, 葉物サラダ
 nl: Bladsla
+pl: Sałaty liściaste
 agribalyse_food_code:en: 25604
 ciqual_food_code:en: 25604
 ciqual_food_name:en: Green salad, raw, without seasoning


### PR DESCRIPTION
I added translations for the ones I saw in my products and were not translated.

I removed the "Słodycze" from en:Candies and moved to en:Confectioneries - I believe it's a better match to PL language.

I don't have a docker setup to run `make lint_taxonomies`. Sorry. I tried to remove ending white characters from the lines manually 

<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

<!-- Describe the changes made and why they were made instead of how they were made. -->

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #[ISSUE NUMBER]

