### PR TITLE
ci: Remove empty PR build jobs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,20 +19,6 @@ concurrency:
 
 jobs:
 
-  # those are just until we de-activate their mandatory
-  gulp:
-    name: Gulp
-    runs-on: ubuntu-latest
-    steps:
-    - name: just finish
-      run: exit 0
-  dev:
-    name: Dev
-    runs-on: ubuntu-latest
-    steps:
-    - name: just finish
-      run: exit 0
-
   lint:
     name: 🕵️‍♀️ NPM lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes the two PR build jobs that just finished without doing anything.