### PR TITLE
fix: FLAVOR_NAME is openproductsfacts

### DIFF
--- a/env/env.opf
+++ b/env/env.opf
@@ -8,6 +8,6 @@ COMPOSE_PROJECT_NAME=po_opf
 APACHE_ENVVARS=/etc/apache2/off-envvars
 
 # app configuration
-PRODUCT_OPENER_FLAVOR=openproductfacts
+PRODUCT_OPENER_FLAVOR=openproductsfacts
 PRODUCT_OPENER_FLAVOR_SHORT=opf
 NUTRIPATROL_URL=https://nutripatrol.openfoodfacts.org/


### PR DESCRIPTION
This was generating dumps with the wrong name on Open Products Facts !

Fixes https://github.com/openfoodfacts/openfoodfacts-server/issues/11118