### PR TITLE
fix: disable rate limiting for internal trafic

### DIFF
--- a/lib/ProductOpener/Config_off.pm
+++ b/lib/ProductOpener/Config_off.pm
@@ -1623,7 +1623,9 @@ $options{rate_limit_product} = 100;
 
 # Rate limit allow list
 $options{rate_limit_allow_list} = {
+	'146.59.148.140' => 1,    # OVH1
 	'51.210.154.203' => 1,    # OVH2
+	'51.210.32.79' => 1,    # OVH3
 	'45.147.209.254' => 1,    # Moji server (actually OSM proxy, Moji only has ipv6)
 };
 

--- a/lib/ProductOpener/Routing.pm
+++ b/lib/ProductOpener/Routing.pm
@@ -1006,6 +1006,12 @@ sub set_rate_limit_attributes ($request_ref, $ip) {
 				$block_message
 					= "Rate-limiter blocking is disabled for local IP addresses, but the user has reached the rate-limit";
 			}
+			# Check that the ip is not in the OFF private network
+			elsif ($ip =~ /^10\.1\./) {
+				# The IP address is in the OFF private network, we don't block the request
+				$block_message
+					= "Rate-limiter blocking is disabled for the OFF private network, but the user has reached the rate-limit";
+			}
 			# Check that the IP address is not in the allow list
 			elsif (defined $options{rate_limit_allow_list}{$ip}) {
 				# The IP address is in the allow list, we don't block the request


### PR DESCRIPTION
This is to whitelist internal users of product opener running on off1, off2, ovh1/2/3 and moji.