### PR TITLE
chore: fix make prod_up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,15 +156,15 @@ up: build create_folders _up
 # Used by staging so that shared services are not created
 prod_up: build create_folders
 	@echo "🥫 Starting containers …"
-	${DOCKER_COMPOSE_BUILD} up -d 2>&1
+	${DOCKER_COMPOSE} up -d 2>&1
 
 down:
 	@echo "🥫 Bringing down containers …"
-	${DOCKER_COMPOSE_BUILD} down
+	${DOCKER_COMPOSE} down
 
 hdown:
 	@echo "🥫 Bringing down containers and associated volumes …"
-	${DOCKER_COMPOSE_BUILD} down -v
+	${DOCKER_COMPOSE} down -v --remove-orphans
 
 reset: hdown up
 


### PR DESCRIPTION
We did not use the right docker compose command… due to a change november, but I think as long as some container where still running in staging it was invisible ! But as they go down (maybe a restart of the VM), it refuses to start on staging.