### PR TITLE
build: run apt update in needed in Dockerfile at various steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,9 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt set -x && \
     # rerun apt update, because last RUN might be in cache
-    ( [[ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ]] && apt update || true ) && \
+    ( ( [[ ! -e /var/cache/apt/pkgcache.bin ]] || [[ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ]] ) && \
+      apt update || true \
+    ) && \
     apt install -y \
         #
         # cpan dependencies that can be satisfied by apt even if the package itself can't:
@@ -213,7 +215,9 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=cpanm-cache,target=/root/.cpanm \
     set -x && \
     # also run apt update if needed because some package might need to apt install
-    ( [[ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ]] && apt update || true ) && \
+    ( ( [[ ! -e /var/cache/apt/pkgcache.bin ]] || [[ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ]] ) && \
+      apt update || true \
+    ) && \
     # first install some dependencies that are not well handled
     cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ "Apache::Bootstrap" && \
     cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
         libemail-valid-perl
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt set -x && \
+    # rerun apt update, because last RUN might be in cache
+    ( [[ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ]] && apt update || true ) && \
     apt install -y \
         #
         # cpan dependencies that can be satisfied by apt even if the package itself can't:
@@ -210,6 +212,8 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt \
     --mount=type=cache,id=lib-apt-cache,target=/var/lib/apt \
     --mount=type=cache,id=cpanm-cache,target=/root/.cpanm \
     set -x && \
+    # also run apt update if needed because some package might need to apt install
+    ( [[ $(($(date +%s) - $(stat --format=%Y /var/cache/apt/pkgcache.bin))) -gt 3600 ]] && apt update || true ) && \
     # first install some dependencies that are not well handled
     cpanm --notest --quiet --skip-satisfied --local-lib /tmp/local/ "Apache::Bootstrap" && \
     cpanm $CPANMOPTS --notest --quiet --skip-satisfied --local-lib /tmp/local/ --installdeps . \


### PR DESCRIPTION
Because first step that runs apt update might be taken from cache.
