### PR TITLE
taxonomy: more Rainforest Alliance labels

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -18379,10 +18379,10 @@ pl: Wieprzowina bez domieszek
 pt: Carne de porco pura, Puro bife, 100% bife, bife puro, pura carne de porco, 100% carne de porco
 
 en: Rainforest Alliance
-xx: Rainforest Alliance
+xx: Rainforest Alliance, Rainforest Alliance People & Nature, Rainforest Alliance People and Nature, Rainforest
 ca: Aliança Tropical
 es: Rainforest Alliance, Alianza para Bosques
-fr: Rainforest Alliance, Vérifié Rainforest Alliance, Rainforest minimum 30% cacao, Certifié Rainforest Alliance
+fr: Rainforest Alliance, Vérifié Rainforest Alliance, Certifié Rainforest Alliance
 hr: Rainforest Alliance, Certificirano Rainforest Alliance
 it: Alleanza della Foresta Pluviale
 sv: Rainforest Alliance, Rainforest Alliance-certifierad
@@ -18390,9 +18390,38 @@ auth_url:en: https://www.rainforest-alliance.org
 wikidata:en: Q2034373
 
 < en:Rainforest Alliance
+en: Rainforest Alliance Tea
+xx: Rainforest Alliance Tea
+de: Rainforest Alliance Tee
+fr: Rainforest Alliance Thé
+nl: Rainforest Alliance Thee
+
+< en:Rainforest Alliance
+en: Rainforest Alliance Rooibos
+xx: Rainforest Alliance Rooibos
+
+< en:Rainforest Alliance
 en: Rainforest Alliance Black Tea
 xx: Rainforest Alliance Black Tea
 de: Rainforest Alliance Schwarzer Tee
+fr: Rainforest Alliance Thé noir
+
+< en:Rainforest Alliance Vanilla
+xx: Rainforest Alliance Vanilla
+de: Rainforest Alliance Vanille
+fr: Rainforest Alliance Vanille
+nl: Rainforest Alliance Vanille
+
+< en:Rainforest alliance
+en: Rainforest Alliance Ginger
+xx: Rainforest Alliance Ginger
+fr: Rainforest Alliance Gingembre
+nl: Rainforest Alliance Gember
+
+< en: Rainforest Alliance
+en: Rainforest Alliance Coffee
+de: Rainforest Alliance Kaffee
+fr: Rainforest Alliance Café
 
 < en:Rainforest Alliance
 en: Rainforest Alliance Cocoa
@@ -18406,6 +18435,20 @@ sv: Rainforest Alliance Kakao
 < en:Rainforest Alliance
 en: Rainforest Alliance Cassave
 xx: Rainforest Alliance Cassave
+
+< en:Rainforest Alliance
+en: Rainforest Alliance Hazelnut
+xx: Rainforest Alliance Hazelnut
+de: Rainforest Alliance Haselnuss
+fr: Rainforest Alliance Noisettes
+nl: Rainforest Alliance Hazelnoot
+sv: Rainforest Alliance Hasselnöt
+
+< en:Rainforest Alliance
+en: Rainforest Alliance Bananas
+xx: Rainforest Alliance Bananas
+de: Rainforest Alliance Banane, Rainforest Alliance Bananen
+fr: Rainforest Alliance Bananes
 
 < en:Rainforest Alliance
 en: Rainforest Alliance Mango

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -18406,7 +18406,7 @@ xx: Rainforest Alliance Black Tea
 de: Rainforest Alliance Schwarzer Tee
 fr: Rainforest Alliance Thé noir
 
-< en:Rainforest Alliance Vanilla
+< en:Rainforest Alliance
 xx: Rainforest Alliance Vanilla
 de: Rainforest Alliance Vanille
 fr: Rainforest Alliance Vanille


### PR DESCRIPTION
Added ssme Rainforest Alliance labels found on products, + full name as synonym