### PR TITLE
fix: gen_feeds_daily.sh: failure email for export_database.pl

### DIFF
--- a/scripts/export_database.pl
+++ b/scripts/export_database.pl
@@ -94,6 +94,9 @@ sub sanitize_field_content {
 	return $content;
 }
 
+# Record if the script had errors
+my $errors = 0;
+
 my %tags_fields = (
 	packaging => 1,
 	brands => 1,
@@ -534,6 +537,7 @@ XML
 	else {
 		print STDERR "Not overwriting previous CSV. Old size = $csv_size_old, new size = $csv_size_new.\n";
 		unlink "$csv_filename.temp2";
+		$errors++;
 	}
 
 	my %links = ();
@@ -591,8 +595,9 @@ XML
 	else {
 		print STDERR "Not overwriting previous RDF. Old size = $rdf_size_old, new size = $rdf_size_new.\n";
 		unlink "$rdf_filename.temp";
+		$errors++;
 	}
 
 }
 
-exit(0);
+exit($errors);

--- a/scripts/gen_feeds_daily.sh
+++ b/scripts/gen_feeds_daily.sh
@@ -31,6 +31,9 @@ fi
 
 cd $OFF_SCRIPTS_DIR
 
+ERRORS=0
+FAILED_COMMANDS=""
+
 # off-pro flavor: we don't generate most exports
 # but we have some special processing
 if [ "$PRODUCT_OPENER_FLAVOR_SHORT" == "off-pro" ]; then
@@ -40,13 +43,22 @@ if [ "$PRODUCT_OPENER_FLAVOR_SHORT" == "off-pro" ]; then
     exit 0
 fi
 
-
 ./remove_empty_products.pl
 ./gen_top_tags_per_country.pl
 
 # Generate the CSV and RDF exports
-./export_database.pl
+./export_database_nok.pl
+RETURN=$?
 
+if [ $RETURN -ne 0 ];
+then
+    echo "export_database.pl not executed successfully - return value: $RETURN"
+    ERRORS=`expr $ERRORS + 1`
+    FAILED_COMMANDS="${FAILED_COMMANDS}export_database.pl
+"
+fi
+
+# compress CSV exports
 cd $OFF_PUBLIC_DATA_DIR
 for export in en.$PRODUCT_OPENER_DOMAIN.products.csv fr.$PRODUCT_OPENER_DOMAIN.products.csv en.$PRODUCT_OPENER_DOMAIN.products.rdf fr.$PRODUCT_OPENER_DOMAIN.products.rdf; do
    nice pigz < $export > new.$export.gz
@@ -113,4 +125,17 @@ then
     ./generate_madenearme_pages.sh
 fi
 
+# If there were commands that resulted in errors,
+# echo the list of commands so that it is included in the
+# failure e-mail sent to root
+if [ $ERRORS -gt 0 ];
+then
+    echo "$ERRORS ERROR(S) DURING EXECUTION OF gen_fields_daily.sh"
+    echo "FAILED COMMANDS:
+$FAILED_COMMANDS"
+    exit 1
+else
+    echo "No errors during execution of gen_fields_daily.sh"
+    exit 0
+fi
 

--- a/scripts/gen_feeds_daily.sh
+++ b/scripts/gen_feeds_daily.sh
@@ -47,7 +47,7 @@ fi
 ./gen_top_tags_per_country.pl
 
 # Generate the CSV and RDF exports
-./export_database_nok.pl
+./export_database.pl
 RETURN=$?
 
 if [ $RETURN -ne 0 ];

--- a/scripts/gen_feeds_daily.sh
+++ b/scripts/gen_feeds_daily.sh
@@ -52,7 +52,7 @@ RETURN=$?
 
 if [ $RETURN -ne 0 ];
 then
-    echo "export_database.pl not executed successfully - return value: $RETURN"
+    >&2 echo "export_database.pl not executed successfully - return value: $RETURN"
     ERRORS=`expr $ERRORS + 1`
     FAILED_COMMANDS="${FAILED_COMMANDS}export_database.pl
 "
@@ -130,8 +130,8 @@ fi
 # failure e-mail sent to root
 if [ $ERRORS -gt 0 ];
 then
-    echo "$ERRORS ERROR(S) DURING EXECUTION OF gen_fields_daily.sh"
-    echo "FAILED COMMANDS:
+    >&2 echo "$ERRORS ERROR(S) DURING EXECUTION OF gen_fields_daily.sh"
+    >&2 echo "FAILED COMMANDS:
 $FAILED_COMMANDS"
     exit 1
 else


### PR DESCRIPTION
As suggested by @alexgarel , this PR adds a mechanism to see if some of the commands failed, and list them at the end so that we get them in the email failure.

If this is ok, we can add checks for the other commands (and possibly make those commands return a non 0 status on errors if they don't already).