### PR TITLE
ci: Config to disable automatic Gemini Assist before enabling it on the repo

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,9 @@
+have_fun: true
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,9 +1,9 @@
-have_fun: true
+have_fun: false
 code_review:
-  disable: false
+  disable: true
   comment_severity_threshold: MEDIUM
   max_review_comments: -1
   pull_request_opened:
     help: false
-    summary: true
-    code_review: true
+    summary: false
+    code_review: false


### PR DESCRIPTION
### What

- ci: Test Gemini Code Assist, only on explicit requests (https://github.com/marketplace/gemini-code-assist) 
- Once this PR is merged, I'll need to enable it on the repo, and then you'll be able to require a review manually at any time
- https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github?hl=fr#default-configuration
- https://blog.google/technology/developers/gemini-code-assist-free/