### PR TITLE
taxonomy: More Swedish (sv) labels

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -7587,7 +7587,7 @@ ro: E319, Butilhidrochinonă terțiară (tbhq), Terț-butil-1\,4-benzendiol
 ru: E319, e319, Трет-бутилгидрохинон, Трет бутилгидрохинон
 sk: E319, Terciálny butylhydrochinón (tbhq), Terc-butyl-1\,4-benzéndiol
 sl: E319, Terc-butilhidrokinon (tbhq), terc-butil-1\,4-benzendiol
-sv: E319, Tertiär-butylhydrokinon (tbhq), Tertbutyl-1\,4-bensendiol
+sv: E319, Tertiär-butylhydrokinon (tbhq), Tertbutyl-1\,4-bensendiol, tertiär butylhydrokinon
 additives_classes:en: en:antioxidant
 e_number:en: 319
 efsa_evaluation:en: Statement on the refined exposure assessment of tertiary-butyl hydroquinone (E 319)
@@ -17687,7 +17687,7 @@ sh: E551, Silicijum dioksid
 sk: E551, Oxid kremičitý, Kremeň
 sl: E551, Silicijev dioksid, silikagel
 sr: E551, силицијум диоксид, sredstvo protiv zgrudnjavanja E551
-sv: E551, Kiseldioxid, Kvarts, klumpförebyggande medel E551
+sv: E551, Kiseldioxid, Kvarts, klumpförebyggande medel E551, silikondioxid
 ta: E551, சிலிக்கா
 th: E551, ซิลิกอนไดออกไซด์
 tr: E551, Silisyum dioksit
@@ -19186,7 +19186,7 @@ ro: E635, 5'-ribonucleotidă disodică
 ru: E635, e635, 5-рибонуклеотиды натрия 2-замещенные, 2-замещенный 5'-гуанилат натрия, 5 гуанилат натрия 2 замещенный
 sk: E635, 5'-ribonukleotid disodný
 sl: E635, Dinatrijev 5'-ribonukleotid
-sv: E635, Dinatrium-5'-ribonukleotider
+sv: E635, Dinatrium-5'-ribonukleotider, dinatrium-5'-ribonuk-leider
 e_number:en: 635
 vegan:en: maybe
 vegetarian:en: maybe

--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -545,7 +545,7 @@ ro: Emulsifiant, Emulgator, emulsifianți
 ru: Эмульгатор, эмульгаторы
 sk: Emulgátor
 sl: Emulgator
-sv: Emulgeringsmedel, Emulgering
+sv: Emulgeringsmedel, Emulgering, emulgator
 description:en: Emulsifiers are substances which make it possible to form or maintain a homogenous mixture of two or more immiscible phases such as oil and water in a foodstuff.
 description:cs: Emulgátory se rozumějí látky, které umožňují vytvořit nebo uchovat v potravině stejnorodou směs dvou nebo více nemísitelných fází, například oleje a vody.
 description:da: Emulgatorer: stoffer, hvormed man kan danne eller opretholde en homogen blanding af to eller flere ikke-blandbare faser som f.eks. olie og vand i en fødevare.

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -8819,6 +8819,7 @@ nl: Kruidentheeën, Kruidenthee
 pl: Herbaty ziołowe
 pt: Chás de ervas, infusões de ervas, infusões
 ru: Травяные чаи и настойки
+sv: Örtte
 agribalyse_proxy_food_code:en: 18020
 agribalyse_proxy_food_name:en: Tea, brewed, without sugar
 gpc_category_code:en: 10000119
@@ -8828,6 +8829,7 @@ wikidata:en: Q379932
 
 < en:Herbal teas
 en: Herbal teas in tea bags, Herbal teas in bags
+da: Urtete i poser
 de: Kräutertee aus Teebeuteln
 es: Plantas para infusiones en bolsitas, Infusiones en bolsitas, Tisanas en bolsitas
 fi: Yrttipussiteet
@@ -8839,6 +8841,7 @@ lt: Žolelių arbatos maišeliuose
 nl: Kruidenthee in zakjes, Kruidenthee in buidels
 pl: Herbatki ziołowe w torebkach, Herbaty ziołowe w torebkach
 ru: Чай в пакетиках
+sv: Örtte i pås
 # should not be in pnns_group_2:en:Teas and herbal teas and coffees
 pnns_group_2:en: unknown
 # should not be in food_groups:en: en:Teas and herbal teas and coffees
@@ -9797,6 +9800,7 @@ pl: Zielona herbata, Herbata zielona
 pt: Chás verdes
 ro: Ceauri verzi, Ceai verde
 ru: Зелёный чай
+sv: Grönt te
 tr: Yeşil çay
 zh: 绿茶
 agribalyse_proxy_food_code:en: 18155
@@ -38271,7 +38275,7 @@ pl: Czekolada mleczna
 pt: Chocolates de leite, chocolate de leite
 ro: Ciocolată cu lapte
 ru: Молочный шоколад, Шоколад молочный
-sv: Mjölkchoklad
+sv: Mjölkchoklad, ljus choklad
 tr: Sütlü çikolata
 zh: 牛奶巧克力
 agribalyse_proxy_food_code:en: 31004

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -491,7 +491,7 @@ wikidata:en: Q53792073
 
 # nova:en:lecithin
 < en:E322i
-en: soya lecithin, soy lecithin, soybean lecithin
+en: soya lecithin, soy lecithin, soybean lecithin, emulsifer soya lecithin
 bg: соев лецитин, соеви лецитини
 bs: emulgator sojin lecitin
 ca: Lecitina de soja, lecitines de soja
@@ -15648,7 +15648,7 @@ so: dux
 sq: yndyra
 sr: масти
 su: lemak
-sv: fett, fet, matfett
+sv: fett, fet, matfett, fetter
 ta: கொழுப்பு
 te: కొలెస్టరాల్‌
 th: ไขมัน
@@ -16647,6 +16647,7 @@ nl: geheel geharde palm, geheel geharde palmolie
 pl: całkowicie utwardzony olej palmowy, olej roślinny palmowy całkowicie utwardzony
 ro: unt de palmier complet hidrogenat
 sl: popolnoma hidrogenirano palmino olje
+sv: helt hydrerad palmolja
 
 < en:hydrogenated palm oil
 en: partially hydrogenated palm oil
@@ -18257,7 +18258,7 @@ sk: Slnečnicový olej
 sl: Sončnično olje
 sq: Vaji i lulediellit
 sr: сунцокретово уље
-sv: solrosolja
+sv: solrosolja, vegetabilisk solrosolja
 te: పొద్దుతిరుగుడు నూనె
 th: น้ำมันดอกทานตะวัน
 tr: Ayçiçek yağı
@@ -19000,7 +19001,7 @@ pl: ocet winny, octu winnego
 pt: vinagre de vinho
 ro: oțet din vin, otet din vin, oţet de vin
 ru: Винный уксус
-sv: vinsvinäger, vinättika, vinäger av vin
+sv: vinsvinäger, vinättika, vinäger av vin, vinvinäger
 carbon_footprint_fr_foodges_ingredient:fr: Vinaigre de vin
 carbon_footprint_fr_foodges_value:fr: 4.2
 
@@ -26649,7 +26650,7 @@ nn: fullkornshavregryn
 pl: płatki owsiane z pełnego przemiału, płatki owsiane pełnoziarniste, pełnoziarniste płatki owsiane, płatki z pełnego ziarna owsa
 pt: flocos de aveia integral
 sl: ovseni polnozrnati kosmiči
-sv: fullkornshavregryn
+sv: fullkornshavregryn, fullkorn havregryn
 
 < en:whole grain oat flakes
 en: british wholegrain oat flakes
@@ -29261,7 +29262,7 @@ it: fiocchi di mais, cornflakes
 nl: maïsvlokken, cornflakes
 pl: płatki kukurydziane
 pt: flocos de milho
-sv: majsflingor
+sv: majsflingor, cornflakes
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/cornflakes
 # 11 products in 2 languages @2018-09-23
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/corn-flakes
@@ -30525,6 +30526,11 @@ sv: riskrisp, puffat ris
 # ingredient/fr:riz-soufflé has 180 products in 10 languages @2018-12-19
 # ingredient/fr:riz-croustillant has 44 products in 2 languages @2018-12-19
 # usage:en:crisped rice (Rice, Sugar, Salt, Barley Malt Extract)
+
+< en:corn
+< en:puffed rice
+en: puffed rice and corn, rice and corn crisps
+sv: ris- och majskrisp
 
 < en:rice
 fr: galette de riz
@@ -34473,6 +34479,10 @@ hr: obrani kakao prah
 it: Polvere di cacao magra
 ja: 脱脂ココアパウダー
 ru: обезжиренный какаопорошок, сухой обезжиренный остаток какао
+
+< en:cocoa powder
+en: cocoa powder with reduced cocoa butter content
+sv: kakaopulver med reducerad kakaosmörhalt
 
 < en:cocoa
 en: cocoa solids
@@ -73913,7 +73923,7 @@ pt: cogumelos-de-Paris, Champignon
 qu: Champiñun
 ru: Шампиньон двуспоровый, шампиньоны сушеные
 sl: Dvotrosni kukmak
-sv: Portabello, champinjon, champinjoner, vit champinjon, vita champinjoner
+sv: Portabello, champinjon, champinjoner, vit champinjon, vita champinjoner, champinjon agaricus bisporus
 ta: அகாரிகஸ் பைஸ்போரஸ்
 uk: Печериця садова
 zh: 雙孢蘑菇

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1808,7 +1808,7 @@ it: soffiato, soffiati, soffiata, soffiate
 nl: gepoft, gepofte
 pl: dmuchany, dmuchane, dmuchana, preparowany, preparowana, preparowane, ekspandowany, ekspandowane, ekspandowana
 se: puffat
-sv: puffat
+sv: puffat, puffad, krisp
 
 en: pre-fried, prefried
 bg: предварително пържени, предварително пържено, предварително пържена, предварително пържени

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -18563,7 +18563,7 @@ es: Rainforest Alliance, Alianza para Bosques
 fr: Rainforest Alliance, Vérifié Rainforest Alliance, Certifié Rainforest Alliance
 hr: Rainforest Alliance, Certificirano Rainforest Alliance
 it: Alleanza della Foresta Pluviale
-sv: Rainforest Alliance, Rainforest Alliance-certifierad
+sv: Rainforest Alliance, Rainforest Alliance-certifierad, Rainforest Alliance Certified
 auth_url:en: https://www.rainforest-alliance.org
 wikidata:en: Q2034373
 
@@ -18573,6 +18573,7 @@ xx: Rainforest Alliance Tea
 de: Rainforest Alliance Tee
 fr: Rainforest Alliance Thé
 nl: Rainforest Alliance Thee
+sv: Rainforest Alliance Te
 
 < en:Rainforest Alliance
 en: Rainforest Alliance Rooibos


### PR DESCRIPTION
### What

A number of (mostly) Swedish entries were added, based on unrecognised ingredients on product pages:

- https://world.openfoodfacts.org/product/8601900503411/eurocream-spread-takovo#health
- https://se.openfoodfacts.org/product/86019101/eurokr%C3%A4m-swisslion#health
- https://se.openfoodfacts.org/product/8606103381842/instant-noodle-vegies-has#health
- https://se.openfoodfacts.org/product/7340083459436/pesto-bomba-calabrese-garant#health
- https://se.openfoodfacts.org/product/7340083472329/granola-kokos-quinoa-garant#health
- https://se.openfoodfacts.org/product/7311590002262/n%C3%B6t-cr%C3%A8me-original#health
- https://se.openfoodfacts.org/product/4000194331894/vegan-light-chocolate-salty-caramel-green-star#health
- https://se.openfoodfacts.org/product/7311043006090/ekologiskt-citrongr%C3%A4s-f%C3%A4nk%C3%A5l-ingef%C3%A4ra-%C3%B6rt-och-gr%C3%B6nt-te-garant
