### PR TITLE
taxonomy: Copy some `se` entries to `sv`

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -50740,10 +50740,12 @@ pl: Skyr owocowy
 xx: Viili, Filmjölk
 fi: Viili
 se: Filmjölk, filbunke
+sv: Filmjölk
 
 < en:Fermented dairy desserts with fruits
 < fi:Viili
 se: Filmjölk med frukt
+sv: Filmjölk med frukt
 
 < en:Fermented milk products
 # <en:ingredient:en:cheese

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -44692,6 +44692,7 @@ nl: kokoscreme
 pl: śmietanka kokosowa, śmietanki kokosowej, krem kokosowy
 pt: Creme de coco
 se: Kokosgrädde
+sv: Kokosgrädde
 ciqual_food_code:en: 18041
 ciqual_food_name:en: Coconut milk or coconut cream
 ciqual_food_name:fr: Lait de coco ou Crème de coco
@@ -58228,6 +58229,7 @@ pl: pomidory truskawkowe
 pt: tomate cherry pêra
 ro: rosii cherry prunisoare
 se: babyplommontomater
+sv: babyplommontomater
 
 < en:tomato
 fr: tomates semi-séchées, tomate mi-séchée, tomates mi-séchées

--- a/taxonomies/ingredients_processing.txt
+++ b/taxonomies/ingredients_processing.txt
@@ -1808,6 +1808,7 @@ it: soffiato, soffiati, soffiata, soffiate
 nl: gepoft, gepofte
 pl: dmuchany, dmuchane, dmuchana, preparowany, preparowana, preparowane, ekspandowany, ekspandowane, ekspandowana
 se: puffat
+sv: puffat
 
 en: pre-fried, prefried
 bg: предварително пържени, предварително пържено, предварително пържена, предварително пържени

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -1581,6 +1581,7 @@ it: la isomaltulosio è una fonte di glucosio e fruttosio
 nl: isomaltulose is een bron van glucose en fructose
 pl: izomaltuloza jest źródłem glukozy i fruktozy
 se: isomaltulos är en källa till glukos och fruktos
+sv: isomaltulos är en källa till glukos och fruktos
 
 en: source of fibre
 xx: source of fibre
@@ -5298,6 +5299,7 @@ nl: Niet aanbevolen voor zwangere vrouwen
 pt: Não recomendado para mulheres grávidas, não aconselhado para mulheres grávidas, não recomendado a mulheres grávidas, não aconselhado a mulheres grávidas, Desaconselhado a mulheses grávidas, desaconselhado para mulheres grávidas
 ru: Не рекомендовано для беременных женщин
 se: Recommanderas ej till gravida
+sv: Rekommanderas ej till gravida
 th: ไม่แนะนำสำหรับคนท้อง
 
 < en:Not advised for specific people
@@ -5313,6 +5315,7 @@ nl: Afgeraden voor kinderen en zwangere vrouwen
 pt: Não recomendado para crianças e mulheres grávidas, não recomendado a crianças e mulheres grávidas
 ru: Не рекомендовано для детей и беременных женщин
 se: Rekommenderas ej till barn samt gravida
+sv: Rekommenderas ej till barn samt gravida
 
 < en:Not advised for specific people
 en: Not recommended for children under 3 years


### PR DESCRIPTION
### What

`se` is the language code for Northern Sámi, but all the copied entries are in Swedish (`sv`). It is common to mistakenly use `se` for Swedish, since `se` is also the country code for Sweden.

I didn’t remove the Sámi entries since North Sámi _is_ spoken in parts currently occupied by Sweden, so there is likely some loan words and other linguistic influences. I have my doubts with a lot of these though, but I’m not a Sámi speaker of any sort and I don’t know the circumstances of why they were added.
