### PR TITLE
docs: Grep Invalid Option Fix

### DIFF
--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -20,9 +20,9 @@ Docker provides an isolated environment, very close to a Virtual Machine. This e
 **Installation steps:**
 - GIT version >= 2.25.0
 - [Install Docker CE](https://docs.docker.com/engine/install/)
-> If you run e.g. Debian, don't forget to add your user to the `docker` group!
+> If you run e.g. Debian, don't forget to add your user to the `docker` group!  
 
-### macOS: Installing GNU grep for Full Regex Support
+### MacOS Prerequisites: Installing GNU grep for Full Regex Support
 
 On macOS, the default version of **grep** is BSD grep, which does not support certain GNU-specific options—most notably, the `-P` flag for Perl-compatible regular expressions. If you encounter errors like:
 
@@ -31,7 +31,7 @@ grep: invalid option -- P
 usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]] …
 ```
 
-you can resolve the issue by installing GNU grep and prioritizing it in your shell's PATH.
+You can resolve the issue by installing GNU grep and prioritizing it in your shell's PATH.
 
 #### Steps to Install GNU grep
 

--- a/docs/dev/how-to-quick-start-guide.md
+++ b/docs/dev/how-to-quick-start-guide.md
@@ -22,6 +22,69 @@ Docker provides an isolated environment, very close to a Virtual Machine. This e
 - [Install Docker CE](https://docs.docker.com/engine/install/)
 > If you run e.g. Debian, don't forget to add your user to the `docker` group!
 
+### macOS: Installing GNU grep for Full Regex Support
+
+On macOS, the default version of **grep** is BSD grep, which does not support certain GNU-specific options—most notably, the `-P` flag for Perl-compatible regular expressions. If you encounter errors like:
+
+```console
+grep: invalid option -- P
+usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]] …
+```
+
+you can resolve the issue by installing GNU grep and prioritizing it in your shell's PATH.
+
+#### Steps to Install GNU grep
+
+1. **Install GNU grep via Homebrew:**
+
+   ```console
+   brew install grep
+   ```
+
+2. **Update Your PATH:**
+
+   Add the following line to your `~/.zshrc` (or your shell’s configuration file):
+
+   ```console
+   export PATH="$(brew --prefix grep)/libexec/gnubin:$PATH"
+   ```
+
+   This ensures that the GNU version (often available as `ggrep`) is used by default instead of BSD grep.
+
+3. **Apply the Changes:**
+
+   Restart your terminal or run:
+
+   ```console
+   source ~/.zshrc
+   ```
+
+4. **Verify Installed Version:**
+
+Run the following command to ensure that GNU grep is installed and properly configured:
+
+```console
+grep --version
+```
+
+You should see an output similar to the example below, indicating that GNU grep (with Homebrew packaging) is active and supports the `-P` option via PCRE2:
+
+```console
+grep (GNU grep) 3.11
+Packaged by Homebrew
+Copyright (C) 2023 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Written by Mike Haertel and others; see
+<https://git.savannah.gnu.org/cgit/grep.git/tree/AUTHORS>.
+
+grep -P uses PCRE2 10.44 2024-06-07
+```
+
+After completing these steps, running grep commands (for example, as part of `make log`) will use GNU grep with full support for options like `-P`.
+
 ### Windows Prerequisites
 
 When running with Windows, install [Docker Desktop](https://www.docker.com/products/docker-desktop/) **which will cover all of the above**.


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

This pull request updates the "How to setup the Dev environment (quick start guide)" documentation with new instructions specifically for macOS users. The changes include:

- **Installing GNU grep:**  
  Added detailed steps on installing GNU grep via Homebrew, which resolves issues with the default BSD grep lacking support for the `-P` option.

- **Updating PATH:**  
  Provided instructions to update the shell's PATH to prioritize GNU grep, ensuring that commands like `grep -P` work as expected.

- **Version Verification:**  
  Included a section on how to check the installed version of GNU grep to confirm that it meets the required version (e.g., GNU grep 3.11).

These changes help prevent errors like:

```console
openfoodfacts-server git:(main) make log
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
```

and streamline the developer setup process on macOS.

**Impact:**  
- Improves the developer experience for macOS users by ensuring they have the correct version of grep installed.
- Provides clarity and consistency in the setup process for running the Open Food Facts server locally.
- Helps new contributors avoid common pitfalls related to grep compatibility issues.

Please review the changes and let me know if further adjustments are needed.


<!-- Describe the changes made and why they were made instead of how they were made. -->


### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->

If we do not update the GNU version then this can lead to unexpected behaviors during built time.
1. `“binary operator expected” & “cd: too many arguments” Error:`
<br>The error messages:

```swift
/opt/homebrew/bin/bash: line 1: [: /Users/jagjeevankashid/Developer/open: binary operator expected  
/opt/homebrew/bin/bash: line 1: cd: too many arguments
```
  2.  or by ignoring the error and directly running `make dev` could lead to below errors  
![Screenshot 2025-03-02 at 9 55 27 AM](https://github.com/user-attachments/assets/dddecded-ee43-4429-97e0-3b2534acda16)


