### PR TITLE
docs: in the YAML schema, fix the link to product_quality.yaml

### DIFF
--- a/docs/api/ref/api.yml
+++ b/docs/api/ref/api.yml
@@ -529,8 +529,6 @@ components:
       $ref: "./schemas/product_nutriscore.yaml#/components/schemas/NutriscoreAll"
     "Product-Quality":
       $ref: ./schemas/product_quality.yaml
-    "Product-Data-Quality":
-      $ref: ./schemas/product_knowledge_panels.yaml
     "Product-Extended":
       $ref: ./schemas/product_extended.yaml
     "Product-Metadata":

--- a/docs/api/ref/schemas/product.yaml
+++ b/docs/api/ref/schemas/product.yaml
@@ -27,7 +27,7 @@ allOf:
   - $ref: "../api.yml#/components/schemas/Product-Ingredients"
   - $ref: "../api.yml#/components/schemas/Product-Nutrition"
   - $ref: "../api.yml#/components/schemas/Product-Nutriscore"
-  - $ref: "../api.yml#/components/schemas/Product-Data-Quality"
+  - $ref: "../api.yml#/components/schemas/Product-Quality"
   - $ref: "../api.yml#/components/schemas/Product-Extended"
   - $ref: "../api.yml#/components/schemas/Product-Metadata"
   - $ref: "../api.yml#/components/schemas/Product-Knowledge-Panels"


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [X] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [X] Code is well documented
- [X] Include unit tests for new functionality
- [X] Code passes GitHub workflow checks in your branch
- [X] If you have multiple commits please combine them into one commit by squashing them.
- [X] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

This change corrects a misalignment between product.yaml and api.yml by updating the reference in product.yaml from Product-Data-Quality to Product-Quality, ensuring it correctly points to the intended schema. Additionally, the redundant Product-Data-Quality component definition in api.yml is removed, as it incorrectly referenced product_knowledge_panels.yaml instead of the appropriate product_quality.yaml.

### Screenshot
<!-- Optional, you can delete if not relevant -->

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #11275

