### PR TITLE
fix: Override no_cache parameter if database is explicitly set to off-query

### DIFF
--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1640,8 +1640,14 @@ sub set_cache_results ($key, $results) {
 }
 
 sub can_use_query_cache() {
-	return (    ((not defined single_param("no_cache")) or (not single_param("no_cache")))
-			and (not $server_options{producers_platform}));
+	return (
+		(
+				   (not defined single_param("no_cache"))
+				or (not single_param("no_cache"))
+				or (single_param("database") eq "off-query")
+		)
+			and (not $server_options{producers_platform})
+	);
 }
 
 sub generate_query_cache_key ($name, $context_ref, $request_ref) {


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

When testing popularity queries via off-query we need to set the no_cache parameter but this supresses using off-query for some counts

### Related issue(s) and discussion
- Part of #11334

