### PR TITLE
fix: Use off_query parameter to not clash with existing database parameter

### DIFF
--- a/lib/ProductOpener/Data.pm
+++ b/lib/ProductOpener/Data.pm
@@ -125,7 +125,7 @@ sub execute_count_tags_query ($query) {
 sub execute_product_query ($parameters_ref, $query_ref, $fields_ref, $sort_ref = undef, $limit = undef, $skip = undef) {
 	# Currently only send descending popularity_key sorts to off-query
 	# Note that $sort_ref is a Tie::IxHash so can't use $sort_ref->{popularity_key}
-	if ($parameters_ref->{database} eq 'off-query' && $sort_ref && $sort_ref->FETCH('popularity_key') == -1) {
+	if ($parameters_ref->{off_query} && $sort_ref && $sort_ref->FETCH('popularity_key') == -1) {
 		# Convert sort into an array so that the order of keys is not ambiguous
 		my @sort_array = ();
 		foreach my $k ($sort_ref->Keys) {

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -1639,12 +1639,12 @@ sub set_cache_results ($key, $results) {
 	return;
 }
 
-sub can_use_query_cache() {
+sub can_use_off_query() {
 	return (
 		(
 				   (not defined single_param("no_cache"))
 				or (not single_param("no_cache"))
-				or (single_param("database") eq "off-query")
+				or (single_param("off_query"))
 		)
 			and (not $server_options{producers_platform})
 	);
@@ -1779,7 +1779,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 		$results = undef;
 		# do not use the postgres cache if ?no_cache=1
 		# or if we are on the producers platform
-		if (can_use_query_cache()) {
+		if (can_use_off_query()) {
 			set_request_stats_time_start($request_ref->{stats}, "off_query_aggregate_tags_query");
 			$results = execute_aggregate_tags_query($aggregate_parameters);
 			set_request_stats_time_end($request_ref->{stats}, "off_query_aggregate_tags_query");
@@ -1852,7 +1852,7 @@ sub query_list_of_tags ($request_ref, $query_ref) {
 			my $count_results;
 			# do not use the smaller postgres cache if ?no_cache=1
 			# or if we are on the producers platform
-			if (can_use_query_cache()) {
+			if (can_use_off_query()) {
 				set_request_stats_time_start($request_ref->{stats}, "off_query_aggregate_tags_query");
 				$count_results = execute_aggregate_tags_query($aggregate_count_parameters);
 				set_request_stats_time_end($request_ref->{stats}, "off_query_aggregate_tags_query");
@@ -4747,8 +4747,8 @@ sub get_products_collection_request_parameters ($request_ref, $additional_parame
 	# for obsolete products
 	$parameters_ref->{obsolete} = request_param($request_ref, "obsolete");
 
-	# Allow the database to be specified. Currently defaults to mongodb but can set to off-query to use that instead
-	$parameters_ref->{database} = request_param($request_ref, "database");
+	# Allow the source to be specified. Currently defaults to mongodb but can set to use off-query instead
+	$parameters_ref->{off_query} = request_param($request_ref, "off_query");
 
 	# Admin users can request a specific query_timeout for MongoDB queries
 	if ($request_ref->{admin}) {
@@ -5830,7 +5830,7 @@ sub estimate_result_count ($request_ref, $query_ref, $cache_results_flag) {
 			$log->debug("count not in cache for query", {key => $key_count}) if $log->is_debug();
 
 			# Count queries are very expensive, if possible, execute them on the postgres cache
-			if (can_use_query_cache()) {
+			if (can_use_off_query()) {
 				set_request_stats_time_start($request_ref->{stats}, "off_query_count_tags_query");
 				$count = execute_count_tags_query($query_ref);
 				set_request_stats_time_end($request_ref->{stats}, "off_query_count_tags_query");


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What

database=off-query parameter was clashing with an existing database parameter passed into MongoDB. Changed to use off_query=1

### Related issue(s) and discussion
- Part of #11334

