### PR TITLE
chore: use a .log extension for apache2 logs

### DIFF
--- a/conf/apache-2.4/sites-available/off.conf
+++ b/conf/apache-2.4/sites-available/off.conf
@@ -26,8 +26,8 @@ Require all granted
 <VirtualHost *>
 DocumentRoot /srv/off/html
 ServerName openfoodfacts.org
-ErrorLog /srv/off/logs/error_log_${APACHE2_PORT}
-CustomLog /srv/off/logs/access_log_${APACHE2_PORT} proxy
+ErrorLog /srv/off/logs/error_${APACHE2_PORT}.log
+CustomLog /srv/off/logs/access_${APACHE2_PORT}.log proxy
 LogLevel warn
 ScriptAlias /cgi/ "/srv/off/cgi/"
 


### PR DESCRIPTION
To have logrotate works correctly

(Already deployed to production)