### PR TITLE
fix: data quality label threshold source of vitamins and minerals

### DIFF
--- a/lib/ProductOpener/DataQualityFood.pm
+++ b/lib/ProductOpener/DataQualityFood.pm
@@ -2356,76 +2356,76 @@ sub check_labels ($product_ref) {
 		my %vitamins_and_minerals_labelling = (
 			europe => {
 				"vitamin-a" => {
-					"en:vitamin-a-source" => 0.0008,    # 800 µg
-					"en:rich-in-vitamin-a" => 0.0016,
+					"en:vitamin-a-source" => 0.0008 * 0.15,    # 800 µg * 0.15
+					"en:rich-in-vitamin-a" => 0.0016 * 0.15,
 				},
 				"vitamin-d" => {
-					"en:vitamin-d-source" => 0.000005,    # 5 µg
-					"en:rich-in-vitamin-d" => 0.00001,
+					"en:vitamin-d-source" => 0.000005 * 0.15,    # 5 µg * 0.15
+					"en:rich-in-vitamin-d" => 0.00001 * 0.15,
 				},
 				"vitamin-e" => {
-					"en:vitamin-e-source" => 0.01,    # 10 mg
-					"en:rich-in-vitamin-e" => 0.02,
+					"en:vitamin-e-source" => 0.01 * 0.15,    # 10 mg * 0.15
+					"en:rich-in-vitamin-e" => 0.02 * 0.15,
 				},
 				"vitamin-c" => {
-					"en:vitamin-c-source" => 0.06,    # 10 mg
-					"en:rich-in-vitamin-c" => 0.12,
+					"en:vitamin-c-source" => 0.06 * 0.15,    # 10 mg * 0.15
+					"en:rich-in-vitamin-c" => 0.12 * 0.15,
 				},
 				"vitamin-b1" => {
-					"en:vitamin-b1-source" => 0.0014,    # 1.4 mg, thiamin
-					"en:rich-in-vitamin-b1" => 0.0028,
+					"en:vitamin-b1-source" => 0.0014 * 0.15,    # 1.4 mg * 0.15 (vitamin b1 = thiamin)
+					"en:rich-in-vitamin-b1" => 0.0028 * 0.15,
 				},
 				"vitamin-b2" => {
-					"en:vitamin-b2-source" => 0.0016,    # 1.6 mg, riboflavin
-					"en:rich-in-vitamin-b2" => 0.0032,
+					"en:vitamin-b2-source" => 0.0016 * 0.15,    # 1.6 mg * 0.15 (vitamin b2 = riboflavin)
+					"en:rich-in-vitamin-b2" => 0.0032 * 0.15,
 				},
 				"vitamin-b3" => {
-					"en:vitamin-b3-source" => 0.018,    # 18 mg, niacin
-					"en:rich-in-vitamin-b3" => 0.036,
+					"en:vitamin-b3-source" => 0.018 * 0.15,    # 18 mg * 0.15 (vitamin b3 = niacin)
+					"en:rich-in-vitamin-b3" => 0.036 * 0.15,
 				},
 				"vitamin-b6" => {
-					"en:vitamin-b6-source" => 0.002,    # 2 mg
-					"en:rich-in-vitamin-b6" => 0.004,
+					"en:vitamin-b6-source" => 0.002 * 0.15,    # 2 mg * 0.15
+					"en:rich-in-vitamin-b6" => 0.004 * 0.15,
 				},
 				"vitamin-b9" => {
-					"en:vitamin-b9-source" => 0.0002,    # 200 µg, folacin
-					"en:rich-in-vitamin-b9" => 0.0004,
+					"en:vitamin-b9-source" => 0.0002 * 0.15,    # 200 µg * 0.15 (vitamin b9 = folacin)
+					"en:rich-in-vitamin-b9" => 0.0004 * 0.15,
 				},
 				"vitamin-b12" => {
-					"en:vitamin-b12-source" => 0.000001,    # 1 µg
-					"en:rich-in-vitamin-b12" => 0.000002,
+					"en:vitamin-b12-source" => 0.000001 * 0.15,    # 1 µg * 0.15
+					"en:rich-in-vitamin-b12" => 0.000002 * 0.15,
 				},
 				"biotin" => {
-					"en:source-of-biotin" => 0.00015,    # 0.15 mg
-					"en:high-in-biotin" => 0.0003,
+					"en:source-of-biotin" => 0.00015 * 0.15,    # 0.15 mg * 0.15
+					"en:high-in-biotin" => 0.0003 * 0.15,
 				},
 				"pantothenic-acid" => {
-					"en:source-of-pantothenic-acid" => 0.006,    # 6 mg
-					"en:high-in-pantothenic-acid" => 0.012,
+					"en:source-of-pantothenic-acid" => 0.006 * 0.15,    # 6 mg * 0.15
+					"en:high-in-pantothenic-acid" => 0.012 * 0.15,
 				},
 				"calcium" => {
-					"en:calcium-source" => 0.8,    # 800 mg
-					"en:high-in-calcium" => 1.6,
+					"en:calcium-source" => 0.8 * 0.15,    # 800 mg * 0.15
+					"en:high-in-calcium" => 1.6 * 0.15,
 				},
 				"phosphorus" => {
-					"en:phosphore-source" => 0.8,    # 800 mg
-					"en:high-in-phosphore" => 1.6,
+					"en:phosphore-source" => 0.8 * 0.15,    # 800 mg * 0.15
+					"en:high-in-phosphore" => 1.6 * 0.15,
 				},
 				"iron" => {
-					"en:iron-source" => 0.014,    # 14 mg
-					"en:high-in-iron" => 0.028,
+					"en:iron-source" => 0.014 * 0.15,    # 14 mg * 0.15
+					"en:high-in-iron" => 0.028 * 0.15,
 				},
 				"magnesium" => {
-					"en:magnesium-source" => 0.3,    # 300 mg
-					"en:high-in-magnesium" => 0.6,
+					"en:magnesium-source" => 0.3 * 0.15,    # 300 mg * 0.15
+					"en:high-in-magnesium" => 0.6 * 0.15,
 				},
 				"zinc" => {
-					"en:zinc-source" => 0.015,    # 15 mg
-					"en:high-in-zinc" => 0.03,
+					"en:zinc-source" => 0.015 * 0.15,    # 15 mg * 0.15
+					"en:high-in-zinc" => 0.03 * 0.15,
 				},
 				"iodine" => {
-					"en:iodine-source" => 0.00015,    # 150 µg
-					"en:high-in-iodine" => 0.0003,
+					"en:iodine-source" => 0.00015 * 0.15,    # 150 µg * 0.15
+					"en:high-in-iodine" => 0.0003 * 0.15,
 				},
 			},
 		);

--- a/taxonomies/data_quality.txt
+++ b/taxonomies/data_quality.txt
@@ -3715,147 +3715,147 @@ description:en: In EU, a claim that a food is high in protein may only be made w
 
 < en:Data quality warnings
 en: vitamin a source label claim but vitamin a below 0.0008
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin a label claim but vitamin a below 0.0016
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: Vitamin D source label claim but Vitamin D below 5e-06
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: Rich in Vitamin D label claim but Vitamin D below 1e-05
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin e source label claim but vitamin e below 0.01
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin e label claim but vitamin e below 0.02
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin c source label claim but vitamin c below 0.06
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin c label claim but vitamin c below 0.12
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin b1 source label claim but vitamin b1 below 0.0014
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin b1 label claim but vitamin b1 below 0.0028
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin b2 source label claim but vitamin b2 below 0.0016
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin b2 label claim but vitamin b2 below 0.0032
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin b3 source label claim but vitamin b3 below 0.018
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin b3 label claim but vitamin b3 below 0.036
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin b6 source label claim but vitamin b6 below 0.002
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin b6 label claim but vitamin b6 below 0.004
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin b9 source label claim but vitamin b9 below 0.0002
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin b9 label claim but vitamin b9 below 0.0004
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: vitamin b12 source label claim but vitamin b12 below 1e-06
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: rich in vitamin b12 label claim but vitamin b12 below 2e-06
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: source of biotin label claim but biotin below 0.00015
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in biotin label claim but biotin below 0.0003
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: source of pantothenic acid label claim but pantothenic acid below 0.006
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in pantothenic acid label claim but pantothenic acid below 0.012
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: calcium source label claim but calcium below 0.8
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in calcium label claim but calcium below 1.6
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: phosphore source label claim but phosphorus below 0.8
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in phosphore label claim but phosphorus below 1.6
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: iron source label claim but iron below 0.014
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in iron label claim but iron below 0.028
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: magnesium source label claim but magnesium below 0.3
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in magnesium label claim but magnesium below 0.6
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: zinc source label claim but zinc below 0.015
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in zinc label claim but zinc below 0.03
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: iodine source label claim but iodine below 0.00015
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: high in iodine label claim but iodine below 0.0003
-description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496
+description:en: In EU, claim that a food is a source of vitamins and/or minerals may only be made where the product contains at least a significant amount as defined in the Annex to Directive 90/496/EEC. See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 
 < en:Data quality warnings
 en: source of omega 3 label claim but ala or sum of epa and dha below limitation

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -71,8 +71,8 @@ stopwords:de: und, mit, von
 # For categories for which a minimum amount of specific ingredients is required in some countries
 # we put expected_minimal_amount_specific_ingredients:en followed by the specific ingredient,
 #   the quantity in g and the country where it applies.
-# additional countries can be added separated by a semi colon (";"). Example for en:fruit, 35g, in EU and en:fruit, 35g in en:other-country:
-# expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu;  en:fruit, 35, en:other-country
+# additional countries can be added separated by a semi colon (";"). Example for en:fruit, 45g, in EU and en:fruit, 45g in en:other-country:
+# expected_minimal_amount_specific_ingredients:en: en:fruit, 45, en:eu;  en:fruit, 45, en:other-country
 
 # if two labels are not compatible, they can be assigned the property 'incompatible_with:en:'
 # for example
@@ -67963,7 +67963,7 @@ protected_name_type:en: pgi
 
 
 # in eu, Blackcurrants jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Berries
 en: Blackcurrants, black currant
 bg: Касис
@@ -102374,7 +102374,7 @@ fr: Tartinades de gingembre
 < en:Ginger preserves
 en: Ginger jams
 fr: Confitures de gingembre
-expected_minimal_amount_specific_ingredients:en: en:fruit, 15, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 18, en:eu
 
 < en:Plant-based spreads
 < en:Sweet spreads
@@ -102414,7 +102414,7 @@ sv: Rårörda lingon
 wikidata:en: Q10658749
 
 # in eu, jams should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 #   otherwise it should have another name than jam
 #   remark: marmelade = citrus jam
 #   remark: jam = mixture, brought to a suitable gelled consistency, of sugars,
@@ -102457,12 +102457,12 @@ agribalyse_proxy_food_code:en: 31024
 ciqual_proxy_food_code:en: 31024
 ciqual_proxy_food_name:en: Jam, strawberry
 ciqual_proxy_food_name:fr: Confiture de fraise (extra ou classique)
-expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 45, en:eu
 intake24_category_code:en: JAMS
 wikidata:en: Q8752059
 
 # in eu, extra-jams should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 #   that is high amount of fruit than jams
 #   otherwise it should have another name than extra-jam
 #   remark: marmelade = citrus jam
@@ -102494,7 +102494,7 @@ ro: Gemul de calitate superioară
 sk: Extra džem
 sl: Ekstra džem
 sv: Extra sylt
-expected_minimal_amount_specific_ingredients:en: en:fruit, 45, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 50, en:eu
 
 < en:Jams
 en: Shelf-stable jams
@@ -102682,7 +102682,7 @@ hr: Džemovi od crnog ribiza
 hu: Fekete ribizli lekvár
 it: Confetture di ribes nero, Marmellate di ribes nero
 nl: Cassisjams
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 < en:Berry jams
 en: Blackberry jams
@@ -102716,7 +102716,7 @@ en: Forest berry jams
 nl: Bosvruchtenjams
 
 # in eu, redcurrents jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Berry jams
 en: Redcurrants jams
 de: Rote Johannisbeere Konfitüren
@@ -102727,7 +102727,7 @@ hu: Vörös ribizli lekvár
 it: Confetture di ribes, Marmellate di ribes, Confetture di ribes rosso, Marmellate di ribes rosso
 nl: Aalbessenjams
 pt: Doces de groselha
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 < en:Berry jams
 en: Gooseberries jams, gooseberry jams
@@ -102985,7 +102985,7 @@ es: cabello de ángel
 fr: Cabell d'àngel
 
 # in eu, quince jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Jams
 en: Quince jams
 bg: Конфитюр от дюли
@@ -102999,7 +102999,7 @@ agribalyse_proxy_food_code:en: 31037
 ciqual_proxy_food_code:en: 31037
 ciqual_proxy_food_name:en: Jam, apricot
 ciqual_proxy_food_name:fr: Confiture d'abricot (extra ou classique)
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 wikidata:en: Q6855605
 
 < en:Jams
@@ -103016,7 +103016,7 @@ pt: Doces de ruibarbo
 wikidata:en: Q89999895
 
 # in eu, rosehip jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Jams
 en: Rosehip jams, rosehip jam
 bg: Шипков мармалад
@@ -103027,10 +103027,10 @@ hu: Csipkebogyó lekvár
 it: Confetture di rosa canina, Marmellate di rosa canina
 nl: Rozenbotteljam
 sv: Nyponsylter
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 # in eu, Sea-buckthorn jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Jams
 en: Sea-buckthorn jams
 de: Sanddorn Konfitüren
@@ -103039,7 +103039,7 @@ fi: Tyrnihillot
 fr: Confitures d'argousiers
 hr: Džemovi od krkavine
 it: Confetture di olivello spinoso, Marmellate di olivello spinoso
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 < en:Jams
 en: Sweet pepper jams
@@ -103201,7 +103201,7 @@ expected_minimal_amount_specific_ingredients:en: en:fruit, 20, en:eu
 wikidata:en: Q5834964
 
 # in eu, citrus jams (marmalades) should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 # remark: marmalade = citrus jam + peel and pulp
 # usually, actual "filtered" citrus jams-only are not commercialised, but the marmalade/jam term is used interchangeably
 < en:Citrus jams
@@ -103293,7 +103293,7 @@ it: Marmellate di mandarini tangerini, Confetture di mandarini tangerini
 
 #################### jellies and extra jellies in alphebetical order for English ####################
 # in eu, jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 # same amount as jams
 < en:Fruit and vegetable preserves
 en: Fruit jellies, jellies, jelly
@@ -103326,7 +103326,7 @@ ciqual_proxy_food_name:en: Jam, strawberry
 ciqual_proxy_food_name:fr: Confiture de fraise (extra ou classique)
 
 # in eu, extra-jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 # same amount as extra-jams
 < en:Fruit and vegetable preserves
 en: extra fruit jellies, extra jellies, extra jelly
@@ -103379,7 +103379,7 @@ nl: Zwarte bessengeleien
 sv: Björnbärsgeléer
 
 # in eu, Blackcurrants jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Fruit jellies
 en: Blackcurrants jellies
 de: Schwarze Johannisbeere Gelees
@@ -103387,7 +103387,7 @@ fi: Mustaherukkahyytelöt
 fr: Gelées de cassis
 hr: Žele od crnog ribiza
 sv: Svartvinbärsgeléer, Svartvinbärsgelé
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 < en:Fruit jellies
 en: Elderberry jellies
@@ -103438,10 +103438,10 @@ ja: パッションフルーツゼリー
 nl: Passievruchtgeleien
 pt: Geleias de maracujá
 sv: Passionsfruktgeléer
-expected_minimal_amount_specific_ingredients:en: en:fruit, 6, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 8, en:eu
 
 # in eu, quince jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Fruit jellies
 en: Quince jellies
 de: Quitten Gelees, Quitten-Gelee
@@ -103451,7 +103451,7 @@ hr: Žele od dunja
 nl: Kweepeergeleien
 pt: Geleias de marmelo
 sv: Kvittengeléer
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 < en:Fruit jellies
 en: Raspberry jellies
@@ -103465,7 +103465,7 @@ pt: Geleias de framboesa
 sv: Hallongeléer
 
 # in eu, redcurrents jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Fruit jellies
 en: Redcurrants jellies
 de: Rote Johannisbeere Gelees
@@ -103476,17 +103476,17 @@ hr: Žele od crvenog ribiza
 nl: Aalbessengeleien
 pt: Geleias de groselha
 sv: Vinbärsgeléer
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 # in eu, Sea-buckthorn jams/jellies should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Fruit jellies
 en: Sea-buckthorn jellies
 de: Sanddorn Gelees
 fi: Tyrnihyytelöt
 fr: Gelées d'argousiers
 hr: Žele od krkavine
-expected_minimal_amount_specific_ingredients:en: en:fruit, 25, en:eu
+expected_minimal_amount_specific_ingredients:en: en:fruit, 35, en:eu
 
 < en:Fruit jellies
 en: Wine jellies, wine gelees
@@ -103496,7 +103496,7 @@ pt: Geleias de vinho
 
 #################### Sweetened chestnut purée ####################
 # in eu, Sweetened chestnut purée should have specific
-# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02001L0113-20131118
+# content of fruits: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024L1438
 < en:Nuts and their products
 < en:Plant-based spreads
 en: Chestnut spreads, Chestnut purees, Creme de marrons, Cremes de marrons, Chestnut jams, Chestnut cream, Sweetened chestnut purée
@@ -119683,3 +119683,4 @@ fr: Spirales de blé dur complet
 
 en: Semi whole durum wheat spirals
 fr: Spirales de blé dur semi-complet
+

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1576,7 +1576,7 @@ ok(!has_tag($product_ref, 'data_quality', 'en:missing-fruit-content-for-jams-or-
 ok(
 	!has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-jams'
 	),
 	'en:fruit content ok'
 ) or diag Dumper $product_ref;
@@ -1601,7 +1601,7 @@ ok(!has_tag($product_ref, 'data_quality', 'en:missing-fruit-content-for-jams-or-
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-jams'
 	),
 	'en:fruit content too small'
 ) or diag Dumper $product_ref;
@@ -1623,14 +1623,14 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	!has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-jams'
 	),
 	'en:fruit content too small for jam but has more specific category with smaller threshold'
 ) or diag Dumper $product_ref;
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-redcurrants-jams'
 	),
 	'en:fruit content too small'
 ) or diag Dumper $product_ref;
@@ -1652,14 +1652,14 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	!has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-jams'
 	),
 	'en:fruit content too small for jam but has more specific category with smaller threshold'
 ) or diag Dumper $product_ref;
 ok(
 	!has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-redcurrants-jams'
 	),
 	'en:fruit content too small'
 ) or diag Dumper $product_ref;
@@ -1681,7 +1681,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-45-for-category-extra-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-50-for-category-extra-jams'
 	),
 	'en:fruit content too small extra jams'
 ) or diag Dumper $product_ref;
@@ -1703,7 +1703,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrant-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-blackcurrant-jams'
 	),
 	'en:fruit content too small blackcurrant jams'
 ) or diag Dumper $product_ref;
@@ -1725,7 +1725,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-15-for-category-ginger-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-18-for-category-ginger-jams'
 	),
 	'en:fruit content too small ginger jams'
 ) or diag Dumper $product_ref;
@@ -1747,7 +1747,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-quince-jams'
 	),
 	'en:fruit content too small quince jams'
 ) or diag Dumper $product_ref;
@@ -1769,7 +1769,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-rosehip-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-rosehip-jams'
 	),
 	'en:fruit content too small rosehip jams'
 ) or diag Dumper $product_ref;
@@ -1791,7 +1791,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jams'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-sea-buckthorn-jams'
 	),
 	'en:fruit content too small sea-buckthorn jams'
 ) or diag Dumper $product_ref;
@@ -1857,7 +1857,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-blackcurrants-jellies'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-blackcurrants-jellies'
 	),
 	'en:fruit content too small blackcurrants jellies'
 ) or diag Dumper $product_ref;
@@ -1879,7 +1879,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-6-for-category-passion-fruit-jellies'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-8-for-category-passion-fruit-jellies'
 	),
 	'en:fruit content too small passion fruit jellies'
 ) or diag Dumper $product_ref;
@@ -1901,7 +1901,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-quince-jellies'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-quince-jellies'
 	),
 	'en:fruit content too small quince jellies'
 ) or diag Dumper $product_ref;
@@ -1923,7 +1923,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-redcurrants-jellies'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-redcurrants-jellies'
 	),
 	'en:fruit content too small redcurrants jellies'
 ) or diag Dumper $product_ref;
@@ -1945,7 +1945,7 @@ ProductOpener::DataQuality::check_quality($product_ref);
 ok(
 	has_tag(
 		$product_ref, 'data_quality',
-		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-25-for-category-sea-buckthorn-jellies'
+		'en:specific-ingredient-fruit-quantity-is-below-the-minimum-value-of-35-for-category-sea-buckthorn-jellies'
 	),
 	'en:fruit content too small sea-buckthorn jellies'
 ) or diag Dumper $product_ref;

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -1642,9 +1642,9 @@ $product_ref = {
 		{
 			id => "en:fruit",
 			ingredient => "fruit",
-			quantity => "30 g",
-			quantity_g => 30,
-			text => "Prepared with 30g of fruit per 100g",
+			quantity => "40 g",
+			quantity_g => 40,
+			text => "Prepared with 40g of fruit per 100g",
 		},
 	]
 };

--- a/tests/unit/dataqualityfood_labels.t
+++ b/tests/unit/dataqualityfood_labels.t
@@ -274,24 +274,24 @@ $product_ref = {
 		sodium_100g => 0.4,    # above 0.12 and 0.04 and 0.005
 		salt_100g => 1,    # above 0.3 and 0.1 and 0.0125
 		fiber_100g => 2,    # below 3 and 6
-		"vitamin-a_100g" => 0.0007,    # below 0.0008 and 0.0016
-		"vitamin-d_100g" => 0.000004,    # below 0.000005 and 0.00001
-		"vitamin-e_100g" => 0.009,    # below 0.01 and 0.02
-		"vitamin-c_100g" => 0.05,    # below 0.06 and 0.12
-		"vitamin-b1_100g" => 0.0013,    # below 0.0014 and 0.0028
-		"vitamin-b2_100g" => 0.0015,    # below 0.0016 and 0.0032
-		"vitamin-b3_100g" => 0.017,    # below 0.018 and 0.036
-		"vitamin-b6_100g" => 0.001,    # below 0.002 and 0.004
-		"vitamin-b9_100g" => 0.0001,    # below 0.0002 and 0.0004
-		"vitamin-b12_100g" => 0.0000009,    # below 0.000001 and 0.000002
-		"biotin_100g" => 0.00014,    # below 0.00015 and 0.0003
-		"pantothenic-acid_100g" => 0.005,    # below 0.006 and 0.012
-		"calcium_100g" => 0.7,    # below 0.8 and 1.6
-		"phosphorus_100g" => 0.7,    # below 0.8 and 1.6
-		"iron_100g" => 0.013,    # below 0.014 and 0.028
-		"magnesium_100g" => 0.2,    # below 0.3 and 0.6
-		"zinc_100g" => 0.014,    # below 0.015 and 0.03
-		"iodine_100g" => 0.00014,    # below 0.00015 and 0.0003
+		"vitamin-a_100g" => 0.00011,    # below 0.00012 and 0.00024 (15% of 800 µg and 1600 µg)
+		"vitamin-d_100g" => 0.00000074,    # below 0.00000075 and 0.0000015 (15% of 5 µg and 10 µg)
+		"vitamin-e_100g" => 0.0014,    # below 0.0015 and 0.003 (15% of 10 mg and 20 mg)
+		"vitamin-c_100g" => 0.008,    # below 0.009 and 0.018 (15% of 60 mg and 120 mg)
+		"vitamin-b1_100g" => 0.0002,    # below 0.00021 and 0.00042 (15% of 1.4 mg and 2.8 mg)
+		"vitamin-b2_100g" => 0.00023,    # below 0.00024 and 0.00048 (15% of 1.6 mg and 3.2 mg)
+		"vitamin-b3_100g" => 0.0026,    # below 0.0027 and 0.0054 (15% of 18 mg and 36 mg)
+		"vitamin-b6_100g" => 0.0002,    # below 0.0003 and 0.0006 (15% of 2 mg and 4 mg)
+		"vitamin-b9_100g" => 0.00002,    # below 0.00003 and 0.00006 (15% of 200 µg and 400 µg)
+		"vitamin-b12_100g" => 0.00000014,    # below 0.00000015 and 0.0000003 (15% of 1 µg and 2 µg)
+		"biotin_100g" => 0.0000224,    # below 0.0000225 and 0.000045 (15% of 0.15 mg and 0.3 mg)
+		"pantothenic-acid_100g" => 0.0008,    # below 0.0009 and 0.0018 (15% of 6 mg and 12 mg)
+		"calcium_100g" => 0.11,    # below 0.12 and 0.24 (15% of 800 mg and 1600 mg)
+		"phosphorus_100g" => 0.11,    # below 0.12 and 0.24 (15% of 800 mg and 1600 mg)
+		"iron_100g" => 0.002,    # below 0.0021 and 0.0042 (15% of 14 mg and 28 mg)
+		"magnesium_100g" => 0.044,    # below 0.045 and 0.09 (15% of 300 mg and 600 mg)
+		"zinc_100g" => 0.00224,    # below 0.00225 and 0.0045 (15% of 15 mg and 30 mg)
+		"iodine_100g" => 0.0000224,    # below 0.0000225 and 0.000045 (15% of 150 µg and 300 µg)
 		"alpha-linolenic-acid_100g" => 0.2    # below 0.3 and 0.6
 	},
 	quantity => "500 mg",
@@ -398,182 +398,182 @@ check_quality_and_test_product_has_quality_tag(
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-a-source-label-claim-but-vitamin-a-below-0.0008',
+	'en:vitamin-a-source-label-claim-but-vitamin-a-below-0.00012',
 	'under limitation for vitamin-a source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-a-label-claim-but-vitamin-a-below-0.0016',
+	'en:rich-in-vitamin-a-label-claim-but-vitamin-a-below-0.00024',
 	'under limitation for rich in vitamin-a label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-d-source-label-claim-but-vitamin-d-below-5e-06',
+	'en:vitamin-d-source-label-claim-but-vitamin-d-below-7.5e-07',
 	'under limitation for vitamin-d source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-d-label-claim-but-vitamin-d-below-1e-05',
+	'en:rich-in-vitamin-d-label-claim-but-vitamin-d-below-1.5e-06',
 	'under limitation for rich in vitamin-d label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-e-source-label-claim-but-vitamin-e-below-0.01',
+	'en:vitamin-e-source-label-claim-but-vitamin-e-below-0.0015',
 	'under limitation for vitamin-e source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-e-label-claim-but-vitamin-e-below-0.02',
+	'en:rich-in-vitamin-e-label-claim-but-vitamin-e-below-0.003',
 	'under limitation for rich in vitamin-e label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-c-source-label-claim-but-vitamin-c-below-0.06',
+	'en:vitamin-c-source-label-claim-but-vitamin-c-below-0.009',
 	'under limitation for vitamin-c source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-c-label-claim-but-vitamin-c-below-0.12',
+	'en:rich-in-vitamin-c-label-claim-but-vitamin-c-below-0.018',
 	'under limitation for rich in vitamin-c label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-b1-source-label-claim-but-vitamin-b1-below-0.0014',
+	'en:vitamin-b1-source-label-claim-but-vitamin-b1-below-0.00021',
 	'under limitation for vitamin-b1 source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-b1-label-claim-but-vitamin-b1-below-0.0028',
+	'en:rich-in-vitamin-b1-label-claim-but-vitamin-b1-below-0.00042',
 	'under limitation for rich in vitamin-b1 label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-b2-source-label-claim-but-vitamin-b2-below-0.0016',
+	'en:vitamin-b2-source-label-claim-but-vitamin-b2-below-0.00024',
+	'under limitation for vitamin-b2 source label', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:rich-in-vitamin-b2-label-claim-but-vitamin-b2-below-0.00048',
+	'under limitation for rich in vitamin-b2 label', 1
+);
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:vitamin-b3-source-label-claim-but-vitamin-b3-below-0.0027',
 	'under limitation for vitamin-b3 source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-b2-label-claim-but-vitamin-b2-below-0.0032',
+	'en:rich-in-vitamin-b3-label-claim-but-vitamin-b3-below-0.0054',
 	'under limitation for rich in vitamin-b3 label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-b3-source-label-claim-but-vitamin-b3-below-0.018',
-	'under limitation for vitamin-b3 source label', 1
-);
-check_quality_and_test_product_has_quality_tag(
-	$product_ref,
-	'en:rich-in-vitamin-b3-label-claim-but-vitamin-b3-below-0.036',
-	'under limitation for rich in vitamin-b3 label', 1
-);
-check_quality_and_test_product_has_quality_tag(
-	$product_ref,
-	'en:vitamin-b6-source-label-claim-but-vitamin-b6-below-0.002',
+	'en:vitamin-b6-source-label-claim-but-vitamin-b6-below-0.0003',
 	'under limitation for vitamin-b6 source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-b6-label-claim-but-vitamin-b6-below-0.004',
+	'en:rich-in-vitamin-b6-label-claim-but-vitamin-b6-below-0.0006',
 	'under limitation for rich in vitamin-b6 label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-b9-source-label-claim-but-vitamin-b9-below-0.0002',
+	'en:vitamin-b9-source-label-claim-but-vitamin-b9-below-3e-05',
 	'under limitation for vitamin-b9 source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-b9-label-claim-but-vitamin-b9-below-0.0004',
+	'en:rich-in-vitamin-b9-label-claim-but-vitamin-b9-below-6e-05',
 	'under limitation for rich in vitamin-b9 label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:vitamin-b12-source-label-claim-but-vitamin-b12-below-1e-06',
+	'en:vitamin-b12-source-label-claim-but-vitamin-b12-below-1.5e-07',
 	'under limitation for vitamin-b12 source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:rich-in-vitamin-b12-label-claim-but-vitamin-b12-below-2e-06',
+	'en:rich-in-vitamin-b12-label-claim-but-vitamin-b12-below-3e-07',
 	'under limitation for rich in vitamin-b12 label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:source-of-biotin-label-claim-but-biotin-below-0.00015',
+	'en:source-of-biotin-label-claim-but-biotin-below-2.25e-05',
 	'under limitation for biotin source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-biotin-label-claim-but-biotin-below-0.0003',
+	'en:high-in-biotin-label-claim-but-biotin-below-4.5e-05',
 	'under limitation for high in biotin label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:source-of-pantothenic-acid-label-claim-but-pantothenic-acid-below-0.006',
+	'en:source-of-pantothenic-acid-label-claim-but-pantothenic-acid-below-0.0009',
 	'under limitation for pantothenic-acid source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-pantothenic-acid-label-claim-but-pantothenic-acid-below-0.012',
+	'en:high-in-pantothenic-acid-label-claim-but-pantothenic-acid-below-0.0018',
 	'under limitation for high in pantothenic-acid label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:calcium-source-label-claim-but-calcium-below-0.8',
+	'en:calcium-source-label-claim-but-calcium-below-0.12',
 	'under limitation for calcium source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-calcium-label-claim-but-calcium-below-1.6',
+	'en:high-in-calcium-label-claim-but-calcium-below-0.24',
 	'under limitation for high in calcium label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:phosphore-source-label-claim-but-phosphorus-below-0.8',
+	'en:phosphore-source-label-claim-but-phosphorus-below-0.12',
 	'under limitation for phosphore source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-phosphore-label-claim-but-phosphorus-below-1.6',
+	'en:high-in-phosphore-label-claim-but-phosphorus-below-0.24',
 	'under limitation for high in phosphore label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:iron-source-label-claim-but-iron-below-0.014',
+	'en:iron-source-label-claim-but-iron-below-0.0021',
 	'under limitation for iron source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-iron-label-claim-but-iron-below-0.028',
+	'en:high-in-iron-label-claim-but-iron-below-0.0042',
 	'under limitation for high in iron label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:magnesium-source-label-claim-but-magnesium-below-0.3',
+	'en:magnesium-source-label-claim-but-magnesium-below-0.045',
 	'under limitation for magnesium source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-magnesium-label-claim-but-magnesium-below-0.6',
+	'en:high-in-magnesium-label-claim-but-magnesium-below-0.09',
 	'under limitation for high in magnesium label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:zinc-source-label-claim-but-zinc-below-0.015',
+	'en:zinc-source-label-claim-but-zinc-below-0.00225',
 	'under limitation for zinc source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-zinc-label-claim-but-zinc-below-0.03',
+	'en:high-in-zinc-label-claim-but-zinc-below-0.0045',
 	'under limitation for high in zinc label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:iodine-source-label-claim-but-iodine-below-0.00015',
+	'en:iodine-source-label-claim-but-iodine-below-2.25e-05',
 	'under limitation for iodine source label', 1
 );
 check_quality_and_test_product_has_quality_tag(
 	$product_ref,
-	'en:high-in-iodine-label-claim-but-iodine-below-0.0003',
+	'en:high-in-iodine-label-claim-but-iodine-below-4.5e-05',
 	'under limitation for high in iodine label', 1
 );
 check_quality_and_test_product_has_quality_tag(


### PR DESCRIPTION
### What
There is a bug with quality facets for this product: https://world.openfoodfacts.org/product/5411188128311/coconut-unsweetened-alpro

Calcium source label claim but calcium below 0.8
Vitamin b12 source label claim but vitamin b12 below 1e-06
Vitamin D source label claim but Vitamin D below 5e-06

Here is the reference EU regulation document: https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:31990L0496 (see Annex)
See also https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02006R1924-20141213 for difference between source of something and rich in something

The threshold for all vitamins and minerals in the reference EU regulation document should not be the values given but 15% of the values.

\+ also update thresholds values for jam, extra jam and jelly to reflect last version of EU regulation.


### Related issue(s) and discussion
- Fixes #11531
