### PR TITLE
fix: remove duplicates in taxonomies 2

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -12738,7 +12738,7 @@ xx: E540
 ar: E540, فوسفات ثنائي الكالسيوم
 bg: E540, Дикалциев дифосфат
 ca: E540, Difosfat dicàlcic
-cs: E540, Dihydrogendifosforečnan vápenatý
+cs: E540
 da: E540, Dicalciumdiphosphat
 de: E540, Dicalciumdiphosphat
 el: E540, Διφωσφορικό διασβέστιο
@@ -25480,3 +25480,4 @@ ja: 有機酸
 en: Inorganic salts
 it: Sali inorganici
 ja: 無機塩
+

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -23526,18 +23526,6 @@ pt: aroma de cafeína
 sv: koffein arom
 
 < en:flavouring
-#<en:crustacean
-fr: arôme crabe
-da: krabbe aroma
-es: aroma de cangrejo
-fi: rapuaromi
-it: aroma di granchio
-nl: krabaroma
-pt: aroma de caranguejo
-sv: krabbarom
-allergens:en: en:crustaceans
-
-< en:flavouring
 fr: arôme identique nature
 
 < en:flavouring
@@ -35687,7 +35675,7 @@ it: gocce di cioccolato senza zucchero
 < en:chocolate
 en: chocolate filling, filling cream with chocolate
 de: Schokoladenfüllung
-es: Relleno de chocolate, Relleno de cacao, Relleno cacao
+es: Relleno de chocolate
 fi: suklaatäyte
 fr: fourrage au chocolat, fourrage chocolat
 hr: keks s kakaom, punilo okusa čokolade, punjenje okusa čokolade
@@ -36939,7 +36927,7 @@ ciqual_food_name:fr: Soja, graine entière
 < en:soya bean
 en: sprouted soybeans
 de: Sojabohnensprossen
-fr: pousses de soja
+fr: germes de soja, pousses de soja
 hr: proklijala soja
 it: germogli di soia
 nl: sojaspruiten
@@ -38701,7 +38689,6 @@ sv: Kalciumdivätedifosfat, Kalciumpyrofosfatsyra, e450vii
 
 < en:disodium diphosphate
 < en:sodium hydrogen carbonate
-bg: натриев хидроген карбонат
 ca: carbonat àcid de sodi i difosfat de disodi
 fr: diphosphate disodique et carbonate acide de sodium
 ru: сода, сода пищевая, гидрокарбонат натрия, разрыхлитель гидрокарбонат натрия
@@ -38729,13 +38716,13 @@ sv: trifosfat
 < en:triphosphates
 en: Pentasodium triphosphate, Pentasodium tripolyphosphate
 ar: مالفرق بين
-bg: Пентанатриев трифосфат, Пентанатриев триполифосфат, Натриев триполифосфат , e451i, e 451, e-451i
+bg: Пентанатриев трифосфат, Пентанатриев триполифосфат, e451i, e 451, e-451i
 ca: trifosfat sòdic, e451i, e 451, e-451i
 cs: Trifosforečnan pentasodný, e451i, e 451, e-451i
 da: Pentanatriumtriphosphat, Pentanatriumtripolyphosphat, e451i, e 451, e-451i
 de: Pentanatriumtriphosphat, Pentanatriumtripolyphosphat, e451i, e 451, e-451i
-el: Τριφωσφορικο νατριο, Τριπολυφωσφορικό νάτριο, e451i, e 451, e-451i
-es: tripolifosfato de sodio, Trifosfato de pentasodio, Tripolifosfato pentasódico, e451i, e 451, e-451i
+el: Τριφωσφορικο νατριο, e451i, e 451, e-451i
+es: Trifosfato de pentasodio, Tripolifosfato pentasódico, e451i, e 451, e-451i
 et: Pentanaatriumtrifosfaat, Pentanaatriumtripolüfosfaat, e451i, e 451, e-451i
 fa: سدیم تری‌فسفات
 fi: Pentanatriumtrifosfaatti, Pentanatriumtripolyfosfaatti, e451i, e 451, e-451i
@@ -38748,7 +38735,7 @@ lt: Pentanatrio trifosfatas, Pentanatrio tripolifosfatas, e451i, e 451, e-451i
 lv: Pentanātrija trifosfāts, Pentanātrija tripolifosfāts, e451i, e 451, e-451i
 nl: Pentanatriumtrifosfaat, Pentanatriumtripolyfosfaat, e451i, e 451, e-451i
 pl: Trifosforan pentasodowy, Trójpolifosforan pięciosodowy, e451i, e 451, e-451i
-pt: trifosfato pentassódico, tripolifosfato de sódio, e451i, e 451, e-451i
+pt: trifosfato pentassódico, e451i, e 451, e-451i
 ro: Trifosfat pentasodic, Tripolifosfat pentasodic, e451i, e 451, e-451i
 ru: трифосфат натрия, e451i, e 451, e-451i
 sh: Natrijum trifosfat, e451i, e 451, e-451i
@@ -38758,7 +38745,7 @@ sr: натријум трифосфат, e451i, e 451, e-451i
 sv: Pentanatriumtrifosfat, Pentanatriumtripolyfosfat, e451i, e 451, e-451i
 uk: Трифосфат натрію, e451i, e 451, e-451i
 vi: Natri tripolyphôtphat, e451i, e 451, e-451i
-zh: 三聚磷酸钠, e451i, e 451, e-451i
+zh: e451i, e 451, e-451i
 # azb:سودیوم تریفوسفات
 # mt:Trifosfat pentasodiku, Tripolifosfat pentasodiku, e451i, e 451, e-451i
 # sr-ec:натријум трифосфат, e451i, e 451, e-451i
@@ -39122,11 +39109,6 @@ ciqual_food_code:en: 13997
 ciqual_food_name:en: Red berries (raspberries, strawberries, red currants, black currants) , raw
 ciqual_food_name:fr: Fruits rouges, crus (framboises, fraises, groseilles, cassis)
 #461 in 8 @2021-10-15
-
-< en:fruit
-en: vine fruit, mixed vine fruit
-de: Trauben
-it: frutto della vite
 
 # description:en:A berry is a small, pulpy, and often edible fruit. Typically, berries are juicy, rounded, brightly colored, sweet or sour, and do not have a stone or pit, although many pips or seeds may be present. Common examples are strawberries, raspberries, blueberries, blackberries, red currants, white currants and blackcurrants
 
@@ -42064,7 +42046,7 @@ es: Zumo de manzana desde concentrado, zumo de manzana a partir de concentrado, 
 fi: omenamehu tiivisteestä
 fr: jus de pomme à base de concentré, jus de pomme à base de jus concentré, Jus de pomme à base de jus de pomme concentré, jus de pomme à partir de concentré
 hr: jabuke od koncentriranog soka, sok od jabuke od koncentriranog soka, sok iz jabuke proizveđen iz koncentrata
-hu: sűrített almalé, almalé sűrítmény, almalé koncentrátum, almalé koncentrátumból
+hu: sűrített almalé, almalé koncentrátum, almalé koncentrátumból
 it: succo di mele a base di concentrato
 nb: eplejuice fra konsentrat
 nl: appelsap uit concentraat
@@ -42326,7 +42308,7 @@ cs: plodů kešu
 da: kasjufrugt
 de: Kaschuäpfeln
 el: ανακάρδιο
-es: anacardos
+es: manzana de cajú
 et: akažuuõunte
 fi: cashew-omenaa
 fr: anacardes
@@ -42338,7 +42320,7 @@ lv: kešjukoka augļiem
 mt: tuffieħ tal-cashew
 nl: cashewappelen
 pl: owoców nerkowca
-pt: castanhas de caju
+pt: caju
 ro: alunelor de caju
 sk: jabĺčka kešu
 sl: granatna jabolka
@@ -42728,7 +42710,6 @@ wikidata:en: Q353817
 
 < en:pomelo
 en: pomelo pulp
-it: polpa di pompelmo
 ciqual_food_code:en: 13040
 ciqual_food_name:en: Grapefruit, pulp, raw
 ciqual_food_name:fr: Pomelo (dit Pamplemousse), pulpe, cru
@@ -42761,7 +42742,6 @@ fr: pomelo ruby red
 < en:pomelo
 en: pomelo juice
 fr: jus de pomelo
-it: succo di pompelmo
 
 < en:pomelo
 fr: extrait naturel de pomelo
@@ -43036,7 +43016,6 @@ es: cáscara de limón
 fi: sitruunankuori
 fr: écorce de citron, écorces de citron, écorces de citrons
 hr: limunova korica
-it: scorza di limone
 nl: citroenschil, schillen citroen
 nn: citronskal
 pl: skórka cytryny, skórka z cytryny, skórka cytrynowa
@@ -43050,7 +43029,6 @@ en: lemon peel extract
 da: citronskalextract
 fi: sitruunankuoriuute
 hr: ekstrakt kore limuna
-it: estratto di scorza di limone
 nl: citroenschilextract
 nn: citronskalextract
 ro: extract de coaja de lamaie
@@ -43268,7 +43246,6 @@ fi: sitruunauute
 fr: concentré de citron, extrait de citron
 # hr:ekstrakt limuna # see ingredients_processing.txt
 it: estratto di limone, concentrato di limone
-nl: citroenconcentraat
 sv: citronextrakt
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/lemon-extract
 # 137 products @2018-10-01
@@ -43475,7 +43452,6 @@ es: Zumo de lima, jugo de lima
 fi: limettimehu, limetäysmehu, limetinmehu, limen mehu
 fr: jus de citron vert
 hr: sok od limete
-hu: Citromlé
 it: succo di lime
 ja: ライムジュース, ライム果汁
 nl: limoensap
@@ -43589,7 +43565,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Mandarin_orange
 < en:mandarin
 en: tangerine, tangerines
 hr: crvena mandarina
-it: mandarino
 
 < en:tangerine
 en: tangerine oil
@@ -44054,7 +44029,7 @@ nl: geperste sinaasappelsap met vruchtvlees
 en: orange juice without pulp
 bg: сок от портокал без пулп
 es: zumo de naranjas sin pulpa
-fr: Jus d'orange sans pulpe, pur jus d'oranges avec sa pulpe
+fr: Jus d'orange sans pulpe
 hr: sok od naranče bez pulpe
 it: succo d'arancia senza polpa
 nl: Sinaasappelsap zonder vruchtvlees
@@ -44567,7 +44542,6 @@ eo: Arbusta rubuso
 es: Rubus fruticosus
 et: Pampel
 eu: Rubus fruticosus
-fi: Karhunvatukka
 fr: Ronce commune
 gl: Silva brava
 hr: rubus fructicosus L
@@ -44817,9 +44791,9 @@ pl: borówka amerykańska, borówka wysoka, niebieska jagoda, borówki amerykań
 
 < en:blueberry
 en: bilberry, bilberries, huckleberry, huckleberries, whortleberry, whortleberries
-fi: mustikka, mustikat
+fi: mustikat
 # hr:borovnica
-it: mirtillo, mirtilli, mirtillo rosso, mirtilli rossi, mirtillo rosso, mirtilli rossi
+it: mirtillo rosso, mirtilli rossi, mirtillo rosso, mirtilli rossi
 la: Vaccinium myrtillus
 pl: borówka czarna, jagoda, jagoda czarna, czarna jagoda, czarne jagody, czarnej jagody, czernica, borówka czernica, borówki czernicy, jagoda, jagody, jagodowy, jagodowe, jagodowa
 eurocode_2_group_3:en: 9.30.42
@@ -46798,7 +46772,6 @@ eurocode_2_group_3:en: 9.30.44
 en: wild lingonberry, wild lingonberries
 de: Wild-Preiselbeere, Wild-Preiselbeeren, Wildpreiselbeere, Wildpreiselbeeren
 fr: airelle sauvage, airelles sauvages
-it: mirtillo rosso selvatico
 # hr:divlja borovnica
 
 # No products
@@ -47062,7 +47035,6 @@ fa: طالبی
 fi: cantaloupe-meloni, cantaloupe
 fr: melon cantaloup
 hi: खरबूजा
-hr: galija dinja
 ht: kantaloup
 hy: կանտալուպ
 id: blewah
@@ -48077,7 +48049,7 @@ fr: écorces de grenade
 
 < en:fruit
 en: custard apple, cherimoya
-de: Zimtapfel, Rahmapfel
+de: Rahmapfel
 es: chirimoya
 hr: kremasta jabuka
 it: mela crema, frutto dell'Annona reticulata
@@ -48430,8 +48402,7 @@ nb: Nype
 nl: Rozenbottel, rozebottel, rozenbottels
 nn: Nype
 os: Уагъылы
-pl: dzikiej róży
-pt: Cinórrodo, roseira brava
+pt: Cinórrodo
 ro: Măceș, măceșelor
 ru: Шиповник
 sk: šípka, Ruža šipkova, šípky
@@ -48821,7 +48792,7 @@ de: Mehrfruchtsaft aus Mehrfruchtsaftkonzentrat
 
 < en:berries
 < en:fruit
-en: grape
+en: grape, vine fruit, mixed vine fruit
 af: druiwe
 am: ወይን
 an: uga
@@ -48865,7 +48836,7 @@ ia: uva
 id: anggur
 io: vito
 is: vínber
-it: uva
+it: uva, frutto della vite
 ja: ブドウ, ぶどう
 jv: anggur
 ka: ყურძენი
@@ -49093,11 +49064,9 @@ en: red grape fruit juice
 bg: сок от червено грозде
 de: Rotweintraubensaft
 es: jugo de uva roja
-fr: jus de raisin rouge
 hr: voćni sok crvenog grožđa
 it: succo di uva rossa
 nl: rode druivensap
-pl: sok z czerwonych winogron
 pt: suco de uva vermelha
 
 # description:en:A RAISIN is a dried grape.
@@ -49464,7 +49433,6 @@ it: succo d'uva Concord
 
 < en:red grape juice
 en: Muscadine grape juice
-it: succo d'uva moscato
 
 < en:grape juice
 en: pure grape juice
@@ -51745,7 +51713,7 @@ gl: Agrón
 hr: potočarka
 id: Selada Air
 io: Kreso
-it: Crescione
+it: crescione d'acqua
 ja: オランダガラシ, クレソン, クレス
 ko: 물냉이
 la: Nasturtium officinale
@@ -52997,7 +52965,7 @@ ga: càl
 gv: caayl jiarg
 he: כרוב על
 hi: एक प्रकार का गोभी
-hr: kelj pupčar
+hr: kelj
 hu: fodros kel
 id: kubis keriting
 is: grænkál
@@ -53068,7 +53036,6 @@ ja: 小松菜, コマツナ
 
 < en:vegetable
 en: collard greens, collard
-it: cavolo cappuccio
 wikidata:en: Q14879985
 
 < en:kale
@@ -53076,7 +53043,6 @@ en: baby kale
 de: Kohlsprossen
 fr: Jeunes pousses de chou frisé
 hr: mladi kelj
-it: cavolo riccio
 #103 in en @2021-10-19
 
 < en:kale
@@ -53114,7 +53080,6 @@ fi: kurttukaali
 fr: chou vert, choux verts, chou de milan, chou de savoie
 ga: cabáiste saváí
 gv: cabbash chraplit
-hr: kelj
 hu: kelkáposzta
 id: kubis savoy
 is: blöðrukál
@@ -54501,7 +54466,7 @@ fr: oignon rouge, oignons rouges
 he: בצל סגול
 hi: लाल प्याज
 hr: crveni luk, luk crveni
-hu: lilahagyma, vöröshagyma
+hu: lilahagyma
 is: rauðlaukur
 it: cipolla rossa
 ja: 赤たまねぎ
@@ -56731,7 +56696,6 @@ it: patate britanniche
 < en:potato
 en: potato flour
 bg: брашно от картофи, картофено брашно
-de: Kartoffelmehl
 es: harina de patata
 fi: perunajauho
 fr: farine de pomme de terre, farine de pommes de terre, pomme de terre en poudre
@@ -57569,7 +57533,7 @@ af: Beet
 bg: цвекло
 ca: remolatxa
 da: rødbede, rødbeder
-de: Rüben, Randen, Rote-Bete
+de: Rüben, Randen
 es: remolacha, betarraga
 fi: punajuuri
 fr: betterave, betteraves
@@ -57665,7 +57629,6 @@ fi: punajuuritiiviste
 it: concentrato di barbabietola
 ja: ビーツ濃縮液
 lt: raudonųjų burokėlių koncentratas
-nl: bietensapconcentraat
 pl: koncentrat z buraka
 pt: concentrado de beterraba
 ru: концентрат свеклы
@@ -57687,7 +57650,6 @@ bg: червено цвекло
 cs: červená řepa
 de: Rote Bete, Rote Beete
 es: Remolacha roja
-fi: punajuuri
 fr: betterave rouge, betteraves rouges
 hr: crvena cikla
 it: barbabietole rosse
@@ -58557,7 +58519,6 @@ ciqual_food_name:fr: Poivron vert, cru
 
 < en:green bell pepper
 en: italian bell pepper
-es: pimiento italiano
 it: peperone italiano
 
 < en:bell pepper
@@ -58660,7 +58621,7 @@ bs: Čili
 ca: bitxo
 cs: chilli paprička
 da: Chili, chilipeber
-de: Peperoni, chilischoten, Pfefferoni, Chili, Piment
+de: Peperoni, chilischoten, Pfefferoni, Chili
 el: Τσίλι
 eo: Kapsiketo
 es: guindilla, ají, chile, pimenton picante, pimiento picante
@@ -59256,26 +59217,6 @@ en: hot paprika
 it: paprika piccante
 pl: ostra papryka, ostra papryka w proszku, papryka ostra, papryka ostra mielona
 
-# in some languages paprika is either the spice or the vegetable
-< en:plant
-en: spice or bell pepper
-bg: червен пипер, паприка
-cs: paprika
-da: paprika
-de: Paprika
-fi: paprika
-hr: začin ili paprika
-hu: paprika
-it: spezie o peperone
-lv: paprika
-nb: paprika
-nl: paprika
-nn: paprika
-no: paprika
-pl: papryka, papryki, paprykowy, paprykowe, paprykowa
-sl: paprika
-sv: paprika
-
 < en:vegetable
 en: fruit vegetable
 it: frutta verdura
@@ -59676,7 +59617,6 @@ es: tomates tamizados
 fi: seulotut tomaatit
 fr: coulis de tomates, coulis de tomate
 hr: prosijanu rajčicu
-it: passata di pomodoro
 nl: gezeefde tomaten
 nn: mosede tomater
 pl: passata, passata pomidorowa
@@ -59758,7 +59698,7 @@ fi: tomaattitahna
 fr: concentré de tomate, concentré de tomates, pâte de tomate, concentre de tomate
 # hr:koncentrat rajčice # see ingredients_processing.txt
 hr: rajčice od koncentrirane kaše rajčice
-hu: Paradicsom sűrítmény
+hu: Paradicsom sűrítmény, paradicsom sűrítményből
 it: concentrato di pomodoro
 ja: トマトペースト
 lt: pomidorų pasta
@@ -59782,7 +59722,7 @@ es: puré de tomate concentrado, pure de tomate concentrado, puré de tomates co
 fi: tiivistetty tomaattipyree, tiivistettyä tomaattipyreetä
 fr: purée de tomate concentrée, purée de tomates concentrée, purée de tomates concentrées
 hr: koncentriranog pirea od rajčice
-hu: sűrített paradicsompüré, sűrített paradicsom, paradicsom (sűrítmény), paradicsom (sűrítményből)
+hu: sűrített paradicsompüré, sűrített paradicsom
 it: passata di pomodoro concentrata
 nl: geconentreerde tomatenpuree
 sv: koncentrerad tomatpuré
@@ -60728,9 +60668,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Phaseolus_vulgaris
 en: bean sprouts, beansprouts
 da: bønnespirer
 et: idudega
-fr: germes de soja, pousses de soja
 hr: klice graha
-it: germogli di soia
 lt: šparaginės pupelės
 lv: diedzētas pupinas
 
@@ -61258,7 +61196,7 @@ wikidata:en: Q74663825
 < en:pulse
 en: mung bean, mungbean, Mung dal, Moong dal
 ar: بقلة الماش
-bg: папуда, птичи боб, бебриджа
+bg: птичи боб, бебриджа
 bn: মুগ
 bo: སྲན་ལྗང་།
 ca: mongeta mung
@@ -61605,7 +61543,7 @@ nl: gerehydrateerde vermicelli van erwten
 nl: veldbonen
 
 < en:pod and seed vegetable
-en: broad bean, fava bean, faba bean, Vicia faba
+en: broad bean, fava bean, faba bean, Vicia faba, horse bean
 am: ባቄላ
 ar: فول
 ay: Jawasa
@@ -61624,7 +61562,7 @@ et: Põlduba
 eu: Baba
 fa: باقلا
 fi: Härkäpapu
-fr: fève, fèves, féverole
+fr: fève, fèves, féverole, féverolle
 ga: Pónaire leathan
 gl: Faballón
 he: פול
@@ -61635,7 +61573,7 @@ hy: Բակլա
 id: Kara oncet
 io: Fabo
 is: Bóndabaunir
-it: fave
+it: fave, fagiolo
 ja: ソラマメ
 ka: ცერცვი
 kk: Ат бұршақ
@@ -61741,12 +61679,6 @@ ciqual_food_code:en: 20517
 ciqual_food_name:en: Broad bean, to shell, fresh
 ciqual_food_name:fr: Fève à écosser, fraîche
 eurocode_2_group_3:en: 8.45.20
-
-< en:pulse
-en: horse bean
-fr: féverole, féverolle
-it: fagiolo
-
 
 # rare bean from the Lyon region in France
 < en:pulse
@@ -62202,7 +62134,7 @@ it: ceci reidratati
 #category/chickpea flours
 < en:chickpea
 < en:flour
-en: chickpea flour, chick pea flour, gram flour, garbanzo bean flour
+en: chickpea flour, chick pea flour, gram flour, garbanzo bean flour, besan
 ar: طحين حمص
 bg: брашно от нахут
 bn: বেসন
@@ -62248,10 +62180,6 @@ ciqual_food_name:fr: Farine de pois chiche
 wikidata:en: Q651829
 wikipedia:en: https://en.wikipedia.org/wiki/Gram_flour
 #1086 in 17 @2021-10-16
-
-< en:chickpea flour
-en: besan
-it: farina di ceci
 
 < en:vegetable
 en: pod and seed vegetable
@@ -65505,7 +65433,6 @@ fr: Poivres noir et blanc
 hr: bijeli biber
 it: pepe nero e bianco
 nl: zwarte en witte peper
-ru: перец белый
 
 < en:pepper
 en: long pepper
@@ -65575,7 +65502,7 @@ fi: viherpippuri
 fr: poivre vert
 hr: zeleni papar
 it: Peperone verde
-nl: groene peper, groene paprika
+nl: groene peper
 pl: zielony pieprz, pieprz zielony
 sv: grönpeppar
 # openfoodfacts:https://world.openfoodfacts.org/ingredient/fr:poivre-vert
@@ -66218,7 +66145,6 @@ lt: prieskoniai
 nb: krydder, krydderi, krydderier
 nl: specerijen, specerij
 no: krydder
-pl: Przyprawa, przyprawy
 pt: Tempero, temperos, especiaria, especiarias
 ro: Picant
 ru: Специи, пряности
@@ -66463,7 +66389,6 @@ es: Extracto de plantas
 fi: kasviuute, kasviuutteet
 fr: extraits de plantes, extraits de plantes aromatiques
 hr: biljni ekstrakti
-it: estratti vegetali
 nb: planteekstrakt
 nl: plantextracten
 pl: ekstrakty roślinne, roślinne ekstrakty
@@ -66474,7 +66399,6 @@ en: organic plant extracts
 fi: luomu kasviuute
 fr: extraits de plantes bio
 hr: organski biljni ekstrakti
-it: estratti vegetali biologici
 nl: biologische plantextracten
 # ingredient/fr:extraits-de-plantes-bio has 9 products in french @2019-05-29
 # usage:fr:Extraits de plantes Bio: Aubépine Bio, Fleur d'oranger Bio, Passiflore Bio, Houblon Bio, Mélisse Bio
@@ -68362,7 +68286,7 @@ de: Rosa Pfeffer, Rosa Beeren, rosa Pfefferbeeren
 es: pimienta rosa
 fa: فلفل صورتی
 fi: roseepippuri, rosépippuri, perunroseepippuri, ruusupippuri
-fr: baies roses, baies, poivre rose
+fr: baies roses, poivre rose
 hr: ružčasti papar, Schinus jagoda
 it: pepe rosa
 ja: ピンクペッパー
@@ -69532,7 +69456,6 @@ it: verbena
 ja: クマツヅラ
 kk: Дәрілік нарқайсар
 ko: 마편초
-la: Lippia citriodora
 lt: Vaistinė verbena
 nl: ijzerhard, verbena
 pl: Werbena, werbeny
@@ -69579,6 +69502,7 @@ la: Aloysia citrodora, lippia citriodora
 nl: citroenverbena
 eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.46
+wikidata:en: Q206532
 
 < en:herb
 en: hemp
@@ -73696,7 +73620,6 @@ fi: puhdas vaniljauute
 fr: extrait pur de vanille
 hr: čisti ekstrakt vanilije
 it: estratto puro di vaniglia
-nl: Vanille extract
 # ingredient/fr:extrait-pur-de-vanille has 65 products in 5 languages @2019-02-24
 
 < en:natural extract
@@ -74692,7 +74615,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Saccharina_japonica
 
 < en:seaweed
 en: laver
-de: laver, Seetang
+de: laver
 it: porphyra (alga nori)
 
 # en:description:Nori (海苔) is the Japanese name for edible seaweed (a "sea vegetable") species of the red algae genus Pyropia, including P. yezoensis and P. tenera.
@@ -75186,7 +75109,7 @@ co: Ghjalletta
 cs: liška obecná
 cy: Siantrel
 da: Almindelig Kantarel
-de: Pfifferlinge, Echter Pfifferling (cantharellus cibarius)
+de: Echter Pfifferling, cantharellus cibarius
 el: Κανθαρέλλα
 eo: Kantarelo
 es: Chantarela
@@ -75257,7 +75180,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Boletus
 # description:en:BOLETUS EDULIS (English:penny bun, cep, porcino or porcini) is a basidiomycete fungus, and the type species of the genus Boletus.
 
 < en:boletus
-en: cep, porcini mushroom, porcini mushrooms
+en: cep, porcini mushroom, porcini mushrooms, Boletus edulis
 ar: بوليط مأكول
 ba: Аҡ бәшмәк
 be: Баравік
@@ -75269,23 +75192,23 @@ cs: hřib smrkový
 cv: Шур кăмпа
 cy: Wicsen gron
 da: Karl Johan
-de: Steinpilze
+de: Steinpilze, Boletus edulis
 el: Βωλίτης ο εδώδιμος
-es: boletus
+es: boletus, seta común, Boletus edulis
 et: kivipuravik, harilik kivipuravik
 eu: Onddozuri
 fa: قارچ تیره‌سر
-fi: Herkkutatti
-fr: cèpe, cèpes, bolets, cèpe de Bordeaux
+fi: Herkkutatti, Boletus edulis
+fr: cèpe, cèpes, bolets, cèpe de Bordeaux, Boletus edulis
 ga: Ceap
 gl: Andoa
 he: פורצ'יני
-hr: ljetni vrganj, vrganji
+hr: ljetni vrganj, vrganji, Boletus edulis
 hu: Ízletes vargánya
 hy: Սպիտակ սունկ
 io: Cepo
 is: Kóngssveppur
-it: funghi porcini
+it: funghi porcini, Boletus edulis
 ja: ヤマドリタケ
 ka: დათვისსოკო
 kk: Ақ саңырауқұлақ
@@ -75332,16 +75255,6 @@ zh: 美味牛肝菌
 wikidata:en: Q19740
 wikipedia:en: https://en.wikipedia.org/wiki/Boletus_edulis
 # en:cep has 98 products in 5 languages @2018-11-02
-
-< en:cep
-en: Boletus edulis
-de: Boletus edulis
-es: Boletus edulis, seta común
-fi: boletus edulis
-fr: Boletus edulis
-hr: boletus edulis
-it: boletus edulis
-la: Boletus edulis
 
 < en:cep
 en: dried cep, dried porcini mushroom, dried porcini mushrooms
@@ -76825,7 +76738,6 @@ hr: nauljena riba
 hu: Olajos hal
 it: Pesce oleoso
 nb: feit fisk, fet fisk. oljete fisk
-nl: Visolie
 
 < en:fish
 en: white fish
@@ -77093,7 +77005,7 @@ fi: Alaskanseiti
 fr: Colin d'Alaska, Theragra chalcogramma
 hr: aljaška kolja
 is: Alaskaufsi
-it: merluzzo d'Alaska, pollack, Pollack d'Alaska, Theragra chalcogramma
+it: merluzzo d'Alaska, Pollack d'Alaska, Theragra chalcogramma
 ja: スケトウダラ
 ka: მინტაი
 kk: Минтай
@@ -77154,7 +77066,7 @@ ca: Engràulid, anxoves, anxova
 cs: sardel obecná
 da: ansjos, Ansjoser
 de: Sardellen, Serdellen, Anchovis
-es: Anchoa, anchoas, boquerones, anchoveta
+es: Anchoa, anchoas, anchoveta
 fa: موتوماهیان
 fi: anjovis, anjovikset
 fr: anchois
@@ -78502,7 +78414,7 @@ fi: kummeli
 fr: merlu commun, merlu européen, merlu blanc, filets de merlu blanc, lieu
 ga: Colmóir
 hr: europski oslić
-it: nasello
+it: nasello europeo
 la: Merluccius merluccius
 nl: gewone heek, Europese heek
 nn: lysing
@@ -78868,8 +78780,8 @@ it: aringa baltica
 la: Clupea harengus membras
 nl: Oostzeeharing
 pl: śledź bałtycki, śledzia bałtyckiego, śledzie bałtyckie
-ru: Салака
-ua: Салака
+ru: балтийская сельдь
+ua: балтийская сельдь
 
 
 < en:fish
@@ -78985,7 +78897,6 @@ wikipedia:en: https://en.wikipedia.org/wiki/Trisopterus_luscus
 < en:fish
 en: snapper
 fr: vivaneau
-it: dentice
 ciqual_food_code:en: 26146
 ciqual_food_name:en: Snapper, raw
 ciqual_food_name:fr: Vivaneau, cru
@@ -79905,7 +79816,6 @@ wikidata:en: Q166204
 en: thread-fin bream
 ar: عندق
 bg: Тънкопери каракуди
-de: Scheinschnapper
 fi: viiriahven
 fr: cohana
 he: נימי
@@ -80193,7 +80103,7 @@ cy: Marlin
 de: Echter Bonito
 dv: ކަޅުބިލަ މަސް
 eo: Vera bonito
-es: Bonito de altura, listado, bonito del norte
+es: Bonito de altura, listado
 eu: Lanpo sabelmarradun
 fa: هوور مسقطی
 fi: Boniitti
@@ -80539,7 +80449,6 @@ pl: filet z makreli kolias, filety z makreli kolias
 en: horse mackerel
 bg: сафрид
 hr: šur
-it: sgombro
 nl: horsmakrel
 description:en: Horse mackerel is a vague vernacular term for a range of species of fish throughout the English-speaking world.
 
@@ -80557,7 +80466,6 @@ fr: chinchard
 he: טרכון
 hr: jack skuša
 hy: Ստավրիդներ
-it: sgombro
 ja: アジ、鯵
 ka: სტავრიდა
 kk: Ставрида
@@ -80740,7 +80648,7 @@ hi: स्पेरिदे
 hr: ljuskavke
 hu: Tengeri durbincsfélék
 ia: Sparidae
-it: orata
+it: Sparidae
 ja: タイ科
 ka: სპარუსისებრნი
 kn: ಸ್ಪಾರಿಡೇ
@@ -81793,7 +81701,6 @@ gd: Slige-chabon
 gl: Cárdidos
 hr: kukuljice
 id: Kerang darah
-it: vongole
 ja: ザルガイ科
 ko: 꼬막
 la: Cardiidae
@@ -83403,9 +83310,16 @@ sv: krabbextrakt
 en: crab flavour
 bg: ароматизант от раци
 ca: aroma de cranc
+da: krabbe aroma
 es: aroma de cangrejo
+fi: rapuaromi
+fr: arôme crabe
 hr: okus rakova
 it: sapore di granchio
+nl: krabaroma
+pt: aroma de caranguejo
+sv: krabbarom
+allergens:en: en:crustaceans
 
 # description:en:Cancer pagurus, commonly known as the edible crab or brown crab, is a species of crab found in the North Sea, North Atlantic Ocean
 
@@ -84191,11 +84105,6 @@ wikipedia:nl: https://nl.wikipedia.org/wiki/Pandalus_jordani
 la: Solenocera Crassicornis
 wikipedia:nl: https://nl.wikipedia.org/wiki/Solenocera_crassicornis
 
-< en:crayfish
-< en:shrimp
-en: crayfish or shrimp
-it: gambero, gamberi
-
 # en:description:Psyllium, or ispaghula, is the common name used for several members of the plant genus Plantago whose seeds are used commercially for the production of mucilage.
 
 # en:description:psyllium can be used for the fibres or as infusion
@@ -84273,7 +84182,7 @@ ay: Misk'i
 az: Bal
 ba: Бал
 be: мёд
-bg: мед
+# bg: мед # also copper
 bn: মধু
 br: Mel
 bs: Med
@@ -84672,10 +84581,6 @@ nl: heidehoning
 < fr:miel de bruyere
 fr: miel de bruyere blanche
 nl: witte heidehoning
-
-# is this really honey, it is often translated as cane sugar
-< en:honey
-es: miel de caña
 
 < en:honey
 fr: miel de carotte sauvage
@@ -86446,13 +86351,6 @@ it: succo di cetriolo da concentrato
 nl: komkommersap uit concentraat
 # ingredient/cucumber-juice-from-concentrate has 1 product @2019-05-15
 
-#For languages that do not differentiate between the two
-< en:cucumber
-< en:gherkin
-en: cumcumber or gherkin
-de: Gurke
-it: cetriolo o cetriolo
-
 < en:cucumber
 # processing:en: en:fermented
 cs: kvašáky
@@ -87031,7 +86929,6 @@ fr: produit à base de viande de poulet
 
 < en:chicken meat
 en: white chicken meat
-de: Hähnchenfleisch
 fr: viande blanche de poulet
 hr: bijelo pileće meso
 it: carne di pollo bianca
@@ -87090,9 +86987,6 @@ fr: extrait de poulet
 
 < en:chicken meat
 fr: viande de poitrine de poulet
-
-< en:chicken meat
-fr: viande de poulet séparée mécaniquement
 
 < en:chicken meat
 en: precooked chicken meat
@@ -89719,7 +89613,7 @@ vegan:en: no
 en: cocoa filling
 bg: какаов пълнеж
 de: Kakaofüllung
-es: relleno de cacao
+es: relleno de cacao, Relleno cacao
 fi: kaakaotäyte
 fr: fourrage au cacao
 hr: kakaovo punjenje, nadjev s okusom kakaa
@@ -90232,7 +90126,7 @@ fr: canneloni
 < en:pasta
 en: risoni
 fi: risoni, risonipasta
-it: risoni, orzo
+it: risoni, risoni orzo
 pl: makaron orzo
 wikidata:en: Q1317552
 wikipedia:en: https://en.wikipedia.org/wiki/Orzo
@@ -95336,7 +95230,7 @@ wikidata:en: Q11264544
 
 < en:hot sauce
 en: salsa
-it: salsa
+it: spagnolo salsa
 pl: pikantny sos salsa
 description:en: Mexican table sauces, especially the chunky tomato-and-chili-based pico de gallo.
 wikipedia:en: https://en.wikipedia.org/wiki/Salsa_(food)
@@ -95927,6 +95821,35 @@ hr: biljni pigment
 it: pigmento vegetale
 ja: 野菜色素
 
-en: charbon végétal
-it: carbone vegetale
+
+
+# following ingredients have two meanings in some languages
+
+< en:crayfish
+< en:shrimp
+en: crayfish or shrimp
+it: gambero, gamberi
+
+< en:cucumber
+< en:gherkin
+en: cumcumber or gherkin
+de: Gurke
+it: cetriolo o cetriolo
+
+< en:plant
+en: spice or bell pepper
+bg: червен пипер, паприка
+cs: paprika
+da: paprika
+de: Paprika
+fi: paprika
+hu: paprika
+lv: paprika
+nb: paprika
+nl: paprika
+nn: paprika
+no: paprika
+pl: papryka, papryki, paprykowy, paprykowe, paprykowa
+sl: paprika
+sv: paprika
 

--- a/taxonomies/minerals.txt
+++ b/taxonomies/minerals.txt
@@ -2454,7 +2454,7 @@ fi: ferridifosfaatti, ferripyrofosfaatti
 fr: diphosphate ferrique, pyrophosphate ferrique, diphosphate de fer, pyrophosphate de fer
 hr: željezo pirofosfat
 hu: vas-difoszfát, ferri-pirofoszfát
-it: difosfato di ferro, pirofosfato ferrico
+it: difosfato di ferro
 ja: ピロリン酸第二鉄, ピロリン酸鉄
 lt: geležies difosfatas, geležies pirofosfata
 lv: dzelzs difosfāts, dzelzs pirofosfāts


### PR DESCRIPTION
### What

Remove duplicate appearing when rebuilding taxonomies

Moved at the very end all ingredients that can be 2 different ingredients in some languages:
```
# following ingredients have two meanings in some languages

< en:crayfish
< en:shrimp
en: crayfish or shrimp
it: gambero, gamberi

< en:cucumber
< en:gherkin
en: cumcumber or gherkin
de: Gurke
it: cetriolo o cetriolo

< en:plant
en: spice or bell pepper
bg: червен пипер, паприка
cs: paprika
da: paprika
de: Paprika
fi: paprika
hu: paprika
lv: paprika
nb: paprika
nl: paprika
nn: paprika
no: paprika
pl: papryka, papryki, paprykowy, paprykowe, paprykowa
sl: paprika
sv: paprika
```


### Related issue(s) and discussion
- Fixes #-none-