### PR TITLE
taxonomy: Some Danish and Swedish translations

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -85,6 +85,7 @@ stopwords:de: und, mit, von
 en: Incorrect product type
 bg: Неправилен product type
 ca: Tipus de producte incorrecte
+da: Forkert produkttype
 de: Falscher product type
 es: Tipo de producto incorrecto
 fi: Väärä product type
@@ -129,11 +130,13 @@ wikidata:en: Q1521410
 < en:Open Products Facts
 en: books
 bg: книги
+da: bøger, bog
 de: Bücher
 fr: livres
 hr: knjige, knjiga
 ja: 本
 nl: Boeken
+sv: böcker, bok
 wikidata:en: Q571
 
 < en:Open Products Facts
@@ -1164,6 +1167,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Royal_jelly
 
 < en:Bee products
 en: Pollens
+da: Pollen
 de: Pollen
 es: Polen
 fr: Pollens
@@ -1181,6 +1185,7 @@ wikidata:en: Q79932
 
 < en:Pollens
 en: Partially dried pollen
+da: Delvist tørret pollen
 de: Teilweise getrockneter Pollen
 es: Polen parcialmente seco
 fr: Pollen partiellement séché
@@ -1193,6 +1198,7 @@ ciqual_food_name:fr: Pollen, partiellement séché
 
 < en:Pollens
 en: Fresh pollen
+da: Frisk pollen
 de: Frischer Pollen
 es: Polen fresco
 fr: Pollen frais
@@ -1725,18 +1731,15 @@ wikidata:en: Q16976
 wikipedia:en: https://en.wikipedia.org/wiki/Pastis
 
 < en:Alcoholic beverages
+xx: Sake
 en: Sake, Rice wines
 bg: Саке
-de: Sake
-fi: Sake
 fr: Saké, Alcools de riz
-hr: Sake
-hu: Szaké, Sake
+hu: Szaké
 it: Sake, Sakè
 ja: 日本酒, にほんしゅ
 nl: Saké
 pl: Sake, Wina ryżowe
-ro: Sake
 agribalyse_food_code:en: 1026
 ciqual_food_code:en: 1026
 ciqual_food_name:en: Sake or rice wine
@@ -2219,6 +2222,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Smoked_beer
 
 < en:Beers
 en: Christmas beers
+da: juleøl
 de: Weihnachtsbiere
 es: Cervezas de Navidad
 fr: Bières de Noël
@@ -2360,6 +2364,7 @@ wikidata:en: Q260417
 < en:Beers
 en: Wheat beers, Wheat beer, White beer, White beers
 xx: Witbier
+da: Hvedeøl
 de: Weißbier, Weizenbier
 dk: Hvedeöl
 es: Cerveza blanca
@@ -2524,6 +2529,7 @@ description:en: Festbier is a German lager that is lighter in color and is consi
 < en:Lagers
 en: Pilsners, Pilsner, Pilsner beers, Pils
 xx: Pilsners, Pilsner, Pils
+da: pilsnere
 nl: Pilseners
 wikidata:en: Q152281
 wikipedia:en: https://en.wikipedia.org/wiki/Pilsner
@@ -2609,6 +2615,7 @@ wikidata:en: Q1234364
 < en:Products without gluten
 en: Beers without gluten, gluten free beers
 bg: Бира без глутен
+da: glutenfrie øl
 de: Glutenfreies Bier
 es: Cervezas sin gluten
 fr: Bières sans gluten
@@ -2666,6 +2673,7 @@ lt: Šaliai būdingas alus
 
 < en:Country specific beers
 en: American beers, Beers from the USA
+da: amerikanske øl
 fr: Bières américaines, Bières des Etats-Unis, Bières des USA
 hr: Američka piva
 it: Birre americane, Birre dagli USA, Birre dagli Stati Uniti d'America
@@ -2677,6 +2685,7 @@ wikidata:en: Q15146313
 
 < en:Country specific beers
 en: Dutch beers, Beers from the Netherlands
+da: hollandske øl
 de: Niederländische Biere, Biere aus den Niederlanden
 es: Cervezas holandesas, Cervezas de los Países Bajos
 fr: Bières néerlandaises, Bières des Pays-Bas
@@ -2688,6 +2697,7 @@ wikidata:en: Q2247929
 
 < en:Country specific beers
 en: Finnish beers, Beers from Finland
+da: finske øl
 es: Cervezas finlandesas, Cervezas de Finlandia
 fr: Bières finnoises, bières finlandaises, Bières de Finlande
 hr: Finska piva
@@ -2706,6 +2716,7 @@ wikidata:en: Q3042275
 < en:Country specific beers
 en: French beers, Beers from France
 bg: Френска бира
+da: franske øl
 de: Französische Biere
 es: Cervezas francesas, Cervezas de Francia
 fi: ranskalaiset oluet
@@ -2744,6 +2755,7 @@ wikidata:en: Q2905049
 
 < en:Country specific beers
 en: Irish beers, Beers from Ireland
+da: irske øl
 de: Irische Biere
 fr: Bières irlandaises
 hr: Irska piva
@@ -2759,6 +2771,7 @@ wikidata:en: Q4880005
 
 < en:Country specific beers
 en: Italian beers, Beers from Italy
+da: italienske øl
 de: Italienische Biere
 fi: Italialaiset oluet, Oluet Italiasta
 fr: Bières italiennes
@@ -2774,6 +2787,7 @@ wikidata:en: Q3640378
 
 < en:Country specific beers
 en: Latvian beers, Beers from Latvia
+da: lettiske øl
 de: Lettische Biere, Bier aus Lettland
 es: Cervezas letonas, Cervezas de Letonia
 fi: latvialaiset oluet, oluet Latviasta
@@ -2789,6 +2803,7 @@ wikidata:en: Q15873100
 < en:Country specific beers
 en: Lithuanian beers, Beers from Lithuania
 bg: Литовски бири, Бири от Литва
+da: litauiske øl
 de: Litauische Biere
 es: Cervezas lituanas
 fi: liettualaiset oluet
@@ -2812,6 +2827,7 @@ protected_name_type:en: pgi
 < en:Country specific beers
 en: Belgian beers, Beers from Belgium
 bg: Белгийска бира
+da: belgiske øl
 de: Belgische Biere
 es: Cervezas belgas
 fi: belgialaiset oluet
@@ -3004,6 +3020,7 @@ protected_name_type:en: pgi
 < en:Country specific beers
 en: Danish beers, Beers from Denmark
 bg: Датска бира
+da: danske øl, øl fra Danmark
 hr: Danska piva
 lt: Daniškas alus, alus iš Danijos
 wikidata:en: Q3655862
@@ -3011,6 +3028,7 @@ wikidata:en: Q3655862
 < en:Country specific beers
 en: Estonian beers, Beers from Estonia
 bg: Естонска бира
+da: estiske øl
 fr: Bières estoniennes
 hr: Estonska piva
 lt: Estiškas alus, alus iš Estijos
@@ -3019,6 +3037,7 @@ wikidata:en: Q15392318
 < en:Country specific beers
 en: Beers from Germany, German beers
 bg: Германска бира
+da: tyske øl
 de: Deutsche Biere
 es: Cervezas de alemania
 fi: saksalaiset oluet
@@ -3119,6 +3138,7 @@ wikidata:en: Q880640
 < en:Country specific beers
 en: Norwegian beers
 bg: Норвежка бира
+da: norske øl
 hr: Norveška piva
 lt: Norvegiškas alus
 wikidata:en: Q3655589
@@ -3126,6 +3146,7 @@ wikidata:en: Q3655589
 < en:Country specific beers
 en: Beers from Poland, Polish beers
 bg: Полска бира
+da: polske øl
 de: Biere aus Polen
 fr: Bières polonaises
 hr: Piva iz Poljske
@@ -3139,6 +3160,7 @@ wikidata:en: Q4880014
 < en:Country specific beers
 en: Spanish beers
 bg: Испанска бира
+da: spanske øl
 de: Spanische Biere
 fr: Bières espagnoles
 hr: Španjolska piva
@@ -3150,6 +3172,7 @@ wikidata:en: Q4550225
 < en:Country specific beers
 en: Swedish beers
 bg: Шведска бира
+da: svenske øl
 de: Schwedische Biere
 es: Cervezas suecas
 fr: Bières suédoises
@@ -3161,6 +3184,7 @@ wikidata:en: Q3655894
 
 < en:Country specific beers
 en: Ukrainian beers, Beers from Ukraine
+da: ukrainske øl
 lt: Ukrainietiškas alus, alus iš Ukrainos
 wikidata:en: Q4880025
 
@@ -3196,6 +3220,7 @@ protected_name_type:en: pgi
 
 < en:Beers from United Kingdom
 en: Scottish beers
+da: skotske øl
 de: Schottische Biere
 es: Cervezas escocesas
 fr: Bières écossaises
@@ -6942,6 +6967,7 @@ zh: 植物性饮料
 < en:Plant-based beverages
 en: Coconut waters, coconut water
 bg: Кокосова вода
+da: kokosvand
 de: Kokoswasser
 es: Agua de coco
 fi: kookosvedet
@@ -6953,6 +6979,7 @@ lt: Kokosų vanduo
 nl: Kokoswater
 pl: Woda kokosowa
 pt: Águas de coco
+sv: kokosvatten
 agribalyse_food_code:en: 18011
 ciqual_food_code:en: 18011
 ciqual_food_name:en: Coconut water
@@ -7104,6 +7131,7 @@ ciqual_food_name:fr: Boisson au soja et jus de fruits concentrés
 < en:Plant-based beverages
 en: Smoothies
 bg: Смути
+da: Smoothies
 de: Smoothies
 es: Smoothies
 fi: smoothiet
@@ -52112,6 +52140,7 @@ nl: Gierstdranken
 en: Oat-based drinks, Oat milks, Oat drinks, Plain oat-based drinks
 bg: Напитка с овес
 ca: Beguda de civada
+da: havredrikke, havremælk
 de: Hafermilch, Hafermilche, Hafermilchen, Hafer-Drinks, Hafer-Drink, Haferdrink, Haferdrinks
 es: Bebidas de avena, Leches de avena
 fi: kaurajuomat
@@ -52143,6 +52172,7 @@ fr: Boissons végétales d'avoine nature sucrées
 < en:Oat-based drinks
 en: Cocoa oat-based drinks, Cocoa oat milks
 fr: Boissons végétales d'avoine au cacao
+sv: chokladhavredryck, kakaohavredryck, havredryck choklad
 
 < en:Oat-based drinks
 en: Vanilla oat-based drinks, Vanilla oat milks
@@ -52166,6 +52196,7 @@ pt: Bebidas de quinoa
 en: Rice-based drinks, Rice milks, Rice drinks
 bg: Напитка с ориз
 ca: Beguda d'arròs
+da: risdrikke, rismælk
 de: Reismilch, Reismilche, Reismilchen, Reis-Drinks, Reis-Drink, Reisdrink, Reisdrinks
 es: Bebidas de arroz, Leches de arroz
 fi: riisijuomat
@@ -52179,6 +52210,7 @@ lt: Ryžių pienas
 nl: Rijstdranken
 pl: Mleka ryżowe
 pt: Bebidas de arroz
+sv: Risdryckor
 agribalyse_food_code:en: 18904
 ciqual_food_code:en: 18904
 ciqual_food_name:en: Rice-based drink, plain
@@ -52333,6 +52365,7 @@ pt: Leites de legumes
 en: Soy-based drinks, Soy milks, Soya milks, Soya drinks, Soy drinks
 bg: Соево мляко
 ca: Beguda de soja
+da: sojadrikke, sojamælk
 de: Sojamilch, Sojamilche, Sojamilchen, Soja-Drinks, Soja-Drink, Sojadrink, Sojadrinks
 es: Bebidas de soja, bebida de soya, Leches de soja
 fi: soijajuomat
@@ -52387,6 +52420,7 @@ pt: Bebidas de soja com baunilha
 
 < en:Soy-based drinks
 en: Chocolate soy-based drinks, Chocolate soy milks, Cocoa soy milks, Cocoa soy drinks, Chocolate soy drinks
+da: chokoladesojamælk
 de: Schokoladensojamilch
 es: Bebidas de soja con cacao, Bebidas de soja con chocolate, Leches de soja con cacao, Leches de soja con chocolate
 fi: Soijakaakaot
@@ -52445,6 +52479,7 @@ pt: Leites de mistura de plantas
 en: Nut-based drinks, Nut milks, Nut drinks
 bg: Ядкови млека, ядково мляко
 ca: Beguda de fruits secs
+da: nødemælk
 de: Nussmilch, Nussmilche, Nussmilchen, Nuss-Drinks, Nuss-Drink, Nussdrink, Nussdrinks
 es: Leches de frutos de cáscara, Bebidas de frutos de cáscara, Bebidas de frutos secos, Leches de frutos secos
 fi: pähkinäjuomat
@@ -52470,6 +52505,7 @@ intake24_category_code:fr: 19NMLK
 en: Almond-based drinks, Almond milks, Almond drinks
 bg: Бадемово мляко
 ca: Beguda d'ametlla
+da: mandelmælk
 de: Mandelmilch, Mandelmilche, Mandelmilchen, Mandel-Drinks, Mandel-Drink, Mandeldrink, Mandeldrinks
 es: Leches de almendras, Bebidas de almendras
 fi: mantelijuomat
@@ -52534,6 +52570,7 @@ nl: Kastanjedranken
 
 < en:Nut-based drinks
 en: Hazelnut-based drinks, Hazelnut milks, Hazelnut drinks
+da: hasselnødemælk
 de: Haselnussmilch, Haselnussmilche, Haselnussmilchen, Haselnuss-Drinks, Haselnuss-Drink, Haselnussdrink, Haselnussdrinks
 es: Leches de avellanas, Bebidas de avellanas
 fi: Hasselpähkinäjuomat, Hasselpähkinämaidot
@@ -52587,6 +52624,7 @@ hr: Smrznuti horchatas de chufa
 
 < en:Frozen vegetables
 en: Frozen peas and carrots, Frozen garden peas and carrots
+da: frosne ærter och gulerødder
 fr: Petits pois et carottes surgelés
 hr: Smrznuti grašak i mrkva
 lt: Šaldyti žirneliai ir morkos
@@ -52606,6 +52644,7 @@ ciqual_food_name:fr: Petits pois et carottes, surgelés, cuits
 
 < en:Frozen vegetables
 en: Frozen mixed vegetables for ratatouille
+da: frosne blandede grøntsager til ratatouille
 fr: Légumes pour ratatouille surgelés
 agribalyse_food_code:en: 20266
 ciqual_food_code:en: 20266
@@ -52614,6 +52653,7 @@ ciqual_food_name:fr: Légumes pour ratatouille, surgelés
 
 < en:Frozen vegetables
 en: Frozen mixed vegetables for couscous
+da: frosne blandede grøntsager til couscous
 fr: Légumes pour couscous surgelés
 agribalyse_food_code:en: 20496
 ciqual_food_code:en: 20496

--- a/taxonomies/packaging_shapes.txt
+++ b/taxonomies/packaging_shapes.txt
@@ -266,6 +266,7 @@ it: Bottiglia
 nl: Fles, Flessen
 pl: Butelka
 pt: Garrafa, garrafas
+sv: Flaska
 # suggest:packaging_materials:nl: en:glass
 # associated_packagings: en:cap
 description:nl: Een langgerekt, cilindrisch en meestal van glas vervaardigd vat met een nauwe hals die met een dop of kurk af te sluiten is
@@ -429,7 +430,7 @@ pt: Pote individual, potes individuais, boião individual, boiões individuais
 
 # <en:pot
 # fr:salière
-# image:xx:pot-5.svg 
+# image:xx:pot-5.svg
 # (image looks like a salière)
 # suggest:category: en:salts, en:peppers
 
@@ -445,7 +446,7 @@ en: Tube, tubes
 de: Tube, Tuben
 fr: Tube, tubes
 hu: Tubus, tubusok, Cső, csövek, cső alakú
-# image:xx:tube-1.svg 
+# image:xx:tube-1.svg
 # suggest:packaging_materials: en:cardboard, en:metal, en:glass, en:plastic, en:others
 # associated_packagings: en:cap
 it: Tubo, tubi
@@ -460,7 +461,7 @@ describtion:nl: Een verpakking in kokervorm gemaakt van metaal of plastic gevuld
 
 # <en:Tube
 # fr:Tube avec bouchon refermable
-# image:xx:tube-2.svg 
+# image:xx:tube-2.svg
 # associated_packagings: en:cap
 
 en: Fastener, clip
@@ -496,6 +497,7 @@ hu: Zacskó, zacskók, tasak, tasakos
 it: Sacco, sacchetto, sacchettino
 nl: Zak, Sachet, Tas, verzendzak, Zakken, Zakje, Zakjes
 pt: Saco, sacos, saquinho, saquinhos, saqueta, saquetas
+sv: Väska, väskor
 description:nl: Slappe, vormeloze verpakking
 
 # image:xx:sac-sachet-poche-1.svg (sachet avec poignée)
@@ -603,6 +605,7 @@ fr: coiffe, coiffes
 
 < en:Lid or cap
 en: Lid, cover, lids, covers
+da: Låg
 de: Deckel
 el: Καπάκι
 fr: Couvercle, couvercles
@@ -617,6 +620,7 @@ nb: Lokk
 nl: Deksel, deksels
 pl: Nakrętka, Zakrętka, Pokrywka, Wieczko, Wieko
 pt: Tampa, tampas
+sv: Lock
 
 < en:Lid or cap
 en: Bottle cap, bottle top, cap, top, bottle caps, bottle tops, caps, tops
@@ -811,10 +815,12 @@ pt: Cápsulas de café compatíveis com Senseo
 
 en: Tea bag
 bg: Чаена торбичка
+da: Tepose, teposer
 # suggest:packaging_materials:en: en:paper
 # related_categories:en: en:Tea bags
 it: bustina di tè, bustina di te, bustina
 nl: Theezakje
+sv: Tepåse, tepåsar
 
 # keep the plural as the main name
 # fr:Baguettes / Couverts / Paille -> entry from Les Mousquetaires
@@ -868,6 +874,7 @@ it: coltello, coltelli, coltellino, coltellini
 nl: Mes, messen
 pl: Nóż, noże
 pt: Faca, facas
+sv: Kniv
 wikidata:en: Q32489
 
 < en:Cutlery
@@ -882,6 +889,7 @@ it: forchetta, forchette, forchettina, forchettine
 nl: Vork, vorken
 pl: Widelec, widelce
 pt: Garfo, garfos
+sv: Gaffel
 wikidata:en: Q81881
 
 < en:Cutlery
@@ -907,18 +915,22 @@ wikidata:en: Q81895
 < en:Spoon
 en: teaspoon
 bg: чаена лъжичка, чаена лъжица
+da: teske, teskeer
 fr: cuillère à café
 it: cucchiaino da tè
 nl: theelepel
 pl: Łyżeczki, Łyżeczka
+sv: tesked, teskedar
 wikidata:en: Q216425
 
 < en:Spoon
 en: tablespoon
 bg: супена лъжица
+da: spiseske, spiseskeer
 fr: cuillère à soupe
 it: cucchiaino
 nl: soeplepel
+sv: matsked, matskedar
 wikidata:en: Q2002583
 
 # fr:Plaque / Intercalaire in data from Les Mousquetaires
@@ -1175,12 +1187,12 @@ fr: Rouleau, Bobine, Mandrin, Mandrin / Rouleau
 
 # <en:Roll
 # fr:rouleau de sopalin
-# image:xx:bobine-rouleau-1.svg 
+# image:xx:bobine-rouleau-1.svg
 # suggest:packaging_materials:en: en:cardboard, en:paper
 
 # <en:Roll
 # fr:rouleau de papier toilette
-# image:xx:bobine-rouleau-2.svg 
+# image:xx:bobine-rouleau-2.svg
 # suggest:packaging_materials:en: en:cardboard, en:paper
 
 < en:Jug or canister
@@ -1259,10 +1271,12 @@ fr: Gaine, gaines, manchon, manchons, sleever, sleevers
 
 en: envelope
 bg: плик
+da: konvolut
 es: sobre
 fr: enveloppe
 it: busta
 nl: wikkel, vensterenvelop, sleeve
+sv: kuvert
 # suggest:packaging_materials:en: en:cardboard, en:paper
 # image:xx:enveloppe-papier.svg
 # image:xx:enveloppe-carton.svg
@@ -1414,6 +1428,7 @@ wikidata:en: Q47107
 
 < en:bucket
 en: small bucket
+da: lille spand
 nl: emmertje
 pl: wiaderko
 


### PR DESCRIPTION
### What

Adds some Danish (`da`) and Swedish (`sv`) translations of a few categories and packaging shapes.