### PR TITLE
fix: wrap long username in cards

### DIFF
--- a/scss/_off.scss
+++ b/scss/_off.scss
@@ -456,6 +456,7 @@ nav.tab-bar > div {
 p.details {
   color: gray;
   font-size: 0.8em;
+  word-wrap: break-word;
 }
 
 .select2-dropdown.select2-dropdown--below {


### PR DESCRIPTION
### What
Wrapped long username in data source card

### Screenshot
<img width="1018" alt="Screenshot 2025-03-11 at 1 56 48 PM" src="https://github.com/user-attachments/assets/4d949f2f-5787-4684-bc93-06d3e672b5d0" />

### Related issue(s) and discussion
- Fixes #7496 

