### PR TITLE
taxonomy: Add “Baby spinach” synonym

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -109598,8 +109598,10 @@ sales_format:en: package, weight
 season_in_country_fr:en: 1,2,3,4,5,9,10,11,12
 
 < en:Fresh spinachs
-en: Spinach young leaves
+en: Spinach young leaves, Baby spinach
+da: babyspinat
 fr: Jeunes pousses d'épinards pour salades
+sv: babyspenat
 agribalyse_food_code:en: 20270
 ciqual_food_code:en: 20270
 ciqual_food_name:en: Spinach, young leaves, raw


### PR DESCRIPTION
### What

Adds “Baby spinach” as synonym for “Spinach young leaves” and adds Danish and Swedish translations.

See also discussion on Slack:
https://openfoodfacts.slack.com/archives/C02VDSWHT/p1741637133755419