### PR TITLE
fix: spacing between numbers in pagination

### DIFF
--- a/scss/_product-list.scss
+++ b/scss/_product-list.scss
@@ -199,6 +199,7 @@ $productsGutter:12;
     display: flex;
     align-items: center;
     padding-top: 1rem;
+    gap: 0.75rem;
     li:last-child {
         margin-left: auto;
     }
@@ -213,6 +214,7 @@ $productsGutter:12;
             text-align: center;
             padding: 0;
             display: flex;
+            min-width: 3rem;
             justify-content: center;
             align-items: center;
             font-size: 0.9em;


### PR DESCRIPTION
### What
fix spacing between numbers in pagination

### Screenshot
<img width="766" alt="Screenshot 2025-03-11 at 4 20 47 PM" src="https://github.com/user-attachments/assets/dcf911e2-afbd-46a6-96db-388158e077fe" />

### Related issue(s) and discussion
<!-- Please add the issue number this issue will close, that way, once your pull request is merged, the issue will be closed as well -->
- Fixes #11257 

