### PR TITLE
ci: replaced dorny/path-filter to tj-actions/changed-files

### DIFF
--- a/.github/scripts/path-filter.sh
+++ b/.github/scripts/path-filter.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+# Check each changed file
+for file in $@; do
+  if ! echo "$file" | grep -E -q '\.md$|^docs/'; then
+    echo "code_modified=true" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+done
+
+# If only Markdown or docs files are changed
+echo "code_modified=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Filter changed paths"
     runs-on: ubuntu-latest
     outputs:
-      code_modified: ${{ steps.filter.outputs.code }}
+      code_modified: ${{ steps.filter.outputs.code_modified }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,17 +25,16 @@ jobs:
     outputs:
       code_modified: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get changed files
+        uses: tj-actions/changed-files@v45
+        id: changed_files
+
+      - name: Filter non-markdown and non-docs files
         id: filter
-        with:
-          # FIXME: we need to consider more than these files
-          # We need to consider every file in the repository and have it in a category
-          # Maybe using negative match: https://github.com/micromatch/picomatch?tab=readme-ov-file#advanced-globbing
-          filters: |
-            code:
-            - '**/*'       # Catch everything else
-            - '!**/*.md'   # Exclude all Markdown files
-            - '!docs/**'   # Exclude docs/ folder
+        run: ./.github/scripts/path-filter.sh "${{ steps.changed_files.outputs.all_changed_files }}"
 
   lint:
     name: 🕵️‍♀️ NPM lint


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->


Hey @stephanegigandet and @alexgarel, we finally made it! 🎉    

I've tested this solution in my local repo, so there won't be any further excuses. I just want to clarify that the issue last time wasn't with the merge file solution — that was correct. The real problem was with the `dorny/path-filter` action, which turned out to be buggy.    

I've now switched to `tj-actions/changed-files`, which works perfectly and is well-maintained. ✅

