### PR TITLE
docs: Documentation for 'last_updated_t'.

### DIFF
--- a/docs/api/ref/schemas/product_meta.yaml
+++ b/docs/api/ref/schemas/product_meta.yaml
@@ -67,6 +67,14 @@ properties:
     type: integer
     description: |
       Date when the product page was last modified.
+      This date is updated only when primary data is modified (data entered by the user or updated by an interface)
+  last_updated_t:
+    type: integer
+    description: |
+      Date when the product page was last modified.
+      This date is updated when primary data or secondary data is modified
+      (primary: data entered by a user or read from an interface, secondary: data computed by a utility
+      such as update_all_products.pl)
   owner:
     description: |
       Id of the producer in case he provides his own data about a product (producer platform).


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [ ] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [ ] Code is well documented
- [ ] Include unit tests for new functionality
- [ ] Code passes GitHub workflow checks in your branch
- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### docs: Documentation for 'last_updated_t'.

When I found that many documents contained an undocumented `last_updated_t` property,
I first thought it was a typo for `last_modified_t`. But after reading
[issue 9646](https://github.com/openfoodfacts/openfoodfacts-server/pull/9646),
[the change log](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CHANGELOG.md)
and the 
[message](https://github.com/openfoodfacts/openfoodfacts-server/compare/v2.25.0...v2.26.0).
for tag 2.26.0,
I understood this is a real property.
So here is its documentation.

Some other properties need to be documented, but I do not know what to say
about them and in which file the documentation should be written. These
properties are:

* packaging_materials_tags

* packaging_recycling_tags

* packaging_shapes_tags

* packagings_materials
