### PR TITLE
fix: CORS headers for image upload API

### DIFF
--- a/cgi/product_image_upload.pl
+++ b/cgi/product_image_upload.pl
@@ -37,6 +37,7 @@ use ProductOpener::Images
 use ProductOpener::Products qw/:all/;
 use ProductOpener::Text qw/remove_tags_and_quote/;
 use ProductOpener::APIProductWrite qw/:all/;
+use ProductOpener::HTTP qw/write_cors_headers/;
 
 use CGI qw/:cgi :form escapeHTML/;
 use URI::Escape::XS;
@@ -79,6 +80,8 @@ $log->debug(
 		ip => remote_addr()
 	}
 ) if $log->is_debug();
+
+write_cors_headers();
 
 # By default, don't select images uploaded (e.g. through the product edit form)
 


### PR DESCRIPTION
Added CORS headers to image upload API (needed for openfoodfacts-explorer)

```
curl -I http://world.openfoodfacts.localhost/cgi/product_image_upload.pl
HTTP/1.1 200 OK
Server: nginx/1.26.3
Date: Mon, 24 Mar 2025 09:37:34 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive
Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,If-None-Match,Authorization
Access-Control-Allow-Methods: HEAD, GET, PATCH, POST, PUT, OPTIONS
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Content-Length,Content-Range
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-XSS-Protection: 1; mode=block
X-Request-ID: fZzSBGJoBRay1IUx
```
