### PR TITLE
fix: OBF brands categories, ingredients panels

### DIFF
--- a/lib/ProductOpener/Config_obf.pm
+++ b/lib/ProductOpener/Config_obf.pm
@@ -351,6 +351,7 @@ HTML
 	data_quality data_quality_bugs data_quality_info data_quality_warnings data_quality_errors data_quality_warnings_producers data_quality_errors_producers
 	improvements
 	inci_functions
+	brands
 );
 
 # tag types (=facets) that should be indexed by web crawlers, all other tag types are not indexable

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -5182,7 +5182,7 @@ sub get_knowledge_content ($tagtype, $tagid, $target_lc, $target_cc) {
 	# en:250 -> en_250
 	$tagid =~ s/:/_/g;
 
-	my $base_dir = "$lang_dir/$target_lc/knowledge_panels/$tagtype";
+	my $base_dir = "$lang_dir/$flavor/$target_lc/knowledge_panels/$tagtype";
 
 	foreach my $cc ($target_cc, "world") {
 		my $file_path = "$base_dir/$tagid" . "_" . "$cc.html";

--- a/taxonomies/beauty/brands.txt
+++ b/taxonomies/beauty/brands.txt
@@ -1,1198 +1,1198 @@
-en: Henkel
+xx: Henkel
 
-< en:Henkel
-en: Boraxo
+< xx:Henkel
+xx: Boraxo
 
-< en:Henkel
-en: Dial
+< xx:Henkel
+xx: Dial
 
-< en:Henkel
-en: Dry Idea
+< xx:Henkel
+xx: Dry Idea
 
-< en:Henkel
-en: Fa
+< xx:Henkel
+xx: Fa
 
-< en:Henkel
-en: Fels-Naptha
+< xx:Henkel
+xx: Fels-Naptha
 
-< en:Henkel
-en: Loctite
+< xx:Henkel
+xx: Loctite
 
-< en:Henkel
-en: Persil
+< xx:Henkel
+xx: Persil
 
-< en:Henkel
-en: Pritt
+< xx:Henkel
+xx: Pritt
 
-< en:Henkel
-en: Purex
+< xx:Henkel
+xx: Purex
 
-< en:Henkel
-en: Renuzit
+< xx:Henkel
+xx: Renuzit
 
-< en:Henkel
-en: Right Guard
+< xx:Henkel
+xx: Right Guard
 
-< en:Henkel
-en: Snuggle
+< xx:Henkel
+xx: Snuggle
 
-< en:Henkel
-en: Surf
+< xx:Henkel
+xx: Surf
 
-< en:Henkel
-en: 20 Mule Team Borax
+< xx:Henkel
+xx: 20 Mule Team Borax
 
-< en:Henkel
-en: Bonderite
+< xx:Henkel
+xx: Bonderite
 
-< en:Henkel
-en: Dial
+< xx:Henkel
+xx: Dial
 
-< en:Henkel
-en: Loctite
+< xx:Henkel
+xx: Loctite
 
-< en:Henkel
-en: Persil
+< xx:Henkel
+xx: Persil
 
-< en:Henkel
-en: Pril
+< xx:Henkel
+xx: Pril
 
-< en:Henkel
-en: Purex
+< xx:Henkel
+xx: Purex
 
-< en:Henkel
-en: Schwarzkopf
+< xx:Henkel
+xx: Schwarzkopf
 
-< en:Henkel
-en: Syoss
+< xx:Henkel
+xx: Syoss
 
-< en:Henkel
-en: Technomelt
+< xx:Henkel
+xx: Technomelt
 
-< en:Henkel
-en: Agorex
+< xx:Henkel
+xx: Agorex
 
-< en:Henkel
-en: Allume-vite
+< xx:Henkel
+xx: Allume-vite
 
-< en:Henkel
-en: Alterna Haircare
+< xx:Henkel
+xx: Alterna Haircare
 
-< en:Henkel
-en: Antica Erboristeria
+< xx:Henkel
+xx: Antica Erboristeria
 
-< en:Henkel
-en: Aok
+< xx:Henkel
+xx: Aok
 
-< en:Henkel
-en: Aok
+< xx:Henkel
+xx: Aok
 
-< en:Henkel
-en: Aquence
+< xx:Henkel
+xx: Aquence
 
-< en:Henkel
-en: Ariasana
+< xx:Henkel
+xx: Ariasana
 
-< en:Henkel
-en: BC Bonacure
+< xx:Henkel
+xx: BC Bonacure
 
-< en:Henkel
-en: Ballerina
+< xx:Henkel
+xx: Ballerina
 
-< en:Henkel
-en: Big D
+< xx:Henkel
+xx: Big D
 
-< en:Henkel
-en: Bio Presto
+< xx:Henkel
+xx: Bio Presto
 
-< en:Henkel
-en: BlondMe
+< xx:Henkel
+xx: BlondMe
 
-< en:Henkel
-en: Blonde Schwarzkopf
+< xx:Henkel
+xx: Blonde Schwarzkopf
 
-< en:Henkel
-en: Bloom
+< xx:Henkel
+xx: Bloom
 
-< en:Henkel
-en: Blue Star
+< xx:Henkel
+xx: Blue Star
 
-< en:Henkel
-en: Boston
+< xx:Henkel
+xx: Boston
 
-< en:Henkel
-en: Bref
+< xx:Henkel
+xx: Bref
 
-< en:Henkel
-en: Brillance
+< xx:Henkel
+xx: Brillance
 
-< en:Henkel
-en: Bruynzeel
+< xx:Henkel
+xx: Bruynzeel
 
-< en:Henkel
-en: Bull Glue
+< xx:Henkel
+xx: Bull Glue
 
-< en:Henkel
-en: Bully
+< xx:Henkel
+xx: Bully
 
-< en:Henkel
-en: Cascola
+< xx:Henkel
+xx: Cascola
 
-< en:Henkel
-en: Catch
+< xx:Henkel
+xx: Catch
 
-< en:Henkel
-en: Ceresit
+< xx:Henkel
+xx: Ceresit
 
-< en:Henkel
-en: Ceresit Stop
+< xx:Henkel
+xx: Ceresit Stop
 
-< en:Henkel
-en: Cimsec
+< xx:Henkel
+xx: Cimsec
 
-< en:Henkel
-en: Clin
+< xx:Henkel
+xx: Clin
 
-< en:Henkel
-en: Clynol
+< xx:Henkel
+xx: Clynol
 
-< en:Henkel
-en: Cold Power
+< xx:Henkel
+xx: Cold Power
 
-< en:Henkel
-en: Color Mask
+< xx:Henkel
+xx: Color Mask
 
-< en:Henkel
-en: Color Ultîme
+< xx:Henkel
+xx: Color Ultîme
 
-< en:Henkel
-en: Coloria
+< xx:Henkel
+xx: Coloria
 
-< en:Henkel
-en: Combat
+< xx:Henkel
+xx: Combat
 
-< en:Henkel
-en: Conejo
+< xx:Henkel
+xx: Conejo
 
-< en:Henkel
-en: Country Colors
+< xx:Henkel
+xx: Country Colors
 
-< en:Henkel
-en: Croc Odor
+< xx:Henkel
+xx: Croc Odor
 
-< en:Henkel
-en: Cucal
+< xx:Henkel
+xx: Cucal
 
-< en:Henkel
-en: Dac
+< xx:Henkel
+xx: Dac
 
-< en:Henkel
-en: Dato
+< xx:Henkel
+xx: Dato
 
-< en:Henkel
-en: Deni
+< xx:Henkel
+xx: Deni
 
-< en:Henkel
-en: Denivit
+< xx:Henkel
+xx: Denivit
 
-< en:Henkel
-en: Der General
+< xx:Henkel
+xx: Der General
 
-< en:Henkel
-en: Diadem
+< xx:Henkel
+xx: Diadem
 
-< en:Henkel
-en: Diadermine
+< xx:Henkel
+xx: Diadermine
 
-< en:Henkel
-en: Diosa
+< xx:Henkel
+xx: Diosa
 
-< en:Henkel
-en: Dixan
+< xx:Henkel
+xx: Dixan
 
-< en:Henkel
-en: Dixan Piatti
+< xx:Henkel
+xx: Dixan Piatti
 
-< en:Henkel
-en: Dixi
+< xx:Henkel
+xx: Dixi
 
-< en:Henkel
-en: Doigts Nets
+< xx:Henkel
+xx: Doigts Nets
 
-< en:Henkel
-en: Drago
+< xx:Henkel
+xx: Drago
 
-< en:Henkel
-en: Dry Idea
+< xx:Henkel
+xx: Dry Idea
 
-< en:Henkel
-en: DumDum
+< xx:Henkel
+xx: DumDum
 
-< en:Henkel
-en: Dylon
+< xx:Henkel
+xx: Dylon
 
-< en:Henkel
-en: Dylon Colour Catcher
+< xx:Henkel
+xx: Dylon Colour Catcher
 
-< en:Henkel
-en: Dynamo
+< xx:Henkel
+xx: Dynamo
 
-< en:Henkel
-en: Décap’Four
+< xx:Henkel
+xx: Décap’Four
 
-< en:Henkel
-en: E
+< xx:Henkel
+xx: E
 
-< en:Henkel
-en: Eau Ecarlate
+< xx:Henkel
+xx: Eau Ecarlate
 
-< en:Henkel
-en: Econ
+< xx:Henkel
+xx: Econ
 
-< en:Henkel
-en: Eparcyl
+< xx:Henkel
+xx: Eparcyl
 
-< en:Henkel
-en: Essensity
+< xx:Henkel
+xx: Essensity
 
-< en:Henkel
-en: EstoSello
+< xx:Henkel
+xx: EstoSello
 
-< en:Henkel
-en: Estrella
+< xx:Henkel
+xx: Estrella
 
-< en:Henkel
-en: Fa
+< xx:Henkel
+xx: Fa
 
-< en:Henkel
-en: Fab
+< xx:Henkel
+xx: Fab
 
-< en:Henkel
-en: Fester
+< xx:Henkel
+xx: Fester
 
-< en:Henkel
-en: Fewa
+< xx:Henkel
+xx: Fewa
 
-< en:Henkel
-en: Fibreplex
+< xx:Henkel
+xx: Fibreplex
 
-< en:Henkel
-en: Fix Polvo
+< xx:Henkel
+xx: Fix Polvo
 
-< en:Henkel
-en: Fleuril
+< xx:Henkel
+xx: Fleuril
 
-< en:Henkel
-en: Freshlight
+< xx:Henkel
+xx: Freshlight
 
-< en:Henkel
-en: Furia
+< xx:Henkel
+xx: Furia
 
-< en:Henkel
-en: General
+< xx:Henkel
+xx: General
 
-< en:Henkel
-en: Gliss Kur
+< xx:Henkel
+xx: Gliss Kur
 
-< en:Henkel
-en: Globol
+< xx:Henkel
+xx: Globol
 
-< en:Henkel
-en: Grey
+< xx:Henkel
+xx: Grey
 
-< en:Henkel
-en: Guang Ming
+< xx:Henkel
+xx: Guang Ming
 
-< en:Henkel
-en: göt2b
+< xx:Henkel
+xx: göt2b
 
-< en:Henkel
-en: Haiermian
+< xx:Henkel
+xx: Haiermian
 
-< en:Henkel
-en: Havu Mäntysuopa
+< xx:Henkel
+xx: Havu Mäntysuopa
 
-< en:Henkel
-en: Home Mat & Home Keeper
+< xx:Henkel
+xx: Home Mat & Home Keeper
 
-< en:Henkel
-en: Hurricane
+< xx:Henkel
+xx: Hurricane
 
-< en:Henkel
-en: Häxan
+< xx:Henkel
+xx: Häxan
 
-< en:Henkel
-en: IBA
+< xx:Henkel
+xx: IBA
 
-< en:Henkel
-en: Igora
+< xx:Henkel
+xx: Igora
 
-< en:Henkel
-en: Indola
+< xx:Henkel
+xx: Indola
 
-< en:Henkel
-en: Instanet
+< xx:Henkel
+xx: Instanet
 
-< en:Henkel
-en: K2R
+< xx:Henkel
+xx: K2R
 
-< en:Henkel
-en: Kenra Professional
+< xx:Henkel
+xx: Kenra Professional
 
-< en:Henkel
-en: Keratin Color
+< xx:Henkel
+xx: Keratin Color
 
-< en:Henkel
-en: Kindness
+< xx:Henkel
+xx: Kindness
 
-< en:Henkel
-en: Kinsale Candles
+< xx:Henkel
+xx: Kinsale Candles
 
-< en:Henkel
-en: Kit Racines
+< xx:Henkel
+xx: Kit Racines
 
-< en:Henkel
-en: Konzil
+< xx:Henkel
+xx: Konzil
 
-< en:Henkel
-en: La Toja
+< xx:Henkel
+xx: La Toja
 
-< en:Henkel
-en: Laska
+< xx:Henkel
+xx: Laska
 
-< en:Henkel
-en: Le Chat
+< xx:Henkel
+xx: Le Chat
 
-< en:Henkel
-en: Le Chat
+< xx:Henkel
+xx: Le Chat
 
-< en:Henkel
-en: LePage
+< xx:Henkel
+xx: LePage
 
-< en:Henkel
-en: Licor del Polo
+< xx:Henkel
+xx: Licor del Polo
 
-< en:Henkel
-en: Live Color XXL
+< xx:Henkel
+xx: Live Color XXL
 
-< en:Henkel
-en: Lord Sheraton
+< xx:Henkel
+xx: Lord Sheraton
 
-< en:Henkel
-en: Losk
+< xx:Henkel
+xx: Losk
 
-< en:Henkel
-en: Lovables
+< xx:Henkel
+xx: Lovables
 
-< en:Henkel
-en: Magno
+< xx:Henkel
+xx: Magno
 
-< en:Henkel
-en: Makroflex
+< xx:Henkel
+xx: Makroflex
 
-< en:Henkel
-en: Mas
+< xx:Henkel
+xx: Mas
 
-< en:Henkel
-en: Men Perfect
+< xx:Henkel
+xx: Men Perfect
 
-< en:Henkel
-en: Metylan
+< xx:Henkel
+xx: Metylan
 
-< en:Henkel
-en: Micolor
+< xx:Henkel
+xx: Micolor
 
-< en:Henkel
-en: Million Color
+< xx:Henkel
+xx: Million Color
 
-< en:Henkel
-en: Mini Risk
+< xx:Henkel
+xx: Mini Risk
 
-< en:Henkel
-en: Minidou
+< xx:Henkel
+xx: Minidou
 
-< en:Henkel
-en: Mir
+< xx:Henkel
+xx: Mir
 
-< en:Henkel
-en: Miror
+< xx:Henkel
+xx: Miror
 
-< en:Henkel
-en: Mistol
+< xx:Henkel
+xx: Mistol
 
-< en:Henkel
-en: Moment
+< xx:Henkel
+xx: Moment
 
-< en:Henkel
-en: Natural & Easy
+< xx:Henkel
+xx: Natural & Easy
 
-< en:Henkel
-en: Natural Styling
+< xx:Henkel
+xx: Natural Styling
 
-< en:Henkel
-en: Nectra Color
+< xx:Henkel
+xx: Nectra Color
 
-< en:Henkel
-en: Nelsen
+< xx:Henkel
+xx: Nelsen
 
-< en:Henkel
-en: Neutrakal
+< xx:Henkel
+xx: Neutrakal
 
-< en:Henkel
-en: Neutrex
+< xx:Henkel
+xx: Neutrex
 
-< en:Henkel
-en: Neutromed
+< xx:Henkel
+xx: Neutromed
 
-< en:Henkel
-en: Nitromors
+< xx:Henkel
+xx: Nitromors
 
-< en:Henkel
-en: Nordic Blonde
+< xx:Henkel
+xx: Nordic Blonde
 
-< en:Henkel
-en: Novelle
+< xx:Henkel
+xx: Novelle
 
-< en:Henkel
-en: Opti
+< xx:Henkel
+xx: Opti
 
-< en:Henkel
-en: Osi
+< xx:Henkel
+xx: Osi
 
-< en:Henkel
-en: Osis+
+< xx:Henkel
+xx: Osis+
 
-< en:Henkel
-en: Oust Descalers
+< xx:Henkel
+xx: Oust Descalers
 
-< en:Henkel
-en: Palette
+< xx:Henkel
+xx: Palette
 
-< en:Henkel
-en: Paon Essence Rich
+< xx:Henkel
+xx: Paon Essence Rich
 
-< en:Henkel
-en: Pattex
+< xx:Henkel
+xx: Pattex
 
-< en:Henkel
-en: Pattex Chemoprén
+< xx:Henkel
+xx: Pattex Chemoprén
 
-< en:Henkel
-en: Pemolux
+< xx:Henkel
+xx: Pemolux
 
-< en:Henkel
-en: Pemos
+< xx:Henkel
+xx: Pemos
 
-< en:Henkel
-en: Perfax
+< xx:Henkel
+xx: Perfax
 
-< en:Henkel
-en: Perfect Mousse
+< xx:Henkel
+xx: Perfect Mousse
 
-< en:Henkel
-en: Perlan
+< xx:Henkel
+xx: Perlan
 
-< en:Henkel
-en: Perlana
+< xx:Henkel
+xx: Perlana
 
-< en:Henkel
-en: Persil
+< xx:Henkel
+xx: Persil
 
-< en:Henkel
-en: Pert
+< xx:Henkel
+xx: Pert
 
-< en:Henkel
-en: Perwoll
+< xx:Henkel
+xx: Perwoll
 
-< en:Henkel
-en: Plastic Padding
+< xx:Henkel
+xx: Plastic Padding
 
-< en:Henkel
-en: Poly Color Cream Hair Dye
+< xx:Henkel
+xx: Poly Color Cream Hair Dye
 
-< en:Henkel
-en: Poly Swing
+< xx:Henkel
+xx: Poly Swing
 
-< en:Henkel
-en: Polybit
+< xx:Henkel
+xx: Polybit
 
-< en:Henkel
-en: Ponal
+< xx:Henkel
+xx: Ponal
 
-< en:Henkel
-en: Pritt
+< xx:Henkel
+xx: Pritt
 
-< en:Henkel
-en: Punch
+< xx:Henkel
+xx: Punch
 
-< en:Henkel
-en: Punch Dishmatic
+< xx:Henkel
+xx: Punch Dishmatic
 
-< en:Henkel
-en: Pur
+< xx:Henkel
+xx: Pur
 
-< en:Henkel
-en: Renuzit
+< xx:Henkel
+xx: Renuzit
 
-< en:Henkel
-en: Resistol
+< xx:Henkel
+xx: Resistol
 
-< en:Henkel
-en: Rex
+< xx:Henkel
+xx: Rex
 
-< en:Henkel
-en: Right Guard
+< xx:Henkel
+xx: Right Guard
 
-< en:Henkel
-en: Rubson
+< xx:Henkel
+xx: Rubson
 
-< en:Henkel
-en: SK Men
+< xx:Henkel
+xx: SK Men
 
-< en:Henkel
-en: Sard Wonder
+< xx:Henkel
+xx: Sard Wonder
 
-< en:Henkel
-en: Schauma
+< xx:Henkel
+xx: Schauma
 
-< en:Henkel
-en: Scorpio
+< xx:Henkel
+xx: Scorpio
 
-< en:Henkel
-en: Seah
+< xx:Henkel
+xx: Seah
 
-< en:Henkel
-en: Sellotape
+< xx:Henkel
+xx: Sellotape
 
-< en:Henkel
-en: Septifos
+< xx:Henkel
+xx: Septifos
 
-< en:Henkel
-en: Sexy Hair
+< xx:Henkel
+xx: Sexy Hair
 
-< en:Henkel
-en: Sidol
+< xx:Henkel
+xx: Sidol
 
-< en:Henkel
-en: Silan
+< xx:Henkel
+xx: Silan
 
-< en:Henkel
-en: Silhouette
+< xx:Henkel
+xx: Silhouette
 
-< en:Henkel
-en: Sista
+< xx:Henkel
+xx: Sista
 
-< en:Henkel
-en: Smooth 'N Shine
+< xx:Henkel
+xx: Smooth 'N Shine
 
-< en:Henkel
-en: Sofix
+< xx:Henkel
+xx: Sofix
 
-< en:Henkel
-en: Soft Scrub
+< xx:Henkel
+xx: Soft Scrub
 
-< en:Henkel
-en: Solvite
+< xx:Henkel
+xx: Solvite
 
-< en:Henkel
-en: Somat
+< xx:Henkel
+xx: Somat
 
-< en:Henkel
-en: Sonasol
+< xx:Henkel
+xx: Sonasol
 
-< en:Henkel
-en: Spee
+< xx:Henkel
+xx: Spee
 
-< en:Henkel
-en: Spree
+< xx:Henkel
+xx: Spree
 
-< en:Henkel
-en: Strait Styling
+< xx:Henkel
+xx: Strait Styling
 
-< en:Henkel
-en: Super Croix
+< xx:Henkel
+xx: Super Croix
 
-< en:Henkel
-en: Supreme Keratin
+< xx:Henkel
+xx: Supreme Keratin
 
-< en:Henkel
-en: Supreme Selection
+< xx:Henkel
+xx: Supreme Selection
 
-< en:Henkel
-en: Taft
+< xx:Henkel
+xx: Taft
 
-< en:Henkel
-en: Tangit
+< xx:Henkel
+xx: Tangit
 
-< en:Henkel
-en: Tend
+< xx:Henkel
+xx: Tend
 
-< en:Henkel
-en: Tenn
+< xx:Henkel
+xx: Tenn
 
-< en:Henkel
-en: Teraxyl
+< xx:Henkel
+xx: Teraxyl
 
-< en:Henkel
-en: Teroson
+< xx:Henkel
+xx: Teroson
 
-< en:Henkel
-en: Terra
+< xx:Henkel
+xx: Terra
 
-< en:Henkel
-en: Theramed
+< xx:Henkel
+xx: Theramed
 
-< en:Henkel
-en: Tolu
+< xx:Henkel
+xx: Tolu
 
-< en:Henkel
-en: Tone
+< xx:Henkel
+xx: Tone
 
-< en:Henkel
-en: Unibond
+< xx:Henkel
+xx: Unibond
 
-< en:Henkel
-en: Vademecum
+< xx:Henkel
+xx: Vademecum
 
-< en:Henkel
-en: Vape
+< xx:Henkel
+xx: Vape
 
-< en:Henkel
-en: Vapona
+< xx:Henkel
+xx: Vapona
 
-< en:Henkel
-en: Vernel
+< xx:Henkel
+xx: Vernel
 
-< en:Henkel
-en: Vigor
+< xx:Henkel
+xx: Vigor
 
-< en:Henkel
-en: Viking
+< xx:Henkel
+xx: Viking
 
-< en:Henkel
-en: Vim
+< xx:Henkel
+xx: Vim
 
-< en:Henkel
-en: Viva
+< xx:Henkel
+xx: Viva
 
-< en:Henkel
-en: Vu
+< xx:Henkel
+xx: Vu
 
-< en:Henkel
-en: WC Frisch
+< xx:Henkel
+xx: WC Frisch
 
-< en:Henkel
-en: WD-40
+< xx:Henkel
+xx: WD-40
 
-< en:Henkel
-en: WK Ultra
+< xx:Henkel
+xx: WK Ultra
 
-< en:Henkel
-en: Weisser Riese
+< xx:Henkel
+xx: Weisser Riese
 
-< en:Henkel
-en: Wipp Express
+< xx:Henkel
+xx: Wipp Express
 
-< en:Henkel
-en: Witte Reus
+< xx:Henkel
+xx: Witte Reus
 
-< en:Henkel
-en: X-TRA
+< xx:Henkel
+xx: X-TRA
 
-< en:Henkel
-en: Xtreme
+< xx:Henkel
+xx: Xtreme
 
-< en:Henkel
-en: Zen’sect
+< xx:Henkel
+xx: Zen’sect
 
-< en:Henkel
-en: [3D]Men
+< xx:Henkel
+xx: [3D]Men
 
-en: Johnson & Johnson
-wikidata:en: Q333718
+xx: Johnson & Johnson
+wikidata:xx: Q333718
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Aveeno
-wikidata:en: Q4827975
+wikidata:xx: Q4827975
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Biafine
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Neutrogena
-wikidata:en: Q2451589
+wikidata:xx: Q2451589
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: RoC
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Compeed
-wikidata:en: Q20078703
+wikidata:xx: Q20078703
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Actifed
-wikidata:en: Q4676820
+wikidata:xx: Q4676820
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Nicorette
-wikidata:en: Q2566669
+wikidata:xx: Q2566669
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Hextril
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Listerine
-wikidata:en: Q944073
+wikidata:xx: Q944073
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Imodium
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Microlax
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Lansoÿl
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Titanoréine
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Laboratoires Vendôme
-wikidata:en: Q3214523
+wikidata:xx: Q3214523
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Le Petit Marseillais
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Prim'âge
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Vania
 
-< en:Johnson & Johnson
+< xx:Johnson & Johnson
 fr: Nett
 
-en: L'Oréal
-wikidata:en: Q156077
+xx: L'Oréal
+wikidata:xx: Q156077
 
-< en:L'Oréal
-en: LASCAD
-wikidata:en: Q21294908
+< xx:L'Oréal
+xx: LASCAD
+wikidata:xx: Q21294908
 
-< en:LASCAD
+< xx:LASCAD
 fr: Mixa
 
-< en:LASCAD
+< xx:LASCAD
 fr: Cadum
-wikidata:en: Q2932784
+wikidata:xx: Q2932784
 
-< en:LASCAD
+< xx:LASCAD
 fr: Narta
 
-< en:LASCAD
+< xx:LASCAD
 fr: Ushuaia
 
-< en:LASCAD
+< xx:LASCAD
 fr: Dop
 
-< en:LASCAD
+< xx:LASCAD
 fr: P’tit Dop
 
-< en:LASCAD
+< xx:LASCAD
 fr: Mennen
-wikidata:en: Q6817173
+wikidata:xx: Q6817173
 
-< en:LASCAD
+< xx:LASCAD
 fr: Dessange
 
-< en:LASCAD
+< xx:LASCAD
 fr: Franck Provost
 
-< en:LASCAD
+< xx:LASCAD
 fr: Jean–Louis David
 
-< en:LASCAD
+< xx:LASCAD
 fr: Vivelle Dop
 
-< en:LASCAD
+< xx:LASCAD
 fr: Daniel Hechter
 
-< en:LASCAD
+< xx:LASCAD
 fr: H pour HOMME
 
-< en:LASCAD
+< xx:LASCAD
 fr: Eau Jeune
 
-< en:LASCAD
+< xx:LASCAD
 fr: Gloria Vanderbilt
 
-< en:LASCAD
+< xx:LASCAD
 fr: Slava Zaïtsev
 
-< en:LASCAD
+< xx:LASCAD
 fr: Bien-être
 
-< en:LASCAD
+< xx:LASCAD
 fr: Savon le naturel
 
-< en:LASCAD
+< xx:LASCAD
 fr: Fluoryl
 
-< en:L'Oréal
-en: L'Oréal Professional products
+< xx:L'Oréal
+xx: L'Oréal Professional products
 
-< en:L'Oréal Professional products
-en: L'Oréal Technique
+< xx:L'Oréal Professional products
+xx: L'Oréal Technique
 
-< en:L'Oréal Professional products
-en: L'Oréal Professionnel
-wikidata:en: Q6455840
+< xx:L'Oréal Professional products
+xx: L'Oréal Professionnel
+wikidata:xx: Q6455840
 
-< en:L'Oréal Professional products
-en: ARTec
+< xx:L'Oréal Professional products
+xx: ARTec
 
-< en:L'Oréal Professional products
-en: Innate
+< xx:L'Oréal Professional products
+xx: Innate
 
-< en:L'Oréal Professional products
+< xx:L'Oréal Professional products
 fr: Kérastase
-wikidata:en: Q1999812
+wikidata:xx: Q1999812
 
-< en:L'Oréal Professional products
+< xx:L'Oréal Professional products
 fr: Kéraskin Esthetics
 
-< en:L'Oréal Professional products
-en: Matrix Essentials
+< xx:L'Oréal Professional products
+xx: Matrix Essentials
 
-< en:L'Oréal Professional products
-en: Mizani
+< xx:L'Oréal Professional products
+xx: Mizani
 
-< en:L'Oréal Professional products
-en: PureOlogy Research
-wikidata:en: Q7261179
+< xx:L'Oréal Professional products
+xx: PureOlogy Research
+wikidata:xx: Q7261179
 
-< en:L'Oréal Professional products
-en: Redken 5th Avenue NYC
-wikidata:en: Q7305998
+< xx:L'Oréal Professional products
+xx: Redken 5th Avenue NYC
+wikidata:xx: Q7305998
 
-< en:L'Oréal Professional products
-en: Shu Uemura Art of Hair
+< xx:L'Oréal Professional products
+xx: Shu Uemura Art of Hair
 
-< en:L'Oréal
-en: L'Oreal Luxe
+< xx:L'Oréal
+xx: L'Oreal Luxe
 
-< en:L'Oreal Luxe
-en: Lancôme
-wikidata:en: Q1541268
+< xx:L'Oreal Luxe
+xx: Lancôme
+wikidata:xx: Q1541268
 
-< en:L'Oreal Luxe
-en: YSL
+< xx:L'Oreal Luxe
+xx: YSL
 
-< en:L'Oreal Luxe
-en: Giorgio Armani
+< xx:L'Oreal Luxe
+xx: Giorgio Armani
 
-< en:L'Oreal Luxe
-en: Biotherm
-wikidata:en: Q2494771
+< xx:L'Oreal Luxe
+xx: Biotherm
+wikidata:xx: Q2494771
 
-< en:L'Oreal Luxe
-en: Cacharel
+< xx:L'Oreal Luxe
+xx: Cacharel
 
-< en:L'Oreal Luxe
-en: Diesel
+< xx:L'Oreal Luxe
+xx: Diesel
 
-< en:L'Oreal Luxe
-en: Maison Martin Margiela
+< xx:L'Oreal Luxe
+xx: Maison Martin Margiela
 
-< en:L'Oreal Luxe
-en: Viktor & Rolf
+< xx:L'Oreal Luxe
+xx: Viktor & Rolf
 
-< en:L'Oreal Luxe
-en: Ralph Lauren
+< xx:L'Oreal Luxe
+xx: Ralph Lauren
 
-< en:L'Oreal Luxe
-en: Kiehl's
-wikidata:en: Q3196447
+< xx:L'Oreal Luxe
+xx: Kiehl's
+wikidata:xx: Q3196447
 
-< en:L'Oreal Luxe
-en: The Body Shop
-wikidata:en: Q837851
+< xx:L'Oreal Luxe
+xx: The Body Shop
+wikidata:xx: Q837851
 
-< en:L'Oreal Luxe
-en: Shu Uemura
+< xx:L'Oreal Luxe
+xx: Shu Uemura
 
-< en:L'Oreal Luxe
-en: Stella McCartney
+< xx:L'Oreal Luxe
+xx: Stella McCartney
 
-< en:L'Oreal Luxe
-en: Clarisonic
-wikidata:en: Q5127056
+< xx:L'Oreal Luxe
+xx: Clarisonic
+wikidata:xx: Q5127056
 
-< en:L'Oreal Luxe
-en: Paloma Picasso
+< xx:L'Oreal Luxe
+xx: Paloma Picasso
 
-< en:L'Oreal Luxe
-en: Drakkar noir
-wikidata:en: Q5305669
+< xx:L'Oreal Luxe
+xx: Drakkar noir
+wikidata:xx: Q5305669
 
-< en:L'Oreal Luxe
-en: Urban Decay
-wikidata:en: Q153264
+< xx:L'Oreal Luxe
+xx: Urban Decay
+wikidata:xx: Q153264
 
-< en:L'Oreal Luxe
-en: Yue Sai
+< xx:L'Oreal Luxe
+xx: Yue Sai
 
-< en:L'Oreal Luxe
-en: Helena Rubinstein
-wikidata:en: Q3129665
+< xx:L'Oreal Luxe
+xx: Helena Rubinstein
+wikidata:xx: Q3129665
 
-< en:L'Oreal Luxe
-en: EM Michelle Phan
+< xx:L'Oreal Luxe
+xx: EM Michelle Phan
 
-< en:L'Oreal Luxe
-en: Decléor
-wikidata:en: Q16546558
+< xx:L'Oreal Luxe
+xx: Decléor
+wikidata:xx: Q16546558
 
-< en:L'Oréal
-en: L'Oreal Consumer products
+< xx:L'Oréal
+xx: L'Oreal Consumer products
 
-< en:L'Oreal Consumer products
-en: L’Oréal Paris
+< xx:L'Oreal Consumer products
+xx: L’Oréal Paris
 
-< en:L'Oreal Consumer products
-en: Ombrelle
+< xx:L'Oreal Consumer products
+xx: Ombrelle
 
-< en:L'Oreal Consumer products
-en: Garnier
-wikidata:en: Q599755
+< xx:L'Oreal Consumer products
+xx: Garnier
+wikidata:xx: Q599755
 
-< en:L'Oreal Consumer products
-en: Maybelline
-wikidata:en: Q1351054
+< xx:L'Oreal Consumer products
+xx: Maybelline
+wikidata:xx: Q1351054
 
-< en:L'Oreal Consumer products
-en: SoftSheen-Carson
-wikidata:en: Q10372938
+< xx:L'Oreal Consumer products
+xx: SoftSheen-Carson
+wikidata:xx: Q10372938
 
-< en:L'Oreal Consumer products
+< xx:L'Oreal Consumer products
 fr: Créateurs de Beauté
-wikidata:en: Q1809810
+wikidata:xx: Q1809810
 
-< en:L'Oreal Consumer products
-en: Essie
+< xx:L'Oreal Consumer products
+xx: Essie
 
-< en:L'Oreal Consumer products
-en: Magic
+< xx:L'Oreal Consumer products
+xx: Magic
 
-< en:L'Oreal
-en: L'Oreal Active cosmetics
+< xx:L'Oreal
+xx: L'Oreal Active cosmetics
 
-< en:L'Oreal Active cosmetics
+< xx:L'Oreal Active cosmetics
 fr: Vichy
-wikidata:en: Q2079719
+wikidata:xx: Q2079719
 
-< en:L'Oreal Active cosmetics
+< xx:L'Oreal Active cosmetics
 fr: La Roche Posay
-wikidata:en: Q1356442
+wikidata:xx: Q1356442
 
-< en:L'Oreal Active cosmetics
-en: Inneov
+< xx:L'Oreal Active cosmetics
+xx: Inneov
 
-< en:L'Oreal Active cosmetics
-en: Skinceuticals
-wikidata:en: Q7535296
+< xx:L'Oreal Active cosmetics
+xx: Skinceuticals
+wikidata:xx: Q7535296
 
-< en:L'Oreal Active cosmetics
+< xx:L'Oreal Active cosmetics
 fr: Roger & Gallet
-wikidata:en: Q3438623
+wikidata:xx: Q3438623
 
-< en:L'Oreal Active cosmetics
+< xx:L'Oreal Active cosmetics
 fr: Sanoflore
 
-< en:L'Oreal Active cosmetics
-en: Dermablend
+< xx:L'Oreal Active cosmetics
+xx: Dermablend
 
-< en:L'Oreal Active cosmetics
-en: EM Michelle Phan
+< xx:L'Oreal Active cosmetics
+xx: EM Michelle Phan
 
-en: Unilever
+xx: Unilever
 
-< en:Unilever
-en: Axe/Lynx
-wikidata:en: Q791930
+< xx:Unilever
+xx: Axe/Lynx
+wikidata:xx: Q791930
 
-< en:Unilever
-en: Bed Head
-wikidata:en: Q4878948
+< xx:Unilever
+xx: Bed Head
+wikidata:xx: Q4878948
 
-< en:Unilever
-en: Brylcreem
-wikidata:en: Q2337259
+< xx:Unilever
+xx: Brylcreem
+wikidata:xx: Q2337259
 
-< en:Unilever
-en: Degree
+< xx:Unilever
+xx: Degree
 
-< en:Unilever
-en: Dove
-wikidata:en: Q962709
+< xx:Unilever
+xx: Dove
+wikidata:xx: Q962709
 
-< en:Unilever
-en: Faberge
+< xx:Unilever
+xx: Faberge
 
-< en:Unilever
-en: Helene Curtis
+< xx:Unilever
+xx: Helene Curtis
 
-< en:Unilever
-en: Impulse
+< xx:Unilever
+xx: Impulse
 
-< en:Unilever
-en: Lakmé
-wikidata:en: Q6479731
+< xx:Unilever
+xx: Lakmé
+wikidata:xx: Q6479731
 
-< en:Unilever
-en: Lifebuoy
-wikidata:en: Q4244899
+< xx:Unilever
+xx: Lifebuoy
+wikidata:xx: Q4244899
 
-< en:Unilever
-en: Lux
+< xx:Unilever
+xx: Lux
 
-< en:Unilever
-en: Noxzema
-wikidata:en: Q7067326
+< xx:Unilever
+xx: Noxzema
+wikidata:xx: Q7067326
 
-< en:Unilever
-en: Pears soap
-wikidata:en: Q4046564
+< xx:Unilever
+xx: Pears soap
+wikidata:xx: Q4046564
 
-< en:Unilever
-en: Pepsodent
-wikidata:en: Q2709613
+< xx:Unilever
+xx: Pepsodent
+wikidata:xx: Q2709613
 
-< en:Unilever
-en: Pond's
+< xx:Unilever
+xx: Pond's
 
-< en:Unilever
-en: Prince Matchabelli
-wikidata:en: Q7244151
+< xx:Unilever
+xx: Prince Matchabelli
+wikidata:xx: Q7244151
 
-< en:Unilever
-en: Q-tips
+< xx:Unilever
+xx: Q-tips
 
-< en:Unilever
-en: Radox
-wikidata:en: Q7281681
+< xx:Unilever
+xx: Radox
+wikidata:xx: Q7281681
 
-< en:Unilever
-en: Rexona
-wikidata:en: Q1183694
+< xx:Unilever
+xx: Rexona
+wikidata:xx: Q1183694
 
-< en:Unilever
-en: Salon Selectives
-wikidata:en: Q7405676
+< xx:Unilever
+xx: Salon Selectives
+wikidata:xx: Q7405676
 
-< en:Unilever
-en: Signal
+< xx:Unilever
+xx: Signal
 
-< en:Unilever
-en: Simple
+< xx:Unilever
+xx: Simple
 
-< en:Unilever
-en: Suave
+< xx:Unilever
+xx: Suave
 
-< en:Unilever
-en: Sunsilk
-wikidata:en: Q596546
+< xx:Unilever
+xx: Sunsilk
+wikidata:xx: Q596546
 
-< en:Unilever
-en: Sure
+< xx:Unilever
+xx: Sure
 
-< en:Unilever
-en: Timotei
-wikidata:en: Q1997791
+< xx:Unilever
+xx: Timotei
+wikidata:xx: Q1997791
 
-< en:Unilever
-en: Twink
+< xx:Unilever
+xx: Twink
 
-< en:Unilever
-en: Vaseline
-wikidata:en: Q185120
+< xx:Unilever
+xx: Vaseline
+wikidata:xx: Q185120
 
-< en:Unilever
-en: zendium
+< xx:Unilever
+xx: zendium
 
-en: Shisheido
-wikidata:en: Q728185
+xx: Shisheido
+wikidata:xx: Q728185
 
-< en:Shisheido
-en: Aupres
+< xx:Shisheido
+xx: Aupres
 
-< en:Shisheido
-en: Ayura
+< xx:Shisheido
+xx: Ayura
 
-< en:Shisheido
-en: Bare Escentuals
+< xx:Shisheido
+xx: Bare Escentuals
 
-< en:Shisheido
-en: Beauté Prestige International
+< xx:Shisheido
+xx: Beauté Prestige International
 
-< en:Beauté Prestige International
+< xx:Beauté Prestige International
 fr: Jean-Paul Gaultier
 
-< en:Beauté Prestige International
-en: Issey Miyake
+< xx:Beauté Prestige International
+xx: Issey Miyake
 
-< en:Beauté Prestige International
-en: Narciso Rodriguez
+< xx:Beauté Prestige International
+xx: Narciso Rodriguez
 
-< en:Beauté Prestige International
-en: Elie Saab
+< xx:Beauté Prestige International
+xx: Elie Saab
 
-< en:Beauté Prestige International
+< xx:Beauté Prestige International
 fr: Azzedine Alaïa
 
-< en:Shisheido
+< xx:Shisheido
 fr: Clé de Peau
 
-< en:Shisheido
-en: d-program
+< xx:Shisheido
+xx: d-program
 
-< en:Shisheido
-en: Aqualabel
+< xx:Shisheido
+xx: Aqualabel
 
-< en:Shisheido
-en: Za
+< xx:Shisheido
+xx: Za
 
-< en:Shisheido
-en: IPSA
+< xx:Shisheido
+xx: IPSA
 
-< en:Shisheido
-en: ISO Hair
+< xx:Shisheido
+xx: ISO Hair
 
-< en:Shisheido
-en: Joico
+< xx:Shisheido
+xx: Joico
 
-< en:Shisheido
-en: NARS Cosmetics
-wikidata:en: Q3869356
+< xx:Shisheido
+xx: NARS Cosmetics
+wikidata:xx: Q3869356
 
-< en:Shisheido
-en: Qiora
+< xx:Shisheido
+xx: Qiora
 
-< en:Shisheido
-en: Revital
+< xx:Shisheido
+xx: Revital
 
-< en:Shisheido
-en: Senscience
+< xx:Shisheido
+xx: Senscience
 
-< en:Shisheido
+< xx:Shisheido
 fr: Serge Lutens
 
-< en:Shisheido
-en: UNO
+< xx:Shisheido
+xx: UNO
 
-< en:Shisheido
-en: UV White
+< xx:Shisheido
+xx: UV White
 
-< en:Shisheido
-en: Zotos International
+< xx:Shisheido
+xx: Zotos International
 


### PR DESCRIPTION
all brands must be in xx:

note that the current OBF brands taxonomy has parents for groups like Unilever and Henkel, which is probably not wanted