### PR TITLE
feat: reload element after complete nutrient element

### DIFF
--- a/html/js/off-webcomponents-utils.js
+++ b/html/js/off-webcomponents-utils.js
@@ -1,4 +1,5 @@
 /**
+
  * This is related to robotoff insight validation.
  *
  * It enables showing / hiding the div containing the web component with is_hidden css class.
@@ -6,20 +7,20 @@
  * @param {Event} eventToListenTo - Event emitted by the web-component,
  * with a state attribute. We react to "has-data" (show) and "annotated" (hide).
  * @param {string} elementId - The web component id.
- * @param {string} parentSelector - A web selector of the containing div.
+ * @param {object} options - Options.
+ * @param {string} options.parentSelector - A web selector of the containing div.
  * If omitted, we will only id the web-component.
- * @param {boolean} reloadOnAnnotated - If true, we reload the page when the insight is annotated.
+ * @param {boolean} options.reloadOnAnnotated - If true, we reload the page when the insight is annotated.
  * @returns {void}
  */
 window.listenEventToShowHideAlert = function (
   eventToListenTo,
   elementId,
-  parentSelector,
-  reloadOnAnnotated = false
+  options = {}
 ) {
   const element = document.getElementById(elementId);
-  const parentElement = parentSelector
-    ? document.querySelector(parentSelector)
+  const parentElement = options.parentSelector
+    ? document.querySelector(options.parentSelector)
     : element.parentElement;
   parentElement.classList.add("is_hidden");
   element.addEventListener(eventToListenTo, (event) => {
@@ -27,7 +28,7 @@ window.listenEventToShowHideAlert = function (
       parentElement.classList.remove("is_hidden");
     } else if (event.detail.state === "annotated") {
       // reload the page to show the new insight
-      if (reloadOnAnnotated) {
+      if (options.reloadOnAnnotated) {
         window.location.reload();
       } else {
         // hide the element after 3 seconds

--- a/templates/web/common/includes/robotoff_nutrients.tt.html
+++ b/templates/web/common/includes/robotoff_nutrients.tt.html
@@ -18,12 +18,10 @@
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     // display the section only if we have data to validate
-    window.listenEventToShowHideAlert(
-      "nutrient-state",
-      "robotoff-nutrients",
-      "#row-nutrients",
-      true
-    );
+    window.listenEventToShowHideAlert("nutrient-state", "robotoff-nutrients", {
+      parentSelector: "#row-nutrients",
+      reloadOnAnnotated: true,
+    });
   });
 </script>
 


### PR DESCRIPTION
<!-- IMPORTANT CHECKLIST
Make sure you've done all the following (You can delete the checklist before submitting)
- [x] PR title is prefixed by one of the following: feat, fix, docs, style, refactor, test, build, ci, chore, revert, l10n, taxonomy
- [x] Code is well documented
- [x] Include unit tests for new functionality
- [x] Code passes GitHub workflow checks in your branch
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)
-->
### What

- Reload page after submit nutrients

### Related issue(s) and discussion
- https://openfoodfacts.slack.com/archives/CF0286BRQ/p1743173876711409?thread_ts=1743173291.345609&cid=CF0286BRQ
