### PR TITLE
refactor: Update allergens tests

### DIFF
--- a/tests/unit/allergens.t
+++ b/tests/unit/allergens.t
@@ -8,549 +8,368 @@ use Data::Dumper;
 $Data::Dumper::Terse = 1;
 $Data::Dumper::Sortkeys = 1;
 use Log::Any::Adapter 'TAP';
+use JSON;
 
 use ProductOpener::Products qw/compute_languages/;
 use ProductOpener::Tags qw/:all/;
 use ProductOpener::Ingredients qw/detect_allergens_from_text get_allergens_taxonomyid/;
+use ProductOpener::Test qw/compare_to_expected_results init_expected_results/;
 
-# dummy product for testing
+my ($test_id, $test_dir, $expected_result_dir, $update_expected_results) = (init_expected_results(__FILE__));
 
-my $product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr =>
-		"Eau, LAIT, farine de BLE, sucre, sel, _oeufs_, moutarde, _crustacés_, fruits à coque, _céleri_, POISSON, crème de cassis. Contient mollusques. Peut contenir des traces d'arachide, de _soja_, de LUPIN, et de sésame "
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is(
-	$product_ref->{allergens_tags},
+my @tests = (
+	# French basic allergens test
 	[
-		'en:celery', 'en:crustaceans', 'en:eggs', 'en:fish', 'en:gluten', 'en:milk',
-		'en:molluscs', 'en:mustard', 'en:nuts',
-	]
-) || diag Dumper($product_ref->{allergens_tags});
+		'fr-basic-allergens',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr =>
+				"Eau, LAIT, farine de BLE, sucre, sel, _oeufs_, moutarde, _crustacés_, fruits à coque, _céleri_, POISSON, crème de cassis. Contient mollusques. Peut contenir des traces d'arachide, de _soja_, de LUPIN, et de sésame "
+		}
+	],
 
-is($product_ref->{traces_tags}, ['en:lupin', 'en:peanuts', 'en:sesame-seeds', 'en:soybeans',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Farine (blé), graines [sésame], condiments (moutarde), sucre de canne, lait de coco"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ["en:gluten", "en:mustard", "en:sesame-seeds",]);
-
-is($product_ref->{traces_tags}, []);
-
-is($product_ref->{ingredients_text_with_allergens_fr},
-	'Farine (<span class="allergen">blé</span>), graines [<span class="allergen">sésame</span>], condiments (<span class="allergen">moutarde</span>), sucre de canne, lait de coco'
-);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr =>
-		"Farine de blé et de lupin, épices (soja, moutarde et céleri), crème de cassis, traces de fruits à coques, d'arachide et de poisson"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ["en:celery", "en:gluten", "en:lupin", "en:mustard", "en:soybeans",]);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{traces_tags}, ["en:fish", "en:nuts", "en:peanuts",]);
-
-is($product_ref->{ingredients_text_with_allergens_fr},
-	'Farine de <span class="allergen">blé</span> et de <span class="allergen">lupin</span>, épices (<span class="allergen">soja</span>, <span class="allergen">moutarde</span> et <span class="allergen">céleri</span>), crème de cassis, traces de <span class="allergen">fruits à coques</span>, d\'<span class="allergen">arachide</span> et de <span class="allergen">poisson</span>'
-);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr =>
-		"Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de blé, sel, amidon de maïs), mozzarella 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, lactose, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté.",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:milk',]);
-
-is($product_ref->{traces_tags}, []);
-
-is($product_ref->{ingredients_text_with_allergens_fr},
-	'Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de <span class="allergen">blé</span>, sel, amidon de maïs), <span class="allergen">mozzarella</span> 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, <span class="allergen">lactose</span>, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté.'
-);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr =>
-		"Traces éventuelles de céréales contenant du gluten, fruits à coques, arachide, soja et oeuf.",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, []);
-
-is($product_ref->{traces_tags}, ['en:eggs', 'en:gluten', 'en:nuts', 'en:peanuts', 'en:soybeans',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Noix de Saint-Jacques"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:molluscs',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Noix de St-Jacques"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:molluscs',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Saint Jacques"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:molluscs',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "St Jacques"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:molluscs',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Farine de blé 97%"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:gluten',]);
-
-is($product_ref->{ingredients_text_with_allergens_fr}, 'Farine de <span class="allergen">blé</span> 97%');
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Farine de blé 97%"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:gluten',]);
-
-is($product_ref->{ingredients_text_with_allergens_fr}, 'Farine de <span class="allergen">blé</span> 97%');
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr => "Farine de blé 97%",
-	allergens => "Sulfites",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper($product_ref->{allergens_tags});
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:sulphur-dioxide-and-sulphites',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	ingredients_text_fr =>
-		"farine de graines de moutarde, 100 % semoule de BLE dur de qualité supérieure Traces éventuelles d'oeufs",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:mustard',]);
-
-is($product_ref->{traces_tags}, ['en:eggs',]);
-
-$product_ref = {
-	lc => "fr",
-	lang => "fr",
-	allergens => "Lait de vache, autres fruits à coque, autres céréales contenant du gluten",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:milk', 'en:nuts',]);
-
-#Finnish
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi =>
-		"Vesi, MAITO, VEHNÄjauho, sokeri, suola, _kananmunat_, sinappi, _äyriäiset_, pähkinöitä, _selleri_, KALA, _nilviäisiä_. Saattaa sisältää pieniä määriä LUPIINEJA, maapähkinöitä, _soijaa_ ja seesamia "
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper $product_ref->{allergens_tags};
-
-is(
-	$product_ref->{allergens_tags},
+	# French ingredients with allergens
 	[
-		'en:celery', 'en:crustaceans', 'en:eggs', 'en:fish', 'en:gluten', 'en:milk',
-		'en:molluscs', 'en:mustard', 'en:nuts',
+		'fr-ingredients-allergens',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "Farine (blé), graines [sésame], condiments (moutarde), sucre de canne, lait de coco"
+		}
+	],
+
+	# French multiple allergens
+	[
+		'fr-multiple-allergens',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr =>
+				"Farine de blé et de lupin, épices (soja, moutarde et céleri), crème de cassis, traces de fruits à coques, d'arachide et de poisson"
+		}
+	],
+
+	# French pizza ingredients
+	[
+		'fr-pizza-ingredients',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr =>
+				"Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de blé, sel, amidon de maïs), mozzarella 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, lactose, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté."
+		}
+	],
+
+	# French traces
+	[
+		'fr-traces',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr =>
+				"Traces éventuelles de céréales contenant du gluten, fruits à coques, arachide, soja et oeuf."
+		}
+	],
+
+	# French scallops
+	[
+		'fr-noix-saint-jacques',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "Noix de Saint-Jacques"
+		}
+	],
+
+	# French scallops abbreviated
+	[
+		'fr-noix-st-jacques',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "Noix de St-Jacques"
+		}
+	],
+
+	# French scallops without "noix"
+	[
+		'fr-saint-jacques',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "Saint Jacques"
+		}
+	],
+
+	# French scallops abbreviated without "noix"
+	[
+		'fr-st-jacques',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "St Jacques"
+		}
+	],
+
+	# French wheat flour
+	[
+		'fr-farine-ble',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "Farine de blé 97%"
+		}
+	],
+
+	# French wheat flour with allergens in allergens field
+	[
+		'fr-farine-ble-sulfites',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr => "Farine de blé 97%",
+			allergens => "Sulfites"
+		}
+	],
+
+	# French multiple allergens with traces
+	[
+		'fr-moutarde-ble-traces-oeufs',
+		{
+			lc => "fr",
+			lang => "fr",
+			ingredients_text_fr =>
+				"farine de graines de moutarde, 100 % semoule de BLE dur de qualité supérieure Traces éventuelles d'oeufs"
+		}
+	],
+
+	# French allergens field only
+	[
+		'fr-allergens-field-only',
+		{
+			lc => "fr",
+			lang => "fr",
+			allergens => "Lait de vache, autres fruits à coque, autres céréales contenant du gluten"
+		}
+	],
+
+	# Finnish basic allergens
+	[
+		'fi-basic-allergens',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi =>
+				"Vesi, MAITO, VEHNÄjauho, sokeri, suola, _kananmunat_, sinappi, _äyriäiset_, pähkinöitä, _selleri_, KALA, _nilviäisiä_. Saattaa sisältää pieniä määriä LUPIINEJA, maapähkinöitä, _soijaa_ ja seesamia "
+		}
+	],
+
+	# Finnish ingredients with allergens
+	[
+		'fi-ingredients-allergens',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi => "Jauho (vehnä), siemenet [seesami], mausteet (sinappi), ruokosokeri, kookosmaito"
+		}
+	],
+
+	# Finnish multiple allergens with traces
+	[
+		'fi-multiple-allergens-traces',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi =>
+				"vehnä ja lupiinijauho, mausteet (soija, sinappi ja selleri), saattaa sisältää pieniä määriä pähkinöitä, maapähkinöitä ja kalaa"
+		}
+	],
+
+	# Finnish pizza ingredients
+	[
+		'fi-pizza-ingredients',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi =>
+				"Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, vehnäjauho, suola, maissitärkkelys), mozzarella 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, laktoosi, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano."
+		}
+	],
+
+	# Finnish traces
+	[
+		'fi-traces',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi =>
+				"Saattaa sisältää muita gluteenia sisältäviä viljoja, pähkinöitä, maapähkinöitä, soijaa ja kananmunia."
+		}
+	],
+
+	# Finnish wheat flour
+	[
+		'fi-vehnajauho',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi => "vehnäjauho 97%"
+		}
+	],
+
+	# Finnish wheat flour with allergens in allergens field
+	[
+		'fi-vehnajauho-sulfiitteja',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi => "vehnäjauho 97%",
+			allergens => "Sulfiitteja"
+		}
+	],
+
+	# Finnish mustard and wheat with traces of eggs
+	[
+		'fi-sinappi-vehna-kananmuna',
+		{
+			lc => "fi",
+			lang => "fi",
+			ingredients_text_fi => "sinappijauhe, VEHNÄsuurimo. Saattaa sisältää kananmunaa"
+		}
+	],
+
+	# Finnish allergens field only
+	[
+		'fi-allergens-field-only',
+		{
+			lc => "fi",
+			lang => "fi",
+			allergens => "Lehmänmaito, pähkinöitä, gluteenia sisältäviä viljoja."
+		}
+	],
+
+	# French allergens with markup styles
+	[
+		'fr-allergens-markup',
+		{
+			lc => "fr",
+			ingredients_text_fr => "Eau, BLE, _CELERI_, __GLUTEN__, _poisson_, FRAISE, _banane_, lupin, _mollusque_"
+		}
+	],
+
+	# French salmon not highlighted
+	[
+		'fr-salmon-not-highlighted',
+		{
+			lc => "fr",
+			ingredients_text_fr => "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)"
+		}
+	],
+
+	# French allergens in ingredients and separate field
+	[
+		'fr-allergens-ingredients-and-field',
+		{
+			lc => "fr",
+			ingredients_text_fr => "Saumon, oeufs, blé, chocolat",
+			allergens => "Moutarde. Traces éventuelles de lupin"
+		}
+	],
+
+	# French allergens and traces in separate fields
+	[
+		'fr-allergens-traces-fields',
+		{
+			lc => "fr",
+			ingredients_text_fr => "Filet de saumon sauvage",
+			allergens => "Céleri, crustacés et lupin. Peut contenir du soja, des sulfites et de la moutarde.",
+			traces => "Oeufs"
+		}
+	],
+
+	# French allergens uppercase format
+	[
+		'fr-allergens-uppercase',
+		{
+			lc => "fr",
+			allergens =>
+				"GLUTEN. TRACES POTENTIELLES: CRUSTACÉS, ŒUFS, POISSONS, SOJA, LAIT, FRUITS À COQUES, CÉLERI, MOUTARDE ET SULFITES."
+		}
+	],
+
+	# English oat flakes
+	[
+		'en-oat-flakes',
+		{
+			lc => "en",
+			lang => "en",
+			ingredients_text_en => "Whole Grain Oat Flakes (65.0%)"
+		}
+	],
+
+	# German with underscores
+	[
+		'de-underscores',
+		{
+			lc => "de",
+			lang => "de",
+			ingredients_text_de =>
+				"Seitan 65% (_Weizen_eiweiß, Wasser), Rapsöl, Kidneybohnen, _Dinkel_vollkornmehl (_Weizen_art), Apfelessig, Gewürze, Tomatenmark, _Soja_soße (Wasser, _Soja_bohnen, Salz, _Weizen_mehl), Kartoffelstärke, Salz."
+		}
+	],
+
+	# French salmon allergens and multiple traces
+	[
+		'fr-saumon-allergens-multiple-traces',
+		{
+			lc => "fr",
+			ingredients_text_fr =>
+				"Filet de saumon* 93%, jus de citron* 5%, sel marin, poivre*. *Ingrédients issus de l'agriculture biologique. Traces possibles de crustacés, mollusques, lait et gluten.",
+			allergens => "poisson",
+			traces => "crustacés, mollusques, lait, gluten"
+		}
 	]
-) || diag Dumper $product_ref->{allergens_tags};
-
-is($product_ref->{traces_tags}, ['en:lupin', 'en:peanuts', 'en:sesame-seeds', 'en:soybeans',]);
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi => "Jauho (vehnä), siemenet [seesami], mausteet (sinappi), ruokosokeri, kookosmaito"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ["en:gluten", "en:mustard", "en:sesame-seeds",]);
-
-is($product_ref->{traces_tags}, []);
-
-is($product_ref->{ingredients_text_with_allergens_fi},
-	'Jauho (<span class="allergen">vehnä</span>), siemenet [<span class="allergen">seesami</span>], mausteet (<span class="allergen">sinappi</span>), ruokosokeri, kookosmaito'
 );
 
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi =>
-		"vehnä ja lupiinijauho, mausteet (soija, sinappi ja selleri), saattaa sisältää pieniä määriä pähkinöitä, maapähkinöitä ja kalaa"
-};
+foreach my $test_ref (@tests) {
+	my $testid = $test_ref->[0];
+	my $product_ref = $test_ref->[1];
 
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
+	# Run the test
+	compute_languages($product_ref);
+	detect_allergens_from_text($product_ref);
 
-is($product_ref->{allergens_tags}, ["en:celery", "en:gluten", "en:lupin", "en:mustard", "en:soybeans",]);
-
-diag Dumper $product_ref->{allergens_tags};
-
-is($product_ref->{traces_tags}, ["en:fish", "en:nuts", "en:peanuts",]);
-
-is($product_ref->{ingredients_text_with_allergens_fi},
-	'<span class="allergen">vehnä</span> ja <span class="allergen">lupiinijauho</span>, mausteet (<span class="allergen">soija</span>, <span class="allergen">sinappi</span> ja <span class="allergen">selleri</span>), saattaa sisältää pieniä määriä <span class="allergen">pähkinöitä</span>, <span class="allergen">maapähkinöitä</span> ja <span class="allergen">kalaa</span>'
-);
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi =>
-		"Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, vehnäjauho, suola, maissitärkkelys), mozzarella 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, laktoosi, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano.",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:milk',]);
-
-is($product_ref->{traces_tags}, []);
-
-is($product_ref->{ingredients_text_with_allergens_fi},
-	'Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, <span class="allergen">vehnäjauho</span>, suola, maissitärkkelys), <span class="allergen">mozzarella</span> 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, <span class="allergen">laktoosi</span>, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano.'
-);
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi =>
-		"Saattaa sisältää muita gluteenia sisältäviä viljoja, pähkinöitä, maapähkinöitä, soijaa ja kananmunia.",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, []);
-
-is($product_ref->{traces_tags}, ['en:eggs', 'en:gluten', 'en:nuts', 'en:peanuts', 'en:soybeans',]);
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi => "vehnäjauho 97%"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper $product_ref->{allergens_tags};
-
-is($product_ref->{allergens_tags}, ['en:gluten',]);
-
-is($product_ref->{ingredients_text_with_allergens_fi}, '<span class="allergen">vehnäjauho</span> 97%');
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi => "vehnäjauho 97%",
-	allergens => "Sulfiitteja",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper $product_ref->{allergens_tags};
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:sulphur-dioxide-and-sulphites',]);
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	ingredients_text_fi => "sinappijauhe, VEHNÄsuurimo. Saattaa sisältää kananmunaa",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:mustard',]);
-
-is($product_ref->{traces_tags}, ['en:eggs',]);
-
-$product_ref = {
-	lc => "fi",
-	lang => "fi",
-	allergens => "Lehmänmaito, pähkinöitä, gluteenia sisältäviä viljoja.",
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:milk', 'en:nuts',]);
-
-$product_ref = {
-	lc => "fr",
-	ingredients_text_fr => "Eau, BLE, _CELERI_, __GLUTEN__, _poisson_, FRAISE, _banane_, lupin, _mollusque_"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-is($product_ref->{ingredients_text_with_allergens_fr},
-	'Eau, <span class="allergen">BLE</span>, <span class="allergen">CELERI</span>, <span class="allergen">GLUTEN</span>, <span class="allergen">poisson</span>, FRAISE, <span class="allergen">banane</span>, <span class="allergen">lupin</span>, <span class="allergen">mollusque</span>'
-);
-
-$product_ref = {
-	lc => "fr",
-	ingredients_text_fr => "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
-};
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{ingredients_text_with_allergens_fr},
-	"Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)")
-	or diag Dumper $product_ref;
-
-$product_ref = {
-	lc => "fr",
-	ingredients_text_fr => "Saumon, oeufs, blé, chocolat",
-	allergens => "Moutarde. Traces éventuelles de lupin"
-};
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-delete($product_ref->{allergens_from_user});
-delete($product_ref->{traces_from_user});
-is(
-	$product_ref,
-	{
-		'allergens' => 'en:mustard',
-		'allergens_from_ingredients' => "Saumon, oeufs, bl\x{e9}",
-		'allergens_hierarchy' => ['en:eggs', 'en:fish', 'en:gluten', 'en:mustard'],
-		'allergens_tags' => ['en:eggs', 'en:fish', 'en:gluten', 'en:mustard'],
-		'ingredients_lc' => 'fr',
-		'ingredients_text' => "Saumon, oeufs, bl\x{e9}, chocolat",
-		'ingredients_text_fr' => "Saumon, oeufs, bl\x{e9}, chocolat",
-		'ingredients_text_with_allergens' =>
-			"<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">bl\x{e9}</span>, chocolat",
-		'ingredients_text_with_allergens_fr' =>
-			"<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">bl\x{e9}</span>, chocolat",
-		'languages' => {
-			'en:french' => 1
-		},
-		'languages_codes' => {
-			'fr' => 1
-		},
-		'languages_hierarchy' => ['en:french'],
-		'languages_tags' => ['en:french', 'en:1'],
-		'lc' => 'fr',
-		'traces' => 'en:lupin',
-		'traces_from_ingredients' => '',
-		'traces_hierarchy' => ['en:lupin'],
-		'traces_tags' => ['en:lupin']
+	# Remove any user-specific fields that might cause test failures
+	if (exists $product_ref->{allergens_from_user}) {
+		delete $product_ref->{allergens_from_user};
+	}
+	if (exists $product_ref->{traces_from_user}) {
+		delete $product_ref->{traces_from_user};
 	}
 
-) or diag Dumper $product_ref;
+	# Compare with expected results
+	compare_to_expected_results($product_ref, "$expected_result_dir/$testid.json", $update_expected_results);
+}
 
-$product_ref = {
-	lc => "fr",
-	ingredients_text_fr => "Filet de saumon sauvage",
-	allergens => "Céleri, crustacés et lupin. Peut contenir du soja, des sulfites et de la moutarde.",
-	traces => "Oeufs"
-};
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-delete($product_ref->{allergens_from_user});
-delete($product_ref->{traces_from_user});
+# Additional tests for get_allergens_taxonomyid
+is(get_allergens_taxonomyid("en", "egg"), "en:eggs", "Testing get_allergens_taxonomyid for egg (en)");
+is(get_allergens_taxonomyid("fr", "fromage"), "en:milk", "Testing get_allergens_taxonomyid for fromage (fr)");
+is(get_allergens_taxonomyid("en", "tuna"), "en:fish", "Testing get_allergens_taxonomyid for tuna (en)");
 
-is(
-	$product_ref,
-	{
-		'allergens' => "en:celery,en:crustaceans,en:lupin",
-		'allergens_from_ingredients' => '',
-		'allergens_hierarchy' => ['en:celery', 'en:crustaceans', 'en:lupin'],
-		'allergens_tags' => ['en:celery', 'en:crustaceans', 'en:lupin'],
-		'ingredients_lc' => 'fr',
-		'ingredients_text' => 'Filet de saumon sauvage',
-		'ingredients_text_fr' => 'Filet de saumon sauvage',
-		'ingredients_text_with_allergens' => 'Filet de saumon sauvage',
-		'ingredients_text_with_allergens_fr' => 'Filet de saumon sauvage',
-		'languages' => {
-			'en:french' => 1
-		},
-		'languages_codes' => {
-			'fr' => 1
-		},
-		'languages_hierarchy' => ['en:french'],
-		'languages_tags' => ['en:french', 'en:1'],
-		'lc' => 'fr',
-		'traces' => 'en:eggs,en:mustard,en:soybeans,en:sulphur-dioxide-and-sulphites',
-		'traces_from_ingredients' => '',
-		'traces_hierarchy' => ['en:eggs', 'en:mustard', 'en:soybeans', 'en:sulphur-dioxide-and-sulphites'],
-		'traces_tags' => ['en:eggs', 'en:mustard', 'en:soybeans', 'en:sulphur-dioxide-and-sulphites']
-	}
-
-) or diag Dumper $product_ref;
-
-$product_ref = {
-	lc => "fr",
-	allergens =>
-		"GLUTEN. TRACES POTENTIELLES: CRUSTACÉS, ŒUFS, POISSONS, SOJA, LAIT, FRUITS À COQUES, CÉLERI, MOUTARDE ET SULFITES.",
-};
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-delete($product_ref->{ingredients_text_fr});
-delete($product_ref->{allergens_from_user});
-delete($product_ref->{traces_from_user});
-
-is(
-	$product_ref,
-	{
-		'allergens' => 'en:gluten',
-		'allergens_from_ingredients' => '',
-		'allergens_hierarchy' => ['en:gluten'],
-		'allergens_tags' => ['en:gluten'],
-		'languages' => {},
-		'languages_codes' => {},
-		'languages_hierarchy' => [],
-		'languages_tags' => ['en:0'],
-		'lc' => 'fr',
-		'traces' =>
-			"en:celery,en:crustaceans,en:eggs,en:fish,en:milk,en:mustard,en:nuts,en:soybeans,en:sulphur-dioxide-and-sulphites",
-		'traces_from_ingredients' => '',
-		'traces_hierarchy' => [
-			'en:celery', 'en:crustaceans', 'en:eggs', 'en:fish', 'en:milk', 'en:mustard', 'en:nuts', 'en:soybeans',
-			'en:sulphur-dioxide-and-sulphites'
-		],
-		'traces_tags' => [
-			'en:celery', 'en:crustaceans', 'en:eggs', 'en:fish', 'en:milk', 'en:mustard', 'en:nuts', 'en:soybeans',
-			'en:sulphur-dioxide-and-sulphites'
-		]
-	}
-) or diag Dumper $product_ref;
-
-# bug https://github.com/openfoodfacts/openfoodfacts-server/issues/4365
-
-$product_ref = {
-	lc => "en",
-	lang => "en",
-	ingredients_text_en => "Whole Grain Oat Flakes (65.0%)"
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-is($product_ref->{ingredients_text_with_allergens_en}, "Whole Grain Oat Flakes (65.0%)");
-
-# German and underscores, see issue #8386
-$product_ref = {
-	lc => "de",
-	lang => "de",
-	ingredients_text_de =>
-		"Seitan 65% (_Weizen_eiweiß, Wasser), Rapsöl, Kidneybohnen, _Dinkel_vollkornmehl (_Weizen_art), Apfelessig, Gewürze, Tomatenmark, _Soja_soße (Wasser, _Soja_bohnen, Salz, _Weizen_mehl), Kartoffelstärke, Salz."
-};
-
-compute_languages($product_ref);
-detect_allergens_from_text($product_ref);
-
-diag Dumper $product_ref->{allergens_tags};
-
-is($product_ref->{allergens_tags}, ['en:gluten', 'en:soybeans',]) || diag Dumper $product_ref->{allergens_tags};
-
-# Get an allergens id from the allergens taxonomy
-is(get_allergens_taxonomyid("en", "egg"), "en:eggs");
-is(get_allergens_taxonomyid("fr", "fromage"), "en:milk");
-is(get_allergens_taxonomyid("en", "tuna"), "en:fish");
 # Get an allergens id from the ingredients taxonomy, using the allergens:en: property
-is(get_allergens_taxonomyid("en", "monkfish"), "en:fish");
-is(get_allergens_taxonomyid("en", "en:monkfish"), "en:fish");
-is(get_allergens_taxonomyid("es", "en:monkfish"), "en:fish");
+is(get_allergens_taxonomyid("en", "monkfish"), "en:fish", "Testing get_allergens_taxonomyid for monkfish (en)");
+is(get_allergens_taxonomyid("en", "en:monkfish"), "en:fish", "Testing get_allergens_taxonomyid for en:monkfish (en)");
+is(get_allergens_taxonomyid("es", "en:monkfish"), "en:fish", "Testing get_allergens_taxonomyid for en:monkfish (es)");
+
 # Ingredients that are not in the allergens taxonomy
-is(get_allergens_taxonomyid("en", "pineapple"), "pineapple");
-# Ingredients that are not the ingredients taxonomy
-is(get_allergens_taxonomyid("en", "some very strange ingredient"), "some-very-strange-ingredient");
+is(get_allergens_taxonomyid("en", "pineapple"), "pineapple", "Testing get_allergens_taxonomyid for pineapple (en)");
+
+# Ingredients that are not in the ingredients taxonomy
+is(
+	get_allergens_taxonomyid("en", "some very strange ingredient"),
+	"some-very-strange-ingredient",
+	"Testing get_allergens_taxonomyid for strange ingredient (en)"
+);
 
 done_testing();

--- a/tests/unit/expected_test_results/allergens/de-underscores.json
+++ b/tests/unit/expected_test_results/allergens/de-underscores.json
@@ -1,0 +1,36 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "Weizen, Dinkel, Weizen, Soja, Soja, Weizen",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:soybeans"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:soybeans"
+   ],
+   "ingredients_lc" : "de",
+   "ingredients_text" : "Seitan 65% (_Weizen_eiweiß, Wasser), Rapsöl, Kidneybohnen, _Dinkel_vollkornmehl (_Weizen_art), Apfelessig, Gewürze, Tomatenmark, _Soja_soße (Wasser, _Soja_bohnen, Salz, _Weizen_mehl), Kartoffelstärke, Salz.",
+   "ingredients_text_de" : "Seitan 65% (_Weizen_eiweiß, Wasser), Rapsöl, Kidneybohnen, _Dinkel_vollkornmehl (_Weizen_art), Apfelessig, Gewürze, Tomatenmark, _Soja_soße (Wasser, _Soja_bohnen, Salz, _Weizen_mehl), Kartoffelstärke, Salz.",
+   "ingredients_text_with_allergens" : "Seitan 65% (<span class=\"allergen\">Weizen</span>eiweiß, Wasser), Rapsöl, Kidneybohnen, <span class=\"allergen\">Dinkel</span>vollkornmehl (<span class=\"allergen\">Weizen</span>art), Apfelessig, Gewürze, Tomatenmark, <span class=\"allergen\">Soja</span>soße (Wasser, <span class=\"allergen\">Soja</span>bohnen, Salz, <span class=\"allergen\">Weizen</span>mehl), Kartoffelstärke, Salz.",
+   "ingredients_text_with_allergens_de" : "Seitan 65% (<span class=\"allergen\">Weizen</span>eiweiß, Wasser), Rapsöl, Kidneybohnen, <span class=\"allergen\">Dinkel</span>vollkornmehl (<span class=\"allergen\">Weizen</span>art), Apfelessig, Gewürze, Tomatenmark, <span class=\"allergen\">Soja</span>soße (Wasser, <span class=\"allergen\">Soja</span>bohnen, Salz, <span class=\"allergen\">Weizen</span>mehl), Kartoffelstärke, Salz.",
+   "lang" : "de",
+   "languages" : {
+      "en:german" : 1
+   },
+   "languages_codes" : {
+      "de" : 1
+   },
+   "languages_hierarchy" : [
+      "en:german"
+   ],
+   "languages_tags" : [
+      "en:german",
+      "en:1"
+   ],
+   "lc" : "de",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/en-oat-flakes.json
+++ b/tests/unit/expected_test_results/allergens/en-oat-flakes.json
@@ -1,0 +1,30 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "ingredients_lc" : "en",
+   "ingredients_text" : "Whole Grain Oat Flakes (65.0%)",
+   "ingredients_text_en" : "Whole Grain Oat Flakes (65.0%)",
+   "ingredients_text_with_allergens" : "Whole Grain Oat Flakes (65.0%)",
+   "ingredients_text_with_allergens_en" : "Whole Grain Oat Flakes (65.0%)",
+   "lang" : "en",
+   "languages" : {
+      "en:english" : 1
+   },
+   "languages_codes" : {
+      "en" : 1
+   },
+   "languages_hierarchy" : [
+      "en:english"
+   ],
+   "languages_tags" : [
+      "en:english",
+      "en:1"
+   ],
+   "lc" : "en",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fi-allergens-field-only.json
+++ b/tests/unit/expected_test_results/allergens/fi-allergens-field-only.json
@@ -1,0 +1,26 @@
+{
+   "allergens" : "en:gluten,en:milk,en:nuts",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:milk",
+      "en:nuts"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:milk",
+      "en:nuts"
+   ],
+   "lang" : "fi",
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fi-basic-allergens.json
+++ b/tests/unit/expected_test_results/allergens/fi-basic-allergens.json
@@ -1,0 +1,60 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "kananmunat, äyriäiset, selleri, nilviäisiä, MAITO, KALA, MAITO, KALA, VEHNÄjauho, sinappi, pähkinöitä",
+   "allergens_hierarchy" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:eggs",
+      "en:fish",
+      "en:gluten",
+      "en:milk",
+      "en:molluscs",
+      "en:mustard",
+      "en:nuts"
+   ],
+   "allergens_tags" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:eggs",
+      "en:fish",
+      "en:gluten",
+      "en:milk",
+      "en:molluscs",
+      "en:mustard",
+      "en:nuts"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "Vesi, MAITO, VEHNÄjauho, sokeri, suola, _kananmunat_, sinappi, _äyriäiset_, pähkinöitä, _selleri_, KALA, _nilviäisiä_. Saattaa sisältää pieniä määriä LUPIINEJA, maapähkinöitä, _soijaa_ ja seesamia ",
+   "ingredients_text_fi" : "Vesi, MAITO, VEHNÄjauho, sokeri, suola, _kananmunat_, sinappi, _äyriäiset_, pähkinöitä, _selleri_, KALA, _nilviäisiä_. Saattaa sisältää pieniä määriä LUPIINEJA, maapähkinöitä, _soijaa_ ja seesamia ",
+   "ingredients_text_with_allergens" : "Vesi, <span class=\"allergen\">MAITO</span>, <span class=\"allergen\">VEHNÄjauho</span>, sokeri, suola, <span class=\"allergen\">kananmunat</span>, <span class=\"allergen\">sinappi</span>, <span class=\"allergen\">äyriäiset</span>, <span class=\"allergen\">pähkinöitä</span>, <span class=\"allergen\">selleri</span>, <span class=\"allergen\">KALA</span>, <span class=\"allergen\">nilviäisiä</span>. Saattaa sisältää pieniä määriä <span class=\"allergen\">LUPIINEJA</span>, <span class=\"allergen\">maapähkinöitä</span>, <span class=\"allergen\">soijaa</span> ja <span class=\"allergen\">seesamia</span> ",
+   "ingredients_text_with_allergens_fi" : "Vesi, <span class=\"allergen\">MAITO</span>, <span class=\"allergen\">VEHNÄjauho</span>, sokeri, suola, <span class=\"allergen\">kananmunat</span>, <span class=\"allergen\">sinappi</span>, <span class=\"allergen\">äyriäiset</span>, <span class=\"allergen\">pähkinöitä</span>, <span class=\"allergen\">selleri</span>, <span class=\"allergen\">KALA</span>, <span class=\"allergen\">nilviäisiä</span>. Saattaa sisältää pieniä määriä <span class=\"allergen\">LUPIINEJA</span>, <span class=\"allergen\">maapähkinöitä</span>, <span class=\"allergen\">soijaa</span> ja <span class=\"allergen\">seesamia</span> ",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "soijaa, LUPIINEJA, LUPIINEJA, maapähkinöitä, seesamia",
+   "traces_hierarchy" : [
+      "en:lupin",
+      "en:peanuts",
+      "en:sesame-seeds",
+      "en:soybeans"
+   ],
+   "traces_tags" : [
+      "en:lupin",
+      "en:peanuts",
+      "en:sesame-seeds",
+      "en:soybeans"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fi-ingredients-allergens.json
+++ b/tests/unit/expected_test_results/allergens/fi-ingredients-allergens.json
@@ -1,0 +1,38 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "vehnä, seesami, sinappi",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:mustard",
+      "en:sesame-seeds"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:mustard",
+      "en:sesame-seeds"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "Jauho (vehnä), siemenet [seesami], mausteet (sinappi), ruokosokeri, kookosmaito",
+   "ingredients_text_fi" : "Jauho (vehnä), siemenet [seesami], mausteet (sinappi), ruokosokeri, kookosmaito",
+   "ingredients_text_with_allergens" : "Jauho (<span class=\"allergen\">vehnä</span>), siemenet [<span class=\"allergen\">seesami</span>], mausteet (<span class=\"allergen\">sinappi</span>), ruokosokeri, kookosmaito",
+   "ingredients_text_with_allergens_fi" : "Jauho (<span class=\"allergen\">vehnä</span>), siemenet [<span class=\"allergen\">seesami</span>], mausteet (<span class=\"allergen\">sinappi</span>), ruokosokeri, kookosmaito",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fi-multiple-allergens-traces.json
+++ b/tests/unit/expected_test_results/allergens/fi-multiple-allergens-traces.json
@@ -1,0 +1,50 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "vehnä, lupiinijauho, soija, sinappi, selleri",
+   "allergens_hierarchy" : [
+      "en:celery",
+      "en:gluten",
+      "en:lupin",
+      "en:mustard",
+      "en:soybeans"
+   ],
+   "allergens_tags" : [
+      "en:celery",
+      "en:gluten",
+      "en:lupin",
+      "en:mustard",
+      "en:soybeans"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "vehnä ja lupiinijauho, mausteet (soija, sinappi ja selleri), saattaa sisältää pieniä määriä pähkinöitä, maapähkinöitä ja kalaa",
+   "ingredients_text_fi" : "vehnä ja lupiinijauho, mausteet (soija, sinappi ja selleri), saattaa sisältää pieniä määriä pähkinöitä, maapähkinöitä ja kalaa",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">vehnä</span> ja <span class=\"allergen\">lupiinijauho</span>, mausteet (<span class=\"allergen\">soija</span>, <span class=\"allergen\">sinappi</span> ja <span class=\"allergen\">selleri</span>), saattaa sisältää pieniä määriä <span class=\"allergen\">pähkinöitä</span>, <span class=\"allergen\">maapähkinöitä</span> ja <span class=\"allergen\">kalaa</span>",
+   "ingredients_text_with_allergens_fi" : "<span class=\"allergen\">vehnä</span> ja <span class=\"allergen\">lupiinijauho</span>, mausteet (<span class=\"allergen\">soija</span>, <span class=\"allergen\">sinappi</span> ja <span class=\"allergen\">selleri</span>), saattaa sisältää pieniä määriä <span class=\"allergen\">pähkinöitä</span>, <span class=\"allergen\">maapähkinöitä</span> ja <span class=\"allergen\">kalaa</span>",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "pähkinöitä, maapähkinöitä, kalaa",
+   "traces_hierarchy" : [
+      "en:fish",
+      "en:nuts",
+      "en:peanuts"
+   ],
+   "traces_tags" : [
+      "en:fish",
+      "en:nuts",
+      "en:peanuts"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fi-pizza-ingredients.json
+++ b/tests/unit/expected_test_results/allergens/fi-pizza-ingredients.json
@@ -1,0 +1,36 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "vehnäjauho, mozzarella, laktoosi",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:milk"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:milk"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, vehnäjauho, suola, maissitärkkelys), mozzarella 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, laktoosi, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano.",
+   "ingredients_text_fi" : "Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, vehnäjauho, suola, maissitärkkelys), mozzarella 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, laktoosi, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano.",
+   "ingredients_text_with_allergens" : "Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, <span class=\"allergen\">vehnäjauho</span>, suola, maissitärkkelys), <span class=\"allergen\">mozzarella</span> 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, <span class=\"allergen\">laktoosi</span>, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano.",
+   "ingredients_text_with_allergens_fi" : "Täyte 61% : tomaattikastike 32% (tomaattipyree, vesi, <span class=\"allergen\">vehnäjauho</span>, suola, maissitärkkelys), <span class=\"allergen\">mozzarella</span> 26%, kinkku 21% (siankinkku, vesi, suola, dekstroosi, glukoosisiirappi, stabilisointiaine : E451, luontaiset aromit, hyytelöimisaine : E407, <span class=\"allergen\">laktoosi</span>, sianlihaliemi, hapettumisenestoaine : E316, säilöntäaine : E250, hapatteet), herkkusienet 15% (herkkusienet, luontainen herkkusieniuute), mustat oliivit (stabilisointiaine : E579), sinappikaali 0,6%, basilika ja oregano.",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fi-sinappi-vehna-kananmuna.json
+++ b/tests/unit/expected_test_results/allergens/fi-sinappi-vehna-kananmuna.json
@@ -1,0 +1,40 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "sinappijauhe, VEHNÄsuurimo",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:mustard"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:mustard"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "sinappijauhe, VEHNÄsuurimo. Saattaa sisältää kananmunaa",
+   "ingredients_text_fi" : "sinappijauhe, VEHNÄsuurimo. Saattaa sisältää kananmunaa",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">sinappijauhe</span>, <span class=\"allergen\">VEHNÄsuurimo</span>. Saattaa sisältää <span class=\"allergen\">kananmunaa</span>",
+   "ingredients_text_with_allergens_fi" : "<span class=\"allergen\">sinappijauhe</span>, <span class=\"allergen\">VEHNÄsuurimo</span>. Saattaa sisältää <span class=\"allergen\">kananmunaa</span>",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "kananmunaa",
+   "traces_hierarchy" : [
+      "en:eggs"
+   ],
+   "traces_tags" : [
+      "en:eggs"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fi-traces.json
+++ b/tests/unit/expected_test_results/allergens/fi-traces.json
@@ -1,0 +1,42 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "Saattaa sisältää muita gluteenia sisältäviä viljoja, pähkinöitä, maapähkinöitä, soijaa ja kananmunia.",
+   "ingredients_text_fi" : "Saattaa sisältää muita gluteenia sisältäviä viljoja, pähkinöitä, maapähkinöitä, soijaa ja kananmunia.",
+   "ingredients_text_with_allergens" : "Saattaa sisältää muita <span class=\"allergen\">gluteenia sisältäviä viljoja</span>, <span class=\"allergen\">pähkinöitä</span>, <span class=\"allergen\">maapähkinöitä</span>, <span class=\"allergen\">soijaa</span> ja <span class=\"allergen\">kananmunia</span>.",
+   "ingredients_text_with_allergens_fi" : "Saattaa sisältää muita <span class=\"allergen\">gluteenia sisältäviä viljoja</span>, <span class=\"allergen\">pähkinöitä</span>, <span class=\"allergen\">maapähkinöitä</span>, <span class=\"allergen\">soijaa</span> ja <span class=\"allergen\">kananmunia</span>.",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "gluteenia sisältäviä viljoja, pähkinöitä, maapähkinöitä, soijaa, kananmunia",
+   "traces_hierarchy" : [
+      "en:eggs",
+      "en:gluten",
+      "en:nuts",
+      "en:peanuts",
+      "en:soybeans"
+   ],
+   "traces_tags" : [
+      "en:eggs",
+      "en:gluten",
+      "en:nuts",
+      "en:peanuts",
+      "en:soybeans"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fi-vehnajauho-sulfiitteja.json
+++ b/tests/unit/expected_test_results/allergens/fi-vehnajauho-sulfiitteja.json
@@ -1,0 +1,36 @@
+{
+   "allergens" : "en:sulphur-dioxide-and-sulphites",
+   "allergens_from_ingredients" : "vehnäjauho",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:sulphur-dioxide-and-sulphites"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:sulphur-dioxide-and-sulphites"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "vehnäjauho 97%",
+   "ingredients_text_fi" : "vehnäjauho 97%",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">vehnäjauho</span> 97%",
+   "ingredients_text_with_allergens_fi" : "<span class=\"allergen\">vehnäjauho</span> 97%",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fi-vehnajauho.json
+++ b/tests/unit/expected_test_results/allergens/fi-vehnajauho.json
@@ -1,0 +1,34 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "vehnäjauho",
+   "allergens_hierarchy" : [
+      "en:gluten"
+   ],
+   "allergens_tags" : [
+      "en:gluten"
+   ],
+   "ingredients_lc" : "fi",
+   "ingredients_text" : "vehnäjauho 97%",
+   "ingredients_text_fi" : "vehnäjauho 97%",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">vehnäjauho</span> 97%",
+   "ingredients_text_with_allergens_fi" : "<span class=\"allergen\">vehnäjauho</span> 97%",
+   "lang" : "fi",
+   "languages" : {
+      "en:finnish" : 1
+   },
+   "languages_codes" : {
+      "fi" : 1
+   },
+   "languages_hierarchy" : [
+      "en:finnish"
+   ],
+   "languages_tags" : [
+      "en:finnish",
+      "en:1"
+   ],
+   "lc" : "fi",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-allergens-field-only.json
+++ b/tests/unit/expected_test_results/allergens/fr-allergens-field-only.json
@@ -1,0 +1,26 @@
+{
+   "allergens" : "en:gluten,en:milk,en:nuts",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:milk",
+      "en:nuts"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:milk",
+      "en:nuts"
+   ],
+   "lang" : "fr",
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-allergens-ingredients-and-field.json
+++ b/tests/unit/expected_test_results/allergens/fr-allergens-ingredients-and-field.json
@@ -1,0 +1,43 @@
+{
+   "allergens" : "en:mustard",
+   "allergens_from_ingredients" : "Saumon, oeufs, blé",
+   "allergens_hierarchy" : [
+      "en:eggs",
+      "en:fish",
+      "en:gluten",
+      "en:mustard"
+   ],
+   "allergens_tags" : [
+      "en:eggs",
+      "en:fish",
+      "en:gluten",
+      "en:mustard"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Saumon, oeufs, blé, chocolat",
+   "ingredients_text_fr" : "Saumon, oeufs, blé, chocolat",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">blé</span>, chocolat",
+   "ingredients_text_with_allergens_fr" : "<span class=\"allergen\">Saumon</span>, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">blé</span>, chocolat",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "en:lupin",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [
+      "en:lupin"
+   ],
+   "traces_tags" : [
+      "en:lupin"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-allergens-markup.json
+++ b/tests/unit/expected_test_results/allergens/fr-allergens-markup.json
@@ -1,0 +1,43 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "GLUTEN, CELERI, poisson, banane, mollusque, BLE, CELERI, GLUTEN, BLE, CELERI, GLUTEN, lupin",
+   "allergens_hierarchy" : [
+      "en:celery",
+      "en:fish",
+      "en:gluten",
+      "en:lupin",
+      "en:molluscs",
+      "fr:banane"
+   ],
+   "allergens_tags" : [
+      "en:celery",
+      "en:fish",
+      "en:gluten",
+      "en:lupin",
+      "en:molluscs",
+      "fr:banane"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Eau, BLE, _CELERI_, __GLUTEN__, _poisson_, FRAISE, _banane_, lupin, _mollusque_",
+   "ingredients_text_fr" : "Eau, BLE, _CELERI_, __GLUTEN__, _poisson_, FRAISE, _banane_, lupin, _mollusque_",
+   "ingredients_text_with_allergens" : "Eau, <span class=\"allergen\">BLE</span>, <span class=\"allergen\">CELERI</span>, <span class=\"allergen\">GLUTEN</span>, <span class=\"allergen\">poisson</span>, FRAISE, <span class=\"allergen\">banane</span>, <span class=\"allergen\">lupin</span>, <span class=\"allergen\">mollusque</span>",
+   "ingredients_text_with_allergens_fr" : "Eau, <span class=\"allergen\">BLE</span>, <span class=\"allergen\">CELERI</span>, <span class=\"allergen\">GLUTEN</span>, <span class=\"allergen\">poisson</span>, FRAISE, <span class=\"allergen\">banane</span>, <span class=\"allergen\">lupin</span>, <span class=\"allergen\">mollusque</span>",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-allergens-traces-fields.json
+++ b/tests/unit/expected_test_results/allergens/fr-allergens-traces-fields.json
@@ -1,0 +1,47 @@
+{
+   "allergens" : "en:celery,en:crustaceans,en:lupin",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:lupin"
+   ],
+   "allergens_tags" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:lupin"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Filet de saumon sauvage",
+   "ingredients_text_fr" : "Filet de saumon sauvage",
+   "ingredients_text_with_allergens" : "Filet de saumon sauvage",
+   "ingredients_text_with_allergens_fr" : "Filet de saumon sauvage",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "en:eggs,en:mustard,en:soybeans,en:sulphur-dioxide-and-sulphites",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [
+      "en:eggs",
+      "en:mustard",
+      "en:soybeans",
+      "en:sulphur-dioxide-and-sulphites"
+   ],
+   "traces_tags" : [
+      "en:eggs",
+      "en:mustard",
+      "en:soybeans",
+      "en:sulphur-dioxide-and-sulphites"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-allergens-uppercase.json
+++ b/tests/unit/expected_test_results/allergens/fr-allergens-uppercase.json
@@ -1,0 +1,41 @@
+{
+   "allergens" : "en:gluten",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [
+      "en:gluten"
+   ],
+   "allergens_tags" : [
+      "en:gluten"
+   ],
+   "languages" : {},
+   "languages_codes" : {},
+   "languages_hierarchy" : [],
+   "languages_tags" : [
+      "en:0"
+   ],
+   "lc" : "fr",
+   "traces" : "en:celery,en:crustaceans,en:eggs,en:fish,en:milk,en:mustard,en:nuts,en:soybeans,en:sulphur-dioxide-and-sulphites",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:eggs",
+      "en:fish",
+      "en:milk",
+      "en:mustard",
+      "en:nuts",
+      "en:soybeans",
+      "en:sulphur-dioxide-and-sulphites"
+   ],
+   "traces_tags" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:eggs",
+      "en:fish",
+      "en:milk",
+      "en:mustard",
+      "en:nuts",
+      "en:soybeans",
+      "en:sulphur-dioxide-and-sulphites"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-basic-allergens.json
+++ b/tests/unit/expected_test_results/allergens/fr-basic-allergens.json
@@ -1,0 +1,60 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "oeufs, crustacés, céleri, LAIT, BLE, POISSON, LAIT, BLE, POISSON, moutarde, fruits à coque, mollusques",
+   "allergens_hierarchy" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:eggs",
+      "en:fish",
+      "en:gluten",
+      "en:milk",
+      "en:molluscs",
+      "en:mustard",
+      "en:nuts"
+   ],
+   "allergens_tags" : [
+      "en:celery",
+      "en:crustaceans",
+      "en:eggs",
+      "en:fish",
+      "en:gluten",
+      "en:milk",
+      "en:molluscs",
+      "en:mustard",
+      "en:nuts"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Eau, LAIT, farine de BLE, sucre, sel, _oeufs_, moutarde, _crustacés_, fruits à coque, _céleri_, POISSON, crème de cassis. Contient mollusques. Peut contenir des traces d'arachide, de _soja_, de LUPIN, et de sésame ",
+   "ingredients_text_fr" : "Eau, LAIT, farine de BLE, sucre, sel, _oeufs_, moutarde, _crustacés_, fruits à coque, _céleri_, POISSON, crème de cassis. Contient mollusques. Peut contenir des traces d'arachide, de _soja_, de LUPIN, et de sésame ",
+   "ingredients_text_with_allergens" : "Eau, <span class=\"allergen\">LAIT</span>, farine de <span class=\"allergen\">BLE</span>, sucre, sel, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">moutarde</span>, <span class=\"allergen\">crustacés</span>, <span class=\"allergen\">fruits à coque</span>, <span class=\"allergen\">céleri</span>, <span class=\"allergen\">POISSON</span>, crème de cassis. Contient <span class=\"allergen\">mollusques</span>. Peut contenir des traces d'<span class=\"allergen\">arachide</span>, de <span class=\"allergen\">soja</span>, de <span class=\"allergen\">LUPIN</span>, et de <span class=\"allergen\">sésame</span> ",
+   "ingredients_text_with_allergens_fr" : "Eau, <span class=\"allergen\">LAIT</span>, farine de <span class=\"allergen\">BLE</span>, sucre, sel, <span class=\"allergen\">oeufs</span>, <span class=\"allergen\">moutarde</span>, <span class=\"allergen\">crustacés</span>, <span class=\"allergen\">fruits à coque</span>, <span class=\"allergen\">céleri</span>, <span class=\"allergen\">POISSON</span>, crème de cassis. Contient <span class=\"allergen\">mollusques</span>. Peut contenir des traces d'<span class=\"allergen\">arachide</span>, de <span class=\"allergen\">soja</span>, de <span class=\"allergen\">LUPIN</span>, et de <span class=\"allergen\">sésame</span> ",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "soja, LUPIN, LUPIN, arachide, sésame",
+   "traces_hierarchy" : [
+      "en:lupin",
+      "en:peanuts",
+      "en:sesame-seeds",
+      "en:soybeans"
+   ],
+   "traces_tags" : [
+      "en:lupin",
+      "en:peanuts",
+      "en:sesame-seeds",
+      "en:soybeans"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-farine-ble-sulfites.json
+++ b/tests/unit/expected_test_results/allergens/fr-farine-ble-sulfites.json
@@ -1,0 +1,36 @@
+{
+   "allergens" : "en:sulphur-dioxide-and-sulphites",
+   "allergens_from_ingredients" : "blé",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:sulphur-dioxide-and-sulphites"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:sulphur-dioxide-and-sulphites"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Farine de blé 97%",
+   "ingredients_text_fr" : "Farine de blé 97%",
+   "ingredients_text_with_allergens" : "Farine de <span class=\"allergen\">blé</span> 97%",
+   "ingredients_text_with_allergens_fr" : "Farine de <span class=\"allergen\">blé</span> 97%",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-farine-ble.json
+++ b/tests/unit/expected_test_results/allergens/fr-farine-ble.json
@@ -1,0 +1,34 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "blé",
+   "allergens_hierarchy" : [
+      "en:gluten"
+   ],
+   "allergens_tags" : [
+      "en:gluten"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Farine de blé 97%",
+   "ingredients_text_fr" : "Farine de blé 97%",
+   "ingredients_text_with_allergens" : "Farine de <span class=\"allergen\">blé</span> 97%",
+   "ingredients_text_with_allergens_fr" : "Farine de <span class=\"allergen\">blé</span> 97%",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-ingredients-allergens.json
+++ b/tests/unit/expected_test_results/allergens/fr-ingredients-allergens.json
@@ -1,0 +1,38 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "blé, sésame, moutarde",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:mustard",
+      "en:sesame-seeds"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:mustard",
+      "en:sesame-seeds"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Farine (blé), graines [sésame], condiments (moutarde), sucre de canne, lait de coco",
+   "ingredients_text_fr" : "Farine (blé), graines [sésame], condiments (moutarde), sucre de canne, lait de coco",
+   "ingredients_text_with_allergens" : "Farine (<span class=\"allergen\">blé</span>), graines [<span class=\"allergen\">sésame</span>], condiments (<span class=\"allergen\">moutarde</span>), sucre de canne, lait de coco",
+   "ingredients_text_with_allergens_fr" : "Farine (<span class=\"allergen\">blé</span>), graines [<span class=\"allergen\">sésame</span>], condiments (<span class=\"allergen\">moutarde</span>), sucre de canne, lait de coco",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-moutarde-ble-traces-oeufs.json
+++ b/tests/unit/expected_test_results/allergens/fr-moutarde-ble-traces-oeufs.json
@@ -1,0 +1,40 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "BLE , BLE, moutarde",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:mustard"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:mustard"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "farine de graines de moutarde, 100 % semoule de BLE dur de qualité supérieure Traces éventuelles d'oeufs",
+   "ingredients_text_fr" : "farine de graines de moutarde, 100 % semoule de BLE dur de qualité supérieure Traces éventuelles d'oeufs",
+   "ingredients_text_with_allergens" : "farine de graines de <span class=\"allergen\">moutarde</span>, 100 % semoule de <span class=\"allergen\">BLE</span> </span>dur de qualité supérieure Traces éventuelles d'<span class=\"allergen\">oeufs</span>",
+   "ingredients_text_with_allergens_fr" : "farine de graines de <span class=\"allergen\">moutarde</span>, 100 % semoule de <span class=\"allergen\">BLE</span> </span>dur de qualité supérieure Traces éventuelles d'<span class=\"allergen\">oeufs</span>",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "oeufs",
+   "traces_hierarchy" : [
+      "en:eggs"
+   ],
+   "traces_tags" : [
+      "en:eggs"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-multiple-allergens.json
+++ b/tests/unit/expected_test_results/allergens/fr-multiple-allergens.json
@@ -1,0 +1,50 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "blé, lupin, soja, moutarde, céleri",
+   "allergens_hierarchy" : [
+      "en:celery",
+      "en:gluten",
+      "en:lupin",
+      "en:mustard",
+      "en:soybeans"
+   ],
+   "allergens_tags" : [
+      "en:celery",
+      "en:gluten",
+      "en:lupin",
+      "en:mustard",
+      "en:soybeans"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Farine de blé et de lupin, épices (soja, moutarde et céleri), crème de cassis, traces de fruits à coques, d'arachide et de poisson",
+   "ingredients_text_fr" : "Farine de blé et de lupin, épices (soja, moutarde et céleri), crème de cassis, traces de fruits à coques, d'arachide et de poisson",
+   "ingredients_text_with_allergens" : "Farine de <span class=\"allergen\">blé</span> et de <span class=\"allergen\">lupin</span>, épices (<span class=\"allergen\">soja</span>, <span class=\"allergen\">moutarde</span> et <span class=\"allergen\">céleri</span>), crème de cassis, traces de <span class=\"allergen\">fruits à coques</span>, d'<span class=\"allergen\">arachide</span> et de <span class=\"allergen\">poisson</span>",
+   "ingredients_text_with_allergens_fr" : "Farine de <span class=\"allergen\">blé</span> et de <span class=\"allergen\">lupin</span>, épices (<span class=\"allergen\">soja</span>, <span class=\"allergen\">moutarde</span> et <span class=\"allergen\">céleri</span>), crème de cassis, traces de <span class=\"allergen\">fruits à coques</span>, d'<span class=\"allergen\">arachide</span> et de <span class=\"allergen\">poisson</span>",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "fruits à coques, arachide, poisson",
+   "traces_hierarchy" : [
+      "en:fish",
+      "en:nuts",
+      "en:peanuts"
+   ],
+   "traces_tags" : [
+      "en:fish",
+      "en:nuts",
+      "en:peanuts"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-noix-saint-jacques.json
+++ b/tests/unit/expected_test_results/allergens/fr-noix-saint-jacques.json
@@ -1,0 +1,34 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "Noix de Saint-Jacques",
+   "allergens_hierarchy" : [
+      "en:molluscs"
+   ],
+   "allergens_tags" : [
+      "en:molluscs"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Noix de Saint-Jacques",
+   "ingredients_text_fr" : "Noix de Saint-Jacques",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">Noix de Saint-Jacques</span>",
+   "ingredients_text_with_allergens_fr" : "<span class=\"allergen\">Noix de Saint-Jacques</span>",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-noix-st-jacques.json
+++ b/tests/unit/expected_test_results/allergens/fr-noix-st-jacques.json
@@ -1,0 +1,34 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "Noix de St-Jacques",
+   "allergens_hierarchy" : [
+      "en:molluscs"
+   ],
+   "allergens_tags" : [
+      "en:molluscs"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Noix de St-Jacques",
+   "ingredients_text_fr" : "Noix de St-Jacques",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">Noix de St-Jacques</span>",
+   "ingredients_text_with_allergens_fr" : "<span class=\"allergen\">Noix de St-Jacques</span>",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-pizza-ingredients.json
+++ b/tests/unit/expected_test_results/allergens/fr-pizza-ingredients.json
@@ -1,0 +1,36 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "blé, mozzarella, lactose",
+   "allergens_hierarchy" : [
+      "en:gluten",
+      "en:milk"
+   ],
+   "allergens_tags" : [
+      "en:gluten",
+      "en:milk"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de blé, sel, amidon de maïs), mozzarella 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, lactose, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté.",
+   "ingredients_text_fr" : "Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de blé, sel, amidon de maïs), mozzarella 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, lactose, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté.",
+   "ingredients_text_with_allergens" : "Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de <span class=\"allergen\">blé</span>, sel, amidon de maïs), <span class=\"allergen\">mozzarella</span> 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, <span class=\"allergen\">lactose</span>, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté.",
+   "ingredients_text_with_allergens_fr" : "Garniture 61% : sauce tomate 32% (purée de tomate, eau, farine de <span class=\"allergen\">blé</span>, sel, amidon de maïs), <span class=\"allergen\">mozzarella</span> 26%, chiffonnade de jambon cuit standard 21% (jambon de porc, eau, sel, dextrose, sirop de glucose, stabilisant : E451, arômes naturels, gélifiant : E407, <span class=\"allergen\">lactose</span>, bouillon de porc, antioxydant : E316, conservateur : E250, ferments), champignons de Paris 15% (champignons, extrait naturel de champignon concentré), olives noires avec noyau (stabilisant : E579), roquette 0,6%, basilic et origan. Pourcentages exprimés sur la garniture. Pâte 39% : farine de blé, eau, levure boulangère, sel, farine de blé malté.",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-saint-jacques.json
+++ b/tests/unit/expected_test_results/allergens/fr-saint-jacques.json
@@ -1,0 +1,34 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "Saint Jacques",
+   "allergens_hierarchy" : [
+      "en:molluscs"
+   ],
+   "allergens_tags" : [
+      "en:molluscs"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Saint Jacques",
+   "ingredients_text_fr" : "Saint Jacques",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">Saint Jacques</span>",
+   "ingredients_text_with_allergens_fr" : "<span class=\"allergen\">Saint Jacques</span>",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-salmon-not-highlighted.json
+++ b/tests/unit/expected_test_results/allergens/fr-salmon-not-highlighted.json
@@ -1,0 +1,29 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
+   "ingredients_text_fr" : "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
+   "ingredients_text_with_allergens" : "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
+   "ingredients_text_with_allergens_fr" : "Filet de saumon sauvage certifié MSC, pêché en Pacifique Nord-est (100%)",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-saumon-allergens-multiple-traces.json
+++ b/tests/unit/expected_test_results/allergens/fr-saumon-allergens-multiple-traces.json
@@ -1,0 +1,43 @@
+{
+   "allergens" : "en:fish",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [
+      "en:fish"
+   ],
+   "allergens_tags" : [
+      "en:fish"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Filet de saumon* 93%, jus de citron* 5%, sel marin, poivre*. *Ingrédients issus de l'agriculture biologique. Traces possibles de crustacés, mollusques, lait et gluten.",
+   "ingredients_text_fr" : "Filet de saumon* 93%, jus de citron* 5%, sel marin, poivre*. *Ingrédients issus de l'agriculture biologique. Traces possibles de crustacés, mollusques, lait et gluten.",
+   "ingredients_text_with_allergens" : "Filet de saumon* 93%, jus de citron* 5%, sel marin, poivre*. *Ingrédients issus de l'agriculture biologique. Traces possibles de <span class=\"allergen\">crustacés</span>, <span class=\"allergen\">mollusques</span>, <span class=\"allergen\">lait</span> et <span class=\"allergen\">gluten</span>.",
+   "ingredients_text_with_allergens_fr" : "Filet de saumon* 93%, jus de citron* 5%, sel marin, poivre*. *Ingrédients issus de l'agriculture biologique. Traces possibles de <span class=\"allergen\">crustacés</span>, <span class=\"allergen\">mollusques</span>, <span class=\"allergen\">lait</span> et <span class=\"allergen\">gluten</span>.",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "en:crustaceans,en:gluten,en:milk,en:molluscs",
+   "traces_from_ingredients" : "crustacés, mollusques, lait, gluten",
+   "traces_hierarchy" : [
+      "en:crustaceans",
+      "en:gluten",
+      "en:milk",
+      "en:molluscs"
+   ],
+   "traces_tags" : [
+      "en:crustaceans",
+      "en:gluten",
+      "en:milk",
+      "en:molluscs"
+   ]
+}

--- a/tests/unit/expected_test_results/allergens/fr-st-jacques.json
+++ b/tests/unit/expected_test_results/allergens/fr-st-jacques.json
@@ -1,0 +1,34 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "St Jacques",
+   "allergens_hierarchy" : [
+      "en:molluscs"
+   ],
+   "allergens_tags" : [
+      "en:molluscs"
+   ],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "St Jacques",
+   "ingredients_text_fr" : "St Jacques",
+   "ingredients_text_with_allergens" : "<span class=\"allergen\">St Jacques</span>",
+   "ingredients_text_with_allergens_fr" : "<span class=\"allergen\">St Jacques</span>",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "",
+   "traces_hierarchy" : [],
+   "traces_tags" : []
+}

--- a/tests/unit/expected_test_results/allergens/fr-traces.json
+++ b/tests/unit/expected_test_results/allergens/fr-traces.json
@@ -1,0 +1,42 @@
+{
+   "allergens" : "",
+   "allergens_from_ingredients" : "",
+   "allergens_hierarchy" : [],
+   "allergens_tags" : [],
+   "ingredients_lc" : "fr",
+   "ingredients_text" : "Traces éventuelles de céréales contenant du gluten, fruits à coques, arachide, soja et oeuf.",
+   "ingredients_text_fr" : "Traces éventuelles de céréales contenant du gluten, fruits à coques, arachide, soja et oeuf.",
+   "ingredients_text_with_allergens" : "Traces éventuelles de céréales contenant du <span class=\"allergen\">gluten</span>, <span class=\"allergen\">fruits à coques</span>, <span class=\"allergen\">arachide</span>, <span class=\"allergen\">soja</span> et <span class=\"allergen\">oeuf</span>.",
+   "ingredients_text_with_allergens_fr" : "Traces éventuelles de céréales contenant du <span class=\"allergen\">gluten</span>, <span class=\"allergen\">fruits à coques</span>, <span class=\"allergen\">arachide</span>, <span class=\"allergen\">soja</span> et <span class=\"allergen\">oeuf</span>.",
+   "lang" : "fr",
+   "languages" : {
+      "en:french" : 1
+   },
+   "languages_codes" : {
+      "fr" : 1
+   },
+   "languages_hierarchy" : [
+      "en:french"
+   ],
+   "languages_tags" : [
+      "en:french",
+      "en:1"
+   ],
+   "lc" : "fr",
+   "traces" : "",
+   "traces_from_ingredients" : "gluten, fruits à coques, arachide, soja, oeuf",
+   "traces_hierarchy" : [
+      "en:eggs",
+      "en:gluten",
+      "en:nuts",
+      "en:peanuts",
+      "en:soybeans"
+   ],
+   "traces_tags" : [
+      "en:eggs",
+      "en:gluten",
+      "en:nuts",
+      "en:peanuts",
+      "en:soybeans"
+   ]
+}


### PR DESCRIPTION
### What
This PR updates allergens.t to use the compare_to_expected_results() method for comparing and validating expected results. It also ensures that user-specific fields (allergens_from_user, traces_from_user) do not interfere with test outcomes.

### Related issue(s) and discussion
Fixes #11560

